### PR TITLE
chore(ci): improve E2E smoke log visibility

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Wait for preview server
         run: npx wait-on http://127.0.0.1:5173
-      - name: e2e router + nav smoke (chromium + smoke)
+      - name: E2E router + nav smoke (chromium + smoke)
         env:
           TZ: Asia/Tokyo
           PW_USE_PREVIEW: 1
@@ -100,7 +100,20 @@ jobs:
           VITE_E2E: '1'
           VITE_E2E_MSAL_MOCK: '1'
           VITE_SKIP_LOGIN: '1'
-        run: npx playwright test tests/e2e/router.smoke.spec.ts tests/e2e/nav.smoke.spec.ts --config=playwright.config.ts
+        run: |
+          echo "=== E2E flags ==="
+          echo "VITE_E2E=$VITE_E2E"
+          echo "VITE_E2E_MSAL_MOCK=$VITE_E2E_MSAL_MOCK"
+          echo "VITE_SKIP_LOGIN=$VITE_SKIP_LOGIN"
+          echo "=== Tooling ==="
+          node -v
+          npx playwright --version
+          echo "=== Run ==="
+          npx playwright test \
+            tests/e2e/router.smoke.spec.ts \
+            tests/e2e/nav.smoke.spec.ts \
+            --config=playwright.config.ts \
+            --reporter=line
       - name: e2e smoke tests (all)
         env:
           TZ: Asia/Tokyo


### PR DESCRIPTION
## What
Improve readability and diagnosability of E2E router/nav smoke step in CI.

## Changes
- Echo E2E env flags (VITE_E2E / VITE_E2E_MSAL_MOCK / VITE_SKIP_LOGIN) at step start
- Add Node + Playwright versions to log for faster environment triage
- Use Playwright --reporter=line for concise, one-line-per-test output
- Rename step to 'E2E router + nav smoke' for search clarity

## Why
- Faster cut when smoke fails (no ambiguity about step execution)
- Verifiable env state without guessing
- Cleaner CI logs overall

## After merge
CI logs will show:
```
=== E2E flags ===
VITE_E2E=1
VITE_E2E_MSAL_MOCK=1
VITE_SKIP_LOGIN=1
=== Tooling ===
v20.x.x
Version 1.56.x
=== Run ===
[line reporter output]
```