### PR TITLE
docs: add TL;DR to router flags runbook

### DIFF
--- a/docs/runbooks/testing-router-flags-smoke.md
+++ b/docs/runbooks/testing-router-flags-smoke.md
@@ -1,5 +1,10 @@
 # Router Flags Smoke Test - Troubleshooting Guide
 
+## TL;DR
+- **Drawer**: Always open → wait visible (MUI keeps hidden elements in DOM)
+- **Guards**: Use runtime env functions for mockability (not build-time constants)
+- **JSDOM**: Dispatch popstate when route doesn't update (React Router needs events)
+
 ## Overview
 This runbook documents solutions to common issues encountered in `tests/smoke/router.flags.spec.tsx`, particularly when testing React Router v7 future flags with MUI components and authorization guards.
 


### PR DESCRIPTION
## Summary
Add concise 3-line TL;DR section at the top of the runbook for quick reference.

## TL;DR Added
- **Drawer**: Always open → wait visible (MUI keeps hidden elements in DOM)
- **Guards**: Use runtime env functions for mockability (not build-time constants)
- **JSDOM**: Dispatch popstate when route doesn't update (React Router needs events)

## Why This Matters
Follows best practice of providing immediate value for developers who need quick answers without reading the full troubleshooting guide.

## Checklist
- [x] Added TL;DR section at top of runbook
- [x] Kept existing content unchanged