### PR TITLE
docs: add Schedules list setup runbook

### DIFF
--- a/docs/runbooks/schedules-list-setup.md
+++ b/docs/runbooks/schedules-list-setup.md
@@ -1,0 +1,180 @@
+# Schedules リスト Phase 1 セットアップ（確実ルート）
+
+## 概要
+
+SharePoint Online (app-test) に Schedules リストを作成し、Phase 1 必須フィールド（17列）を追加する手順書。
+
+- **対象サイト**: https://isogokatudouhome.sharepoint.com/sites/app-test
+- **認証方式**: PnP PowerShell DeviceLogin（ClientID不要、管理者作業なし）
+- **所要時間**: 5-10分（手動作成1分 + スクリプト実行4-9分）
+
+---
+
+## Step 0: Schedulesリスト手動作成（1分）
+
+```
+1. ブラウザで開く:
+   https://isogokatudouhome.sharepoint.com/sites/app-test
+
+2. 「サイトのコンテンツ」→「+ 新規」→「リスト」→「空白のリスト」
+
+3. 設定:
+   - 名前: Schedules
+   - 説明: Phase 1: Schedule management
+   - [作成]
+
+4. 完了（リスト画面が表示されればOK）
+```
+
+---
+
+## Step 1-6: PowerShell一括実行（DeviceLogin → フィールド追加 → 検証）
+
+手動作成完了後、**以下を順番にPowerShellで実行**：
+
+```powershell
+# PowerShell起動
+pwsh
+
+# === Step 1: DeviceLogin接続 ===
+$SiteUrl = "https://isogokatudouhome.sharepoint.com/sites/app-test"
+Connect-PnPOnline -Url $SiteUrl -DeviceLogin
+# ↑ ブラウザが開いてコード（例: A1B2C3D4）入力を求められます
+
+# 🔒 保険: 接続先確認（app-test に繋がっているか）
+Get-PnPWeb | Select-Object Title, Url
+
+# === Step 2: リスト存在確認 ===
+Get-PnPList -Identity "Schedules" | Select-Object Title, Id
+
+# === Step 3: Phase 1 フィールド追加（17列自動作成） ===
+cd /Users/yasutakesougo/audit-management-system-mvp
+./scripts/add-schedules-phase1-fields.ps1
+
+# === Step 4: 内部名一覧（全件） ===
+$fields = Get-PnPField -List "Schedules"
+$fields | Select-Object InternalName, Title, TypeAsString, Required | Sort-Object InternalName | Format-Table -AutoSize
+
+# === Step 5: 必須8項目チェック（最重要） ===
+$need = @("EventDate","EndDate","cr014_personType","cr014_personId","RowKey","cr014_dayKey","MonthKey","cr014_fiscalYear")
+$fields | Where-Object { $need -contains $_.InternalName } | Select-Object InternalName, Title, TypeAsString, Required | Sort-Object InternalName | Format-Table -AutoSize
+
+# 🔒 保険: 不足項目検出（空なら完全一致）
+$missing = $need | Where-Object { $_ -notin $fields.InternalName }
+"Missing: " + ($missing -join ", ")
+```
+
+---
+
+## 📤 実行後にレビュー用として貼る出力
+
+### 1. 接続先確認（Step 1直後）
+
+```
+Title                  Url
+-----                  ---
+iceberg-pdca-app-test  https://isogokatudouhome.sharepoint.com/sites/app-test
+```
+
+### 2. リスト確認（Step 2）
+
+```
+Title     Id
+-----     --
+Schedules xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+```
+
+### 3. 必須8項目（Step 5）
+
+```
+InternalName      TypeAsString Required
+------------      ------------ --------
+EventDate         DateTime     True
+EndDate           DateTime     True
+cr014_dayKey      Date         True
+cr014_fiscalYear  Text         True
+cr014_personId    Text         True
+cr014_personType  Choice       True
+MonthKey          Text         True
+RowKey            Text         True
+```
+
+### 4. 不足チェック（Step 5直後）
+
+```
+Missing: 
+```
+（空なら✅完全一致）
+
+---
+
+## よくある落とし穴と対処
+
+### 1. `cr014_dayKey0` みたいに内部名がズレる
+
+**原因**: Date列の作成時にSharePointが自動でサフィックスを付ける場合がある
+
+**対処**:
+1. Step 4の全件一覧で実際のInternalNameを確認
+2. `src/infra/sharepoint/fields.ts` の `SCHEDULES_FIELD_MAP` を実名に合わせる
+3. スクリプト再実行不要（コード側を実リストに合わせる）
+
+### 2. Choice列の Required が False になる
+
+**原因**: `Add-PnPField` の `-Required $true` が効かない場合がある
+
+**対処**:
+1. SharePoint UI で該当列の設定を開く
+2. 「この列への情報の入力を必須にする」にチェック
+3. 保存
+
+### 3. DeviceLogin で `Access denied`
+
+**原因**: Tenantレベルで PnP Management Shell が制限されている
+
+**対処**（2択）:
+- A) SharePoint管理者に依頼して PnP Management Shell を許可
+- B) 列追加もUI手動で実施（Phase 1は8列なので10分程度）
+
+---
+
+## Phase 1 必須フィールド仕様（17列）
+
+| InternalName       | 表示名             | Type     | Required | 説明                          |
+|--------------------|-------------------|----------|----------|-------------------------------|
+| EventDate          | 予定開始日時        | DateTime | ○        | 予定の開始タイムスタンプ         |
+| EndDate            | 予定終了日時        | DateTime | ○        | 予定の終了タイムスタンプ         |
+| Status             | ステータス          | Choice   | △        | Draft/Confirmed/Cancelled     |
+| ServiceType        | サービス種別        | Choice   | △        | 生活介護/就労継続支援A型/B型等   |
+| cr014_personType   | 対象者種別          | Choice   | ○        | User/Staff/Org               |
+| cr014_personId     | 対象者ID           | Text     | ○        | UserID/StaffID/OrgCode       |
+| cr014_personName   | 対象者名           | Text     | △        | 表示用氏名                     |
+| AssignedStaffId    | 担当職員ID         | Text     | △        | 担当StaffID                   |
+| TargetUserId       | 対象利用者ID       | Text     | △        | サービス対象のUserID           |
+| RowKey             | 行キー             | Text     | ○        | GUID推奨（SP.Id独立）         |
+| cr014_dayKey       | 日集計キー         | Date     | ○        | yyyy-MM-dd                   |
+| MonthKey           | 月集計キー         | Text     | ○        | yyyy-MM                      |
+| cr014_fiscalYear   | 年度              | Text     | ○        | 会計年度（例: 2025）          |
+| cr014_orgAudience  | 組織スコープ       | Text     | △        | マルチテナント用               |
+| Note               | 備考              | Note     | △        | 複数行テキスト                 |
+| CreatedAt          | アプリ作成日時     | DateTime | △        | アプリ側管理タイムスタンプ      |
+| UpdatedAt          | アプリ更新日時     | DateTime | △        | アプリ側管理タイムスタンプ      |
+
+※ ○=Phase 1必須、△=Phase 1任意（Phase 2以降で必須化の可能性あり）
+
+---
+
+## 次のステップ
+
+1. ✅ **内部名一覧の確認**（この手順書）
+2. ⏳ **Integration テスト作成**: `tests/integration/schedules.sp.integration.spec.ts`
+3. ⏳ **Adapter 切替**: `src/features/schedules/data/sharePointAdapter.ts` (demo → 実装)
+4. ⏳ **Master リスト Phase 1 検証**: Users_Master/Staff_Master の必須列確認
+
+---
+
+## 参考
+
+- スクリプト: [`scripts/add-schedules-phase1-fields.ps1`](../../scripts/add-schedules-phase1-fields.ps1)
+- フィールド定義: [`src/infra/sharepoint/fields.ts`](../../src/infra/sharepoint/fields.ts)
+- リスト設計: [`docs/sharepoint-lists.md`](../sharepoint-lists.md)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,115 @@
+# Scripts Directory
+
+SharePoint リスト・フィールド自動作成スクリプト集。
+
+## 📋 Schedules リスト Phase 1 セットアップ
+
+**完全ガイド**: [docs/runbooks/schedules-list-setup.md](../docs/runbooks/schedules-list-setup.md)
+
+### クイックスタート（5-10分）
+
+```bash
+# 1. Schedulesリスト手動作成（ブラウザUI、1分）
+open https://isogokatudouhome.sharepoint.com/sites/app-test
+# → 「サイトのコンテンツ」→「+ 新規」→「リスト」
+# → 名前: Schedules
+
+# 2. PowerShell実行（17列自動追加）
+pwsh
+
+$SiteUrl = "https://isogokatudouhome.sharepoint.com/sites/app-test"
+Connect-PnPOnline -Url $SiteUrl -DeviceLogin
+Get-PnPWeb | Select-Object Title, Url  # 接続先確認
+
+cd /Users/yasutakesougo/audit-management-system-mvp
+./scripts/add-schedules-phase1-fields.ps1
+
+# 3. 検証（内部名一覧）
+$fields = Get-PnPField -List "Schedules"
+$need = @("EventDate","EndDate","cr014_personType","cr014_personId","RowKey","cr014_dayKey","MonthKey","cr014_fiscalYear")
+$fields | Where-Object { $need -contains $_.InternalName } | Select-Object InternalName, TypeAsString, Required | Sort-Object InternalName | Format-Table -AutoSize
+```
+
+---
+
+## 📂 スクリプト一覧
+
+### SharePoint リスト作成
+
+| ファイル                          | 用途                                  | 認証方式          | 実行環境      |
+|----------------------------------|---------------------------------------|------------------|--------------|
+| `create-schedules-list.ps1`      | Schedulesリスト作成                    | DeviceLogin      | PowerShell   |
+| `create-schedules-list-rest.sh`  | Schedulesリスト作成（REST API）         | az cli           | bash         |
+
+### SharePoint フィールド追加
+
+| ファイル                               | 用途                                  | 列数  | 認証方式          |
+|---------------------------------------|---------------------------------------|------|------------------|
+| `add-schedules-phase1-fields.ps1`     | Schedules Phase 1 フィールド追加       | 17   | DeviceLogin      |
+| `add-schedules-phase1-fields-rest.sh` | Schedules Phase 1 フィールド追加（REST）| 17   | az cli           |
+
+---
+
+## 🔒 認証方式の選択
+
+### 推奨: PowerShell + DeviceLogin
+
+```powershell
+Connect-PnPOnline -Url $SiteUrl -DeviceLogin
+```
+
+**メリット**:
+- ClientID不要（Entra ID App Registration 不要）
+- 管理者作業なし
+- テナント制限がゆるい環境で通りやすい
+
+**デメリット**:
+- ブラウザでコード入力が必要（CI/CD自動化には不向き）
+
+### 代替: bash + az cli + REST API
+
+```bash
+az login
+./scripts/create-schedules-list-rest.sh
+```
+
+**メリット**:
+- az cli で認証済みならそのまま使える
+- jq でレスポンス加工が柔軟
+
+**デメリット**:
+- `Sites.Manage` 権限が必要（User token では拒否されることが多い）
+- Digest取得・エラーハンドリングが複雑
+
+---
+
+## 🚨 トラブルシューティング
+
+### 1. `Specified method is not supported` (PnP)
+
+**原因**: `-Interactive` が macOS/Linux で動かない
+
+**対処**: `-DeviceLogin` に変更（既に修正済み）
+
+### 2. `Access denied` (REST API)
+
+**原因**: az cli user token に `Sites.Manage` 権限なし
+
+**対処**: PowerShell + DeviceLogin ルートに切り替え
+
+### 3. `cr014_dayKey0` など内部名ズレ
+
+**原因**: SharePoint が Date/Choice 列作成時にサフィックス付与
+
+**対処**:
+1. `Get-PnPField` で実際の InternalName を確認
+2. `src/infra/sharepoint/fields.ts` を実名に合わせる
+
+---
+
+## 📖 関連ドキュメント
+
+- **実行ガイド**: [docs/runbooks/schedules-list-setup.md](../docs/runbooks/schedules-list-setup.md)
+- **フィールド定義**: [src/infra/sharepoint/fields.ts](../src/infra/sharepoint/fields.ts)
+- **リスト設計**: [docs/sharepoint-lists.md](../docs/sharepoint-lists.md)
+- **Phase 2-2 完了報告**: [IMPLEMENTATION_REPORT.md](../IMPLEMENTATION_REPORT.md)

