### PR TITLE
feat(pdca): add daily table jump link from PDCA

### DIFF
--- a/src/features/daily/hooks/useTableDailyRecordForm.ts
+++ b/src/features/daily/hooks/useTableDailyRecordForm.ts
@@ -8,6 +8,23 @@ import { emitDailySubmissionEvents } from '@/features/iceberg-pdca/dailyMetricsA
 const TABLE_DAILY_DRAFT_STORAGE_KEY = 'daily-table-record:draft:v1';
 const TABLE_DAILY_UNSENT_FILTER_STORAGE_KEY = 'daily-table-record:unsent-filter:v1';
 const TABLE_DAILY_UNSENT_FILTER_QUERY_KEY = 'unsent';
+const TABLE_DAILY_DATE_QUERY_KEY = 'date';
+
+const isValidDateValue = (value: string): boolean => /^\d{4}-\d{2}-\d{2}$/.test(value);
+
+const getDateFromUrl = (): string | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const params = new URLSearchParams(window.location.search);
+  const date = params.get(TABLE_DAILY_DATE_QUERY_KEY);
+  if (!date || !isValidDateValue(date)) {
+    return null;
+  }
+
+  return date;
+};
 
 const isUnsentFilterEnabledInUrl = (): boolean => {
   if (typeof window === 'undefined') {
@@ -105,7 +122,7 @@ type TableDailyRecordDraft = {
 };
 
 const createInitialFormData = (): TableDailyRecordData => ({
-  date: new Date().toISOString().split('T')[0],
+  date: getDateFromUrl() ?? new Date().toISOString().split('T')[0],
   reporter: {
     name: '',
     role: '生活支援員',

--- a/src/features/iceberg-pdca/IcebergPdcaPage.tsx
+++ b/src/features/iceberg-pdca/IcebergPdcaPage.tsx
@@ -22,7 +22,7 @@ import {
   ToggleButtonGroup,
   Typography,
 } from '@mui/material';
-import { useSearchParams } from 'react-router-dom';
+import { Link as RouterLink, useSearchParams } from 'react-router-dom';
 
 import { useFeatureFlag } from '@/config/featureFlags';
 import { useAuthStore } from '@/features/auth/store';
@@ -294,6 +294,15 @@ export const IcebergPdcaPage: React.FC<IcebergPdcaPageProps> = ({ writeEnabled: 
             <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5 }}>
               判定基準: 完了率 ±{completionTolerancePoint}pt / リードタイム ±{leadTimeToleranceMinutes}分
             </Typography>
+            <Button
+              size="small"
+              component={RouterLink}
+              to={`/daily/table?date=${today}&unsent=1`}
+              aria-label="日次入力へ移動"
+              sx={{ alignSelf: 'flex-start', mt: 0.5 }}
+            >
+              今日の入力へ
+            </Button>
           </Stack>
         </Paper>
 


### PR DESCRIPTION
## Summary
- Add one-click action from PDCA TrendCard to /daily/table
- Navigate with query: date=YYYY-MM-DD&unsent=1
- Keep accessibility with aria-label (no color dependency)
- Add minimal date query support on /daily/table form initialization

## Validation
- typecheck green
- targeted unit green