### PR TITLE
test: enhance failure artifacts with console and page error logs

### DIFF
--- a/tests/e2e/_helpers/diagArtifacts.ts
+++ b/tests/e2e/_helpers/diagArtifacts.ts
@@ -1,5 +1,53 @@
 import { expect, type Page, type TestInfo } from '@playwright/test';
 
+/**
+ * Ring buffer for console messages (max 100 entries to avoid OOM)
+ */
+export class ConsoleLogger {
+  private logs: string[] = [];
+  private readonly maxSize = 100;
+
+  add(type: string, text: string) {
+    this.logs.push(`[${type.toUpperCase()}] ${text}`);
+    if (this.logs.length > this.maxSize) {
+      this.logs.shift();
+    }
+  }
+
+  get content(): string {
+    return this.logs.join('\n');
+  }
+}
+
+/**
+ * Collector for page errors
+ */
+export class PageErrorCollector {
+  private errors: string[] = [];
+
+  add(error: Error) {
+    this.errors.push(`${error.name}: ${error.message}\n${error.stack || ''}`);
+  }
+
+  get content(): string {
+    return this.errors.join('\n---\n');
+  }
+}
+
+export async function setupConsoleAndErrorCapture(
+  page: Page,
+  consoleLogger: ConsoleLogger,
+  errorCollector: PageErrorCollector
+) {
+  page.on('console', (msg) => {
+    consoleLogger.add(msg.type(), msg.text());
+  });
+
+  page.on('pageerror', (error) => {
+    errorCollector.add(error);
+  });
+}
+
 export async function attachUIState(page: Page, testInfo: TestInfo, name = 'ui-state') {
   // URL
   await testInfo.attach(`${name}.url.txt`, {
@@ -13,11 +61,14 @@ export async function attachUIState(page: Page, testInfo: TestInfo, name = 'ui-s
     body: Buffer.from(html, 'utf-8'),
     contentType: 'text/html',
   });
-
-  // Console logs（必要なら後でon('console')で蓄積する方式に拡張）
 }
 
-export async function attachOnFailure(page: Page, testInfo: TestInfo) {
+export async function attachOnFailure(
+  page: Page,
+  testInfo: TestInfo,
+  consoleLogger?: ConsoleLogger,
+  errorCollector?: PageErrorCollector
+) {
   if (testInfo.status !== testInfo.expectedStatus) {
     // screenshot / trace は config で取れてる前提でも、ここで追撃の1枚を確実に残す
     await testInfo.attach('failure.png', {
@@ -26,6 +77,22 @@ export async function attachOnFailure(page: Page, testInfo: TestInfo) {
     });
 
     await attachUIState(page, testInfo, 'failure');
+
+    // Attach console logs if captured
+    if (consoleLogger && consoleLogger.content) {
+      await testInfo.attach('failure.console.log', {
+        body: Buffer.from(consoleLogger.content, 'utf-8'),
+        contentType: 'text/plain',
+      });
+    }
+
+    // Attach page errors if captured
+    if (errorCollector && errorCollector.content) {
+      await testInfo.attach('failure.pageerror.log', {
+        body: Buffer.from(errorCollector.content, 'utf-8'),
+        contentType: 'text/plain',
+      });
+    }
   }
 }
 

--- a/tests/e2e/diagnostics-health-save.smoke.spec.ts
+++ b/tests/e2e/diagnostics-health-save.smoke.spec.ts
@@ -1,9 +1,19 @@
 import { test, expect } from '@playwright/test';
-import { attachOnFailure } from './_helpers/diagArtifacts';
+import { attachOnFailure, ConsoleLogger, PageErrorCollector, setupConsoleAndErrorCapture } from './_helpers/diagArtifacts';
 
 test.describe('Diagnostics Health - run & save', () => {
+  let consoleLogger: ConsoleLogger;
+  let errorCollector: PageErrorCollector;
+
+  test.beforeEach(async ({ page }) => {
+    // Initialize capture
+    consoleLogger = new ConsoleLogger();
+    errorCollector = new PageErrorCollector();
+    await setupConsoleAndErrorCapture(page, consoleLogger, errorCollector);
+  });
+
   test.afterEach(async ({ page }, testInfo) => {
-    await attachOnFailure(page, testInfo);
+    await attachOnFailure(page, testInfo, consoleLogger, errorCollector);
   });
 
   test('診断実行 → SharePoint 保存成功', async ({ page }) => {

--- a/tests/e2e/monthly.summary-smoke.spec.ts
+++ b/tests/e2e/monthly.summary-smoke.spec.ts
@@ -4,16 +4,24 @@ import {
     monthlyTestIds,
     triggerReaggregateAndWait
 } from './_helpers/enableMonthly';
-import { attachOnFailure } from './_helpers/diagArtifacts';
+import { attachOnFailure, ConsoleLogger, PageErrorCollector, setupConsoleAndErrorCapture } from './_helpers/diagArtifacts';
 
 test.describe('Monthly Records - Summary Smoke Tests', () => {
+  let consoleLogger: ConsoleLogger;
+  let errorCollector: PageErrorCollector;
+
   test.beforeEach(async ({ page }) => {
+    // Initialize capture
+    consoleLogger = new ConsoleLogger();
+    errorCollector = new PageErrorCollector();
+    await setupConsoleAndErrorCapture(page, consoleLogger, errorCollector);
+
     // 月次記録ページに移動（Feature Flag 有効化込み）
     await gotoMonthlyRecordsPage(page);
   });
 
   test.afterEach(async ({ page }, testInfo) => {
-    await attachOnFailure(page, testInfo);
+    await attachOnFailure(page, testInfo, consoleLogger, errorCollector);
   });
 
   test('@ci-smoke monthly summary page renders', async ({ page }) => {


### PR DESCRIPTION
Captures browser console logs and page error events to artifacts for dramatically faster root cause investigation.

Added:
- ConsoleLogger: ring buffer (max 100 messages) for browser console
- PageErrorCollector: captures all page error events
- setupConsoleAndErrorCapture: attaches listeners to page events
- Enhanced attachOnFailure: now also captures console.log and pageerror.log

Impact: Next CI smoke failure will include failure.console.log and failure.pageerror.log alongside screenshot/URL/DOM, eliminating need for log scraping.

Builds on PR #205 failure artifacts infrastructure.