### PR TITLE
ci: enable schedule acceptance suite in Phase 2.2

### DIFF
--- a/.github/workflows/ci-preflight.yml
+++ b/.github/workflows/ci-preflight.yml
@@ -34,6 +34,7 @@ jobs:
       VITE_FEATURE_SCHEDULES: "1"
       # Phase 2: E2E feature flag guards
       E2E_FEATURE_SCHEDULE_NAV: "1"
+      E2E_FEATURE_SCHEDULE_ACCEPTANCE: "1"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
       VITE_FEATURE_SCHEDULES: "1"
       # Phase 2: E2E feature flag guards
       E2E_FEATURE_SCHEDULE_NAV: "1"
+      E2E_FEATURE_SCHEDULE_ACCEPTANCE: "1"
     
     steps:
       - name: Checkout code

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -32,6 +32,7 @@ jobs:
       VITE_FEATURE_SCHEDULES: "1"
       # Phase 2: E2E feature flag guards
       E2E_FEATURE_SCHEDULE_NAV: "1"
+      E2E_FEATURE_SCHEDULE_ACCEPTANCE: "1"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -52,6 +53,7 @@ jobs:
       VITE_FEATURE_SCHEDULES: "1"
       # Phase 2: E2E feature flag guards
       E2E_FEATURE_SCHEDULE_NAV: "1"
+      E2E_FEATURE_SCHEDULE_ACCEPTANCE: "1"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
     env:
       # Phase 2: E2E feature flag guards
       E2E_FEATURE_SCHEDULE_NAV: "1"
+      E2E_FEATURE_SCHEDULE_ACCEPTANCE: "1"
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
- Add E2E_FEATURE_SCHEDULE_ACCEPTANCE=1 to ci / ci-preflight / smoke / test workflows
- Enables env-guarded acceptance suites in CI
- Follows Phase 2 rollout plan