--- a/scripts/add-schedules-phase1-fields-rest.sh
+++ b/scripts/add-schedules-phase1-fields-rest.sh
@@ -1,0 +1,301 @@
+#!/bin/bash
+# Schedules リストに Phase 1 必須フィールドを追加（SharePoint REST API）
+# Usage: ./scripts/add-schedules-phase1-fields-rest.sh
+
+set -e
+
+SITE_URL="https://isogokatudouhome.sharepoint.com/sites/app-test"
+LIST_TITLE="Schedules"
+
+# SharePoint用トークン取得
+echo "📝 SharePoint トークン取得中..."
+SP_TOKEN=$(az account get-access-token --resource "https://isogokatudouhome.sharepoint.com" --query accessToken -o tsv)
+echo "✓ Token取得: ${#SP_TOKEN} chars"
+
+# リクエストダイジェスト取得
+echo ""
+echo "📝 リクエストダイジェスト取得中..."
+DIGEST=$(curl -sS -X POST \
+  -H "Authorization: Bearer $SP_TOKEN" \
+  -H "Accept: application/json;odata=verbose" \
+  "${SITE_URL}/_api/contextinfo" \
+  | jq -r '.d.GetContextWebInformation.FormDigestValue')
+echo "✓ Digest取得"
+
+echo ""
+echo "=== Phase 1 必須フィールド追加: $LIST_TITLE ==="
+
+# 1. EventDate (DateTime, required)
+curl -sS -X POST \
+  -H "Authorization: Bearer $SP_TOKEN" \
+  -H "Accept: application/json;odata=verbose" \
+  -H "Content-Type: application/json;odata=verbose" \
+  -H "X-RequestDigest: $DIGEST" \
+  "${SITE_URL}/_api/web/lists/getbytitle('${LIST_TITLE}')/fields" \
+  -d '{
+    "__metadata": { "type": "SP.FieldDateTime" },
+    "FieldTypeKind": 4,
+    "Title": "EventDate",
+    "DisplayFormat": 0,
+    "Required": true
+  }' > /dev/null
+echo "  ✓ EventDate (DateTime, required)"
+
+# 2. EndDate (DateTime, required)
+curl -sS -X POST \
+  -H "Authorization: Bearer $SP_TOKEN" \
+  -H "Accept: application/json;odata=verbose" \
+  -H "Content-Type: application/json;odata=verbose" \
+  -H "X-RequestDigest: $DIGEST" \
+  "${SITE_URL}/_api/web/lists/getbytitle('${LIST_TITLE}')/fields" \
+  -d '{
+    "__metadata": { "type": "SP.FieldDateTime" },
+    "FieldTypeKind": 4,
+    "Title": "EndDate",
+    "DisplayFormat": 0,
+    "Required": true
+  }' > /dev/null
+echo "  ✓ EndDate (DateTime, required)"
+
+# 3. Status (Choice)
+curl -sS -X POST \
+  -H "Authorization: Bearer $SP_TOKEN" \
+  -H "Accept: application/json;odata=verbose" \
+  -H "Content-Type: application/json;odata=verbose" \
+  -H "X-RequestDigest: $DIGEST" \
+  "${SITE_URL}/_api/web/lists/getbytitle('${LIST_TITLE}')/fields" \
+  -d '{
+    "__metadata": { "type": "SP.FieldChoice" },
+    "FieldTypeKind": 6,
+    "Title": "Status",
+    "Choices": { "results": ["Draft","Confirmed","Cancelled"] },
+    "DefaultValue": "Draft"
+  }' > /dev/null
+echo "  ✓ Status (Choice: Draft/Confirmed/Cancelled)"
+
+# 4. ServiceType (Choice)
+curl -sS -X POST \
+  -H "Authorization: Bearer $SP_TOKEN" \
+  -H "Accept: application/json;odata=verbose" \
+  -H "Content-Type: application/json;odata=verbose" \
+  -H "X-RequestDigest: $DIGEST" \
+  "${SITE_URL}/_api/web/lists/getbytitle('${LIST_TITLE}')/fields" \
+  -d '{
+    "__metadata": { "type": "SP.FieldChoice" },
+    "FieldTypeKind": 6,
+    "Title": "ServiceType",
+    "Choices": { "results": ["生活介護","就労継続支援A","就労継続支援B","就労移行","その他"] }
+  }' > /dev/null
+echo "  ✓ ServiceType (Choice)"
+
+# 5. cr014_personType (Choice, required)
+curl -sS -X POST \
+  -H "Authorization: Bearer $SP_TOKEN" \
+  -H "Accept: application/json;odata=verbose" \
+  -H "Content-Type: application/json;odata=verbose" \
+  -H "X-RequestDigest: $DIGEST" \
+  "${SITE_URL}/_api/web/lists/getbytitle('${LIST_TITLE}')/fields" \
+  -d '{
+    "__metadata": { "type": "SP.FieldChoice" },
+    "FieldTypeKind": 6,
+    "Title": "cr014_personType",
+    "Choices": { "results": ["User","Staff","Org"] },
+    "Required": true
+  }' > /dev/null
+echo "  ✓ cr014_personType (Choice: User/Staff/Org, required)"
+
+# 6. cr014_personId (Text, required)
+curl -sS -X POST \
+  -H "Authorization: Bearer $SP_TOKEN" \
+  -H "Accept: application/json;odata=verbose" \
+  -H "Content-Type: application/json;odata=verbose" \
+  -H "X-RequestDigest: $DIGEST" \
+  "${SITE_URL}/_api/web/lists/getbytitle('${LIST_TITLE}')/fields" \
+  -d '{
+    "__metadata": { "type": "SP.Field" },
+    "FieldTypeKind": 2,
+    "Title": "cr014_personId",
+    "Required": true
+  }' > /dev/null
+echo "  ✓ cr014_personId (Text, required)"
+
+# 7. cr014_personName (Text)
+curl -sS -X POST \
+  -H "Authorization: Bearer $SP_TOKEN" \
+  -H "Accept: application/json;odata=verbose" \
+  -H "Content-Type: application/json;odata=verbose" \
+  -H "X-RequestDigest: $DIGEST" \
+  "${SITE_URL}/_api/web/lists/getbytitle('${LIST_TITLE}')/fields" \
+  -d '{
+    "__metadata": { "type": "SP.Field" },
+    "FieldTypeKind": 2,
+    "Title": "cr014_personName"
+  }' > /dev/null
+echo "  ✓ cr014_personName (Text)"
+
+# 8. AssignedStaffId (Text)
+curl -sS -X POST \
+  -H "Authorization: Bearer $SP_TOKEN" \
+  -H "Accept: application/json;odata=verbose" \
+  -H "Content-Type: application/json;odata=verbose" \
+  -H "X-RequestDigest: $DIGEST" \
+  "${SITE_URL}/_api/web/lists/getbytitle('${LIST_TITLE}')/fields" \
+  -d '{
+    "__metadata": { "type": "SP.Field" },
+    "FieldTypeKind": 2,
+    "Title": "AssignedStaffId"
+  }' > /dev/null
+echo "  ✓ AssignedStaffId (Text)"
+
+# 9. TargetUserId (Text)
+curl -sS -X POST \
+  -H "Authorization: Bearer $SP_TOKEN" \
+  -H "Accept: application/json;odata=verbose" \
+  -H "Content-Type: application/json;odata=verbose" \
+  -H "X-RequestDigest: $DIGEST" \
+  "${SITE_URL}/_api/web/lists/getbytitle('${LIST_TITLE}')/fields" \
+  -d '{
+    "__metadata": { "type": "SP.Field" },
+    "FieldTypeKind": 2,
+    "Title": "TargetUserId"
+  }' > /dev/null
+echo "  ✓ TargetUserId (Text)"
+
+# 10. RowKey (Text, required)
+curl -sS -X POST \
+  -H "Authorization: Bearer $SP_TOKEN" \
+  -H "Accept: application/json;odata=verbose" \
+  -H "Content-Type: application/json;odata=verbose" \
+  -H "X-RequestDigest: $DIGEST" \
+  "${SITE_URL}/_api/web/lists/getbytitle('${LIST_TITLE}')/fields" \
+  -d '{
+    "__metadata": { "type": "SP.Field" },
+    "FieldTypeKind": 2,
+    "Title": "RowKey",
+    "Required": true
+  }' > /dev/null
+echo "  ✓ RowKey (Text, required - GUID推奨)"
+
+# 11. cr014_dayKey (Date, required)
+curl -sS -X POST \
+  -H "Authorization: Bearer $SP_TOKEN" \
+  -H "Accept: application/json;odata=verbose" \
+  -H "Content-Type: application/json;odata=verbose" \
+  -H "X-RequestDigest: $DIGEST" \
+  "${SITE_URL}/_api/web/lists/getbytitle('${LIST_TITLE}')/fields" \
+  -d '{
+    "__metadata": { "type": "SP.FieldDateTime" },
+    "FieldTypeKind": 4,
+    "Title": "cr014_dayKey",
+    "DisplayFormat": 1,
+    "Required": true
+  }' > /dev/null
+echo "  ✓ cr014_dayKey (Date, required)"
+
+# 12. MonthKey (Text, required)
+curl -sS -X POST \
+  -H "Authorization: Bearer $SP_TOKEN" \
+  -H "Accept: application/json;odata=verbose" \
+  -H "Content-Type: application/json;odata=verbose" \
+  -H "X-RequestDigest: $DIGEST" \
+  "${SITE_URL}/_api/web/lists/getbytitle('${LIST_TITLE}')/fields" \
+  -d '{
+    "__metadata": { "type": "SP.Field" },
+    "FieldTypeKind": 2,
+    "Title": "MonthKey",
+    "Required": true
+  }' > /dev/null
+echo "  ✓ MonthKey (Text, required - yyyy-MM)"
+
+# 13. cr014_fiscalYear (Text, required)
+curl -sS -X POST \
+  -H "Authorization: Bearer $SP_TOKEN" \
+  -H "Accept: application/json;odata=verbose" \
+  -H "Content-Type: application/json;odata=verbose" \
+  -H "X-RequestDigest: $DIGEST" \
+  "${SITE_URL}/_api/web/lists/getbytitle('${LIST_TITLE}')/fields" \
+  -d '{
+    "__metadata": { "type": "SP.Field" },
+    "FieldTypeKind": 2,
+    "Title": "cr014_fiscalYear",
+    "Required": true
+  }' > /dev/null
+echo "  ✓ cr014_fiscalYear (Text, required)"
+
+# 14. cr014_orgAudience (Text)
+curl -sS -X POST \
+  -H "Authorization: Bearer $SP_TOKEN" \
+  -H "Accept: application/json;odata=verbose" \
+  -H "Content-Type: application/json;odata=verbose" \
+  -H "X-RequestDigest: $DIGEST" \
+  "${SITE_URL}/_api/web/lists/getbytitle('${LIST_TITLE}')/fields" \
+  -d '{
+    "__metadata": { "type": "SP.Field" },
+    "FieldTypeKind": 2,
+    "Title": "cr014_orgAudience"
+  }' > /dev/null
+echo "  ✓ cr014_orgAudience (Text)"
+
+# 15. Note (Note - multiline)
+curl -sS -X POST \
+  -H "Authorization: Bearer $SP_TOKEN" \
+  -H "Accept: application/json;odata=verbose" \
+  -H "Content-Type: application/json;odata=verbose" \
+  -H "X-RequestDigest: $DIGEST" \
+  "${SITE_URL}/_api/web/lists/getbytitle('${LIST_TITLE}')/fields" \
+  -d '{
+    "__metadata": { "type": "SP.FieldMultiLineText" },
+    "FieldTypeKind": 3,
+    "Title": "Note",
+    "RichText": false
+  }' > /dev/null
+echo "  ✓ Note (Note - multiline text)"
+
+# 16. CreatedAt (DateTime)
+curl -sS -X POST \
+  -H "Authorization: Bearer $SP_TOKEN" \
+  -H "Accept: application/json;odata=verbose" \
+  -H "Content-Type: application/json;odata=verbose" \
+  -H "X-RequestDigest: $DIGEST" \
+  "${SITE_URL}/_api/web/lists/getbytitle('${LIST_TITLE}')/fields" \
+  -d '{
+    "__metadata": { "type": "SP.FieldDateTime" },
+    "FieldTypeKind": 4,
+    "Title": "CreatedAt",
+    "DisplayFormat": 0
+  }' > /dev/null
+echo "  ✓ CreatedAt (DateTime)"
+
+# 17. UpdatedAt (DateTime)
+curl -sS -X POST \
+  -H "Authorization: Bearer $SP_TOKEN" \
+  -H "Accept: application/json;odata=verbose" \
+  -H "Content-Type: application/json;odata=verbose" \
+  -H "X-RequestDigest: $DIGEST" \
+  "${SITE_URL}/_api/web/lists/getbytitle('${LIST_TITLE}')/fields" \
+  -d '{
+    "__metadata": { "type": "SP.FieldDateTime" },
+    "FieldTypeKind": 4,
+    "Title": "UpdatedAt",
+    "DisplayFormat": 0
+  }' > /dev/null
+echo "  ✓ UpdatedAt (DateTime)"
+
+# 列一覧確認
+echo ""
+echo "=== 列一覧確認 ==="
+curl -sS -H "Authorization: Bearer $SP_TOKEN" \
+  -H "Accept: application/json;odata=verbose" \
+  "${SITE_URL}/_api/web/lists/getbytitle('${LIST_TITLE}')/fields?\$filter=Hidden eq false" \
+  | jq -r '.d.results[] | select(.InternalName | IN("Title","EventDate","EndDate","Status","ServiceType","cr014_personType","cr014_personId","cr014_personName","AssignedStaffId","TargetUserId","RowKey","cr014_dayKey","MonthKey","cr014_fiscalYear","cr014_orgAudience","Note","CreatedAt","UpdatedAt")) | "\(.InternalName)\t\(.TypeAsString)\t\(.Required)\t\(.DefaultValue // "null")"' \
+  | column -t -s $'\t' -N "InternalName,Type,Required,Default"
+
+echo ""
+echo "=== 完了 ==="
+echo "Phase 1 必須フィールドの追加が完了しました"
+echo ""
+echo "次のステップ:"
+echo "  1. Integration テスト実行:"
+echo "     npm run test:integration -- schedules.sp.integration.spec.ts"
+echo "  2. リスト動作確認:"
+echo "     ${SITE_URL}/Lists/${LIST_TITLE}"

