### PR TITLE
feat: actionable briefing alerts for Today Execution Layer

### DIFF
--- a/src/features/dashboard/sections/types.ts
+++ b/src/features/dashboard/sections/types.ts
@@ -1,10 +1,10 @@
 /**
  * Dashboard Sections Layer (UI Layer 1: Contracts)
- * 
+ *
  * セクションの型定義を一元管理。
  * - DashboardSectionKey: セクションの ID（固定文字列）
  * - DashboardSectionDef: セクション定義（タイトル・anchorId・audience）
- * 
+ *
  * 利点：
  * ✓ anchor は ロール関わらず常に揃う（sectionIdByKey の undefined 参照ナシ）
  * ✓ audience で表示条件を宣言的に管理
@@ -23,7 +23,7 @@ export type DashboardSectionKey =
 
 /**
  * セクション定義の構造（A層=表示契約・audience 判定）
- * 
+ *
  * - key: ユニークな識別子（E2E テスト・ナビ向け）
  * - title: 画面上の見出し
  * - anchorId: HTML id（常に 8 個全部揃う）
@@ -31,7 +31,7 @@ export type DashboardSectionKey =
  *   - 'both': admin / staff 両方
  *   - 'admin': admin のみ
  *   - 'staff': staff のみ
- * 
+ *
  * 重要：このオブジェクトは「非表示を含めて全セクション定義」を保持
  * → sectionIdByKey は常に Record<DashboardSectionKey, string> を満たす
  */
@@ -44,12 +44,12 @@ export type DashboardSectionDef = {
 
 /**
  * 朝会・ブリーフィング用アラート定義
- * 
+ *
  * 役割：
  * - 朝会時に「今、確認すべき重要情報」を優先度付して表示
  * - 各アラートはセクションへのナビゲーション用anchorIdを持つ
  * - severity に応じた視覚的強調（色・アイコン）
- * 
+ *
  * 使用例：
  * - 欠席が3件 → { type: 'absent', severity: 'error', count: 3 }
  * - 重要申し送り2件待ち → { type: 'urgent_handover', severity: 'warning', count: 2 }
@@ -62,5 +62,6 @@ export type BriefingAlert = {
   count: number;  // 該当件数
   targetAnchorId: string;  // クリック時のジャンプ先（sec-attendance など）
   description?: string;  // 追加説明（「田中、山田」など）
+  /** Per-user items for actionable alerts (Today Execution Layer) */
+  items?: { userId: string; userName: string }[];
 };
-

--- a/src/features/dashboard/selectors/useAttendanceAnalytics.ts
+++ b/src/features/dashboard/selectors/useAttendanceAnalytics.ts
@@ -61,6 +61,16 @@ export function useAttendanceAnalytics(
       return member?.name ?? member?.staffId ?? `職員${index + 1}`;
     });
 
+    // Per-user items for actionable alerts (Today Execution Layer)
+    const absenceItems = absenceVisits.map((v) => ({
+      userId: v.userCode,
+      userName: userCodeMap.get(v.userCode) ?? v.userCode,
+    }));
+    const lateOrEarlyItems = lateOrEarlyVisits.map((v) => ({
+      userId: v.userCode,
+      userName: userCodeMap.get(v.userCode) ?? v.userCode,
+    }));
+
     return {
       facilityAttendees,
       lateOrEarlyLeave,
@@ -71,6 +81,8 @@ export function useAttendanceAnalytics(
       lateOrShiftAdjust,
       outStaff,
       outStaffNames,
+      absenceItems,
+      lateOrEarlyItems,
     };
   }, [attendanceCounts, staff.length, users, visits]);
 
@@ -86,6 +98,7 @@ export function useAttendanceAnalytics(
         count: attendanceSummary.absenceCount,
         targetAnchorId: 'sec-attendance',
         description: attendanceSummary.absenceNames?.slice(0, 3).join('、'),
+        items: attendanceSummary.absenceItems,
       });
     }
 
@@ -98,6 +111,7 @@ export function useAttendanceAnalytics(
         count: attendanceSummary.lateOrEarlyLeave,
         targetAnchorId: 'sec-attendance',
         description: attendanceSummary.lateOrEarlyNames?.slice(0, 3).join('、'),
+        items: attendanceSummary.lateOrEarlyItems,
       });
     }
 

