### PR TITLE
feat: staff attendance monthly summary page

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -67,6 +67,7 @@ const StaffAttendanceInput = React.lazy(() =>
 );
 
 const StaffAttendanceAdminPage = React.lazy(() => import('@/pages/StaffAttendanceAdminPage'));
+const StaffAttendanceMonthlySummaryPage = React.lazy(() => import('@/pages/StaffAttendanceMonthlySummaryPage'));
 
 // Diagnostics pages
 const HealthPage = React.lazy(() => import('@/pages/HealthPage'));
@@ -567,6 +568,24 @@ const childRoutes: RouteObject[] = [
             )}
           >
             <StaffAttendanceAdminPage />
+          </React.Suspense>
+        </RouteHydrationErrorBoundary>
+      </AdminGate>
+    ),
+  },
+  {
+    path: 'admin/staff-attendance/summary',
+    element: (
+      <AdminGate>
+        <RouteHydrationErrorBoundary>
+          <React.Suspense
+            fallback={(
+              <div className="p-4 text-sm text-slate-600" role="status">
+                月次サマリーを読み込んでいます…
+              </div>
+            )}
+          >
+            <StaffAttendanceMonthlySummaryPage />
           </React.Suspense>
         </RouteHydrationErrorBoundary>
       </AdminGate>

--- a/src/features/staff/attendance/__tests__/summary.spec.ts
+++ b/src/features/staff/attendance/__tests__/summary.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildMonthlySummary,
+  buildStaffBreakdown,
+  countByStatus,
+  listAllStatuses,
+  type AttendanceLike,
+} from "../summary";
+
+const mk = (recordDate: string, staffId: string, status: string): AttendanceLike => ({
+  recordDate,
+  staffId,
+  status,
+});
+
+describe("staff attendance summary", () => {
+  it("countByStatus counts and normalizes blanks", () => {
+    const items = [
+      mk("2026-02-01", "S001", "出勤"),
+      mk("2026-02-01", "S001", "出勤"),
+      mk("2026-02-01", "S001", "遅刻"),
+      mk("2026-02-02", "S002", ""),
+    ];
+    expect(countByStatus(items)).toEqual({ "出勤": 2, "遅刻": 1, "(unknown)": 1 });
+  });
+
+  it("buildMonthlySummary returns totals + unique staff count", () => {
+    const items = [
+      mk("2026-02-01", "S001", "出勤"),
+      mk("2026-02-01", "S002", "欠勤"),
+      mk("2026-02-02", "S002", "出勤"),
+    ];
+    const s = buildMonthlySummary(items);
+    expect(s.totalItems).toBe(3);
+    expect(s.uniqueStaffCount).toBe(2);
+    expect(s.countsByStatus).toEqual({ "出勤": 2, "欠勤": 1 });
+  });
+
+  it("buildStaffBreakdown groups by staff and sorts by total desc", () => {
+    const items = [
+      mk("2026-02-01", "S001", "出勤"),
+      mk("2026-02-02", "S001", "遅刻"),
+      mk("2026-02-01", "S002", "出勤"),
+    ];
+    const rows = buildStaffBreakdown(items);
+    expect(rows.map((r) => r.staffId)).toEqual(["S001", "S002"]);
+    expect(rows[0].countsByStatus).toEqual({ "出勤": 1, "遅刻": 1 });
+    expect(rows[0].total).toBe(2);
+    expect(rows[1].total).toBe(1);
+  });
+
+  it("listAllStatuses returns sorted status keys", () => {
+    expect(listAllStatuses({ "遅刻": 1, "出勤": 2, "欠勤": 3 })).toEqual(["欠勤", "出勤", "遅刻"]);
+  });
+});

--- a/src/features/staff/attendance/summary.ts
+++ b/src/features/staff/attendance/summary.ts
@@ -1,0 +1,70 @@
+export type AttendanceLike = {
+  recordDate: string; // YYYY-MM-DD
+  staffId: string;
+  status: string;
+};
+
+export type AttendanceCounts = Record<string, number>;
+
+export type MonthlySummary = {
+  totalItems: number;
+  uniqueStaffCount: number;
+  countsByStatus: AttendanceCounts;
+};
+
+export type StaffBreakdownRow = {
+  staffId: string;
+  countsByStatus: AttendanceCounts;
+  total: number;
+};
+
+const normalizeKey = (v: unknown): string => {
+  const s = String(v ?? "").trim();
+  return s.length > 0 ? s : "(unknown)";
+};
+
+export const countByStatus = <T extends AttendanceLike>(items: T[]): AttendanceCounts => {
+  const out: AttendanceCounts = {};
+  for (const it of items) {
+    const key = normalizeKey(it.status);
+    out[key] = (out[key] ?? 0) + 1;
+  }
+  return out;
+};
+
+export const buildMonthlySummary = <T extends AttendanceLike>(items: T[]): MonthlySummary => {
+  const staffSet = new Set<string>();
+  for (const it of items) {
+    staffSet.add(normalizeKey(it.staffId));
+  }
+  return {
+    totalItems: items.length,
+    uniqueStaffCount: staffSet.size,
+    countsByStatus: countByStatus(items),
+  };
+};
+
+export const buildStaffBreakdown = <T extends AttendanceLike>(items: T[]): StaffBreakdownRow[] => {
+  const map = new Map<string, AttendanceCounts>();
+  for (const it of items) {
+    const staffId = normalizeKey(it.staffId);
+    const status = normalizeKey(it.status);
+    const cur = map.get(staffId) ?? {};
+    cur[status] = (cur[status] ?? 0) + 1;
+    map.set(staffId, cur);
+  }
+
+  const rows: StaffBreakdownRow[] = [];
+  for (const [staffId, countsByStatus] of map.entries()) {
+    const total = Object.values(countsByStatus).reduce((a, b) => a + b, 0);
+    rows.push({ staffId, countsByStatus, total });
+  }
+
+  // total desc -> staffId asc (stable)
+  rows.sort((a, b) => (b.total - a.total) || a.staffId.localeCompare(b.staffId));
+  return rows;
+};
+
+export const listAllStatuses = (countsByStatus: AttendanceCounts): string[] => {
+  return Object.keys(countsByStatus).sort((a, b) => a.localeCompare(b, "ja"));
+};

--- a/src/pages/StaffAttendanceMonthlySummaryPage.tsx
+++ b/src/pages/StaffAttendanceMonthlySummaryPage.tsx
@@ -1,0 +1,217 @@
+import { useMemo, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from "@mui/material";
+
+import { useStaffAttendanceAdmin } from "@/features/staff/attendance/hooks/useStaffAttendanceAdmin";
+import { useStaffStore } from "@/features/staff/store";
+import {
+  buildMonthlySummary,
+  buildStaffBreakdown,
+  listAllStatuses,
+  type AttendanceLike,
+} from "@/features/staff/attendance/summary";
+
+const pad2 = (n: number) => String(n).padStart(2, "0");
+const toISODate = (y: number, m: number, d: number) => `${y}-${pad2(m)}-${pad2(d)}`;
+const lastDayOfMonth = (y: number, m: number) => new Date(y, m, 0).getDate(); // m: 1-12
+
+const defaultMonthValue = (): string => {
+  const now = new Date();
+  return `${now.getFullYear()}-${pad2(now.getMonth() + 1)}`; // YYYY-MM
+};
+
+const monthToRange = (ym: string): { from: string; to: string } => {
+  const [yStr, mStr] = ym.split("-");
+  const y = Number(yStr);
+  const m = Number(mStr);
+  const from = toISODate(y, m, 1);
+  const to = toISODate(y, m, lastDayOfMonth(y, m));
+  return { from, to };
+};
+
+export default function StaffAttendanceMonthlySummaryPage() {
+  const {
+    listItems,
+    listLoading,
+    listError,
+    fetchListByDateRange,
+  } = useStaffAttendanceAdmin(""); // dummy date since we control range via monthValue
+
+  const { byId: staffById } = useStaffStore();
+
+  const [monthValue, setMonthValue] = useState<string>(() => defaultMonthValue());
+  const { from, to } = useMemo(() => monthToRange(monthValue), [monthValue]);
+
+  const items = (listItems ?? []) as AttendanceLike[];
+
+  const summary = useMemo(() => buildMonthlySummary(items), [items]);
+  const breakdown = useMemo(() => buildStaffBreakdown(items), [items]);
+  const statuses = useMemo(() => listAllStatuses(summary.countsByStatus), [summary.countsByStatus]);
+
+  const resolveStaffName = (staffId: string): string => {
+    // Try parsing as number for staffById Map lookup
+    const numId = Number(staffId);
+    const s = Number.isFinite(numId) ? staffById?.get(numId) : undefined;
+    return s?.name ?? staffId;
+  };
+
+  return (
+    <Box sx={{ p: 2 }}>
+      <Stack spacing={2}>
+        <Typography variant="h5" sx={{ fontWeight: 700 }}>
+          勤怠 月次サマリー
+        </Typography>
+
+        <Paper sx={{ p: 2 }}>
+          <Stack direction={{ xs: "column", sm: "row" }} spacing={2} alignItems={{ sm: "center" }}>
+            <TextField
+              label="対象月"
+              type="month"
+              value={monthValue}
+              onChange={(e) => setMonthValue(e.target.value)}
+              inputProps={{ "data-testid": "staff-attendance-summary-month" }}
+              sx={{ width: 220 }}
+            />
+            <Box sx={{ flex: 1 }} />
+            <Button
+              variant="contained"
+              onClick={() => fetchListByDateRange(from, to)}
+              disabled={listLoading}
+              data-testid="staff-attendance-summary-fetch"
+            >
+              {listLoading ? <CircularProgress size={20} /> : "読み込み"}
+            </Button>
+          </Stack>
+
+          <Typography variant="body2" sx={{ mt: 1, color: "text.secondary" }}>
+            範囲: {from} 〜 {to}
+          </Typography>
+        </Paper>
+
+        {listError && (
+          <Alert severity="error" data-testid="staff-attendance-summary-error">
+            {String(listError)}
+          </Alert>
+        )}
+
+        <Paper sx={{ p: 2 }}>
+          <Typography variant="h6" sx={{ fontWeight: 700, mb: 2 }}>
+            サマリー
+          </Typography>
+          <Stack direction={{ xs: "column", md: "row" }} spacing={2}>
+            <Paper variant="outlined" sx={{ p: 1.5, minWidth: 220 }}>
+              <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                総件数
+              </Typography>
+              <Typography variant="h6" data-testid="staff-attendance-summary-total">
+                {summary.totalItems}
+              </Typography>
+            </Paper>
+
+            <Paper variant="outlined" sx={{ p: 1.5, minWidth: 220 }}>
+              <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                職員数
+              </Typography>
+              <Typography variant="h6" data-testid="staff-attendance-summary-staffcount">
+                {summary.uniqueStaffCount}
+              </Typography>
+            </Paper>
+
+            {statuses.map((st) => (
+              <Paper key={st} variant="outlined" sx={{ p: 1.5, minWidth: 220 }}>
+                <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                  {st}
+                </Typography>
+                <Typography
+                  variant="h6"
+                  data-testid={`staff-attendance-summary-status-${st}`}
+                >
+                  {summary.countsByStatus[st] ?? 0}
+                </Typography>
+              </Paper>
+            ))}
+          </Stack>
+        </Paper>
+
+        <Paper sx={{ p: 2 }}>
+          <Typography variant="h6" sx={{ fontWeight: 700, mb: 2 }}>
+            職員別
+          </Typography>
+
+          {!listLoading && breakdown.length === 0 && !listError && (
+            <Alert severity="info" data-testid="staff-attendance-summary-empty">
+              データがありません。対象月を選び「読み込み」を押してください。
+            </Alert>
+          )}
+
+          {listLoading && (
+            <Stack direction="row" spacing={2} alignItems="center">
+              <CircularProgress size={20} />
+              <Typography>読み込み中…</Typography>
+            </Stack>
+          )}
+
+          {breakdown.length > 0 && (
+            <Table size="small" data-testid="staff-attendance-summary-table">
+              <TableHead>
+                <TableRow>
+                  <TableCell sx={{ fontWeight: 800 }}>職員</TableCell>
+                  {statuses.map((st) => (
+                    <TableCell
+                      key={`head-${st}`}
+                      align="right"
+                      sx={{ fontWeight: 800 }}
+                    >
+                      {st}
+                    </TableCell>
+                  ))}
+                  <TableCell align="right" sx={{ fontWeight: 800 }}>
+                    合計
+                  </TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {breakdown.map((r) => (
+                  <TableRow key={r.staffId}>
+                    <TableCell>
+                      {resolveStaffName(r.staffId)}{" "}
+                      <Typography
+                        component="span"
+                        variant="body2"
+                        sx={{ color: "text.secondary" }}
+                      >
+                        ({r.staffId})
+                      </Typography>
+                    </TableCell>
+                    {statuses.map((st) => (
+                      <TableCell
+                        key={`${r.staffId}-${st}`}
+                        align="right"
+                      >
+                        {r.countsByStatus[st] ?? 0}
+                      </TableCell>
+                    ))}
+                    <TableCell align="right">{r.total}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </Paper>
+      </Stack>
+    </Box>
+  );
+}


### PR DESCRIPTION
Phase 3.5-A: add a new admin page for monthly attendance summary.

## Changes
- Add pure summary utilities + unit tests
- Add /admin/staff-attendance/summary page (month picker, summary cards, staff breakdown)
- Route is protected by AdminGate (same as admin page)

## Quality
- TypeCheck PASS
- Lint PASS
- Unit tests PASS (summary.spec.ts)