### PR TITLE
perf(dashboard): add DEV-only profiling to useDashboardSummary

### DIFF
--- a/src/features/dashboard/useDashboardSummary.ts
+++ b/src/features/dashboard/useDashboardSummary.ts
@@ -117,8 +117,9 @@ export function useDashboardSummary(args: UseDashboardSummaryArgs): DashboardSum
     generateMockActivityRecords,
   } = args;
 
-  // DEV-only perf profiling setup
-  const isDevProfiling = process.env.NODE_ENV === 'development'
+  // DEV-only perf profiling setup (Vite optimized)
+  // import.meta.env.DEV is tree-shaken in production
+  const isDevProfiling = import.meta.env.DEV
     && typeof localStorage !== 'undefined'
     && localStorage.getItem('debug')?.includes('dashboard:perf');
 
@@ -133,7 +134,7 @@ export function useDashboardSummary(args: UseDashboardSummaryArgs): DashboardSum
       try {
         performance.measure(`${label}-duration`, label);
         const duration = performance.getEntriesByName(`${label}-duration`)[0]?.duration || 0;
-        if (process.env.NODE_ENV === 'development') {
+        if (import.meta.env.DEV) {
           // eslint-disable-next-line no-console
           console.debug(
             `[Dashboard Perf] ${label}: ${duration.toFixed(2)}ms`,


### PR DESCRIPTION
Phase 3C-2 (baseline measurement):
- DEV-only performance.mark/measure tracking for each memoization block
- 8 computation stages: activityRecords, usageMap, intensiveSupportUsers, stats, attendanceSummary, dailyRecordStatus, scheduleLanes, prioritizedUsers
- Enable via: localStorage.debug = 'dashboard:perf'
- Output: console.debug [Dashboard Perf] block-name: X.XXms
- No production overhead (guards on NODE_ENV === 'development')

Usage:
  1. Open DevTools console
  2. localStorage.debug = 'dashboard:perf'
  3. Refresh dashboard page
  4. See timing breakdown in console

Purpose: Baseline measurement before Phase 3C-3 (optimization)
All tests pass ✅ E2E dashboard-minimal: 3 passed ✅

## 概要
useDashboardSummary hook に DEV限定のパフォーマンスプロファイリング機能を追加しました（Phase 3C-2）。

## 目的
- Phase 3C-3（最適化）前のベースライン計測
- 各 useMemo ブロックの計算時間を可視化
- 最適化効果の定量的測定

## 変更内容
- ✅ 8つの memoization ブロックにパフォーマンス計測を追加
  - activityRecords
  - usageMap
  - intensiveSupportUsers
  - stats
  - attendanceSummary
  - dailyRecordStatus
  - scheduleLanes
  - prioritizedUsers
- ✅ DEV mode のみ有効（localStorage.debug による制御）
- ✅ 計算時間を console.debug で出力

## 使い方
```javascript
// Chrome DevTools Console で実行
localStorage.debug = 'dashboard:perf';
// ページをリロード → Dashboard にアクセス
// コンソールに以下のように出力される:
// [Dashboard Perf] activityRecords-calc: 2.34ms
// [Dashboard Perf] usageMap-calc: 1.05ms
// [Dashboard Perf] stats-calc: 0.87ms
// ...