### PR TITLE
feat(today-ops): P0 — 「今日の業務」本体化

### DIFF
--- a/src/features/today/hooks/useNextAction.ts
+++ b/src/features/today/hooks/useNextAction.ts
@@ -1,0 +1,61 @@
+/**
+ * useNextAction — スケジュールから「次のアクション」を算出
+ *
+ * scheduleLanesToday の全レーンから現在時刻以降の最初の予定を返す。
+ * P1 auto-next 実装時にも再利用可能。
+ */
+import type { ScheduleItem } from '@/features/dashboard/selectors/useScheduleLanes';
+import { useMemo } from 'react';
+
+export type NextActionItem = {
+  id: string;
+  time: string;      // "HH:MM"
+  title: string;
+  location?: string;
+  owner?: string;
+  minutesUntil: number;
+};
+
+/**
+ * Parse "HH:MM" into minutes since midnight
+ */
+function parseTimeToMinutes(time: string): number {
+  const [h, m] = time.split(':').map(Number);
+  return (h || 0) * 60 + (m || 0);
+}
+
+/**
+ * Get current time in minutes since midnight
+ */
+function nowMinutes(): number {
+  const now = new Date();
+  return now.getHours() * 60 + now.getMinutes();
+}
+
+export function useNextAction(
+  lanes: {
+    userLane: ScheduleItem[];
+    staffLane: ScheduleItem[];
+    organizationLane: ScheduleItem[];
+  }
+): NextActionItem | null {
+  return useMemo(() => {
+    const current = nowMinutes();
+
+    const allItems = [
+      ...lanes.userLane,
+      ...lanes.staffLane,
+      ...lanes.organizationLane,
+    ];
+
+    const upcoming = allItems
+      .map(item => ({
+        ...item,
+        minutesUntil: parseTimeToMinutes(item.time) - current,
+      }))
+      .filter(item => item.minutesUntil > 0)
+      .sort((a, b) => a.minutesUntil - b.minutesUntil);
+
+    return upcoming[0] ?? null;
+  }, [lanes]);
+}

--- a/src/features/today/layouts/TodayOpsLayout.tsx
+++ b/src/features/today/layouts/TodayOpsLayout.tsx
@@ -1,6 +1,18 @@
+/**
+ * TodayOpsLayout — 「今日の業務」画面レイアウト
+ *
+ * 左カラム: Hero → 出席サマリー → ブリーフィングアラート → 利用者一覧
+ * 右カラム: 次のアクション → 送迎状況(P1)
+ */
+import type { BriefingAlert } from '@/features/dashboard/sections/types';
 import { Box, Container, Grid, Paper, Stack, Typography } from '@mui/material';
 import React from 'react';
+import type { NextActionItem } from '../hooks/useNextAction';
+import type { AttendanceSummaryCardProps } from '../widgets/AttendanceSummaryCard';
+import { AttendanceSummaryCard } from '../widgets/AttendanceSummaryCard';
+import { BriefingAlertList } from '../widgets/BriefingAlertList';
 import { HeroUnfinishedBanner } from '../widgets/HeroUnfinishedBanner';
