### PR TITLE
feat(firebase): anonymous auth minimum for Firestore rules

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,23 @@ VITE_WRITE_ENABLED=0
 VITE_ALLOW_WRITE_FALLBACK=0
 VITE_SKIP_ENSURE_SCHEDULE=0
 
+# --- Firebase / Firestore (PDCA persistence) ---
+# Firebase project config (from Firebase Console)
+VITE_FIREBASE_API_KEY=
+VITE_FIREBASE_AUTH_DOMAIN=
+VITE_FIREBASE_PROJECT_ID=
+VITE_FIREBASE_APP_ID=
+
+# Firestore local emulator (for development without auth/billing)
+VITE_FIRESTORE_USE_EMULATOR=0
+VITE_FIRESTORE_EMULATOR_HOST=localhost
+VITE_FIRESTORE_EMULATOR_PORT=8080
+
+# Firebase Auth emulator (for local dev, disabled by default in production)
+VITE_FIREBASE_AUTH_USE_EMULATOR=0
+VITE_FIREBASE_AUTH_EMULATOR_URL=http://localhost:9099
+
+
 # --- Schedules Feature Flags ---
 VITE_FEATURE_SCHEDULES=0
 VITE_FEATURE_SCHEDULES_CREATE=0

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ src/
 
 ### Firestore Emulator (PDCA persistence)
 
-- Start Firestore emulator: `npm run firestore:emu`
+- Start Firestore + Auth emulators: `npm run firestore:emu`
 - Start app with emulator connection: `npm run dev:firestore`
 - Optional persisted emulator data: `npm run firestore:emu:export`
 
@@ -185,6 +185,11 @@ Environment flags used by the app:
 - `VITE_FIRESTORE_USE_EMULATOR=1`
 - `VITE_FIRESTORE_EMULATOR_HOST=127.0.0.1`
 - `VITE_FIRESTORE_EMULATOR_PORT=8080`
+- `VITE_FIREBASE_AUTH_USE_EMULATOR=1` (Auth emulator)
+- `VITE_FIREBASE_AUTH_EMULATOR_URL=http://localhost:9099` (Auth emulator URL)
+
+Note: Both Firestore and Auth emulators are started together with `npm run firestore:emu` (Firebase CLI defaults). App will automatically route to emulator if flags are set.
+
 
 > Override precedence: values passed directly to `ensureConfig` (e.g. in tests) always win. `VITE_SP_RESOURCE` / `VITE_SP_SITE_RELATIVE` from the env override `VITE_SP_SITE_URL`, and the full URL fallback is only used when both override values are omitted.
 

--- a/src/infra/firestore/auth.ts
+++ b/src/infra/firestore/auth.ts
@@ -1,0 +1,67 @@
+import { getAuth, signInAnonymously } from 'firebase/auth';
+import { getFlag, get } from '@/env';
+import { getFirebaseApp } from './client';
+
+/**
+ * Initialize Firebase Authentication (anonymous mode)
+ * 
+ * Purpose:
+ * - Satisfies Firestore rules `signedIn()` precondition
+ * - Firestore rules require authenticated UID to track events
+ * 
+ * Strategy:
+ * - Anonymous auth: No user interaction, instant token, perfect for demo + local dev
+ * - Emulator support: Routes to local emulator if VITE_FIREBASE_AUTH_USE_EMULATOR=1
+ * - Non-blocking: If auth fails, app continues (graceful degradation)
+ * - Token refresh: Automatic via Firebase SDK
+ * 
+ * Designed for easy swap:
+ * - Replace signInAnonymously() with custom token / MSAL exchange
+ * - No dependency on Firestore client.ts (separate init)
+ * - Emulator pattern mirrors Firestore client
+ * 
+ * @throws {FirebaseError} On fatal auth config errors (logs only, does not throw)
+ */
+export async function initFirebaseAuth(): Promise<void> {
+  try {
+    const app = getFirebaseApp();
+    const auth = getAuth(app);
+
+    // ✅ Connect to Emulator if enabled
+    if (getFlag('VITE_FIREBASE_AUTH_USE_EMULATOR')) {
+      const emulatorUrl = get('VITE_FIREBASE_AUTH_EMULATOR_URL') || 'http://localhost:9099';
+      try {
+        // connectAuthEmulator only allows ONE call per app instance
+        // Safe to call multiple times if already connected
+        if (auth.emulatorConfig === null) {
+          const { connectAuthEmulator } = await import('firebase/auth');
+          connectAuthEmulator(auth, emulatorUrl, { disableWarnings: true });
+          console.info('[firebase-auth] ✅ emulator connected', { emulatorUrl });
+        }
+      } catch (error) {
+        // Emulator already connected, or connection failed - log and continue
+        console.warn('[firebase-auth] emulator connection warning (may already be connected)', error);
+      }
+    }
+
+    // ✅ Sign in anonymously
+    // If user is already signed in, this is a no-op
+    // If persist disabled or localStorage unavailable, token lives in memory (tablet-friendly)
+    if (!auth.currentUser) {
+      const cred = await signInAnonymously(auth);
+      console.info('[firebase-auth] ✅ anonymous sign-in successful', {
+        uid: cred.user.uid,
+        isAnonymous: cred.user.isAnonymous,
+      });
+    } else {
+      console.info('[firebase-auth] ℹ️  user already authenticated', {
+        uid: auth.currentUser.uid,
+        isAnonymous: auth.currentUser.isAnonymous,
+      });
+    }
+  } catch (error) {
+    // Non-fatal: Log but don't throw
+    // App can continue with limited Firestore access or fallback to adapter
+    console.error('[firebase-auth] ❌ initialization failed', error);
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -243,6 +243,21 @@ const run = async (): Promise<void> => {
       throw error;
     });
 
+  // ✅ Step 1.5: Initialize Firebase Auth (anonymous) for Firestore rules
+  const completeFirebaseAuth = beginHydrationSpan('bootstrap:firebase-auth', { group: 'hydration', meta: { budget: 20 } });
+  if (hasWindow) {
+    try {
+      const { initFirebaseAuth } = await import('./infra/firestore/auth');
+      await initFirebaseAuth();
+      finalizeHydrationSpan(completeFirebaseAuth);
+    } catch (error) {
+      finalizeHydrationSpan(completeFirebaseAuth, error);
+      console.warn('[main] Firebase Auth init error (non-fatal, continuing)', error);
+    }
+  } else {
+    finalizeHydrationSpan(completeFirebaseAuth);
+  }
+
   // ✅ Step 2: Initialize MSAL singleton + handle redirect BEFORE React renders
   if (hasWindow) {
     const hasAuthResponse = (): boolean => {


### PR DESCRIPTION
Add Firebase Auth anonymous initialization to satisfy Firestore rules signedIn() precondition. Continues PLAN→DO→CHECK pipeline from PR #552. Unlocks production Firestore rules deployment.