### PR TITLE
feat(pdca): add weekly/monthly trend metrics to PDCA dashboard

### DIFF
--- a/src/features/iceberg-pdca/__tests__/dailyMetricsAdapter.test.ts
+++ b/src/features/iceberg-pdca/__tests__/dailyMetricsAdapter.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getMonthlyMetrics,
+  getTrend,
+  getWeeklyMetrics,
+  type DailySubmissionEvent,
+} from '../dailyMetricsAdapter';
+
+const targetUserIds = ['U001', 'U002'];
+
+const createEvent = (params: {
+  userId: string;
+  recordDate: string;
+  leadTimeMinutes?: number;
+}): DailySubmissionEvent => {
+  const submittedAt = `${params.recordDate}T10:00:00+09:00`;
+  const leadMinutes = params.leadTimeMinutes ?? 0;
+
+  const draftCreatedAt = leadMinutes > 0
+    ? new Date(new Date(submittedAt).getTime() - leadMinutes * 60_000).toISOString()
+    : undefined;
+
+  return {
+    userId: params.userId,
+    recordDate: params.recordDate,
+    submittedAt,
+    draftCreatedAt,
+  };
+};
+
+describe('dailyMetricsAdapter trend functions', () => {
+  it('returns current-week metrics when only this week has events', () => {
+    const referenceDate = new Date('2026-02-11T12:00:00+09:00');
+    const events = [
+      createEvent({ userId: 'U001', recordDate: '2026-02-10', leadTimeMinutes: 20 }),
+    ];
+
+    const weekly = getWeeklyMetrics({ events, targetUserIds, referenceDate });
+
+    expect(weekly.current.submittedCount).toBe(1);
+    expect(weekly.previous.submittedCount).toBe(0);
+    expect(weekly.completionTrend).toBe('up');
+  });
+
+  it('returns up trend when current completion rate improves over previous week', () => {
+    const referenceDate = new Date('2026-02-11T12:00:00+09:00');
+    const events = [
+      createEvent({ userId: 'U001', recordDate: '2026-02-03' }),
+      createEvent({ userId: 'U001', recordDate: '2026-02-10' }),
+      createEvent({ userId: 'U002', recordDate: '2026-02-10' }),
+    ];
+
+    const weekly = getWeeklyMetrics({ events, targetUserIds, referenceDate });
+
+    expect(weekly.completionTrend).toBe('up');
+  });
+
+  it('returns down trend when current completion rate worsens over previous week', () => {
+    const referenceDate = new Date('2026-02-11T12:00:00+09:00');
+    const events = [
+      createEvent({ userId: 'U001', recordDate: '2026-02-03' }),
+      createEvent({ userId: 'U002', recordDate: '2026-02-03' }),
+      createEvent({ userId: 'U001', recordDate: '2026-02-10' }),
+    ];
+
+    const weekly = getWeeklyMetrics({ events, targetUserIds, referenceDate });
+
+    expect(weekly.completionTrend).toBe('down');
+  });
+
+  it('returns flat trend when difference is inside threshold', () => {
+    expect(getTrend(0.5004, 0.5)).toBe('flat');
+    expect(getTrend(0.5, 0.5004)).toBe('flat');
+  });
+
+  it('aggregates month boundary correctly for current and previous month', () => {
+    const referenceDate = new Date('2026-03-15T12:00:00+09:00');
+    const events = [
+      createEvent({ userId: 'U001', recordDate: '2026-03-03', leadTimeMinutes: 10 }),
+      createEvent({ userId: 'U002', recordDate: '2026-03-10', leadTimeMinutes: 30 }),
+      createEvent({ userId: 'U001', recordDate: '2026-02-12', leadTimeMinutes: 40 }),
+    ];
+
+    const monthly = getMonthlyMetrics({ events, targetUserIds, referenceDate });
+
+    expect(monthly.current.dayCount).toBe(31);
+    expect(monthly.previous.dayCount).toBe(28);
+    expect(monthly.current.averageLeadTimeMinutes).toBe(20);
+    expect(monthly.previous.averageLeadTimeMinutes).toBe(40);
+    expect(monthly.leadTimeTrend).toBe('up');
+  });
+});

