### PR TITLE
test(smoke): stabilize daily-activity smoke tests

### DIFF
--- a/tests/e2e/_helpers/bootDaily.ts
+++ b/tests/e2e/_helpers/bootDaily.ts
@@ -1,0 +1,102 @@
+import type { Page } from '@playwright/test';
+import { setupPlaywrightEnv } from './setupPlaywrightEnv';
+import { setupSharePointStubs } from './setupSharePointStubs';
+
+const FEATURE_ENV = {
+  VITE_E2E: '1',
+  VITE_E2E_MSAL_MOCK: '1',
+  VITE_SKIP_LOGIN: '1',
+  VITE_SKIP_SHAREPOINT: '1',
+  VITE_MSAL_CLIENT_ID: 'e2e-mock-client-id-12345678',
+  VITE_MSAL_TENANT_ID: 'common',
+  VITE_DEMO_MODE: '0',
+  VITE_WRITE_ENABLED: '1',
+} as const;
+
+const FEATURE_STORAGE = {
+  skipLogin: '1',
+  demo: '0',
+  writeEnabled: '1',
+} as const;
+
+type MockUser = {
+  Id: number;
+  UserID: string;
+  FullName: string;
+};
+
+type MockDailyRecord = {
+  Id: number;
+  Title: string;
+  cr013_recorddate: string;
+  cr013_specialnote: string | null;
+  cr013_amactivity: string | null;
+  cr013_pmactivity: string | null;
+  cr013_lunchamount: string | null;
+  cr013_behaviorcheck: { results: string[] };
+  cr013_userid: string;
+  cr013_fullname: string;
+};
+
+const mockUsers: MockUser[] = Array.from({ length: 12 }).map((_, index) => ({
+  Id: index + 1,
+  UserID: `U-${String(index + 1).padStart(3, '0')}`,
+  FullName: [
+    '田中太郎',
+    '佐藤花子',
+    '鈴木次郎',
+    '高橋美咲',
+    '山田健一',
+    '渡辺由美',
+    '伊藤雄介',
+    '中村恵子',
+    '小林智子',
+    '加藤秀樹',
+    '吉田京子',
+    '清水達也',
+  ][index % 12],
+}));
+
+const mockDailyRecords: MockDailyRecord[] = mockUsers.slice(0, 6).map((user, index) => ({
+  Id: index + 101,
+  Title: `${user.FullName} ${new Date().toISOString().split('T')[0]}`,
+  cr013_recorddate: new Date().toISOString(),
+  cr013_specialnote: index % 2 === 0 ? '特記事項あり' : null,
+  cr013_amactivity: '午前活動',
+  cr013_pmactivity: '午後活動',
+  cr013_lunchamount: '完食',
+  cr013_behaviorcheck: { results: [] as string[] },
+  cr013_userid: user.UserID,
+  cr013_fullname: user.FullName,
+}));
+
+export async function bootDaily(page: Page): Promise<void> {
+  setupPlaywrightEnv(page, FEATURE_ENV, FEATURE_STORAGE);
+
+  await page.route('**/login.microsoftonline.com/**', (route) => route.fulfill({ status: 204, body: '' }));
+  await page.route('https://graph.microsoft.com/**', (route) =>
+    route.fulfill({
+      status: 200,
+      headers: { 'content-type': 'application/json; charset=utf-8' },
+      body: JSON.stringify({ value: [] }),
+    }),
+  );
+
+  await setupSharePointStubs(page, {
+    currentUser: { status: 200, body: { Id: 12345, Title: 'Mock User' } },
+    lists: [
+      {
+        name: 'Users_Master',
+        items: mockUsers,
+        sort: (items) => [...(items as MockUser[])].sort((a, b) => a.UserID.localeCompare(b.UserID)),
+      },
+      {
+        name: 'SupportRecord_Daily',
+        items: mockDailyRecords,
+        insertPosition: 'start',
+        sort: (items) => [...(items as MockDailyRecord[])].sort((a, b) => b.Id - a.Id),
+      },
+    ],
+    fallback: { status: 200, body: { value: [] } },
+  });
+}

--- a/tests/e2e/daily-activity.smoke.spec.ts
+++ b/tests/e2e/daily-activity.smoke.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { primeOpsEnv } from './helpers/ops';
+import { bootDaily } from './_helpers/bootDaily';
 
 // Smoke: /daily/activity happy path navigation and quick sanity checks
 // - open activity list
@@ -9,7 +9,7 @@ import { primeOpsEnv } from './helpers/ops';
 
 test.describe('Daily activity smoke', () => {
   test('opens activity, shows records, and round-trips via nav/footer', async ({ page }) => {
-    await primeOpsEnv(page);
+    await bootDaily(page);
 
     // Open activity page
     await page.goto('/daily/activity', { waitUntil: 'domcontentloaded' });
@@ -43,7 +43,7 @@ test.describe('Daily activity smoke', () => {
   });
 
   test('opens edit dialog, cancels, and returns to list', async ({ page }) => {
-    await primeOpsEnv(page);
+    await bootDaily(page);
 
     await page.goto('/daily/activity', { waitUntil: 'domcontentloaded' });
     await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => undefined);


### PR DESCRIPTION
- Created bootDaily.ts helper with unified env bootstrap (MSAL mock, SP skip)
- Migrated daily-activity.smoke.spec.ts from primeOpsEnv to bootDaily
- Follows same pattern as bootSchedule (fixtures mode, skip SharePoint)
- Includes mock data for Users_Master and SupportRecord_Daily

Result: 2 passed (was 0/2 before)

## Summary
Fixes daily-activity smoke tests where the page stayed empty (heading not visible) by unifying the E2E bootstrap env.

## Changes
- Add `tests/e2e/_helpers/bootDaily.ts` with unified bootstrap env:
  - MSAL mock env injected
  - SharePoint calls skipped (smoke-safe)
- Migrate `tests/e2e/daily-activity.smoke.spec.ts` from `primeOpsEnv` to `bootDaily`

## Why
Daily activity page did not mount under smoke because `primeOpsEnv` lacked MSAL CLIENT_ID/TENANT_ID, causing auth initialization to fail and leaving the root empty.

## Test Results
- ✅ `npx playwright test --config=playwright.smoke.config.ts --grep "daily-activity"` → **2 passed**

