### PR TITLE
feat(daily): Phase 2-1 - 申し送り→支援記録 フォーカス遷移

### DIFF
--- a/src/features/cross-module/navigationState.ts
+++ b/src/features/cross-module/navigationState.ts
@@ -1,0 +1,43 @@
+/**
+ * cross-module/navigationState.ts
+ * 
+ * モジュール間遷移で使用する navigation state の型定義
+ * React Router の location.state として渡される
+ */
+
+/**
+ * DailyRecordPage への遷移時に使用する state
+ */
+export type DailyActivityNavState = {
+  /**
+   * ハイライトする利用者ID
+   * 指定された利用者のカードへスクロール＋一時ハイライト表示
+   */
+  highlightUserId?: string;
+
+  /**
+   * ハイライトする日付 (YYYY-MM-DD, local)
+   * 指定された日付の記録にフィルタ/フォーカス
+   */
+  highlightDate?: string;
+};
+
+/**
+ * HandoffTimelinePage への遷移時に使用する state
+ */
+export type HandoffTimelineNavState = {
+  /**
+   * 日付スコープ (今日/昨日)
+   */
+  dayScope?: 'today' | 'yesterday';
+
+  /**
+   * 時間帯フィルタ
+   */
+  timeFilter?: 'all' | 'morning' | 'evening';
+
+  /**
+   * フォーカスする利用者ID（将来の Phase で使用予定）
+   */
+  focusUserId?: string;
+};

