### PR TITLE
fix: implement service-provision integration in cross-module snapshot

### DIFF
--- a/src/features/cross-module/types.ts
+++ b/src/features/cross-module/types.ts
@@ -78,6 +78,8 @@ export interface DailyUserSnapshot {
   // ========================================
   /** モジュール間整合性チェック結果 */
   crossModuleIssues?: CrossModuleIssue[];
+  /** サービス提供実績サマリ */
+  serviceProvision?: ServiceProvisionSummary;
   /** 最終更新日時 */
   lastUpdated?: string;
 }
@@ -89,13 +91,13 @@ export interface CrossModuleIssue {
   /** 不整合ID */
   id: string;
   /** 不整合の種別 */
-  type: 'attendance_activity_mismatch' | 'activity_irc_conflict' | 'data_missing';
+  type: 'attendance_activity_mismatch' | 'activity_irc_conflict' | 'data_missing' | 'attendance_provision_mismatch';
   /** 重要度 */
   severity: 'error' | 'warning' | 'info';
   /** 不整合の説明 */
   message: string;
   /** 関連するモジュール */
-  involvedModules: ('attendance' | 'activity' | 'irc')[];
+  involvedModules: ('attendance' | 'activity' | 'irc' | 'provision')[];
   /** 修正提案（オプション） */
   suggestedAction?: string;
 }
@@ -128,6 +130,8 @@ export interface DailyUserSnapshotInput {
     hasIndividualSupport?: boolean;
     hasRehabilitation?: boolean;
   };
+  /** サービス提供実績データ */
+  serviceProvisionData?: ServiceProvisionSummary;
 }
 
 /**


### PR DESCRIPTION
## Summary

Implement missing service-provision integration in the cross-module DailyUserSnapshot system.

### Changes

**types.ts:**
- Add `serviceProvision` to `DailyUserSnapshot`
- Add `serviceProvisionData` to `DailyUserSnapshotInput`
- Extend `CrossModuleIssue.type` with `attendance_provision_mismatch`
- Add `provision` to `involvedModules` union

**dailyUserSnapshot.ts:**
- Add provision data population in `buildDailyUserSnapshot`
- Implement Rule 5: `absence-provision-provided` (error)
- Implement Rule 6: `attended-no-provision-record` (warning)

### Test Results
- Cross-module: 13/13 pass (was 8/13)
- All module tests: 123/123 pass