### PR TITLE
test: fix 3 failing unit tests due to env pollution

### DIFF
--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -444,6 +444,10 @@ export const getSharePointResource = (envOverride?: EnvRecord): string => {
   if (resource) {
     return resource.replace(/\/+$/, '');
   }
+  // If envOverride explicitly provided (even with empty VITE_SP_RESOURCE), don't fallback to runtime
+  if (envOverride && 'VITE_SP_RESOURCE' in envOverride) {
+    return '';
+  }
   const runtime = getRuntimeEnv();
   return (runtime.VITE_SP_RESOURCE ?? '').replace(/\/+$/, '');
 };

--- a/tests/unit/app.SchedulesGate.spec.tsx
+++ b/tests/unit/app.SchedulesGate.spec.tsx
@@ -14,7 +14,11 @@ vi.mock('@/env', async () => {
   const actual = await vi.importActual<typeof import('@/env')>('@/env');
   return {
     ...actual,
-    isE2E: false, // E2Eモードを無効にしてテスト環境で正常動作させる
+    isE2E: false,
+    getFlag: vi.fn((key: string) => {
+      if (key === 'VITE_E2E') return false;
+      return actual.getFlag(key, false);
+    }),
   };
 });
 


### PR DESCRIPTION
Fixes 3 unit test failures:
- SchedulesGate: mock getFlag() to disable E2E bypass  
- env.parse: mock getRuntimeEnv() to prevent .env pollution
- getSharePointResource: respect explicit envOverride

All tests passing + lint/typecheck OK