### PR TITLE
fix: hide debugLogger info/warn in production

### DIFF
--- a/src/lib/debugLogger.ts
+++ b/src/lib/debugLogger.ts
@@ -7,6 +7,9 @@ const enabled = debugConfig.VITE_AUDIT_DEBUG === '1' || debugConfig.VITE_AUDIT_D
 type Level = 'debug' | 'info' | 'warn' | 'error';
 
 function log(level: Level, ns: string, ...args: unknown[]) {
+  // Production: only show errors
+  // Development: show all levels (respecting VITE_AUDIT_DEBUG for debug)
+  if (!import.meta.env.DEV && level !== 'error') return;
   if (!enabled && level === 'debug') return;
   // eslint-disable-next-line no-console
   (console as any)[level](`[audit:${ns}]`, ...args);


### PR DESCRIPTION
Complete production console cleanup by silencing debugLogger info/warn logs.

Only error-level logs will appear in production. Debug/info/warn remain available in development.

This fixes the remaining [audit:flags] log that was still appearing after PR #163.