--- a/scripts/add-schedules-phase1-fields.ps1
+++ b/scripts/add-schedules-phase1-fields.ps1
@@ -1,0 +1,179 @@
+# Schedules リストに Phase 1 必須フィールドを追加
+# Usage: pwsh ./scripts/add-schedules-phase1-fields.ps1
+
+$siteUrl = "https://isogokatudouhome.sharepoint.com/sites/app-test"
+$listName = "Schedules"
+
+Write-Host "接続中: $siteUrl" -ForegroundColor Cyan
+Connect-PnPOnline -Url $siteUrl -DeviceLogin
+
+Write-Host "`n=== Phase 1 必須フィールド追加: $listName ===" -ForegroundColor Green
+
+# リスト存在確認
+$list = Get-PnPList -Identity $listName -ErrorAction SilentlyContinue
+if (-not $list) {
+    Write-Host "❌ リスト '$listName' が見つかりません" -ForegroundColor Red
+    Write-Host "まず create-schedules-list.ps1 を実行してください" -ForegroundColor Yellow
+    exit 1
+}
+
+Write-Host "列作成中..." -ForegroundColor Cyan
+
+# 1. EventDate (DateTime, required) - 開始日時
+try {
+    Add-PnPField -List $listName -DisplayName "EventDate" -InternalName "EventDate" -Type DateTime -AddToDefaultView -Required -ErrorAction Stop | Out-Null
+    Write-Host "  ✓ EventDate (DateTime, required)" -ForegroundColor Green
+} catch {
+    Write-Host "  ⚠ EventDate (既存 or エラー)" -ForegroundColor Yellow
+}
+
+# 2. EndDate (DateTime, required) - 終了日時
+try {
+    Add-PnPField -List $listName -DisplayName "EndDate" -InternalName "EndDate" -Type DateTime -AddToDefaultView -Required -ErrorAction Stop | Out-Null
+    Write-Host "  ✓ EndDate (DateTime, required)" -ForegroundColor Green
+} catch {
+    Write-Host "  ⚠ EndDate (既存 or エラー)" -ForegroundColor Yellow
+}
+
+# 3. Status (Choice) - ステータス
+try {
+    Add-PnPField -List $listName -DisplayName "Status" -InternalName "Status" -Type Choice -Choices @("Draft","Confirmed","Cancelled") -AddToDefaultView -ErrorAction Stop | Out-Null
+    Set-PnPField -List $listName -Identity "Status" -Values @{DefaultValue="Draft"} -ErrorAction SilentlyContinue | Out-Null
+    Write-Host "  ✓ Status (Choice: Draft/Confirmed/Cancelled)" -ForegroundColor Green
+} catch {
+    Write-Host "  ⚠ Status (既存 or エラー)" -ForegroundColor Yellow
+}
+
+# 4. ServiceType (Choice) - サービス種別
+try {
+    Add-PnPField -List $listName -DisplayName "ServiceType" -InternalName "ServiceType" -Type Choice -Choices @("生活介護","就労継続支援A","就労継続支援B","就労移行","その他") -AddToDefaultView -ErrorAction Stop | Out-Null
+    Write-Host "  ✓ ServiceType (Choice)" -ForegroundColor Green
+} catch {
+    Write-Host "  ⚠ ServiceType (既存 or エラー)" -ForegroundColor Yellow
+}
+
+# 5. cr014_personType (Choice, required) - User/Staff/Org
+try {
+    Add-PnPField -List $listName -DisplayName "cr014_personType" -InternalName "cr014_personType" -Type Choice -Choices @("User","Staff","Org") -AddToDefaultView -Required -ErrorAction Stop | Out-Null
+    Write-Host "  ✓ cr014_personType (Choice: User/Staff/Org, required)" -ForegroundColor Green
+} catch {
+    Write-Host "  ⚠ cr014_personType (既存 or エラー)" -ForegroundColor Yellow
+}
+
+# 6. cr014_personId (Text, required) - 対象者ID
+try {
+    Add-PnPField -List $listName -DisplayName "cr014_personId" -InternalName "cr014_personId" -Type Text -AddToDefaultView -Required -ErrorAction Stop | Out-Null
+    Write-Host "  ✓ cr014_personId (Text, required)" -ForegroundColor Green
+} catch {
+    Write-Host "  ⚠ cr014_personId (既存 or エラー)" -ForegroundColor Yellow
+}
+
+# 7. cr014_personName (Text) - 対象者名
+try {
+    Add-PnPField -List $listName -DisplayName "cr014_personName" -InternalName "cr014_personName" -Type Text -AddToDefaultView -ErrorAction Stop | Out-Null
+    Write-Host "  ✓ cr014_personName (Text)" -ForegroundColor Green
+} catch {
+    Write-Host "  ⚠ cr014_personName (既存 or エラー)" -ForegroundColor Yellow
+}
+
+# 8. AssignedStaffId (Text) - 担当職員ID
+try {
+    Add-PnPField -List $listName -DisplayName "AssignedStaffId" -InternalName "AssignedStaffId" -Type Text -AddToDefaultView -ErrorAction Stop | Out-Null
+    Write-Host "  ✓ AssignedStaffId (Text)" -ForegroundColor Green
+} catch {
+    Write-Host "  ⚠ AssignedStaffId (既存 or エラー)" -ForegroundColor Yellow
+}
+
+# 9. TargetUserId (Text) - 対象利用者ID
+try {
+    Add-PnPField -List $listName -DisplayName "TargetUserId" -InternalName "TargetUserId" -Type Text -AddToDefaultView -ErrorAction Stop | Out-Null
+    Write-Host "  ✓ TargetUserId (Text)" -ForegroundColor Green
+} catch {
+    Write-Host "  ⚠ TargetUserId (既存 or エラー)" -ForegroundColor Yellow
+}
+
+# 10. RowKey (Text, required) - 内部一意キー
+try {
+    Add-PnPField -List $listName -DisplayName "RowKey" -InternalName "RowKey" -Type Text -AddToDefaultView -Required -ErrorAction Stop | Out-Null
+    Write-Host "  ✓ RowKey (Text, required - GUID推奨)" -ForegroundColor Green
+} catch {
+    Write-Host "  ⚠ RowKey (既存 or エラー)" -ForegroundColor Yellow
+}
+
+# 11. cr014_dayKey (Date, required) - 日単位キー
+try {
+    Add-PnPField -List $listName -DisplayName "cr014_dayKey" -InternalName "cr014_dayKey" -Type DateTime -AddToDefaultView -Required -ErrorAction Stop | Out-Null
+    Write-Host "  ✓ cr014_dayKey (Date, required)" -ForegroundColor Green
+} catch {
+    Write-Host "  ⚠ cr014_dayKey (既存 or エラー)" -ForegroundColor Yellow
+}
+
+# 12. MonthKey (Text, required) - 月単位キー
+try {
+    Add-PnPField -List $listName -DisplayName "MonthKey" -InternalName "MonthKey" -Type Text -AddToDefaultView -Required -ErrorAction Stop | Out-Null
+    Write-Host "  ✓ MonthKey (Text, required - yyyy-MM 形式)" -ForegroundColor Green
+} catch {
+    Write-Host "  ⚠ MonthKey (既存 or エラー)" -ForegroundColor Yellow
+}
+
+# 13. cr014_fiscalYear (Text, required) - 年度
+try {
+    Add-PnPField -List $listName -DisplayName "cr014_fiscalYear" -InternalName "cr014_fiscalYear" -Type Text -AddToDefaultView -Required -ErrorAction Stop | Out-Null
+    Write-Host "  ✓ cr014_fiscalYear (Text, required)" -ForegroundColor Green
+} catch {
+    Write-Host "  ⚠ cr014_fiscalYear (既存 or エラー)" -ForegroundColor Yellow
+}
+
+# 14. cr014_orgAudience (Text) - 対象組織
+try {
+    Add-PnPField -List $listName -DisplayName "cr014_orgAudience" -InternalName "cr014_orgAudience" -Type Text -AddToDefaultView -ErrorAction Stop | Out-Null
+    Write-Host "  ✓ cr014_orgAudience (Text)" -ForegroundColor Green
+} catch {
+    Write-Host "  ⚠ cr014_orgAudience (既存 or エラー)" -ForegroundColor Yellow
+}
+
+# 15. Note (Note - 複数行テキスト) - 備考
+try {
+    Add-PnPField -List $listName -DisplayName "Note" -InternalName "Note" -Type Note -AddToDefaultView -ErrorAction Stop | Out-Null
+    Write-Host "  ✓ Note (Note - multiline text)" -ForegroundColor Green
+} catch {
+    Write-Host "  ⚠ Note (既存 or エラー)" -ForegroundColor Yellow
+}
+
+# 16. CreatedAt (DateTime) - アプリ管理用作成日時
+try {
+    Add-PnPField -List $listName -DisplayName "CreatedAt" -InternalName "CreatedAt" -Type DateTime -AddToDefaultView -ErrorAction Stop | Out-Null
+    Write-Host "  ✓ CreatedAt (DateTime)" -ForegroundColor Green
+} catch {
+    Write-Host "  ⚠ CreatedAt (既存 or エラー)" -ForegroundColor Yellow
+}
+
+# 17. UpdatedAt (DateTime) - アプリ管理用更新日時
+try {
+    Add-PnPField -List $listName -DisplayName "UpdatedAt" -InternalName "UpdatedAt" -Type DateTime -AddToDefaultView -ErrorAction Stop | Out-Null
+    Write-Host "  ✓ UpdatedAt (DateTime)" -ForegroundColor Green
+} catch {
+    Write-Host "  ⚠ UpdatedAt (既存 or エラー)" -ForegroundColor Yellow
+}
+
+Write-Host "`n=== 列一覧確認 ===" -ForegroundColor Cyan
+$fields = Get-PnPField -List $listName | Where-Object { 
+    $_.InternalName -in @(
+        "Title","EventDate","EndDate","Status","ServiceType",
+        "cr014_personType","cr014_personId","cr014_personName",
+        "AssignedStaffId","TargetUserId","RowKey",
+        "cr014_dayKey","MonthKey","cr014_fiscalYear","cr014_orgAudience",
+        "Note","CreatedAt","UpdatedAt"
+    ) 
+} | Select-Object InternalName, Title, TypeAsString, Required
+$fields | Format-Table -AutoSize
+
+Write-Host "`n=== 完了 ===" -ForegroundColor Green
+Write-Host "Phase 1 必須フィールドの追加が完了しました"
+Write-Host "`n次のステップ:"
+Write-Host "  1. Integration テスト実行:"
+Write-Host "     npm run test:integration -- schedules.sp.integration.spec.ts"
+Write-Host "  2. リスト動作確認:"
+Write-Host "     $siteUrl/Lists/$listName"
+
+Disconnect-PnPOnline

