### PR TITLE
fix(e2e): enable VITE_FEATURE_STAFF_ATTENDANCE in smoke tests

### DIFF
--- a/playwright.smoke.config.ts
+++ b/playwright.smoke.config.ts
@@ -45,6 +45,7 @@ const webServerEnvVarsSmoke = {
   VITE_DEV_HARNESS: '1',
   VITE_SCHEDULES_TZ: 'Asia/Tokyo',
   VITE_FEATURE_SCHEDULES: '1',
+  VITE_FEATURE_STAFF_ATTENDANCE: '1',
   VITE_SCHEDULES_SAVE_MODE: 'mock',
   VITE_AUDIT_DEBUG: process.env.VITE_AUDIT_DEBUG ?? '0',
   E2E_SAVE_MODE: 'mock',


### PR DESCRIPTION
## Summary
Enable VITE_FEATURE_STAFF_ATTENDANCE in smoke test configuration

## Changes
- Add VITE_FEATURE_STAFF_ATTENDANCE=1 to playwright.smoke.config.ts
- Resolves 2 failing tests in staff attendance and authorization routes

## Testing
- ✅ 45/45 E2E Smoke tests PASS (100%)
- ✅ AdminGate authorization validation PASS
- ✅ Execution time: 25.8s

## Related
- Fixes: authz.reception-attendance-finalize-action.spec.ts
- Fixes: attendance.finalize-audit-meta.spec.ts