### PR TITLE
chore(e2e): gate sharepoint-dependent schedules specs for A-mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "test:coverage": "vitest run --coverage --no-file-parallelism",
     "test:prefetch": "vitest run tests/unit/prefetch.*.spec.ts* --run",
     "test:e2e": "playwright test",
+    "test:e2e:schedules:a": "E2E_BASE_URL=http://127.0.0.1:4173 E2E_REQUIRE_SCHEDULE_DATA=1 VITE_E2E=1 VITE_E2E_MSAL_MOCK=1 VITE_E2E_FORCE_SCHEDULES_WRITE=1 VITE_SKIP_SHAREPOINT=1 VITE_SKIP_LOGIN=1 VITE_FEATURE_SCHEDULES=1 VITE_FEATURE_SCHEDULES_WEEK_V2=1 VITE_SCHEDULES_SAVE_MODE=mock VITE_FEATURE_SCHEDULES_GRAPH=0 VITE_FEATURE_SCHEDULES_SP=0 VITE_FORCE_SHAREPOINT=0 VITE_DEMO_MODE=0 VITE_ALLOW_SHAREPOINT_OUTSIDE_SPFX=1 VITE_SCHEDULE_FIXTURES=1 VITE_SCHEDULES_FIXTURES=1 npx playwright test tests/e2e/schedule-*.spec.ts tests/e2e/schedules*.spec.ts tests/e2e/dashboard-schedule-flow.spec.ts --project=chromium --workers=1",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:prefetch": "playwright test tests/e2e/prefetch.*.spec.ts --reporter=list",
     "test:e2e:users": "playwright test tests/e2e/users.detail-flow.spec.ts",

--- a/tests/e2e/schedule-day-view.spec.ts
+++ b/tests/e2e/schedule-day-view.spec.ts
@@ -5,9 +5,13 @@ import { bootSchedule } from './_helpers/bootSchedule';
 import { getSchedulesTodaySeedDate } from './_helpers/schedulesTodaySeed';
 import { gotoDay } from './utils/scheduleNav';
 import { assertDayHasUserCareEvent, waitForDayViewReady, waitForWeekViewReady } from './utils/scheduleActions';
