### PR TITLE
refactor(ui): consolidate month navigation to SchedulesHeader

### DIFF
--- a/src/features/schedules/MonthPage.tsx
+++ b/src/features/schedules/MonthPage.tsx
@@ -139,34 +139,6 @@ export default function MonthPage({ items, loading = false, activeCategory = 'Al
   const headingId = TESTIDS.SCHEDULES_MONTH_HEADING_ID;
   const rangeId = TESTIDS.SCHEDULES_MONTH_RANGE_ID;
 
-  const setMonthAnchor = useCallback(
-    (nextAnchor: Date) => {
-      const nextIso = toDateIso(nextAnchor);
-      setAnchorDate(nextAnchor);
-      setActiveDateIso(nextIso);
-      const next = new URLSearchParams(searchParams);
-      next.set('date', nextIso);
-      setSearchParams(next, { replace: true });
-    },
-    [searchParams, setSearchParams],
-  );
-
-  const shiftMonth = useCallback(
-    (delta: number) => {
-      setMonthAnchor(addMonths(anchorDate, delta));
-    },
-    [anchorDate, setMonthAnchor],
-  );
-
-  const handlePrevMonth = useCallback(() => shiftMonth(-1), [shiftMonth]);
-  const handleNextMonth = useCallback(() => shiftMonth(1), [shiftMonth]);
-  const handleCurrentMonth = useCallback(
-    () => {
-      setMonthAnchor(startOfMonth(new Date()));
-    },
-    [setMonthAnchor],
-  );
-
   // Empty state: skip rendering large grid to achieve zero-scroll on iPad landscape
   if (!loading && totalCount === 0) {
     return (
@@ -177,50 +149,7 @@ export default function MonthPage({ items, loading = false, activeCategory = 'Al
         tabIndex={-1}
         style={{ paddingBottom: isCompact ? 16 : 32 }}
       >
-        {/* Month controls (preserved for navigation) */}
-        <Box sx={{ px: 2, py: isCompact ? 1 : 1.5, display: 'flex', alignItems: 'center', gap: isCompact ? 0 : 1 }}>
-          <Button
-            variant="outlined"
-            size="small"
-            onClick={handlePrevMonth}
-            aria-label="前の月へ移動"
-            data-testid={TESTIDS.SCHEDULES_MONTH_PREV}
-          >
-            前
-          </Button>
-          <Box sx={{ flex: 1 }}>
-            <Typography
-              variant="h6"
-              id={headingId}
-              data-testid={TESTIDS.SCHEDULES_MONTH_HEADING_ID}
-              sx={{ mb: isCompact ? 0 : 0.5, fontSize: isCompact ? 16 : undefined }}
-            >
-              {monthLabel}
-            </Typography>
-            <Typography variant="body2" color="text.secondary" sx={{ fontSize: isCompact ? 11 : 12 }}>
-              予定 {totalCount} 件
-            </Typography>
-          </Box>
-          <Button
-            variant="outlined"
-            size="small"
-            onClick={handleCurrentMonth}
-            aria-label="今月に移動"
-          >
-            今月
-          </Button>
-          <Button
-            variant="outlined"
-            size="small"
-            onClick={handleNextMonth}
-            aria-label="次の月へ移動"
-            data-testid={TESTIDS.SCHEDULES_MONTH_NEXT}
-          >
-            次
-          </Button>
-        </Box>
-
-        {/* Empty hint (compact mode for zero-scroll) */}
+        {/* Empty state: navigation via SchedulesHeader, content via ScheduleEmptyHint */}
         <Box sx={{ px: 2 }}>
           <ScheduleEmptyHint view="month" compact={isCompact} categoryFilter={activeCategory} />
         </Box>
@@ -237,48 +166,6 @@ export default function MonthPage({ items, loading = false, activeCategory = 'Al
       tabIndex={-1}
       style={{ paddingBottom: 32 }}
     >
-      <Box sx={{ px: 2, py: isCompact ? 1 : 1.5, display: 'flex', alignItems: 'center', gap: isCompact ? 0 : 1 }}>
-        <Button
-          variant="outlined"
-          size="small"
-          onClick={handlePrevMonth}
-          aria-label="前の月へ移動"
-          data-testid={TESTIDS.SCHEDULES_MONTH_PREV}
-        >
-          前
-        </Button>
-        <Box sx={{ flex: 1 }}>
-          <Typography
-            variant="h6"
-            id={headingId}
-            data-testid={TESTIDS.SCHEDULES_MONTH_HEADING_ID}
-            sx={{ mb: isCompact ? 0 : 0.5, fontSize: isCompact ? 16 : undefined }}
-          >
-            {monthLabel}
-          </Typography>
-          <Typography variant="body2" color="text.secondary" sx={{ fontSize: isCompact ? 11 : 12 }}>
-            予定 {totalCount} 件
-          </Typography>
-        </Box>
-        <Button
-          variant="outlined"
-          size="small"
-          onClick={handleCurrentMonth}
-          aria-label="今月に移動"
-        >
-          今月
-        </Button>
-        <Button
-          variant="outlined"
-          size="small"
-          onClick={handleNextMonth}
-          aria-label="次の月へ移動"
-          data-testid={TESTIDS.SCHEDULES_MONTH_NEXT}
-        >
-          次
-        </Button>
-      </Box>
-
       <div
         style={{ padding: isCompact ? '12px 8px 24px' : '16px 12px 32px' }}
         aria-busy={loading || undefined}

--- a/src/features/schedules/WeekPage.tsx
+++ b/src/features/schedules/WeekPage.tsx
@@ -350,6 +350,32 @@ export default function WeekPage() {
     syncDateParam(todayIso);
   }, [primeRouteReset, syncDateParam]);
 
+  // Month-specific navigation handlers
+  const handlePrevMonth = useCallback(() => {
+    const prevMonthDate = new Date(focusDate);
+    prevMonthDate.setMonth(prevMonthDate.getMonth() - 1);
+    const iso = toDateIso(prevMonthDate);
+    setActiveDateIso(iso);
+    primeRouteReset();
+    syncDateParam(iso);
+  }, [focusDate, primeRouteReset, syncDateParam]);
+
+  const handleNextMonth = useCallback(() => {
+    const nextMonthDate = new Date(focusDate);
+    nextMonthDate.setMonth(nextMonthDate.getMonth() + 1);
+    const iso = toDateIso(nextMonthDate);
+    setActiveDateIso(iso);
+    primeRouteReset();
+    syncDateParam(iso);
+  }, [focusDate, primeRouteReset, syncDateParam]);
+
+  const handleTodayMonth = useCallback(() => {
+    const todayIso = toDateIso(new Date());
+    setActiveDateIso(todayIso);
+    primeRouteReset();
+    syncDateParam(todayIso);
+  }, [primeRouteReset, syncDateParam]);
+
   const handleScheduleDialogSubmit = useCallback(
     async (input: CreateScheduleEventInput) => {
       if (dialogMode === 'edit' && dialogEventId) {
@@ -488,6 +514,11 @@ export default function WeekPage() {
                 ? `表示期間: ${new Intl.DateTimeFormat('ja-JP', { year: 'numeric', month: 'short', day: 'numeric' }).format(monthDate)}`
                 : `表示期間: ${weekLabel}`;
 
+          // Mode-aware navigation handlers
+          const navPrev = mode === 'month' ? handlePrevMonth : handlePrevWeek;
+          const navNext = mode === 'month' ? handleNextMonth : handleNextWeek;
+          const navToday = mode === 'month' ? handleTodayMonth : handleTodayWeek;
+
           return (
             <>
                   <SchedulesHeader
@@ -496,9 +527,9 @@ export default function WeekPage() {
                 subLabel={headerSubLabel}
                 periodLabel={headerPeriodLabel}
                 compact={compact}
-          onPrev={handlePrevWeek}
-          onNext={handleNextWeek}
-          onToday={handleTodayWeek}
+          onPrev={navPrev}
+          onNext={navNext}
+          onToday={navToday}
           onPrimaryCreate={canEdit && canWrite ? handleFabClick : undefined}
                   showPrimaryAction={isDesktopSize}
                   primaryActionLabel="予定を追加"


### PR DESCRIPTION
## What
Remove redundant month navigation UI from MonthPage and consolidate all Day/Week/Month navigation through SchedulesHeader.

## Why
- Reduces visual & cognitive redundancy on iPad landscape
- Two sets of nav buttons (header + month page) creates "重複".
- Simplifies route state management (single source of truth for nav handlers)
- Month page can focus on core content (grid or empty state)

## Changes
- **MonthPage**: Remove month nav UI from empty state + normal state
- **WeekPage**: Add mode-aware nav handlers (month vs week/day)
  - handlePrevMonth / handleNextMonth / handleTodayMonth
  - mode-conditional routing to SchedulesHeader (navPrev / navNext / navToday)
- Result: All navigation flows through SchedulesHeader regardless of view mode

## Tested
- typecheck: ✅ PASS
- lint: ✅ PASS