### PR TITLE
chore(firestore): add minimal rules and indexes for pdca persistence

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,6 @@
+{
+  "firestore": {
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
+  }
+}

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,4 @@
+{
+  "indexes": [],
+  "fieldOverrides": []
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,25 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    function signedIn() { return request.auth != null; }
+
+    match /orgs/{orgId}/events/{eventId} {
+      allow read: if signedIn();
+
+      allow create: if signedIn()
+        && request.resource.data.orgId == orgId
+        && !exists(/databases/$(database)/documents/orgs/$(orgId)/events/$(eventId));
+
+      allow update, delete: if false;
+    }
+
+    match /orgs/{orgId}/dailySnapshots/{snapId} {
+      allow read: if signedIn();
+
+      allow create, update: if signedIn()
+        && request.resource.data.orgId == orgId;
+
+      allow delete: if false;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add minimal Firestore rules for create-only events and snapshot upsert
- Add empty Firestore indexes config (docId-first strategy)
- Add firebase.json mapping rules/indexes files

## Validation
- npm run typecheck: green