--- a/src/features/today/actions/alertActions.storage.ts
+++ b/src/features/today/actions/alertActions.storage.ts
@@ -1,0 +1,58 @@
+/**
+ * Alert Action State Repository (v1: localStorage)
+ *
+ * 永続先を将来 SP に差し替え可能な Repository pattern。
+ * スコープ: 端末 × 日付 × ログインユーザー
+ *
+ * Key format: today-alert-actions.v1:{ymd}:{loginUserKey}
+ */
+import type { ActionStatus, AlertActionState } from './alertActions.types';
+
+const STORAGE_PREFIX = 'today-alert-actions.v1';
+
+/** localStorage キーを生成 */
+export function buildStorageKey(ymd: string, loginUserKey: string): string {
+  return `${STORAGE_PREFIX}:${ymd}:${loginUserKey}`;
+}
+
+/** Repository Interface (将来 SP 実装に差し替え可能) */
+export interface AlertActionRepository {
+  load(): AlertActionState;
+  setState(alertKey: string, status: ActionStatus): void;
+  getState(alertKey: string): ActionStatus;
+  clear(): void;
+}
+
+/** v1: localStorage Implementation */
+export function createLocalStorageRepo(ymd: string, loginUserKey: string): AlertActionRepository {
+  const key = buildStorageKey(ymd, loginUserKey);
+
+  return {
+    load(): AlertActionState {
+      if (typeof window === 'undefined') return {};
+      try {
+        const raw = window.localStorage.getItem(key);
+        return raw ? (JSON.parse(raw) as AlertActionState) : {};
+      } catch {
+        return {};
+      }
+    },
+
+    setState(alertKey: string, status: ActionStatus): void {
+      if (typeof window === 'undefined') return;
+      const current = this.load();
+      current[alertKey] = status;
+      window.localStorage.setItem(key, JSON.stringify(current));
+    },
+
+    getState(alertKey: string): ActionStatus {
+      const current = this.load();
+      return current[alertKey] ?? 'todo';
+    },
+
+    clear(): void {
+      if (typeof window === 'undefined') return;
+      window.localStorage.removeItem(key);
+    },
+  };
+}

--- a/src/features/today/actions/alertActions.types.ts
+++ b/src/features/today/actions/alertActions.types.ts
@@ -1,0 +1,41 @@
+/**
+ * Alert Action Types
+ *
+ * Today Execution Layer: 朝会アラートを "行動リスト" として扱うための型定義。
+ * ステータスは全アラート共通、アクションは種類別。
+ */
+
+/** 共通ステータス（全アラート共通） */
+export type ActionStatus = 'todo' | 'doing' | 'done' | 'snoozed';
+
+/** アラート種類ごとのアクション定義 */
+export type ActionDef = {
+  id: string;
+  label: string;
+  primary?: boolean;
+};
+
+/** 種類別アクション定義マップ */
+export const ALERT_ACTION_DEFS: Record<string, ActionDef[]> = {
+  absent: [
+    { id: 'contact-confirm', label: '📞 連絡確認', primary: true },
+    { id: 'handover-create', label: '📝 申し送り作成' },
+  ],
+  late: [
+    { id: 'arrival-confirm', label: '⏱ 到着確認', primary: true },
+    { id: 'transport-confirm', label: '🚗 送迎確認' },
+    { id: 'handover-create', label: '📝 申し送り作成' },
+  ],
+  early: [
+    { id: 'departure-confirm', label: '✅ 退所確認', primary: true },
+    { id: 'handover-create', label: '📝 申し送り作成' },
+  ],
+};
+
+/** アラートキー生成 */
+export function buildAlertKey(alertType: string, userId: string, ymd: string): string {
+  return `${alertType}:${userId}:${ymd}`;
+}
+
+/** localStorage の状態マップ: alertKey → ActionStatus */
+export type AlertActionState = Record<string, ActionStatus>;

--- a/src/features/today/actions/index.ts
+++ b/src/features/today/actions/index.ts
@@ -1,0 +1,5 @@
+export { buildStorageKey, createLocalStorageRepo } from './alertActions.storage';
+export type { AlertActionRepository } from './alertActions.storage';
+export { ALERT_ACTION_DEFS, buildAlertKey } from './alertActions.types';
+export type { ActionDef, ActionStatus, AlertActionState } from './alertActions.types';
+export { useAlertActionState } from './useAlertActionState';

