### PR TITLE
refactor(schedules): extract TZ-aware dateKey helper

### DIFF
--- a/src/features/schedules/lib/dateKey.test.ts
+++ b/src/features/schedules/lib/dateKey.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { getSchedulesTz, toDateKey } from './dateKey';
+
+describe('dateKey', () => {
+  describe('toDateKey', () => {
+    it('returns YYYY-MM-DD format', () => {
+      const key = toDateKey(new Date('2026-02-18T00:00:00.000Z'));
+      expect(key).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+
+    it('respects VITE_SCHEDULES_TZ environment', () => {
+      const originalEnv = window.__ENV__;
+      window.__ENV__ = { VITE_SCHEDULES_TZ: 'Asia/Tokyo' };
+      try {
+        const key = toDateKey(new Date('2026-02-18T00:00:00.000Z'));
+        expect(key).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+        // Verify it used a timezone-aware formatter (exact date depends on TZ)
+        expect(key).toBeDefined();
+      } finally {
+        window.__ENV__ = originalEnv;
+      }
+    });
+
+    it('falls back to Asia/Tokyo when env not set', () => {
+      const originalEnv = window.__ENV__;
+      (window as Record<string, unknown>).__ENV__ = undefined;
+      try {
+        const key = toDateKey(new Date('2026-02-18T05:00:00.000Z'));
+        expect(key).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+        // 2026-02-18T05:00:00Z should be 2026-02-18 in Asia/Tokyo (UTC+9)
+        expect(key).toBe('2026-02-18');
+      } finally {
+        window.__ENV__ = originalEnv;
+      }
+    });
+  });
+
+  describe('getSchedulesTz', () => {
+    it('returns configured TZ from window.__ENV__', () => {
+      const originalEnv = window.__ENV__;
+      window.__ENV__ = { VITE_SCHEDULES_TZ: 'America/New_York' };
+      try {
+        expect(getSchedulesTz()).toBe('America/New_York');
+      } finally {
+        window.__ENV__ = originalEnv;
+      }
+    });
+
+    it('falls back to Asia/Tokyo by default', () => {
+      const originalEnv = window.__ENV__;
+      (window as Record<string, unknown>).__ENV__ = undefined;
+      try {
+        expect(getSchedulesTz()).toBe('Asia/Tokyo');
+      } finally {
+        window.__ENV__ = originalEnv;
+      }
+    });
+  });
+});

--- a/src/features/schedules/lib/dateKey.ts
+++ b/src/features/schedules/lib/dateKey.ts
@@ -1,0 +1,16 @@
+// TZ-aware date key helper for schedules
+// Ensures "today" label respects the configured timezone, not UTC
+
+export const getSchedulesTz = (): string =>
+  window.__ENV__?.VITE_SCHEDULES_TZ ?? 'Asia/Tokyo';
+
+/** Date -> "YYYY-MM-DD" in schedules timezone */
+export const toDateKey = (date: Date): string => {
+  const tz = getSchedulesTz();
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: tz,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(date);
+};

--- a/src/features/schedules/routes/MonthPage.tsx
+++ b/src/features/schedules/routes/MonthPage.tsx
@@ -21,8 +21,7 @@ import {
   type CSSProperties,
 } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import type { SchedItem } from '../data';
-
+import type { SchedItem } from '../data';import { toDateKey } from '../lib/dateKey';
 const WEEKDAY_LABELS = ['月', '火', '水', '木', '金', '土', '日'];
 
 type CalendarDay = {
@@ -55,12 +54,12 @@ export default function MonthPage({ items, loading = false, activeCategory = 'Al
   const requestedIso = searchParams.get('date');
   const focusDate = useMemo(() => parseDateParam(requestedIso), [requestedIso]);
   const [anchorDate, setAnchorDate] = useState<Date>(() => startOfMonth(focusDate));
-  const [activeDateIso, setActiveDateIso] = useState<string>(() => toDateIso(focusDate));
+  const [activeDateIso, setActiveDateIso] = useState<string>(() => toDateKey(focusDate));
 
   useEffect(() => {
     const nextAnchor = startOfMonth(focusDate);
     setAnchorDate((prev) => (prev.getTime() === nextAnchor.getTime() ? prev : nextAnchor));
-    const nextIso = toDateIso(focusDate);
+    const nextIso = toDateKey(focusDate);
     setActiveDateIso((prev) => (prev === nextIso ? prev : nextIso));
   }, [focusDate]);
 
@@ -69,11 +68,11 @@ export default function MonthPage({ items, loading = false, activeCategory = 'Al
       return;
     }
     const next = new URLSearchParams(searchParams);
-    next.set('date', toDateIso(focusDate));
+    next.set('date', toDateKey(focusDate));
     setSearchParams(next, { replace: true });
   }, [focusDate, requestedIso, searchParams, setSearchParams]);
 
-  const resolvedActiveDateIso = activeDateIso ?? toDateIso(anchorDate);
+  const resolvedActiveDateIso = activeDateIso ?? toDateKey(anchorDate);
 
   const daySummaries = useMemo(() => buildDaySummaries(items), [items]);
   const weeks = useMemo(
@@ -407,8 +406,6 @@ const addMonths = (date: Date, delta: number): Date => {
 
 const startOfCalendar = (anchor: Date): Date => startOfWeek(startOfMonth(anchor));
 
-const toDateIso = (date: Date): string => date.toISOString().slice(0, 10);
-
 const parseDateParam = (value: string | null): Date => {
   if (!value) return new Date();
   const parsed = new Date(`${value}T00:00:00`);
@@ -440,7 +437,7 @@ const buildDaySummaries = (
     const cursor = startOfDay(start);
     const boundary = startOfDay(end);
     while (cursor <= boundary) {
-      const iso = toDateIso(cursor);
+      const iso = toDateKey(cursor);
       counts[iso] = (counts[iso] ?? 0) + 1;
       const title = item.title || item.notes || '';
       if (title) {
@@ -468,13 +465,13 @@ const buildCalendarWeeks = (
   titles: Record<string, string[]>,
 ): CalendarWeek[] => {
   const start = startOfCalendar(anchorDate);
-  const todayIso = toDateIso(new Date());
+  const todayIso = toDateKey(new Date());
   const weeks: CalendarWeek[] = [];
   let cursor = new Date(start);
   for (let week = 0; week < 6; week++) {
     const days: CalendarDay[] = [];
     for (let dayIndex = 0; dayIndex < 7; dayIndex++) {
-      const iso = toDateIso(cursor);
+      const iso = toDateKey(cursor);
       days.push({
         iso,
         day: cursor.getDate(),
@@ -486,7 +483,7 @@ const buildCalendarWeeks = (
       });
       cursor = addDays(cursor, 1);
     }
-    weeks.push({ id: `${days[0]?.iso ?? `${toDateIso(start)}-${week}`}`, days });
+    weeks.push({ id: `${days[0]?.iso ?? `${toDateKey(start)}-${week}`}`, days });
   }
   return weeks;
 };
@@ -505,7 +502,7 @@ const countEventsInMonth = (counts: Record<string, number>, anchorDate: Date): n
   const cursor = new Date(monthStart);
   let total = 0;
   while (cursor < monthEnd) {
-    const iso = toDateIso(cursor);
+    const iso = toDateKey(cursor);
     total += counts[iso] ?? 0;
     cursor.setDate(cursor.getDate() + 1);
   }

--- a/src/features/schedules/routes/WeekView.tsx
+++ b/src/features/schedules/routes/WeekView.tsx
@@ -24,6 +24,7 @@ import {
   WeekServiceSummaryChips,
   type WeekServiceSummaryItem,
 } from '../components/WeekServiceSummaryChips';
+import { toDateKey } from '../lib/dateKey';
 
 export type WeekViewProps = {
   items?: WeekSchedItem[];
@@ -252,7 +253,7 @@ const WeekViewContent = ({ items, loading, onDayClick, activeDateIso, range, onI
     });
   }, [resolvedRange.from]);
 
-  const todayIso = new Date().toISOString().slice(0, 10);
+  const todayIso = toDateKey(new Date());
   const resolvedActiveIso = activeDateIso ?? weekDays[0]?.iso ?? todayIso;
 
   const groupedItems = useMemo(() => {


### PR DESCRIPTION
## What
Extract TZ-aware date key helper used for 'today' labeling across schedules views.

## Why
Prevents reintroducing UTC-based off-by-one day bugs and removes code duplication between MonthPage and WeekView.

## How
- Add `src/features/schedules/lib/dateKey.ts` with:
  - `toDateKey(date)`: Returns YYYY-MM-DD in configured timezone
  - `getSchedulesTz()`: Reads VITE_SCHEDULES_TZ or defaults to Asia/Tokyo
- Replace duplicated logic in MonthPage.tsx and WeekView.tsx
- Add unit tests for timezone handling

## Testing
- ✅ lint (0 errors)
- ✅ typecheck (0 errors)  
- ✅ vitest (5 tests passed)

## Notes
Builds on PR #502 (iPad landscape layout) and prevents future UTC-based date bugs in DayView and TimelineView.