### PR TITLE
feat(schedules): simplify create entrypoints

### DIFF
--- a/src/features/schedules/DayView.tsx
+++ b/src/features/schedules/DayView.tsx
@@ -86,7 +86,6 @@ type DayViewProps = {
   range?: DateRange;
   categoryFilter?: 'All' | ScheduleCategory;
   emptyCtaLabel?: string;
-  onCreate?: () => void;
 };
 
 export default function DayView(props: DayViewProps = {}) {
@@ -100,7 +99,6 @@ export default function DayView(props: DayViewProps = {}) {
         range={props.range!}
         categoryFilter={props.categoryFilter}
         emptyCtaLabel={props.emptyCtaLabel}
-        onCreate={props.onCreate}
       />
     );
   }
@@ -124,7 +122,6 @@ const DayViewWithData = (props: DayViewProps) => {
       range={resolvedRange}
       categoryFilter={props.categoryFilter}
       emptyCtaLabel={props.emptyCtaLabel}
-      onCreate={props.onCreate}
     />
   );
 };
@@ -135,14 +132,12 @@ const DayViewContent = ({
   range,
   categoryFilter,
   emptyCtaLabel,
-  onCreate,
 }: {
   items: SchedItem[];
   loading: boolean;
   range: DateRange;
   categoryFilter?: 'All' | ScheduleCategory;
   emptyCtaLabel?: string;
-  onCreate?: () => void;
 }) => {
   const headingId = useId();
   const listLabelId = useId();
@@ -163,6 +158,11 @@ const DayViewContent = ({
   const dayLabel = useMemo(() => formatDayLabel(range.from), [range.from]);
   const resolvedCtaLabel =
     emptyCtaLabel ?? (categoryFilter === 'Org' ? '施設予定を追加' : '予定を追加');
+  const emptyHint = `右下の「＋」から${resolvedCtaLabel}できます。`;
+  const emptyDescription =
+    categoryFilter === 'Org'
+      ? `${emptyHint}会議・全体予定・共有タスクは「施設」へ。`
+      : emptyHint;
 
   return (
     <section
@@ -292,26 +292,9 @@ const DayViewContent = ({
           <div style={{ display: 'grid', gap: 12 }}>
             <EmptyState
               title="予定はまだありません"
-              description="「＋予定を追加」から登録できます。会議・全体予定・共有タスクは「施設」へ。"
+              description={emptyDescription}
               data-testid="schedule-day-empty"
             />
-            {onCreate ? (
-              <button
-                type="button"
-                onClick={onCreate}
-                style={{
-                  alignSelf: 'flex-start',
-                  padding: '8px 14px',
-                  borderRadius: 999,
-                  border: '1px solid rgba(0,0,0,0.2)',
-                  background: '#fff',
-                  fontSize: 14,
-                  cursor: 'pointer',
-                }}
-              >
-                {resolvedCtaLabel}
-              </button>
-            ) : null}
           </div>
         ) : (
           <ol

--- a/src/features/schedules/WeekPage.tsx
+++ b/src/features/schedules/WeekPage.tsx
@@ -713,6 +713,7 @@ export default function WeekPage() {
           onNext={handleNextWeek}
           onToday={handleTodayWeek}
           onPrimaryCreate={canEdit ? handleFabClick : undefined}
+          showPrimaryAction={false}
           primaryActionAriaLabel="この週に新規予定を作成"
           headingId={headingId}
           titleTestId={TESTIDS['schedules-week-heading']}
@@ -806,7 +807,6 @@ export default function WeekPage() {
                 range={activeDayRange}
                 categoryFilter={categoryFilter}
                 emptyCtaLabel={categoryFilter === 'Org' ? '施設予定を追加' : '予定を追加'}
-                onCreate={canEdit ? handleFabClick : undefined}
               />
             )}
             {mode === 'month' && (

--- a/src/features/schedules/components/ScheduleEmptyHint.tsx
+++ b/src/features/schedules/components/ScheduleEmptyHint.tsx
@@ -27,7 +27,7 @@ export function ScheduleEmptyHint(props: ScheduleEmptyHintProps) {
       <Typography variant="body2" color="text.secondary">
         {description}
       </Typography>
-      <Typography variant="body2" color="primary">
+      <Typography variant="body2" color="text.secondary">
         {cta}
       </Typography>
     </Box>

--- a/src/features/schedules/domain/categoryLabels.ts
+++ b/src/features/schedules/domain/categoryLabels.ts
@@ -13,5 +13,5 @@ export const scheduleFacilityHelpText = '個人ではなく、施設全体に関
 export const scheduleFacilityEmptyCopy = {
   title: '施設の予定はまだありません',
   description: '会議や全体予定、共有タスクなど、施設全体に関わる予定を登録できます。',
-  cta: '施設の予定を追加',
+  cta: '右下の「＋」から追加できます。',
 };


### PR DESCRIPTION
## What
- Hide header create button (FAB is the sole entrypoint)
- Replace day empty-state CTA with guidance text
- Demote empty hint CTA styling and copy to FAB guidance

## Why
- Remove multiple competing create entrypoints
- Make the "right action" unambiguous

## Test
- npm run lint
- npm run typecheck