### PR TITLE
feat(pdca): harden CHECK snapshot validation and fallback visibility

### DIFF
--- a/src/features/iceberg-pdca/__tests__/readDailySnapshot.test.ts
+++ b/src/features/iceberg-pdca/__tests__/readDailySnapshot.test.ts
@@ -2,34 +2,89 @@ import { describe, expect, it } from 'vitest';
 
 import { makeDailySnapshotId, parseDailySnapshotMetrics } from '../readDailySnapshot';
 
+const expected = {
+  templateId: 'daily-support.v1',
+  targetDate: '2026-02-22',
+  targetUserId: 'U001',
+};
+
+const fakeTimestamp = () => ({
+  toMillis: () => Date.now(),
+});
+
 describe('readDailySnapshot helpers', () => {
   it('builds snapshot id from template/date/user', () => {
     expect(makeDailySnapshotId({
-      templateId: 'daily-support.v1',
-      targetDate: '2026-02-22',
-      targetUserId: 'U001',
+      templateId: expected.templateId,
+      targetDate: expected.targetDate,
+      targetUserId: expected.targetUserId,
     })).toBe('daily-support.v1__2026-02-22__U001');
   });
 
   it('parses valid snapshot payload', () => {
     const parsed = parseDailySnapshotMetrics({
+      templateId: expected.templateId,
       completionRate: 0.9,
       leadTimeMinutes: 12,
-      targetDate: '2026-02-22',
-      targetUserId: 'U001',
-    });
+      targetDate: expected.targetDate,
+      targetUserId: expected.targetUserId,
+      createdAt: fakeTimestamp(),
+      updatedAt: fakeTimestamp(),
+    }, expected);
 
     expect(parsed).toEqual({
-      completionRate: 0.9,
-      leadTimeMinutes: 12,
-      targetDate: '2026-02-22',
-      targetUserId: 'U001',
+      status: 'ok',
+      metrics: {
+        completionRate: 0.9,
+        leadTimeMinutes: 12,
+        targetDate: '2026-02-22',
+        targetUserId: 'U001',
+      },
     });
   });
 
   it('returns null for invalid payload', () => {
-    expect(parseDailySnapshotMetrics(null)).toBeNull();
-    expect(parseDailySnapshotMetrics({ completionRate: '0.9', leadTimeMinutes: 12 })).toBeNull();
-    expect(parseDailySnapshotMetrics({ completionRate: 0.9 })).toBeNull();
+    expect(parseDailySnapshotMetrics(null, expected)).toEqual({
+      status: 'invalid',
+      reason: 'snapshot payload is not an object',
+    });
+    expect(parseDailySnapshotMetrics({ completionRate: '0.9', leadTimeMinutes: 12 }, expected)).toEqual({
+      status: 'invalid',
+      reason: 'snapshot metrics are missing or not numeric',
+    });
+    expect(parseDailySnapshotMetrics({ completionRate: 0.9 }, expected)).toEqual({
+      status: 'invalid',
+      reason: 'snapshot metrics are missing or not numeric',
+    });
+  });
+
+  it('returns invalid for identity mismatch', () => {
+    expect(parseDailySnapshotMetrics({
+      templateId: 'daily-support.v2',
+      completionRate: 0.9,
+      leadTimeMinutes: 12,
+      targetDate: expected.targetDate,
+      targetUserId: expected.targetUserId,
+      createdAt: fakeTimestamp(),
+      updatedAt: fakeTimestamp(),
+    }, expected)).toEqual({
+      status: 'invalid',
+      reason: 'templateId mismatch: expected=daily-support.v1 actual=daily-support.v2',
+    });
+  });
+
+  it('returns invalid for out-of-range metrics', () => {
+    expect(parseDailySnapshotMetrics({
+      templateId: expected.templateId,
+      completionRate: 1.2,
+      leadTimeMinutes: 12,
+      targetDate: expected.targetDate,
+      targetUserId: expected.targetUserId,
+      createdAt: fakeTimestamp(),
+      updatedAt: fakeTimestamp(),
+    }, expected)).toEqual({
+      status: 'invalid',
+      reason: 'completionRate out of range: 1.2',
+    });
   });
 });