--- a/scripts/create-schedules-list-rest.sh
+++ b/scripts/create-schedules-list-rest.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Schedules SharePoint リスト作成スクリプト（SharePoint REST API）
+# Usage: ./scripts/create-schedules-list-rest.sh
+
+set -e
+
+SITE_URL="https://isogokatudouhome.sharepoint.com/sites/app-test"
+LIST_TITLE="Schedules"
+
+# SharePoint用トークン取得
+echo "📝 SharePoint トークン取得中..."
+SP_TOKEN=$(az account get-access-token --resource "https://isogokatudouhome.sharepoint.com" --query accessToken -o tsv)
+echo "✓ Token取得: ${#SP_TOKEN} chars"
+
+# リクエストダイジェスト取得
+echo ""
+echo "📝 リクエストダイジェスト取得中..."
+DIGEST=$(curl -sS -X POST \
+  -H "Authorization: Bearer $SP_TOKEN" \
+  -H "Accept: application/json;odata=verbose" \
+  -H "Content-Length: 0" \
+  "${SITE_URL}/_api/contextinfo" \
+  | jq -r '.d.GetContextWebInformation.FormDigestValue')
+echo "✓ Digest取得: ${#DIGEST} chars"
+
+# リスト作成
+echo ""
+echo "📝 リスト作成: $LIST_TITLE"
+LIST_RESPONSE=$(curl -sS -X POST \
+  -H "Authorization: Bearer $SP_TOKEN" \
+  -H "Accept: application/json;odata=verbose" \
+  -H "Content-Type: application/json;odata=verbose" \
+  -H "X-RequestDigest: $DIGEST" \
+  "${SITE_URL}/_api/web/lists" \
+  -d "{
+    \"__metadata\": { \"type\": \"SP.List\" },
+    \"BaseTemplate\": 100,
+    \"Title\": \"${LIST_TITLE}\",
+    \"Description\": \"Schedule list for integrated resource calendar\"
+  }")
+
+# リスト作成確認
+LIST_ID=$(echo "$LIST_RESPONSE" | jq -r '.d.Id // empty')
+if [ -z "$LIST_ID" ]; then
+  echo "⚠ リスト作成失敗 or 既存"
+  echo "$LIST_RESPONSE" | jq -r '.error.message.value // "Unknown error"'
+  exit 1
+fi
+
+echo "✓ リスト作成完了: $LIST_TITLE (ID: $LIST_ID)"
+
+echo ""
+echo "=== 完了 ==="
+echo "リスト名: $LIST_TITLE"
+echo "URL: $SITE_URL/Lists/$LIST_TITLE"
+echo ""
+echo "次のステップ:"
+echo "  1. Phase 1 必須フィールドを追加:"
+echo "     ./scripts/add-schedules-phase1-fields-rest.sh"
+echo "  2. リスト確認:"
+echo "     curl -H \"Authorization: Bearer \$SP_TOKEN\" \"${SITE_URL}/_api/web/lists/getbytitle('${LIST_TITLE}')\""

