### PR TITLE
fix(ui): month empty state short-circuit for zero-scroll

### DIFF
--- a/src/features/schedules/MonthPage.tsx
+++ b/src/features/schedules/MonthPage.tsx
@@ -9,6 +9,7 @@ import { TESTIDS } from '@/testids';
 import type { ScheduleCategory } from './domain/types';
 import { getDayChipSx } from './theme/dateStyles';
 import { DayPopover } from './components/DayPopover';
+import { ScheduleEmptyHint } from './components/ScheduleEmptyHint';
 import {
   useCallback,
   useEffect,
@@ -165,6 +166,67 @@ export default function MonthPage({ items, loading = false, activeCategory = 'Al
     },
     [setMonthAnchor],
   );
+
+  // Empty state: skip rendering large grid to achieve zero-scroll on iPad landscape
+  if (!loading && totalCount === 0) {
+    return (
+      <section
+        data-testid={TESTIDS.SCHEDULES_MONTH_PAGE}
+        aria-label="月間スケジュール"
+        aria-labelledby={headingId}
+        tabIndex={-1}
+        style={{ paddingBottom: isCompact ? 16 : 32 }}
+      >
+        {/* Month controls (preserved for navigation) */}
+        <Box sx={{ px: 2, py: isCompact ? 1 : 1.5, display: 'flex', alignItems: 'center', gap: isCompact ? 0 : 1 }}>
+          <Button
+            variant="outlined"
+            size="small"
+            onClick={handlePrevMonth}
+            aria-label="前の月へ移動"
+            data-testid={TESTIDS.SCHEDULES_MONTH_PREV}
+          >
+            前
+          </Button>
+          <Box sx={{ flex: 1 }}>
+            <Typography
+              variant="h6"
+              id={headingId}
+              data-testid={TESTIDS.SCHEDULES_MONTH_HEADING_ID}
+              sx={{ mb: isCompact ? 0 : 0.5, fontSize: isCompact ? 16 : undefined }}
+            >
+              {monthLabel}
+            </Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ fontSize: isCompact ? 11 : 12 }}>
+              予定 {totalCount} 件
+            </Typography>
+          </Box>
+          <Button
+            variant="outlined"
+            size="small"
+            onClick={handleCurrentMonth}
+            aria-label="今月に移動"
+          >
+            今月
+          </Button>
+          <Button
+            variant="outlined"
+            size="small"
+            onClick={handleNextMonth}
+            aria-label="次の月へ移動"
+            data-testid={TESTIDS.SCHEDULES_MONTH_NEXT}
+          >
+            次
+          </Button>
+        </Box>
+
+        {/* Empty hint (compact mode for zero-scroll) */}
+        <Box sx={{ px: 2 }}>
+          <ScheduleEmptyHint view="month" compact={isCompact} />
+        </Box>
+      </section>
+    );
+  }
 
   return (
     <section

--- a/src/features/schedules/components/ScheduleEmptyHint.tsx
+++ b/src/features/schedules/components/ScheduleEmptyHint.tsx
@@ -8,11 +8,28 @@ export type ScheduleEmptyHintProps = {
   view: 'day' | 'week' | 'month';
   periodLabel?: string;
   sx?: SxProps<Theme>;
+  compact?: boolean;
 };
 
 export function ScheduleEmptyHint(props: ScheduleEmptyHintProps) {
   const { title, description, cta } = scheduleFacilityEmptyCopy;
-  const { sx } = props;
+  const { sx, compact } = props;
+
+  // Compact mode: single-line hint for zero-scroll on tablet landscape
+  if (compact) {
+    return (
+      <Box
+        role="status"
+        aria-live="polite"
+        data-testid={TESTIDS.SCHEDULES_EMPTY_HINT}
+        sx={{ mb: 0.5, ...sx }}
+      >
+        <Typography variant="body2" color="text.secondary" sx={{ fontSize: 12 }}>
+          予定はまだありません（＋から追加）
+        </Typography>
+      </Box>
+    );
+  }
 
   return (
     <Box


### PR DESCRIPTION
## What
Short-circuit Month view when the filtered month has 0 events to prevent vertical overflow on tablet landscape.

## Changes
- MonthPage: when not loading and totalCount === 0, render controls + EmptyHint only (skip month grid)
- ScheduleEmptyHint: add compact prop (compact: 1-line hint)

## Why
Empty month previously rendered full grid + hint, causing main overflow (e.g. diff ~207px).
Now empty month fits with diff ~0px in iPad landscape.

## Tested
- typecheck: PASS
- lint: PASS
- health: PASS
- manual measurement: main diff 0px on /schedules/week?tab=month