### PR TITLE
docs(runbook): add jobs=0 quick triage

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -4,6 +4,7 @@
 
 関連ガイド:
 - [認証トラブルシューティング (MSAL / リダイレクト)](runbook/auth-troubleshooting.md)
+- [CI workflow parse（jobs=0）切り分け](runbooks/ci-workflow-parse.md)
 
 ---
 ## 1. インシデント分類クイックテーブル

--- a/docs/runbooks/ci-workflow-parse.md
+++ b/docs/runbooks/ci-workflow-parse.md
@@ -1,5 +1,11 @@
 # CI Runbook: workflow file issue（jobs=0）/ YAML parse error の切り分け
 
+## 即断（最初の10秒）
+- **症状**: Actions run が `failure` なのに **jobs が 0**
+- **判定**: workflow file issue（YAML パース失敗）
+- **即行動**: 対象 workflow を `git show <headSha>:.github/workflows/ci.yml` で取得し、YAML パースで確認
+- **禁止**: 再実行の連打（jobs=0 はテスト失敗ではなくパース不正が原因）
+
 ## 症状
 - GitHub Actions run が `failure` なのに **jobs が 0**（UI に “workflow file issue” などが出る）
 - `gh run view <runId> --json jobs | jq '.jobs | length'` が `0`


### PR DESCRIPTION
## Summary
- Add jobs=0 quick triage block to CI workflow parse runbook
- Link the runbook from the main runbook index

## Why
Make workflow parse failures immediately recognizable and avoid rerun loops.

## Testing
- not run (docs-only)