### PR TITLE
fix: enable MSAL popup with COOP header

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,6 @@
+/*
+  Cross-Origin-Opener-Policy: same-origin-allow-popups
+
+/index.html
+  Cross-Origin-Opener-Policy: same-origin-allow-popups
+  Cache-Control: public, max-age=0, must-revalidate


### PR DESCRIPTION
Add Cross-Origin-Opener-Policy: same-origin-allow-popups header.

This allows secure popup authentication without blocking window.closed checks.
Fixes COOP warnings when using MSAL loginPopup flow.