### PR TITLE
docs(sp): Staff_Attendance setup runbook + npm script

### DIFF
--- a/docs/runbooks/staff-attendance-list-setup.md
+++ b/docs/runbooks/staff-attendance-list-setup.md
@@ -1,0 +1,77 @@
+# Staff_Attendance リスト セットアップ（Phase 3.3-C）
+
+## 目的
+
+SharePoint Online の Staff_Attendance リストを **安全に作成/補完** し、アプリの勤怠管理を SharePoint で動かすための最短手順。
+
+- DRY_RUN 既定で **破壊的変更なし**
+- 足りない列だけ追加（型不一致は警告ログのみ）
+
+---
+
+## 事前準備
+
+- SharePoint サイト URL（例: `https://<tenant>.sharepoint.com/sites/app-test`）
+- 認証: `SP_TOKEN` もしくは `az` CLI ログイン済み
+
+---
+
+## Step 1: DRY_RUN（安全確認）
+
+```bash
+SITE_URL="https://<tenant>.sharepoint.com/sites/app-test" \
+LIST_TITLE="Staff_Attendance" \
+DRY_RUN=true \
+npm run sp:setup:staff-attendance
+```
+
+期待されるログ:
+- `list exists` もしくは `would create list`
+- `Missing fields → would add:` のみ（変更は入らない）
+
+---
+
+## Step 2: 実適用（作成/不足列追加）
+
+```bash
+SITE_URL="https://<tenant>.sharepoint.com/sites/app-test" \
+LIST_TITLE="Staff_Attendance" \
+DRY_RUN=false \
+npm run sp:setup:staff-attendance
+```
+
+期待されるログ:
+- リストがなければ作成
+- 足りない列だけ追加
+- 型不一致は WARN でスキップ（破壊的変更なし）
+
+---
+
+## Step 3: SharePoint UI で確認
+
+- `Staff_Attendance` リストを開く
+- 以下の列が見えていること
+  - `StaffId`, `RecordDate`, `Status`, `Note`, `CheckInAt`, `CheckOutAt`, `LateMinutes`
+
+---
+
+## Step 4: アプリ側の切替（app-test）
+
+`.env.local` などに追加:
+
+```
+VITE_STAFF_ATTENDANCE_STORAGE=sharepoint
+VITE_SP_SITE_URL=https://<tenant>.sharepoint.com/sites/app-test
+```
+
+UI確認:
+- `/admin/staff-attendance`
+- 1件編集（upsert）
+- bulk 編集（status/checkInAt 上書き、note 空なら保持）
+
+---
+
+## 参考
+
+- スクリプト: [scripts/sp/setupStaffAttendanceList.ts](../../scripts/sp/setupStaffAttendanceList.ts)
+- フィールド定義: [src/sharepoint/fields.ts](../../src/sharepoint/fields.ts)

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "test:e2e:users": "playwright test tests/e2e/users.detail-flow.spec.ts",
     "test:hydration:e2e": "playwright test tests/e2e/hydration.routes.spec.ts",
     "test:e2e:smoke": "playwright test --project=smoke",
+    "sp:setup:staff-attendance": "node --loader tsx scripts/sp/setupStaffAttendanceList.ts",
     "e2e:smoke:router-nav": "playwright test tests/e2e/app-shell.smoke.spec.ts tests/e2e/router.smoke.spec.ts tests/e2e/nav.smoke.spec.ts --config=playwright.config.ts --reporter=line",
     "test:e2e:daily-flow": "PLAYWRIGHT_BASE_URL=http://127.0.0.1:3000 PLAYWRIGHT_WEB_SERVER_URL=http://127.0.0.1:3000 playwright test tests/e2e/daily-flow.smoke.spec.ts",
     "e2e": "cross-env VITE_E2E=1 VITE_E2E_MSAL_MOCK=1 playwright test --project=chromium",


### PR DESCRIPTION
## Summary\n- add Staff_Attendance SharePoint setup runbook\n- add npm script to run the setup tool\n\n## Safety\n- DRY_RUN default is true (no destructive changes)\n- explicit SITE_URL required\n\n## How to run\n- SITE_URL=https://<tenant>.sharepoint.com/sites/app-test DRY_RUN=true|false npm run sp:setup:staff-attendance\n\n## Docs\n- docs/runbooks/staff-attendance-list-setup.md