### PR TITLE
fix: ISP/特性アンケートのナビグループ修正

### DIFF
--- a/src/app/config/navigationConfig.ts
+++ b/src/app/config/navigationConfig.ts
@@ -399,7 +399,7 @@ export function createNavItems(config: CreateNavItemsConfig): NavItem[] {
       isActive: (pathname) => pathname.startsWith('/survey/tokusei'),
       icon: undefined,
       audience: NAV_AUDIENCE.staff,
-      group: 'review' as NavGroupKey,
+      group: 'ibd' as NavGroupKey,
     },
     {
       label: 'ISP作成',
@@ -408,7 +408,7 @@ export function createNavItems(config: CreateNavItemsConfig): NavItem[] {
       icon: undefined,
       testId: TESTIDS.nav.supportPlanGuide,
       audience: NAV_AUDIENCE.staff,
-      group: 'review' as NavGroupKey,
+      group: 'isp' as NavGroupKey,
     },
     {
       label: 'ISP更新（前回比較）',
@@ -417,7 +417,7 @@ export function createNavItems(config: CreateNavItemsConfig): NavItem[] {
       icon: undefined,
       testId: TESTIDS.nav.ispEditor,
       audience: NAV_AUDIENCE.staff,
-      group: 'review' as NavGroupKey,
+      group: 'isp' as NavGroupKey,
     },
     {
       label: '利用者',


### PR DESCRIPTION
## Problem
ISP作成・ISP更新がサイドメニューに表示されない。
特性アンケートも 🧩 強度行動障害支援 グループに入っていない。

## Root Cause
\pickGroup()\ は \item.group\ が明示指定されている場合、推論ルール（L167-177）より先にそれを返す。
ナビ分離（#655）で \'review'\ → \'ibd'\/\'isp'\ へのキー変更が漏れていた。

## Fix (3行)
- 特性アンケート: \'review'\ → \'ibd'\
- ISP作成: \'review'\ → \'isp'\
- ISP更新: \'review'\ → \'isp'\

## Verification
- nav tests 36/36 passed
- lint + typecheck green