### PR TITLE
feat(settings): font size control (Phase 7.1)

### DIFF
--- a/src/app/createAppTheme.ts
+++ b/src/app/createAppTheme.ts
@@ -12,6 +12,16 @@ const densitySpacingMap = {
 } as const;
 
 /**
+ * Font size map (Phase 7.1 - Font Size Control)
+ * Maps user-selected fontSize preference to px values
+ */
+const fontSizeMap = {
+  small: 12,       // Compact, high-density display
+  medium: 14,      // Standard, balanced display
+  large: 16,       // Accessible, spacious display
+} as const;
+
+/**
  * Creates MUI theme with user settings (density, fontSize, etc.)
  * 
  * Pure function - no side effects, easy to test
@@ -27,9 +37,13 @@ const densitySpacingMap = {
  */
 export function createAppTheme(settings: UserSettings): Theme {
   const densityBase = densitySpacingMap[settings.density];
+  const baseFontSize = fontSizeMap[settings.fontSize];
 
   return createTheme({
     spacing: densityBase,
+    typography: {
+      fontSize: baseFontSize,
+    },
     components: {
       // Button - density-aware padding
       MuiButton: {

--- a/src/features/settings/SettingsDialog.tsx
+++ b/src/features/settings/SettingsDialog.tsx
@@ -13,7 +13,7 @@ import Brightness4Icon from '@mui/icons-material/Brightness4';
 import Brightness7Icon from '@mui/icons-material/Brightness7';
 import { ColorModeContext } from '@/app/theme';
 import { useSettingsContext } from './SettingsContext';
-import { DensityControl } from './components';
+import { DensityControl, FontSizeControl } from './components';
 
 interface SettingsDialogProps {
   open: boolean;
@@ -26,6 +26,10 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({ open, onClose })
 
   const handleDensityChange = useCallback((newDensity: 'compact' | 'comfortable' | 'spacious') => {
     updateSettings({ density: newDensity });
+  }, [updateSettings]);
+
+  const handleFontSizeChange = useCallback((newFontSize: 'small' | 'medium' | 'large') => {
+    updateSettings({ fontSize: newFontSize });
   }, [updateSettings]);
 
   return (
@@ -78,6 +82,16 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({ open, onClose })
 
           <Divider sx={{ my: 2 }} />
 
+          {/* フォントサイズ設定 */}
+          <Stack spacing={2}>
+            <FontSizeControl
+              value={settings.fontSize}
+              onChange={handleFontSizeChange}
+            />
+          </Stack>
+
+          <Divider sx={{ my: 2 }} />
+
           <FormControlLabel
             control={
               <Switch
@@ -93,7 +107,7 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({ open, onClose })
 
           {/* 将来の設定項目プレースホルダー */}
           <Typography variant="caption" color="text.secondary" sx={{ pt: 2 }}>
-            その他の表示設定（フォントサイズ、色カスタマイズなど）は今後実装予定です。
+            その他の表示設定（色カスタマイズなど）は今後実装予定です。
           </Typography>
         </Stack>
       </DialogContent>

--- a/src/features/settings/components/FontSizeControl.tsx
+++ b/src/features/settings/components/FontSizeControl.tsx
@@ -1,0 +1,147 @@
+import React, { useCallback } from 'react';
+import {
+  FormControl,
+  FormControlLabel,
+  FormLabel,
+  Radio,
+  RadioGroup,
+  Stack,
+  Typography,
+  Box,
+} from '@mui/material';
+import type { UserSettings } from '@/features/settings/settingsModel';
+
+export type FontSize = UserSettings['fontSize'];
+
+interface FontSizeControlProps {
+  value: FontSize;
+  onChange: (fontSize: FontSize) => void;
+}
+
+/**
+ * FontSize Control Component
+ * Allows users to select from 3 predefined font sizes
+ * - small: 12px (compact, high density)
+ * - medium: 14px (standard, comfortable)
+ * - large: 16px (accessible, spacious)
+ *
+ * Applied via createAppTheme typography.fontSize
+ */
+export const FontSizeControl: React.FC<FontSizeControlProps> = ({ value, onChange }) => {
+  const handleChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      onChange(event.target.value as FontSize);
+    },
+    [onChange]
+  );
+
+  const fontSizeOptions = [
+    { value: 'small' as const, label: '小', description: '12px - コンパクト表示' },
+    { value: 'medium' as const, label: '標準', description: '14px - 標準表示' },
+    { value: 'large' as const, label: '大', description: '16px - 読みやすい' },
+  ];
+
+  return (
+    <FormControl component="fieldset" fullWidth>
+      <FormLabel component="legend" sx={{ fontWeight: 700, mb: 1.5 }}>
+        フォントサイズ
+      </FormLabel>
+      <RadioGroup value={value} onChange={handleChange} data-testid="font-size-radio-group">
+        <Stack spacing={1.5}>
+          {fontSizeOptions.map((option) => (
+            <Box
+              key={option.value}
+              sx={{
+                display: 'flex',
+                alignItems: 'flex-start',
+                p: 1.5,
+                borderRadius: 1,
+                backgroundColor:
+                  value === option.value ? 'action.hover' : 'transparent',
+                transition: 'background-color 0.2s ease',
+                cursor: 'pointer',
+                '&:hover': {
+                  backgroundColor: 'action.hover',
+                },
+              }}
+            >
+              <FormControlLabel
+                value={option.value}
+                control={
+                  <Radio
+                    size="small"
+                    sx={{ mr: 1.5, mt: 0.25 }}
+                    data-testid={`font-size-radio-${option.value}`}
+                  />
+                }
+                label={
+                  <Stack spacing={0.25}>
+                    <Typography
+                      variant="body2"
+                      sx={{
+                        fontWeight: value === option.value ? 600 : 500,
+                      }}
+                    >
+                      {option.label}
+                    </Typography>
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{ fontSize: '0.7rem' }}
+                    >
+                      {option.description}
+                    </Typography>
+                  </Stack>
+                }
+                sx={{ width: '100%', m: 0 }}
+              />
+            </Box>
+          ))}
+        </Stack>
+      </RadioGroup>
+
+      {/* Preview text showing actual font sizes */}
+      <Stack
+        spacing={1}
+        sx={{
+          mt: 2.5,
+          pt: 2,
+          borderTop: '1px solid',
+          borderColor: 'divider',
+        }}
+      >
+        <Typography variant="caption" color="text.secondary">
+          プレビュー:
+        </Typography>
+        <Box
+          sx={{
+            '& .preview-small': {
+              fontSize: '12px',
+              lineHeight: 1.5,
+            },
+            '& .preview-medium': {
+              fontSize: '14px',
+              lineHeight: 1.5,
+            },
+            '& .preview-large': {
+              fontSize: '16px',
+              lineHeight: 1.5,
+            },
+          }}
+        >
+          <Typography className="preview-small" variant="caption">
+            小サイズ表示です
+          </Typography>
+          <Typography className="preview-medium" variant="caption">
+            標準サイズ表示です
+          </Typography>
+          <Typography className="preview-large" variant="caption">
+            大サイズ表示です
+          </Typography>
+        </Box>
+      </Stack>
+    </FormControl>
+  );
+};
+
+export default FontSizeControl;

--- a/src/features/settings/components/__tests__/FontSizeControl.spec.tsx
+++ b/src/features/settings/components/__tests__/FontSizeControl.spec.tsx
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FontSizeControl } from '../FontSizeControl';
+
+describe('FontSizeControl', () => {
+  describe('Rendering', () => {
+    it('should render the font size control with all options', () => {
+      const onChange = vi.fn();
+      render(<FontSizeControl value="medium" onChange={onChange} />);
+
+      expect(screen.getByText('フォントサイズ')).toBeInTheDocument();
+      expect(screen.getByText('小')).toBeInTheDocument();
+      expect(screen.getByText('標準')).toBeInTheDocument();
+      expect(screen.getByText('大')).toBeInTheDocument();
+    });
+
+    it('should render radio buttons for each font size option', () => {
+      const onChange = vi.fn();
+      render(<FontSizeControl value="medium" onChange={onChange} />);
+
+      const radioGroup = screen.getByTestId('font-size-radio-group');
+      expect(radioGroup).toBeInTheDocument();
+
+      expect(screen.getByTestId('font-size-radio-small')).toBeInTheDocument();
+      expect(screen.getByTestId('font-size-radio-medium')).toBeInTheDocument();
+      expect(screen.getByTestId('font-size-radio-large')).toBeInTheDocument();
+    });
+
+    it('should render descriptions for each font size option', () => {
+      const onChange = vi.fn();
+      render(<FontSizeControl value="medium" onChange={onChange} />);
+
+      expect(screen.getByText('12px - コンパクト表示')).toBeInTheDocument();
+      expect(screen.getByText('14px - 標準表示')).toBeInTheDocument();
+      expect(screen.getByText('16px - 読みやすい')).toBeInTheDocument();
+    });
+
+    it('should render preview examples', () => {
+      const onChange = vi.fn();
+      render(<FontSizeControl value="medium" onChange={onChange} />);
+
+      expect(screen.getByText('プレビュー:')).toBeInTheDocument();
+      expect(screen.getByText('小サイズ表示です')).toBeInTheDocument();
+      expect(screen.getByText('標準サイズ表示です')).toBeInTheDocument();
+      expect(screen.getByText('大サイズ表示です')).toBeInTheDocument();
+    });
+  });
+
+  describe('Selection State', () => {
+    it('should have radio buttons with correct values', () => {
+      const onChange = vi.fn();
+      render(<FontSizeControl value="small" onChange={onChange} />);
+
+      const radios = screen.getAllByRole('radio');
+      expect(radios[0]).toHaveAttribute('value', 'small');
+      expect(radios[1]).toHaveAttribute('value', 'medium');
+      expect(radios[2]).toHaveAttribute('value', 'large');
+    });
+  });
+
+  describe('Interactions', () => {
+    it('should call onChange when selecting a different font size', async () => {
+      const onChange = vi.fn();
+      const user = userEvent.setup();
+
+      render(<FontSizeControl value="medium" onChange={onChange} />);
+
+      const smallRadio = screen.getByTestId('font-size-radio-small');
+      await user.click(smallRadio);
+
+      expect(onChange).toHaveBeenCalledWith('small');
+      expect(onChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call onChange with correct value for each option', async () => {
+      const onChange = vi.fn();
+      const user = userEvent.setup();
+
+      const { rerender } = render(<FontSizeControl value="small" onChange={onChange} />);
+
+      const mediumRadio = screen.getByTestId('font-size-radio-medium');
+      await user.click(mediumRadio);
+      expect(onChange).toHaveBeenCalledWith('medium');
+
+      onChange.mockClear();
+      rerender(<FontSizeControl value="medium" onChange={onChange} />);
+
+      const largeRadio = screen.getByTestId('font-size-radio-large');
+      await user.click(largeRadio);
+      expect(onChange).toHaveBeenCalledWith('large');
+    });
+
+    it('should handle rapid changes between font sizes', async () => {
+      const onChange = vi.fn();
+      const user = userEvent.setup();
+
+      render(<FontSizeControl value="medium" onChange={onChange} />);
+
+      const smallRadio = screen.getByTestId('font-size-radio-small');
+      const largeRadio = screen.getByTestId('font-size-radio-large');
+
+      await user.click(smallRadio);
+      expect(onChange).toHaveBeenCalledWith('small');
+
+      await user.click(largeRadio);
+      expect(onChange).toHaveBeenCalledWith('large');
+
+      expect(onChange).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('should have proper form control labels', () => {
+      const onChange = vi.fn();
+      render(<FontSizeControl value="medium" onChange={onChange} />);
+
+      const formControl = screen.getByRole('group');
+      expect(formControl).toBeInTheDocument();
+    });
+
+    it('should have proper radio button roles', () => {
+      const onChange = vi.fn();
+      render(<FontSizeControl value="medium" onChange={onChange} />);
+
+      const radios = screen.getAllByRole('radio');
+      expect(radios).toHaveLength(3);
+      expect(radios[0]).toHaveAttribute('value', 'small');
+      expect(radios[1]).toHaveAttribute('value', 'medium');
+      expect(radios[2]).toHaveAttribute('value', 'large');
+    });
+
+    it('should support keyboard navigation', async () => {
+      const onChange = vi.fn();
+      render(<FontSizeControl value="small" onChange={onChange} />);
+
+      const radioGroup = screen.getByTestId('font-size-radio-group');
+      radioGroup.focus();
+
+      // Keyboard navigation is handled by MUI RadioGroup
+      // Verify the radio buttons exist and are keyboard accessible
+      expect(screen.getByTestId('font-size-radio-small')).toBeInTheDocument();
+      expect(screen.getByTestId('font-size-radio-medium')).toBeInTheDocument();
+    });
+
+    it('should maintain label associations', () => {
+      const onChange = vi.fn();
+      render(<FontSizeControl value="medium" onChange={onChange} />);
+
+      const radios = screen.getAllByRole('radio');
+      radios.forEach((radio) => {
+        // Each radio should be associated with a label
+        expect(radio.closest('label')).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/features/settings/components/index.ts
+++ b/src/features/settings/components/index.ts
@@ -1,1 +1,2 @@
 export { DensityControl } from './DensityControl';
+export { FontSizeControl } from './FontSizeControl';


### PR DESCRIPTION
Phase 7.1: Font Size Control

New FontSizeControl component with radio buttons for small/medium/large font sizes (12/14/16px).

Changes:
- FontSizeControl.tsx (NEW): Component with 3 radio button options
- createAppTheme.ts (UPDATE): fontSizeMap + typography override
- SettingsDialog.tsx (UPDATE): Component integration
- FontSizeControl.spec.tsx (NEW): 12 comprehensive tests

Validation:
- Typecheck: PASS
- Lint: PASS
- Tests: 12/12 PASS

Architecture follows Phase 5-6 pattern for settings integration.