### PR TITLE
ui(daily): add hub link to daily dialogs

### DIFF
--- a/src/features/daily/TableDailyRecordPage.tsx
+++ b/src/features/daily/TableDailyRecordPage.tsx
@@ -12,6 +12,7 @@ export const TableDailyRecordPage: React.FC = () => {
       open={vm.open}
       title={vm.title}
       backTo={vm.backTo}
+      hubTo="/dailysupport"
       testId={vm.testId}
       onClose={vm.onClose}
     >

--- a/src/features/daily/components/FullScreenDailyDialogPage.tsx
+++ b/src/features/daily/components/FullScreenDailyDialogPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import {
   AppBar,
   Box,
+  Button,
   Dialog,
   IconButton,
   Toolbar,
@@ -14,6 +15,8 @@ type FullScreenDailyDialogPageProps = {
   open?: boolean;
   title: string;
   backTo?: string;
+  hubTo?: string;
+  hubLabel?: string;
   busy?: boolean;
   onClose?: () => void;
   testId?: string;
@@ -24,6 +27,8 @@ export function FullScreenDailyDialogPage({
   open = true,
   title,
   backTo = '/daily/menu',
+  hubTo,
+  hubLabel = '日次ハブへ',
   busy = false,
   onClose,
   testId,
@@ -36,6 +41,11 @@ export function FullScreenDailyDialogPage({
     if (onClose) return onClose();
     navigate(backTo, { replace: true });
   }, [busy, onClose, navigate, backTo]);
+
+  const handleHubClick = React.useCallback(() => {
+    if (!hubTo) return;
+    navigate(hubTo);
+  }, [hubTo, navigate]);
 
   return (
     <Dialog fullScreen open={open} data-testid={testId}>
@@ -54,6 +64,12 @@ export function FullScreenDailyDialogPage({
           <Typography sx={{ ml: 1, flex: 1 }} variant="h6">
             {title}
           </Typography>
+
+          {hubTo && (
+            <Button size="small" variant="text" onClick={handleHubClick}>
+              {hubLabel}
+            </Button>
+          )}
         </Toolbar>
       </AppBar>
 

--- a/src/pages/AttendanceRecordPage.tsx
+++ b/src/pages/AttendanceRecordPage.tsx
@@ -455,6 +455,7 @@ const AttendanceRecordPage: React.FC<AttendanceRecordPageProps> = ({ 'data-testi
     <FullScreenDailyDialogPage
       title="通所（出欠）"
       backTo="/daily/menu"
+      hubTo="/dailysupport"
       testId="daily-attendance-page"
     >
       <Container maxWidth="lg" sx={{ py: 4 }} data-testid={dataTestId ?? TESTIDS['attendance-page']}>

--- a/src/pages/TimeBasedSupportRecordPage.tsx
+++ b/src/pages/TimeBasedSupportRecordPage.tsx
@@ -175,6 +175,7 @@ const TimeBasedSupportRecordPage: React.FC = () => {
     <FullScreenDailyDialogPage
       title="支援（サポート記録）"
       backTo="/daily/menu"
+      hubTo="/dailysupport"
       testId="daily-support-page"
     >
       <Container


### PR DESCRIPTION
## Summary\n- Add a "日次ハブへ" button in daily full-screen dialogs\n- Provide quick escape to /dailysupport while keeping cancel behavior unchanged\n\n## Testing\n- lint\n- typecheck