### PR TITLE
refactor(users): detail URL cleanup + button label + shared helper

### DIFF
--- a/src/features/users/UserDetailSections/index.tsx
+++ b/src/features/users/UserDetailSections/index.tsx
@@ -330,7 +330,7 @@ const UserDetailSections: React.FC<UserDetailSectionsProps> = ({ user, backLink,
                   to={`/users/${encodeURIComponent(user.UserID || String(user.Id))}`}
                   sx={{ textTransform: 'none', flex: 1 }}
                 >
-                  詳細ページへ
+                  詳細を開く
                 </Button>
               </Stack>
             </>

--- a/src/features/users/UsersPanel/UsersList.tsx
+++ b/src/features/users/UsersPanel/UsersList.tsx
@@ -34,6 +34,7 @@ import ErrorState from '../../../ui/components/ErrorState';
 import Loading from '../../../ui/components/Loading';
 import type { IUserMaster } from '../types';
 import UserDetailSections from '../UserDetailSections/index';
+import { resolveUserIdentifier } from '../UserDetailSections/helpers';
 import {
     getUserStatusChips,
     isUserInactive,
@@ -324,7 +325,7 @@ const UsersList: FC<UsersListProps> = ({
             <TableBody>
               {displayUsers.map((user) => {
                 const rowBusy = busyId === Number(user.Id);
-                const userKey = user.UserID || String(user.Id);
+                const userKey = resolveUserIdentifier(user);
                 const isSelected = selectedUserKey === userKey;
                 const inactive = isUserInactive(user);
                 const { visible: visibleChips, overflow: overflowChips } = getUserStatusChips(user);

--- a/src/features/users/UsersPanel/useUsersPanel.ts
+++ b/src/features/users/UsersPanel/useUsersPanel.ts
@@ -16,6 +16,7 @@ import { ZodError } from 'zod';
 import { AuthRequiredError } from '../../../lib/errors';
 import { useUsersStore } from '../store';
 import type { IUserMaster, IUserMasterCreateDto } from '../types';
+import { resolveUserIdentifier } from '../UserDetailSections/helpers';
 import { useUsersDemoSeed } from '../useUsersDemoSeed';
 
 // ---------------------------------------------------------------------------
@@ -163,7 +164,7 @@ export function useUsersPanel(): UseUsersPanelReturn {
 
   const detailUser = useMemo(() => {
     if (!detailUserKey) return null;
-    return data.find((user) => (user.UserID || String(user.Id)) === detailUserKey) ?? null;
+    return data.find((user) => resolveUserIdentifier(user) === detailUserKey) ?? null;
   }, [data, detailUserKey]);
 
   useEffect(() => {

--- a/src/pages/UserDetailPage.tsx
+++ b/src/pages/UserDetailPage.tsx
@@ -1,3 +1,24 @@
+/**
+ * UserDetailPage — Deep-link redirect to the users list view.
+ *
+ * ## Design Decision
+ * Users module uses a **list-integrated UI** pattern:
+ * - `/users?tab=list&selected=:userId` is the **canonical** URL for viewing a user.
+ * - `/users/:userId` is **NOT canonical** — it exists ONLY as a deep-link entry point.
+ * - It normalizes the URL by redirecting to the list with the `selected` param.
+ *
+ * ## Benefits of this approach
+ * - Single source of truth: selection state lives in UsersList + useUsersPanel.
+ * - No state duplication between a "list page" and "detail page".
+ * - Right pane (embedded variant) and list stay in sync automatically.
+ * - Full editing is handled via dialog (onEdit), not a separate route.
+ *
+ * ## URL Parameter: `selected`
+ * - Value: `user.UserID` (e.g., "U-001") if available, otherwise `String(user.Id)`.
+ * - Resolved by `resolveUserIdentifier()` in UserDetailSections/helpers.tsx.
+ * - ⚠️ Caveat: "U-001" and "123" can both appear as selected values.
+ *   Future evolution: consider splitting to `selectedUserId` / `selectedSpId`.
+ */
 import { useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 


### PR DESCRIPTION
## 概要

/users 詳細ページの設計を明文化し、UI文言と内部実装の一貫性を改善。

## 変更内容

### 1. ボタンラベル修正
- `詳細ページへ` → `詳細を開く`
- 実際の挙動（一覧のselectedへリダイレクト）と一致させる

### 2. UserDetailPage.tsx 設計文書化
- JSDocで「list-integrated UIパターン」の意図を明文化
- `/users/:id` がリダイレクト専用であることを説明
- `selected` パラメータの値仕様を記載

### 3. resolveUserIdentifier 統合
- `UsersList.tsx` と `useUsersPanel.ts` のインライン `UserID || String(Id)` を
  共通ヘルパー `resolveUserIdentifier()` に置換
- キー解決ロジックの単一ソース化（helpers.tsx に集約）