### PR TITLE
test(calendar): fix act warnings in IntegratedResourceCalendarPage smoke tests

### DIFF
--- a/tests/smoke/integrated-resource-calendar.spec.tsx
+++ b/tests/smoke/integrated-resource-calendar.spec.tsx
@@ -10,6 +10,11 @@ import { renderWithAppProviders } from '../helpers/renderWithAppProviders';
 
 const EXTENDED_TIMEOUT = 15000;
 
+const renderPage = async () => {
+  renderWithAppProviders(<IntegratedResourceCalendarPage />);
+  await screen.findByTestId('irc-page');
+};
+
 vi.mock('@fullcalendar/react', () => ({
   __esModule: true,
   default: ({ events }: { events?: Array<{ id: string; title: string }> }) => (
@@ -27,14 +32,14 @@ vi.mock('@fullcalendar/resource-timeline', () => ({ __esModule: true, default: (
 vi.mock('@fullcalendar/interaction', () => ({ __esModule: true, default: () => null }));
 
 describe('IntegratedResourceCalendar smoke tests', () => {
-  it('renders without crashing', () => {
-    expect(() => {
-      renderWithAppProviders(<IntegratedResourceCalendarPage />);
-    }).not.toThrow();
+  it('renders without crashing', async () => {
+    await renderPage();
+
+    expect(screen.getByTestId('irc-page')).toBeInTheDocument();
   });
 
   it('displays the page title', async () => {
-    renderWithAppProviders(<IntegratedResourceCalendarPage />);
+    await renderPage();
 
     // ページタイトルが表示されることを確認
     expect(screen.getByText('統合リソースカレンダー')).toBeInTheDocument();
@@ -42,14 +47,14 @@ describe('IntegratedResourceCalendar smoke tests', () => {
   });
 
   it('shows Sprint 3 implementation notice', async () => {
-    renderWithAppProviders(<IntegratedResourceCalendarPage />);
+    await renderPage();
 
     // Sprint 3実装中の通知が表示されることを確認
     expect(screen.getByText(/Sprint 3 実装中/)).toBeInTheDocument();
   });
 
   it('renders FullCalendar component', async () => {
-    renderWithAppProviders(<IntegratedResourceCalendarPage />);
+    await renderPage();
 
     // FullCalendarの基本要素が存在することを確認
     await waitFor(() => {
@@ -60,7 +65,7 @@ describe('IntegratedResourceCalendar smoke tests', () => {
   });
 
   it('contains mock resource data', async () => {
-    renderWithAppProviders(<IntegratedResourceCalendarPage />);
+    await renderPage();
 
     // FullCalendar stub が resources 列を描画しないため、イベント描画を待つ
     const eventTitles = await screen.findAllByText(/利用者宅訪問|デイサービス送迎/, {}, { timeout: EXTENDED_TIMEOUT });
@@ -68,7 +73,7 @@ describe('IntegratedResourceCalendar smoke tests', () => {
   }, EXTENDED_TIMEOUT);
 
   it('displays mock events', async () => {
-    renderWithAppProviders(<IntegratedResourceCalendarPage />);
+    await renderPage();
 
     expect(await screen.findByText(/利用者宅訪問/, {}, { timeout: EXTENDED_TIMEOUT })).toBeInTheDocument();
     expect(await screen.findByText(/デイサービス送迎/, {}, { timeout: EXTENDED_TIMEOUT })).toBeInTheDocument();
@@ -76,7 +81,7 @@ describe('IntegratedResourceCalendar smoke tests', () => {
 
   // PvsA表示のテスト（ステータスアイコンなど）
   it('shows PvsA status indicators', async () => {
-    renderWithAppProviders(<IntegratedResourceCalendarPage />);
+    await renderPage();
 
     await waitFor(() => {
       // ステータスアイコンが表示されることを確認


### PR DESCRIPTION
### What
- Add async `renderPage()` helper that waits for initial page render (`irc-page`) before assertions
- Update smoke tests to use `await renderPage()`

### Why
- Eliminates React `act(...)` warnings caused by async state updates during initial render

### How to verify
- `npx vitest run tests/smoke/integrated-resource-calendar.spec.tsx --reporter=verbose`