### PR TITLE
chore(schedules): enforce legacy schedule removal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,14 +44,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Guard: no runtime imports from legacy schedules
+      - name: Guard: no legacy schedule references
         run: |
-          if rg "(from ['\"].*features/schedule/|import\s+[^;]*features/schedule/|require\(['\"].*features/schedule/)" src \
-            --glob '!src/features/schedule/**' \
-            --glob '!src/types/module-stubs.d.ts'; then
-            echo "❌ Legacy schedule import detected outside src/features/schedule"
-            exit 1
-          fi
+          test ! -d src/features/schedule
+          rg -n 'features/schedule(?!s)' src tests --pcre2 && exit 1 || true
+          rg -n '@/features/schedule(?!s)' src tests --pcre2 && exit 1 || true
       
       - name: ESLint (enforce ARCHITECTURE_GUARDS)
         id: lint

--- a/docs/ARCHITECTURE_SCHEDULES.md
+++ b/docs/ARCHITECTURE_SCHEDULES.md
@@ -4,12 +4,6 @@
 - `src/features/schedules`
 - すべての新規UI/UXとルーティングはこの系統のみを使用する。
 
-## レガシー (凍結)
-- `src/features/schedule`
-- 新規参照・新規変更は行わない。
-- 既存参照は段階的に `features/schedules` へ移行する。
-
-## 例外ルール
-- legacy 外の例外は `src/types/module-stubs.d.ts`（type-only）に限定する。
-- 例外的に移植が必要な場合は、必ず理由をPRに明記し、
-  追加の参照を増やさない方針で実施する。
+## レガシー (削除済み)
+- `src/features/schedule` は削除済み。
+- 参照は禁止（CI で強制）。


### PR DESCRIPTION
## Summary\n- enforce legacy schedule directory removal in CI guard\n- tighten schedule import checks to only allow schedules (plural)\n- update schedules architecture doc to mark legacy as removed\n\n## Testing\n- npx vitest run\n- npm run lint\n- npm run typecheck