### PR TITLE
fix: stabilize week-to-day lane smoke

### DIFF
--- a/src/features/schedules/routes/WeekPage.tsx
+++ b/src/features/schedules/routes/WeekPage.tsx
@@ -199,25 +199,34 @@ export default function WeekPage() {
     if (dayLane) {
       params.set('lane', dayLane);
     }
+    if (categoryFilter !== 'All') {
+      params.set('cat', categoryFilter);
+    }
     if (orgParam !== 'all') {
       params.set('org', orgParam);
     }
     return `/schedules/day?${params.toString()}`;
-  }, [dayLane, orgParam, resolvedActiveDateIso]);
+  }, [categoryFilter, dayLane, orgParam, resolvedActiveDateIso]);
   const weekViewHref = useMemo(() => {
     const params = new URLSearchParams({ date: resolvedActiveDateIso });
+    if (categoryFilter !== 'All') {
+      params.set('cat', categoryFilter);
+    }
     if (orgParam !== 'all') {
       params.set('org', orgParam);
     }
     return `/schedules/week?${params.toString()}`;
-  }, [orgParam, resolvedActiveDateIso]);
+  }, [categoryFilter, orgParam, resolvedActiveDateIso]);
   const monthViewHref = useMemo(() => {
     const params = new URLSearchParams({ date: resolvedActiveDateIso });
+    if (categoryFilter !== 'All') {
+      params.set('cat', categoryFilter);
+    }
     if (orgParam !== 'all') {
       params.set('org', orgParam);
     }
     return `/schedules/month?${params.toString()}`;
-  }, [orgParam, resolvedActiveDateIso]);
+  }, [categoryFilter, orgParam, resolvedActiveDateIso]);
   const activeDayRange = useMemo(() => {
     const start = new Date(`${resolvedActiveDateIso}T00:00:00`);
     const end = new Date(start);

--- a/tests/e2e/schedule-week-to-day.lane.smoke.spec.ts
+++ b/tests/e2e/schedule-week-to-day.lane.smoke.spec.ts
@@ -45,17 +45,22 @@ test.describe('Schedule week -> day lane', () => {
     await gotoScheduleWeek(page, targetDate);
     await waitForWeekViewReady(page);
 
-    const itemButton = page.getByRole('button', { name: /Org lane smoke/ }).first();
-    await expect(itemButton).toBeVisible();
-    await itemButton.click();
+    await expect
+      .poll(async () => {
+        const weekCategorySelect = await ensureFilterVisible(page);
+        await weekCategorySelect.selectOption('Org').catch(() => undefined);
+        return weekCategorySelect.inputValue().catch(() => '');
+      }, { timeout: 10_000 })
+      .toBe('Org');
 
-    const dialog = page.getByTestId(TESTIDS['schedule-create-dialog']);
-    if (await dialog.isVisible().catch(() => false)) {
+    const filterDialog = page.getByTestId('schedules-filter-dialog');
+    if (await filterDialog.isVisible().catch(() => false)) {
       await page.keyboard.press('Escape');
-      await expect(dialog).toBeHidden({ timeout: 10_000 });
+      await expect(filterDialog).toBeHidden({ timeout: 10_000 });
     }
 
     await page.getByTestId(TESTIDS.SCHEDULES_WEEK_TAB_DAY).click();
+    await expect(page).toHaveURL(/tab=day/);
 
     const categorySelect = await ensureFilterVisible(page);
     await expect(categorySelect).toHaveValue('Org');


### PR DESCRIPTION
## Summary
- stabilize `schedule-week-to-day.lane.smoke.spec.ts` by adding robust lane selection and filter-dialog close gate before tab switch
- preserve `cat` query parameter across week/day/month tab hrefs in WeekPage so selected lane survives navigation
- keep changes minimal (1 route file + 1 spec file)

## Validation
- `VITE_E2E_FORCE_SCHEDULES_WRITE=1 VITE_SKIP_SHAREPOINT=1 npx playwright test tests/e2e/schedule-week-to-day.lane.smoke.spec.ts --project=chromium --workers=1 --reporter=line`
- result: `1 passed`
