### PR TITLE
feat(ui): constrain main layout width on landscape tablets

### DIFF
--- a/src/components/layout/AppShellV2.tsx
+++ b/src/components/layout/AppShellV2.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Box, useMediaQuery, useTheme } from '@mui/material';
 import { LAYOUT } from './layoutTokens';
+import { useLandscapeTablet } from '@/hooks/useLandscapeTablet';
 
 type Props = {
   header?: React.ReactNode;
@@ -33,6 +34,7 @@ export function AppShellV2({
 }: Props) {
   const theme = useTheme();
   const isPhone = useMediaQuery(theme.breakpoints.down('sm'));
+  const isLandscapeTablet = useLandscapeTablet();
 
   const headerH = header ? (isPhone ? LAYOUT.headerH.xs : LAYOUT.headerH.md) : 0;
   const footerH = isPhone ? LAYOUT.footerH.xs : LAYOUT.footerH.md;
@@ -119,6 +121,10 @@ export function AppShellV2({
           overflow: 'auto',
           overscrollBehavior: 'contain',
           WebkitOverflowScrolling: 'touch',
+          ...(isLandscapeTablet && {
+            maxWidth: 1200,
+            margin: '0 auto',
+          }),
         }}
       >
         {/* ✅ メイン内側コンテナ層（ワイドで散らばらせない） */}

--- a/src/hooks/useLandscapeTablet.ts
+++ b/src/hooks/useLandscapeTablet.ts
@@ -1,0 +1,21 @@
+import { useTheme, useMediaQuery } from '@mui/material';
+
+/**
+ * 横長タブレット判定
+ *
+ * 想定:
+ * - iPad 横 / Android 横タブレット
+ * - Desktop は false（レイアウト分岐を増やさないため）
+ */
+export function useLandscapeTablet() {
+  const theme = useTheme();
+
+  // タブレット以上
+  const isTabletUp = useMediaQuery(theme.breakpoints.up('md'));
+  // 横長
+  const isLandscape = useMediaQuery('(orientation: landscape)');
+  // デスクトップ除外（必要なら後で調整）
+  const isDesktopUp = useMediaQuery(theme.breakpoints.up('lg'));
+
+  return isTabletUp && isLandscape && !isDesktopUp;
+}


### PR DESCRIPTION
Add landscape tablet detection and constrain main layout to 1200px for better readability. Targets iPad/Android tablets in landscape. No changes to mobile/desktop.