### PR TITLE
feat: add deploy-guard to prevent unsafe deployments

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "preview": "vite preview",
     "preview:e2e": "npm run build && node scripts/write-e2e-runtime-env.mjs && vite preview --host 127.0.0.1 --port 5173 --strictPort",
     "preview:csp": "node scripts/preview-csp.mjs",
-    "deploy:cf": "DEPLOY_TARGET=cloudflare npm run build && npx wrangler deploy",
+    "deploy:cf": "bash scripts/deploy-guard.sh && DEPLOY_TARGET=cloudflare npm run build && npx wrangler deploy",
     "config:print": "VITE_CONFIG_DEBUG=1 vite --force",
     "gen:system-map": "tsx scripts/generate-system-map.ts",
     "test": "vitest run",

--- a/scripts/deploy-guard.sh
+++ b/scripts/deploy-guard.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -euo pipefail
+
+# Color codes for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+# Check 1: Working tree must be clean
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo -e "${RED}❌ Error: working tree is dirty. Commit or stash before deploy.${NC}"
+  echo ""
+  git status --short
+  exit 1
+fi
+
+# Fetch latest from origin
+git fetch origin main >/dev/null 2>&1 || true
+
+# Check 2: Must be on main branch
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+  echo -e "${RED}❌ Error: not on main branch (current: $CURRENT_BRANCH).${NC}"
+  echo "Please checkout main before deploy."
+  exit 1
+fi
+
+# Check 3: HEAD must match origin/main
+LOCAL="$(git rev-parse HEAD)"
+REMOTE="$(git rev-parse origin/main)"
+
+if [[ "$LOCAL" != "$REMOTE" ]]; then
+  echo -e "${RED}❌ Error: HEAD ($LOCAL) is not synced with origin/main ($REMOTE).${NC}"
+  echo "Please merge to main and pull origin/main before deploy."
+  exit 1
+fi
+
+echo -e "${GREEN}✅ deploy-guard: OK${NC}"
+echo "   - Working tree clean"
+echo "   - On main branch"
+echo "   - HEAD matches origin/main ($LOCAL)"


### PR DESCRIPTION
## What
- Add `scripts/deploy-guard.sh` to validate deployment safety
- Update `deploy:cf` script to run guard before build/deploy

## Why
- Prevent deployments from non-main branches
- Prevent deployments with uncommitted changes
- Prevent deployments when out of sync with origin/main

## How it works
The guard checks:
1. ✅ Working tree is clean (no uncommitted changes)
2. ✅ Current branch is main
3. ✅ HEAD matches origin/main

## Impact
- Ensures production deployments are always traceable to a specific main commit
- Eliminates "mystery deploys" where prod differs from git history