--- a/src/features/iceberg-pdca/persistDailyPdca.ts
+++ b/src/features/iceberg-pdca/persistDailyPdca.ts
@@ -76,6 +76,7 @@ export async function upsertDailySnapshot(input: PersistDailyPdcaInput) {
     templateId: input.templateId,
     targetDate: input.targetDate,
     targetUserId: input.targetUserId,
+    createdAt: serverTimestamp(),
     completionRate: input.metrics?.completionRate ?? 0,
     leadTimeMinutes: input.metrics?.leadTimeMinutes ?? 0,
     submittedAt: submittedAtTs,

--- a/src/features/iceberg-pdca/readDailySnapshot.ts
+++ b/src/features/iceberg-pdca/readDailySnapshot.ts
@@ -9,6 +9,15 @@ export type DailySnapshotMetrics = {
   targetUserId?: string;
 };
 
+export type DailySnapshotReadResult =
+  | { status: 'ok'; metrics: DailySnapshotMetrics }
+  | { status: 'not-found' }
+  | { status: 'invalid'; reason: string };
+
+type SnapshotTimestamp = {
+  toMillis: () => number;
+};
+
 const toNumber = (value: unknown): number | null => {
   if (typeof value !== 'number' || Number.isNaN(value)) {
     return null;
@@ -16,9 +25,25 @@ const toNumber = (value: unknown): number | null => {
   return value;
 };
 
-export const parseDailySnapshotMetrics = (value: unknown): DailySnapshotMetrics | null => {
+const isSnapshotTimestamp = (value: unknown): value is SnapshotTimestamp => {
   if (typeof value !== 'object' || value === null) {
-    return null;
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return typeof record.toMillis === 'function';
+};
+
+export const parseDailySnapshotMetrics = (
+  value: unknown,
+  expected: {
+    templateId: string;
+    targetDate: string;
+    targetUserId: string;
+  },
+): DailySnapshotReadResult => {
+  if (typeof value !== 'object' || value === null) {
+    return { status: 'invalid', reason: 'snapshot payload is not an object' };
   }
 
   const record = value as Record<string, unknown>;
@@ -26,14 +51,50 @@ export const parseDailySnapshotMetrics = (value: unknown): DailySnapshotMetrics 
   const leadTimeMinutes = toNumber(record.leadTimeMinutes);
 
   if (completionRate === null || leadTimeMinutes === null) {
-    return null;
+    return { status: 'invalid', reason: 'snapshot metrics are missing or not numeric' };
+  }
+
+  if (completionRate < 0 || completionRate > 1) {
+    return { status: 'invalid', reason: `completionRate out of range: ${completionRate}` };
+  }
+
+  if (leadTimeMinutes < 0) {
+    return { status: 'invalid', reason: `leadTimeMinutes must be >= 0: ${leadTimeMinutes}` };
+  }
+
+  if (!isSnapshotTimestamp(record.createdAt) || !isSnapshotTimestamp(record.updatedAt)) {
+    return { status: 'invalid', reason: 'snapshot missing createdAt/updatedAt timestamp' };
+  }
+
+  if (record.templateId !== expected.templateId) {
+    return {
+      status: 'invalid',
+      reason: `templateId mismatch: expected=${expected.templateId} actual=${String(record.templateId)}`,
+    };
+  }
+
+  if (record.targetDate !== expected.targetDate) {
+    return {
+      status: 'invalid',
+      reason: `targetDate mismatch: expected=${expected.targetDate} actual=${String(record.targetDate)}`,
+    };
+  }
+
+  if (record.targetUserId !== expected.targetUserId) {
+    return {
+      status: 'invalid',
+      reason: `targetUserId mismatch: expected=${expected.targetUserId} actual=${String(record.targetUserId)}`,
+    };
   }
 
   return {
-    completionRate,
-    leadTimeMinutes,
-    targetDate: typeof record.targetDate === 'string' ? record.targetDate : undefined,
-    targetUserId: typeof record.targetUserId === 'string' ? record.targetUserId : undefined,
+    status: 'ok',
+    metrics: {
+      completionRate,
+      leadTimeMinutes,
+      targetDate: typeof record.targetDate === 'string' ? record.targetDate : undefined,
+      targetUserId: typeof record.targetUserId === 'string' ? record.targetUserId : undefined,
+    },
   };
 };
 
@@ -48,14 +109,18 @@ export const readDailySnapshot = async (params: {
   templateId: string;
   targetDate: string;
   targetUserId: string;
-}): Promise<DailySnapshotMetrics | null> => {
+}): Promise<DailySnapshotReadResult> => {
   const snapshotId = makeDailySnapshotId(params);
   const ref = doc(db, 'orgs', params.orgId, 'dailySnapshots', snapshotId);
   const snap = await getDoc(ref);
 
   if (!snap.exists()) {
-    return null;
+    return { status: 'not-found' };
   }
 
-  return parseDailySnapshotMetrics(snap.data());
+  return parseDailySnapshotMetrics(snap.data(), {
+    templateId: params.templateId,
+    targetDate: params.targetDate,
+    targetUserId: params.targetUserId,
+  });
 };


### PR DESCRIPTION
## Summary
- Add strict daily snapshot quality guards (identity, timestamps, metric ranges)
- Return explicit read result type: ok / not-found / invalid
- In CHECK page, use snapshot only when status is ok
- For invalid snapshot or read errors, keep fallback metrics but surface warning snackbar and logs
- Add createdAt to daily snapshot upsert payload for schema completeness

## Validation
- npm run typecheck
- unit: readDailySnapshot + dailyMetricsAdapter
