### PR TITLE
feat(pdca): show period definition on trend card subtitle

### DIFF
--- a/src/features/iceberg-pdca/IcebergPdcaPage.tsx
+++ b/src/features/iceberg-pdca/IcebergPdcaPage.tsx
@@ -252,6 +252,9 @@ export const IcebergPdcaPage: React.FC<IcebergPdcaPageProps> = ({ writeEnabled: 
 
         <Paper variant="outlined" sx={{ p: 1.5 }} data-testid={TESTIDS['pdca-daily-trend-card']}>
           <Typography variant="subtitle2" sx={{ mb: 1 }}>週次 / 月次トレンド</Typography>
+          <Typography variant="caption" color="text.secondary" sx={{ mb: 1 }}>
+            {trendPeriod === 'weekly' ? '直近7日' : '直近30日'}の集計
+          </Typography>
           <ToggleButtonGroup
             value={trendPeriod}
             exclusive


### PR DESCRIPTION
## Summary

Added period definition text to the TrendCard subtitle to eliminate ambiguity about data aggregation windows.

## Changes

- TrendCard now displays '直近7日' (last 7 days) or '直近30日' (last 30 days) based on selected trend period
- Clarifies whether the week is a rolling 7-day window or calendar week (Mon-Sun)
- Improves transparency in data interpretation for field staff

## Modified Files

- `src/features/iceberg-pdca/IcebergPdcaPage.tsx`: Added period definition caption

## Validation

- ✅ typecheck: No errors
- ✅ UI-only change (no new tests needed)
- ✅ Pre-commit hooks passed