### PR TITLE
feat(monthly): complete user-detail empty state + demo seed (9/9)

### DIFF
--- a/src/testids.ts
+++ b/src/testids.ts
@@ -367,6 +367,7 @@ export const TESTIDS = {
   'monthly-detail-user-select': 'monthly-detail-user-select',
   'monthly-detail-month-select': 'monthly-detail-month-select',
   'monthly-detail-records-table': 'monthly-detail-records-table',
+  'monthly-detail-empty-state': 'monthly-detail-empty-state',
   'monthly-pdf-generate-btn': 'monthly-pdf-generate-btn',
 
   // Mobile Agenda View

--- a/tests/e2e/_fixtures/monthly.records.dev.v1.json
+++ b/tests/e2e/_fixtures/monthly.records.dev.v1.json
@@ -1,0 +1,15 @@
+{
+  "users": [
+    { "userId": "I001", "userName": "山田太郎" }
+  ],
+  "months": ["2025-11"],
+  "summaryRows": [
+    { "userId": "I001", "userName": "山田太郎", "month": "2025-11", "total": 2, "completed": 1 }
+  ],
+  "detailRecords": {
+    "I001": [
+      { "date": "2025-11-01", "rowNo": 1, "situation": "OK", "completed": true },
+      { "date": "2025-11-02", "rowNo": 2, "situation": "", "completed": false }
+    ]
+  }
+}

--- a/tests/e2e/monthly.user-detail.spec.ts
+++ b/tests/e2e/monthly.user-detail.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { gotoMonthlyRecordsPage, switchMonthlyTab } from './_helpers/enableMonthly';
+import { gotoMonthlyRecordsPage, switchMonthlyTab, monthlyTestIds } from './_helpers/enableMonthly';
 
 test.describe('Monthly Records - User Detail (minimal smoke)', () => {
   test.beforeEach(async ({ page }) => {
@@ -24,5 +24,20 @@ test.describe('Monthly Records - User Detail (minimal smoke)', () => {
 
     // Lightweight sanity check: tablist exists
     await expect(page.getByRole('tablist')).toBeVisible();
+  });
+
+  test('@ci-smoke empty state', async ({ page }) => {
+    // Setup with demo seed
+    await gotoMonthlyRecordsPage(page, { seed: { monthlyRecords: true } });
+    await switchMonthlyTab(page, 'detail');
+
+    // Navigate to non-existent user
+    await page.goto('/records/monthly?tab=user-detail&user=NONEXISTENT&month=2025-11', {
+      waitUntil: 'domcontentloaded',
+    });
+
+    // Validate empty state is visible
+    await expect(page.getByTestId(monthlyTestIds.detailEmptyState)).toBeVisible();
+    await expect(page.getByText('データが見つかりませんでした')).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

Completes monthly.user-detail smoke coverage by adding deterministic demo seed + empty state UX.

## Changes
- E2E fixture: monthly.records.dev.v1.json (demo data fixture)
- E2E seed injection: gotoMonthlyRecordsPage(...{ seed: { monthlyRecords } })
- Empty state UI: monthlyTestIds.detailEmptyState
- Smoke: enable the 9th scenario (empty state validation)

## Validation
✅ Typecheck: OK
✅ Lint: OK  
✅ All tests: Ready for CI validation

## Files Changed
- tests/e2e/_fixtures/monthly.records.dev.v1.json (new)
- tests/e2e/_helpers/enableMonthly.ts (seed injection)
- src/testids.ts (detailEmptyState)
- src/pages/MonthlyRecordPage.tsx (E2E seed handling + empty state UI)
- tests/e2e/monthly.user-detail.spec.ts (9th scenario test)
