### PR TITLE
ci(guardrails): require cf/wrangler label on wrangler.toml changes (3.6-E)

### DIFF
--- a/.github/workflows/pr-guardrails.yml
+++ b/.github/workflows/pr-guardrails.yml
@@ -23,7 +23,6 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const core = require('@actions/core');
             const requiredLabel = 'cf/wrangler';
             const owner = context.repo.owner;
             const repo = context.repo.repo;


### PR DESCRIPTION
## Phase 3.6-E: PR Guardrails for Wrangler Changes

### Goal
Prevent accidental / auto-generated PRs that touch Cloudflare configuration from merging without explicit intent.

### What
- Add `.github/workflows/pr-guardrails.yml`
- If `wrangler.toml` changes, **require `cf/wrangler` label**
- If label is set but file not changed, emit warning (not failing)

### Why
- Prevent Cloudflare auto-PR “title mismatch” incidents
- Make Cloudflare config changes explicit and reviewable

