### PR TITLE
feat(schedules): facility lane UX guidance

### DIFF
--- a/src/features/schedules/ScheduleCreateDialog.tsx
+++ b/src/features/schedules/ScheduleCreateDialog.tsx
@@ -50,7 +50,11 @@ import { SCHEDULE_STATUS_OPTIONS } from './statusMetadata';
 import { buildScheduleFailureAnnouncement, buildScheduleSuccessAnnouncement } from './utils/scheduleAnnouncements';
 import { useOrgOptions, type OrgOption } from './useOrgOptions';
 import { useStaffOptions, type StaffOption } from './useStaffOptions';
-import { scheduleCategoryLabels } from './domain/categoryLabels';
+import {
+  scheduleCategoryLabels,
+  scheduleFacilityHelpText,
+  scheduleFacilityPlaceholder,
+} from './domain/categoryLabels';
 
 // ===== Types for Dialog Component Only =====
 // (All business logic types moved to scheduleFormState.ts for Fast Refresh compatibility)
@@ -90,7 +94,7 @@ export type ScheduleCreateDialogProps = ScheduleCreateDialogBaseProps & (Schedul
 const CATEGORY_OPTIONS: { value: string; label: string; helper: string }[] = [
   { value: 'User', label: scheduleCategoryLabels.User, helper: '利用者予定：利用者とサービス種別を指定' },
   { value: 'Staff', label: scheduleCategoryLabels.Staff, helper: '職員予定：担当職員を選択' },
-  { value: 'Org', label: scheduleCategoryLabels.Org, helper: '施設予定：共有イベントや会議など' },
+  { value: 'Org', label: scheduleCategoryLabels.Org, helper: `施設予定：${scheduleFacilityHelpText}` },
 ];
 
 // ===== Component =====
@@ -252,6 +256,10 @@ export const ScheduleCreateDialog: React.FC<ScheduleCreateDialogProps> = (props)
       return { ...prev, title: autoTitleFromForm };
     });
   }, [autoTitleFromForm]);
+
+  const isOrgCategory = form.category === 'Org';
+  const titlePlaceholder = isOrgCategory ? scheduleFacilityPlaceholder : '例）午前 利用者Aさん通所';
+  const titleHelperText = isOrgCategory ? scheduleFacilityHelpText : undefined;
 
   const handleUserChange = (_event: unknown, value: ScheduleUserOption | null) => {
     setForm((prev) => {
@@ -428,7 +436,8 @@ export const ScheduleCreateDialog: React.FC<ScheduleCreateDialogProps> = (props)
             fullWidth
             value={form.title}
             onChange={(e) => handleFieldChange('title', e.target.value)}
-            placeholder="例）午前 利用者Aさん通所"
+            placeholder={titlePlaceholder}
+            helperText={titleHelperText}
             autoFocus
             inputProps={{
               'data-testid': TESTIDS['schedule-create-title'],

--- a/src/features/schedules/WeekPage.tsx
+++ b/src/features/schedules/WeekPage.tsx
@@ -601,7 +601,7 @@ export default function WeekPage() {
     return () => clearTimeout(timeoutId);
   }, [focusScheduleId, filteredItems]);
 
-  const showEmptyHint = !isLoading && filteredItems.length === 0 && mode !== 'week';
+  const showEmptyHint = !isLoading && filteredItems.length === 0;
 
 
   return (
@@ -724,7 +724,7 @@ export default function WeekPage() {
 
       <div>
         {showEmptyHint ? (
-          <ScheduleEmptyHint view="week" periodLabel={weekLabel} sx={{ mb: 2 }} />
+          <ScheduleEmptyHint view={mode} periodLabel={weekLabel} sx={{ mb: 2 }} />
         ) : null}
         {isLoading ? (
           <div aria-busy="true" aria-live="polite" style={{ display: 'grid', gap: 16 }}>

--- a/src/features/schedules/components/ScheduleEmptyHint.tsx
+++ b/src/features/schedules/components/ScheduleEmptyHint.tsx
@@ -2,6 +2,7 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import type { SxProps, Theme } from '@mui/material/styles';
 import { TESTIDS } from '@/testids';
+import { scheduleFacilityEmptyCopy } from '@/features/schedules/domain/categoryLabels';
 
 export type ScheduleEmptyHintProps = {
   view: 'day' | 'week' | 'month';
@@ -9,48 +10,25 @@ export type ScheduleEmptyHintProps = {
   sx?: SxProps<Theme>;
 };
 
-const resolvePrefix = (view: ScheduleEmptyHintProps['view'], periodLabel?: string): string => {
-  if (periodLabel) {
-    return `${periodLabel}の予定はまだ登録されていません。`;
-  }
-  switch (view) {
-    case 'day':
-      return 'この日の予定はまだ登録されていません。';
-    case 'week':
-      return 'この週の予定はまだ登録されていません。';
-    case 'month':
-      return 'この月の予定はまだ登録されていません。';
-    default:
-      return '予定はまだ登録されていません。';
-  }
-};
-
-const resolveBody = (view: ScheduleEmptyHintProps['view'], prefix: string): string => {
-  switch (view) {
-    case 'day':
-      return `${prefix} 右下の「＋」か画面上部の「新規作成」から予定を追加できます。`;
-    case 'week':
-      return `${prefix} 必要に応じて日表示に切り替えて、予定を追加してください。`;
-    case 'month':
-      return prefix;
-    default:
-      return prefix;
-  }
-};
-
-export function ScheduleEmptyHint({ view, periodLabel, sx }: ScheduleEmptyHintProps) {
-  const prefix = resolvePrefix(view, periodLabel);
-  const message = resolveBody(view, prefix);
+export function ScheduleEmptyHint(props: ScheduleEmptyHintProps) {
+  const { title, description, cta } = scheduleFacilityEmptyCopy;
+  const { sx } = props;
 
   return (
     <Box
       role="status"
       aria-live="polite"
       data-testid={TESTIDS.SCHEDULES_EMPTY_HINT}
-      sx={{ mb: 1.5, ...sx }}
+      sx={{ mb: 1.5, display: 'grid', gap: 0.5, ...sx }}
     >
+      <Typography variant="subtitle2" color="text.primary">
+        {title}
+      </Typography>
       <Typography variant="body2" color="text.secondary">
-        {message}
+        {description}
+      </Typography>
+      <Typography variant="body2" color="primary">
+        {cta}
       </Typography>
     </Box>
   );

--- a/src/features/schedules/domain/categoryLabels.ts
+++ b/src/features/schedules/domain/categoryLabels.ts
@@ -5,3 +5,13 @@ export const scheduleCategoryLabels: Record<ScheduleCategory, string> = {
   Staff: '職員',
   Org: '施設',
 };
+
+export const scheduleFacilityPlaceholder = '例）会議／全体予定／共有タスク';
+
+export const scheduleFacilityHelpText = '個人ではなく、施設全体に関わる予定です。';
+
+export const scheduleFacilityEmptyCopy = {
+  title: '施設の予定はまだありません',
+  description: '会議や全体予定、共有タスクなど、施設全体に関わる予定を登録できます。',
+  cta: '施設の予定を追加',
+};


### PR DESCRIPTION
## Summary
- centralize facility (Org) guidance copy and reuse it across empty states
- strengthen facility placeholder/helper text in schedule create dialog
- show the unified empty-state hint across week/day/month views

## Testing
- not run (copy-only change)