### PR TITLE
ci(e2e): split smoke/deep and make deep non-blocking

### DIFF
--- a/.github/workflows/e2e-deep.yml
+++ b/.github/workflows/e2e-deep.yml
@@ -1,0 +1,52 @@
+name: e2e-deep
+
+on:
+  schedule:
+    - cron: '0 21 * * 1-5' # JST 06:00 weekdays
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+concurrency:
+  group: e2e-deep-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e-deep:
+    if: >
+      github.event_name != 'pull_request' ||
+      (
+        github.event.pull_request.draft == false &&
+        contains(join(github.event.pull_request.labels.*.name, ','), 'run-ci')
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Playwright install
+        run: npx playwright install --with-deps
+
+      - name: E2E Deep
+        env:
+          CI: 'true'
+          TZ: Asia/Tokyo
+        run: npx playwright test --config=playwright.deep.config.ts
+
+      - name: Upload Playwright report (failure only)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-deep-report
+          path: |
+            playwright-report
+            test-results
+          retention-days: 14
+          if-no-files-found: warn

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,7 +1,5 @@
-name: e2e (Nightly)
+name: e2e (Manual)
 on:
-  schedule:
-    - cron: '0 15 * * *'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,4 +1,4 @@
-name: Smoke Tests
+name: e2e-smoke
 
 on:
   pull_request:
@@ -81,49 +81,15 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
-      - name: Playwright install (preview server)
-        run: PW_USE_PREVIEW=1 npx playwright install --with-deps
-      - name: Build (preview server)
-        run: VITE_E2E='1' VITE_E2E_MSAL_MOCK='1' VITE_FEATURE_SCHEDULES='1' VITE_SKIP_LOGIN='1' npm run build --if-present
-      - name: Start preview server
-        run: npm run preview -- --host 127.0.0.1 --port 5173 --strictPort &
-
-      - name: Wait for preview server
-        run: npx wait-on http://127.0.0.1:5173
-      - name: E2E router + nav smoke (chromium + smoke)
+      - name: Playwright install
+        run: npx playwright install --with-deps
+      - name: E2E Smoke (short set)
         env:
           TZ: Asia/Tokyo
-          PW_USE_PREVIEW: 1
-          PLAYWRIGHT_BASE_URL: http://127.0.0.1:5173
-          PLAYWRIGHT_WEB_SERVER_URL: http://127.0.0.1:5173
-          PLAYWRIGHT_SKIP_BUILD: '1'
-          VITE_E2E: '1'
-          VITE_E2E_MSAL_MOCK: '1'
-          VITE_SKIP_LOGIN: '1'
-        run: |
-          echo "=== E2E flags ==="
-          echo "VITE_E2E=$VITE_E2E"
-          echo "VITE_E2E_MSAL_MOCK=$VITE_E2E_MSAL_MOCK"
-          echo "VITE_SKIP_LOGIN=$VITE_SKIP_LOGIN"
-          echo "=== Tooling ==="
-          node -v
-          npx playwright --version
-          echo "=== Run ==="
-          npm run e2e:smoke:router-nav
-      - name: e2e smoke tests (all)
-        env:
-          TZ: Asia/Tokyo
-          PW_USE_PREVIEW: 1
-          PLAYWRIGHT_BASE_URL: http://127.0.0.1:5173
-          PLAYWRIGHT_WEB_SERVER_URL: http://127.0.0.1:5173
-          PLAYWRIGHT_SKIP_BUILD: '1'
-          VITE_E2E: '1'
-          VITE_E2E_MSAL_MOCK: '1'
-          VITE_SKIP_LOGIN: '1'
-          VITE_FEATURE_SCHEDULES: '1'
-        run: npx playwright test tests/e2e --config=playwright.config.ts --project=smoke --trace on
-      - if: always()
-        name: Upload Playwright artifacts
+          CI: 'true'
+        run: npx playwright test --config=playwright.smoke.config.ts
+      - if: failure()
+        name: Upload Playwright artifacts (failure only)
         uses: actions/upload-artifact@v4
         with:
           name: playwright-artifacts
@@ -132,8 +98,8 @@ jobs:
             test-results/**
           retention-days: 7
           if-no-files-found: warn
-      - if: always()
-        name: Upload JUnit report
+      - if: failure()
+        name: Upload JUnit report (failure only)
         uses: actions/upload-artifact@v4
         with:
           name: junit-e2e-smoke

--- a/docs/E2E_STRATEGY.md
+++ b/docs/E2E_STRATEGY.md
@@ -1,0 +1,41 @@
+# E2E Strategy (Smoke / Deep)
+
+このリポジトリでは Playwright E2E を **Smoke** と **Deep** に分離して運用します。
+
+## Goals
+
+- **Smoke**: PR 必須（短い・安定・主要導線）
+- **Deep**: 非ブロッキング（夜間 or 手動 / `run-ci` ラベル時のみ）
+- **Artifacts**: 失敗時のみアップロード（容量節約）
+
+## Smoke
+
+- 実行: PR で常時実行
+- 対象: 主要導線のみ（最小セット）
+- 設定: [playwright.smoke.config.ts](../playwright.smoke.config.ts)
+- Workflow: [.github/workflows/smoke.yml](../.github/workflows/smoke.yml)
+
+## Deep
+
+- 実行: schedule / workflow_dispatch / `run-ci` ラベル
+- 対象: Smoke 以外の E2E 全体
+- 設定: [playwright.deep.config.ts](../playwright.deep.config.ts)
+- Workflow: [.github/workflows/e2e-deep.yml](../.github/workflows/e2e-deep.yml)
+
+## Run-CI Gating
+
+- `run-ci` ラベルが付与された PR で **Deep** が起動
+- Draft PR では起動しません
+
+## Smoke 対象（最小セット）
+
+- `tests/e2e/app-shell.smoke.spec.ts`
+- `tests/e2e/router.smoke.spec.ts`
+- `tests/e2e/nav.smoke.spec.ts`
+- `tests/e2e/users-crud.smoke.spec.ts`
+- `tests/e2e/schedule-day.aria.smoke.spec.ts`
+
+## Notes
+
+- Deep から Smoke を除外するため `testIgnore: /.*smoke.*\.spec\.ts$/i` を使用
+- Smoke の内容は安定性優先で最小セットに保つ

--- a/playwright.deep.config.ts
+++ b/playwright.deep.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from '@playwright/test';
+import baseConfig from './playwright.config';
+
+const isCI = !!process.env.CI;
+const deepProjects = (baseConfig.projects ?? []).filter((project) => project.name === 'chromium');
+
+export default defineConfig({
+  ...baseConfig,
+  timeout: 60_000,
+  expect: { timeout: 15_000 },
+  retries: isCI ? 1 : baseConfig.retries,
+  workers: isCI ? 2 : baseConfig.workers,
+  reporter: [['html', { open: 'never' }]],
+  testIgnore: /.*smoke.*\.spec\.ts$/i,
+  use: {
+    ...(baseConfig.use ?? {}),
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+    baseURL: process.env.E2E_BASE_URL ?? (baseConfig.use ?? {}).baseURL,
+  },
+  projects: deepProjects,
+});

--- a/playwright.smoke.config.ts
+++ b/playwright.smoke.config.ts
@@ -10,6 +10,13 @@ const mobileChrome = {
 const devPort = Number(process.env.E2E_PORT) || 5173;
 const baseURL = `http://127.0.0.1:${devPort}`;
 
+const smokeTestMatch = [
+  'tests/e2e/app-shell.smoke.spec.ts',
+  'tests/e2e/router.smoke.spec.ts',
+  'tests/e2e/nav.smoke.spec.ts',
+  'tests/e2e/schedule-day.aria.smoke.spec.ts',
+];
+
 const webServerEnvVarsSmoke = {
   VITE_SP_RESOURCE: 'https://isogokatudouhome.sharepoint.com',
   VITE_SP_SITE_RELATIVE: '/sites/app-test',
@@ -54,6 +61,7 @@ export default defineConfig({
     .filter((project) => project.name === 'smoke')
     .map((project) => ({
       ...project,
+      testMatch: smokeTestMatch,
       use: {
         ...(project.use ?? {}),
         ...mobileChrome,


### PR DESCRIPTION
## Summary
Split Playwright E2E into smoke (PR-required, short critical paths) and deep (non-blocking).

## Why
- Keep PR feedback fast and stable
- Run broader coverage nightly / manual / run-ci label without blocking merges
- Reduce duplicate runs and artifact noise

## Changes
- Update smoke.yml: keep PR-required smoke short; upload artifacts only on failure
- Add e2e-deep.yml: scheduled + workflow_dispatch + run-ci label gated for PRs
- Update playwright.smoke.config.ts: limit to smoke specs
- Add playwright.deep.config.ts: exclude smoke and use failure-only artifacts policy
- Disable legacy nightly schedule in e2e.yml to avoid duplicate runs
- Add docs/E2E_STRATEGY.md

## Verification
- [x] npx playwright test --config=playwright.smoke.config.ts (local)
- [x] npx playwright test --config=playwright.deep.config.ts tests/e2e/audit-basic.spec.ts (local)
- [ ] CI: smoke workflow passes
- [ ] Deep workflow: runs on schedule/manual and on PR when run-ci label is applied

## Rollback
Revert this PR (workflows/config/docs only; no product code changes).
