### PR TITLE
feat(ui): focus mode (in-app full-screen)

### DIFF
--- a/src/features/settings/SettingsDialog.tsx
+++ b/src/features/settings/SettingsDialog.tsx
@@ -76,6 +76,21 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({ open, onClose })
             />
           </Stack>
 
+          <Divider sx={{ my: 2 }} />
+
+          <FormControlLabel
+            control={
+              <Switch
+                checked={settings.layoutMode === 'focus'}
+                onChange={(_, checked) =>
+                  updateSettings({ layoutMode: checked ? 'focus' : 'normal' })
+                }
+                inputProps={{ 'aria-label': '集中モード（全画面）' }}
+              />
+            }
+            label="集中モード（全画面）"
+          />
+
           {/* 将来の設定項目プレースホルダー */}
           <Typography variant="caption" color="text.secondary" sx={{ pt: 2 }}>
             その他の表示設定（フォントサイズ、色カスタマイズなど）は今後実装予定です。

--- a/src/features/settings/settingsModel.ts
+++ b/src/features/settings/settingsModel.ts
@@ -18,6 +18,9 @@ export type UserSettings = {
   // Color presets (Phase 2+)
   colorPreset: 'default' | 'highContrast' | 'custom';
 
+  // Layout mode (Phase 6: Focus Mode)
+  layoutMode: 'normal' | 'focus';
+
   // Timestamp for sync validation
   lastModified: number;
 };
@@ -28,6 +31,7 @@ export const DEFAULT_SETTINGS: UserSettings = {
   density: 'comfortable',
   fontSize: 'medium',
   colorPreset: 'default',
+  layoutMode: 'normal',
   lastModified: Date.now(),
 };
 
@@ -61,6 +65,7 @@ export function loadSettingsFromStorage(): UserSettings {
       density: parsed.density as UserSettings['density'],
       fontSize: parsed.fontSize as UserSettings['fontSize'],
       colorPreset: parsed.colorPreset || 'default',
+      layoutMode: parsed.layoutMode || 'normal',
       lastModified: parsed.lastModified || Date.now(),
     };
   } catch (error) {


### PR DESCRIPTION
## Summary
- Add layoutMode (normal/focus) to settings
- Add Focus Mode toggle in SettingsDialog
- Hide AppBar/Drawer and maximize main area in focus mode
- Provide exit via FAB + ESC

## Notes
- Side-effects remain centralized (no extra CSS writes here).
