### PR TITLE
ci: lighten required Quality Gates by splitting vitest workload

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,7 @@ jobs:
         continue-on-error: true
       - name: Test (PR)
         if: ${{ github.event_name == 'pull_request' }}
-        run: npm run test:ci
+        run: npm run test:ci:required
       - name: Test (coverage)
         if: ${{ github.event_name != 'pull_request' }}
         run: npm run test:coverage -- --reporter=default
@@ -213,6 +213,28 @@ jobs:
               echo "coverage summary not found"
             } >> "$GITHUB_STEP_SUMMARY"
           fi
+
+  quality_extended:
+    name: quality_extended
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      E2E_FEATURE_SCHEDULE_NAV: "1"
+      E2E_FEATURE_SCHEDULE_ACCEPTANCE: "1"
+      E2E_FEATURE_SCHEDULE_WEEK_MONTH_TAB: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+      - name: Install deps
+        run: npm ci
+      - name: Test (ci full)
+        run: npm run test:ci
 
   canary:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "test:schedule:e2e": "playwright test tests/e2e/schedule-week.aria.smoke.spec.ts",
     "test:schedule-week": "PLAYWRIGHT_BASE_URL=http://localhost:5175 PLAYWRIGHT_WEB_SERVER_URL=http://localhost:5175 PLAYWRIGHT_WEB_SERVER_COMMAND=\"npm run dev:schedules\" VITE_E2E=1 VITE_SKIP_LOGIN=1 VITE_E2E_MSAL_MOCK=1 VITE_SKIP_SHAREPOINT=1 VITE_FEATURE_SCHEDULES=1 VITE_FEATURE_SCHEDULES_WEEK_V2=1 npx playwright test schedule-week --config=playwright.smoke.config.ts --project=smoke",
     "test:schedule": "npm run test:schedule:unit && npm run test:schedule:e2e",
+    "test:ci:required": "vitest run --run --reporter=default --pool=forks --maxWorkers=2",
     "test:ci": "vitest run --run --reporter=verbose --no-file-parallelism --pool=forks --maxWorkers=1 --hookTimeout=${HOOK_TIMEOUT:-10000}",
     "test:hydration": "vitest run tests/unit/hydration --reporter=verbose --no-file-parallelism",
     "test:store": "vitest run tests/unit/users.store.spec.ts tests/unit/operation-hub.useOperationHubData.spec.ts tests/unit/operation-hub.useOperationHubData.branches.spec.ts tests/unit/operation-hub.useOperationHubData.full.spec.tsx --reporter=verbose --no-file-parallelism",


### PR DESCRIPTION
Why:
- PR時のQuality Gates支配点(テスト直列)をrequiredから外して待ち時間短縮

What:
- requiredのqualityは維持し、PR時は軽量 test:ci:required を実行
- 重い test:ci は quality_extended (PRのみ / non-required想定) へ分離
- main/workflow_dispatchは従来どおりcoverageを維持

Validation:
- 変更は package.json + test.yml のみ
