### PR TITLE
fix(ui): restore category-aware empty hint copy

### DIFF
--- a/src/features/schedules/DayView.tsx
+++ b/src/features/schedules/DayView.tsx
@@ -1,5 +1,5 @@
-import EmptyState from '@/ui/components/EmptyState';
 import Loading from '@/ui/components/Loading';
+import ScheduleEmptyHint from './components/ScheduleEmptyHint';
 import { TESTIDS } from '@/testids';
 import { useId, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -159,7 +159,6 @@ const DayViewContent = ({
     [filteredItems],
   );
   const dayLabel = useMemo(() => formatDayLabel(range.from), [range.from]);
-  const emptyTitle = categoryFilter === 'Org' ? '施設の予定はまだありません。' : '予定はまだありません。';
 
   return (
     <section
@@ -289,11 +288,7 @@ const DayViewContent = ({
           </div>
         ) : typedItems.length === 0 ? (
           <div style={{ display: 'grid', gap: isCompact ? 8 : 12 }}>
-            <EmptyState
-              title={emptyTitle}
-              description={null}
-              data-testid="schedule-day-empty"
-            />
+            <ScheduleEmptyHint view="day" compact={isCompact} categoryFilter={categoryFilter} />
           </div>
         ) : (
           <ol

--- a/src/features/schedules/MonthPage.tsx
+++ b/src/features/schedules/MonthPage.tsx
@@ -222,7 +222,7 @@ export default function MonthPage({ items, loading = false, activeCategory = 'Al
 
         {/* Empty hint (compact mode for zero-scroll) */}
         <Box sx={{ px: 2 }}>
-          <ScheduleEmptyHint view="month" compact={isCompact} />
+          <ScheduleEmptyHint view="month" compact={isCompact} categoryFilter={activeCategory} />
         </Box>
       </section>
     );

--- a/src/features/schedules/WeekPage.tsx
+++ b/src/features/schedules/WeekPage.tsx
@@ -594,7 +594,7 @@ export default function WeekPage() {
 
       <div>
         {showEmptyHint ? (
-          <ScheduleEmptyHint view={mode} periodLabel={weekLabel} sx={{ mb: 2 }} />
+          <ScheduleEmptyHint view={mode} periodLabel={weekLabel} sx={{ mb: 2 }} categoryFilter={categoryFilter} />
         ) : null}
         {isLoading ? (
           <div aria-busy="true" aria-live="polite" style={{ display: 'grid', gap: 16 }}>

--- a/src/features/schedules/components/ScheduleEmptyHint.tsx
+++ b/src/features/schedules/components/ScheduleEmptyHint.tsx
@@ -3,16 +3,18 @@ import Typography from '@mui/material/Typography';
 import type { SxProps, Theme } from '@mui/material/styles';
 import { TESTIDS } from '@/testids';
 import { scheduleFacilityEmptyCopy } from '@/features/schedules/domain/categoryLabels';
+import type { ScheduleCategory } from '@/features/schedules/domain/types';
 
 export type ScheduleEmptyHintProps = {
   view: 'day' | 'week' | 'month';
   periodLabel?: string;
   sx?: SxProps<Theme>;
   compact?: boolean;
+  categoryFilter?: 'All' | ScheduleCategory;
 };
 
 export function ScheduleEmptyHint(props: ScheduleEmptyHintProps) {
-  const { title } = scheduleFacilityEmptyCopy;
+  const { title } = props.categoryFilter === 'Org' ? scheduleFacilityEmptyCopy : { title: '予定はまだありません' };
   const { sx, compact } = props;
   const emptyLine = title.endsWith('。') ? title : `${title}。`;
 


### PR DESCRIPTION
## What
Restore category-aware empty-state hint copy while keeping the 1-line compact layout.

## Why
After PR #486, empty hints always showed the facility (Org) message even when filtered to other categories.

## Changes
- ScheduleEmptyHint: vary copy by category (Org vs others)
- Day/Week/Month: pass categoryFilter into ScheduleEmptyHint

## Tested
- typecheck: PASS
- lint: PASS
