### PR TITLE
fix(ci): use NodeNext tsconfig for Playwright

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,10 @@
 import { defineConfig, devices } from '@playwright/test';
 import type { ReporterDescription } from '@playwright/test';
 
+if (!process.env.TS_NODE_PROJECT) {
+  process.env.TS_NODE_PROJECT = 'tsconfig.playwright.json';
+}
+
 const isCI = !!process.env.CI;
 const skipBuild = process.env.PLAYWRIGHT_SKIP_BUILD === '1';
 const baseUrlEnv = process.env.PLAYWRIGHT_BASE_URL;

--- a/tsconfig.playwright.json
+++ b/tsconfig.playwright.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": ["node", "@playwright/test"]
+  },
+  "include": ["playwright.config.ts", "tests/e2e/**/*.ts", "tests/e2e/**/*.tsx"],
+  "exclude": ["node_modules", "dist", "build", "coverage"]
+}


### PR DESCRIPTION
## Why
Deep E2E runs Playwright in ESM, but ts-node was compiling tests to CJS (`require`), causing `ReferenceError: require is not defined in ES module scope`.

## What
- Add `tsconfig.playwright.json` with `module`/`moduleResolution` set to `NodeNext`
- Ensure Playwright uses this tsconfig via `TS_NODE_PROJECT`

## Result
Playwright E2E can load specs in ESM without the `require` crash.