### PR TITLE
Update name in Wrangler configuration file to match deployed Worker

### DIFF
--- a/.github/workflows/nightly-health.yml
+++ b/.github/workflows/nightly-health.yml
@@ -18,12 +18,20 @@ jobs:
         env:
           TZ: Asia/Tokyo
       - run: npx playwright install --with-deps chromium
-      - run: npm run ci:e2e
+      - name: E2E (nightly health)
+        run: npm run ci:e2e
         env:
           VITE_E2E: "1"
           VITE_SKIP_LOGIN: "1"
           VITE_E2E_MSAL_MOCK: "1"
-          VITE_SKIP_SHAREPOINT: "1"
+
+          # Nightly uses SharePoint stubs for robust validation
+          VITE_SKIP_SHAREPOINT: "0"
+          VITE_ALLOW_SHAREPOINT_OUTSIDE_SPFX: "1"
+
+          # Require-data smoke: catch zero-data regressions
+          E2E_REQUIRE_SCHEDULE_DATA: "1"
+
           VITE_SP_SCOPE_DEFAULT: ${{ secrets.VITE_SP_SCOPE_DEFAULT }}
           NOTIFY_WEBHOOK_URL: ${{ secrets.NOTIFY_WEBHOOK_URL }}
       - name: Perf report (LHCI + Web Vitals)


### PR DESCRIPTION
The Worker name in your Wrangler configuration file does not match the name of the deployed Worker in the Cloudflare Dashboard.
		Cloudflare automatically generated this PR to resolve the mismatch and avoid inconsistencies between environments. For more information, see: https://developers.cloudflare.com/workers/ci-cd/builds/troubleshoot/#workers-name-requirement