### PR TITLE
feat(firebase): custom token auth bridge mode (frontend-first)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,14 @@ VITE_FIRESTORE_EMULATOR_PORT=8080
 VITE_FIREBASE_AUTH_USE_EMULATOR=0
 VITE_FIREBASE_AUTH_EMULATOR_URL=http://localhost:9099
 
+# Firebase Auth strategy
+# - anonymous: signInAnonymously (default)
+# - customToken: exchange MSAL access token -> Firebase custom token -> signInWithCustomToken
+VITE_FIREBASE_AUTH_MODE=anonymous
+VITE_FIREBASE_TOKEN_EXCHANGE_URL=
+# If omitted, fallback defaults to ON in development / OFF in production
+VITE_FIREBASE_AUTH_ALLOW_ANON_FALLBACK=
+
 
 # --- Schedules Feature Flags ---
 VITE_FEATURE_SCHEDULES=0

--- a/README.md
+++ b/README.md
@@ -187,8 +187,20 @@ Environment flags used by the app:
 - `VITE_FIRESTORE_EMULATOR_PORT=8080`
 - `VITE_FIREBASE_AUTH_USE_EMULATOR=1` (Auth emulator)
 - `VITE_FIREBASE_AUTH_EMULATOR_URL=http://localhost:9099` (Auth emulator URL)
+- `VITE_FIREBASE_AUTH_MODE=anonymous|customToken` (default: anonymous)
+- `VITE_FIREBASE_TOKEN_EXCHANGE_URL=https://...` (required for customToken mode)
+- `VITE_FIREBASE_AUTH_ALLOW_ANON_FALLBACK=1|0` (optional; defaults to dev-only fallback when omitted)
 
 Note: Both Firestore and Auth emulators are started together with `npm run firestore:emu` (Firebase CLI defaults). App will automatically route to emulator if flags are set.
+
+Custom token mode flow:
+
+1. Acquire MSAL access token (existing silent acquire path)
+2. POST exchange endpoint with `Authorization: Bearer <msalAccessToken>`
+3. Receive `firebaseCustomToken`
+4. Sign in via Firebase `signInWithCustomToken`
+
+If custom token mode is enabled but exchange fails, auth falls back to anonymous only when fallback is enabled.
 
 
 > Override precedence: values passed directly to `ensureConfig` (e.g. in tests) always win. `VITE_SP_RESOURCE` / `VITE_SP_SITE_RELATIVE` from the env override `VITE_SP_SITE_URL`, and the full URL fallback is only used when both override values are omitted.

--- a/src/infra/firestore/auth.ts
+++ b/src/infra/firestore/auth.ts
@@ -1,6 +1,121 @@
-import { getAuth, signInAnonymously } from 'firebase/auth';
-import { getFlag, get } from '@/env';
+import { getAuth, signInAnonymously, signInWithCustomToken } from 'firebase/auth';
+import { getFlag, get, isDev } from '@/env';
 import { getFirebaseApp } from './client';
