### PR TITLE
fix(schedules): add diagnostics for ScheduleEvents read parse failures

### DIFF
--- a/src/features/schedules/data/sharePointAdapter.ts
+++ b/src/features/schedules/data/sharePointAdapter.ts
@@ -172,7 +172,17 @@ const fetchRange = async (
     throw error;
   }
   const payload = (await response.json()) as SharePointResponse<unknown>;
-  return parseSpScheduleRows(payload.value ?? []);
+  try {
+    return parseSpScheduleRows(payload.value ?? []);
+  } catch (parseError) {
+    // Dump raw payload on parse failure (helps diagnose field/shape issues)
+    console.error('[schedules] fetchRange parse failed', {
+      url,
+      status: response.status,
+      payloadPreview: JSON.stringify(payload).slice(0, 2000),
+    });
+    throw parseError;
+  }
 };
 
 const buildRangeFilter = (range: DateRange): string => {

--- a/src/features/schedules/useSchedules.ts
+++ b/src/features/schedules/useSchedules.ts
@@ -90,10 +90,11 @@ export function useSchedules(range: DateRange): UseSchedulesResult {
         if (!alive) return;
         const error = err instanceof Error ? err.message : 'Failed to fetch schedules';
         // eslint-disable-next-line no-console
-        console.error('[useSchedules] Error detail:', {
+        console.error('[useSchedules] Failed to load schedule items', {
           message: error,
-          errorFull: err,
+          err,
           status: (err as { status?: number }).status,
+          url: (err as { url?: string }).url,
           body: (err as { body?: string }).body,
         });
         setLastError({ message: error } as ResultError);


### PR DESCRIPTION
Adds targeted logging to capture OData shape variance and Zod issues for ScheduleEvents read failures (Issue #313).