### PR TITLE
fix(schedules): remove duplicate empty hint message

### DIFF
--- a/src/features/schedules/routes/WeekPage.tsx
+++ b/src/features/schedules/routes/WeekPage.tsx
@@ -9,7 +9,6 @@ import { MASTER_SCHEDULE_TITLE_JA } from '@/features/schedules/constants';
 import type { ScheduleCategory } from '@/features/schedules/domain/types';
 import { scheduleCategoryLabels } from '@/features/schedules/domain/categoryLabels';
 import ScheduleCreateDialog from './ScheduleCreateDialog';
-import ScheduleEmptyHint from '@/features/schedules/components/ScheduleEmptyHint';
 import SchedulesFilterResponsive from '@/features/schedules/components/SchedulesFilterResponsive';
 import SchedulesHeader from '@/features/schedules/components/SchedulesHeader';
 import type { CreateScheduleEventInput, SchedItem, ScheduleServiceType } from '@/features/schedules/data';
@@ -466,8 +465,6 @@ export default function WeekPage() {
     return () => clearTimeout(timeoutId);
   }, [focusScheduleId, filteredItems]);
 
-  const showEmptyHint = !isLoading && filteredItems.length === 0;
-
 
   return (
     <section
@@ -630,9 +627,6 @@ export default function WeekPage() {
       )}
 
       <div>
-        {showEmptyHint ? (
-          <ScheduleEmptyHint view={mode} periodLabel={weekLabel} sx={{ mb: 2 }} categoryFilter={categoryFilter} />
-        ) : null}
         {isLoading ? (
           <div aria-busy="true" aria-live="polite" style={{ display: 'grid', gap: 16 }}>
             <Loading />


### PR DESCRIPTION
## Issue
Empty state message duplicated in schedule page.

## Solution
Removed redundant ScheduleEmptyHint from WeekPage. Each view component (WeekView, DayView, MonthPage) now handles its own empty state.

## Changes
- Removed ScheduleEmptyHint rendering from WeekPage
- Removed unused showEmptyHint variable
- Removed unused import

## Validation
- lint ✅
- typecheck ✅

### Design Note
Empty state responsibility is owned by each view component to avoid cross-view duplication.