### PR TITLE
chore: Playwright smoke test infrastructure & documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,11 @@ lsof -ti :5173 | xargs -r kill -9
 
 - スケジュール週ビューを変更した場合: `npm run test:schedule-week`
 
+## Playwright Smoke テスト実行
+
+Mobile Chrome smoke テストの実行ガイドは [`docs/PLAYWRIGHT_SMOKE_RUNBOOK.md`](docs/PLAYWRIGHT_SMOKE_RUNBOOK.md) を参照してください。
+基本的には `npx playwright test --config=playwright.smoke.config.ts --reporter=line` で、`CONNECTION_REFUSED` が出た場合のトラブルシューティングも記載されています。
+
 ## E2E Skip Reduction Strategy (Schedule Suite)
 
 When improving Schedule E2E test coverage, classify skips into **categories**:

--- a/docs/PLAYWRIGHT_SMOKE_RUNBOOK.md
+++ b/docs/PLAYWRIGHT_SMOKE_RUNBOOK.md
@@ -1,0 +1,75 @@
+# Playwright Smoke テスト実行ガイド
+
+このリポジトリの Smoke テストは `playwright.smoke.config.ts` の `webServer` 設定により、
+**dev server 起動 → readiness wait → smoke 実行** を自動で行います。
+
+---
+
+## 通常実行（ローカル / CI デフォルト）
+
+```bash
+npx playwright test --config=playwright.smoke.config.ts --reporter=line
+```
+
+**期待動作：**
+- Vite dev server が起動（既に起動済みなら再利用）
+- baseURL に対して疎通が取れてからテスト開始
+- smoke suite が実行される
+
+---
+
+## ポート衝突回避（5173 が使用中の場合）
+
+別プロセスが 5173 を使用している場合：
+
+```bash
+E2E_PORT=6173 npx playwright test --config=playwright.smoke.config.ts --reporter=line
+```
+
+**メモ：**
+- `E2E_PORT` は `webServer.url` と `use.baseURL` の両方に反映される想定
+- CI で並列ジョブがある場合にも有効
+
+---
+
+## CONNECTION_REFUSED トラブルシューティング
+
+### まず疑うポイント（最重要）
+
+`playwright.smoke.config.ts` の  
+`webServer.url` / `use.baseURL` / Vite 起動時の `--host` / `--port` が  
+**完全に一致**しているかを確認します。
+
+- `url` と `baseURL` の host がズレていないか  
+  （例：`localhost` vs `127.0.0.1`）
+- `--host` が `127.0.0.1` になっているか  
+  （DNS / IPv6 由来のズレ回避）
+- `E2E_PORT` を使う場合、`url` / `baseURL` が同じ PORT を指しているか
+
+### 30秒チェック（手元で疎通確認）
+
+```bash
+# 実際に listen しているか
+lsof -nP -iTCP:${E2E_PORT:-5173} -sTCP:LISTEN
+
+# HTTP 疎通が取れるか
+curl -s -I http://127.0.0.1:${E2E_PORT:-5173} | head -3
+```
+
+### よくある原因
+
+- Vite が `localhost` で listen、Playwright が `127.0.0.1` を見ている（または逆）
+- `E2E_PORT` を指定したが、config 側の `url` / `baseURL` が固定のまま
+- 別のプロセスが同ポートを使用中（起動失敗 or 別サーバを参照）
+
+### 相談時に貼るもの
+
+- `playwright.smoke.config.ts` の `webServer` と `use.baseURL` 周辺（該当箇所）
+- smoke 実行時の先頭 30〜50 行のログ
+
+---
+
+## 参考資料
+
+- [playwright.smoke.config.ts](../playwright.smoke.config.ts) - webServer 設定の詳細
+- [playwright.config.ts](../playwright.config.ts) - ベース設定（デバイス、タイムアウト等）

--- a/playwright.smoke.config.ts
+++ b/playwright.smoke.config.ts
@@ -6,8 +6,21 @@ const mobileChrome = {
   viewport: { width: 390, height: 844 },
 };
 
+// Port configuration for CI/local portability
+const PORT = process.env.E2E_PORT ?? '5173';
+const BASE_URL = `http://127.0.0.1:${PORT}`;
+
 export default defineConfig({
   ...baseConfig,
+  webServer: {
+    command: `npm run dev -- --host 127.0.0.1 --port ${PORT}`,
+    url: BASE_URL,
+    reuseExistingServer: true,
+    timeout: 120_000,
+  },
+  use: {
+    baseURL: BASE_URL,
+  },
   projects: (baseConfig.projects ?? [])
     .filter((project) => project.name === 'smoke')
     .map((project) => ({
@@ -15,6 +28,7 @@ export default defineConfig({
       use: {
         ...(project.use ?? {}),
         ...mobileChrome,
+        baseURL: BASE_URL,
       },
     })),
 });


### PR DESCRIPTION
## Summary

Stabilize Playwright smoke test execution with self-healing infrastructure and comprehensive troubleshooting documentation.

## Changes

- **playwright.smoke.config.ts**
  - Added webServer config for automatic dev server startup
  - Configured `--host 127.0.0.1` binding to prevent IPv6/DNS resolution issues
  - Added E2E_PORT environment variable support for CI parallelization

- **docs/PLAYWRIGHT_SMOKE_RUNBOOK.md** (new)
  - Normal run patterns
  - Port collision handling (E2E_PORT=6173)
  - CONNECTION_REFUSED troubleshooting with diagnostic commands (lsof, curl)
  - Common causes and reporting template

- **CONTRIBUTING.md**
  - Linked runbook from "Playwright Smoke テスト実行" section

## Impact

- Infrastructure only (no code changes to features)
- Prevents CONNECTION_REFUSED failures in local and CI environments
- Provides clear diagnosis path for future developers
- Zero breaking changes

## QA Status

- ✅ Lint pass
- ✅ Typecheck pass  
- ✅ 813 unit tests pass (138 files)