### PR TITLE
fix: prevent Org_Master infinite fetch by separating IS_DEMO and IS_SKIP_SHAREPOINT

### DIFF
--- a/src/features/org/store.ts
+++ b/src/features/org/store.ts
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
-import { isDemoModeEnabled, skipSharePoint } from '@/lib/env';
+import { IS_SKIP_SHAREPOINT } from '@/lib/env';
 import { useSP } from '@/lib/spClient';
 
 import {
@@ -10,6 +10,18 @@ import {
     SpOrgRowSchema,
     type OrgMasterRecord,
 } from './data/orgRowSchema';
+
+// ============================================================================
+// In-flight dedupe: Prevent multiple simultaneous Org_Master fetches
+// (solves React 18 StrictMode double-invocation in dev)
+// ============================================================================
+let orgLoadPromise: Promise<void> | null = null;
+
+// ============================================================================
+// Module-scope cache: Session-wide cache to prevent refetch on remount
+// (survives React state reset, route transitions, and HMR)
+// ============================================================================
+let orgCachedOptions: OrgOption[] | null = null;
 
 export type OrgOption = {
   id: string;
@@ -55,93 +67,147 @@ const sortRecords = (records: OrgMasterRecord[]): OrgMasterRecord[] =>
 
 export function useOrgStore(): OrgStoreState {
   const sp = useSP();
+  const spRef = useRef(sp);
+  
+  // Keep ref updated to latest sp client (for refresh after auth state change)
+  useEffect(() => {
+    spRef.current = sp;
+  }, [sp]);
+
   const [items, setItems] = useState<OrgOption[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const [loadedOnce, setLoadedOnce] = useState<boolean>(false);
-  const sharePointDisabled = useMemo(() => isDemoModeEnabled() || skipSharePoint(), []);
 
   const loadOrgOptions = useCallback(async (signal?: AbortSignal) => {
+    // Guard -1: Skip SharePoint (demo / baseUrl empty / skip-login / automation)
+    // ✅ Master guard: prevents ALL SharePoint operations in non-SP scenarios
+    // ✅ Promise is never created if SharePoint should be skipped
+    if (IS_SKIP_SHAREPOINT) {
+      console.info('[useOrgStore] Guard -1: skip SharePoint, using fallback');
+      orgCachedOptions = null; // Clear cache
+      setItems(FALLBACK_ORG_OPTIONS);
+      setLoadedOnce(true);
+      setLoading(false); // ← CRITICAL: complete state transition
+      return; // ← EXIT POINT: SHAREPOINT SKIPPED - PROMISE NEVER CREATED
+    }
+
+    // Guard 0: Module cache hit (only for SP mode)
+    if (orgCachedOptions) {
+      console.debug('[useOrgStore] Guard 0: cache hit, restoring from module cache');
+      setItems(orgCachedOptions);
+      setLoadedOnce(true);
+      setLoading(false);
+      return;
+    }
+
+    // Guard 1: Already loaded - avoid redundant fetch (synchronous check)
+    if (loadedOnce) {
+      console.debug('[useOrgStore] Guard 1: already loaded, skipping');
+      return;
+    }
+
+    // Guard 2: In-flight dedupe (StrictMode protection)
+    // If already fetching, return the same promise instead of fetching again
+    if (orgLoadPromise) {
+      console.debug('[useOrgStore] Guard 2: in-flight promise found, reusing');
+      return orgLoadPromise;
+    }
+
     if (signal?.aborted) {
       return;
     }
-    setLoading(true);
-    setError(null);
 
-    try {
-      if (sharePointDisabled) {
-        setItems(FALLBACK_ORG_OPTIONS);
-        setLoadedOnce(true);
-        return;
-      }
-
-      const fetchRows = async () => {
-        try {
-          return await sp.listItems<Record<string, unknown>>(ORG_MASTER_LIST_TITLE, {
-            select: Array.from(ORG_MASTER_SELECT_FIELDS),
-            orderby: `${ORG_MASTER_FIELDS.title} asc`,
-            top: 500,
-            signal,
-          });
-        } catch (err) {
-          const status = (err as { status?: number }).status;
-          if (status === 400) {
-            return await sp.listItems<Record<string, unknown>>(ORG_MASTER_LIST_TITLE, {
+    console.debug('[useOrgStore] Guard 3: creating new load promise (SharePoint fetch)');
+    // Guard 3: Promise先取り確保（await前に確保して、同時呼び出しを同じPromiseに吸収）
+    // ✅ sharePointDisabled NEVER true here — Guard -1 already handled all demo mode cases
+    orgLoadPromise = (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const fetchRows = async () => {
+          try {
+            return await spRef.current.listItems<Record<string, unknown>>(ORG_MASTER_LIST_TITLE, {
+              select: Array.from(ORG_MASTER_SELECT_FIELDS),
               orderby: `${ORG_MASTER_FIELDS.title} asc`,
               top: 500,
               signal,
             });
+          } catch (err) {
+            const status = (err as { status?: number }).status;
+            if (status === 400) {
+              return await spRef.current.listItems<Record<string, unknown>>(ORG_MASTER_LIST_TITLE, {
+                orderby: `${ORG_MASTER_FIELDS.title} asc`,
+                top: 500,
+                signal,
+              });
+            }
+            throw err;
           }
-          throw err;
+        };
+
+        const rows = await fetchRows();
+        if (signal?.aborted) {
+          return;
         }
-      };
 
-      const rows = await fetchRows();
-      if (signal?.aborted) {
-        return;
-      }
+        const normalizedRows = Array.isArray(rows) ? rows : (rows as { value?: unknown[] })?.value ?? [];
+        const parsedRows = SpOrgRowSchema.array().safeParse(normalizedRows);
+        if (!parsedRows.success) {
+          console.warn('[Org_Master] parse failed, fallback used', parsedRows.error.flatten());
+          setError('Org master schema mismatch');
+          setItems(FALLBACK_ORG_OPTIONS);
+          setLoadedOnce(true);
+          return;
+        }
 
-      const normalizedRows = Array.isArray(rows) ? rows : (rows as { value?: unknown[] })?.value ?? [];
-      const parsedRows = SpOrgRowSchema.array().safeParse(normalizedRows);
-      if (!parsedRows.success) {
-        console.warn('[Org_Master] parse failed, fallback used', parsedRows.error.flatten());
-        setError('Org master schema mismatch');
+        const activeRecords = parsedRows.data.filter((record) => record.isActive);
+
+        const sortedRecords = sortRecords(activeRecords);
+        const nextItems = sortedRecords.length ? buildOrgOptions(sortedRecords) : FALLBACK_ORG_OPTIONS;
+        
+        // Cache successful result at module scope
+        orgCachedOptions = nextItems;
+        
+        setItems(nextItems);
+        setLoadedOnce(true);
+      } catch (err) {
+        if (signal?.aborted) {
+          return;
+        }
+        const message = err instanceof Error ? err.message : '事業所マスターの取得に失敗しました';
+        console.warn('[useOrgStore] failed to load org options', err);
+        setError(message);
         setItems(FALLBACK_ORG_OPTIONS);
         setLoadedOnce(true);
-        return;
+      } finally {
+        if (!signal?.aborted) {
+          setLoading(false);
+        }
+        // Clear in-flight cache on completion (both success and failure)
+        // This allows retry on next call if needed
+        orgLoadPromise = null;
       }
+    })();
 
-      const activeRecords = parsedRows.data.filter((record) => record.isActive);
-
-      const sortedRecords = sortRecords(activeRecords);
-      const nextItems = sortedRecords.length ? buildOrgOptions(sortedRecords) : FALLBACK_ORG_OPTIONS;
-      setItems(nextItems);
-      setLoadedOnce(true);
-    } catch (err) {
-      if (signal?.aborted) {
-        return;
-      }
-      const message = err instanceof Error ? err.message : '事業所マスターの取得に失敗しました';
-      console.warn('[useOrgStore] failed to load org options', err);
-      setError(message);
-      setItems(FALLBACK_ORG_OPTIONS);
-      setLoadedOnce(true);
-    } finally {
-      if (!signal?.aborted) {
-        setLoading(false);
-      }
-    }
-  }, [sharePointDisabled, sp]);
+    return orgLoadPromise;
+  }, []); // No dependencies: IS_DEMO is module-level constant, sp via spRef
 
   const refresh = useCallback(async () => {
     await loadOrgOptions();
   }, [loadOrgOptions]);
 
   useEffect(() => {
+    // Guard: only load if not already loaded
+    // This prevents infinite effect cycles even if loadOrgOptions reference changes
+    if (loadedOnce) {
+      return;
+    }
+
     const controller = new AbortController();
     void loadOrgOptions(controller.signal);
     return () => controller.abort();
-  }, [loadOrgOptions]);
+  }, [loadedOnce, loadOrgOptions]);
 
   return { items, loading, error, loadedOnce, refresh };
 }

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -572,3 +572,32 @@ export const getSharePointDefaultScope = (envOverride?: EnvRecord): string => {
 
   return raw;
 };
+
+/**
+ * ✅ SINGLE SOURCE OF TRUTH: When to SKIP SharePoint
+ * 
+ * This is the canonical check for all stores (useOrgStore, useStaffStore, etc.)
+ * to determine whether SharePoint API should be touched.
+ * 
+ * SharePoint is skipped if ANY of these are true:
+ * 1. VITE_DEMO_MODE === '1' (true demo mode)
+ * 2. VITE_SP_SITE_URL is not configured (empty/invalid baseUrl)
+ * 3. VITE_SKIP_LOGIN is enabled (automation/testing mode)
+ * 
+ * This prevents accidental SharePoint calls in demo/test scenarios.
+ */
+export const SP_SITE_URL = String(import.meta.env.VITE_SP_SITE_URL || '').trim();
+export const SP_BASE_URL = SP_SITE_URL; // Alias for clarity
+
+export const IS_DEMO = import.meta.env.VITE_DEMO_MODE === '1';
+export const IS_SKIP_LOGIN = readBool('VITE_SKIP_LOGIN', false);
+
+/**
+ * ✅ Master guard: Should we skip all SharePoint operations?
+ * This is what stores actually check — more accurate than IS_DEMO alone.
+ */
+export const IS_SKIP_SHAREPOINT = IS_DEMO || !SP_BASE_URL || IS_SKIP_LOGIN;
+
+// Legacy aliases (keep for backward compat, but prefer IS_SKIP_SHAREPOINT)
+export const SP_ENABLED = !IS_SKIP_SHAREPOINT;
+export const SP_DISABLED = IS_SKIP_SHAREPOINT;


### PR DESCRIPTION
## Summary
Prevent infinite Org_Master fetch by clearly separating demo mode and SharePoint skip responsibility.

## Root Cause
Demo mode and SharePoint skip logic were mixed, causing guard branching and unintended fetch execution.

## Solution
- Introduced clear separation between IS_DEMO and IS_SKIP_SHAREPOINT
- Stores now rely solely on IS_SKIP_SHAREPOINT
- Guard -1 exits early with fallback data

## Result
- Guard 2/3: 0 times
- Org_Master fetch: 0 times
- DevMock calls: 0 times
- Logs and behavior are fully aligned

## Technical Details
### Before
- `IS_DEMO` was used inconsistently across UI/Store layers
- Guard -1 didn't cover all no-SharePoint scenarios (baseUrl empty, skip-login, etc.)

### After
- `IS_DEMO`: True demo mode (VITE_DEMO_MODE === '1')
- `IS_SKIP_SHAREPOINT`: Master guard (IS_DEMO OR no baseUrl OR skip-login)
- useOrgStore uses IS_SKIP_SHAREPOINT for Guard -1
- Promise never created when SharePoint should be skipped
