### PR TITLE
test: add failure artifacts capture to smoke tests

### DIFF
--- a/tests/e2e/_helpers/diagArtifacts.ts
+++ b/tests/e2e/_helpers/diagArtifacts.ts
@@ -1,0 +1,48 @@
+import { expect, type Page, type TestInfo } from '@playwright/test';
+
+export async function attachUIState(page: Page, testInfo: TestInfo, name = 'ui-state') {
+  // URL
+  await testInfo.attach(`${name}.url.txt`, {
+    body: Buffer.from(page.url(), 'utf-8'),
+    contentType: 'text/plain',
+  });
+
+  // DOM snapshot（巨大になりやすいので軽めに）
+  const html = await page.content();
+  await testInfo.attach(`${name}.html`, {
+    body: Buffer.from(html, 'utf-8'),
+    contentType: 'text/html',
+  });
+
+  // Console logs（必要なら後でon('console')で蓄積する方式に拡張）
+}
+
+export async function attachOnFailure(page: Page, testInfo: TestInfo) {
+  if (testInfo.status !== testInfo.expectedStatus) {
+    // screenshot / trace は config で取れてる前提でも、ここで追撃の1枚を確実に残す
+    await testInfo.attach('failure.png', {
+      body: await page.screenshot({ fullPage: true }),
+      contentType: 'image/png',
+    });
+
+    await attachUIState(page, testInfo, 'failure');
+  }
+}
+
+export async function expectVisibleWithShot(
+  locator: ReturnType<Page['locator']> | any,
+  page: Page,
+  testInfo: TestInfo,
+  label: string,
+  timeout = 10_000
+) {
+  try {
+    await expect(locator).toBeVisible({ timeout });
+  } catch (e) {
+    await testInfo.attach(`missing-${label}.png`, {
+      body: await page.screenshot({ fullPage: true }),
+      contentType: 'image/png',
+    });
+    throw e;
+  }
+}

--- a/tests/e2e/diagnostics-health-save.smoke.spec.ts
+++ b/tests/e2e/diagnostics-health-save.smoke.spec.ts
@@ -1,6 +1,11 @@
 import { test, expect } from '@playwright/test';
+import { attachOnFailure } from './_helpers/diagArtifacts';
 
 test.describe('Diagnostics Health - run & save', () => {
+  test.afterEach(async ({ page }, testInfo) => {
+    await attachOnFailure(page, testInfo);
+  });
+
   test('診断実行 → SharePoint 保存成功', async ({ page }) => {
     // 1) open
     await page.goto('/diagnostics/health');

--- a/tests/e2e/monthly.summary-smoke.spec.ts
+++ b/tests/e2e/monthly.summary-smoke.spec.ts
@@ -4,11 +4,16 @@ import {
     monthlyTestIds,
     triggerReaggregateAndWait
 } from './_helpers/enableMonthly';
+import { attachOnFailure } from './_helpers/diagArtifacts';
 
 test.describe('Monthly Records - Summary Smoke Tests', () => {
   test.beforeEach(async ({ page }) => {
     // 月次記録ページに移動（Feature Flag 有効化込み）
     await gotoMonthlyRecordsPage(page);
+  });
+
+  test.afterEach(async ({ page }, testInfo) => {
+    await attachOnFailure(page, testInfo);
   });
 
   test('@ci-smoke monthly summary page renders', async ({ page }) => {


### PR DESCRIPTION
Reduces investigation time when CI smoke tests fail by capturing full-page screenshot, URL, and DOM snapshot on test failure. Applied to monthly.summary-smoke and diagnostics-health-save.smoke specs.