### PR TITLE
fix(wrangler): add ASSETS binding

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,3 +5,4 @@ main = "src/worker.ts"
 [assets]
 directory = "./dist"
 not_found_handling = "single-page-application"
+binding = "ASSETS"


### PR DESCRIPTION
Fix TypeError: Cannot read properties of undefined (reading 'fetch')

- PR #167 was merged without binding = "ASSETS" in [wrangler.toml](http://_vscodecontentref_/1)
- This prevents env.ASSETS from being available in Worker
- Causes /dashboard to return 1101 error (Worker exception)