+
+const skipSp = process.env.VITE_SKIP_SHAREPOINT === '1' || process.env.VITE_FEATURE_SCHEDULES_SP === '0';
+
 const TEST_DATE = new Date(getSchedulesTodaySeedDate());
 
 test.describe('Schedule day view', () => {
+  test.skip(skipSp, 'SharePoint/SP disabled in this run');
   test.beforeEach(async ({ page }) => {
     page.on('console', (message) => {
       if (message.type() === 'info' && message.text().startsWith('[schedulesClient] fixtures=')) {

--- a/tests/e2e/schedule-list-view.spec.ts
+++ b/tests/e2e/schedule-list-view.spec.ts
@@ -7,6 +7,8 @@ import { hookConsole } from './utils/console';
 import { registerScheduleMocks, TIME_ZONE, type ScheduleItem } from './utils/spMock';
 import { clickEnabledFilterAction } from './utils/waiters';
 
+const skipSp = process.env.VITE_SKIP_SHAREPOINT === '1' || process.env.VITE_FEATURE_SCHEDULES_SP === '0';
+
 const TEST_NOW = '2025-10-08T03:00:00.000Z';
 const TEST_DATE = new Date(TEST_NOW);
 
@@ -74,6 +76,7 @@ const materializeScheduleItems = (items: ReturnType<typeof buildScheduleFixtures
   });
 
 test.describe('schedule list view', () => {
+  test.skip(skipSp, 'SharePoint/SP disabled in this run');
   test('filters, sorts, paginates, and shows details', async ({ page }) => {
     const consoleGuard = hookConsole(page);
 

--- a/tests/e2e/schedule-month-to-day.smoke.spec.ts
+++ b/tests/e2e/schedule-month-to-day.smoke.spec.ts
@@ -7,7 +7,10 @@ import { gotoMonth } from './utils/scheduleNav';
 import { waitForMonthViewReady, waitForDayViewReady } from './utils/scheduleActions';
 import { waitForScheduleReady } from './utils/wait';
 
+const skipSp = process.env.VITE_SKIP_SHAREPOINT === '1' || process.env.VITE_FEATURE_SCHEDULES_SP === '0';
+
 test.describe('Schedule month→day navigation smoke', () => {
+  test.skip(skipSp, 'SharePoint/SP disabled in this run');
   const ensureFilterVisible = async (page: import('@playwright/test').Page) => {
     const categoryFilter = page.getByTestId(TESTIDS['schedules-filter-category']);
     if (await categoryFilter.isVisible().catch(() => false)) {

--- a/tests/e2e/schedule-org-filter.deep.spec.ts
+++ b/tests/e2e/schedule-org-filter.deep.spec.ts
@@ -8,6 +8,8 @@ import { getWeekRowById, waitForWeekScheduleItems, waitForWeekViewReady } from '
 import { gotoWeek } from './utils/scheduleNav';
 import { registerScheduleMocks, TIME_ZONE } from './utils/spMock';
 
+const skipSp = process.env.VITE_SKIP_SHAREPOINT === '1' || process.env.VITE_FEATURE_SCHEDULES_SP === '0';
+
 const TEST_DATE = new Date(SCHEDULE_FIXTURE_BASE_DATE);
 const TEST_DATE_KEY = formatInTimeZone(TEST_DATE, TIME_ZONE, 'yyyy-MM-dd');
 
@@ -17,6 +19,7 @@ const buildScheduleItems = () => {
 };
 
 test.describe('Schedule org filter deep', () => {
+  test.skip(skipSp, 'SharePoint/SP disabled in this run');
   test.beforeEach(async ({ page }) => {
     const fixtures = buildScheduleFixturesForDate(TEST_DATE);
     await registerScheduleMocks(page, fixtures);

--- a/tests/e2e/schedule-week.deeplink.spec.ts
+++ b/tests/e2e/schedule-week.deeplink.spec.ts
@@ -5,7 +5,10 @@ import { bootstrapScheduleEnv } from './utils/scheduleEnv';
 import { gotoWeek } from './utils/scheduleNav';
 import { waitForWeekViewReady } from './utils/wait';
 
+const skipSp = process.env.VITE_SKIP_SHAREPOINT === '1' || process.env.VITE_FEATURE_SCHEDULES_SP === '0';
+
 test.describe('Schedule week deep link', () => {
+  test.skip(skipSp, 'SharePoint/SP disabled in this run');
   test.beforeEach(async ({ page }) => {
     await bootstrapScheduleEnv(page);
   });

--- a/tests/e2e/schedule-week.filter.mobile.spec.ts
+++ b/tests/e2e/schedule-week.filter.mobile.spec.ts
@@ -5,7 +5,10 @@ import { bootstrapScheduleEnv } from './utils/scheduleEnv';
 import { gotoWeek } from './utils/scheduleNav';
 import { waitForWeekViewReady } from './utils/wait';
 
+const skipSp = process.env.VITE_SKIP_SHAREPOINT === '1' || process.env.VITE_FEATURE_SCHEDULES_SP === '0';
+
 test.describe('Schedule week – mobile toolbar/search', () => {
+  test.skip(skipSp, 'SharePoint/SP disabled in this run');
   test.beforeEach(async ({ page }) => {
     await bootstrapScheduleEnv(page);
   });

--- a/tests/e2e/schedule-week.keyboard.spec.ts
+++ b/tests/e2e/schedule-week.keyboard.spec.ts
@@ -5,12 +5,15 @@ import { bootstrapScheduleEnv } from './utils/scheduleEnv';
 import { gotoWeek } from './utils/scheduleNav';
 import { waitForDayTimeline, waitForWeekViewReady } from './utils/wait';
 
+const skipSp = process.env.VITE_SKIP_SHAREPOINT === '1' || process.env.VITE_FEATURE_SCHEDULES_SP === '0';
+
 const focusLocator = async (locator: Locator): Promise<void> => {
   await locator.scrollIntoViewIfNeeded();
   await locator.focus();
 };
 
 test.describe('Schedule week keyboard navigation', () => {
+  test.skip(skipSp, 'SharePoint/SP disabled in this run');
   test.beforeEach(async ({ page }) => {
     page.on('console', (message) => {
       if (message.type() === 'error' && message.text().includes('SharePoint')) {

--- a/tests/e2e/schedule-week.lanes.smoke.spec.ts
+++ b/tests/e2e/schedule-week.lanes.smoke.spec.ts
@@ -6,7 +6,10 @@ import { bootstrapScheduleEnv } from './utils/scheduleEnv';
 import { gotoScheduleWeek } from './utils/scheduleWeek';
 import { waitForWeekViewReady } from './utils/wait';
 
+const skipSp = process.env.VITE_SKIP_SHAREPOINT === '1' || process.env.VITE_FEATURE_SCHEDULES_SP === '0';
+
 test.describe('Schedule week lanes', () => {
+  test.skip(skipSp, 'SharePoint/SP disabled in this run');
   test.beforeEach(async ({ page }) => {
     await bootstrapScheduleEnv(page);
   });

--- a/tests/e2e/schedules-day-create-facility.smoke.spec.ts
+++ b/tests/e2e/schedules-day-create-facility.smoke.spec.ts
@@ -8,7 +8,10 @@ import { bootstrapScheduleEnv } from './utils/scheduleEnv';
 import { gotoDay } from './utils/scheduleNav';
 import { waitForDayTimeline, waitForScheduleReady } from './utils/wait';
 
+const skipSp = process.env.VITE_SKIP_SHAREPOINT === '1' || process.env.VITE_FEATURE_SCHEDULES_SP === '0';
+
 test.describe('Schedules day create flow (facility)', () => {
+  test.skip(skipSp, 'SharePoint/SP disabled in this run');
   test('Week lane -> Day create defaults to facility', async ({ page }) => {
     await bootstrapScheduleEnv(page, {
       storage: { 'e2e:schedules.v1': JSON.stringify([]) },


### PR DESCRIPTION
## What
- Add explicit SharePoint skip gates to schedules E2E specs categorized as SharePoint/integration dependency.
- Gate condition uses existing pattern: `VITE_SKIP_SHAREPOINT=1 || VITE_FEATURE_SCHEDULES_SP=0`.
- Add reproducible A-mode command in `package.json`:
  - `npm run test:e2e:schedules:a`

## Files
- tests/e2e/schedule-day-view.spec.ts
- tests/e2e/schedule-list-view.spec.ts
- tests/e2e/schedule-month-to-day.smoke.spec.ts
- tests/e2e/schedule-org-filter.deep.spec.ts
- tests/e2e/schedule-week.deeplink.spec.ts
- tests/e2e/schedule-week.filter.mobile.spec.ts
- tests/e2e/schedule-week.keyboard.spec.ts
- tests/e2e/schedule-week.lanes.smoke.spec.ts
- tests/e2e/schedules-day-create-facility.smoke.spec.ts
- package.json

## Evidence
- Under A-mode flags, the 9 SharePoint-dependent specs are now skipped deterministically (15 tests skipped).
- Remaining failures in broad schedules run are concentrated in non-SP categories (timing/navigation), expected for Phase A.

## Why
- Freeze a stable, CI-compatible schedules E2E surface (A) before splitting SharePoint smoke to dedicated job (B).
