### PR TITLE
feat: operationalize staff attendance monthly summary

### DIFF
--- a/src/features/staff/attendance/__tests__/summary.spec.ts
+++ b/src/features/staff/attendance/__tests__/summary.spec.ts
@@ -7,10 +7,16 @@ import {
   type AttendanceLike,
 } from "../summary";
 
-const mk = (recordDate: string, staffId: string, status: string): AttendanceLike => ({
+const mk = (
+  recordDate: string,
+  staffId: string,
+  status: string,
+  lateMinutes?: number | null,
+): AttendanceLike => ({
   recordDate,
   staffId,
   status,
+  lateMinutes,
 });
 
 describe("staff attendance summary", () => {
@@ -24,29 +30,35 @@ describe("staff attendance summary", () => {
     expect(countByStatus(items)).toEqual({ "出勤": 2, "遅刻": 1, "(unknown)": 1 });
   });
 
-  it("buildMonthlySummary returns totals + unique staff count", () => {
+  it("buildMonthlySummary returns totals + unique staff count + derived counts", () => {
     const items = [
       mk("2026-02-01", "S001", "出勤"),
       mk("2026-02-01", "S002", "欠勤"),
-      mk("2026-02-02", "S002", "出勤"),
+      mk("2026-02-02", "S002", "出勤", 5),
     ];
     const s = buildMonthlySummary(items);
     expect(s.totalItems).toBe(3);
     expect(s.uniqueStaffCount).toBe(2);
+    expect(s.attendanceCount).toBe(2);
+    expect(s.absenceCount).toBe(1);
+    expect(s.lateCount).toBe(1);
+    expect(s.earlyLeaveCount).toBe(0);
     expect(s.countsByStatus).toEqual({ "出勤": 2, "欠勤": 1 });
   });
 
-  it("buildStaffBreakdown groups by staff and sorts by total desc", () => {
+  it("buildStaffBreakdown groups by staff and sorts by absence/late/total", () => {
     const items = [
       mk("2026-02-01", "S001", "出勤"),
       mk("2026-02-02", "S001", "遅刻"),
-      mk("2026-02-01", "S002", "出勤"),
+      mk("2026-02-01", "S002", "欠勤"),
+      mk("2026-02-02", "S002", "出勤", 3),
     ];
     const rows = buildStaffBreakdown(items);
-    expect(rows.map((r) => r.staffId)).toEqual(["S001", "S002"]);
-    expect(rows[0].countsByStatus).toEqual({ "出勤": 1, "遅刻": 1 });
-    expect(rows[0].total).toBe(2);
-    expect(rows[1].total).toBe(1);
+    expect(rows.map((r) => r.staffId)).toEqual(["S002", "S001"]);
+    expect(rows[0].countsByStatus).toEqual({ "欠勤": 1, "出勤": 1 });
+    expect(rows[0].absenceCount).toBe(1);
+    expect(rows[0].lateCount).toBe(1);
+    expect(rows[1].lateCount).toBe(1);
   });
 
   it("listAllStatuses returns sorted status keys", () => {

--- a/src/features/staff/attendance/summary.ts
+++ b/src/features/staff/attendance/summary.ts
@@ -2,6 +2,7 @@ export type AttendanceLike = {
   recordDate: string; // YYYY-MM-DD
   staffId: string;
   status: string;
+  lateMinutes?: number | null;
 };
 
 export type AttendanceCounts = Record<string, number>;
@@ -9,6 +10,10 @@ export type AttendanceCounts = Record<string, number>;
 export type MonthlySummary = {
   totalItems: number;
   uniqueStaffCount: number;
+  attendanceCount: number;
+  absenceCount: number;
+  lateCount: number;
+  earlyLeaveCount: number;
   countsByStatus: AttendanceCounts;
 };
 
@@ -16,11 +21,29 @@ export type StaffBreakdownRow = {
   staffId: string;
   countsByStatus: AttendanceCounts;
   total: number;
+  attendanceCount: number;
+  absenceCount: number;
+  lateCount: number;
+  earlyLeaveCount: number;
 };
+
+export const ATTENDANCE_STATUS_SET = new Set(['出勤', '外出中', '遅刻', '早退']);
+export const ABSENCE_STATUS_SET = new Set(['欠勤']);
+export const LATE_STATUS_SET = new Set(['遅刻']);
+export const EARLY_LEAVE_STATUS_SET = new Set(['早退']);
 
 const normalizeKey = (v: unknown): string => {
   const s = String(v ?? "").trim();
   return s.length > 0 ? s : "(unknown)";
+};
+
+const classifyStatus = (status: string, lateMinutes?: number | null) => {
+  const key = normalizeKey(status);
+  const isLate = LATE_STATUS_SET.has(key) || (lateMinutes ?? 0) > 0;
+  const isEarlyLeave = EARLY_LEAVE_STATUS_SET.has(key);
+  const isAbsence = ABSENCE_STATUS_SET.has(key);
+  const isAttendance = ATTENDANCE_STATUS_SET.has(key) || isLate || isEarlyLeave;
+  return { key, isAttendance, isAbsence, isLate, isEarlyLeave };
 };
 
 export const countByStatus = <T extends AttendanceLike>(items: T[]): AttendanceCounts => {
@@ -34,34 +57,76 @@ export const countByStatus = <T extends AttendanceLike>(items: T[]): AttendanceC
 
 export const buildMonthlySummary = <T extends AttendanceLike>(items: T[]): MonthlySummary => {
   const staffSet = new Set<string>();
+  let attendanceCount = 0;
+  let absenceCount = 0;
+  let lateCount = 0;
+  let earlyLeaveCount = 0;
   for (const it of items) {
     staffSet.add(normalizeKey(it.staffId));
+    const { isAttendance, isAbsence, isLate, isEarlyLeave } = classifyStatus(it.status, it.lateMinutes);
+    if (isAttendance) attendanceCount += 1;
+    if (isAbsence) absenceCount += 1;
+    if (isLate) lateCount += 1;
+    if (isEarlyLeave) earlyLeaveCount += 1;
   }
   return {
     totalItems: items.length,
     uniqueStaffCount: staffSet.size,
+    attendanceCount,
+    absenceCount,
+    lateCount,
+    earlyLeaveCount,
     countsByStatus: countByStatus(items),
   };
 };
 
 export const buildStaffBreakdown = <T extends AttendanceLike>(items: T[]): StaffBreakdownRow[] => {
-  const map = new Map<string, AttendanceCounts>();
+  const map = new Map<string, {
+    countsByStatus: AttendanceCounts;
+    attendanceCount: number;
+    absenceCount: number;
+    lateCount: number;
+    earlyLeaveCount: number;
+  }>();
   for (const it of items) {
     const staffId = normalizeKey(it.staffId);
-    const status = normalizeKey(it.status);
-    const cur = map.get(staffId) ?? {};
-    cur[status] = (cur[status] ?? 0) + 1;
+    const { key, isAttendance, isAbsence, isLate, isEarlyLeave } = classifyStatus(it.status, it.lateMinutes);
+    const cur = map.get(staffId) ?? {
+      countsByStatus: {},
+      attendanceCount: 0,
+      absenceCount: 0,
+      lateCount: 0,
+      earlyLeaveCount: 0,
+    };
+    cur.countsByStatus[key] = (cur.countsByStatus[key] ?? 0) + 1;
+    if (isAttendance) cur.attendanceCount += 1;
+    if (isAbsence) cur.absenceCount += 1;
+    if (isLate) cur.lateCount += 1;
+    if (isEarlyLeave) cur.earlyLeaveCount += 1;
     map.set(staffId, cur);
   }
 
   const rows: StaffBreakdownRow[] = [];
-  for (const [staffId, countsByStatus] of map.entries()) {
-    const total = Object.values(countsByStatus).reduce((a, b) => a + b, 0);
-    rows.push({ staffId, countsByStatus, total });
+  for (const [staffId, payload] of map.entries()) {
+    const total = Object.values(payload.countsByStatus).reduce((a, b) => a + b, 0);
+    rows.push({
+      staffId,
+      countsByStatus: payload.countsByStatus,
+      total,
+      attendanceCount: payload.attendanceCount,
+      absenceCount: payload.absenceCount,
+      lateCount: payload.lateCount,
+      earlyLeaveCount: payload.earlyLeaveCount,
+    });
   }
 
-  // total desc -> staffId asc (stable)
-  rows.sort((a, b) => (b.total - a.total) || a.staffId.localeCompare(b.staffId));
+  // absence desc -> late desc -> total desc -> staffId asc (stable)
+  rows.sort((a, b) =>
+    (b.absenceCount - a.absenceCount)
+    || (b.lateCount - a.lateCount)
+    || (b.total - a.total)
+    || a.staffId.localeCompare(b.staffId)
+  );
   return rows;
 };
 

--- a/src/pages/StaffAttendanceAdminPage.tsx
+++ b/src/pages/StaffAttendanceAdminPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useCallback } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 import {
   Box,
   Paper,
@@ -466,9 +466,19 @@ export default function StaffAttendanceAdminPage(): JSX.Element {
       <Divider sx={{ my: 4 }} />
 
       <Stack spacing={2}>
-        <Typography variant="h6" sx={{ fontWeight: 800 }}>
-          勤怠一覧（読み取り）
-        </Typography>
+        <Stack direction="row" alignItems="center" justifyContent="space-between" spacing={2}>
+          <Typography variant="h6" sx={{ fontWeight: 800 }}>
+            勤怠一覧（読み取り）
+          </Typography>
+          <Button
+            component={Link}
+            to="/admin/staff-attendance/summary"
+            size="small"
+            variant="outlined"
+          >
+            月次サマリーへ
+          </Button>
+        </Stack>
 
         <Paper variant="outlined" sx={{ p: 2 }}>
           <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems={{ sm: 'center' }}>


### PR DESCRIPTION
Phase 3.5-B: operationalize the monthly summary page.

## Changes
- Add status classification sets + derived counts (attendance/absence/late/early-leave)
- Sort staff breakdown by absence -> late -> total
- Month param sync (?month=YYYY-MM) and last-fetched metadata
- Add navigation links between admin list and summary

## Quality
- TypeCheck PASS
- Lint PASS
- Unit tests PASS (summary.spec.ts)