### PR TITLE
chore(vitest): add lcov to default coverage reporters

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
     ],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'html'],
+      reporter: ['text', 'lcov', 'json', 'html'],
       exclude: [
         'node_modules/',
         'src/tests/',


### PR DESCRIPTION
- **Problem:** `--reporter=text` configures the test reporter (and can be treated as a custom reporter), not coverage output.
- **Change:** Add `lcov` to `coverage.reporter` so `npm run test:coverage` always emits `coverage/lcov.info` alongside existing `text/json/html`.
- **How to verify:** `npm run test:coverage` and confirm `coverage/lcov.info` exists.
- **Notes:** No script changes; coverage folder remains git-ignored.