--- a/src/features/today/actions/useAlertActionState.ts
+++ b/src/features/today/actions/useAlertActionState.ts
@@ -1,0 +1,48 @@
+/**
+ * useAlertActionState — Hook for managing alert action completion state
+ *
+ * Uses localStorage repository scoped to date + login user.
+ * loginUserKey: account.username from MSAL (email), fallback 'anonymous'.
+ */
+import { useAuth } from '@/auth/useAuth';
+import { useCallback, useMemo, useState } from 'react';
+import { createLocalStorageRepo } from './alertActions.storage';
+import type { ActionStatus, AlertActionState } from './alertActions.types';
+
+export function useAlertActionState() {
+  const { account } = useAuth();
+  const loginUserKey = account?.username ?? 'anonymous';
+  const ymd = new Date().toISOString().split('T')[0];
+
+  const repo = useMemo(
+    () => createLocalStorageRepo(ymd, loginUserKey),
+    [ymd, loginUserKey],
+  );
+
+  // Load initial state from localStorage
+  const [states, setStates] = useState<AlertActionState>(() => repo.load());
+
+  const setState = useCallback(
+    (alertKey: string, status: ActionStatus) => {
+      repo.setState(alertKey, status);
+      setStates((prev) => ({ ...prev, [alertKey]: status }));
+    },
+    [repo],
+  );
+
+  const getState = useCallback(
+    (alertKey: string): ActionStatus => states[alertKey] ?? 'todo',
+    [states],
+  );
+
+  /** 完了率を計算（totalKeys 中の done 件数） */
+  const completionStats = useCallback(
+    (alertKeys: string[]) => {
+      const done = alertKeys.filter((k) => states[k] === 'done').length;
+      return { done, total: alertKeys.length };
+    },
+    [states],
+  );
+
+  return { states, setState, getState, completionStats };
+}

--- a/src/features/today/layouts/TodayOpsLayout.tsx
+++ b/src/features/today/layouts/TodayOpsLayout.tsx
@@ -10,7 +10,7 @@ import React from 'react';
 import type { NextActionWithProgress } from '../hooks/useNextAction';
 import type { AttendanceSummaryCardProps } from '../widgets/AttendanceSummaryCard';
 import { AttendanceSummaryCard } from '../widgets/AttendanceSummaryCard';
-import { BriefingAlertList } from '../widgets/BriefingAlertList';
+import { BriefingActionList } from '../widgets/BriefingActionList';
 import { HeroUnfinishedBanner } from '../widgets/HeroUnfinishedBanner';
 import { NextActionCard } from '../widgets/NextActionCard';
 import { UserCompactList, type UserRow } from '../widgets/UserCompactList';
