### PR TITLE
test(schedules): add SharePoint contract validation (list/fields/choices)

### DIFF
--- a/src/features/schedules/data/contract.spec.ts
+++ b/src/features/schedules/data/contract.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { SpScheduleCategoryRaw } from './spRowSchema';
+import { SCHEDULES_FIELDS } from './spSchema';
+import { buildContractErrorMessage, validateSchedulesListContract, type ListFieldMeta } from './contract';
+
+const baseFields: ListFieldMeta[] = [
+  { internalName: SCHEDULES_FIELDS.title, type: 'Text', required: true },
+  { internalName: SCHEDULES_FIELDS.start, type: 'DateTime', required: true },
+  { internalName: SCHEDULES_FIELDS.end, type: 'DateTime', required: true },
+  {
+    internalName: SCHEDULES_FIELDS.serviceType,
+    type: 'Choice',
+    required: true,
+    choices: [...SpScheduleCategoryRaw.options],
+  },
+  { internalName: SCHEDULES_FIELDS.locationName, type: 'Text', required: false },
+];
+
+const resolveTitle = async (env: Record<string, string | undefined>) => {
+  vi.resetModules();
+  vi.doMock('@/lib/env', () => ({
+    readEnv: (key: string, fallback = '') => env[key] ?? fallback,
+  }));
+  const mod = await import('./spSchema');
+  return mod.getSchedulesListTitle();
+};
+
+describe('schedules contract', () => {
+  it('resolves list title with correct precedence', async () => {
+    await expect(resolveTitle({})).resolves.toBe('ScheduleEvents');
+    await expect(resolveTitle({ VITE_SP_LIST_SCHEDULES: 'LegacySchedules' })).resolves.toBe('LegacySchedules');
+    await expect(resolveTitle({ VITE_SCHEDULES_LIST_TITLE: 'PreferredSchedules' })).resolves.toBe('PreferredSchedules');
+    await expect(resolveTitle({
+      VITE_SCHEDULES_LIST_TITLE: 'PreferredSchedules',
+      VITE_SP_LIST_SCHEDULES: 'LegacySchedules',
+    })).resolves.toBe('PreferredSchedules');
+  });
+
+  it('detects missing required fields', () => {
+    const fields = baseFields.filter((field) => field.internalName !== SCHEDULES_FIELDS.end);
+    const result = validateSchedulesListContract(fields);
+
+    expect(result.ok).toBe(false);
+    expect(result.missingFields).toEqual([SCHEDULES_FIELDS.end]);
+    expect(buildContractErrorMessage(result)).toContain('Missing fields');
+  });
+
+  it('detects missing category choices', () => {
+    const fields = baseFields.map((field) =>
+      field.internalName === SCHEDULES_FIELDS.serviceType
+        ? { ...field, choices: ['User', 'Org'] }
+        : field,
+    );
+    const result = validateSchedulesListContract(fields);
+
+    expect(result.ok).toBe(false);
+    expect(result.missingChoices[0]?.field).toBe(SCHEDULES_FIELDS.serviceType);
+    expect(result.missingChoices[0]?.missing).toContain('Staff');
+    expect(buildContractErrorMessage(result)).toContain('Missing choices');
+  });
+});

--- a/src/features/schedules/data/contract.ts
+++ b/src/features/schedules/data/contract.ts
@@ -1,0 +1,65 @@
+import { SpScheduleCategoryRaw } from './spRowSchema';
+import { SCHEDULES_FIELDS } from './spSchema';
+
+export type ListFieldMeta = {
+  internalName: string;
+  type: string;
+  required: boolean;
+  choices?: string[];
+};
+
+export type ContractValidationResult = {
+  ok: boolean;
+  missingFields: string[];
+  missingChoices: Array<{ field: string; missing: string[] }>;
+};
+
+const REQUIRED_FIELDS: readonly string[] = [
+  SCHEDULES_FIELDS.title,
+  SCHEDULES_FIELDS.start,
+  SCHEDULES_FIELDS.end,
+  SCHEDULES_FIELDS.serviceType,
+  SCHEDULES_FIELDS.locationName,
+];
+
+const REQUIRED_CATEGORY_CHOICES = SpScheduleCategoryRaw.options;
+
+const normalizeChoices = (choices?: string[]): string[] =>
+  (choices ?? []).map((value) => value.trim()).filter(Boolean);
+
+export const validateSchedulesListContract = (fields: ListFieldMeta[]): ContractValidationResult => {
+  const fieldMap = new Map(fields.map((field) => [field.internalName, field]));
+  const missingFields = REQUIRED_FIELDS.filter((name) => !fieldMap.has(name));
+
+  const missingChoices: Array<{ field: string; missing: string[] }> = [];
+  const categoryField = fieldMap.get(SCHEDULES_FIELDS.serviceType);
+  if (categoryField) {
+    const choices = normalizeChoices(categoryField.choices);
+    const missing = REQUIRED_CATEGORY_CHOICES.filter((value) => !choices.includes(value));
+    if (missing.length > 0) {
+      missingChoices.push({ field: categoryField.internalName, missing });
+    }
+  }
+
+  return {
+    ok: missingFields.length === 0 && missingChoices.length === 0,
+    missingFields,
+    missingChoices,
+  };
+};
+
+export const buildContractErrorMessage = (result: ContractValidationResult): string => {
+  const parts: string[] = [];
+  if (result.missingFields.length > 0) {
+    parts.push(`Missing fields: ${result.missingFields.join(', ')}`);
+  }
+  if (result.missingChoices.length > 0) {
+    const choiceMessages = result.missingChoices.map(
+      (entry) => `${entry.field}: ${entry.missing.join(', ')}`,
+    );
+    parts.push(`Missing choices: ${choiceMessages.join(' | ')}`);
+  }
+  return parts.join(' / ');
+};
+
+export const getRequiredSchedulesFields = (): readonly string[] => REQUIRED_FIELDS;

--- a/src/features/schedules/data/index.ts
+++ b/src/features/schedules/data/index.ts
@@ -7,4 +7,5 @@ export type {
 	CreateScheduleEventInput, DateRange, SchedItem, ScheduleCategory,
 	ScheduleServiceType, SchedulesPort, ScheduleStatus, ScheduleVisibility, UpdateScheduleEventInput
 } from './port';
-export { makeSharePointSchedulesPort } from './sharePointAdapter';
+export { makeSharePointSchedulesPort, getListFieldsMeta } from './sharePointAdapter';
+export type { ListFieldMeta } from './sharePointAdapter';


### PR DESCRIPTION
## What
- Validate SharePoint schema contracts before mutations
- Check required fields: Title, EventDate, EndDate, Category, Location
- Verify Category choice enum is complete
- Add getListFieldsMeta() for field introspection

## Why
Prevent production outages from schema drift (missing fields/choices)

## How to test
```bash
npm test -- contract.spec.ts
npm run typecheck
```

## Evidence
- ✅ contract.spec.ts: 3/3 pass
- ✅ getListFieldsMeta: Fetches and normalizes SharePoint Fields
- ✅ typecheck: Pass