### PR TITLE
feat(schedules): apply filters to month view

### DIFF
--- a/docs/design/schedules-contracts.md
+++ b/docs/design/schedules-contracts.md
@@ -1,0 +1,66 @@
+# Schedules Contracts (Day/Week/Month)
+
+## 0. Purpose
+Keep Day, Week, and Month aligned on the same filter and navigation contracts to prevent UI drift and E2E flakes.
+
+## 1. Terms
+- items: list returned by `useSchedules(range)` (normalized).
+- filteredItems: `items` after applying filters (category, query, etc.).
+- activeCategory: `User | Staff | Org` (Org is displayed as 施設).
+- activeDateIso: `YYYY-MM-DD`.
+- mode/tab: `day | week | month`.
+
+## A. Items Unification (Display Contract)
+### A1. Single Source of Truth
+- Day/Week/Month must render from the same `filteredItems` pipeline.
+- Month badge counts and popover lists must also be derived from `filteredItems`.
+
+**A2: Month reflects filters (YES).**
+
+**Expected effect**
+- If the header filter is set to 施設, Month must not show all-category counts or lists.
+
+## B. Tab Navigation (State Carry-over Contract)
+### B1. Week -> Day lane carry-over
+- Week lane (施設/利用者/職員) must carry into Day category filter.
+- `lane=` in the URL is allowed as a one-time handoff; Day may clear it after applying.
+
+### B2. Month -> Day carry-over
+- Month -> Day must preserve the active filter (especially category).
+- **activeCategory must be preserved on Month -> Day navigation.**
+
+## C. Count vs List Consistency (UX Contract)
+### C1. Month badge count == Popover list count
+- Both are computed from the same `filteredItems` for that date.
+
+**Note on multi-day events (Contract v1)**
+- Current spec: count by start date.
+- If this changes later, document as Contract v2 and lock with unit tests.
+
+## 2. Test Lock (Minimal Set)
+### E2E (required)
+- Month -> Day keeps category (e.g., 施設).
+- Expectation: Day category filter is 施設; create dialog default category is 施設.
+
+### Unit (optional, light)
+- Month day summary count/list consistency after multi-day spec is finalized.
+
+## 3. D-3 Mapping (Minimal Changes)
+Goal: Month must use the same `filteredItems` contract as Week/Day.
+
+### Expected edits
+1) `WeekPage.tsx`
+- Expose `filteredItems` to Month (via props is the smallest diff).
+
+2) `MonthPage.tsx`
+- Stop calling `useSchedules(calendarRange)`.
+- Use props `items` for `buildDaySummaries` and `getItemsForDate`.
+
+3) Month -> Day navigation
+- Carry `activeCategory` through navigation (e.g., `tab=day&lane=<activeCategory>`).
+
+### E2E update
+- Update the existing `schedule-month-to-day.smoke.spec.ts` to assert Month -> Day keeps category.
+
+## 4. Decision
+- A2 is **YES**: Month reflects active filters.

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -19,7 +19,6 @@ const ChecklistPage = React.lazy(() => import('@/features/compliance-checklist/C
 const AuditPanel = React.lazy(() => import('@/features/audit/AuditPanel'));
 
 const NewSchedulesWeekPage = lazyWithPreload(() => import('@/features/schedules/WeekPage'));
-const SchedulesMonthPage = React.lazy(() => import('@/features/schedules/MonthPage'));
 const DailyRecordPage = React.lazy(() => import('@/pages/DailyRecordPage'));
 const DailyRecordMenuPage = React.lazy(() => import('@/pages/DailyRecordMenuPage'));
 const TableDailyRecordPage = React.lazy(() => import('@/features/daily/TableDailyRecordPage'));
@@ -101,19 +100,6 @@ const SuspendedNewSchedulesWeekPage: React.FC = () => (
   </RouteHydrationErrorBoundary>
 );
 
-const SuspendedSchedulesMonthPage: React.FC = () => (
-  <RouteHydrationErrorBoundary>
-    <React.Suspense
-      fallback={(
-        <div className="p-4 text-sm text-slate-600" role="status">
-          月別予定を読み込んでいます…
-        </div>
-      )}
-    >
-      <SchedulesMonthPage />
-    </React.Suspense>
-  </RouteHydrationErrorBoundary>
-);
 
 const DashboardRedirect: React.FC = () => {
   const location = useLocation();
@@ -132,6 +118,14 @@ const SchedulesDayRedirect: React.FC = () => {
   const location = useLocation();
   const nextParams = new URLSearchParams(location.search);
   nextParams.set('tab', 'day');
+  const suffix = nextParams.toString();
+  return <Navigate to={`/schedules/week${suffix ? `?${suffix}` : ''}`} replace />;
+};
+
+const SchedulesMonthRedirect: React.FC = () => {
+  const location = useLocation();
+  const nextParams = new URLSearchParams(location.search);
+  nextParams.set('tab', 'month');
   const suffix = nextParams.toString();
   return <Navigate to={`/schedules/week${suffix ? `?${suffix}` : ''}`} replace />;
 };
@@ -786,7 +780,7 @@ const childRoutes: RouteObject[] = [
       <SchedulesGate>
         <ProtectedRoute flag="schedules">
           <RequireAudience audience="staff">
-            <SuspendedSchedulesMonthPage />
+            <SchedulesMonthRedirect />
           </RequireAudience>
         </ProtectedRoute>
       </SchedulesGate>

--- a/src/features/schedules/WeekPage.tsx
+++ b/src/features/schedules/WeekPage.tsx
@@ -47,6 +47,21 @@ const endOfWeek = (start: Date): Date => {
   return end;
 };
 
+const startOfMonth = (date: Date): Date => {
+  const next = new Date(date);
+  next.setDate(1);
+  next.setHours(0, 0, 0, 0);
+  return next;
+};
+
+const startOfCalendar = (anchor: Date): Date => startOfWeek(startOfMonth(anchor));
+
+const endOfCalendar = (start: Date): Date => {
+  const end = new Date(start);
+  end.setDate(end.getDate() + 6 * 7);
+  return end;
+};
+
 const formatRangeLabel = (fromIso: string, toIso: string): string => {
   const start = new Date(fromIso);
   const end = new Date(toIso);
@@ -255,7 +270,14 @@ export default function WeekPage() {
     const start = startOfWeek(focusDate);
     return makeRange(start, endOfWeek(start));
   }, [focusDate]);
-  const { items, loading: isLoading, create, update, remove, lastError, clearLastError, refetch } = useSchedules(weekRange);
+  const monthRange = useMemo(() => {
+    const anchor = startOfMonth(focusDate);
+    const from = startOfCalendar(anchor);
+    const to = endOfCalendar(from);
+    return makeRange(from, to);
+  }, [focusDate]);
+  const dataRange = mode === 'month' ? monthRange : weekRange;
+  const { items, loading: isLoading, create, update, remove, lastError, clearLastError, refetch } = useSchedules(dataRange);
   const filteredItems = useMemo(() => {
     const needle = query.trim().toLowerCase();
     return items.filter((item) => {
@@ -788,7 +810,11 @@ export default function WeekPage() {
               />
             )}
             {mode === 'month' && (
-              <MonthPage />
+              <MonthPage
+                items={filteredItems}
+                loading={isLoading}
+                activeCategory={categoryFilter}
+              />
             )}
           </>
         )}

--- a/tests/e2e/schedule-month-to-day.smoke.spec.ts
+++ b/tests/e2e/schedule-month-to-day.smoke.spec.ts
@@ -17,6 +17,10 @@ test.describe('Schedule month→day navigation smoke', () => {
     await waitForScheduleReady(page, { tab: 'month' });
     await waitForMonthViewReady(page);
 
+    const categoryFilter = page.getByTestId(TESTIDS['schedules-filter-category']);
+    await expect(categoryFilter).toBeVisible();
+    await categoryFilter.selectOption('Org');
+
     // Get any day card and click it (opens popover)
     const dayCards = page.locator(`[data-testid^="${TESTIDS.SCHEDULES_MONTH_DAY_PREFIX}-"]`);
     if ((await dayCards.count()) === 0) {
@@ -34,6 +38,11 @@ test.describe('Schedule month→day navigation smoke', () => {
 
     // Verify navigation to day view with correct query params
     await waitForDayViewReady(page);
+    await expect(categoryFilter).toHaveValue('Org');
+    const dayCta = page.getByRole('button', { name: '施設予定を追加' });
+    if ((await dayCta.count()) > 0) {
+      await expect(dayCta).toBeVisible();
+    }
     await expect(page).toHaveURL(/tab=day/);
     const url = page.url();
     // Current routing uses /schedules/week with tab=day query param for day view


### PR DESCRIPTION
## What
- Month view renders from filteredItems (consistent with Day/Week)
- Month→Day carries active category via lane
- Contracts clarified (A2/B2/C1)

## Why
- Keep Day/Week/Month behavior consistent under filters

## Test
- npx playwright test tests/e2e/schedule-month-to-day.smoke.spec.ts