### PR TITLE
feat(layout): formalize bottom-nav-height CSS variable in AppShell

### DIFF
--- a/src/components/layout/AppShellV2.tsx
+++ b/src/components/layout/AppShellV2.tsx
@@ -52,6 +52,7 @@ export function AppShellV2({
   return (
     <Box
       sx={{
+        '--bottom-nav-height': '88px', // CSS variable for LandscapeFab positioning
         height: '100dvh',
         overflow: 'hidden',
         display: 'grid',


### PR DESCRIPTION
## 基盤層確定：AppShell CSS変数正式化

### 背景
LandscapeFab で既に使用している下部ナビ高さ変数を、AppShell 側で正式定義します。

### 変更内容
- AppShell root Box に `--bottom-nav-height: 88px` を定義
- 単一の真実として機能（これまで fallback の 88px）
- LandscapeFab がこの変数を参照可能に

### メリット
✅ フッター高さ変更時は AppShell only 修正
✅ レイアウト責任が Shell 層に集約
✅ デバイス別対応も AppShell で一元管理
✅ 将来の SafeArea / Inset 対応も用意

### 影響範囲
- モバイル：影響なし
- デスクトップ：影響なし
- 横長タブレット：FAB位置安定化