### PR TITLE
fix: stabilize week smoke a11y violations (gridcell role + aria-label)

### DIFF
--- a/src/features/schedules/routes/WeekView.tsx
+++ b/src/features/schedules/routes/WeekView.tsx
@@ -414,9 +414,6 @@ const WeekViewContent = ({ items, loading, onDayClick: _onDayClick, onTimeSlotCl
         {/* Time Grid View */}
         <div
           aria-label="週ごとの時間割"
-          role="grid"
-          aria-rowcount={32}
-          aria-colcount={8}
           data-testid={TESTIDS['schedules-week-grid']}
           className="w-full"
           style={{
@@ -526,9 +523,7 @@ const WeekViewContent = ({ items, loading, onDayClick: _onDayClick, onTimeSlotCl
                     <button
                       type="button"
                       key={cellKey}
-                      role="gridcell"
-                      aria-rowindex={slotIndex + 2}
-                      aria-colindex={dayIndex + 2}
+                      aria-label={`${day.label} ${timeStr}時間帯`}
                       data-testid="schedules-week-slot"
                       data-day={day.iso}
                       data-time={timeStr}

--- a/tests/e2e/schedule-week.smoke.spec.ts
+++ b/tests/e2e/schedule-week.smoke.spec.ts
@@ -39,7 +39,7 @@ test.describe('Schedule week smoke', () => {
       grid,
       `testid not found: ${TESTIDS['schedules-week-grid']} (allowed for smoke)`
     );
-    await expect(grid.getByRole('gridcell').first()).toBeVisible();
+    await expect(grid.locator('button').first()).toBeVisible();
 
     await runA11ySmoke(page, 'Schedules Week', {
       selectors: `[data-testid="${TESTIDS['schedules-week-page']}"]`,


### PR DESCRIPTION
Fixes axe a11y violations in schedule-week smoke test:

**Issues Fixed:**
- ~~aria-required-children~~ → Removed role=grid (CSS grid sufficient)
- ~~aria-required-parent~~ → Removed gridcell role (buttons don't need grid role)
- ~~button-name~~ → Added aria-label for accessible naming

**Changes:**
- Removed ARIA grid semantics from WeekView gridcell button structure
- Added aria-label to time-slot buttons for screen readers
- Updated test selector from gridcell role to button locator

**Test Result:** All 6 week smoke tests pass (0 violations)

Minimal diff: 7 lines removed, 2 added.