### PR TITLE
fix(auth): add /auth/callback route

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -12,6 +12,7 @@ import { createBrowserRouter, Navigate, Outlet, type RouteObject, useLocation } 
 import AppShell from './AppShell';
 import { routerFutureFlags } from './routerFuture';
 import SchedulesGate from './SchedulesGate';
+import { AuthCallbackRoute } from '@/auth/AuthCallbackRoute';
 
 const RecordList = React.lazy(() => import('@/features/records/RecordList'));
 const ChecklistPage = React.lazy(() => import('@/features/compliance-checklist/ChecklistPage'));
@@ -528,6 +529,7 @@ const SuspendedHandoffTimelinePage: React.FC = () => (
   </RouteHydrationErrorBoundary>
 );
 const childRoutes: RouteObject[] = [
+  { path: 'auth/callback', element: <AuthCallbackRoute /> },
   { index: true, element: <DashboardRedirect /> },
   { path: 'dashboard', element: <SuspendedStaffDashboardPage /> },
   {

--- a/src/auth/AuthCallbackRoute.tsx
+++ b/src/auth/AuthCallbackRoute.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { getPcaSingleton } from '@/auth/azureMsal';
+
+const POST_LOGIN_REDIRECT_KEY = 'postLoginRedirect';
+
+export function AuthCallbackRoute(): JSX.Element {
+  const navigate = useNavigate();
+
+  React.useEffect(() => {
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const msalInstance = await getPcaSingleton();
+        await msalInstance.handleRedirectPromise();
+
+        const to = sessionStorage.getItem(POST_LOGIN_REDIRECT_KEY) || '/dashboard';
+        sessionStorage.removeItem(POST_LOGIN_REDIRECT_KEY);
+        if (!cancelled) {
+          navigate(to, { replace: true });
+        }
+      } catch (error) {
+        console.error('[auth] callback handling failed', error);
+        if (!cancelled) {
+          navigate('/dashboard', { replace: true });
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [navigate]);
+
+  return <div style={{ padding: 16 }}>サインイン処理中…</div>;
+}


### PR DESCRIPTION
## What
- Add a dedicated `/auth/callback` route outside ProtectedRoute
- Ensure `handleRedirectPromise()` runs and redirects back to `postLoginRedirect` or `/dashboard`

## Why
- Prevent getting stuck at `/auth/callback#code=...`

## Test
- npx tsc -p tsconfig.build.json --noEmit
- npm test -- tests/unit/ui.components.spec.tsx
- manual: sign-in redirect returns to app