### PR TITLE
fix(auth): Remove duplicate handleRedirectPromise

### DIFF
--- a/src/auth/azureMsal.ts
+++ b/src/auth/azureMsal.ts
@@ -56,29 +56,7 @@ export const getPcaSingleton = async (): Promise<PublicClientApplication> => {
 
 	pcaInstance = new PublicClientApplication(config);
 
-	// Handle redirect promise (critical for redirect flow)
-	pcaInstance
-		.handleRedirectPromise()
-		.then((result) => {
-			if (result?.account) {
-				pcaInstance?.setActiveAccount(result.account);
-				console.info('[msal] redirect login completed, account set from result');
-			} else {
-				// Fallback: restore active account from cache if available
-				// (handles restart after redirect when result is null)
-				const active = pcaInstance?.getActiveAccount();
-				if (!active) {
-					const accounts = pcaInstance?.getAllAccounts() ?? [];
-					if (accounts.length > 0) {
-						pcaInstance?.setActiveAccount(accounts[0]);
-						console.info('[msal] restored active account from fallback');
-					}
-				}
-			}
-		})
-		.catch((err) => {
-			console.warn('[msal] handleRedirectPromise error (may be normal if not redirect flow)', err);
-		});
+	// (handleRedirectPromise responsibility moved to main.tsx)
 
 	// Cache in globalThis for use by MsalProvider + other consumers
 	(globalThis as MsalGlobalCarrier).__MSAL_PUBLIC_CLIENT__ = pcaInstance;


### PR DESCRIPTION
fix(auth): Remove duplicate handleRedirectPromise from azureMsal

**Problem:**
- handleRedirectPromise() was called twice:
  1. In azureMsal.ts (getPcaSingleton)
  2. In main.tsx (app initialization)
- This caused redirect hash (#code, #state) consumption race
- Second call always got null → "no redirect result" → login failure

**Solution:**
- Removed all redirect handling from getPcaSingleton()
- Centralized handleRedirectPromise responsibility to main.tsx only
- PCA singleton is now a pure factory (no side effects)

**Design:**
- azureMsal.ts: PCA creation & caching only
- main.tsx: Redirect handling at app startup

**Impact:**
- ✅ Eliminates redirect hash consumption race
- ✅ Fixes "logged in but treated as logged out" issue
- ✅ Improves login reliability & E2E test stability

**Reference:**
- MSAL principle: handleRedirectPromise() consumes hash exactly once
- Double invocation = guaranteed failure pattern