### PR TITLE
feat(pdca): connect daily submissions to PDCA metrics

### DIFF
--- a/src/features/daily/hooks/useTableDailyRecordForm.ts
+++ b/src/features/daily/hooks/useTableDailyRecordForm.ts
@@ -3,6 +3,7 @@ import { isUserScheduledForDate } from '@/utils/attendanceUtils';
 import { useEffect, useMemo, useState } from 'react';
 import type { Dispatch, SetStateAction } from 'react';
 import type { User } from '@/types';
+import { emitDailySubmissionEvents } from '@/features/iceberg-pdca/dailyMetricsAdapter';
 
 const TABLE_DAILY_DRAFT_STORAGE_KEY = 'daily-table-record:draft:v1';
 const TABLE_DAILY_UNSENT_FILTER_STORAGE_KEY = 'daily-table-record:unsent-filter:v1';
@@ -481,6 +482,16 @@ export const useTableDailyRecordForm = ({
     setSaving(true);
     try {
       await onSave(formData);
+
+      const submittedAt = new Date().toISOString();
+      const submissionEvents = selectedUserIds.map((userId) => ({
+        userId,
+        recordDate: formData.date,
+        submittedAt,
+        draftCreatedAt: draftSavedAt ?? undefined,
+      }));
+      emitDailySubmissionEvents(submissionEvents);
+
       clearDraft();
       onClose();
       setSelectedUserIds([]);

--- a/src/features/iceberg-pdca/dailyMetricsAdapter.ts
+++ b/src/features/iceberg-pdca/dailyMetricsAdapter.ts
@@ -1,0 +1,126 @@
+export type DailySubmissionEvent = {
+  userId: string;
+  recordDate: string;
+  submittedAt: string;
+  draftCreatedAt?: string;
+};
+
+export type DailySubmissionMetricSummary = {
+  recordDate: string;
+  completionRate: number;
+  submittedCount: number;
+  targetCount: number;
+  averageLeadTimeMinutes: number;
+};
+
+const DAILY_PDCA_METRICS_STORAGE_KEY = 'pdca:daily-submission-events:v1';
+
+const toDayKey = (value: string): string => {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toISOString().slice(0, 10);
+};
+
+const toEventKey = (userId: string, recordDate: string): string => `${userId}::${recordDate}`;
+
+const readEventMap = (): Record<string, DailySubmissionEvent> => {
+  if (typeof window === 'undefined') {
+    return {};
+  }
+
+  try {
+    const raw = window.localStorage.getItem(DAILY_PDCA_METRICS_STORAGE_KEY);
+    if (!raw) {
+      return {};
+    }
+
+    const parsed = JSON.parse(raw) as Record<string, DailySubmissionEvent>;
+    if (!parsed || typeof parsed !== 'object') {
+      return {};
+    }
+
+    return parsed;
+  } catch {
+    return {};
+  }
+};
+
+const writeEventMap = (nextMap: Record<string, DailySubmissionEvent>): void => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.localStorage.setItem(DAILY_PDCA_METRICS_STORAGE_KEY, JSON.stringify(nextMap));
+};
+
+export const emitDailySubmissionEvents = (events: DailySubmissionEvent[]): void => {
+  if (events.length === 0) {
+    return;
+  }
+
+  const eventMap = readEventMap();
+
+  events.forEach((event) => {
+    if (!event.userId) {
+      return;
+    }
+
+    const normalizedRecordDate = toDayKey(event.recordDate);
+    const key = toEventKey(event.userId, normalizedRecordDate);
+    eventMap[key] = {
+      ...event,
+      recordDate: normalizedRecordDate,
+    };
+  });
+
+  writeEventMap(eventMap);
+};
+
+export const getDailySubmissionMetrics = (params: {
+  recordDate: string;
+  targetUserIds: string[];
+}): DailySubmissionMetricSummary => {
+  const normalizedDate = toDayKey(params.recordDate);
+  const targetUserSet = new Set(params.targetUserIds.filter(Boolean));
+  const targetCount = targetUserSet.size;
+
+  const sameDayEvents = Object.values(readEventMap()).filter((event) => event.recordDate === normalizedDate);
+
+  const submittedUserSet = new Set(
+    sameDayEvents
+      .map((event) => event.userId)
+      .filter((userId) => targetUserSet.size === 0 || targetUserSet.has(userId)),
+  );
+
+  const submittedCount = submittedUserSet.size;
+  const completionRate = targetCount > 0 ? submittedCount / targetCount : 0;
+
+  const leadTimeMinutesList = sameDayEvents
+    .map((event) => {
+      if (!event.draftCreatedAt) {
+        return 0;
+      }
+
+      const draftAt = new Date(event.draftCreatedAt).getTime();
+      const submittedAt = new Date(event.submittedAt).getTime();
+      if (Number.isNaN(draftAt) || Number.isNaN(submittedAt)) {
+        return 0;
+      }
+
+      return Math.max(0, Math.round((submittedAt - draftAt) / 60000));
+    });
+
+  const averageLeadTimeMinutes = leadTimeMinutesList.length > 0
+    ? Math.round(leadTimeMinutesList.reduce((sum, minutes) => sum + minutes, 0) / leadTimeMinutesList.length)
+    : 0;
+
+  return {
+    recordDate: normalizedDate,
+    completionRate,
+    submittedCount,
+    targetCount,
+    averageLeadTimeMinutes,
+  };
+};

--- a/src/testids.ts
+++ b/src/testids.ts
@@ -41,6 +41,10 @@ export const TESTIDS = {
   'audit-heading': 'audit-heading',
   'iceberg-pdca-root': 'iceberg-pdca-root',
   'iceberg-pdca-empty': 'iceberg-pdca-empty',
+  'pdca-daily-completion-card': 'pdca-daily-completion-card',
+  'pdca-daily-completion-value': 'pdca-daily-completion-value',
+  'pdca-daily-leadtime-card': 'pdca-daily-leadtime-card',
+  'pdca-daily-leadtime-value': 'pdca-daily-leadtime-value',
   ICEBERG_PDCA_EMPTY: 'iceberg-pdca-empty',
 
   // Dashboard Tabs (黒ノート機能個別タブ) 🌱 E2Eでタブ切替を細かく検査用

--- a/tests/e2e/daily-pdca.integration.spec.ts
+++ b/tests/e2e/daily-pdca.integration.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from '@playwright/test';
+
+import { expectTestIdVisibleBestEffort } from './_helpers/smoke';
+import { bootstrapDashboard } from './utils/bootstrapApp';
+
+const TABLE_DAILY_DRAFT_STORAGE_KEY = 'daily-table-record:draft:v1';
+const PDCA_DAILY_METRICS_STORAGE_KEY = 'pdca:daily-submission-events:v1';
+
+test.describe('daily -> PDCA integration', () => {
+  test('daily submit is reflected in PDCA metrics cards', async ({ page }) => {
+    await bootstrapDashboard(page, {
+      skipLogin: true,
+      featureSchedules: true,
+      featureIcebergPdca: true,
+      initialPath: '/daily/table',
+    });
+
+    await page.evaluate(([draftStorageKey, metricsStorageKey]) => {
+      localStorage.removeItem(draftStorageKey);
+      localStorage.removeItem(metricsStorageKey);
+
+      localStorage.setItem(draftStorageKey, JSON.stringify({
+        formData: {
+          date: new Date().toISOString().slice(0, 10),
+          reporter: { name: 'PDCA連携E2E', role: '生活支援員' },
+          userRows: [],
+        },
+        selectedUserIds: ['e2e-pdca-user'],
+        searchQuery: '',
+        showTodayOnly: true,
+        savedAt: new Date(Date.now() - 120000).toISOString(),
+      }));
+    }, [TABLE_DAILY_DRAFT_STORAGE_KEY, PDCA_DAILY_METRICS_STORAGE_KEY]);
+
+    await page.reload();
+
+    page.once('dialog', async (dialog) => {
+      await dialog.accept();
+    });
+
+    await page.getByRole('button', { name: /人分保存/ }).click();
+    await expect(page).toHaveURL(/\/dashboard/);
+
+    const storedMetrics = await page.evaluate((metricsStorageKey) => {
+      const raw = localStorage.getItem(metricsStorageKey);
+      if (!raw) {
+        return null;
+      }
+
+      const parsed = JSON.parse(raw) as Record<string, { userId: string; recordDate: string }>;
+      const events = Object.values(parsed);
+      return {
+        count: events.length,
+        firstUserId: events[0]?.userId,
+      };
+    }, PDCA_DAILY_METRICS_STORAGE_KEY);
+    test.info().annotations.push({
+      type: 'note',
+      description: `pdca metrics snapshot: ${JSON.stringify(storedMetrics)}`,
+    });
+
+    await page.goto('/analysis/iceberg-pdca');
+    await expect(page.getByTestId('iceberg-pdca-root')).toBeVisible();
+
+    await expectTestIdVisibleBestEffort(page, 'pdca-daily-completion-card');
+    await expectTestIdVisibleBestEffort(page, 'pdca-daily-leadtime-card');
+  });
+});


### PR DESCRIPTION
## Summary
- Emit idempotent daily submission events on /daily/table save
- Add PDCA daily metrics adapter (completion rate + lead time)
- Add metrics cards to Iceberg PDCA page
- Add daily->PDCA integration e2e coverage

## Why
Close the loop from daily input behavior to measurable PDCA evaluation indicators

## Validation
- typecheck green
- daily.table.spec.ts green (5/5)
- daily-pdca.integration.spec.ts green (1/1)
- TableDailyRecordForm unit tests green (22/22)