+
+type FirebaseAuthMode = 'anonymous' | 'customToken';
+
+type CustomTokenExchangeResponse = {
+  firebaseCustomToken: string;
+  orgId?: string;
+  actor?: {
+    id?: string;
+    name?: string;
+  };
+  expiresInSec?: number;
+};
+
+const normalizeAuthMode = (rawMode: string): FirebaseAuthMode => {
+  const normalized = rawMode.trim().toLowerCase();
+  return normalized === 'customtoken' ? 'customToken' : 'anonymous';
+};
+
+const resolveAuthMode = (): FirebaseAuthMode => {
+  const raw = get('VITE_FIREBASE_AUTH_MODE', 'anonymous');
+  return normalizeAuthMode(raw);
+};
+
+const allowAnonymousFallback = (): boolean => {
+  const raw = get('VITE_FIREBASE_AUTH_ALLOW_ANON_FALLBACK', '');
+  if (!raw) {
+    return isDev;
+  }
+  return getFlag('VITE_FIREBASE_AUTH_ALLOW_ANON_FALLBACK', false);
+};
+
+const acquireMsalAccessToken = async (): Promise<string> => {
+  const [{ getPcaSingleton }, { SP_RESOURCE }] = await Promise.all([
+    import('@/auth/azureMsal'),
+    import('@/auth/msalConfig'),
+  ]);
+
+  const msal = await getPcaSingleton();
+  const account = msal.getActiveAccount() ?? msal.getAllAccounts()[0] ?? null;
+  if (!account) {
+    throw new Error('MSAL account is not available for token exchange');
+  }
+
+  const scopeResource = (SP_RESOURCE || get('VITE_SP_RESOURCE', '')).replace(/\/+$/, '');
+  if (!scopeResource) {
+    throw new Error('VITE_SP_RESOURCE is required for custom token exchange');
+  }
+
+  const token = await msal.acquireTokenSilent({
+    scopes: [`${scopeResource}/.default`],
+    account,
+  });
+
+  if (!token.accessToken) {
+    throw new Error('MSAL access token acquisition returned empty token');
+  }
+
+  return token.accessToken;
+};
+
+const exchangeFirebaseCustomToken = async (): Promise<CustomTokenExchangeResponse> => {
+  const exchangeUrl = get('VITE_FIREBASE_TOKEN_EXCHANGE_URL', '').trim();
+  if (!exchangeUrl) {
+    throw new Error('VITE_FIREBASE_TOKEN_EXCHANGE_URL is not configured');
+  }
+
+  const msalAccessToken = await acquireMsalAccessToken();
+  const response = await fetch(exchangeUrl, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${msalAccessToken}`,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`custom token exchange failed: ${response.status} ${response.statusText}`);
+  }
+
+  const payload = (await response.json()) as Partial<CustomTokenExchangeResponse>;
+  if (typeof payload.firebaseCustomToken !== 'string' || payload.firebaseCustomToken.length === 0) {
+    throw new Error('custom token exchange response missing firebaseCustomToken');
+  }
+
+  return {
+    firebaseCustomToken: payload.firebaseCustomToken,
+    orgId: payload.orgId,
+    actor: payload.actor,
+    expiresInSec: payload.expiresInSec,
+  };
+};
+
+const signInWithConfiguredStrategy = async (
+  auth: ReturnType<typeof getAuth>,
+  mode: FirebaseAuthMode,
+): Promise<void> => {
+  if (mode === 'customToken') {
+    const exchange = await exchangeFirebaseCustomToken();
+    const result = await signInWithCustomToken(auth, exchange.firebaseCustomToken);
+    console.info('[firebase-auth] ✅ custom token sign-in successful', {
+      uid: result.user.uid,
+      orgId: exchange.orgId ?? null,
+      actorId: exchange.actor?.id ?? null,
+      actorName: exchange.actor?.name ?? null,
+      expiresInSec: exchange.expiresInSec ?? null,
+    });
+    return;
+  }
+
+  const cred = await signInAnonymously(auth);
+  console.info('[firebase-auth] ✅ anonymous sign-in successful', {
+    uid: cred.user.uid,
+    isAnonymous: cred.user.isAnonymous,
+  });
+};
 
 /**
  * Initialize Firebase Authentication (anonymous mode)
@@ -26,6 +141,7 @@ export async function initFirebaseAuth(): Promise<void> {
   try {
     const app = getFirebaseApp();
     const auth = getAuth(app);
+    const mode = resolveAuthMode();
 
     // ✅ Connect to Emulator if enabled
     if (getFlag('VITE_FIREBASE_AUTH_USE_EMULATOR')) {
@@ -44,20 +160,24 @@ export async function initFirebaseAuth(): Promise<void> {
       }
     }
 
-    // ✅ Sign in anonymously
-    // If user is already signed in, this is a no-op
-    // If persist disabled or localStorage unavailable, token lives in memory (tablet-friendly)
-    if (!auth.currentUser) {
-      const cred = await signInAnonymously(auth);
-      console.info('[firebase-auth] ✅ anonymous sign-in successful', {
-        uid: cred.user.uid,
-        isAnonymous: cred.user.isAnonymous,
-      });
-    } else {
+    if (auth.currentUser) {
       console.info('[firebase-auth] ℹ️  user already authenticated', {
         uid: auth.currentUser.uid,
         isAnonymous: auth.currentUser.isAnonymous,
       });
+      return;
+    }
+
+    try {
+      await signInWithConfiguredStrategy(auth, mode);
+    } catch (error) {
+      const shouldFallback = mode === 'customToken' && allowAnonymousFallback();
+      if (!shouldFallback) {
+        throw error;
+      }
+
+      console.warn('[firebase-auth] custom token auth failed, falling back to anonymous', error);
+      await signInWithConfiguredStrategy(auth, 'anonymous');
     }
   } catch (error) {
     // Non-fatal: Log but don't throw


### PR DESCRIPTION
## Summary
- Add Firebase Auth strategy mode: anonymous | customToken
- Implement custom token exchange flow in auth init layer only
- Reuse existing MSAL silent token acquisition path for exchange auth header
- Keep anonymous as development fallback when custom token exchange fails
- No changes to PLAN/DO/CHECK Firestore usage paths

## Env
- VITE_FIREBASE_AUTH_MODE
- VITE_FIREBASE_TOKEN_EXCHANGE_URL
- VITE_FIREBASE_AUTH_ALLOW_ANON_FALLBACK

## Validation
- npm run typecheck
