### PR TITLE
ci: enable schedule week/month tab suite in Phase 2.3

### DIFF
--- a/.github/workflows/ci-preflight.yml
+++ b/.github/workflows/ci-preflight.yml
@@ -35,6 +35,7 @@ jobs:
       # Phase 2: E2E feature flag guards
       E2E_FEATURE_SCHEDULE_NAV: "1"
       E2E_FEATURE_SCHEDULE_ACCEPTANCE: "1"
+      E2E_FEATURE_SCHEDULE_WEEK_MONTH_TAB: "1"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       # Phase 2: E2E feature flag guards
       E2E_FEATURE_SCHEDULE_NAV: "1"
       E2E_FEATURE_SCHEDULE_ACCEPTANCE: "1"
+      E2E_FEATURE_SCHEDULE_WEEK_MONTH_TAB: "1"
     
     steps:
       - name: Checkout code

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -33,6 +33,7 @@ jobs:
       # Phase 2: E2E feature flag guards
       E2E_FEATURE_SCHEDULE_NAV: "1"
       E2E_FEATURE_SCHEDULE_ACCEPTANCE: "1"
+      E2E_FEATURE_SCHEDULE_WEEK_MONTH_TAB: "1"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -54,6 +55,7 @@ jobs:
       # Phase 2: E2E feature flag guards
       E2E_FEATURE_SCHEDULE_NAV: "1"
       E2E_FEATURE_SCHEDULE_ACCEPTANCE: "1"
+      E2E_FEATURE_SCHEDULE_WEEK_MONTH_TAB: "1"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
       # Phase 2: E2E feature flag guards
       E2E_FEATURE_SCHEDULE_NAV: "1"
       E2E_FEATURE_SCHEDULE_ACCEPTANCE: "1"
+      E2E_FEATURE_SCHEDULE_WEEK_MONTH_TAB: "1"
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Phase 2.3: Week/Month Tab Suite

Add `E2E_FEATURE_SCHEDULE_WEEK_MONTH_TAB=1` to enable env-guarded week/month tab E2E suites.

### Changes
- ci.yml: Add WEEK_MONTH_TAB flag
- ci-preflight.yml: Add WEEK_MONTH_TAB flag
- smoke.yml: Add WEEK_MONTH_TAB flag (typecheck + vitest jobs)
- test.yml: Add WEEK_MONTH_TAB flag

### Phase 2 Rollout Complete
- ✅ Phase 2 (NAV): PR #175
- ✅ Phase 2.2 (ACCEPTANCE): PR #176
- ✅ Phase 2.3 (WEEK_MONTH_TAB): This PR

### Prerequisites
- Quality Gates dev server fix: PR #177 ✅ (2 consecutive SUCCESS confirmed)

Enables: `tests/e2e/schedule-week.aria.smoke.spec.ts`