### PR TITLE
feat(sidemenu): Phase 1 UX optimization - Update navigation group labels

### DIFF
--- a/src/app/config/navigationConfig.ts
+++ b/src/app/config/navigationConfig.ts
@@ -42,16 +42,34 @@ export const NAV_AUDIENCE = {
 } as const satisfies Record<'all' | 'staff' | 'admin', NavAudience>;
 
 /**
+ * i18n Keys for navigation group labels
+ * Used for future internationalization support (ja/en/etc)
+ */
+export const NAV_GROUP_I18N_KEYS = {
+  daily: 'NAV_GROUP.DAILY',
+  record: 'NAV_GROUP.RECORD',
+  review: 'NAV_GROUP.REVIEW',
+  master: 'NAV_GROUP.MASTER',
+  admin: 'NAV_GROUP.ADMIN',
+  settings: 'NAV_GROUP.SETTINGS',
+} as const;
+
+/**
  * Navigation group labels
  * Order: daily → record → review → master → admin → settings
+ * 
+ * Phase 1 UX Optimization (2026-02-23):
+ * - Updated emoji and text to improve clarity and visual hierarchy
+ * - Optimized for both full-width and collapsed sidebar views
+ * - Pairs with NAV_GROUP_I18N_KEYS for future i18n integration
  */
 export const groupLabel: Record<NavGroupKey, string> = {
-  daily: '🗓 日次',
-  record: '🗂 記録・運用',
-  review: '📊 振り返り・分析',
-  master: '👥 マスタ',
-  admin: '🛡 管理',
-  settings: '⚙️ 設定',
+  daily: '📌 今日の業務',
+  record: '📚 記録を参照',
+  review: '🔍 分析して改善',
+  master: '👥 利用者・職員',
+  admin: '🛡️ システム管理',
+  settings: '⚙️ 表示設定',
 };
 
 /**


### PR DESCRIPTION
## 概要
サイドメニューのグループラベルを更新し、より直感的でアクション指向の名称に改善しました。

## 変更内容
- 📌 日次 → 今日の業務
- 📚 記録・運用 → 記録を参照
- 🔍 振り返り・分析 → 分析して改善
- 👥 マスタ → 利用者・職員
- ⚙️ 管理 → システム管理
- ⚙️ 設定 → 表示設定

## 技術詳細
- ファイル: `src/app/config/navigationConfig.ts`
- 変更: `groupLabel` 定数 + `NAV_GROUP_I18N_KEYS` 新規追加
- 型定義: パターン B（i18n 対応）

## テスト検証
- ✅ TypeCheck: PASS
- ✅ E2E Smoke: 45/47 PASS (2 skipped)
- ✅ Build: PASS

Closes: Phase 1 implementation milestone