### PR TITLE
fix(build): react-is manualChunks AsyncMode crash

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -200,7 +200,9 @@ export default defineConfig(({ mode }) => {
               normalized.includes('/react-markdown/') ||
               normalized.includes('/react-router') ||
               normalized.includes('/react-hot-toast/') ||
-              normalized.includes('/react-is/') ||
+              // NOTE: react-is intentionally omitted — multiple versions exist
+              // (v16 from hoist-non-react-statics, v19 from MUI 7) and forcing
+              // them into one chunk causes AsyncMode runtime crash.
               normalized.includes('/remark-') ||
               normalized.includes('/rehype-') ||
               normalized.includes('/micromark/') ||


### PR DESCRIPTION
## 🔥 Hotfix: Production crash

**Symptom:** `Cannot set properties of undefined (setting 'AsyncMode')`

**Root cause:** `manualChunks` in `vite.config.ts` forced all `react-is` versions into the `react` chunk. MUI 7 needs `react-is@19`, but `hoist-non-react-statics` brings `react-is@16`. When bundled together, MUI gets the v16 version which lacks v19 exports.

**Fix:** Remove `react-is` from the `react` chunk so Rollup handles versioning naturally.