### PR TITLE
[Phase 3.2-B] StaffAttendance Admin UI (edit via upsert)

### DIFF
--- a/src/features/staff/attendance/components/StaffAttendanceEditDialog.tsx
+++ b/src/features/staff/attendance/components/StaffAttendanceEditDialog.tsx
@@ -1,0 +1,146 @@
+import * as React from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+  MenuItem,
+} from '@mui/material';
+import type { StaffAttendance, StaffAttendanceStatus } from '../types';
+
+type Props = {
+  open: boolean;
+  recordDate: string; // 選択中の日付（キー/保存に必要）
+  initial: StaffAttendance | null;
+  onClose: () => void;
+  onSave: (next: StaffAttendance) => Promise<void>;
+  saving?: boolean;
+};
+
+const STATUS_OPTIONS: StaffAttendanceStatus[] = ['出勤', '欠勤', '外出中'];
+
+export function StaffAttendanceEditDialog(props: Props): JSX.Element {
+  const { open, recordDate, initial, onClose, onSave, saving = false } = props;
+
+  const [status, setStatus] = React.useState<StaffAttendanceStatus>('出勤');
+  const [note, setNote] = React.useState<string>('');
+  const [checkInAt, setCheckInAt] = React.useState<string>(''); // "HH:MM" で扱う想定
+
+  React.useEffect(() => {
+    if (!initial) return;
+    setStatus(initial.status);
+    setNote(initial.note ?? '');
+    // checkInAt は ISO datetime → HH:MM に変換
+    if (initial.checkInAt) {
+      try {
+        const dt = new Date(initial.checkInAt);
+        const hh = String(dt.getHours()).padStart(2, '0');
+        const mm = String(dt.getMinutes()).padStart(2, '0');
+        setCheckInAt(`${hh}:${mm}`);
+      } catch {
+        setCheckInAt('');
+      }
+    } else {
+      setCheckInAt('');
+    }
+  }, [initial]);
+
+  const canSave = !!initial && !!recordDate && !!initial.staffId;
+
+  const handleSave = async () => {
+    if (!initial) return;
+
+    // checkInAt を ISO datetime に変換（recordDate + "T" + time）
+    let checkInAtISO: string | undefined;
+    if (checkInAt) {
+      checkInAtISO = `${recordDate}T${checkInAt}:00`;
+    }
+
+    await onSave({
+      ...initial,
+      recordDate,
+      status,
+      note: note.trim() ? note : undefined,
+      checkInAt: checkInAtISO,
+    });
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={saving ? undefined : onClose}
+      fullWidth
+      maxWidth="sm"
+      data-testid="staff-attendance-edit-dialog"
+    >
+      <DialogTitle>勤怠編集</DialogTitle>
+
+      <DialogContent sx={{ display: 'grid', gap: 2, pt: 1 }}>
+        <TextField
+          label="職員ID"
+          value={initial?.staffId ?? ''}
+          disabled
+          fullWidth
+        />
+
+        <TextField
+          select
+          label="ステータス"
+          value={status}
+          onChange={(e) => setStatus(e.target.value as StaffAttendanceStatus)}
+          fullWidth
+          inputProps={{ 'data-testid': 'staff-attendance-edit-status' }}
+        >
+          {STATUS_OPTIONS.map((s) => (
+            <MenuItem key={s} value={s}>
+              {s}
+            </MenuItem>
+          ))}
+        </TextField>
+
+        <TextField
+          label="メモ"
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          multiline
+          minRows={2}
+          fullWidth
+          inputProps={{ 'data-testid': 'staff-attendance-edit-note' }}
+        />
+
+        <TextField
+          label="出勤時刻"
+          type="time"
+          value={checkInAt}
+          onChange={(e) => setCheckInAt(e.target.value)}
+          fullWidth
+          inputProps={{ 'data-testid': 'staff-attendance-edit-checkin' }}
+          InputLabelProps={{
+            shrink: true,
+          }}
+        />
+      </DialogContent>
+
+      <DialogActions>
+        <Button
+          onClick={onClose}
+          disabled={saving}
+          data-testid="staff-attendance-edit-cancel"
+        >
+          キャンセル
+        </Button>
+
+        <Button
+          variant="contained"
+          disabled={!canSave || saving}
+          data-testid="staff-attendance-edit-save"
+          onClick={handleSave}
+        >
+          {saving ? '保存中...' : '保存'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/features/staff/attendance/hooks/useStaffAttendanceAdmin.ts
+++ b/src/features/staff/attendance/hooks/useStaffAttendanceAdmin.ts
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import { getStaffAttendancePort } from '../storage';
+import type { StaffAttendance } from '../types';
+
+type State = {
+  items: StaffAttendance[];
+  loading: boolean;
+  error: string | null;
+  saving: boolean;
+};
+
+export function useStaffAttendanceAdmin(recordDate: string) {
+  const port = React.useMemo(() => getStaffAttendancePort(), []);
+  const [state, setState] = React.useState<State>({
+    items: [],
+    loading: false,
+    error: null,
+    saving: false,
+  });
+
+  const refetch = React.useCallback(async () => {
+    setState((s) => ({ ...s, loading: true, error: null }));
+    const res = await port.listByDate(recordDate);
+    if (res.isOk) {
+      setState((s) => ({ ...s, items: res.value, loading: false }));
+    } else {
+      setState((s) => ({
+        ...s,
+        loading: false,
+        error: res.error.message || res.error.kind || 'unknown',
+      }));
+    }
+  }, [port, recordDate]);
+
+  React.useEffect(() => {
+    void refetch();
+  }, [refetch]);
+
+  const save = React.useCallback(
+    async (next: StaffAttendance) => {
+      setState((s) => ({ ...s, saving: true, error: null }));
+      const res = await port.upsert(next);
+      if (!res.isOk) {
+        setState((s) => ({
+          ...s,
+          saving: false,
+          error: res.error.message || res.error.kind || 'unknown',
+        }));
+        return;
+      }
+      // 安定最優先：再取得
+      await refetch();
+      setState((s) => ({ ...s, saving: false }));
+    },
+    [port, refetch]
+  );
+
+  return {
+    ...state,
+    refetch,
+    save,
+  };
+}


### PR DESCRIPTION
## 🎯 概要
Phase 3.2-B: 勤怠管理画面に **編集（upsert）** を追加します（stacked on 3.2-A）

## 🏗️ 変更内容
### 追加
- `src/features/staff/attendance/components/StaffAttendanceEditDialog.tsx`
  - status / note / checkInAt 編集
  - testids:
    - staff-attendance-edit-dialog
    - staff-attendance-edit-status
    - staff-attendance-edit-note
    - staff-attendance-edit-checkin
    - staff-attendance-edit-save
    - staff-attendance-edit-cancel

- `src/features/staff/attendance/hooks/useStaffAttendanceAdmin.ts`
  - listByDate + save(upsert) + 成功後refetch
  - Result型で error/saving を型安全に制御

### 更新
- `src/pages/StaffAttendanceAdminPage.tsx`
  - 行クリック → dialog
  - 保存 → port.upsert → refetch
  - testid: staff-attendance-row-{staffId}

## ✅ 検証
- typecheck: Pass
- lint: Pass

## 🔗 関連
- Phase 3.2-A (read-only admin list) の上に積んでいます（base: feat/phase3-2a-attendance-admin-ui）

