### PR TITLE
chore(dev): add dev:5173 and document local E2E smoke workflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "@vitest/coverage-v8": "^4.0.16",
         "@vitest/ui": "^4.0.16",
         "axe-core": "^4.10.3",
-        "baseline-browser-mapping": "^2.8.29",
+        "baseline-browser-mapping": "^2.9.16",
         "changelogithub": "^13.16.0",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
@@ -4525,9 +4525,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.29",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.29.tgz",
-      "integrity": "sha512-sXdt2elaVnhpDNRDz+1BDx1JQoJRuNk7oVlAlbGiFkLikHCAQiccexF/9e91zVi6RCgqspl04aP+6Cnl9zRLrA==",
+      "version": "2.9.16",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.16.tgz",
+      "integrity": "sha512-KeUZdBuxngy825i8xvzaK1Ncnkx0tBmb3k8DkEuqjKRkmtvNTjey2ZsNeh8Dw4lfKvbCOu9oeNx2TKm2vHqcRw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "vite",
+    "dev:5173": "vite --host 127.0.0.1 --port 5173 --strictPort",
     "dev:schedules": "VITE_SKIP_LOGIN=1 VITE_FORCE_SHAREPOINT=0 vite --port 5175",
     "dev:attendance": "VITE_SKIP_LOGIN=1 VITE_FORCE_SHAREPOINT=0 vite --port 5176",
     "dev:daily": "VITE_SKIP_LOGIN=1 VITE_FORCE_SHAREPOINT=0 vite --port 5177",
@@ -136,7 +137,7 @@
     "@vitest/coverage-v8": "^4.0.16",
     "@vitest/ui": "^4.0.16",
     "axe-core": "^4.10.3",
-    "baseline-browser-mapping": "^2.8.29",
+    "baseline-browser-mapping": "^2.9.16",
     "changelogithub": "^13.16.0",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",


### PR DESCRIPTION
- dev: restore default vite command
- dev:5173: stable local dev server for Playwright smoke (TTY-free friendly)
- docs: add local E2E steps + troubleshooting
- deps: update baseline-browser-mapping to remove stale-data warning
