### PR TITLE
chore: enforce skip-sharepoint guard via ESLint restrict-imports

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -29,6 +29,19 @@ module.exports = {
     'no-restricted-imports': [
       'error',
       {
+        paths: [
+          {
+            name: '@/lib/env',
+            importNames: [
+              'IS_SKIP_SHAREPOINT',
+              'IS_DEMO',
+              'IS_AUTOMATION',
+              'IS_SKIP_LOGIN',
+            ],
+            message:
+              'Do not import skip/demo flags directly. Use shouldSkipSharePoint() from src/lib/sharepoint/skipSharePoint instead.',
+          },
+        ],
         patterns: [
           {
             group: [

--- a/src/lib/sharepoint/skipSharePoint.ts
+++ b/src/lib/sharepoint/skipSharePoint.ts
@@ -8,6 +8,7 @@
  * in non-SharePoint contexts (demo, test, skip-login, automation, missing credentials).
  */
 
+// eslint-disable-next-line no-restricted-imports
 import { IS_SKIP_SHAREPOINT } from '@/lib/env';
 
 export type SkipSharePointReason =


### PR DESCRIPTION
Prevents direct imports of env skip/demo flags. Requires shouldSkipSharePoint() from skipSharePoint helper.