### PR TITLE
feat(schedules): improve facility create UX

### DIFF
--- a/src/features/schedules/ScheduleCreateDialog.tsx
+++ b/src/features/schedules/ScheduleCreateDialog.tsx
@@ -53,7 +53,6 @@ import { useStaffOptions, type StaffOption } from './useStaffOptions';
 import {
   scheduleCategoryLabels,
   scheduleFacilityHelpText,
-  scheduleFacilityOneTimeGuide,
   scheduleFacilityPlaceholder,
 } from './domain/categoryLabels';
 
@@ -97,6 +96,8 @@ const CATEGORY_OPTIONS: { value: string; label: string; helper: string }[] = [
   { value: 'Staff', label: scheduleCategoryLabels.Staff, helper: '職員予定：担当職員を選択' },
   { value: 'Org', label: scheduleCategoryLabels.Org, helper: `施設予定：${scheduleFacilityHelpText}` },
 ];
+
+const FACILITY_ONE_TIME_GUIDE = '施設レーンは「会議・全体予定・共有タスク」用です。';
 
 // ===== Component =====
 
@@ -443,7 +444,7 @@ export const ScheduleCreateDialog: React.FC<ScheduleCreateDialogProps> = (props)
 
         {showFacilityGuide ? (
           <Alert severity="info" sx={{ mb: 2 }}>
-            {scheduleFacilityOneTimeGuide}
+            {FACILITY_ONE_TIME_GUIDE}
           </Alert>
         ) : null}
 

--- a/src/features/schedules/domain/categoryLabels.ts
+++ b/src/features/schedules/domain/categoryLabels.ts
@@ -6,16 +6,12 @@ export const scheduleCategoryLabels: Record<ScheduleCategory, string> = {
   Org: '施設',
 };
 
-export const scheduleFacilityPlaceholder = '例）朝礼／職員会議／全体イベント準備／送迎調整／設備点検';
+export const scheduleFacilityPlaceholder = '例）会議／全体予定／共有タスク';
 
-export const scheduleFacilityHelpText =
-  '「施設」は、会議・全体予定・共有タスクなど“みんなに影響する予定”を入れるレーンです。';
-
-export const scheduleFacilityOneTimeGuide =
-  '施設レーンは「会議・全体予定・共有タスク」用です。';
+export const scheduleFacilityHelpText = '個人ではなく、施設全体に関わる予定です。';
 
 export const scheduleFacilityEmptyCopy = {
-  title: '予定はまだありません',
-  description: '「＋予定を追加」から登録できます。会議・全体予定・共有タスクは「施設」へ。',
-  cta: '＋予定を追加',
+  title: '施設の予定はまだありません',
+  description: '会議や全体予定、共有タスクなど、施設全体に関わる予定を登録できます。',
+  cta: '施設の予定を追加',
 };


### PR DESCRIPTION
## Summary
- refresh facility guidance copy for the Org category
- update facility placeholders/helpers to match new examples
- show a one-time facility guide in the create dialog

## Testing
- not run (copy-only change)