### PR TITLE
ui(daily): simplify hub to three cards

### DIFF
--- a/src/pages/DailyRecordMenuPage.tsx
+++ b/src/pages/DailyRecordMenuPage.tsx
@@ -1,7 +1,6 @@
 import AssignmentIcon from '@mui/icons-material/Assignment';
 import AttendanceIcon from '@mui/icons-material/AssignmentInd';
 import SupportIcon from '@mui/icons-material/AssignmentTurnedIn';
-import ActivityIcon from '@mui/icons-material/EventNote';
 import GroupIcon from '@mui/icons-material/Group';
 import PeopleIcon from '@mui/icons-material/People';
 import Box from '@mui/material/Box';
@@ -155,71 +154,6 @@ const DailyRecordMenuPage: React.FC = () => {
                 data-testid="btn-open-table-activity"
               >
                 一覧形式で記録作成
-              </Button>
-            </CardActions>
-          </Card>
-
-          {/* 支援記録（ケース記録） */}
-          <Card
-            data-testid="daily-card-activity"
-            sx={{
-              flex: 1,
-              display: 'flex',
-              flexDirection: 'column',
-              transition: 'transform 0.2s, elevation 0.2s',
-              '&:hover': {
-                transform: 'translateY(-4px)',
-                elevation: 8
-              }
-            }}
-          >
-            <CardContent sx={{ flexGrow: 1, p: 3 }}>
-              <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
-                <ActivityIcon sx={{ fontSize: 32, color: 'primary.main', mr: 2 }} />
-                <Typography variant="h5" component="h2">
-                  支援記録（ケース記録）
-                </Typography>
-              </Box>
-
-              <Typography variant="body1" color="text.secondary" sx={{ mb: 2 }}>
-                利用者を1人ずつ選択して詳細な記録を作成します
-              </Typography>
-
-                <Stack spacing={1}>
-                  <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                    <PeopleIcon sx={{ fontSize: 16, mr: 1, color: 'text.secondary' }} />
-                    <Typography variant="body2" color="text.secondary">
-                      対象：利用者全員（{totalUsers}名）
-                    </Typography>
-                  </Box>
-                <Typography variant="body2" color="text.secondary">
-                  • AM/PM活動内容
-                </Typography>
-                <Typography variant="body2" color="text.secondary">
-                  • 昼食摂取量
-                </Typography>
-                <Typography variant="body2" color="text.secondary">
-                  • 問題行動記録（自傷・暴力・大声・異食・その他）
-                </Typography>
-                <Typography variant="body2" color="text.secondary">
-                  • 発作記録（時刻・持続時間・重度・詳細）
-                </Typography>
-                <Typography variant="body2" color="text.secondary">
-                  • 特記事項
-                </Typography>
-              </Stack>
-            </CardContent>
-
-            <CardActions sx={{ p: 3, pt: 0 }}>
-              <Button
-                variant="contained"
-                size="large"
-                fullWidth
-                onClick={() => navigate('/daily/activity')}
-                startIcon={<ActivityIcon />}
-                data-testid="btn-open-activity"
-              >
-                支援記録（ケース記録）を開く
               </Button>
             </CardActions>
           </Card>


### PR DESCRIPTION
## Summary\n- Keep daily hub focused on three direct cards (table/support/attendance)\n- Remove the extra activity card to reduce choice overload\n\n## Testing\n- lint\n- typecheck