### PR TITLE
chore(cf): align wrangler worker name to audit-management-system-mvp

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,8 +1,9 @@
 # ⚠️ CRITICAL:
 # This `name` must exactly match the Cloudflare Dashboard Worker name (case-sensitive).
 # A mismatch can deploy/update a different Worker and break production auth flows (e.g., MSAL callback/token handling).
-# Verified: 2026-01-24 (account: Momosantanuki@gmail.com's Account)
-name = "isogo-system"
+# Verified: 2026-02-01 (account: Momosantanuki@gmail.com's Account)
+# Production Worker: audit-management-system-mvp (isogo-system is legacy/standby)
+name = "audit-management-system-mvp"
 compatibility_date = "2026-01-17"
 main = "src/worker.ts"
 


### PR DESCRIPTION
Align wrangler.toml worker name to the deployed Worker (audit-management-system-mvp). Keep isogo-system as legacy/standby. No runtime logic changes.

This change only updates deployment metadata (wrangler.toml); application runtime is unchanged.