### PR TITLE
chore(auth): add msal redirect observability logs

### DIFF
--- a/src/auth/MsalProvider.tsx
+++ b/src/auth/MsalProvider.tsx
@@ -1,5 +1,5 @@
 import type { IPublicClientApplication } from '@azure/msal-browser';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { isE2eMsalMockEnabled } from '../lib/env';
 import { authDiagnostics } from '@/features/auth/diagnostics';
 
@@ -186,6 +186,22 @@ const MsalBridge: React.FC<{ instance: MsalInstance; useMsal: MsalReactModule['u
     typeof window === 'undefined'
       ? true
       : (window as Window & { __MSAL_REDIRECT_DONE__?: boolean }).__MSAL_REDIRECT_DONE__ === true;
+  const lastLogRef = useRef('');
+  useEffect(() => {
+    const snapshot = JSON.stringify({
+      authReady,
+      inProgress,
+      accounts: accounts.length,
+    });
+    if (snapshot !== lastLogRef.current) {
+      lastLogRef.current = snapshot;
+      console.info('[msal] bridge state', {
+        authReady,
+        inProgress,
+        accounts: accounts.length,
+      });
+    }
+  }, [accounts.length, authReady, inProgress]);
   const value = useMemo(
     () => ({ instance, accounts, inProgress, authReady }),
     [instance, accounts, inProgress, authReady],

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -253,7 +253,7 @@ const run = async (): Promise<void> => {
         const msalKeys = Object.keys(sessionStorage).filter(k => k.toLowerCase().includes('msal'));
         console.info('[msal] sessionStorage MSAL keys:', msalKeys);
       } else {
-        console.info('[msal] ℹ️  no redirect result (first load or no auth callback)');
+        console.info('[msal] ℹ️  handleRedirectPromise returned null');
       }
     } catch (error) {
       // Non-fatal: continue app bootstrap even if MSAL init/redirect fails
@@ -261,6 +261,10 @@ const run = async (): Promise<void> => {
     } finally {
       if (typeof window !== 'undefined') {
         window.__MSAL_REDIRECT_DONE__ = true;
+        console.info('[msal] __MSAL_REDIRECT_DONE__ set true', {
+          path: window.location.pathname,
+          search: window.location.search,
+        });
       }
     }
   }


### PR DESCRIPTION
## What
- Add observation-only logs around handleRedirectPromise and auth readiness

## Why
- Identify where MSAL redirect flow stalls on workers.dev / Safari

## Test
- npm run lint
- npx tsc -p tsconfig.build.json --noEmit --pretty false