### PR TITLE
fix(schedules): make org filter stable (org tab + route preservation)

### DIFF
--- a/src/features/schedules/components/SchedulesHeader.tsx
+++ b/src/features/schedules/components/SchedulesHeader.tsx
@@ -10,7 +10,7 @@ import type { Theme } from '@mui/material/styles';
 import React, { type FocusEventHandler } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-type ViewMode = 'day' | 'week' | 'month';
+type ViewMode = 'day' | 'week' | 'month' | 'org';
 type ViewModeOption = ViewMode;
 
 type Props = {
@@ -118,7 +118,7 @@ export const SchedulesHeader: React.FC<Props> = ({
     if (value === mode) {
       return;
     }
-    const nextHref = { day: dayHref, week: weekHref, month: monthHref }[value];
+    const nextHref = { day: dayHref, week: weekHref, month: monthHref, org: weekHref }[value];
     if (!nextHref) return;
     // Append tab parameter to maintain tab state in URL for E2E tests and history tracking
     const urlObj = new URL(nextHref, window.location.origin);
@@ -194,6 +194,14 @@ export const SchedulesHeader: React.FC<Props> = ({
               value="month"
               sx={{ minHeight: tabMinHeight, minWidth: tabMinWidth, px: tabPaddingX }}
               data-testid="schedules-view-tab-month"
+            />
+          )}
+          {modes.includes('org') && (
+            <Tab
+              label="組織"
+              value="org"
+              sx={{ minHeight: tabMinHeight, minWidth: tabMinWidth, px: tabPaddingX }}
+              data-testid="schedule-tab-org"
             />
           )}
         </Tabs>

--- a/src/features/schedules/hooks/useWeekPageRouteState.ts
+++ b/src/features/schedules/hooks/useWeekPageRouteState.ts
@@ -4,7 +4,7 @@ import { useMatch, useSearchParams } from 'react-router-dom';
 import type { ScheduleCategory } from '@/features/schedules/domain/types';
 import { ensureDateParam, normalizeToDayStart, pickDateParam } from '@/features/schedules/utils/dateQuery';
 
-export type ScheduleTab = 'week' | 'day' | 'month';
+export type ScheduleTab = 'week' | 'day' | 'month' | 'org';
 export type WeekDialogMode = 'create' | 'edit';
 
 export type DialogIntentParams = {
@@ -34,7 +34,7 @@ type RouteState = {
   setDateIso: (dateIso: string) => void;
 };
 
-const LEGACY_TABS = ['day', 'week', 'timeline', 'month'] as const;
+const LEGACY_TABS = ['day', 'week', 'timeline', 'month', 'org'] as const;
 type LegacyTab = typeof LEGACY_TABS[number];
 
 const DEFAULT_DIALOG_START = '10:00';


### PR DESCRIPTION
## What
- Add Schedules Org tab and make it targetable by E2E.
  - Provide stable locators (schedule-tab-org, schedule-org-select).
- Teach week route state to recognize tab=org.
- Preserve org query while navigating day/week/month so filters do not drop.

## Why
- A-lane real run shows 3 failures in schedule-org-filter.spec.ts due to missing Org tab, route state, and query preservation.

## Evidence
```bash
VITE_E2E_FORCE_SCHEDULES_WRITE=1 VITE_SKIP_SHAREPOINT=1 \
npx playwright test tests/e2e/schedule-org-filter.spec.ts \
  --project=chromium --workers=1 --reporter=line
# => 3 passed
```

## Scope
- Only 3 files:
  - src/features/schedules/components/SchedulesHeader.tsx
  - src/features/schedules/hooks/useWeekPageRouteState.ts
  - src/features/schedules/routes/WeekPage.tsx
