### PR TITLE
test(e2e): seal staff attendance read-only mode

### DIFF
--- a/src/features/staff/attendance/components/StaffAttendanceBulkInputDrawer.tsx
+++ b/src/features/staff/attendance/components/StaffAttendanceBulkInputDrawer.tsx
@@ -17,6 +17,7 @@ type Props = {
   saving: boolean;
   error: string | null;
   onClose: () => void;
+  writeEnabled?: boolean;
 
   // "適用"で生成するための入力値
   value: {
@@ -32,7 +33,7 @@ type Props = {
 const STATUS_OPTIONS: StaffAttendanceStatus[] = ['出勤', '欠勤', '外出中'];
 
 export function StaffAttendanceBulkInputDrawer(props: Props): JSX.Element {
-  const { open, selectedCount, saving, error, onClose, value, onChange, onSave } = props;
+  const { open, selectedCount, saving, error, onClose, value, onChange, onSave, writeEnabled = true } = props;
 
   return (
     <Drawer
@@ -103,7 +104,7 @@ export function StaffAttendanceBulkInputDrawer(props: Props): JSX.Element {
             <Button
               variant="contained"
               onClick={onSave}
-              disabled={saving || selectedCount === 0}
+              disabled={saving || selectedCount === 0 || !writeEnabled}
               data-testid="staff-attendance-bulk-save"
             >
               {saving ? '保存中...' : '保存'}

--- a/src/features/staff/attendance/components/StaffAttendanceEditDialog.tsx
+++ b/src/features/staff/attendance/components/StaffAttendanceEditDialog.tsx
@@ -17,12 +17,13 @@ type Props = {
   onClose: () => void;
   onSave: (next: StaffAttendance) => Promise<void>;
   saving?: boolean;
+  writeEnabled?: boolean;
 };
 
 const STATUS_OPTIONS: StaffAttendanceStatus[] = ['出勤', '欠勤', '外出中'];
 
 export function StaffAttendanceEditDialog(props: Props): JSX.Element {
-  const { open, recordDate, initial, onClose, onSave, saving = false } = props;
+  const { open, recordDate, initial, onClose, onSave, saving = false, writeEnabled = true } = props;
 
   const [status, setStatus] = React.useState<StaffAttendanceStatus>('出勤');
   const [note, setNote] = React.useState<string>('');
@@ -134,7 +135,7 @@ export function StaffAttendanceEditDialog(props: Props): JSX.Element {
 
         <Button
           variant="contained"
-          disabled={!canSave || saving}
+          disabled={!canSave || saving || !writeEnabled}
           data-testid="staff-attendance-edit-save"
           onClick={handleSave}
         >

--- a/src/features/staff/attendance/hooks/useStaffAttendanceAdmin.ts
+++ b/src/features/staff/attendance/hooks/useStaffAttendanceAdmin.ts
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import { getStaffAttendancePort } from '../storage';
+import { useAuth } from '@/auth/useAuth';
+import { toSafeError } from '@/lib/errors';
+import { skipSharePoint } from '@/lib/env';
+import { ensureConfig } from '@/lib/spClient';
+import { result } from '@/shared/result';
+import { createSharePointStaffAttendanceAdapter } from '../adapters';
+import type { StaffAttendancePort } from '../port';
+import { getStaffAttendancePort, getStaffAttendanceStorageKind, getStaffAttendanceWriteEnabled } from '../storage';
 import type { StaffAttendance } from '../types';
 
 type State = {
@@ -9,8 +16,20 @@ type State = {
   saving: boolean;
 };
 
+const createBlockedPort = (message: string): StaffAttendancePort => ({
+  upsert: async () => result.forbidden(message),
+  remove: async () => result.forbidden(message),
+  getByKey: async () => result.forbidden(message),
+  listByDate: async () => result.forbidden(message),
+  countByDate: async () => result.forbidden(message),
+});
+
 export function useStaffAttendanceAdmin(recordDate: string) {
-  const port = React.useMemo(() => getStaffAttendancePort(), []);
+  const storageKind = React.useMemo(() => getStaffAttendanceStorageKind(), []);
+  const writeEnabledEnv = React.useMemo(() => getStaffAttendanceWriteEnabled(), []);
+  const { acquireToken } = useAuth();
+  const [readOnlyReason, setReadOnlyReason] = React.useState<string | null>(null);
+  const [spReady, setSpReady] = React.useState<boolean>(storageKind !== 'sharepoint');
   const [state, setState] = React.useState<State>({
     items: [],
     loading: false,
@@ -18,18 +37,65 @@ export function useStaffAttendanceAdmin(recordDate: string) {
     saving: false,
   });
 
+  React.useEffect(() => {
+    if (storageKind !== 'sharepoint') {
+      setSpReady(true);
+      setReadOnlyReason(null);
+      return;
+    }
+
+    if (skipSharePoint()) {
+      setSpReady(false);
+      setReadOnlyReason('SharePoint が設定で無効化されています。');
+      return;
+    }
+
+    try {
+      const { baseUrl } = ensureConfig();
+      if (!baseUrl) {
+        setSpReady(false);
+        setReadOnlyReason('SharePoint 接続が無効です（デモ/スキップ設定）。');
+        return;
+      }
+      setSpReady(true);
+      setReadOnlyReason(null);
+    } catch (err) {
+      const safe = toSafeError(err);
+      setSpReady(false);
+      setReadOnlyReason(safe.message || 'SharePoint 接続設定が未完了です。');
+    }
+  }, [storageKind]);
+
+  const port = React.useMemo(() => {
+    if (storageKind !== 'sharepoint') return getStaffAttendancePort();
+    if (!spReady) return createBlockedPort(readOnlyReason ?? 'SharePoint 接続が無効です。');
+    return createSharePointStaffAttendanceAdapter({ acquireToken });
+  }, [acquireToken, readOnlyReason, spReady, storageKind]);
+
+  const effectiveReadOnlyReason = readOnlyReason ?? (!writeEnabledEnv ? '書き込みが無効です（設定）。' : null);
+  const writeEnabled = writeEnabledEnv && !readOnlyReason;
+  const readOnly = !writeEnabled;
+
   const refetch = React.useCallback(async () => {
     setState((s) => ({ ...s, loading: true, error: null }));
     const res = await port.listByDate(recordDate);
     if (res.isOk) {
       setState((s) => ({ ...s, items: res.value, loading: false }));
-    } else {
-      setState((s) => ({
-        ...s,
-        loading: false,
-        error: res.error.message || res.error.kind || 'unknown',
-      }));
+      return;
     }
+
+    if (res.error.kind === 'forbidden') {
+      const message = res.error.message || 'SharePoint にアクセスできません（権限不足）。';
+      setReadOnlyReason(message);
+      setState((s) => ({ ...s, loading: false, error: null }));
+      return;
+    }
+
+    setState((s) => ({
+      ...s,
+      loading: false,
+      error: res.error.message || res.error.kind || 'unknown',
+    }));
   }, [port, recordDate]);
 
   React.useEffect(() => {
@@ -38,9 +104,24 @@ export function useStaffAttendanceAdmin(recordDate: string) {
 
   const save = React.useCallback(
     async (next: StaffAttendance) => {
+      if (!writeEnabled) {
+        setState((s) => ({
+          ...s,
+          saving: false,
+          error: effectiveReadOnlyReason ?? '書き込みが無効です（読み取り専用）。',
+        }));
+        return;
+      }
+
       setState((s) => ({ ...s, saving: true, error: null }));
       const res = await port.upsert(next);
       if (!res.isOk) {
+        if (res.error.kind === 'forbidden') {
+          const message = res.error.message || 'SharePoint にアクセスできません（権限不足）。';
+          setReadOnlyReason(message);
+          setState((s) => ({ ...s, saving: false, error: null }));
+          return;
+        }
         setState((s) => ({
           ...s,
           saving: false,
@@ -52,15 +133,21 @@ export function useStaffAttendanceAdmin(recordDate: string) {
       await refetch();
       setState((s) => ({ ...s, saving: false }));
     },
-    [port, refetch]
+    [port, refetch, writeEnabled]
   );
 
   return {
     ...state,
+    writeEnabled,
+    canWrite: writeEnabled,
+    readOnly,
+    readOnlyReason: effectiveReadOnlyReason,
+    isSharePointReady: spReady,
     refetch,
     save,
     // ✅ Bulk 用に公開（挙動は変えない）
     port,
     recordDate,
+    storageKind,
   };
 }

--- a/src/features/staff/attendance/hooks/useStaffAttendanceBulk.ts
+++ b/src/features/staff/attendance/hooks/useStaffAttendanceBulk.ts
@@ -33,8 +33,10 @@ export function useStaffAttendanceBulk(args: {
   recordDate: string; // YYYY-MM-DD
   items: StaffAttendance[]; // その日の一覧（既存/空含む）
   refetch: () => Promise<void>;
+  writeEnabled: boolean;
+  readOnlyReason?: string | null;
 }) {
-  const { port, recordDate, items, refetch } = args;
+  const { port, recordDate, items, refetch, writeEnabled, readOnlyReason } = args;
 
   const [state, setState] = React.useState<State>(() => ({
     bulkMode: false,
@@ -80,6 +82,14 @@ export function useStaffAttendanceBulk(args: {
 
   const bulkSave = React.useCallback(async () => {
     if (state.selectedIds.size === 0) return;
+
+    if (!writeEnabled) {
+      setState((s) => ({
+        ...s,
+        error: readOnlyReason ?? '書き込みが無効です（読み取り専用）',
+      }));
+      return;
+    }
 
     setState((s) => ({ ...s, saving: true, error: null }));
 
@@ -136,7 +146,7 @@ export function useStaffAttendanceBulk(args: {
       selectedIds: new Set<string>(),
       error: null,
     }));
-  }, [items, port, recordDate, refetch, state.selectedIds, state.value]);
+  }, [items, port, recordDate, refetch, state.selectedIds, state.value, writeEnabled, readOnlyReason]);
 
   return {
     bulkMode: state.bulkMode,

--- a/src/features/staff/attendance/storage.ts
+++ b/src/features/staff/attendance/storage.ts
@@ -4,8 +4,27 @@ import { localStorageStaffAttendanceAdapter, sharePointStaffAttendanceAdapter } 
 
 export type StaffAttendanceStorageKind = 'local' | 'sharepoint';
 
+const parseBoolean = (value?: string, fallback = true): boolean => {
+  if (!value) return fallback;
+  const normalized = value.trim().toLowerCase();
+  if (['1', 'true', 'yes', 'y', 'on', 'enabled'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'n', 'off', 'disabled'].includes(normalized)) return false;
+  return fallback;
+};
+
+export const getStaffAttendanceStorageKind = (): StaffAttendanceStorageKind => {
+  return (readOptionalEnv('VITE_STAFF_ATTENDANCE_STORAGE') ?? 'local') as StaffAttendanceStorageKind;
+};
+
+export const getStaffAttendanceWriteEnabled = (): boolean => {
+  const explicit = readOptionalEnv('VITE_STAFF_ATTENDANCE_WRITE');
+  if (explicit !== undefined) return parseBoolean(explicit, true);
+  const globalWrite = readOptionalEnv('VITE_WRITE_ENABLED');
+  return parseBoolean(globalWrite, true);
+};
+
 export const getStaffAttendancePort = (): StaffAttendancePort => {
-  const kind = (readOptionalEnv('VITE_STAFF_ATTENDANCE_STORAGE') ?? 'local') as StaffAttendanceStorageKind;
+  const kind = getStaffAttendanceStorageKind();
   if (kind === 'sharepoint') {
     return sharePointStaffAttendanceAdapter;
   }

--- a/tests/e2e/staff-attendance.readonly.smoke.spec.ts
+++ b/tests/e2e/staff-attendance.readonly.smoke.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test';
+import { bootstrapDashboard } from './utils/bootstrapApp';
+
+const ATTENDANCE_KEY = 'staff-attendance.v1';
+
+function ymd(d: Date) {
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+test.describe('staff attendance read-only guard', () => {
+  test('shows read-only notice and disables saves', async ({ page }) => {
+    const date = ymd(new Date());
+
+    const seed = {
+      attendances: [
+        {
+          staffId: 'S001',
+          recordDate: date,
+          status: '出勤',
+          note: 'seed note',
+          checkInAt: `${date}T09:00:00.000Z`,
+        },
+      ],
+    };
+    const seedJson = JSON.stringify(seed);
+
+    await page.addInitScript(
+      ([key, value]) => {
+        localStorage.setItem(key, value);
+      },
+      [ATTENDANCE_KEY, seedJson]
+    );
+
+    await page.addInitScript(() => {
+      const w = window as typeof window & { __ENV__?: Record<string, string> };
+      w.__ENV__ = {
+        ...(w.__ENV__ ?? {}),
+        VITE_STAFF_ATTENDANCE_STORAGE: 'local',
+        VITE_STAFF_ATTENDANCE_WRITE: '0',
+      };
+    });
+
+    await bootstrapDashboard(page, { skipLogin: true, featureSchedules: true, initialPath: '/admin/staff-attendance' });
+
+    await expect(page.getByTestId('staff-attendance-admin-root')).toBeVisible();
+    await expect(page.getByTestId('staff-attendance-readonly')).toBeVisible();
+
+    await page.getByTestId('staff-attendance-row-S001').click();
+    await expect(page.getByTestId('staff-attendance-edit-dialog')).toBeVisible();
+    await expect(page.getByTestId('staff-attendance-edit-save')).toBeDisabled();
+    await page.getByTestId('staff-attendance-edit-cancel').click();
+
+    await page.getByTestId('staff-attendance-bulk-toggle').click();
+    await page.getByTestId('staff-attendance-select-S001').click();
+    await page.getByTestId('staff-attendance-bulk-open').click();
+    await expect(page.getByTestId('staff-attendance-bulk-drawer')).toBeVisible();
+    await expect(page.getByTestId('staff-attendance-bulk-save')).toBeDisabled();
+  });
+});


### PR DESCRIPTION
🔒 Phase 3.4-A seal: enforce read-only behavior when SharePoint is skipped

- Force read-only via VITE_SKIP_SHAREPOINT or VITE_STAFF_ATTENDANCE_WRITE=0
- Show read-only notice with clear reason
- Allow opening edit dialog / bulk drawer for inspection
- Hard-disable edit/bulk save buttons via Hook and UI
- E2E smoke test verifies notice + disabled saves
- No silent fallback to localStorage (write gate enforced)