### PR TITLE
ci(lint): add boundary rules (warn)

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -7,7 +7,7 @@ module.exports = {
     sourceType: 'module',
     ecmaFeatures: { jsx: true }
   },
-  plugins: ['@typescript-eslint'],
+  plugins: ['@typescript-eslint', 'boundaries'],
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
@@ -63,6 +63,29 @@ module.exports = {
           }
         ]
       }
+    ],
+    // Phase 1: boundaries (warn)
+    'boundaries/element-types': ['warn', {
+      default: 'disallow',
+      rules: [
+        // app → feature/lib/utils/shared OK
+        { from: 'app', allow: ['feature', 'lib', 'utils', 'shared'] },
+        // feature → lib/utils/shared OK (feature↔feature は原則禁止)
+        { from: 'feature', allow: ['lib', 'utils', 'shared'] },
+        // lib/utils/shared は限定的に許可
+        { from: 'lib', allow: ['utils', 'shared'] },
+        { from: 'utils', allow: ['shared'] },
+        { from: 'shared', allow: ['utils'] }
+      ]
+    }]
+  },
+  settings: {
+    'boundaries/elements': [
+      { type: 'app', pattern: 'src/app/*' },
+      { type: 'feature', pattern: 'src/features/*' },
+      { type: 'lib', pattern: 'src/lib/*' },
+      { type: 'utils', pattern: 'src/utils/*' },
+      { type: 'shared', pattern: 'src/components/*' }
     ]
   },
   env: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "cross-env": "^10.1.0",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
+        "eslint-plugin-boundaries": "^5.4.0",
         "husky": "^9.1.7",
         "jest-axe": "^10.0.0",
         "jsdom": "^26.1.0",
@@ -1700,6 +1701,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@boundaries/elements": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@boundaries/elements/-/elements-1.2.0.tgz",
+      "integrity": "sha512-W65Gum02liMd3hmNrLmDBX1u5BmRMcunouFjLXyhxHnNY4YlK1kTxsgfflZ5XBGSnPnO0MkiUzAcoGzYrlx0RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-import-resolver-node": "0.3.9",
+        "eslint-module-utils": "2.12.1",
+        "handlebars": "4.7.8",
+        "is-core-module": "2.16.1",
+        "micromatch": "4.0.8"
+      },
+      "engines": {
+        "node": ">=18.18"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -8289,6 +8307,76 @@
         "eslint": ">=7.0.0"
       }
     },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
+      "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "is-core-module": "^2.13.0",
+        "resolve": "^1.22.4"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
+      "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-boundaries": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-boundaries/-/eslint-plugin-boundaries-5.4.0.tgz",
+      "integrity": "sha512-6SQmEhXCqGrrxm9YiM24SC95CqrVi2MUOm5SDrfquceh/os8MIAvZYsDU69zvtCSb1S6UbNEmdioi1gCDc8+VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@boundaries/elements": "1.2.0",
+        "chalk": "4.1.2",
+        "eslint-import-resolver-node": "0.3.9",
+        "eslint-module-utils": "2.12.1",
+        "micromatch": "4.0.8"
+      },
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
@@ -9401,6 +9489,38 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/handlebars/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/has-bigints": {
@@ -13017,6 +13137,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/netmask": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
@@ -16102,6 +16229,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -17341,6 +17482,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
     "cross-env": "^10.1.0",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-boundaries": "^5.4.0",
     "husky": "^9.1.7",
     "jest-axe": "^10.0.0",
     "jsdom": "^26.1.0",


### PR DESCRIPTION
## Summary
Introduce boundary lint rules in warn mode to visualize cross-feature dependencies without breaking CI.

## Why
- Establish dependency direction guards (app → feature → lib/utils/shared)
- Surface cross-feature imports early
- Prepare for Phase 2 (error enforcement)

## Changes
- Add eslint-plugin-boundaries (dev dependency)
- Configure boundaries elements and warn-level element-types rules
- Keep shared components allowed (src/components) for now

## Verification
- [x] npm run lint
- [x] npm run typecheck

## Rollback
Revert this PR (lint config only; no product code changes).