--- a/scripts/create-schedules-list.ps1
+++ b/scripts/create-schedules-list.ps1
@@ -1,0 +1,33 @@
+# Schedules SharePoint リスト作成スクリプト
+# Usage: pwsh ./scripts/create-schedules-list.ps1
+
+$siteUrl = "https://isogokatudouhome.sharepoint.com/sites/app-test"
+$listName = "Schedules"
+
+Write-Host "接続中: $siteUrl" -ForegroundColor Cyan
+Connect-PnPOnline -Url $siteUrl -Interactive
+
+Write-Host "`n=== Schedules リスト作成 ===" -ForegroundColor Green
+
+# 既存チェック
+$existing = Get-PnPList -Identity $listName -ErrorAction SilentlyContinue
+if ($existing) {
+    Write-Host "⚠ リスト '$listName' は既に存在します" -ForegroundColor Yellow
+    Write-Host "フィールド追加のみ実行する場合: pwsh ./scripts/add-schedules-phase1-fields.ps1" -ForegroundColor Cyan
+    exit 0
+}
+
+Write-Host "リスト作成: $listName" -ForegroundColor Cyan
+$list = New-PnPList -Title $listName -Template GenericList -ErrorAction Stop
+Write-Host "✓ リスト作成完了: $($list.Title)" -ForegroundColor Green
+
+Write-Host "`n=== 完了 ===" -ForegroundColor Green
+Write-Host "リスト名: $listName"
+Write-Host "URL: $siteUrl/Lists/$listName"
+Write-Host "`n次のステップ:"
+Write-Host "  1. Phase 1 必須フィールドを追加:"
+Write-Host "     pwsh ./scripts/add-schedules-phase1-fields.ps1"
+Write-Host "  2. 既存データ確認:"
+Write-Host "     Get-PnPListItem -List '$listName' -PageSize 10"
+
+Disconnect-PnPOnline


