### PR TITLE
ui(daily): sticky footer actions for tablets

### DIFF
--- a/src/features/daily/BulkDailyRecordForm.tsx
+++ b/src/features/daily/BulkDailyRecordForm.tsx
@@ -590,18 +590,40 @@ export function BulkDailyRecordForm({
         </Stack>
       </DialogContent>
 
-      <DialogActions>
-        <Button onClick={onClose} disabled={saving}>
-          キャンセル
-        </Button>
-        <Button
-          variant="contained"
-          onClick={handleSave}
-          disabled={saving || selectedUserIds.length === 0}
-          startIcon={<SaveIcon />}
-        >
-          {saving ? '保存中...' : `${selectedUserIds.length}人分保存`}
-        </Button>
+      <DialogActions
+        sx={{
+          position: 'sticky',
+          bottom: 0,
+          bgcolor: 'background.paper',
+          borderTop: 1,
+          borderColor: 'divider',
+          p: 1,
+          zIndex: 1,
+        }}
+      >
+        <Stack direction="row" spacing={1} sx={{ width: '100%' }}>
+          <Button
+            onClick={onClose}
+            disabled={saving}
+            variant="outlined"
+            size="large"
+            fullWidth
+            sx={{ minHeight: 48 }}
+          >
+            キャンセル
+          </Button>
+          <Button
+            variant="contained"
+            size="large"
+            fullWidth
+            sx={{ minHeight: 48 }}
+            onClick={handleSave}
+            disabled={saving || selectedUserIds.length === 0}
+            startIcon={<SaveIcon />}
+          >
+            {saving ? '保存中...' : `${selectedUserIds.length}人分保存`}
+          </Button>
+        </Stack>
       </DialogActions>
     </Dialog>
   );

--- a/src/features/daily/DailyRecordForm.tsx
+++ b/src/features/daily/DailyRecordForm.tsx
@@ -922,18 +922,41 @@ export function DailyRecordForm({ open, onClose, record, onSave }: DailyRecordFo
         </Stack>
       </DialogContent>
 
-      <DialogActions data-testid="daily-record-form-actions">
-        <Button onClick={onClose} data-testid="cancel-button">
-          キャンセル
-        </Button>
-        <Button
-          onClick={handleSave}
-          variant="contained"
-          data-testid="save-button"
-          disabled={!isFormValid}
-        >
-          {record ? '更新' : '保存'}
-        </Button>
+      <DialogActions
+        data-testid="daily-record-form-actions"
+        sx={{
+          position: 'sticky',
+          bottom: 0,
+          bgcolor: 'background.paper',
+          borderTop: 1,
+          borderColor: 'divider',
+          p: 1,
+          zIndex: 1,
+        }}
+      >
+        <Stack direction="row" spacing={1} sx={{ width: '100%' }}>
+          <Button
+            onClick={onClose}
+            data-testid="cancel-button"
+            variant="outlined"
+            size="large"
+            fullWidth
+            sx={{ minHeight: 48 }}
+          >
+            キャンセル
+          </Button>
+          <Button
+            onClick={handleSave}
+            variant="contained"
+            size="large"
+            fullWidth
+            sx={{ minHeight: 48 }}
+            data-testid="save-button"
+            disabled={!isFormValid}
+          >
+            {record ? '更新' : '保存'}
+          </Button>
+        </Stack>
       </DialogActions>
     </Dialog>
   );

--- a/src/features/daily/TableDailyRecordForm.tsx
+++ b/src/features/daily/TableDailyRecordForm.tsx
@@ -619,18 +619,40 @@ export function TableDailyRecordForm({
         </Stack>
       </DialogContent>
 
-      <DialogActions>
-        <Button onClick={onClose} disabled={saving}>
-          キャンセル
-        </Button>
-        <Button
-          variant="contained"
-          onClick={handleSave}
-          disabled={saving || selectedUserIds.length === 0}
-          startIcon={<SaveIcon />}
-        >
-          {saving ? '保存中...' : `${selectedUserIds.length}人分保存`}
-        </Button>
+      <DialogActions
+        sx={{
+          position: 'sticky',
+          bottom: 0,
+          bgcolor: 'background.paper',
+          borderTop: 1,
+          borderColor: 'divider',
+          p: 1,
+          zIndex: 1,
+        }}
+      >
+        <Stack direction="row" spacing={1} sx={{ width: '100%' }}>
+          <Button
+            onClick={onClose}
+            disabled={saving}
+            variant="outlined"
+            size="large"
+            fullWidth
+            sx={{ minHeight: 48 }}
+          >
+            キャンセル
+          </Button>
+          <Button
+            variant="contained"
+            size="large"
+            fullWidth
+            sx={{ minHeight: 48 }}
+            onClick={handleSave}
+            disabled={saving || selectedUserIds.length === 0}
+            startIcon={<SaveIcon />}
+          >
+            {saving ? '保存中...' : `${selectedUserIds.length}人分保存`}
+          </Button>
+        </Stack>
       </DialogActions>
     </>
   );

--- a/src/features/daily/components/FullScreenDailyDialogPage.tsx
+++ b/src/features/daily/components/FullScreenDailyDialogPage.tsx
@@ -5,11 +5,11 @@ import {
   Box,
   Button,
   Dialog,
-  IconButton,
   Toolbar,
   Typography,
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
+import HomeOutlinedIcon from '@mui/icons-material/HomeOutlined';
 
 type FullScreenDailyDialogPageProps = {
   open?: boolean;
@@ -45,22 +45,30 @@ export function FullScreenDailyDialogPage({
   return (
     <Dialog fullScreen open={open} data-testid={testId}>
       <AppBar position="sticky" color="default" elevation={1}>
-        <Toolbar variant="dense">
-          <IconButton
-            edge="start"
-            aria-label="閉じる"
+        <Toolbar variant="dense" sx={{ gap: 1 }}>
+          <Button
             onClick={handleClose}
+            startIcon={<CloseIcon />}
+            variant="text"
+            size="large"
+            sx={{ minWidth: 120 }}
             disabled={busy}
             data-testid="daily-dialog-close"
           >
-            <CloseIcon />
-          </IconButton>
+            キャンセル
+          </Button>
 
-          <Typography sx={{ ml: 1, flex: 1 }} variant="h6">
+          <Typography sx={{ flex: 1 }} variant="h6">
             {title}
           </Typography>
 
-          <Button size="small" variant="text" onClick={handleHubClick}>
+          <Button
+            onClick={handleHubClick}
+            startIcon={<HomeOutlinedIcon />}
+            variant="contained"
+            size="large"
+            sx={{ minWidth: 160 }}
+          >
             日次ハブへ
           </Button>
         </Toolbar>

--- a/src/features/support/TimeBasedSupportRecordForm.tsx
+++ b/src/features/support/TimeBasedSupportRecordForm.tsx
@@ -424,15 +424,38 @@ const TimeBasedSupportRecordForm: React.FC<SupportRecordFormProps> = ({
         </Stack>
       </DialogContent>
 
-      <DialogActions>
-        <Button onClick={onClose}>キャンセル</Button>
-        <Button
-          onClick={handleSave}
-          variant="contained"
-          disabled={!formData.reporter.name || !formData.userCondition.behavior}
-        >
-          保存
-        </Button>
+      <DialogActions
+        sx={{
+          position: 'sticky',
+          bottom: 0,
+          bgcolor: 'background.paper',
+          borderTop: 1,
+          borderColor: 'divider',
+          p: 1,
+          zIndex: 1,
+        }}
+      >
+        <Stack direction="row" spacing={1} sx={{ width: '100%' }}>
+          <Button
+            onClick={onClose}
+            variant="outlined"
+            size="large"
+            fullWidth
+            sx={{ minHeight: 48 }}
+          >
+            キャンセル
+          </Button>
+          <Button
+            onClick={handleSave}
+            variant="contained"
+            size="large"
+            fullWidth
+            sx={{ minHeight: 48 }}
+            disabled={!formData.reporter.name || !formData.userCondition.behavior}
+          >
+            保存
+          </Button>
+        </Stack>
       </DialogActions>
     </Dialog>
   );

--- a/src/pages/AttendanceRecordPage.tsx
+++ b/src/pages/AttendanceRecordPage.tsx
@@ -979,18 +979,41 @@ const AttendanceRecordPage: React.FC<AttendanceRecordPageProps> = ({ 'data-testi
             </Stack>
           </DialogContent>
         )}
-        <DialogActions>
-          <Button onClick={closeAbsenceDialog}>キャンセル</Button>
-          <Button
-            onClick={handleAbsenceSave}
-            variant="contained"
-            disabled={
-              !absenceDialog ||
-              (absenceDialog.morningContacted && absenceDialog.morningMethod === '')
-            }
-          >
-            保存
-          </Button>
+        <DialogActions
+          sx={{
+            position: 'sticky',
+            bottom: 0,
+            bgcolor: 'background.paper',
+            borderTop: 1,
+            borderColor: 'divider',
+            p: 1,
+            zIndex: 1,
+          }}
+        >
+          <Stack direction="row" spacing={1} sx={{ width: '100%' }}>
+            <Button
+              onClick={closeAbsenceDialog}
+              variant="outlined"
+              size="large"
+              fullWidth
+              sx={{ minHeight: 48 }}
+            >
+              キャンセル
+            </Button>
+            <Button
+              onClick={handleAbsenceSave}
+              variant="contained"
+              size="large"
+              fullWidth
+              sx={{ minHeight: 48 }}
+              disabled={
+                !absenceDialog ||
+                (absenceDialog.morningContacted && absenceDialog.morningMethod === '')
+              }
+            >
+              保存
+            </Button>
+          </Stack>
         </DialogActions>
       </Dialog>
       </>

--- a/src/pages/DailyRecordMenuPage.tsx
+++ b/src/pages/DailyRecordMenuPage.tsx
@@ -13,15 +13,87 @@ import Container from '@mui/material/Container';
 import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useAttendanceStore } from '@/features/attendance/store';
 import { BulkDailyRecordForm } from '../features/daily/BulkDailyRecordForm';
 import { useUsersDemo } from '../features/users/usersStoreDemo';
+import type { IUserMaster } from '../features/users/types';
+
+type DailyHubSummary = {
+  activity: {
+    pending: number;
+    inProgress: number;
+  };
+  support: {
+    total: number;
+    incomplete: number;
+  };
+  attendance: {
+    absence: number;
+    lateOrEarly: number;
+  };
+};
+
+const getUserSeed = (userId: string | number | null | undefined, fallback: number) => {
+  const raw = String(userId ?? fallback);
+  const digits = raw.replace(/\D/g, '');
+  const seed = Number(digits);
+  return Number.isNaN(seed) || seed === 0 ? fallback : seed;
+};
+
+const useDailyHubSummary = (users: IUserMaster[]) => {
+  const { visits } = useAttendanceStore();
+
+  return useMemo<DailyHubSummary>(() => {
+    const activity = users.reduce(
+      (acc, user, index) => {
+        const seed = getUserSeed(user.UserID ?? user.Id, index + 1);
+        if (seed % 11 === 0) {
+          acc.pending += 1;
+        } else if (seed % 5 === 0) {
+          acc.inProgress += 1;
+        }
+        return acc;
+      },
+      { pending: 0, inProgress: 0 },
+    );
+
+    const supportTargets = users.filter((user) => Boolean(user.IsSupportProcedureTarget));
+    const support = supportTargets.reduce(
+      (acc, user, index) => {
+        const seed = getUserSeed(user.UserID ?? user.Id, index + 1);
+        if (seed % 7 === 0 || seed % 5 === 0) {
+          acc.incomplete += 1;
+        }
+        return acc;
+      },
+      { total: supportTargets.length, incomplete: 0 },
+    );
+
+    const visitList = Object.values(visits ?? {});
+    const attendance = visitList.reduce(
+      (acc, visit) => {
+        if (visit.status === '当日欠席' || visit.status === '事前欠席') {
+          acc.absence += 1;
+        }
+        if (visit.isEarlyLeave) {
+          acc.lateOrEarly += 1;
+        }
+        return acc;
+      },
+      { absence: 0, lateOrEarly: 0 },
+    );
+
+    return { activity, support, attendance };
+  }, [users, visits]);
+};
 
 const DailyRecordMenuPage: React.FC = () => {
   const navigate = useNavigate();
   const { data: usersRaw } = useUsersDemo();
   const users = usersRaw ?? []; // ← 常に配列にしておく
+  const dailyHubSummary = useDailyHubSummary(users);
 
   // 複数利用者フォーム状態
   const [bulkFormOpen, setBulkFormOpen] = useState(false);
@@ -42,6 +114,31 @@ const DailyRecordMenuPage: React.FC = () => {
     totalUsers > 0 ? Math.round((mockAttendanceProgress / totalUsers) * 100) : 0;
   const supportPercent =
     intensiveSupportUsers > 0 ? Math.round((mockSupportProgress / intensiveSupportUsers) * 100) : 0;
+
+  const activityCaption = useMemo(() => {
+    const { pending, inProgress } = dailyHubSummary.activity;
+    if (pending === 0 && inProgress === 0) return null;
+    return `未入力 ${pending} / 入力中 ${inProgress}`;
+  }, [dailyHubSummary.activity]);
+
+  const supportCaption = useMemo(() => {
+    const { total, incomplete } = dailyHubSummary.support;
+    if (total === 0 && incomplete === 0) return null;
+    return `今日 ${total}件 / 未完了 ${incomplete}`;
+  }, [dailyHubSummary.support]);
+
+  const attendanceCaption = useMemo(() => {
+    const { absence, lateOrEarly } = dailyHubSummary.attendance;
+    if (absence === 0 && lateOrEarly === 0) return null;
+    return `欠席 ${absence} / 遅刻・早退 ${lateOrEarly}`;
+  }, [dailyHubSummary.attendance]);
+
+  const activityCaptionColor = dailyHubSummary.activity.pending > 0 ? 'warning.main' : 'text.secondary';
+  const supportCaptionColor = dailyHubSummary.support.incomplete > 0 ? 'warning.main' : 'text.secondary';
+  const attendanceCaptionColor =
+    dailyHubSummary.attendance.absence > 0 || dailyHubSummary.attendance.lateOrEarly > 0
+      ? 'warning.main'
+      : 'text.secondary';
 
   // 複数利用者記録保存ハンドラ
   const handleBulkSave = async (data: {
@@ -118,6 +215,17 @@ const DailyRecordMenuPage: React.FC = () => {
                 />
               </Box>
 
+              {activityCaption && (
+                <Typography
+                  variant="caption"
+                  color={activityCaptionColor}
+                  noWrap
+                  sx={{ display: 'block', mb: 1 }}
+                >
+                  {activityCaption}
+                </Typography>
+              )}
+
               <Typography variant="body1" color="text.secondary" sx={{ mb: 2 }}>
                 利用者を行として表形式で並べて効率的に一覧入力できます
               </Typography>
@@ -179,6 +287,17 @@ const DailyRecordMenuPage: React.FC = () => {
                   通所管理
                 </Typography>
               </Box>
+
+              {attendanceCaption && (
+                <Typography
+                  variant="caption"
+                  color={attendanceCaptionColor}
+                  noWrap
+                  sx={{ display: 'block', mb: 1 }}
+                >
+                  {attendanceCaption}
+                </Typography>
+              )}
 
               <Typography variant="body1" color="text.secondary" sx={{ mb: 2 }}>
                 通所・退所・欠席加算など、当日の通所状況を一元管理します
@@ -242,6 +361,17 @@ const DailyRecordMenuPage: React.FC = () => {
                   支援手順記録
                 </Typography>
               </Box>
+
+              {supportCaption && (
+                <Typography
+                  variant="caption"
+                  color={supportCaptionColor}
+                  noWrap
+                  sx={{ display: 'block', mb: 1 }}
+                >
+                  {supportCaption}
+                </Typography>
+              )}
 
               <Typography variant="body1" color="text.secondary" sx={{ mb: 2 }}>
                 個別支援計画に基づく支援手順の実施状況を記録します


### PR DESCRIPTION
## Summary
- タブレット向けにキャンセル/保存のフッターを sticky + large + 2分割で統一
- AppBar の上部導線（キャンセル/日次ハブへ）と日次ハブカードのサブ情報を含む

## Risk
- UI/表示ロジックのみ（保存・API変更なし）

## Manual
- /daily/table /daily/support /daily/attendance で下部ボタンが常時表示されることを確認