### PR TITLE
feat(pdca): prefer Firestore dailySnapshots in CHECK with fallback

### DIFF
--- a/src/features/iceberg-pdca/__tests__/readDailySnapshot.test.ts
+++ b/src/features/iceberg-pdca/__tests__/readDailySnapshot.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { makeDailySnapshotId, parseDailySnapshotMetrics } from '../readDailySnapshot';
+
+describe('readDailySnapshot helpers', () => {
+  it('builds snapshot id from template/date/user', () => {
+    expect(makeDailySnapshotId({
+      templateId: 'daily-support.v1',
+      targetDate: '2026-02-22',
+      targetUserId: 'U001',
+    })).toBe('daily-support.v1__2026-02-22__U001');
+  });
+
+  it('parses valid snapshot payload', () => {
+    const parsed = parseDailySnapshotMetrics({
+      completionRate: 0.9,
+      leadTimeMinutes: 12,
+      targetDate: '2026-02-22',
+      targetUserId: 'U001',
+    });
+
+    expect(parsed).toEqual({
+      completionRate: 0.9,
+      leadTimeMinutes: 12,
+      targetDate: '2026-02-22',
+      targetUserId: 'U001',
+    });
+  });
+
+  it('returns null for invalid payload', () => {
+    expect(parseDailySnapshotMetrics(null)).toBeNull();
+    expect(parseDailySnapshotMetrics({ completionRate: '0.9', leadTimeMinutes: 12 })).toBeNull();
+    expect(parseDailySnapshotMetrics({ completionRate: 0.9 })).toBeNull();
+  });
+});

--- a/src/features/iceberg-pdca/readDailySnapshot.ts
+++ b/src/features/iceberg-pdca/readDailySnapshot.ts
@@ -1,0 +1,61 @@
+import { doc, getDoc } from 'firebase/firestore';
+
+import { db } from '@/infra/firestore/client';
+
+export type DailySnapshotMetrics = {
+  completionRate: number;
+  leadTimeMinutes: number;
+  targetDate?: string;
+  targetUserId?: string;
+};
+
+const toNumber = (value: unknown): number | null => {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return null;
+  }
+  return value;
+};
+
+export const parseDailySnapshotMetrics = (value: unknown): DailySnapshotMetrics | null => {
+  if (typeof value !== 'object' || value === null) {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  const completionRate = toNumber(record.completionRate);
+  const leadTimeMinutes = toNumber(record.leadTimeMinutes);
+
+  if (completionRate === null || leadTimeMinutes === null) {
+    return null;
+  }
+
+  return {
+    completionRate,
+    leadTimeMinutes,
+    targetDate: typeof record.targetDate === 'string' ? record.targetDate : undefined,
+    targetUserId: typeof record.targetUserId === 'string' ? record.targetUserId : undefined,
+  };
+};
+
+export const makeDailySnapshotId = (params: {
+  templateId: string;
+  targetDate: string;
+  targetUserId: string;
+}): string => `${params.templateId}__${params.targetDate}__${params.targetUserId}`;
+
+export const readDailySnapshot = async (params: {
+  orgId: string;
+  templateId: string;
+  targetDate: string;
+  targetUserId: string;
+}): Promise<DailySnapshotMetrics | null> => {
+  const snapshotId = makeDailySnapshotId(params);
+  const ref = doc(db, 'orgs', params.orgId, 'dailySnapshots', snapshotId);
+  const snap = await getDoc(ref);
+
+  if (!snap.exists()) {
+    return null;
+  }
+
+  return parseDailySnapshotMetrics(snap.data());
+};


### PR DESCRIPTION
## Summary
- Add Firestore dailySnapshot reader for CHECK source
- Prefer dailySnapshots when selected user is present
- Keep existing adapter-derived metrics as fallback
- Add unit tests for snapshot parsing and id generation

## Validation
- npm run typecheck: green
- iceberg-pdca unit tests: green