### PR TITLE
feat(sp): staff attendance list setup skeleton (existence check + dry-run)

### DIFF
--- a/scripts/sp/setupStaffAttendanceList.ts
+++ b/scripts/sp/setupStaffAttendanceList.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process';
 
 const SITE_URL = process.env.SITE_URL?.trim() ?? '';
-const LIST_TITLE = process.env.LIST_TITLE?.trim() || 'StaffAttendance';
+const LIST_TITLE = process.env.LIST_TITLE?.trim() || 'Staff_Attendance';
 const DRY_RUN = parseBoolean(process.env.DRY_RUN ?? '1');
 
 if (!SITE_URL) {


### PR DESCRIPTION
## Summary
- add Phase 3.3-A setup script skeleton for StaffAttendance list
- supports SITE_URL / LIST_TITLE / DRY_RUN inputs
- dry-run default to avoid accidental creation
- resolves SP_TOKEN or falls back to az CLI token

## Usage (dry-run default)
- SITE_URL is required
- LIST_TITLE defaults to StaffAttendance
- DRY_RUN defaults to true

## Notes
- PR 3.3-A only (no field provisioning yet)
- list creation only happens when DRY_RUN=false