@@ -55,7 +55,7 @@ export const TodayOpsLayout: React.FC<TodayOpsProps> = ({
           <Grid size={{ xs: 12, md: 8 }}>
             <AttendanceSummaryCard {...attendance} />
 
-            <BriefingAlertList alerts={briefingAlerts} />
+            <BriefingActionList alerts={briefingAlerts} />
 
             <Typography variant="h6" gutterBottom fontWeight="bold">
               👥 今日の利用者

--- a/src/features/today/widgets/BriefingActionList.tsx
+++ b/src/features/today/widgets/BriefingActionList.tsx
@@ -1,0 +1,157 @@
+/**
+ * BriefingActionList — アクション型朝会アラート（Execution Layer）
+ *
+ * 従来の BriefingAlertList を "行動リスト" に進化。
+ * 各アラートをグループヘッダー + per-user アクション行に分解。
+ *
+ * @see docs/adr/ADR-002-today-execution-layer-guardrails.md
+ */
+import type { BriefingAlert } from '@/features/dashboard/sections/types';
+import {
+    Alert,
+    Box,
+    Button,
+    Chip,
+    Collapse,
+    Paper,
+    Stack,
+    Typography,
+} from '@mui/material';
+import React from 'react';
+import {
+    ALERT_ACTION_DEFS,
+    buildAlertKey,
+    useAlertActionState,
+    type ActionStatus,
+} from '../actions';
+
+export type BriefingActionListProps = {
+  alerts: BriefingAlert[];
+};
+
+const STATUS_CHIP: Record<ActionStatus, { label: string; color: 'default' | 'warning' | 'success' | 'info' }> = {
+  todo: { label: '未対応', color: 'default' },
+  doing: { label: '対応中', color: 'warning' },
+  done: { label: '完了', color: 'success' },
+  snoozed: { label: '後で', color: 'info' },
+};
+
+export const BriefingActionList: React.FC<BriefingActionListProps> = ({ alerts }) => {
+  const { getState, setState, completionStats } = useAlertActionState();
+  const ymd = new Date().toISOString().split('T')[0];
+
+  return (
+    <Collapse in={alerts.length > 0}>
+      <Paper data-testid="today-briefing-actions" sx={{ p: 2, mb: 3 }}>
+        <Stack spacing={2}>
+          {alerts.map((alert) => {
+            const items = alert.items ?? [];
+            const alertKeys = items.map((item) =>
+              buildAlertKey(alert.type, item.userId, ymd),
+            );
+            const stats = completionStats(alertKeys);
+            const actionDefs = ALERT_ACTION_DEFS[alert.type] ?? [];
+
+            return (
+              <Box key={alert.id}>
+                {/* Group Header */}
+                <Alert
+                  severity={alert.severity}
+                  variant="outlined"
+                  sx={{ py: 0.25, mb: 1 }}
+                  action={
+                    items.length > 0 ? (
+                      <Chip
+                        size="small"
+                        label={`${stats.done}/${stats.total} 完了`}
+                        color={stats.done === stats.total && stats.total > 0 ? 'success' : 'default'}
+                        variant="outlined"
+                      />
+                    ) : undefined
+                  }
+                >
+                  <Typography variant="body2" fontWeight={600}>
+                    {alert.label}
+                    {alert.count > 0 && ` (${alert.count}件)`}
+                  </Typography>
+                </Alert>
+
+                {/* Per-user Action Rows */}
+                {items.length > 0 && (
+                  <Stack spacing={0.5} sx={{ pl: 2 }}>
+                    {items.map((item) => {
+                      const key = buildAlertKey(alert.type, item.userId, ymd);
+                      const status = getState(key);
+                      const chipConfig = STATUS_CHIP[status];
+
+                      return (
+                        <Box
+                          key={key}
+                          data-testid={`alert-action-row-${item.userId}`}
+                          sx={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: 1,
+                            py: 0.5,
+                            px: 1,
+                            borderRadius: 1,
+                            bgcolor: status === 'done' ? 'action.hover' : 'transparent',
+                            opacity: status === 'done' ? 0.7 : 1,
+                            transition: 'all 0.2s ease',
+                          }}
+                        >
+                          <Typography
+                            variant="body2"
+                            sx={{
+                              flex: 1,
+                              textDecoration: status === 'done' ? 'line-through' : 'none',
+                            }}
+                          >
+                            {item.userName}
+                          </Typography>
+
+                          <Chip
+                            size="small"
+                            label={chipConfig.label}
+                            color={chipConfig.color}
+                            variant="filled"
+                            sx={{ minWidth: 56 }}
+                          />
+
+                          {actionDefs.map((action) => (
+                            <Button
+                              key={action.id}
+                              size="small"
+                              variant={action.primary ? 'contained' : 'text'}
+                              disabled={status === 'done'}
+                              onClick={() => setState(key, 'done')}
+                              sx={{
+                                textTransform: 'none',
+                                fontSize: '0.75rem',
+                                minWidth: 'auto',
+                                px: 1,
+                              }}
+                            >
+                              {action.label}
+                            </Button>
+                          ))}
+                        </Box>
+                      );
+                    })}
+                  </Stack>
+                )}
+
+                {/* Fallback: no items (backward compat) */}
+                {items.length === 0 && alert.description && (
+                  <Typography variant="caption" color="text.secondary" sx={{ pl: 2 }}>
+                    {alert.description}
+                  </Typography>
+                )}
+              </Box>
+            );
+          })}
+        </Stack>
+      </Paper>
+    </Collapse>
+  );
+};


### PR DESCRIPTION
## Summary

朝会アラートを **表示のみ** → **行動リスト（アクション型）** に進化。
/today Execution Layer として、各アラートが per-user アクション行を持ち、完了状態を追跡可能に。

## Changes

| File | Change |
|---|---|
| src/features/today/actions/alertActions.types.ts | **[NEW]** ActionStatus, ActionDef, アクション定義マップ |
| src/features/today/actions/alertActions.storage.ts | **[NEW]** localStorage Repository (将来SP差し替え可能) |
| src/features/today/actions/useAlertActionState.ts | **[NEW]** Hook: MSAL account 単位の状態管理 |
| src/features/today/actions/index.ts | **[NEW]** Barrel export |
| src/features/today/widgets/BriefingActionList.tsx | **[NEW]** アクション型アラートウィジェット |
| src/features/dashboard/sections/types.ts | **[MOD]** BriefingAlert に optional items[] 追加 |
| src/features/dashboard/selectors/useAttendanceAnalytics.ts | **[MOD]** per-user items を生成 |
| src/features/today/layouts/TodayOpsLayout.tsx | **[MOD]** BriefingAlertList → BriefingActionList |

## Design

- **State**: localStorage v1 (スコープ: 端末×日付×MSALユーザー)
- **Repository pattern**: Interface で将来 SP 永続に差し替え可能
- **backward-compatible**: BriefingAlert.items は optional
- **共通ステータス** (todo/doing/done/snoozed) × **種類別アクション** (連絡確認/到着確認/申し送り作成)

## Verification

- [x] `npx tsc --noEmit` — no new type errors
- [x] Unit tests — 5 files / 35 tests passed
- [x] Pre-commit hooks — lint ✅ typecheck ✅