### PR TITLE
feat: staff attendance route contract

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -34,9 +34,9 @@ const MonthlyRecordPage = React.lazy(() => import('@/pages/MonthlyRecordPage'));
 
 const AttendanceRecordPage = React.lazy(() => import('@/pages/AttendanceRecordPage'));
 const StaffAttendanceAdminPage = React.lazy(() => import('@/pages/StaffAttendanceAdminPage'));
-const StaffAttendanceInput = React.lazy(() =>
-  import('@/features/staff/attendance/StaffAttendanceInput').then((module) => ({
-    default: module.StaffAttendanceInput,
+const StaffAttendanceInputPage = React.lazy(() =>
+  import('@/pages/StaffAttendanceInputPage').then((module) => ({
+    default: module.StaffAttendanceInputPage,
   })),
 );
 
@@ -407,7 +407,7 @@ const SuspendedStaffAttendanceInput: React.FC = () => (
         </div>
       )}
     >
-      <StaffAttendanceInput />
+      <StaffAttendanceInputPage />
     </React.Suspense>
   </RouteHydrationErrorBoundary>
 );
@@ -540,7 +540,7 @@ const childRoutes: RouteObject[] = [
   {
     path: 'staff/attendance',
     element: (
-      <ProtectedRoute flag="schedules">
+      <ProtectedRoute>
         <SuspendedStaffAttendanceInput />
       </ProtectedRoute>
     ),

--- a/src/config/featureFlags.ts
+++ b/src/config/featureFlags.ts
@@ -156,7 +156,7 @@ export const FeatureFlagsProvider: FC<FeatureFlagsProviderProps> = ({ value, chi
   const memoized = useMemo(() => {
     currentSnapshot = snapshot;
     return snapshot;
-  }, [snapshot.schedules, snapshot.complianceForm, snapshot.schedulesWeekV2, snapshot.icebergPdca]);
+  }, [snapshot.schedules, snapshot.complianceForm, snapshot.schedulesWeekV2, snapshot.icebergPdca, snapshot.staffAttendance]);
 
   return createElement(FeatureFlagsContext.Provider, { value: memoized }, children);
 };

--- a/src/pages/StaffAttendanceInputPage.tsx
+++ b/src/pages/StaffAttendanceInputPage.tsx
@@ -1,0 +1,29 @@
+import { Box } from '@mui/material';
+import { useFeatureFlag } from '@/config/featureFlags';
+import EmptyState from '@/ui/components/EmptyState';
+import { StaffAttendanceInput } from '@/features/staff/attendance/StaffAttendanceInput';
+
+export type StaffAttendanceInputPageProps = {
+  className?: string;
+};
+
+export const StaffAttendanceInputPage = ({ className }: StaffAttendanceInputPageProps) => {
+  const staffAttendanceEnabled = useFeatureFlag("staffAttendance");
+
+  if (!staffAttendanceEnabled) {
+    return (
+      <Box className={className} data-testid="staff-attendance-empty-state">
+        <EmptyState
+          title="スタッフ出勤入力は準備中です"
+          description="準備ができ次第、表示されます。"
+        />
+      </Box>
+    );
+  }
+
+  return (
+    <Box className={className} data-testid="staff-attendance-input-root">
+      <StaffAttendanceInput />
+    </Box>
+  );
+};

--- a/tests/e2e/staff-attendance.input.smoke.spec.ts
+++ b/tests/e2e/staff-attendance.input.smoke.spec.ts
@@ -1,0 +1,15 @@
+import { test } from '@playwright/test';
+import { bootstrapDashboard } from './utils/bootstrapApp';
+import { expectTestIdVisibleBestEffort } from './_helpers/smoke';
+
+test.describe('staff attendance input smoke', () => {
+  test('renders input UI when flag is enabled', async ({ page }) => {
+    await bootstrapDashboard(page, {
+      skipLogin: true,
+      featureStaffAttendance: true,
+      initialPath: '/staff/attendance',
+    });
+
+    await expectTestIdVisibleBestEffort(page, 'staff-attendance-input-root');
+  });
+});

--- a/tests/e2e/utils/bootstrapApp.ts
+++ b/tests/e2e/utils/bootstrapApp.ts
@@ -5,6 +5,7 @@ export type BootstrapFlags = {
   skipLogin?: boolean;
   featureSchedules?: boolean;
   featureIcebergPdca?: boolean;
+  featureStaffAttendance?: boolean;
   initialPath?: string;
 };
 
@@ -13,6 +14,7 @@ export async function bootstrapDashboard(page: Page, flags: BootstrapFlags = {})
     skipLogin: flags.skipLogin ?? true,
     featureSchedules: flags.featureSchedules ?? true,
     featureIcebergPdca: flags.featureIcebergPdca ?? true,
+    featureStaffAttendance: flags.featureStaffAttendance ?? false,
     initialPath: flags.initialPath ?? '/dashboard',
   };
 
@@ -28,6 +30,7 @@ export async function bootstrapDashboard(page: Page, flags: BootstrapFlags = {})
       VITE_SCHEDULE_ADMINS_GROUP_ID: 'e2e-admin-group-id',
       ...(opts.featureSchedules ? { VITE_FEATURE_SCHEDULES: '1' } : {}),
       ...(opts.featureIcebergPdca ? { VITE_FEATURE_ICEBERG_PDCA: '1' } : {}),
+      ...(opts.featureStaffAttendance ? { VITE_FEATURE_STAFF_ATTENDANCE: '1' } : {}),
     };
 
     if (opts.skipLogin) {

--- a/tests/rtl/AppShell.nav.test.tsx
+++ b/tests/rtl/AppShell.nav.test.tsx
@@ -84,6 +84,7 @@ describe('AppShell navigation smoke test', () => {
     complianceForm: false,
     schedulesWeekV2: false,
     icebergPdca: false,
+    staffAttendance: false,
   };
 
   const colorMode = { mode: 'light' as const, toggle: vi.fn(), sticky: false };

--- a/tests/unit/AppShell.nav.spec.tsx
+++ b/tests/unit/AppShell.nav.spec.tsx
@@ -17,10 +17,10 @@ const spFetchMock = vi.fn(async (_path: string, _init?: RequestInit) => ({ ok: t
 
 const defaultFlags: FeatureFlagSnapshot = {
   schedules: true,
-  schedulesCreate: true,
   complianceForm: false,
   schedulesWeekV2: false,
   icebergPdca: false,
+  staffAttendance: false,
 };
 
 beforeEach(() => {

--- a/tests/unit/Home.spec.tsx
+++ b/tests/unit/Home.spec.tsx
@@ -13,6 +13,7 @@ const featureFlagsState = vi.hoisted<FeatureFlagSnapshot>(() => ({
   complianceForm: false,
   schedulesWeekV2: false,
   icebergPdca: false,
+  staffAttendance: false,
 }));
 
 vi.mock('@/lib/env', async () => {

--- a/tests/unit/ProtectedRoute.spec.tsx
+++ b/tests/unit/ProtectedRoute.spec.tsx
@@ -37,10 +37,10 @@ const createAuthenticatedState = (
 
 const defaultFlags: FeatureFlagSnapshot = {
   schedules: true,
-  schedulesCreate: true,
   complianceForm: false,
   schedulesWeekV2: false,
   icebergPdca: false,
+  staffAttendance: false,
 };
 
 const LocationProbe: React.FC<{ testId: string }> = ({ testId }) => {

--- a/tests/unit/app.feature-flags.spec.tsx
+++ b/tests/unit/app.feature-flags.spec.tsx
@@ -24,12 +24,12 @@ const renderWithFlags = (flags: FeatureFlagSnapshot) =>
 
 describe('AppShell schedule flag', () => {
   it('hides schedule nav when flag is disabled', () => {
-    renderWithFlags({ schedules: false, schedulesCreate: false, complianceForm: false, schedulesWeekV2: false, icebergPdca: false });
+    renderWithFlags({ schedules: false, complianceForm: false, schedulesWeekV2: false, icebergPdca: false, staffAttendance: false });
     expect(screen.queryByTestId('nav-schedules')).toBeNull();
   });
 
   it('shows schedule nav when flag is enabled', async () => {
-    renderWithFlags({ schedules: true, schedulesCreate: false, complianceForm: false, schedulesWeekV2: true, icebergPdca: false });
+    renderWithFlags({ schedules: true, complianceForm: false, schedulesWeekV2: true, icebergPdca: false, staffAttendance: false });
     expect(await screen.findByTestId('nav-schedules')).toBeInTheDocument();
   });
 });

--- a/tests/unit/auth/ProtectedRoute.flags.spec.tsx
+++ b/tests/unit/auth/ProtectedRoute.flags.spec.tsx
@@ -74,10 +74,10 @@ const createAuthState = (
 
 const defaultFlags: FeatureFlagSnapshot = {
   schedules: true,
-  schedulesCreate: true,
   complianceForm: false,
   schedulesWeekV2: false,
   icebergPdca: false,
+  staffAttendance: false,
 };
 
 const LocationProbe: React.FC<{ testId: string }> = ({ testId }) => {

--- a/tests/unit/config/featureFlags.spec.ts
+++ b/tests/unit/config/featureFlags.spec.ts
@@ -30,19 +30,16 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 describe('featureFlags config', () => {
   beforeEach(() => {
     delete (process as Record<string, unknown>).env?.VITE_FEATURE_SCHEDULES;
-    delete (process as Record<string, unknown>).env?.VITE_FEATURE_SCHEDULES_CREATE;
 
     if (typeof window !== 'undefined') {
       try {
         window.localStorage.removeItem('feature:schedules');
-        window.localStorage.removeItem('feature:schedulesCreate');
       } catch {
         // ignore storage access issues in test env
       }
       const env = (window as unknown as { __ENV__?: Record<string, unknown> }).__ENV__;
       if (env) {
         delete env.VITE_FEATURE_SCHEDULES;
-        delete env.VITE_FEATURE_SCHEDULES_CREATE;
       }
     }
   });
@@ -146,7 +143,6 @@ describe('featureFlags config', () => {
 
     const nextSnapshot = {
       schedules: true,
-      schedulesCreate: false,
       complianceForm: true,
       schedulesWeekV2: false,
       icebergPdca: true,

--- a/tests/unit/staff/staffAttendance.route.spec.tsx
+++ b/tests/unit/staff/staffAttendance.route.spec.tsx
@@ -1,0 +1,41 @@
+import { StaffAttendanceInputPage } from '@/pages/StaffAttendanceInputPage';
+import { FeatureFlagsProvider, type FeatureFlagSnapshot } from '@/config/featureFlags';
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { renderWithAppProviders } from '../../helpers/renderWithAppProviders';
+
+const baseFlags: FeatureFlagSnapshot = {
+  schedules: false,
+  complianceForm: false,
+  schedulesWeekV2: false,
+  icebergPdca: false,
+  staffAttendance: false,
+};
+
+const renderRoute = (flags: FeatureFlagSnapshot) =>
+  renderWithAppProviders(<div />, {
+    initialEntries: ['/staff/attendance'],
+    routeChildren: [
+      {
+        path: 'staff/attendance',
+        element: (
+          <FeatureFlagsProvider value={flags}>
+            <StaffAttendanceInputPage />
+          </FeatureFlagsProvider>
+        ),
+      },
+    ],
+  });
+
+describe('staff attendance route contract', () => {
+  it('shows empty state when flag is disabled', () => {
+    renderRoute(baseFlags);
+    expect(screen.getByTestId('staff-attendance-empty-state')).toBeInTheDocument();
+  });
+
+  it('shows input when flag is enabled', () => {
+    renderRoute({ ...baseFlags, staffAttendance: true });
+    expect(screen.getByTestId('staff-attendance-input-root')).toBeInTheDocument();
+    expect(screen.queryByTestId('staff-attendance-empty-state')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add StaffAttendanceInputPage gate with flag-off empty state and flag-on input
- keep /staff/attendance route always present and auth-protected
- add staff attendance route unit test and E2E input smoke test
- align feature flag snapshots by removing schedulesCreate and adding staffAttendance

## Testing
- npm run lint
- npm run typecheck
- npx vitest run tests/smoke tests/unit/staff/staffAttendance.route.spec.tsx
- npm run test:e2e:smoke -- --grep staff-attendance