### PR TITLE
fix(auth): share sign-in guard across hooks

### DIFF
--- a/src/auth/useAuth.ts
+++ b/src/auth/useAuth.ts
@@ -278,6 +278,12 @@ export const useAuth = () => {
     getListReadyState,
     setListReadyState,
     signIn: async () => {
+      const canInteract = inProgress === InteractionStatus.None || inProgress === 'none';
+      if (!canInteract) {
+        debugLog('login skipped (interaction in progress)');
+        return signInInFlight ?? { success: false };
+      }
+
       if (signInInFlight) {
         debugLog('login skipped (already in flight)');
         return signInInFlight;
@@ -302,18 +308,11 @@ export const useAuth = () => {
 
       signInInFlight = (async () => {
         try {
-          const canInteract = inProgress === InteractionStatus.None || inProgress === 'none';
-          if (!canInteract) {
-            debugLog('loginPopup skipped because another interaction is in progress');
-            return { success: false };
-          }
-
           if (useRedirectLogin) {
             if (canInteract) {
               await instance.loginRedirect({ scopes: [defaultScope], prompt: 'select_account' });
               return { success: true };
             }
-            debugLog('loginRedirect skipped because another interaction is in progress');
             return { success: false };
           }
 
@@ -385,7 +384,6 @@ export const useAuth = () => {
               await instance.loginRedirect({ scopes: [defaultScope], prompt: 'select_account' });
               return { success: true };
             } else {
-              debugLog('loginRedirect skipped because another interaction is in progress');
               return { success: false };
             }
           }


### PR DESCRIPTION
## What
- Promote sign-in in-flight guard to a module-scoped Promise
- Ensure concurrent sign-in triggers share a single MSAL attempt

## Why
- Prevent double /authorize calls when multiple components call `useAuth().signIn()` concurrently
- Keep cooldown and StrictMode guards effective across hook instances

## Test
- Not run (local hooks fail due to broken lint-staged pattern)