### PR TITLE
feat(footer): page accents + mobile label shortening

### DIFF
--- a/src/testids.ts
+++ b/src/testids.ts
@@ -22,6 +22,7 @@ const FOOTER_TESTIDS = {
   // New canonical footer ids (2024+)
   dailyFooterAttendance: 'daily-footer-attendance',
   dailyFooterActivity: 'daily-footer-activity',
+  schedulesFooterMonth: 'schedules-footer-month',
 } as const;
 
 export const TESTIDS = {
@@ -86,6 +87,7 @@ export const TESTIDS = {
   'daily-footer-activity': 'daily-footer-activity',
   'daily-footer-support': 'daily-footer-support',
   'daily-footer-health': 'daily-footer-health',
+  'schedules-footer-month': 'schedules-footer-month',
   'handoff-footer-timeline': 'handoff-footer-timeline',
   'daily-table-record-page': 'daily-table-record-page',
   'daily-table-record-form': 'daily-table-record-form',


### PR DESCRIPTION
## 概要
フッター5タブのアクティブ時アクセント色をページ種別ごとに付与し、スマホ時はラベルを短縮して視認性を改善。

## 変更点
- アクティブ強調：背景変更なし（下線 + 文字色）
- ページ種別ごとのアクセント色（keyベース）
- スマホ時のみラベル短縮（key別テーブル）
- フッターの横スクロールで詰み回避

## 確認
- スマホ：短縮ラベル/横スクロール/押下OK
- PC/タブ：正式ラベル/アクティブ強調OK
