### PR TITLE
feat(schedules): label Org as 施設

### DIFF
--- a/src/features/schedules/ScheduleCreateDialog.tsx
+++ b/src/features/schedules/ScheduleCreateDialog.tsx
@@ -50,6 +50,7 @@ import { SCHEDULE_STATUS_OPTIONS } from './statusMetadata';
 import { buildScheduleFailureAnnouncement, buildScheduleSuccessAnnouncement } from './utils/scheduleAnnouncements';
 import { useOrgOptions, type OrgOption } from './useOrgOptions';
 import { useStaffOptions, type StaffOption } from './useStaffOptions';
+import { scheduleCategoryLabels } from './domain/categoryLabels';
 
 // ===== Types for Dialog Component Only =====
 // (All business logic types moved to scheduleFormState.ts for Fast Refresh compatibility)
@@ -87,9 +88,9 @@ export type ScheduleCreateDialogProps = ScheduleCreateDialogBaseProps & (Schedul
 // ===== Component-local Helpers =====
 
 const CATEGORY_OPTIONS: { value: string; label: string; helper: string }[] = [
-  { value: 'User', label: '利用者', helper: '利用者予定：利用者とサービス種別を指定' },
-  { value: 'Staff', label: '職員', helper: '職員予定：担当職員を選択' },
-  { value: 'Org', label: '事業所', helper: '事業所予定：共有イベントや会議など' },
+  { value: 'User', label: scheduleCategoryLabels.User, helper: '利用者予定：利用者とサービス種別を指定' },
+  { value: 'Staff', label: scheduleCategoryLabels.Staff, helper: '職員予定：担当職員を選択' },
+  { value: 'Org', label: scheduleCategoryLabels.Org, helper: '施設予定：共有イベントや会議など' },
 ];
 
 // ===== Component =====
@@ -559,7 +560,7 @@ export const ScheduleCreateDialog: React.FC<ScheduleCreateDialogProps> = (props)
                 <TextField
                   {...params}
                   label="対象 / 場所（任意）"
-                  placeholder="事業所イベントの対象を選択"
+                  placeholder="施設イベントの対象を選択"
                   inputProps={{
                     ...params.inputProps,
                     'data-testid': TESTIDS['schedule-create-location'],

--- a/src/features/schedules/WeekPage.tsx
+++ b/src/features/schedules/WeekPage.tsx
@@ -7,6 +7,7 @@ import { useAuth } from '@/auth/useAuth';
 import { useUserAuthz } from '@/auth/useUserAuthz';
 import { MASTER_SCHEDULE_TITLE_JA } from '@/features/schedules/constants';
 import type { ScheduleCategory } from '@/features/schedules/domain/types';
+import { scheduleCategoryLabels } from '@/features/schedules/domain/categoryLabels';
 import ScheduleCreateDialog from '@/features/schedules/ScheduleCreateDialog';
 import ScheduleEmptyHint from '@/features/schedules/components/ScheduleEmptyHint';
 import SchedulesFilterResponsive from '@/features/schedules/components/SchedulesFilterResponsive';
@@ -681,9 +682,9 @@ export default function WeekPage() {
                   data-testid={TESTIDS['schedules-filter-category']}
                 >
                   <option value="All">すべて</option>
-                  <option value="User">利用者</option>
-                  <option value="Staff">職員</option>
-                  <option value="Org">事業所</option>
+                  <option value="User">{scheduleCategoryLabels.User}</option>
+                  <option value="Staff">{scheduleCategoryLabels.Staff}</option>
+                  <option value="Org">{scheduleCategoryLabels.Org}</option>
                 </select>
               </label>
               <input

--- a/src/features/schedules/WeekView.tsx
+++ b/src/features/schedules/WeekView.tsx
@@ -19,6 +19,7 @@ import { getDayChipSx } from './theme/dateStyles';
 import { type DateRange } from './data';
 import { makeRange, useSchedules } from './useSchedules';
 import type { ScheduleCategory } from '@/features/schedules/domain/types';
+import { scheduleCategoryLabels } from '@/features/schedules/domain/categoryLabels';
 import {
   WeekServiceSummaryChips,
   type WeekServiceSummaryItem,
@@ -123,9 +124,9 @@ const getServiceTypeMeta = (value?: WeekServiceFilter | null) =>
   value && value !== 'unset' ? SERVICE_TYPE_META[value] : undefined;
 
 const LANE_ORDER: Array<{ key: ScheduleCategory; label: string }> = [
-  { key: 'User', label: '利用者' },
-  { key: 'Staff', label: '職員' },
-  { key: 'Org', label: '事業所' },
+  { key: 'User', label: scheduleCategoryLabels.User },
+  { key: 'Staff', label: scheduleCategoryLabels.Staff },
+  { key: 'Org', label: scheduleCategoryLabels.Org },
 ];
 
 const resolveLaneCategory = (value?: ScheduleCategory | null): ScheduleCategory => {

--- a/src/features/schedules/components/DayPopover.tsx
+++ b/src/features/schedules/components/DayPopover.tsx
@@ -8,6 +8,7 @@ import Divider from '@mui/material/Divider';
 import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
 import type { SchedItem } from '../data';
 import { TESTIDS } from '@/testids';
+import { scheduleCategoryLabels } from '../domain/categoryLabels';
 
 interface DayPopoverProps {
   open: boolean;
@@ -88,7 +89,7 @@ export const DayPopover: React.FC<DayPopoverProps> = ({
                   </Typography>
                   {item.category ? (
                     <Typography variant="caption" color="text.secondary">
-                      {item.category}
+                      {scheduleCategoryLabels[item.category] ?? item.category}
                     </Typography>
                   ) : null}
                 </A11yRowButton>

--- a/src/features/schedules/domain/categoryLabels.ts
+++ b/src/features/schedules/domain/categoryLabels.ts
@@ -1,0 +1,7 @@
+import type { ScheduleCategory } from './types';
+
+export const scheduleCategoryLabels: Record<ScheduleCategory, string> = {
+  User: '利用者',
+  Staff: '職員',
+  Org: '施設',
+};


### PR DESCRIPTION
## What
- Show Org lane as 「施設」 across Week/Day/dialog
- Keep internal category as Org (3-lane model)
- Centralize category labels for reuse

## Why
- Org:1 policy and user-facing terminology

## Test
- npm run lint
- npm run typecheck