--- a/src/features/iceberg-pdca/dailyMetricsAdapter.ts
+++ b/src/features/iceberg-pdca/dailyMetricsAdapter.ts
@@ -13,6 +13,23 @@ export type DailySubmissionMetricSummary = {
   averageLeadTimeMinutes: number;
 };
 
+export type TrendDirection = 'up' | 'down' | 'flat';
+
+export type PeriodMetrics = {
+  completionRate: number;
+  submittedCount: number;
+  targetCount: number;
+  averageLeadTimeMinutes: number;
+  dayCount: number;
+};
+
+export type TrendMetrics = {
+  current: PeriodMetrics;
+  previous: PeriodMetrics;
+  completionTrend: TrendDirection;
+  leadTimeTrend: TrendDirection;
+};
+
 const DAILY_PDCA_METRICS_STORAGE_KEY = 'pdca:daily-submission-events:v1';
 
 const toDayKey = (value: string): string => {
@@ -20,7 +37,124 @@ const toDayKey = (value: string): string => {
   if (Number.isNaN(date.getTime())) {
     return value;
   }
-  return date.toISOString().slice(0, 10);
+
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+const addDays = (base: Date, days: number): Date => {
+  const next = new Date(base);
+  next.setDate(next.getDate() + days);
+  return next;
+};
+
+const startOfIsoWeek = (date: Date): Date => {
+  const d = new Date(date);
+  const day = d.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  d.setDate(d.getDate() + diff);
+  d.setHours(0, 0, 0, 0);
+  return d;
+};
+
+const startOfMonth = (date: Date): Date => {
+  return new Date(date.getFullYear(), date.getMonth(), 1);
+};
+
+const endOfMonth = (date: Date): Date => {
+  return new Date(date.getFullYear(), date.getMonth() + 1, 0);
+};
+
+const getPeriodDayKeys = (startDate: Date, endDate: Date): string[] => {
+  const keys: string[] = [];
+  let cursor = new Date(startDate);
+  cursor.setHours(0, 0, 0, 0);
+
+  const end = new Date(endDate);
+  end.setHours(0, 0, 0, 0);
+
+  while (cursor.getTime() <= end.getTime()) {
+    keys.push(toDayKey(cursor.toISOString()));
+    cursor = addDays(cursor, 1);
+  }
+
+  return keys;
+};
+
+const calculateLeadTimeMinutes = (event: DailySubmissionEvent): number => {
+  if (!event.draftCreatedAt) {
+    return 0;
+  }
+
+  const draftAt = new Date(event.draftCreatedAt).getTime();
+  const submittedAt = new Date(event.submittedAt).getTime();
+  if (Number.isNaN(draftAt) || Number.isNaN(submittedAt)) {
+    return 0;
+  }
+
+  return Math.max(0, Math.round((submittedAt - draftAt) / 60000));
+};
+
+const aggregatePeriodMetrics = (params: {
+  events: DailySubmissionEvent[];
+  targetUserIds: string[];
+  dayKeys: string[];
+}): PeriodMetrics => {
+  const { events, targetUserIds, dayKeys } = params;
+  const targetUserSet = new Set(targetUserIds.filter(Boolean));
+  const targetCount = targetUserSet.size;
+
+  const eventsByDay = new Map<string, DailySubmissionEvent[]>();
+  dayKeys.forEach((key) => eventsByDay.set(key, []));
+
+  events.forEach((event) => {
+    const dayKey = toDayKey(event.recordDate);
+    const existing = eventsByDay.get(dayKey);
+    if (!existing) {
+      return;
+    }
+
+    if (targetUserSet.size > 0 && !targetUserSet.has(event.userId)) {
+      return;
+    }
+
+    existing.push(event);
+  });
+
+  const submittedUsers = new Set<string>();
+  const completionRates: number[] = [];
+  const leadTimes: number[] = [];
+
+  dayKeys.forEach((dayKey) => {
+    const dayEvents = eventsByDay.get(dayKey) ?? [];
+    const dayUsers = new Set(dayEvents.map((event) => event.userId));
+    dayUsers.forEach((userId) => submittedUsers.add(userId));
+
+    const dayCompletionRate = targetCount > 0 ? dayUsers.size / targetCount : 0;
+    completionRates.push(dayCompletionRate);
+
+    dayEvents.forEach((event) => {
+      leadTimes.push(calculateLeadTimeMinutes(event));
+    });
+  });
+
+  const completionRate = completionRates.length > 0
+    ? completionRates.reduce((sum, value) => sum + value, 0) / completionRates.length
+    : 0;
+
+  const averageLeadTimeMinutes = leadTimes.length > 0
+    ? Math.round(leadTimes.reduce((sum, value) => sum + value, 0) / leadTimes.length)
+    : 0;
+
+  return {
+    completionRate,
+    submittedCount: submittedUsers.size,
+    targetCount,
+    averageLeadTimeMinutes,
+    dayCount: dayKeys.length,
+  };
 };
 
 const toEventKey = (userId: string, recordDate: string): string => `${userId}::${recordDate}`;
@@ -55,6 +189,97 @@ const writeEventMap = (nextMap: Record<string, DailySubmissionEvent>): void => {
   window.localStorage.setItem(DAILY_PDCA_METRICS_STORAGE_KEY, JSON.stringify(nextMap));
 };
 
+export const getStoredDailySubmissionEvents = (): DailySubmissionEvent[] => {
+  return Object.values(readEventMap());
+};
+
+export const getTrend = (
+  current: number,
+  previous: number,
+  threshold = 0.005,
+): TrendDirection => {
+  if (current > previous + threshold) {
+    return 'up';
+  }
+
+  if (current < previous - threshold) {
+    return 'down';
+  }
+
+  return 'flat';
+};
+
+export const getWeeklyMetrics = (params: {
+  events: DailySubmissionEvent[];
+  targetUserIds: string[];
+  referenceDate?: Date;
+}): TrendMetrics => {
+  const referenceDate = params.referenceDate ?? new Date();
+  const currentStart = startOfIsoWeek(referenceDate);
+  const currentEnd = addDays(currentStart, 6);
+  const previousStart = addDays(currentStart, -7);
+  const previousEnd = addDays(currentStart, -1);
+
+  const currentDayKeys = getPeriodDayKeys(currentStart, currentEnd);
+  const previousDayKeys = getPeriodDayKeys(previousStart, previousEnd);
+
+  const current = aggregatePeriodMetrics({
+    events: params.events,
+    targetUserIds: params.targetUserIds,
+    dayKeys: currentDayKeys,
+  });
+
+  const previous = aggregatePeriodMetrics({
+    events: params.events,
+    targetUserIds: params.targetUserIds,
+    dayKeys: previousDayKeys,
+  });
+
+  return {
+    current,
+    previous,
+    completionTrend: getTrend(current.completionRate, previous.completionRate),
+    leadTimeTrend: getTrend(previous.averageLeadTimeMinutes, current.averageLeadTimeMinutes),
+  };
+};
+
+export const getMonthlyMetrics = (params: {
+  events: DailySubmissionEvent[];
+  targetUserIds: string[];
+  referenceDate?: Date;
+}): TrendMetrics => {
+  const referenceDate = params.referenceDate ?? new Date();
+
+  const currentMonthStart = startOfMonth(referenceDate);
+  const currentMonthEnd = endOfMonth(referenceDate);
+
+  const previousMonthDate = new Date(referenceDate.getFullYear(), referenceDate.getMonth() - 1, 1);
+  const previousMonthStart = startOfMonth(previousMonthDate);
+  const previousMonthEnd = endOfMonth(previousMonthDate);
+
+  const currentDayKeys = getPeriodDayKeys(currentMonthStart, currentMonthEnd);
+  const previousDayKeys = getPeriodDayKeys(previousMonthStart, previousMonthEnd);
+
+  const current = aggregatePeriodMetrics({
+    events: params.events,
+    targetUserIds: params.targetUserIds,
+    dayKeys: currentDayKeys,
+  });
+
+  const previous = aggregatePeriodMetrics({
+    events: params.events,
+    targetUserIds: params.targetUserIds,
+    dayKeys: previousDayKeys,
+  });
+
+  return {
+    current,
+    previous,
+    completionTrend: getTrend(current.completionRate, previous.completionRate),
+    leadTimeTrend: getTrend(previous.averageLeadTimeMinutes, current.averageLeadTimeMinutes),
+  };
+};
+
 export const emitDailySubmissionEvents = (events: DailySubmissionEvent[]): void => {
   if (events.length === 0) {
     return;
@@ -86,7 +311,7 @@ export const getDailySubmissionMetrics = (params: {
   const targetUserSet = new Set(params.targetUserIds.filter(Boolean));
   const targetCount = targetUserSet.size;
 
-  const sameDayEvents = Object.values(readEventMap()).filter((event) => event.recordDate === normalizedDate);
+  const sameDayEvents = getStoredDailySubmissionEvents().filter((event) => event.recordDate === normalizedDate);
 
   const submittedUserSet = new Set(
     sameDayEvents
@@ -97,20 +322,7 @@ export const getDailySubmissionMetrics = (params: {
   const submittedCount = submittedUserSet.size;
   const completionRate = targetCount > 0 ? submittedCount / targetCount : 0;
 
-  const leadTimeMinutesList = sameDayEvents
-    .map((event) => {
-      if (!event.draftCreatedAt) {
-        return 0;
-      }
-
-      const draftAt = new Date(event.draftCreatedAt).getTime();
-      const submittedAt = new Date(event.submittedAt).getTime();
-      if (Number.isNaN(draftAt) || Number.isNaN(submittedAt)) {
-        return 0;
-      }
-
-      return Math.max(0, Math.round((submittedAt - draftAt) / 60000));
-    });
+  const leadTimeMinutesList = sameDayEvents.map(calculateLeadTimeMinutes);
 
   const averageLeadTimeMinutes = leadTimeMinutesList.length > 0
     ? Math.round(leadTimeMinutesList.reduce((sum, minutes) => sum + minutes, 0) / leadTimeMinutesList.length)

--- a/src/testids.ts
+++ b/src/testids.ts
@@ -45,6 +45,11 @@ export const TESTIDS = {
   'pdca-daily-completion-value': 'pdca-daily-completion-value',
   'pdca-daily-leadtime-card': 'pdca-daily-leadtime-card',
   'pdca-daily-leadtime-value': 'pdca-daily-leadtime-value',
+  'pdca-daily-trend-card': 'pdca-daily-trend-card',
+  'pdca-weekly-completion-trend': 'pdca-weekly-completion-trend',
+  'pdca-monthly-completion-trend': 'pdca-monthly-completion-trend',
+  'pdca-weekly-leadtime-trend': 'pdca-weekly-leadtime-trend',
+  'pdca-monthly-leadtime-trend': 'pdca-monthly-leadtime-trend',
   ICEBERG_PDCA_EMPTY: 'iceberg-pdca-empty',
 
   // Dashboard Tabs (黒ノート機能個別タブ) 🌱 E2Eでタブ切替を細かく検査用


### PR DESCRIPTION
## Summary
- Add pure weekly/monthly aggregation functions to dailyMetricsAdapter
- Add trend detection (↑ ↓ →) with tolerance threshold
- Add compact TrendCard to Iceberg PDCA page
- Add unit coverage for aggregation logic (5 cases)

## Why
Elevate daily completion metrics from single-day evaluation to trend-based organizational insight.

## Validation
- dailyMetricsAdapter tests: 5/5
- typecheck: green
- no E2E additions (pure aggregation layer)