### PR TITLE
test(pdca): add smoke for daily support jump link

### DIFF
--- a/src/pages/TimeBasedSupportRecordPage.tsx
+++ b/src/pages/TimeBasedSupportRecordPage.tsx
@@ -30,6 +30,7 @@ import { useLocation, useSearchParams } from 'react-router-dom';
 const TimeBasedSupportRecordPage: React.FC = () => {
   const location = useLocation();
   const [, setSearchParams] = useSearchParams();
+  // Query contract: /daily/support?date=YYYY-MM-DD&userId=<id> (legacy user=<id> is also accepted).
   const initialSearchParams = useRef(new URLSearchParams(location.search)).current;
   const initialDateParam = initialSearchParams.get('date');
   const initialRecordDate =

--- a/tests/e2e/iceberg-pdca.nav.smoke.spec.ts
+++ b/tests/e2e/iceberg-pdca.nav.smoke.spec.ts
@@ -21,4 +21,17 @@ test.describe('Iceberg PDCA nav smoke', () => {
     await expect(page.getByText('利用者を選択してください')).toBeVisible();
     await expectTestIdVisibleBestEffort(page, TESTIDS['iceberg-pdca-empty']);
   });
+
+  test('navigates from PDCA link to /daily/support with date query', async ({ page }) => {
+    await bootstrapDashboard(page, { skipLogin: true, featureSchedules: true, initialPath: '/dashboard' });
+
+    await openMobileNav(page);
+    const navItem = page.getByTestId(TESTIDS.nav.icebergPdca).first();
+    const navVisible = await navItem.isVisible().catch(() => false);
+    test.skip(!navVisible, 'Iceberg PDCA nav entry is not available in this layout/feature set.');
+    await navItem.click();
+
+    await page.getByRole('link', { name: '対象日の支援記録へ' }).click();
+    await expect(page).toHaveURL(/\/daily\/support(?:\?.*)?[?&]date=\d{4}-\d{2}-\d{2}/);
+  });
 });


### PR DESCRIPTION
## Summary
- Add a minimal PDCA nav smoke that verifies jump to /daily/support includes date query
- Add one-line /daily/support query contract comment (date + userId, legacy user)

## Validation
- npm run typecheck: green
- npx playwright test tests/e2e/iceberg-pdca.nav.smoke.spec.ts --project=chromium (no failures; skipped in current layout)