+import { NextActionCard } from '../widgets/NextActionCard';
 import { UserCompactList, type UserRow } from '../widgets/UserCompactList';
 
 type HeroProps = {
@@ -10,25 +22,24 @@ type HeroProps = {
   onOpenApproval: () => void;
 };
 
-type NextAction = {
-  title: string;
-  timeText: string;
-  onStart?: () => void;
-  onDone?: () => void;
-};
-
 type TransportUser = { userId: string; name: string };
-type AlertItem = { id: string; message: string };
 
 export type TodayOpsProps = {
   hero: HeroProps;
-  nextAction?: NextAction;
+  attendance: AttendanceSummaryCardProps;
+  briefingAlerts: BriefingAlert[];
+  nextAction: NextActionItem | null;
   transport: { pending: TransportUser[]; inProgress: TransportUser[]; onArrived: (id: string) => void };
   users: { items: UserRow[]; onOpenQuickRecord: (id: string) => void };
-  alerts: { items: AlertItem[]; onOpenDetail?: () => void };
 };
 
-export const TodayOpsLayout: React.FC<TodayOpsProps> = ({ hero, nextAction, users, alerts }) => {
+export const TodayOpsLayout: React.FC<TodayOpsProps> = ({
+  hero,
+  attendance,
+  briefingAlerts,
+  nextAction,
+  users,
+}) => {
   return (
     <Box sx={{ minHeight: '100dvh', bgcolor: 'background.default', pb: 8 }}>
       <HeroUnfinishedBanner
@@ -42,20 +53,9 @@ export const TodayOpsLayout: React.FC<TodayOpsProps> = ({ hero, nextAction, user
         <Grid container spacing={3}>
           {/* 左：主動線 */}
           <Grid size={{ xs: 12, md: 8 }}>
-            {alerts.items.length > 0 && (
-              <Paper sx={{ p: 2, mb: 3, borderLeft: 4, borderColor: 'warning.main' }}>
-                <Typography variant="subtitle2" color="warning.main" fontWeight="bold" gutterBottom>
-                  ⚠️ 重要アラート
-                </Typography>
-                <Stack spacing={1}>
-                  {alerts.items.map((a) => (
-                    <Typography key={a.id} variant="body2">
-                      {a.message}
-                    </Typography>
-                  ))}
-                </Stack>
-              </Paper>
-            )}
+            <AttendanceSummaryCard {...attendance} />
+
+            <BriefingAlertList alerts={briefingAlerts} />
 
             <Typography variant="h6" gutterBottom fontWeight="bold">
               👥 今日の利用者
@@ -70,28 +70,14 @@ export const TodayOpsLayout: React.FC<TodayOpsProps> = ({ hero, nextAction, user
           {/* 右：補助線 */}
           <Grid size={{ xs: 12, md: 4 }}>
             <Stack spacing={3}>
-              <Paper sx={{ p: 2 }}>
-                <Typography variant="subtitle2" fontWeight="bold" gutterBottom>
-                  次のアクション
-                </Typography>
-                {nextAction ? (
-                  <>
-                    <Typography variant="h6">{nextAction.timeText}</Typography>
-                    <Typography variant="body1">{nextAction.title}</Typography>
-                  </>
-                ) : (
-                  <Typography variant="body2" color="text.secondary">
-                    予定はありません
-                  </Typography>
-                )}
-              </Paper>
+              <NextActionCard nextAction={nextAction} />
 
               <Paper sx={{ p: 2 }}>
                 <Typography variant="subtitle2" fontWeight="bold" gutterBottom>
                   🚚 送迎状況
                 </Typography>
                 <Typography variant="body2" color="text.secondary">
-                  PR1では仮表示（PR2で実データ接続）
+                  P1で実データ接続予定
                 </Typography>
               </Paper>
             </Stack>

--- a/src/features/today/widgets/AttendanceSummaryCard.spec.tsx
+++ b/src/features/today/widgets/AttendanceSummaryCard.spec.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { AttendanceSummaryCard } from './AttendanceSummaryCard';
+
+describe('AttendanceSummaryCard', () => {
+  it('displays attendance counts', () => {
+    render(
+      <AttendanceSummaryCard
+        facilityAttendees={12}
+        absenceCount={2}
+        absenceNames={['田中', '山田']}
+        lateOrEarlyLeave={1}
+        lateOrEarlyNames={['佐藤']}
+      />
+    );
+
+    expect(screen.getByText(/通所中 12名/)).toBeInTheDocument();
+    expect(screen.getByText(/欠席 2名/)).toBeInTheDocument();
+    expect(screen.getByText(/遅刻・早退 1名/)).toBeInTheDocument();
+    expect(screen.getByText(/田中、山田/)).toBeInTheDocument();
+  });
+
+  it('hides absence chip when count is 0', () => {
+    render(
+      <AttendanceSummaryCard
+        facilityAttendees={15}
+        absenceCount={0}
+        absenceNames={[]}
+        lateOrEarlyLeave={0}
+        lateOrEarlyNames={[]}
+      />
+    );
+
+    expect(screen.getByText(/通所中 15名/)).toBeInTheDocument();
+    expect(screen.queryByText(/欠席/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/遅刻/)).not.toBeInTheDocument();
+  });
+
+  it('has data-testid for integration testing', () => {
+    render(
+      <AttendanceSummaryCard
+        facilityAttendees={10}
+        absenceCount={0}
+        absenceNames={[]}
+        lateOrEarlyLeave={0}
+        lateOrEarlyNames={[]}
+      />
+    );
+
+    expect(screen.getByTestId('today-attendance-card')).toBeInTheDocument();
+  });
+});

--- a/src/features/today/widgets/AttendanceSummaryCard.tsx
+++ b/src/features/today/widgets/AttendanceSummaryCard.tsx
@@ -1,0 +1,69 @@
+/**
+ * AttendanceSummaryCard — 出席状況サマリー
+ *
+ * 通所中/欠席/早退の件数をチップ形式で表示。
+ */
+import { Box, Chip, Paper, Typography } from '@mui/material';
+import React from 'react';
+
+export type AttendanceSummaryCardProps = {
+  facilityAttendees: number;
+  absenceCount: number;
+  absenceNames: string[];
+  lateOrEarlyLeave: number;
+  lateOrEarlyNames: string[];
+};
+
+export const AttendanceSummaryCard: React.FC<AttendanceSummaryCardProps> = ({
+  facilityAttendees,
+  absenceCount,
+  absenceNames,
+  lateOrEarlyLeave,
+  lateOrEarlyNames,
+}) => {
+  return (
+    <Paper data-testid="today-attendance-card" sx={{ p: 2, mb: 3 }}>
+      <Typography variant="subtitle2" fontWeight="bold" gutterBottom>
+        📊 出席状況
+      </Typography>
+
+      <Box sx={{ display: 'flex', gap: 1.5, flexWrap: 'wrap', mb: 1 }}>
+        <Chip
+          label={`通所中 ${facilityAttendees}名`}
+          color="success"
+          size="small"
+          variant="filled"
+        />
+        {absenceCount > 0 && (
+          <Chip
+            label={`欠席 ${absenceCount}名`}
+            color="error"
+            size="small"
+            variant="filled"
+          />
+        )}
+        {lateOrEarlyLeave > 0 && (
+          <Chip
+            label={`遅刻・早退 ${lateOrEarlyLeave}名`}
+            color="warning"
+            size="small"
+            variant="filled"
+          />
+        )}
+      </Box>
+
+      {absenceCount > 0 && absenceNames.length > 0 && (
+        <Typography variant="caption" color="text.secondary">
+          欠席: {absenceNames.join('、')}
+        </Typography>
+      )}
+      {lateOrEarlyLeave > 0 && lateOrEarlyNames.length > 0 && (
+        <Box>
+          <Typography variant="caption" color="text.secondary">
+            遅刻・早退: {lateOrEarlyNames.join('、')}
+          </Typography>
+        </Box>
+      )}
+    </Paper>
+  );
+};

--- a/src/features/today/widgets/BriefingAlertList.tsx
+++ b/src/features/today/widgets/BriefingAlertList.tsx
@@ -1,0 +1,45 @@
+/**
+ * BriefingAlertList — 朝会ブリーフィングアラート
+ *
+ * briefingAlerts を severity アイコン付きで表示。
+ * Collapse で 0件→有件 のレイアウトジャンプを防止。
+ */
+import type { BriefingAlert } from '@/features/dashboard/sections/types';
+import { Alert, Collapse, Paper, Stack, Typography } from '@mui/material';
+import React from 'react';
+
+export type BriefingAlertListProps = {
+  alerts: BriefingAlert[];
+};
+
+export const BriefingAlertList: React.FC<BriefingAlertListProps> = ({ alerts }) => {
+  return (
+    <Collapse in={alerts.length > 0}>
+      <Paper data-testid="today-briefing-alerts" sx={{ p: 2, mb: 3 }}>
+        <Typography variant="subtitle2" fontWeight="bold" gutterBottom>
+          ⚠️ 朝会アラート
+        </Typography>
+        <Stack spacing={1}>
+          {alerts.map((alert) => (
+            <Alert
+              key={alert.id}
+              severity={alert.severity}
+              variant="outlined"
+              sx={{ py: 0.25 }}
+            >
+              <Typography variant="body2" fontWeight={500}>
+                {alert.label}
+                {alert.count > 0 && ` (${alert.count}件)`}
+              </Typography>
+              {alert.description && (
+                <Typography variant="caption" color="text.secondary">
+                  {alert.description}
+                </Typography>
+              )}
+            </Alert>
+          ))}
+        </Stack>
+      </Paper>
+    </Collapse>
+  );
+};

--- a/src/features/today/widgets/NextActionCard.spec.tsx
+++ b/src/features/today/widgets/NextActionCard.spec.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { NextActionCard } from './NextActionCard';
+
+describe('NextActionCard', () => {
+  it('displays next action with time and title', () => {
+    render(
+      <NextActionCard
+        nextAction={{
+          id: 'staff-1',
+          time: '09:00',
+          title: '職員朝会',
+          owner: '生活支援課',
+          minutesUntil: 30,
+        }}
+      />
+    );
+
+    expect(screen.getByText('09:00')).toBeInTheDocument();
+    expect(screen.getByText('職員朝会')).toBeInTheDocument();
+    expect(screen.getByText('生活支援課')).toBeInTheDocument();
+    expect(screen.getByText(/あと 30分/)).toBeInTheDocument();
+  });
+
+  it('formats hours correctly', () => {
+    render(
+      <NextActionCard
+        nextAction={{
+          id: 'org-1',
+          time: '15:00',
+          title: '会議',
+          minutesUntil: 150,
+        }}
+      />
+    );
+
+    expect(screen.getByText(/あと 2時間30分/)).toBeInTheDocument();
+  });
+
+  it('shows completion message when no next action', () => {
+    render(<NextActionCard nextAction={null} />);
+
+    expect(screen.getByText(/本日の予定はすべて完了しました/)).toBeInTheDocument();
+  });
+
+  it('has data-testid for integration testing', () => {
+    render(<NextActionCard nextAction={null} />);
+
+    expect(screen.getByTestId('today-next-action-card')).toBeInTheDocument();
+  });
+});

--- a/src/features/today/widgets/NextActionCard.tsx
+++ b/src/features/today/widgets/NextActionCard.tsx
@@ -1,0 +1,56 @@
+/**
+ * NextActionCard — 次のアクション
+ *
+ * スケジュールから算出した次の予定を表示。
+ * 残り時間つき。予定なし時はプレースホルダ表示。
+ */
+import { Paper, Typography } from '@mui/material';
+import React from 'react';
+import type { NextActionItem } from '../hooks/useNextAction';
+
+export type NextActionCardProps = {
+  nextAction: NextActionItem | null;
+};
+
+function formatMinutesUntil(minutes: number): string {
+  if (minutes < 60) return `あと ${minutes}分`;
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return m > 0 ? `あと ${h}時間${m}分` : `あと ${h}時間`;
+}
+
+export const NextActionCard: React.FC<NextActionCardProps> = ({ nextAction }) => {
+  return (
+    <Paper data-testid="today-next-action-card" sx={{ p: 2 }}>
+      <Typography variant="subtitle2" fontWeight="bold" gutterBottom>
+        ⏭️ 次のアクション
+      </Typography>
+      {nextAction ? (
+        <>
+          <Typography variant="h5" fontWeight="bold" color="primary.main">
+            {nextAction.time}
+          </Typography>
+          <Typography variant="body1" sx={{ mt: 0.5 }}>
+            {nextAction.title}
+          </Typography>
+          {nextAction.owner && (
+            <Typography variant="caption" color="text.secondary">
+              {nextAction.owner}
+            </Typography>
+          )}
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{ display: 'block', mt: 0.5, fontStyle: 'italic' }}
+          >
+            {formatMinutesUntil(nextAction.minutesUntil)}
+          </Typography>
+        </>
+      ) : (
+        <Typography variant="body2" color="text.secondary">
+          本日の予定はすべて完了しました 🎉
+        </Typography>
+      )}
+    </Paper>
+  );
+};

--- a/src/features/today/widgets/UserCompactList.tsx
+++ b/src/features/today/widgets/UserCompactList.tsx
@@ -1,10 +1,12 @@
-import { Button, Paper, Stack, Typography } from '@mui/material';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import { Box, Button, Paper, Stack, Typography } from '@mui/material';
 import React from 'react';
 
 export type UserRow = {
   userId: string;
   name: string;
   status: 'present' | 'absent' | 'unknown';
+  recordFilled?: boolean;
 };
 
 export type UserCompactListProps = {
@@ -50,9 +52,21 @@ export const UserCompactList: React.FC<UserCompactListProps> = ({ items, onOpenQ
             }),
           }}
         >
-          <Typography variant="body1" fontWeight={500}>
-            {u.name}
-          </Typography>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            {u.recordFilled && (
+              <CheckCircleIcon
+                sx={{ fontSize: 18, color: 'success.main' }}
+                aria-label="記録済み"
+              />
+            )}
+            <Typography
+              variant="body1"
+              fontWeight={500}
+              sx={u.recordFilled ? { color: 'text.secondary' } : undefined}
+            >
+              {u.name}
+            </Typography>
+          </Box>
           <Button
             size="small"
             variant="outlined"


### PR DESCRIPTION
## Summary
`/today` ページを **朝開いて使えるページ** に本体化。
既存スケルトン（Hero + ユーザー一覧 + QuickRecord Drawer）に **実データ接続 + 4カード追加**。

### 新規ウィジェット (3件)
- **AttendanceSummaryCard**: 通所中/欠席/早退カウント (Chip形式)
- **NextActionCard**: スケジュール駆動の次予定表示 (残り時間付き)
- **BriefingAlertList**: 朝会アラート (MUI Collapse でジャンプ防止)

### Hook追加
- **useNextAction**: `scheduleLanesToday` から現在時刻以降の次予定を算出

### 既存改善
- **UserCompactList**: `recordFilled` バッジ + 未記録優先ソート
- **TodayOpsLayout**: 4カード構成 (出席/アラート/次予定/送迎P1)
- **TodayOpsPage**: `useDashboardSummary` 実データ接続、recordFilled はページで計算

### 設計ポイント
- useNextAction は hook 切り出し (P1 auto-next 再利用可)
- recordFilled はページで計算、widget は表示だけ (責務分離)
- BriefingAlertList は Collapse (レイアウトジャンプ防止)

### Verification
- `tsc -p tsconfig.build.json --noEmit`: 0 errors
- `vitest`: 11/11 pass (AttendanceSummaryCard 3, NextActionCard 4, HeroUnfinishedBanner 4)