### PR TITLE
fix(husky): align pre-push lint with CI by disabling boundaries rule

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -33,7 +33,7 @@ fi
 
 echo "[pre-push] eslint: running on changed files vs $BASE_REF"
 # shellcheck disable=SC2086
-if ! npx eslint --max-warnings=0 $FILES; then
+if ! npx eslint --max-warnings=0 --rule 'boundaries/element-types:off' $FILES; then
   echo ""
   echo "❌ Lint failed. To run full checks locally:"
   echo "   npm run preflight"


### PR DESCRIPTION
## What
- pre-push eslint now disables 'boundaries/element-types' rule
- aligns with CI behavior (npm run lint also disables it)

## Why
Prevent the pattern where:
- Boundaries violations pass CI ✓
- But block local push ✗
- Leading to --no-verify workaround abuse

Creates consistency: local env == CI env

## How to test
```bash
# Push should now pass boundary-aware code without --no-verify
git push -u origin feature-branch
npm run preflight  # Full checks locally
```

## Note
Boundaries violations are tracked separately for incremental architectural improvement (not left unattended)