### PR TITLE
refactor(shell): remove lockViewportHeight compatibility

### DIFF
--- a/src/app/layout/AppShell.tsx
+++ b/src/app/layout/AppShell.tsx
@@ -22,8 +22,6 @@ export type AppShellProps = {
   contentPaddingY?: number;
   contentMaxWidth?: number;
   viewportMode?: ShellViewportMode;
-  /** @deprecated Use viewportMode instead */
-  lockViewportHeight?: boolean;
 
   children: React.ReactNode;
 };
@@ -43,8 +41,7 @@ export function AppShell(props: AppShellProps) {
   const contentPaddingX = props.contentPaddingX ?? 16;
   const contentPaddingY = props.contentPaddingY ?? 16;
   const contentMaxWidth = props.contentMaxWidth ?? 1200;
-  const viewportMode: ShellViewportMode =
-    props.viewportMode ?? ((props.lockViewportHeight ?? true) ? 'fixed' : 'adaptive');
+  const viewportMode: ShellViewportMode = props.viewportMode ?? 'fixed';
 
   return (
     <Box

--- a/src/components/layout/AppShellV2.tsx
+++ b/src/components/layout/AppShellV2.tsx
@@ -21,8 +21,6 @@ type Props = {
   contentPaddingX?: number; // default 16
   contentPaddingY?: number; // default 16
   viewportMode?: ShellViewportMode;
-  /** @deprecated Use viewportMode instead */
-  lockViewportHeight?: boolean;
 };
 
 export function AppShellV2({
@@ -36,8 +34,7 @@ export function AppShellV2({
   contentMaxWidth = 1200,
   contentPaddingX = 16,
   contentPaddingY = 16,
-  viewportMode,
-  lockViewportHeight: legacyLockViewportHeight,
+  viewportMode = 'fixed',
 }: Props) {
   const theme = useTheme();
   const isPhone = useMediaQuery(theme.breakpoints.down('sm'));
@@ -55,16 +52,12 @@ export function AppShellV2({
   const showActivity = Boolean(activity) && activityW > 0;
   const showSidebar = Boolean(sidebar) && sidebarW > 0;
   const showFooter = Boolean(footer);
-  const fallbackViewportMode: ShellViewportMode =
-    (legacyLockViewportHeight ?? true) ? 'fixed' : 'adaptive';
-  const resolvedViewportMode: ShellViewportMode =
-    viewportMode ?? fallbackViewportMode;
 
   return (
     <Box
       sx={{
         '--bottom-nav-height': '88px', // CSS variable for LandscapeFab positioning
-        ...(resolvedViewportMode === 'fixed' ? { height: '100dvh' } : { minHeight: '100dvh' }),
+        ...(viewportMode === 'fixed' ? { height: '100dvh' } : { minHeight: '100dvh' }),
         overflow: 'hidden',
         display: 'grid',
         gridTemplateAreas: `


### PR DESCRIPTION
## What
- Remove deprecated `lockViewportHeight` from AppShell/AppShellV2
- Keep `viewportMode` as the only viewport contract (default: fixed)

## Why
- Complete deprecation cleanup after observation period
- Reduce dual-path layout logic and maintenance risk

## Validation
- `rg -n "lockViewportHeight" src` == 0
- `npm run typecheck`
- `npx playwright test ./tests/e2e/schedule-layout.regression.spec.ts --config=playwright.config.ts --project=chromium`
