### PR TITLE
[Phase 3.1-A] StaffAttendance Port + Local Adapter

### DIFF
--- a/src/features/staff/attendance/adapters/index.ts
+++ b/src/features/staff/attendance/adapters/index.ts
@@ -1,0 +1,1 @@
+export { localStorageStaffAttendanceAdapter, createLocalStorageAdapter } from './localStorage';

--- a/src/features/staff/attendance/adapters/localStorage.ts
+++ b/src/features/staff/attendance/adapters/localStorage.ts
@@ -1,0 +1,83 @@
+import { result, type Result } from '@/shared/result';
+import type { StaffAttendance, RecordDate } from '../types';
+import type { StaffAttendancePort, AttendanceCounts } from '../port';
+import { useStaffAttendanceStore } from '../store';
+
+/**
+ * Parse key in format "{YYYY-MM-DD}#{STAFF_ID}" to (date, staffId)
+ */
+const parseKey = (key: string): { date: RecordDate; staffId: string } | null => {
+  const [date, staffId] = key.split('#');
+  if (!date || !staffId) return null;
+  return { date: date as RecordDate, staffId };
+};
+
+/**
+ * Local Storage Adapter for StaffAttendancePort
+ * Phase 3.1-A: Wraps existing in-memory store
+ * Phase 3.1-B: Will be replaced by SharePoint adapter
+ */
+export const createLocalStorageAdapter = (): StaffAttendancePort => ({
+  async upsert(a: StaffAttendance): Promise<Result<void>> {
+    try {
+      const store = useStaffAttendanceStore();
+      store.upsert(a);
+      return result.ok(undefined);
+    } catch (e) {
+      return result.unknown('Failed to upsert attendance', e);
+    }
+  },
+
+  async remove(key: string): Promise<Result<void>> {
+    try {
+      const parsed = parseKey(key);
+      if (!parsed) {
+        return result.validation('Invalid key format. Expected "{YYYY-MM-DD}#{STAFF_ID}"');
+      }
+      const store = useStaffAttendanceStore();
+      store.remove(parsed.date, parsed.staffId);
+      return result.ok(undefined);
+    } catch (e) {
+      return result.unknown('Failed to remove attendance', e);
+    }
+  },
+
+  async getByKey(key: string): Promise<Result<StaffAttendance | null>> {
+    try {
+      const parsed = parseKey(key);
+      if (!parsed) {
+        return result.validation('Invalid key format. Expected "{YYYY-MM-DD}#{STAFF_ID}"');
+      }
+      const store = useStaffAttendanceStore();
+      const record = store.get(parsed.date, parsed.staffId);
+      return result.ok(record ?? null);
+    } catch (e) {
+      return result.unknown('Failed to get attendance', e);
+    }
+  },
+
+  async listByDate(date: string): Promise<Result<StaffAttendance[]>> {
+    try {
+      const store = useStaffAttendanceStore();
+      const records = store.listByDate(date as RecordDate);
+      return result.ok(records);
+    } catch (e) {
+      return result.unknown('Failed to list attendance', e);
+    }
+  },
+
+  async countByDate(date: string): Promise<Result<AttendanceCounts>> {
+    try {
+      const store = useStaffAttendanceStore();
+      const counts = store.countByDate(date as RecordDate);
+      return result.ok(counts);
+    } catch (e) {
+      return result.unknown('Failed to count attendance', e);
+    }
+  },
+});
+
+/**
+ * Singleton instance
+ */
+export const localStorageStaffAttendanceAdapter = createLocalStorageAdapter();

--- a/src/features/staff/attendance/port.ts
+++ b/src/features/staff/attendance/port.ts
@@ -1,0 +1,55 @@
+import { Result } from '@/shared/result';
+import { StaffAttendance } from './types';
+
+/**
+ * Count summary for a specific date
+ */
+export type AttendanceCounts = {
+  onDuty: number;
+  out: number;
+  absent: number;
+  total: number;
+};
+
+/**
+ * StaffAttendancePort: Interface for CRUD operations
+ * Implementations: localStorage (Phase 3.1-A), SharePoint (Phase 3.1-B)
+ *
+ * Key strategy: "{YYYY-MM-DD}#{STAFF_ID}" (e.g., "2026-01-31#S001")
+ */
+export interface StaffAttendancePort {
+  /**
+   * Upsert: Create or update attendance record
+   * @param a Staff attendance record
+   * @returns ok(void) on success, err on failure
+   */
+  upsert(a: StaffAttendance): Promise<Result<void>>;
+
+  /**
+   * Remove: Delete attendance record by key
+   * @param key Record key in format "{date}#{staffId}"
+   * @returns ok(void) on success, err on failure
+   */
+  remove(key: string): Promise<Result<void>>;
+
+  /**
+   * Get by key: Retrieve single record
+   * @param key Record key in format "{date}#{staffId}"
+   * @returns ok(StaffAttendance | null) on success, err on failure
+   */
+  getByKey(key: string): Promise<Result<StaffAttendance | null>>;
+
+  /**
+   * List by date: Retrieve all records for a date
+   * @param date Date in format "YYYY-MM-DD"
+   * @returns ok(StaffAttendance[]) on success, err on failure
+   */
+  listByDate(date: string): Promise<Result<StaffAttendance[]>>;
+
+  /**
+   * Count by date: Get aggregated statistics
+   * @param date Date in format "YYYY-MM-DD"
+   * @returns ok(AttendanceCounts) on success, err on failure
+   */
+  countByDate(date: string): Promise<Result<AttendanceCounts>>;
+}


### PR DESCRIPTION
- Introduce StaffAttendancePort interface for CRUD abstraction
- Define AttendanceCounts and error handling with Result type
- Implement localStorageAdapter wrapping existing store
- Key format: YYYY-MM-DD#STAFF_ID for Phase 3.1-B SharePoint integration
- Maintain backward compatibility: all existing tests pass
