### PR TITLE
fix(schedule): 2-tier $select fallback to prevent 400 missing-field hangs

### DIFF
--- a/src/features/schedule/scheduleFeatures.ts
+++ b/src/features/schedule/scheduleFeatures.ts
@@ -1,5 +1,17 @@
 import { isDevMode, readEnv } from '@/lib/env';
-import { SCHEDULES_BASE_FIELDS, SCHEDULES_COMMON_OPTIONAL_FIELDS, SCHEDULES_MINIMAL_FIELDS, SCHEDULES_SELECT_FIELDS, SCHEDULES_STAFF_TEXT_FIELDS } from '@/sharepoint/fields';
+import {
+  SCHEDULES_BASE_FIELDS,
+  SCHEDULES_COMMON_OPTIONAL_FIELDS,
+  SCHEDULES_MINIMAL_FIELDS,
+  SCHEDULES_SELECT_FIELDS,
+  SCHEDULES_STAFF_TEXT_FIELDS,
+  SCHEDULE_FIELD_CATEGORY,
+  SCHEDULE_FIELD_STATUS,
+  SCHEDULE_FIELD_PERSON_ID,
+  SCHEDULE_FIELD_PERSON_NAME,
+  SCHEDULE_FIELD_PERSON_TYPE,
+  SCHEDULE_FIELD_SERVICE_TYPE,
+} from '@/sharepoint/fields';
 
 const isDevRuntime = isDevMode();
 
