### PR TITLE
test: capture request failures in smoke artifacts

### DIFF
--- a/tests/e2e/diagnostics-health-save.smoke.spec.ts
+++ b/tests/e2e/diagnostics-health-save.smoke.spec.ts
@@ -1,19 +1,21 @@
 import { test, expect } from '@playwright/test';
-import { attachOnFailure, ConsoleLogger, PageErrorCollector, setupConsoleAndErrorCapture } from './_helpers/diagArtifacts';
+import { attachOnFailure, ConsoleLogger, PageErrorCollector, RequestLogger, setupConsoleAndErrorCapture } from './_helpers/diagArtifacts';
 
 test.describe('Diagnostics Health - run & save', () => {
   let consoleLogger: ConsoleLogger;
   let errorCollector: PageErrorCollector;
+  let requestLogger: RequestLogger;
 
   test.beforeEach(async ({ page }) => {
     // Initialize capture
     consoleLogger = new ConsoleLogger();
     errorCollector = new PageErrorCollector();
-    await setupConsoleAndErrorCapture(page, consoleLogger, errorCollector);
+    requestLogger = new RequestLogger();
+    await setupConsoleAndErrorCapture(page, consoleLogger, errorCollector, requestLogger);
   });
 
   test.afterEach(async ({ page }, testInfo) => {
-    await attachOnFailure(page, testInfo, consoleLogger, errorCollector);
+    await attachOnFailure(page, testInfo, consoleLogger, errorCollector, requestLogger);
   });
 
   test('診断実行 → SharePoint 保存成功', async ({ page }) => {

--- a/tests/e2e/monthly.summary-smoke.spec.ts
+++ b/tests/e2e/monthly.summary-smoke.spec.ts
@@ -4,24 +4,26 @@ import {
     monthlyTestIds,
     triggerReaggregateAndWait
 } from './_helpers/enableMonthly';
-import { attachOnFailure, ConsoleLogger, PageErrorCollector, setupConsoleAndErrorCapture } from './_helpers/diagArtifacts';
+import { attachOnFailure, ConsoleLogger, PageErrorCollector, RequestLogger, setupConsoleAndErrorCapture } from './_helpers/diagArtifacts';
 
 test.describe('Monthly Records - Summary Smoke Tests', () => {
   let consoleLogger: ConsoleLogger;
   let errorCollector: PageErrorCollector;
+  let requestLogger: RequestLogger;
 
   test.beforeEach(async ({ page }) => {
     // Initialize capture
     consoleLogger = new ConsoleLogger();
     errorCollector = new PageErrorCollector();
-    await setupConsoleAndErrorCapture(page, consoleLogger, errorCollector);
+    requestLogger = new RequestLogger();
+    await setupConsoleAndErrorCapture(page, consoleLogger, errorCollector, requestLogger);
 
     // 月次記録ページに移動（Feature Flag 有効化込み）
     await gotoMonthlyRecordsPage(page);
   });
 
   test.afterEach(async ({ page }, testInfo) => {
-    await attachOnFailure(page, testInfo, consoleLogger, errorCollector);
+    await attachOnFailure(page, testInfo, consoleLogger, errorCollector, requestLogger);
   });
 
   test('@ci-smoke monthly summary page renders', async ({ page }) => {


### PR DESCRIPTION
Adds request failure artifacts to smoke tests for instant network triage.\n\nChanges:\n- Add RequestLogger (ring buffer max 50) capturing page.on('requestfailed')\n- Log method / url / status / resourceType / failureText\n- Attach failure.request.log on test failure alongside console/pageerror/screenshot/DOM\n- Apply to monthly.summary-smoke and diagnostics-health-save smoke specs\n\nImpact:\n- CSP/403/timeout/net::ERR_* 系の特定が即時化\n- Pass 時コストゼロのまま、障害時情報量だけ増強\n\nTesting:\n- ✅ Local: 12/12 passing (both smoke specs)\n\nBuilds on PR #205/#207 failure artifact stack (screenshot+URL+DOM + console/pageerror).