### PR TITLE
test(e2e): remove legacy week timeline waits

### DIFF
--- a/tests/e2e/schedule-conflicts.spec.ts
+++ b/tests/e2e/schedule-conflicts.spec.ts
@@ -2,7 +2,7 @@ import '@/test/captureSp400';
 import { expect, test } from '@playwright/test';
 import { TESTIDS } from '@/testids';
 import { gotoDay, gotoWeek } from './utils/scheduleNav';
-import { waitForDayTimeline, waitForWeekTimeline } from './utils/wait';
+import { waitForDayTimeline, waitForWeekViewReady } from './utils/wait';
 
 const setupEnv = {
   env: {
@@ -22,7 +22,7 @@ const TARGET_DATE = new Date('2025-11-14');
 const CONFLICT_SCENARIO = 'conflicts-basic';
 const CONFLICT_SELECTOR = '[data-testid="schedule-warning-indicator"]';
 
-test.describe('Schedule conflicts – timeline views', () => {
+test.describe('Schedule conflicts – schedule views', () => {
   test.beforeEach(async ({ page }) => {
     page.on('console', (message) => {
       if (message.type() === 'info' && message.text().startsWith('[schedulesClient] fixtures=')) {
@@ -54,9 +54,9 @@ test.describe('Schedule conflicts – timeline views', () => {
     await expect(conflicts.first()).toBeVisible();
   });
 
-  test('highlights the same conflicts in the week timeline', async ({ page }) => {
+  test('highlights the same conflicts in the week view', async ({ page }) => {
     await gotoWeek(page, TARGET_DATE, { searchParams: { scenario: CONFLICT_SCENARIO } });
-    await waitForWeekTimeline(page);
+    await waitForWeekViewReady(page);
 
     const weekRoot = page.getByTestId(TESTIDS.SCHEDULE_WEEK_ROOT);
     await expect(weekRoot).toBeVisible();

--- a/tests/e2e/schedule-day.keyboard.spec.ts
+++ b/tests/e2e/schedule-day.keyboard.spec.ts
@@ -2,7 +2,7 @@ import '@/test/captureSp400';
 import { expect, test } from '@playwright/test';
 import { TESTIDS } from '../../src/testids';
 import { gotoDay } from './utils/scheduleNav';
-import { waitForDayTimeline, waitForWeekTimeline } from './utils/wait';
+import { waitForDayTimeline, waitForWeekViewReady } from './utils/wait';
 
 const setupEnv = {
   env: {
@@ -50,7 +50,7 @@ test.describe('Schedule day keyboard navigation', () => {
 
     await dayTab.press('ArrowLeft');
     await weekTab.press(' ');
-    await waitForWeekTimeline(page);
+    await waitForWeekViewReady(page);
     await expect(weekTab).toBeVisible();
 
     await weekTab.press('ArrowRight');

--- a/tests/e2e/schedule-week.deeplink.spec.ts
+++ b/tests/e2e/schedule-week.deeplink.spec.ts
@@ -3,7 +3,7 @@ import { expect, test, type Page } from '@playwright/test';
 import { TESTIDS } from '../../src/testids';
 import { bootstrapScheduleEnv } from './utils/scheduleEnv';
 import { gotoWeek } from './utils/scheduleNav';
-import { waitForWeekTimeline } from './utils/wait';
+import { waitForWeekViewReady } from './utils/wait';
 
 test.describe('Schedule week deep link', () => {
   test.beforeEach(async ({ page }) => {
@@ -18,7 +18,7 @@ test.describe('Schedule week deep link', () => {
     });
 
   const waitForSchedulePage = async (page: Page, iso?: string): Promise<void> => {
-    await waitForWeekTimeline(page);
+    await waitForWeekViewReady(page);
 
     const heading = page.getByTestId(TESTIDS['schedules-week-heading']).or(
       page.getByRole('heading', { level: 1, name: /スケジュール/ }),

--- a/tests/e2e/schedule-week.filter.mobile.spec.ts
+++ b/tests/e2e/schedule-week.filter.mobile.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from '@playwright/test';
 import { TESTIDS } from '@/testids';
 import { bootstrapScheduleEnv } from './utils/scheduleEnv';
 import { gotoWeek } from './utils/scheduleNav';
-import { waitForWeekTimeline } from './utils/wait';
+import { waitForWeekViewReady } from './utils/wait';
 
 test.describe('Schedule week – mobile toolbar/search', () => {
   test.beforeEach(async ({ page }) => {
@@ -14,7 +14,7 @@ test.describe('Schedule week – mobile toolbar/search', () => {
     await page.setViewportSize({ width: 390, height: 844 });
 
     await gotoWeek(page, new Date('2025-11-24'));
-    await waitForWeekTimeline(page);
+    await waitForWeekViewReady(page);
 
     const filterToggle = page.getByTestId(TESTIDS.SCHEDULES_FILTER_TOGGLE);
     await expect(filterToggle).toBeVisible();

--- a/tests/e2e/schedule-week.keyboard.spec.ts
+++ b/tests/e2e/schedule-week.keyboard.spec.ts
@@ -3,7 +3,7 @@ import { expect, test, type Locator } from '@playwright/test';
 import { TESTIDS } from '@/testids';
 import { bootstrapScheduleEnv } from './utils/scheduleEnv';
 import { gotoWeek } from './utils/scheduleNav';
-import { waitForDayTimeline, waitForWeekTimeline } from './utils/wait';
+import { waitForDayTimeline, waitForWeekViewReady } from './utils/wait';
 
 const focusLocator = async (locator: Locator): Promise<void> => {
   await locator.scrollIntoViewIfNeeded();
@@ -36,9 +36,9 @@ test.describe('Schedule week keyboard navigation', () => {
     await bootstrapScheduleEnv(page);
   });
 
-  test('keyboard focus moves across tabs and restores the week timeline', async ({ page }) => {
+  test('keyboard focus moves across tabs and restores the week view', async ({ page }) => {
     await gotoWeek(page, new Date('2025-11-24'));
-    await waitForWeekTimeline(page);
+    await waitForWeekViewReady(page);
 
     const weekTab = page.getByTestId(TESTIDS.SCHEDULES_WEEK_TAB_WEEK);
     const dayTab = page.getByTestId(TESTIDS.SCHEDULES_WEEK_TAB_DAY);
@@ -56,14 +56,14 @@ test.describe('Schedule week keyboard navigation', () => {
     await focusLocator(dayTab);
     await page.keyboard.press('ArrowLeft');
     await page.keyboard.press('Enter');
-    await waitForWeekTimeline(page);
+    await waitForWeekViewReady(page);
 
     await expect(page.getByTestId(TESTIDS['schedules-week-grid'])).toBeVisible();
   });
 
   test('period navigation buttons respond to keyboard activation', async ({ page }) => {
     await gotoWeek(page, new Date('2025-11-24'));
-    await waitForWeekTimeline(page);
+    await waitForWeekViewReady(page);
 
     const rangeLabel = page.getByTestId(TESTIDS.SCHEDULES_RANGE_LABEL);
     const readRange = async () => (await rangeLabel.textContent())?.trim() ?? '';
@@ -82,7 +82,7 @@ test.describe('Schedule week keyboard navigation', () => {
 
   test('search interactions do not change the active week view', async ({ page }) => {
     await gotoWeek(page, new Date('2025-11-24'));
-    await waitForWeekTimeline(page);
+    await waitForWeekViewReady(page);
 
     const weekTab = page.getByTestId(TESTIDS.SCHEDULES_WEEK_TAB_WEEK);
     const activeDay = page.getByTestId(`${TESTIDS.SCHEDULES_WEEK_DAY_PREFIX}-2025-11-24`);

--- a/tests/e2e/utils/scheduleActions.ts
+++ b/tests/e2e/utils/scheduleActions.ts
@@ -633,7 +633,7 @@ const buildWeekRootCandidates = (page: Page): Locator[] => [
   page.getByTestId(TESTIDS.SCHEDULE_WEEK_VIEW),
 ];
 
-const getWeekTimelineRoot = async (page: Page): Promise<Locator> => {
+const getWeekRoot = async (page: Page): Promise<Locator> => {
   const candidates = buildWeekRootCandidates(page);
   for (const locator of candidates) {
     const candidate = locator.first();
@@ -662,7 +662,7 @@ export async function getWeekScheduleItems(
 ) {
   const { category } = opts;
   const categorySelector = category ? `[data-category="${category}"]` : '';
-  const root = await getWeekTimelineRoot(page);
+  const root = await getWeekRoot(page);
   return root.locator(`[data-testid="${TESTIDS.SCHEDULE_ITEM}"]${categorySelector}`);
 }
 
@@ -681,7 +681,7 @@ export async function waitForWeekScheduleItems(
 }
 
 export async function getWeekRowById(page: Page, id: number | string) {
-  const root = await getWeekTimelineRoot(page);
+  const root = await getWeekRoot(page);
   return root.locator(`[data-testid="${TESTIDS.SCHEDULE_ITEM}"][data-id="${id}"]`).first();
 }
 
@@ -860,7 +860,7 @@ export async function openWeekEventCard(
     await weekTab.first().click();
   }
 
-  const root = await getWeekTimelineRoot(page);
+  const root = await getWeekRoot(page);
   await expect(root).toBeVisible({ timeout: 15_000 });
 
   let locator = await getWeekScheduleItems(page, { category });
@@ -884,7 +884,7 @@ export async function assertWeekHasUserCareEvent(
     memoContains?: string;
   } = {},
 ) {
-  const root = await getWeekTimelineRoot(page);
+  const root = await getWeekRoot(page);
   await expect(root).toBeVisible({ timeout: 15_000 });
 
   const { titleContains, serviceContains, userName, memoContains } = opts;

--- a/tests/e2e/utils/scheduleWeek.ts
+++ b/tests/e2e/utils/scheduleWeek.ts
@@ -5,13 +5,13 @@ import { expect, type Page } from '@playwright/test';
 import { TESTIDS } from '@/testids';
 
 import { gotoWeek } from './scheduleNav';
-import { waitForWeekTimeline } from './wait';
+import { waitForWeekViewReady } from './wait';
 
 type GotoWeekOptions = Parameters<typeof gotoWeek>[2];
 
 export async function gotoScheduleWeek(page: Page, date: Date, options?: GotoWeekOptions): Promise<void> {
   await gotoWeek(page, date, options);
-  await waitForWeekTimeline(page);
+  await waitForWeekViewReady(page);
 }
 
 const toLocalDateTime = (date: Date, time: string): string => {

--- a/tests/e2e/utils/wait.ts
+++ b/tests/e2e/utils/wait.ts
@@ -75,7 +75,7 @@ export async function waitForDayScheduleReady(page: Page, timeout = 15_000): Pro
 }
 
 export async function waitForDayTimeline(page: Page): Promise<void> {
-  // Day view is now a tab within /schedules/week (renders DayView component, not TimelineDay)
+  // Day view is now a tab within /schedules/week (renders DayView component)
   await expect(page).toHaveURL(/\/schedules\/week/);
   
   // Verify tab parameter if present
@@ -101,7 +101,7 @@ export async function waitForDayTimeline(page: Page): Promise<void> {
   await expect(root).toBeVisible();
 }
 
-export async function waitForWeekTimeline(page: Page): Promise<void> {
+export async function waitForWeekViewReady(page: Page): Promise<void> {
   const url = page.url();
 
   const pageRoot = page.getByTestId(TESTIDS.SCHEDULES_PAGE_ROOT);
@@ -171,32 +171,14 @@ export async function waitForWeekTimeline(page: Page): Promise<void> {
     return;
   }
 
-  const legacyRoot = page.getByTestId(TESTIDS.SCHEDULE_WEEK_ROOT);
-  const hasLegacyRoot = await locatorExists(legacyRoot, 3_000);
-  if (!hasLegacyRoot) {
-    let domSnippet = '';
-    try {
-      domSnippet = await page.evaluate(() => document.body.innerHTML.slice(0, 10000));
-      domSnippet = domSnippet.replace(/\s+/g, ' ').trim();
-    } catch {
-      domSnippet = '[failed to capture DOM]';
-    }
-    throw new Error(
-      `Schedule week view not found (neither SchedulePage nor WeekPage nor legacy timeline). url=${url} snippet="${domSnippet}"`,
-    );
+  let domSnippet = '';
+  try {
+    domSnippet = await page.evaluate(() => document.body.innerHTML.slice(0, 10000));
+    domSnippet = domSnippet.replace(/\s+/g, ' ').trim();
+  } catch {
+    domSnippet = '[failed to capture DOM]';
   }
-
-  await expect(legacyRoot).toBeVisible();
-
-  const legacyHeading = page.getByRole('heading', { level: 1, name: /スケジュール/ });
-  await expect(legacyHeading).toBeVisible();
-
-  const legacyWeekTab = page.getByRole('tab', { name: /週/ }).first();
-  await expect(legacyWeekTab).toBeVisible();
-  await expect(legacyWeekTab).toHaveAttribute('aria-selected', 'true');
-
-  const legacyHeader = page.locator('[id^="timeline-week-header-"]').first();
-  await expect(legacyHeader).toBeVisible();
+  throw new Error(`Schedule week view not found. url=${url} snippet="${domSnippet}"`);
 }
 
 export async function waitForMonthTimeline(page: Page): Promise<void> {


### PR DESCRIPTION
## What
- Removed legacy week timeline wait helpers (`waitForWeekTimeline`, `getWeekTimelineRoot`)
- Standardized on `waitForWeekViewReady` / week root waits
- Updated schedules E2E specs and helpers accordingly

## Why
- Timeline view was removed in #419 and physically deleted in #420
- Prevent stale helpers from causing confusion/flakes

## Test
- npm run test:e2e:smoke -- --grep schedules