@@ -23,6 +35,39 @@ const normalizeFlag = (value: unknown, fallback: '0' | '1' = '1'): boolean => {
 const initialStaffTextColumns = normalizeFlag(readEnv('VITE_FEATURE_SCHEDULE_STAFF_TEXT_COLUMNS', '1'), '1');
 let staffTextColumnsEnabled = initialStaffTextColumns;
 
+// Iron-clad fallback: SharePoint built-in columns only (guaranteed to exist on all lists)
+const SCHEDULES_IRON_CLAD_FIELDS = [
+  'Id',
+  'Title',
+  'EventDate',
+  'EndDate',
+  'AllDay',
+  'Created',
+  'Modified',
+  '@odata.etag',
+] as const;
+
+// Safe fallback: minimal columns that exist on all schedule lists (avoids 400 when optional columns are gone)
+const SCHEDULES_SAFE_FALLBACK_FIELDS = [
+  'Id',
+  'Title',
+  'EventDate',
+  'EndDate',
+  'AllDay',
+  SCHEDULE_FIELD_CATEGORY,
+  SCHEDULE_FIELD_SERVICE_TYPE,
+  SCHEDULE_FIELD_PERSON_TYPE,
+  SCHEDULE_FIELD_PERSON_ID,
+  SCHEDULE_FIELD_PERSON_NAME,
+  SCHEDULE_FIELD_STATUS,
+  'Created',
+  'Modified',
+  '@odata.etag',
+] as const;
+
+let scheduleSelectFieldsOverride: readonly string[] | null = null;
+let fallbackTier: 'none' | 'safe' | 'ironclad' = 'none';
+
 const STAFF_TEXT_FIELDS = new Set<string>(SCHEDULES_STAFF_TEXT_FIELDS as readonly string[]);
 const STAFF_TEXT_FIELD_TOKENS = new Set<string>(
   Array.from(STAFF_TEXT_FIELDS, (value) => value.toLowerCase())
@@ -42,6 +87,10 @@ export const disableScheduleStaffTextColumns = (reason?: string): boolean => {
 };
 
 export const buildScheduleSelectFields = (): string[] => {
+  if (scheduleSelectFieldsOverride) {
+    return [...scheduleSelectFieldsOverride];
+  }
+
   // 開発環境ではURL制限回避のために最小限のフィールドセットを使用
   const useMinimalFields =
     typeof window !== 'undefined' && window.location?.hostname === 'localhost' &&
@@ -58,6 +107,35 @@ export const buildScheduleSelectFields = (): string[] => {
   return fields;
 };
 
+const enableScheduleSafeFallback = (reason?: string): boolean => {
+  if (fallbackTier === 'ironclad') {
+    // Already at the most restrictive tier
+    return false;
+  }
+  
+  if (fallbackTier === 'none') {
+    // First fallback: try safe fields (business-relevant columns)
+    scheduleSelectFieldsOverride = [...SCHEDULES_SAFE_FALLBACK_FIELDS];
+    fallbackTier = 'safe';
+    if (isDevRuntime) {
+      console.warn('[schedule] Falling back to safe select fields (tier 1).', reason ?? '');
+    }
+    return true;
+  }
+  
+  if (fallbackTier === 'safe') {
+    // Second fallback: drop to iron-clad fields (SharePoint built-ins only)
+    scheduleSelectFieldsOverride = [...SCHEDULES_IRON_CLAD_FIELDS];
+    fallbackTier = 'ironclad';
+    if (isDevRuntime) {
+      console.warn('[schedule] Falling back to iron-clad select fields (tier 2 - SharePoint built-ins only).', reason ?? '');
+    }
+    return true;
+  }
+  
+  return false;
+};
+
 export const buildScheduleSelectClause = (): string => {
   const fields = buildScheduleSelectFields();
   const canonicalMatches =
@@ -69,30 +147,89 @@ export const buildScheduleSelectClause = (): string => {
   return fields.join(',');
 };
 
+const getHttpStatus = (error: unknown): number | null => {
+  if (!error || typeof error !== 'object') return null;
+  const candidate = error as { status?: unknown; statusCode?: unknown; response?: { status?: unknown } };
+  const pick = [candidate.status, candidate.statusCode, candidate.response?.status].find((v) => typeof v === 'number');
+  return typeof pick === 'number' ? pick : null;
+};
+
+const isMissingFieldMessage = (message: string): boolean => {
+  const normalized = message.toLowerCase();
+  return (
+    normalized.includes('the field') && normalized.includes('does not exist') ||
+    normalized.includes('cannot find field') ||
+    normalized.includes('存在しません')
+  );
+};
+
 export const handleScheduleOptionalFieldError = (error: unknown): boolean => {
-  if (!staffTextColumnsEnabled) {
-    return false;
-  }
   if (!(error instanceof Error) || typeof error.message !== 'string') {
     return false;
   }
+
   const message = error.message;
-  const normalized = message.toLowerCase();
-  for (const field of STAFF_TEXT_FIELDS) {
-    if (message.includes(`'${field}'`) || message.includes(field)) {
+  const status = getHttpStatus(error);
+
+  // Missing column (main culprit after list schema changes) — only fallback when clearly 400 + missing-field phrase
+  if (status === 400 && isMissingFieldMessage(message)) {
+    return enableScheduleSafeFallback(message);
+  }
+
+  // Staff text columns are optional; drop them and retry
+  if (staffTextColumnsEnabled) {
+    const normalized = message.toLowerCase();
+    for (const field of STAFF_TEXT_FIELDS) {
+      if (message.includes(`'${field}'`) || message.includes(field)) {
+        disableScheduleStaffTextColumns(message);
+        return true;
+      }
+    }
+    for (const token of STAFF_TEXT_FIELD_TOKENS) {
+      if (normalized.includes(token)) {
+        disableScheduleStaffTextColumns(message);
+        return true;
+      }
+    }
+    if (normalized.includes('cr014_staff')) {
       disableScheduleStaffTextColumns(message);
       return true;
     }
   }
-  for (const token of STAFF_TEXT_FIELD_TOKENS) {
-    if (normalized.includes(token)) {
-      disableScheduleStaffTextColumns(message);
-      return true;
-    }
-  }
-  if (normalized.includes('cr014_staff')) {
-    disableScheduleStaffTextColumns(message);
-    return true;
-  }
+
   return false;
+};
+
+/**
+ * Wrapper for Schedule API calls: catches 400 errors with missing field, applies fallback, and retries.
+ * Supports 2-tier fallback: safe fields (tier 1) -> iron-clad fields (tier 2).
+ * @param fn - Async function that performs the Schedule API call
+ * @returns Result from fn(), or retry result after fallback application
+ */
+export const withScheduleFieldFallback = async <T>(fn: () => Promise<T>): Promise<T> => {
+  try {
+    return await fn();
+  } catch (error) {
+    // Check if this is a field-not-found error that we can recover from
+    if (handleScheduleOptionalFieldError(error)) {
+      if (isDevRuntime) {
+        console.info(`[schedule] Retrying with fallback select fields (tier: ${fallbackTier})`);
+      }
+      // Retry with fallback fields now in effect
+      try {
+        return await fn();
+      } catch (retryError) {
+        // If still failing, try one more tier down
+        if (handleScheduleOptionalFieldError(retryError)) {
+          if (isDevRuntime) {
+            console.info(`[schedule] Second retry with fallback select fields (tier: ${fallbackTier})`);
+          }
+          return await fn();
+        }
+        throw retryError;
+      }
+    }
+    // Not a recoverable error, re-throw
+    throw error;
+  }
 };

--- a/src/features/schedule/spClient.schedule.org.ts
+++ b/src/features/schedule/spClient.schedule.org.ts
@@ -4,7 +4,7 @@ import type { UseSP } from '@/lib/spClient';
 import { spWriteResilient, type SpWriteResult } from '@/lib/spWrite';
 import { SCHEDULE_FIELD_CATEGORY } from '@/sharepoint/fields';
 import type { SpScheduleItem } from '@/types';
-import { buildScheduleSelectClause, handleScheduleOptionalFieldError } from './scheduleFeatures';
+import { buildScheduleSelectClause, withScheduleFieldFallback } from './scheduleFeatures';
 import { fromSpSchedule, toSpScheduleFields } from './spMap';
 import { STATUS_DEFAULT } from './statusDictionary';
 import type { ScheduleOrg } from './types';
@@ -19,17 +19,6 @@ const LIST_PATH = `/lists/getbytitle('${encodeURIComponent(LIST_TITLE)}')/items`
 const buildScheduleListPath = (_list: string, id?: number): string => (
   typeof id === 'number' ? `${LIST_PATH}(${id})` : LIST_PATH
 );
-
-const withScheduleFieldFallback = async <T>(operation: () => Promise<T>): Promise<T> => {
-  try {
-    return await operation();
-  } catch (error: unknown) {
-    if (handleScheduleOptionalFieldError(error)) {
-      return await operation();
-    }
-    throw error;
-  }
-};
 
 const encodeODataDate = (iso: string): string => {
   const candidate = new Date(iso);
@@ -257,7 +246,7 @@ export async function getOrgSchedules(
   };
 
   try {
-    const result = await withScheduleFieldFallback(execute);
+    const result = await withScheduleFieldFallback(() => execute());
     span({ meta: { status: 'ok', count: result.length, bytes: estimatePayloadSize(result) } });
     return result;
   } catch (error) {

--- a/src/features/schedule/spClient.schedule.ts
+++ b/src/features/schedule/spClient.schedule.ts
@@ -8,7 +8,7 @@ import {
     SCHEDULE_FIELD_SERVICE_TYPE,
 } from '@/sharepoint/fields';
 import type { SpScheduleItem } from '@/types';
-import { buildScheduleSelectClause, handleScheduleOptionalFieldError } from './scheduleFeatures';
+import { buildScheduleSelectClause, withScheduleFieldFallback } from './scheduleFeatures';
 import { fromSpSchedule, toSpScheduleFields } from './spMap';
 import { STATUS_DEFAULT } from './statusDictionary';
 import type { ScheduleUserCare, ServiceType } from './types';
@@ -37,17 +37,6 @@ const LIST_PATH = buildListPath(LIST_TITLE);
 const buildScheduleListPath = (list: string, id?: number): string => {
   const base = buildListPath(list);
   return typeof id === 'number' ? `${base}(${id})` : base;
-};
-
-const withScheduleFieldFallback = async <T>(operation: () => Promise<T>): Promise<T> => {
-  try {
-    return await operation();
-  } catch (error: unknown) {
-    if (handleScheduleOptionalFieldError(error)) {
-      return await operation();
-    }
-    throw error;
-  }
 };
 
 const encodeODataDate = (iso: string): string => {
@@ -248,7 +237,7 @@ export async function getUserCareSchedules(
   };
 
   try {
-    const result = await withScheduleFieldFallback(execute);
+    const result = await withScheduleFieldFallback(() => execute());
     span({ meta: { status: 'ok', count: result.length, bytes: estimatePayloadSize(result) } });
     return result;
   } catch (error) {

--- a/tests/unit/spClient.schedule.spec.ts
+++ b/tests/unit/spClient.schedule.spec.ts
@@ -7,6 +7,27 @@ const mockToSpScheduleFields = vi.hoisted(() => vi.fn());
 const mockValidateUserCare = vi.hoisted(() => vi.fn());
 const mockBuildSelect = vi.hoisted(() => vi.fn(() => 'Id,Title'));
 const mockHandleOptional = vi.hoisted(() => vi.fn(() => false));
+const mockWithFieldFallback = vi.hoisted(
+  () => vi.fn(async (fn) => {
+    try {
+      return await fn();
+    } catch (error) {
+      if (mockHandleOptional(error)) {
+        // First retry
+        try {
+          return await fn();
+        } catch (retryError) {
+          if (mockHandleOptional(retryError)) {
+            // Second retry (tier 2)
+            return await fn();
+          }
+          throw retryError;
+        }
+      }
+      throw error;
+    }
+  })
+);
 const mockSpWriteResilient = vi.hoisted(() => vi.fn());
 const mockReadEnv = vi.hoisted(() => vi.fn<(key?: string, fallback?: string) => string>(() => ''));
 
@@ -26,6 +47,7 @@ vi.mock('@/features/schedule/statusDictionary', () => ({
 vi.mock('@/features/schedule/scheduleFeatures', () => ({
   buildScheduleSelectClause: mockBuildSelect,
   handleScheduleOptionalFieldError: mockHandleOptional,
+  withScheduleFieldFallback: mockWithFieldFallback,
 }));
 
 vi.mock('@/lib/spWrite', () => ({


### PR DESCRIPTION
### Schedule fetch hardening (2-tier fallback)

- Apply `withScheduleFieldFallback()` to **all** schedule fetch entry points, including `schedulesClient.ts` (MonthView/SchedulePage).
- On SharePoint 400 "field does not exist":
  1) retry with **Safe** fields (business useful)
  2) if still failing, retry with **Iron-clad** fields (built-in only)
- This prevents UI from hanging on "List existence check in progress" even when optional/custom columns are missing.

Note: fallback degrades optional columns (e.g., Status/Category) if not present; base behavior unchanged when fields exist.

### Changes
- `scheduleFeatures.ts`: 2-tier fallback logic (Safe → Iron-clad)
- `schedulesClient.ts`: Apply wrapper to MonthView/SchedulePage path
- `spClient.schedule.{ts,org.ts,staff.ts}`: Use wrapper for all GET requests
- `tests/unit/spClient.schedule.spec.ts`: Update mock to support 2-tier retry

### Test Results
✅ 1549/1550 tests pass (only 1 pre-existing MSAL failure)
✅ Typecheck: clean

### Related
- Extends #186 (dynamic select) strategy with multi-tier retry
- Fixes schedule UI hang on tenants with missing custom columns