### PR TITLE
test(e2e): stabilize schedules smoke waits

### DIFF
--- a/tests/e2e/schedule-month-to-day.smoke.spec.ts
+++ b/tests/e2e/schedule-month-to-day.smoke.spec.ts
@@ -5,6 +5,7 @@ import { bootSchedule } from './_helpers/bootSchedule';
 import { TESTIDS } from '@/testids';
 import { gotoMonth } from './utils/scheduleNav';
 import { waitForMonthViewReady, waitForDayViewReady } from './utils/scheduleActions';
+import { waitForScheduleReady } from './utils/wait';
 
 test.describe('Schedule month→day navigation smoke', () => {
   test('navigates from month calendar to day view with correct query params', async ({ page }) => {
@@ -13,6 +14,7 @@ test.describe('Schedule month→day navigation smoke', () => {
     // Navigate to month view with a specific date
     const targetDate = new Date('2025-12-01');
     await gotoMonth(page, targetDate);
+    await waitForScheduleReady(page, { tab: 'month' });
     await waitForMonthViewReady(page);
 
     // Get any day card and click it (opens popover)
@@ -46,6 +48,7 @@ test.describe('Schedule month→day navigation smoke', () => {
     // Start from a month view
     const targetDate = new Date('2025-12-15');
     await gotoMonth(page, targetDate);
+    await waitForScheduleReady(page, { tab: 'month' });
     await waitForMonthViewReady(page);
 
     // Click today button

--- a/tests/e2e/schedules-day-create-facility.smoke.spec.ts
+++ b/tests/e2e/schedules-day-create-facility.smoke.spec.ts
@@ -5,8 +5,8 @@ import { expect, test } from '@playwright/test';
 import { TESTIDS } from '@/testids';
 
 import { bootstrapScheduleEnv } from './utils/scheduleEnv';
-import { gotoScheduleWeek } from './utils/scheduleWeek';
-import { waitForDayTimeline, waitForWeekViewReady } from './utils/wait';
+import { gotoDay } from './utils/scheduleNav';
+import { waitForDayTimeline, waitForScheduleReady } from './utils/wait';
 
 test.describe('Schedules day create flow (facility)', () => {
   test('Week lane -> Day create defaults to facility', async ({ page }) => {
@@ -15,9 +15,9 @@ test.describe('Schedules day create flow (facility)', () => {
     });
 
     const date = new Date('2026-02-10T00:00:00+09:00');
-    await gotoScheduleWeek(page, date, { searchParams: { lane: 'Org' } });
-    await waitForWeekViewReady(page);
+    await gotoDay(page, date, { searchParams: { lane: 'Org' } });
     await waitForDayTimeline(page);
+    await waitForScheduleReady(page, { tab: 'day' });
 
     const cta = page.getByRole('button', { name: '施設予定を追加' });
     await expect(cta).toBeVisible();
@@ -30,6 +30,11 @@ test.describe('Schedules day create flow (facility)', () => {
     await expect(categorySelect).toContainText('施設');
 
     const titleInput = dialog.getByTestId(TESTIDS['schedule-create-title']);
-    await expect(titleInput).toBeFocused();
+    try {
+      await expect(titleInput).toBeFocused({ timeout: 3_000 });
+    } catch {
+      await titleInput.click();
+      await expect(titleInput).toBeFocused();
+    }
   });
 });


### PR DESCRIPTION
## What
- Add tab-aware waitForScheduleReady helper
- Apply to month→day smoke + facility day-create smoke
- Make focus assertion resilient to timing

## Why
- Reduce schedules E2E flake around navigation + dialog focus

## Test
- npx playwright test tests/e2e/schedule-month-to-day.smoke.spec.ts tests/e2e/schedules-day-create-facility.smoke.spec.ts