### PR TITLE
feat: Month registration flow (drawer + create dialog)

### DIFF
--- a/src/features/schedules/components/CreateScheduleDialog.tsx
+++ b/src/features/schedules/components/CreateScheduleDialog.tsx
@@ -1,0 +1,109 @@
+import * as React from 'react';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+
+export type CreateScheduleDraft = {
+  title: string;
+  notes?: string;
+  dateIso: string; // YYYY-MM-DD
+  allDay: boolean;
+};
+
+interface CreateScheduleDialogProps {
+  open: boolean;
+  dateIso: string | null;
+  defaultAllDay?: boolean;
+  onClose: () => void;
+  onSubmit: (draft: CreateScheduleDraft) => void;
+}
+
+export function CreateScheduleDialog({
+  open,
+  dateIso,
+  defaultAllDay = false,
+  onClose,
+  onSubmit,
+}: CreateScheduleDialogProps) {
+  const [title, setTitle] = React.useState('');
+  const [notes, setNotes] = React.useState('');
+
+  React.useEffect(() => {
+    if (!open) return;
+    // Reset on open
+    setTitle('');
+    setNotes('');
+  }, [open]);
+
+  const canSave = Boolean(dateIso) && title.trim().length > 0;
+
+  const handleSave = () => {
+    if (!dateIso) return;
+    const draft: CreateScheduleDraft = {
+      title: title.trim(),
+      notes: notes.trim() ? notes.trim() : undefined,
+      dateIso,
+      allDay: defaultAllDay,
+    };
+    onSubmit(draft);
+    onClose();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && e.ctrlKey && canSave) {
+      handleSave();
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>新規予定</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <Typography variant="body2" color="text.secondary">
+            日付: {dateIso ?? '—'}
+            {defaultAllDay ? '（終日）' : ''}
+          </Typography>
+
+          <TextField
+            autoFocus
+            label="タイトル"
+            placeholder="予定のタイトルを入力"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            onKeyDown={handleKeyDown}
+            required
+            fullWidth
+            inputProps={{ maxLength: 120 }}
+          />
+
+          <TextField
+            label="メモ"
+            placeholder="メモをここに入力（任意）"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            onKeyDown={handleKeyDown}
+            multiline
+            minRows={3}
+            fullWidth
+            inputProps={{ maxLength: 1000 }}
+          />
+        </Stack>
+      </DialogContent>
+
+      <DialogActions sx={{ p: 2 }}>
+        <Button onClick={onClose}>キャンセル</Button>
+        <Button onClick={handleSave} disabled={!canSave} variant="contained">
+          保存
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/features/schedules/components/DaySummaryDrawer.tsx
+++ b/src/features/schedules/components/DaySummaryDrawer.tsx
@@ -17,7 +17,7 @@ interface DaySummaryDrawerProps {
   selectedDateIso: string | null;
   items: SchedItem[];
   onClose: () => void;
-  onAddClick: () => void;
+  onAdd: () => void;
 }
 
 const parseDateIso = (iso: string): Date => {
@@ -38,7 +38,7 @@ export const DaySummaryDrawer: React.FC<DaySummaryDrawerProps> = ({
   selectedDateIso,
   items,
   onClose,
-  onAddClick,
+  onAdd,
 }) => {
   const theme = useTheme();
   const isTablet = useMediaQuery(theme.breakpoints.down('md'));
@@ -105,7 +105,7 @@ export const DaySummaryDrawer: React.FC<DaySummaryDrawerProps> = ({
             <Button
               size="small"
               startIcon={<AddIcon />}
-              onClick={onAddClick}
+              onClick={onAdd}
               variant="contained"
             >
               追加
@@ -132,7 +132,7 @@ export const DaySummaryDrawer: React.FC<DaySummaryDrawerProps> = ({
               <Button
                 size="small"
                 startIcon={<AddIcon />}
-                onClick={onAddClick}
+                onClick={onAdd}
                 variant="outlined"
               >
                 予定を追加

--- a/src/features/schedules/routes/MonthPage.tsx
+++ b/src/features/schedules/routes/MonthPage.tsx
@@ -12,6 +12,7 @@ import { getDayChipSx } from '../theme/dateStyles';
 import { DayPopover } from '../components/DayPopover';
 import { ScheduleEmptyHint } from '../components/ScheduleEmptyHint';
 import { DaySummaryDrawer } from '../components/DaySummaryDrawer';
+import { CreateScheduleDialog, type CreateScheduleDraft } from '../components/CreateScheduleDialog';
 import {
   useCallback,
   useEffect,
@@ -113,6 +114,20 @@ export default function MonthPage({ items, loading = false, activeCategory = 'Al
 
   const handlePanelClose = useCallback(() => {
     setSelectedDateIso(null);
+  }, []);
+
+  // Create schedule dialog state
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [createDateIso, setCreateDateIso] = useState<string | null>(null);
+
+  const handleAddFromPanel = useCallback(() => {
+    if (!selectedDateIso) return;
+    setCreateDateIso(selectedDateIso);
+    setIsCreateOpen(true);
+  }, [selectedDateIso]);
+
+  const handleCloseCreate = useCallback(() => {
+    setIsCreateOpen(false);
   }, []);
 
   useEffect(() => {
@@ -349,9 +364,18 @@ export default function MonthPage({ items, loading = false, activeCategory = 'Al
         selectedDateIso={selectedDateIso}
         items={items}
         onClose={handlePanelClose}
-        onAddClick={() => {
-          // TODO: Open create dialog with selectedDateIso
-          console.log('Open create dialog for:', selectedDateIso);
+        onAdd={handleAddFromPanel}
+      />
+
+      {/* Create Schedule Dialog (Month: all-day default) */}
+      <CreateScheduleDialog
+        open={isCreateOpen}
+        dateIso={createDateIso}
+        defaultAllDay
+        onClose={handleCloseCreate}
+        onSubmit={(draft: CreateScheduleDraft) => {
+          // TODO: Persist to repository (next PR)
+          console.log('[create-schedule-draft-month]', draft);
         }}
       />
     </section>


### PR DESCRIPTION
B案 implementation: Month date tap → Day summary drawer → Create dialog (allDay=true)

- DaySummaryDrawer: Display daily events, +Add button
- CreateScheduleDialog: Title + Notes, fixed allDay
- Full UX flow for Month view registration

Acceptance:
- Date tap → Drawer open
- +Add → Dialog open (allDay fixed)
- Title field required
- Console.log on save (persistence: next PR)

Separate PRs: #510 (HOTFIX iPad), #511 (FAB removal)