### PR TITLE
fix(daily): データ属性の分離 - テスト用と機能用を明確化

### DIFF
--- a/src/features/daily/DailyRecordList.tsx
+++ b/src/features/daily/DailyRecordList.tsx
@@ -154,7 +154,9 @@ export function DailyRecordList({
             <Card
               key={record.id}
               variant="outlined"
-              data-testid={`daily-record-card-${record.personId}`}
+              data-testid={`daily-record-card-${record.id}`}
+              data-person-id={record.personId}
+              data-date-ymd={record.date}
               {...(isHighlighted && {
                 'data-highlighted': 'true',
               })}

--- a/src/pages/DailyRecordPage.tsx
+++ b/src/pages/DailyRecordPage.tsx
@@ -230,7 +230,7 @@ export default function DailyRecordPage() {
 
     // 記録一覧が描画された後にスクロールしたいので、軽く遅延
     const timer = setTimeout(() => {
-      const element = document.querySelector(`[data-testid="daily-record-card-${highlightUserId}"]`);
+      const element = document.querySelector(`[data-person-id="${highlightUserId}"]`);
       if (element) {
         element.scrollIntoView({ behavior: 'smooth', block: 'center' });
         setActiveHighlightUserId(highlightUserId);

--- a/tests/e2e/handoff-daily.phase2-1.spec.ts
+++ b/tests/e2e/handoff-daily.phase2-1.spec.ts
@@ -66,8 +66,9 @@ test.describe('Phase 2-1: handoff → daily highlight navigation', () => {
     // ✅ /daily/activity へ遷移
     await expect(page).toHaveURL(/\/daily\/activity/);
 
-    // ✅ 該当利用者のカードが存在する（personId ベース）
-    const targetCard = page.getByTestId('daily-record-card-001');
+    // ✅ 該当利用者のカードが存在する（record.id ベース）
+    // 最初のレコード（userCode 001）の id は 1
+    const targetCard = page.getByTestId('daily-record-card-1');
     await expect(targetCard).toBeVisible({ timeout: 10_000 });
 
     // ✅ ハイライトバナーが一時表示される


### PR DESCRIPTION
## 🎯 概要
Phase 2-1 実装後のフォローアップ。テスト属性と本番ロジックを分離し、堅牢性を上げます。

## 🔍 修正内容
- DailyRecordList: data-testid を record.id に（ユニーク化）
- DailyRecordList: data-person-id / data-date-ymd を追加（機能用）
- DailyRecordPage: スクロール検索を data-person-id に変更
- E2E: testid 期待値を personId → record.id に修正

## ✅ 検証結果
- Unit Tests: 12/12 PASS ✅
- E2E Tests: 3/3 PASS ✅
- Health Check: 335/336 PASS ✅ (1 skipped)
- TypeScript: 0 errors ✅

## 🎓 設計改善
- テスト属性（data-testid）と本番ロジック（data-person-id）を分離
- 将来の日付フィルタ拡張に対応（data-date-ymd）
- 関心の分離により保守性向上

Refs: #333 (Phase 2-1)
