### PR TITLE
fix: remove COOP/COEP meta tags from index.html (final)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,9 +3,6 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <!-- Dev-only: allow observing MSAL popup -->
-    <meta http-equiv="Cross-Origin-Opener-Policy" content="same-origin-allow-popups" />
-    <meta http-equiv="Cross-Origin-Embedder-Policy" content="unsafe-none" />
     <title>Audit Management MVP</title>
   </head>
   <body>


### PR DESCRIPTION
- Meta tags do not work for COOP/COEP (headers only)
- Removes confusion and ensures clean HTML
- Worker already provides COOP header correctly