--- a/src/features/daily/DailyRecordList.tsx
+++ b/src/features/daily/DailyRecordList.tsx
@@ -31,6 +31,7 @@ interface DailyRecordListProps {
   loading?: boolean;
   highlightUserId?: string | null;
   highlightDate?: string | null;
+  activeHighlightUserId?: string | null; // Phase 2-1: 一時ハイライト表示用
 }
 
 const statusColors: Record<DailyStatus, 'default' | 'primary' | 'secondary' | 'success' | 'error' | 'info' | 'warning'> = {
@@ -53,7 +54,8 @@ export function DailyRecordList({
   onOpenHandoffTimeline, // Phase 9: 申し送り表示用
   loading = false,
   highlightUserId,
-  highlightDate
+  highlightDate,
+  activeHighlightUserId // Phase 2-1: 一時ハイライト表示用
 }: DailyRecordListProps) {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const [selectedRecord, setSelectedRecord] = React.useState<PersonDaily | null>(null);
@@ -127,12 +129,15 @@ export function DailyRecordList({
     <>
       <Stack spacing={2} data-testid="daily-record-list-container">
         {records.map((record) => {
-          // Check if this record should be highlighted
+          // Phase 2-1: Check if this record should be highlighted
           const isHighlighted =
             !!highlightUserId &&
             !!highlightDate &&
             record.personId === highlightUserId &&
             record.date === highlightDate;
+
+          // Phase 2-1: 一時ハイライト（スクロール直後）
+          const isActiveHighlight = activeHighlightUserId === record.personId;
 
           // Check for problem behaviors
           const hasProblemBehavior =
@@ -149,7 +154,7 @@ export function DailyRecordList({
             <Card
               key={record.id}
               variant="outlined"
-              data-testid={`daily-record-card-${record.id}`}
+              data-testid={`daily-record-card-${record.personId}`}
               {...(isHighlighted && {
                 'data-highlighted': 'true',
               })}
@@ -159,9 +164,33 @@ export function DailyRecordList({
                   boxShadow: 4,
                   backgroundColor: 'rgba(25, 118, 210, 0.04)',
                 }),
+                ...(isActiveHighlight && {
+                  outline: '3px solid',
+                  outlineColor: 'warning.main',
+                  transition: 'outline 200ms ease',
+                }),
               }}
             >
             <CardContent>
+              {/* Phase 2-1: ハイライトバナー */}
+              {isActiveHighlight && (
+                <Box
+                  sx={{
+                    mb: 2,
+                    p: 1,
+                    bgcolor: 'warning.50',
+                    borderRadius: 1,
+                    border: '1px solid',
+                    borderColor: 'warning.200',
+                  }}
+                  data-testid="daily-highlight-banner"
+                >
+                  <Typography variant="caption" sx={{ fontWeight: 600, color: 'warning.dark' }}>
+                    📌 申し送りから移動しました
+                  </Typography>
+                </Box>
+              )}
+
               {/* ヘッダー部分 */}
               <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: 2 }}>
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }} data-testid={`record-header-${record.id}`}>

--- a/tests/e2e/handoff-daily.phase2-1.spec.ts
+++ b/tests/e2e/handoff-daily.phase2-1.spec.ts
@@ -1,0 +1,135 @@
+/**
+ * Phase 2-1: 申し送り → 支援記録 フォーカス遷移のE2Eテスト
+ *
+ * 検証内容:
+ * - HandoffTimeline の各カードに「この利用者の記録を開く」CTA が表示される
+ * - CTA をクリックすると /daily/activity へ遷移する
+ * - 該当利用者のカードがハイライト表示される
+ * - ハイライトバナー「📌 申し送りから移動しました」が一時表示される
+ */
+
+import { expect, test } from '@playwright/test';
+import { primeOpsEnv } from './helpers/ops';
+
+test.describe('Phase 2-1: handoff → daily highlight navigation', () => {
+  test.beforeEach(async ({ page }) => {
+    await primeOpsEnv(page);
+  });
+
+  test('timeline item から daily に遷移し、該当利用者がハイライトされる', async ({ page }) => {
+    // ✅ localStorage seed: 申し送りデータを投入（ページ遷移前）
+    await page.goto('/handoff-timeline', { waitUntil: 'domcontentloaded' });
+
+    // データを投入（StorageShape 形式: Record<dateKey, HandoffRecord[]>）
+    await page.evaluate(() => {
+      const key = 'handoff.timeline.dev.v1';
+      const today = new Date();
+      const y = today.getFullYear();
+      const m = `${today.getMonth() + 1}`.padStart(2, '0');
+      const d = `${today.getDate()}`.padStart(2, '0');
+      const dateKey = `${y}-${m}-${d}`;
+
+      const payload = {
+        [dateKey]: [
+          {
+            id: 1,
+            userCode: '001', // テスト用の既存利用者ID（田中太郎）
+            userDisplayName: '田中太郎',
+            message: 'E2E highlight test - この利用者の記録を確認してください',
+            severity: '重要',
+            category: '体調',
+            dateYmd: dateKey,
+            timeBand: 'morning',
+            status: '未対応',
+            createdByName: 'テスト職員',
+            createdAt: new Date().toISOString(),
+          },
+        ],
+      };
+      localStorage.setItem(key, JSON.stringify(payload));
+    });
+
+    // ページをリロードしてデータを反映
+    await page.reload({ waitUntil: 'domcontentloaded' });
+
+    // タイムラインアイテムが表示されるまで待機
+    await page.waitForSelector('[data-testid="agenda-timeline-item"]', { timeout: 10_000 });
+
+    // ✅ CTA ボタンが表示されることを確認
+    const ctaButton = page.getByTestId('handoff-open-daily-highlight').first();
+    await expect(ctaButton).toBeVisible({ timeout: 10_000 });
+    await expect(ctaButton).toHaveText(/この利用者の記録を開く/);
+
+    // ✅ CTA をクリック
+    await ctaButton.click();
+
+    // ✅ /daily/activity へ遷移
+    await expect(page).toHaveURL(/\/daily\/activity/);
+
+    // ✅ 該当利用者のカードが存在する（personId ベース）
+    const targetCard = page.getByTestId('daily-record-card-001');
+    await expect(targetCard).toBeVisible({ timeout: 10_000 });
+
+    // ✅ ハイライトバナーが一時表示される
+    const banner = page.getByTestId('daily-highlight-banner');
+    await expect(banner).toBeVisible({ timeout: 5_000 });
+    await expect(banner).toHaveText(/申し送りから移動しました/);
+  });
+
+  test('userCode が "ALL" の場合、CTA ボタンは表示されない', async ({ page }) => {
+    await page.goto('/handoff-timeline', { waitUntil: 'domcontentloaded' });
+
+    await page.evaluate(() => {
+      const key = 'handoff.timeline.dev.v1';
+      const today = new Date();
+      const y = today.getFullYear();
+      const m = `${today.getMonth() + 1}`.padStart(2, '0');
+      const d = `${today.getDate()}`.padStart(2, '0');
+      const dateKey = `${y}-${m}-${d}`;
+
+      const payload = {
+        [dateKey]: [
+          {
+            id: 2,
+            userCode: 'ALL', // 全体向け申し送り
+            userDisplayName: '全体',
+            message: '全体連絡: 明日は避難訓練があります',
+            severity: '通常',
+            category: 'その他',
+            dateYmd: dateKey,
+            timeBand: 'morning',
+            status: '未対応',
+            createdByName: 'テスト職員',
+            createdAt: new Date().toISOString(),
+          },
+        ],
+      };
+      localStorage.setItem(key, JSON.stringify(payload));
+    });
+
+    await page.reload({ waitUntil: 'domcontentloaded' });
+
+    // タイムラインアイテムが表示されることを確認
+    await page.waitForSelector('[data-testid="agenda-timeline-item"]', { timeout: 10_000 });
+
+    // ✅ CTA ボタンが存在しないことを確認
+    const ctaButton = page.getByTestId('handoff-open-daily-highlight');
+    await expect(ctaButton).toHaveCount(0);
+  });
+
+  test('申し送りが0件の場合、CTA ボタンは表示されない', async ({ page }) => {
+    await page.goto('/handoff-timeline', { waitUntil: 'domcontentloaded' });
+
+    await page.evaluate(() => {
+      const key = 'handoff.timeline.dev.v1';
+      const payload = {};
+      localStorage.setItem(key, JSON.stringify(payload));
+    });
+
+    await page.reload({ waitUntil: 'domcontentloaded' });
+
+    // ✅ CTA ボタンが存在しないことを確認
+    const ctaButton = page.getByTestId('handoff-open-daily-highlight');
+    await expect(ctaButton).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
Phase 1の「見える・飛べる」導線を、着地体験まで完結させる Phase 2-1 実装です。申し送りタイムラインから該当利用者の支援記録へ遷移し、対象を自動スクロール＋一時ハイライトします。

実装内容:
- HandoffTimelineの各申し送りカードに「この利用者の記録を開く」CTA追加
- DailyRecordPageでnavigation state（highlightUserId/highlightDate）受け取り
- 対象行へscrollIntoView + 1.5秒の一時ハイライト表示
- E2E: 導線の存在保証（遷移＋ハイライト出現）3テスト追加

Phase 1: #332