### PR TITLE
Update name in Wrangler configuration file to match deployed Worker

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ import { GRAPH_RESOURCE } from './auth/msalConfig';
 import { MsalProvider } from './auth/MsalProvider';
 import { useAuth } from './auth/useAuth';
 import { ToastProvider, useToast } from './hooks/useToast';
-import { getScheduleSaveMode, readBool } from './lib/env';
+import { getScheduleSaveMode, readBool, readViteBool } from './lib/env';
 import { registerNotifier } from './lib/notice';
 import { hasSpfxContext } from './lib/runtime';
 
@@ -28,16 +28,14 @@ type BridgeProps = {
   children: ReactNode;
 };
 
-const graphEnabled = readBool('VITE_FEATURE_SCHEDULES_GRAPH', false);
-// Diagnostic: check env value at build time vs readBool result
-if (typeof console !== 'undefined') {
-  console.info('[env-check] import.meta.env.VITE_FEATURE_SCHEDULES_GRAPH =', (import.meta.env as Record<string, unknown>).VITE_FEATURE_SCHEDULES_GRAPH);
-  console.info('[env-check] readBool(VITE_FEATURE_SCHEDULES_GRAPH) =', graphEnabled);
-}
+// Feature flags that depend on build-time Vite variables
+// Read directly from import.meta.env to ensure Cloudflare build-time values are respected
+const graphEnabled = readViteBool('VITE_FEATURE_SCHEDULES_GRAPH', false);
+const spEnabled = readViteBool('VITE_FEATURE_SCHEDULES_SP', false);
 
 const hydrationHudEnabled = readBool('VITE_FEATURE_HYDRATION_HUD', false);
 const scheduleSaveMode = getScheduleSaveMode();
-const sharePointFeatureEnabled = readBool('VITE_FEATURE_SCHEDULES_SP', scheduleSaveMode === 'real');
+const sharePointFeatureEnabled = spEnabled || readBool('VITE_FEATURE_SCHEDULES_SP', scheduleSaveMode === 'real');
 const forceSharePointList = readBool('VITE_FORCE_SHAREPOINT', false);
 const sharePointCreateEnabled = sharePointFeatureEnabled;
 // Runtime guard: detect SPFx context explicitly

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -49,6 +49,23 @@ const normalizeString = (value: Primitive): string => {
   return '';
 };
 
+/**
+ * Read Vite build-time environment variables directly from import.meta.env.
+ * Used for feature flags that must be determined at build time (e.g., GraphQL enablement).
+ * This bypasses runtime env handling and reads the value Vite baked into the code.
+ */
+export const readViteBool = (key: string, fallback = false): boolean => {
+  const raw = (import.meta.env as Record<string, unknown>)[key];
+  if (raw === undefined || raw === null) return fallback;
+  if (typeof raw === 'boolean') return raw;
+  if (typeof raw === 'string') {
+    const normalized = raw.trim().toLowerCase();
+    if (normalized === 'true' || normalized === '1' || normalized === 'yes') return true;
+    if (normalized === 'false' || normalized === '0' || normalized === 'no') return false;
+  }
+  return fallback;
+};
+
 const coerceBoolean = (value: Primitive, fallback = false): boolean => {
   if (value === undefined || value === null) return fallback;
   if (typeof value === 'boolean') return value;


### PR DESCRIPTION
The Worker name in your Wrangler configuration file does not match the name of the deployed Worker in the Cloudflare Dashboard.
		Cloudflare automatically generated this PR to resolve the mismatch and avoid inconsistencies between environments. For more information, see: https://developers.cloudflare.com/workers/ci-cd/builds/troubleshoot/#workers-name-requirement