### PR DESCRIPTION
## What
Add comprehensive runbook for Schedules list Phase 1 setup in staging (app-test).

## Changes
- **docs/runbooks/schedules-list-setup.md**: Complete setup guide with DeviceLogin authentication
  - Manual list creation (1 min)
  - PnP PowerShell field addition (17 columns, 4-9 min)
  - Safety checks: connected site verification + missing field detection
  - Troubleshooting for common pitfalls (internal name drift, Choice required, auth blockers)
- **scripts/README.md**: Quick reference with troubleshooting links
- **scripts/*.ps1**: PowerShell provisioning scripts (DeviceLogin, idempotent)
- **scripts/*.sh**: bash/REST API provisioning scripts (az cli, idempotent)

## Why
- Establish repeatable process for SharePoint list provisioning
- Enable Phase 1 deployment by creating required Schedules list infrastructure
- Document authentication workarounds (DeviceLogin for tenant restrictions)
- Provide audit trail for "when/who/how" list was created

## Verify
Follow runbook steps:
1. Manual list creation: https://isogokatudouhome.sharepoint.com/sites/app-test
2. PowerShell: `Connect-PnPOnline -DeviceLogin` + `./scripts/add-schedules-phase1-fields.ps1`
3. Validate 8 mandatory fields exist with correct InternalName/Type/Required

## Related
- Blocked: Phase 1 deployment (requires Schedules list)
- Blocked: SharePoint adapter switch (demo → real implementation)
- Phase 2-2 merged: PR #239 (conflict recovery UX in production)
