### PR TITLE
feat(schedules): remove 'new schedule' default title

### DIFF
--- a/src/features/schedules/WeekPage.tsx
+++ b/src/features/schedules/WeekPage.tsx
@@ -362,7 +362,7 @@ export default function WeekPage() {
       const start = new Date(buildLocalDateTimeInput(input.startLocal, startTime)).toISOString();
       const end = new Date(buildLocalDateTimeInput(input.endLocal, endTime)).toISOString();
       const draft: InlineScheduleDraft = {
-        title: input.title.trim() || '新規予定',
+        title: input.title.trim() || '予定',
         dateIso,
         startTime,
         endTime,
@@ -497,8 +497,8 @@ export default function WeekPage() {
           onToday={handleTodayWeek}
           onPrimaryCreate={canEdit ? handleFabClick : undefined}
                   showPrimaryAction={isDesktopSize}
-                  primaryActionLabel="新規登録"
-          primaryActionAriaLabel="この週に新規予定を作成"
+                  primaryActionLabel="予定を追加"
+          primaryActionAriaLabel="この週に予定を追加"
           headingId={headingId}
           titleTestId={TESTIDS['schedules-week-heading']}
           rangeLabelId={rangeDescriptionId}
@@ -638,7 +638,7 @@ export default function WeekPage() {
           }
         >
           <span aria-hidden="true">＋</span>
-          {isExtendedFab ? <span style={{ fontSize: 14, fontWeight: 600 }}>新規登録</span> : null}
+          {isExtendedFab ? <span style={{ fontSize: 14, fontWeight: 600 }}>予定を追加</span> : null}
         </button>
       ) : null}
       {dialogInitialValues ? (

--- a/src/features/schedules/data/createAdapters.ts
+++ b/src/features/schedules/data/createAdapters.ts
@@ -7,7 +7,7 @@ import { SCHEDULES_FIELDS, SCHEDULES_LIST_TITLE, DEFAULT_SCHEDULE_VISIBILITY, OW
 import { resolveSchedulesTz } from '@/utils/scheduleTz';
 import { normalizeServiceType as normalizeSharePointServiceType } from '@/sharepoint/serviceTypes';
 
-const DEFAULT_TITLE = '新規予定';
+const DEFAULT_TITLE = '予定';
 const SCHEDULES_TZ = resolveSchedulesTz();
 
 export const normalizeUserId = (value: string): string => value.trim().toUpperCase().replace(/[^A-Z0-9]/g, '');

--- a/src/features/schedules/data/demoAdapter.ts
+++ b/src/features/schedules/data/demoAdapter.ts
@@ -170,7 +170,7 @@ const normalizeServiceType = (value: CreateScheduleEventInput['serviceType']): S
 };
 
 const resolveTitle = (input: CreateScheduleEventInput): string =>
-  (input.title ?? '').trim() || '新規予定';
+  (input.title ?? '').trim() || '予定';
 
 export const demoSchedulesPort: SchedulesPort = {
   async list(range) {

--- a/src/features/schedules/domain/categoryLabels.ts
+++ b/src/features/schedules/domain/categoryLabels.ts
@@ -12,6 +12,6 @@ export const scheduleFacilityHelpText = '個人ではなく、施設全体に関
 
 export const scheduleFacilityEmptyCopy = {
   title: '施設の予定はまだありません',
-  description: '会議や全体予定、共有タスクなど、施設全体に関わる予定を登録できます。',
-  cta: '右下の「＋」から追加できます。',
+  description: '会議や全体予定、共有タスクなど、施設全体に関わる予定を追加できます。',
+  cta: '右下の「＋」から予定を追加できます。',
 };

--- a/src/features/schedules/scheduleFormState.ts
+++ b/src/features/schedules/scheduleFormState.ts
@@ -36,7 +36,7 @@ export function buildAutoTitle(params: {
   }
   if (params.assignedStaffId?.trim()) return `担当 ${params.assignedStaffId} の予定`;
   if (params.vehicleId?.trim()) return `車両 ${params.vehicleId} の予定`;
-  return '新規予定';
+  return '';
 }
 
 // ===== Types =====

--- a/src/features/schedules/useSchedulesPageState.ts
+++ b/src/features/schedules/useSchedulesPageState.ts
@@ -154,7 +154,7 @@ export const buildCreateDialogIntent = (category: ScheduleCategory, start: Date,
 export const buildUpdateInput = (eventId: string, input: CreateScheduleEventInput): UpdateScheduleEventInput => ({
   ...input,
   id: eventId,
-  title: input.title.trim() || '新規予定',
+  title: input.title.trim() || '予定',
 });
 
 export const toDateIso = (date: Date): string => {


### PR DESCRIPTION
## What
- Remove remaining “新規予定” fallback title
- Keep dialog default title empty (placeholder guides input)
- Keep safe data-layer fallback as “予定”

## Why
- Make wording consistent with “予定を追加”
- Reduce noisy “新規” language in actual records

## Test
- npm run lint
- npm run typecheck