### PR TITLE
chore(e2e): recover router flags smoke in Playwright

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "test:e2e:users": "playwright test tests/e2e/users.detail-flow.spec.ts",
     "test:hydration:e2e": "playwright test tests/e2e/hydration.routes.spec.ts",
     "test:e2e:smoke": "playwright test --project=smoke",
-    "e2e:smoke:router-nav": "playwright test tests/e2e/router.smoke.spec.ts tests/e2e/nav.smoke.spec.ts --config=playwright.config.ts --reporter=line",
+    "e2e:smoke:router-nav": "playwright test tests/e2e/app-shell.smoke.spec.ts tests/e2e/router.smoke.spec.ts tests/e2e/nav.smoke.spec.ts --config=playwright.config.ts --reporter=line",
     "test:e2e:daily-flow": "PLAYWRIGHT_BASE_URL=http://127.0.0.1:3000 PLAYWRIGHT_WEB_SERVER_URL=http://127.0.0.1:3000 playwright test tests/e2e/daily-flow.smoke.spec.ts",
     "e2e": "cross-env VITE_E2E=1 VITE_E2E_MSAL_MOCK=1 playwright test --project=chromium",
     "e2e:ui": "playwright test --ui",

--- a/tests/e2e/app-shell.smoke.spec.ts
+++ b/tests/e2e/app-shell.smoke.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test, type Page } from '@playwright/test';
+
+async function openNavIfDrawerExists(page: Page) {
+  const openBtn = page.getByTestId('nav-open');
+  if (await openBtn.count()) {
+    await openBtn.first().click({ noWaitAfter: true });
+  }
+}
+
+test.describe('app shell smoke (appRender recovery)', () => {
+  test('renders app shell and exposes navigation', async ({ page }) => {
+    await page.goto('/');
+
+    await openNavIfDrawerExists(page);
+
+    await expect(page.getByTestId('app-shell')).toBeVisible({ timeout: 5000 });
+
+    const navAudit = page.getByTestId('nav-audit');
+    const navChecklist = page.getByTestId('nav-checklist');
+
+    if (await navAudit.count()) {
+      await expect(navAudit.first()).toBeVisible({ timeout: 5000 });
+    }
+
+    if (await navChecklist.count()) {
+      await expect(navChecklist.first()).toBeVisible({ timeout: 5000 });
+    }
+  });
+});


### PR DESCRIPTION
## What\nMove router flags smoke coverage from Vitest skips to Playwright.\n\n## Changes\n- add app-shell.smoke.spec.ts: asserts app-shell renders and nav is exposed when present\n- run unified smoke entry with app-shell + router + nav specs\n- drop Vitest skip block in tests/smoke/router.flags.spec.tsx and document delegation to Playwright\n\n## Why\n- eliminate remaining router.flags skips (skip=0) by delegating to existing E2E harness\n- keep a single smoke entrypoint (npm run e2e:smoke:router-nav) for CI and local\n- reuse nav-open/nav-audit/nav-checklist testids without new UI changes\n\n## Verify\n```bash\nVITE_E2E=1 VITE_E2E_MSAL_MOCK=1 VITE_SKIP_LOGIN=1 npm run e2e:smoke:router-nav\n```\n\nLocal: 10 tests passed (7.4s)