### PR TITLE
feat(today-ops): Ops Flow — 利用者オペレーション業務フロー(6ステップ)

### DIFF
--- a/src/features/dashboard/selectors/useScheduleLanes.ts
+++ b/src/features/dashboard/selectors/useScheduleLanes.ts
@@ -1,12 +1,34 @@
 import type { IUserMaster } from '@/sharepoint/fields';
 import { useMemo } from 'react';
 
+export type OpsFlowStep =
+  | 'intake'
+  | 'temperature'
+  | 'amRecord'
+  | 'lunchCheck'
+  | 'pmRecord'
+  | 'discharge';
+
+/**
+ * 業務フローの順序定数
+ * 同時刻時のソート第二キーとして使用
+ */
+export const OPS_FLOW_ORDER: Record<OpsFlowStep, number> = {
+  intake: 0,
+  temperature: 1,
+  amRecord: 2,
+  lunchCheck: 3,
+  pmRecord: 4,
+  discharge: 5,
+};
+
 export type ScheduleItem = {
   id: string;
   time: string;
   title: string;
   location?: string;
   owner?: string;
+  opsStep?: OpsFlowStep;
 };
 
 export function useScheduleLanes(users: IUserMaster[]) {
@@ -20,11 +42,17 @@ export function useScheduleLanes(users: IUserMaster[]) {
       title: `${user.FullName ?? `利用者${index + 1}`} ${['作業プログラム', '個別支援', 'リハビリ'][index % 3]}`,
       location: ['作業室A', '相談室1', '療育室'][index % 3],
     }));
-    const baseStaffLane = [
-      { id: 'staff-1', time: '08:45', title: '職員朝会 / 申し送り確認', owner: '生活支援課' },
-      { id: 'staff-2', time: '11:30', title: '通所記録レビュー', owner: '管理責任者' },
-      { id: 'staff-3', time: '15:30', title: '支援手順フィードバック会議', owner: '専門職チーム' },
+
+    // 利用者オペレーション業務フロー（6ステップ）
+    const baseStaffLane: ScheduleItem[] = [
+      { id: 'ops-1', time: '09:15', title: '通所受け入れ',       owner: '受付',   opsStep: 'intake' as OpsFlowStep },
+      { id: 'ops-2', time: '09:30', title: '検温・バイタル確認', owner: '看護',   opsStep: 'temperature' as OpsFlowStep },
+      { id: 'ops-3', time: '10:00', title: '午前の過ごし記録',   owner: '支援員', opsStep: 'amRecord' as OpsFlowStep },
+      { id: 'ops-4', time: '12:00', title: '昼食量確認',         owner: '栄養士', opsStep: 'lunchCheck' as OpsFlowStep },
+      { id: 'ops-5', time: '13:30', title: '午後の過ごし記録',   owner: '支援員', opsStep: 'pmRecord' as OpsFlowStep },
+      { id: 'ops-6', time: '16:00', title: '退所対応',           owner: '受付',   opsStep: 'discharge' as OpsFlowStep },
     ];
+
     const baseOrganizationLane: ScheduleItem[] = [
       { id: 'org-1', time: '10:00', title: '自治体監査ヒアリング', owner: '法人本部' },
       { id: 'org-2', time: '13:30', title: '家族向け連絡会資料確認', owner: '連携推進室' },


### PR DESCRIPTION
## Summary
TodayOps を **利用者オペレーション専用フロー** に昇格。
既存 Start/Done/Done-skip がそのまま業務フロー制御として機能。

### 6ステップ業務フロー
```
09:15 通所受け入れ → 09:30 検温 → 10:00 午前記録
→ 12:00 昼食確認 → 13:30 午後記録 → 16:00 退所
```

### 変更内容 (2ファイル, +42/-5)

**useScheduleLanes.ts**
- `OpsFlowStep` 型: intake | temperature | amRecord | lunchCheck | pmRecord | discharge
- `OPS_FLOW_ORDER` 定数: ソート第二キー
- staffLane → 6ステップ業務フロー

**useNextAction.ts**
- ソート強化: 第一キー=時刻, 第二キー=OPS_FLOW_ORDER
- `opsStep` を NextActionItem に伝播

### 設計判断
- 朝会/夕会は **削除** — TodayOps = 利用者対応オペレーション専用
- 将来の拡張: 各ステップに未完了人数バッジ、進捗バー(6/6)

### Verification
- `tsc --noEmit`: 0 errors
- `vitest`: 23/23 pass (既存テスト無影響)