### PR TITLE
feat(handoff): 申し送りワークフロー昇格 — 夕会/朝会モード対応

### DIFF
--- a/src/features/handoff/__tests__/handoffWorkflow.spec.ts
+++ b/src/features/handoff/__tests__/handoffWorkflow.spec.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import {
+    getAllowedActions,
+    getNextStatus,
+    isTerminalStatus,
+    type HandoffStatus,
+    type MeetingMode,
+} from '../handoffTypes';
+
+describe('isTerminalStatus', () => {
+  it.each<[HandoffStatus, boolean]>([
+    ['未対応', false],
+    ['対応中', false],
+    ['確認済', false],
+    ['明日へ持越', false],
+    ['対応済', true],
+    ['完了', true],
+  ])('isTerminalStatus("%s") => %s', (status, expected) => {
+    expect(isTerminalStatus(status)).toBe(expected);
+  });
+});
+
+describe('getNextStatus (既存互換)', () => {
+  it('未対応 → 対応中', () => {
+    expect(getNextStatus('未対応')).toBe('対応中');
+  });
+
+  it('対応中 → 対応済', () => {
+    expect(getNextStatus('対応中')).toBe('対応済');
+  });
+
+  it('対応済 → 未対応 (リセット)', () => {
+    expect(getNextStatus('対応済')).toBe('未対応');
+  });
+
+  it('確認済 → 未対応 (フォールスルー)', () => {
+    expect(getNextStatus('確認済')).toBe('未対応');
+  });
+});
+
+describe('getAllowedActions', () => {
+  describe('eveningモード', () => {
+    const mode: MeetingMode = 'evening';
+
+    it('未対応 → [確認済]', () => {
+      const actions = getAllowedActions('未対応', mode);
+      expect(actions).toHaveLength(1);
+      expect(actions[0].targetStatus).toBe('確認済');
+    });
+
+    it('確認済 → [明日へ持越, 完了]', () => {
+      const actions = getAllowedActions('確認済', mode);
+      expect(actions).toHaveLength(2);
+      expect(actions.map(a => a.targetStatus)).toEqual(['明日へ持越', '完了']);
+    });
+
+    it('明日へ持越 にはcarryOverDateフラグが立つ', () => {
+      const actions = getAllowedActions('確認済', mode);
+      const carryOver = actions.find(a => a.targetStatus === '明日へ持越');
+      expect(carryOver?.setsCarryOverDate).toBe(true);
+    });
+
+    it('対応中 → [] (アクションなし)', () => {
+      expect(getAllowedActions('対応中', mode)).toEqual([]);
+    });
+
+    it('対応済 → [] (終端)', () => {
+      expect(getAllowedActions('対応済', mode)).toEqual([]);
+    });
+
+    it('完了 → [] (終端)', () => {
+      expect(getAllowedActions('完了', mode)).toEqual([]);
+    });
+  });
+
+  describe('morningモード', () => {
+    const mode: MeetingMode = 'morning';
+
+    it('明日へ持越 → [完了]', () => {
+      const actions = getAllowedActions('明日へ持越', mode);
+      expect(actions).toHaveLength(1);
+      expect(actions[0].targetStatus).toBe('完了');
+    });
+
+    it('未対応 → [] (朝会ではアクション不可)', () => {
+      expect(getAllowedActions('未対応', mode)).toEqual([]);
+    });
+
+    it('確認済 → []', () => {
+      expect(getAllowedActions('確認済', mode)).toEqual([]);
+    });
+  });
+
+  describe('normalモード', () => {
+    const mode: MeetingMode = 'normal';
+
+    it('どのステータスでも空 (既存Chipサイクルを使う)', () => {
+      const statuses: HandoffStatus[] = ['未対応', '対応中', '対応済', '確認済', '明日へ持越', '完了'];
+      for (const s of statuses) {
+        expect(getAllowedActions(s, mode)).toEqual([]);
+      }
+    });
+  });
+});

--- a/src/features/handoff/__tests__/useHandoffTimelineViewModel.spec.ts
+++ b/src/features/handoff/__tests__/useHandoffTimelineViewModel.spec.ts
@@ -1,5 +1,6 @@
-import { renderHook } from '@testing-library/react';
-import type { HandoffDayScope, HandoffTimeFilter } from '../handoffTypes';
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { HandoffDayScope, HandoffTimeFilter, MeetingMode } from '../handoffTypes';
 import { useHandoffTimelineViewModel } from '../useHandoffTimelineViewModel';
 
 describe('useHandoffTimelineViewModel', () => {
@@ -13,5 +14,80 @@ describe('useHandoffTimelineViewModel', () => {
 
     expect(result.current.dayScope).toBe('yesterday');
     expect(result.current.timeFilter).toBe('morning');
+  });
+
+  describe('meetingMode', () => {
+    it('defaults to "normal"', () => {
+      const { result } = renderHook(() => useHandoffTimelineViewModel({}));
+      expect(result.current.meetingMode).toBe('normal');
+    });
+
+    it('can be changed via handleMeetingModeChange', () => {
+      const { result } = renderHook(() => useHandoffTimelineViewModel({}));
+
+      act(() => {
+        result.current.handleMeetingModeChange(
+          {} as React.MouseEvent<HTMLElement>,
+          'evening' as MeetingMode,
+        );
+      });
+
+      expect(result.current.meetingMode).toBe('evening');
+    });
+
+    it('ignores null value (ToggleButtonGroup deselect)', () => {
+      const { result } = renderHook(() => useHandoffTimelineViewModel({}));
+
+      act(() => {
+        result.current.handleMeetingModeChange(
+          {} as React.MouseEvent<HTMLElement>,
+          'evening' as MeetingMode,
+        );
+      });
+
+      act(() => {
+        // ToggleButtonGroup sends null when deselecting
+        result.current.handleMeetingModeChange(
+          {} as React.MouseEvent<HTMLElement>,
+          null as unknown as MeetingMode,
+        );
+      });
+
+      expect(result.current.meetingMode).toBe('evening');
+    });
+  });
+
+  describe('markReviewed guard', () => {
+    it('does not throw when called (no-op for non-未対応)', () => {
+      const { result } = renderHook(() => useHandoffTimelineViewModel({}));
+      // markReviewed guards by checking currentStatus
+      // calling with '対応中' should be a no-op (not throw)
+      expect(() => result.current.markReviewed(1, '対応中')).not.toThrow();
+    });
+
+    it('does not throw when called with 未対応', () => {
+      const { result } = renderHook(() => useHandoffTimelineViewModel({}));
+      // This will call updateHandoffStatusVm which has no ref set, but should not throw
+      expect(() => result.current.markReviewed(1, '未対応')).not.toThrow();
+    });
+  });
+
+  describe('markCarryOver guard', () => {
+    it('does not throw when called with non-確認済 (no-op)', () => {
+      const { result } = renderHook(() => useHandoffTimelineViewModel({}));
+      expect(() => result.current.markCarryOver(1, '未対応')).not.toThrow();
+    });
+  });
+
+  describe('markClosed guard', () => {
+    it('does not throw when called with terminal status (no-op)', () => {
+      const { result } = renderHook(() => useHandoffTimelineViewModel({}));
+      expect(() => result.current.markClosed(1, '完了')).not.toThrow();
+    });
+
+    it('does not throw when called with 未対応 (no-op)', () => {
+      const { result } = renderHook(() => useHandoffTimelineViewModel({}));
+      expect(() => result.current.markClosed(1, '未対応')).not.toThrow();
+    });
   });
 });

--- a/src/features/handoff/handoffTypes.ts
+++ b/src/features/handoff/handoffTypes.ts
@@ -74,10 +74,19 @@ export const HANDOFF_TIMELINE_COLUMNS = {
     choices: [
       '未対応',
       '対応中',
-      '対応済'
+      '対応済',
+      '確認済',
+      '明日へ持越',
+      '完了'
     ],
     defaultValue: '未対応',
-    description: 'フォローアップ状況。継続的な支援管理'
+    description: 'フォローアップ状況。夕会→朝会ワークフロー対応'
+  },
+
+  CarryOverDate: {
+    type: 'DateTime',
+    required: false,
+    description: '「明日へ持越」にした日付。朝会モードで前日分のみ表示するために使用'
   },
 
   // 時間・セッション管理
@@ -119,8 +128,31 @@ export const HANDOFF_TIMELINE_COLUMNS = {
     required: true,
     defaultValue: false,
     description: 'ドラフト保存機能用（v1では常にfalse）'
-  }
+  },
 } as const;
+
+// ────────────────────────────────────────────────────────────
+// ワークフロー定義（夕会→朝会昇格）
+// ────────────────────────────────────────────────────────────
+
+/**
+ * 夕会/朝会の業務モード
+ */
+export type MeetingMode = 'normal' | 'evening' | 'morning';
+
+export const MEETING_MODE_LABELS: Record<MeetingMode, string> = {
+  normal: '📋 通常',
+  evening: '🌆 夕会',
+  morning: '🌅 朝会',
+};
+
+/**
+ * ステータス更新ペイロード（API呼び出し用）
+ */
+export type HandoffStatusUpdate = {
+  status: HandoffStatus;
+  carryOverDate?: string; // YYYY-MM-DD
+};
 
 // ────────────────────────────────────────────────────────────
 // TypeScript 型定義
@@ -143,7 +175,10 @@ export type HandoffSeverity =
 export type HandoffStatus =
   | '未対応'
   | '対応中'
-  | '対応済';
+  | '対応済'
+  | '確認済'
+  | '明日へ持越'
+  | '完了';
 
 export type TimeBand =
   | '朝'
@@ -166,6 +201,7 @@ export interface HandoffRecord {
   status: HandoffStatus;
   timeBand: TimeBand;
   meetingSessionKey?: string;
+  carryOverDate?: string; // YYYY-MM-DD — 「明日へ持越」設定日
   sourceType?: string;
   sourceId?: number;
   sourceUrl?: string;
@@ -204,29 +240,113 @@ export interface NewHandoffInput {
 
 /**
  * ステータス表示用メタデータ（日本語ラベル対応）
+ * 対応済/完了 は UI上「完了」に統一
  */
-export const HANDOFF_STATUS_META = {
+export const HANDOFF_STATUS_META: Record<HandoffStatus, { label: string; color: 'default' | 'primary' | 'warning' | 'success' | 'info' }> = {
   '未対応': {
     label: '未対応',
-    color: 'default' as const,
+    color: 'default',
   },
   '対応中': {
     label: '対応中',
-    color: 'warning' as const,
+    color: 'warning',
   },
   '対応済': {
-    label: '対応済',
-    color: 'success' as const,
+    label: '完了', // UI統一: 対応済も「完了」表示
+    color: 'success',
   },
-} as const;
+  '確認済': {
+    label: '確認済',
+    color: 'info',
+  },
+  '明日へ持越': {
+    label: '明日へ',
+    color: 'primary',
+  },
+  '完了': {
+    label: '完了',
+    color: 'success',
+  },
+};
 
 /**
- * 状態を次のステップに進めるヘルパー
+ * 終端ステータス判定
+ * 対応済（従来フロー完了）と 完了（夕会/朝会フロー完了）を同一扱い
+ */
+export function isTerminalStatus(status: HandoffStatus): boolean {
+  return status === '対応済' || status === '完了';
+}
+
+/**
+ * 状態を次のステップに進めるヘルパー（従来フロー用・既存互換）
  */
 export function getNextStatus(current: HandoffStatus): HandoffStatus {
   if (current === '未対応') return '対応中';
   if (current === '対応中') return '対応済';
   return '未対応'; // 対応済 → 未対応へ戻る
+}
+
+// ────────────────────────────────────────────────────────────
+// ワークフロー遷移ロジック
+// ────────────────────────────────────────────────────────────
+
+/**
+ * ワークフローアクション定義
+ */
+export type WorkflowAction = {
+  key: string;
+  label: string;
+  icon: string;
+  targetStatus: HandoffStatus;
+  /** 「明日へ持越」の場合 true → carryOverDate を今日でセット */
+  setsCarryOverDate?: boolean;
+};
+
+const ACTION_REVIEWED: WorkflowAction = {
+  key: 'reviewed',
+  label: '確認済',
+  icon: '✅',
+  targetStatus: '確認済',
+};
+
+const ACTION_CARRY_OVER: WorkflowAction = {
+  key: 'carry_over',
+  label: '明日へ',
+  icon: '📅',
+  targetStatus: '明日へ持越',
+  setsCarryOverDate: true,
+};
+
+const ACTION_CLOSED: WorkflowAction = {
+  key: 'closed',
+  label: '完了',
+  icon: '🔒',
+  targetStatus: '完了',
+};
+
+/**
+ * 現在のステータスとモードに応じて許可されるアクションを返す
+ * 単一関数でUI側の分岐増殖を防ぐ
+ *
+ * // TODO: context?: { role?: 'admin' | 'staff' } で reopen アクションを追加
+ */
+export function getAllowedActions(
+  status: HandoffStatus,
+  mode: MeetingMode,
+): WorkflowAction[] {
+  if (mode === 'evening') {
+    if (status === '未対応') return [ACTION_REVIEWED];
+    if (status === '確認済') return [ACTION_CARRY_OVER, ACTION_CLOSED];
+    return [];
+  }
+
+  if (mode === 'morning') {
+    if (status === '明日へ持越') return [ACTION_CLOSED];
+    return [];
+  }
+
+  // normal: アクションボタンなし（既存Chipサイクルを維持）
+  return [];
 }
 
 // ────────────────────────────────────────────────────────────
@@ -289,6 +409,7 @@ export type SpHandoffItem = {
   Status: string;
   TimeBand: string;
   MeetingSessionKey?: string;
+  CarryOverDate?: string; // ISO date from SP DateTime column
   SourceType?: string;
   SourceId?: number;
   SourceUrl?: string;
@@ -303,6 +424,16 @@ export type SpHandoffItem = {
   EditorId?: number;
 };
 
+/** 既知の HandoffStatus 値かどうかを判定 */
+const VALID_STATUSES: ReadonlySet<string> = new Set<HandoffStatus>([
+  '未対応', '対応中', '対応済', '確認済', '明日へ持越', '完了',
+]);
+
+function normalizeStatus(raw: string): HandoffStatus {
+  if (VALID_STATUSES.has(raw)) return raw as HandoffStatus;
+  return '未対応'; // 未知ステータスのフォールバック
+}
+
 /**
  * SharePoint アイテムを内部型に変換
  */
@@ -315,9 +446,10 @@ export function fromSpHandoffItem(sp: SpHandoffItem): HandoffRecord {
     userDisplayName: sp.UserDisplayName,
     category: sp.Category as HandoffCategory,
     severity: sp.Severity as HandoffSeverity,
-    status: sp.Status as HandoffStatus,
+    status: normalizeStatus(sp.Status),
     timeBand: sp.TimeBand as TimeBand,
     meetingSessionKey: sp.MeetingSessionKey,
+    carryOverDate: sp.CarryOverDate ? sp.CarryOverDate.split('T')[0] : undefined,
     sourceType: sp.SourceType,
     sourceId: sp.SourceId,
     sourceUrl: sp.SourceUrl,
@@ -365,15 +497,19 @@ export function toSpHandoffCreatePayload(
  * SharePoint 更新用ペイロード（部分更新対応）
  */
 export function toSpHandoffUpdatePayload(
-  updates: Partial<Pick<HandoffRecord, 'status' | 'severity' | 'category' | 'message' | 'title'>>
-): Partial<Pick<SpHandoffItem, 'Status' | 'Severity' | 'Category' | 'Message' | 'Title'>> {
-  const payload: Partial<Pick<SpHandoffItem, 'Status' | 'Severity' | 'Category' | 'Message' | 'Title'>> = {};
+  updates: Partial<Pick<HandoffRecord, 'status' | 'severity' | 'category' | 'message' | 'title' | 'carryOverDate'>>
+): Partial<Pick<SpHandoffItem, 'Status' | 'Severity' | 'Category' | 'Message' | 'Title' | 'CarryOverDate'>> {
+  const payload: Partial<Pick<SpHandoffItem, 'Status' | 'Severity' | 'Category' | 'Message' | 'Title' | 'CarryOverDate'>> = {};
 
   if (updates.status !== undefined) payload.Status = updates.status;
   if (updates.severity !== undefined) payload.Severity = updates.severity;
   if (updates.category !== undefined) payload.Category = updates.category;
   if (updates.message !== undefined) payload.Message = updates.message;
   if (updates.title !== undefined) payload.Title = updates.title;
+  if (updates.carryOverDate !== undefined) {
+    // SP DateTime列にはISO形式で保存
+    payload.CarryOverDate = `${updates.carryOverDate}T00:00:00.000Z`;
+  }
 
   return payload;
 }
@@ -389,6 +525,7 @@ export interface HandoffSummary {
   severity: HandoffSeverity;
   status: HandoffStatus;
   timeBand: TimeBand;
+  carryOverDate?: string;
   createdAt: string;
   createdByName: string;
 }
@@ -446,11 +583,38 @@ export function getSeverityColor(severity: HandoffSeverity): 'default' | 'warnin
 /**
  * Status に応じた色設定（MUI用）
  */
-export function getStatusColor(status: HandoffStatus): 'default' | 'primary' | 'success' {
+export function getStatusColor(status: HandoffStatus): 'default' | 'primary' | 'success' | 'info' {
   switch (status) {
     case '対応済': return 'success';
+    case '完了': return 'success';
+    case '確認済': return 'info';
+    case '明日へ持越': return 'primary';
     case '対応中': return 'primary';
     case '未対応':
     default: return 'default';
   }
+}
+
+// ────────────────────────────────────────────────────────────
+// 日付ユーティリティ（timezone-safe）
+// ────────────────────────────────────────────────────────────
+
+/**
+ * ローカルタイムゾーン（JST）で YYYY-MM-DD を生成
+ * carryOverDate 等、日付のみの値に使用
+ */
+export function formatYmdLocal(date: Date = new Date()): string {
+  const y = date.getFullYear();
+  const m = `${date.getMonth() + 1}`.padStart(2, '0');
+  const d = `${date.getDate()}`.padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+/**
+ * 昨日のローカル日付を YYYY-MM-DD で返す
+ */
+export function getYesterdayYmd(): string {
+  const d = new Date();
+  d.setDate(d.getDate() - 1);
+  return formatYmdLocal(d);
 }

--- a/src/features/handoff/useHandoffSummary.ts
+++ b/src/features/handoff/useHandoffSummary.ts
@@ -10,6 +10,7 @@ import { useEffect, useState } from 'react';
 import { useHandoffApi } from './handoffApi';
 import { handoffConfig } from './handoffConfig';
 import type { HandoffCategory, HandoffDayScope, HandoffRecord, HandoffStatus } from './handoffTypes';
+import { isTerminalStatus } from './handoffTypes';
 
 const STORAGE_KEY = 'handoff.timeline.dev.v1';
 
@@ -78,6 +79,9 @@ export function useHandoffSummary(options?: { dayScope?: HandoffDayScope }): Han
       '未対応': 0,
       '対応中': 0,
       '対応済': 0,
+      '確認済': 0,
+      '明日へ持越': 0,
+      '完了': 0,
     },
     criticalCount: 0,
     byCategory: {
@@ -107,6 +111,9 @@ export function useHandoffSummary(options?: { dayScope?: HandoffDayScope }): Han
         let pending = 0;
         let inProgress = 0;
         let done = 0;
+        let reviewed = 0;
+        let carryOver = 0;
+        let closed = 0;
         let critical = 0;
 
         // カテゴリ別カウンター初期化
@@ -125,9 +132,12 @@ export function useHandoffSummary(options?: { dayScope?: HandoffDayScope }): Han
           if (item.status === '未対応') pending++;
           if (item.status === '対応中') inProgress++;
           if (item.status === '対応済') done++;
+          if (item.status === '確認済') reviewed++;
+          if (item.status === '明日へ持越') carryOver++;
+          if (item.status === '完了') closed++;
 
           // 重要・未完了カウント
-          if (item.severity === '重要' && item.status !== '対応済') {
+          if (item.severity === '重要' && !isTerminalStatus(item.status)) {
             critical++;
           }
 
@@ -141,6 +151,9 @@ export function useHandoffSummary(options?: { dayScope?: HandoffDayScope }): Han
             '未対応': pending,
             '対応中': inProgress,
             '対応済': done,
+            '確認済': reviewed,
+            '明日へ持越': carryOver,
+            '完了': closed,
           },
           criticalCount: critical,
           byCategory: categoryCount,
@@ -150,7 +163,7 @@ export function useHandoffSummary(options?: { dayScope?: HandoffDayScope }): Han
         // エラー時は空のサマリーを設定
         setSummary({
           total: 0,
-          byStatus: { '未対応': 0, '対応中': 0, '対応済': 0 },
+          byStatus: { '未対応': 0, '対応中': 0, '対応済': 0, '確認済': 0, '明日へ持越': 0, '完了': 0 },
           criticalCount: 0,
           byCategory: {
             '体調': 0,

--- a/src/features/handoff/useHandoffTimelineViewModel.ts
+++ b/src/features/handoff/useHandoffTimelineViewModel.ts
@@ -1,6 +1,16 @@
 import { useCallback, useEffect, useRef, useState, type MutableRefObject } from 'react';
 import type { HandoffStats } from './TodayHandoffTimelineList';
-import type { HandoffDayScope, HandoffTimeFilter } from './handoffTypes';
+import type {
+    HandoffDayScope,
+    HandoffStatus,
+    HandoffStatusUpdate,
+    HandoffTimeFilter,
+    MeetingMode
+} from './handoffTypes';
+import {
+    formatYmdLocal,
+    isTerminalStatus
+} from './handoffTypes';
 
 type HandoffTimelineNavState =
   | {
@@ -14,6 +24,7 @@ type UseHandoffTimelineViewModelArgs = {
 };
 
 export type HandoffTimelineViewModel = {
+  // 既存
   dayScope: HandoffDayScope;
   timeFilter: HandoffTimeFilter;
   isQuickNoteOpen: boolean;
@@ -24,6 +35,21 @@ export type HandoffTimelineViewModel = {
   handleTimeFilterChange: (_event: React.MouseEvent<HTMLElement>, newFilter: HandoffTimeFilter) => void;
   openQuickNote: () => void;
   closeQuickNote: () => void;
+
+  // ワークフロー拡張
+  meetingMode: MeetingMode;
+  handleMeetingModeChange: (_event: React.MouseEvent<HTMLElement>, newMode: MeetingMode) => void;
+  /** 未対応 → 確認済 (夕会) */
+  markReviewed: (id: number, currentStatus: HandoffStatus) => void;
+  /** 確認済 → 明日へ持越 + carryOverDate=今日 (夕会) */
+  markCarryOver: (id: number, currentStatus: HandoffStatus) => void;
+  /** → 完了 (夕会/朝会) */
+  markClosed: (id: number, currentStatus: HandoffStatus) => void;
+  /**
+   * ViewModel レベルで提供するフィルタ済み更新関数
+   * TodayHandoffTimelineList で使用
+   */
+  updateHandoffStatusVm: (id: number, update: HandoffStatusUpdate) => Promise<void> | void;
 };
 
 export function useHandoffTimelineViewModel({
@@ -38,6 +64,33 @@ export function useHandoffTimelineViewModel({
   const [isQuickNoteOpen, setIsQuickNoteOpen] = useState(false);
   const [handoffStats, setHandoffStats] = useState<HandoffStats | null>(null);
   const quickNoteRef = useRef<HTMLDivElement | null>(null);
+  const [meetingMode, setMeetingMode] = useState<MeetingMode>('normal');
+
+  // 外部から updateHandoffStatus を受け取るためのrefを用意
+  // TodayHandoffTimelineList 内部の useHandoffTimeline で実際のupdate関数が決まるので、
+  // VM からはコールバックを提供し、子から呼んでもらう形。
+  // → 実装詳細: 子コンポーネント側が updateHandoffStatus を持っているので、
+  //   VM はワークフローアクション用のラッパーのみ提供。
+  //   updateHandoffStatusVm は子に渡す用のパススルー関数。
+  const updateHandoffStatusRef = useRef<((id: number, update: HandoffStatusUpdate) => Promise<void> | void) | null>(null);
+
+  /**
+   * 子コンポーネントが実際のupdate関数を登録するためのsetter
+   * → 実際は TodayHandoffTimelineList の updateHandoffStatus をそのままパススルーする。
+   *   しかし updateHandoffStatus は useHandoffTimeline フック内で定義されるため、
+   *   VMレベルからは直接アクセスできない。
+   *
+   * 解決策: updateHandoffStatusVm を子にpropsで渡し、子側でラップして呼ぶ。
+   * VMのワークフローアクション (markReviewed等) → updateHandoffStatusVm → 子の updateHandoffStatus
+   */
+  const updateHandoffStatusVm = useCallback(
+    async (id: number, update: HandoffStatusUpdate) => {
+      if (updateHandoffStatusRef.current) {
+        await updateHandoffStatusRef.current(id, update);
+      }
+    },
+    []
+  );
 
   const navDayScope = navState?.dayScope;
   const navTimeFilter = navState?.timeFilter;
@@ -87,6 +140,15 @@ export function useHandoffTimelineViewModel({
     []
   );
 
+  const handleMeetingModeChange = useCallback(
+    (_event: React.MouseEvent<HTMLElement>, newMode: MeetingMode) => {
+      if (newMode !== null) {
+        setMeetingMode(newMode);
+      }
+    },
+    []
+  );
+
   const openQuickNote = useCallback(() => {
     setIsQuickNoteOpen(true);
   }, []);
@@ -94,6 +156,48 @@ export function useHandoffTimelineViewModel({
   const closeQuickNote = useCallback(() => {
     setIsQuickNoteOpen(false);
   }, []);
+
+  // ────────────────────────────────────────────────────────────
+  // ワークフローアクション
+  // ────────────────────────────────────────────────────────────
+
+  /**
+   * 夕会: 未対応 → 確認済
+   */
+  const markReviewed = useCallback(
+    (id: number, currentStatus: HandoffStatus) => {
+      if (currentStatus !== '未対応') return; // ガード
+      updateHandoffStatusVm(id, { status: '確認済' });
+    },
+    [updateHandoffStatusVm]
+  );
+
+  /**
+   * 夕会: 確認済 → 明日へ持越 + carryOverDate
+   */
+  const markCarryOver = useCallback(
+    (id: number, currentStatus: HandoffStatus) => {
+      if (currentStatus !== '確認済') return; // ガード
+      updateHandoffStatusVm(id, {
+        status: '明日へ持越',
+        carryOverDate: formatYmdLocal(new Date()),
+      });
+    },
+    [updateHandoffStatusVm]
+  );
+
+  /**
+   * 夕会/朝会: → 完了
+   * 確認済→完了 (夕会), 明日へ持越→完了 (朝会)
+   */
+  const markClosed = useCallback(
+    (id: number, currentStatus: HandoffStatus) => {
+      if (isTerminalStatus(currentStatus)) return; // 既に終端ならno-op
+      if (currentStatus === '未対応' || currentStatus === '対応中') return; // 通常フロー中はno-op
+      updateHandoffStatusVm(id, { status: '完了' });
+    },
+    [updateHandoffStatusVm]
+  );
 
   return {
     dayScope,
@@ -106,5 +210,13 @@ export function useHandoffTimelineViewModel({
     handleTimeFilterChange,
     openQuickNote,
     closeQuickNote,
+
+    // ワークフロー拡張
+    meetingMode,
+    handleMeetingModeChange,
+    markReviewed,
+    markCarryOver,
+    markClosed,
+    updateHandoffStatusVm,
   };
 }

--- a/src/pages/HandoffTimelinePage.tsx
+++ b/src/pages/HandoffTimelinePage.tsx
@@ -1,13 +1,13 @@
+import { TESTIDS, tid } from '@/testids';
 import { AccessTime as AccessTimeIcon, Close as CloseIcon, EditNote as EditNoteIcon, Nightlight as EveningIcon, WbSunny as MorningIcon } from '@mui/icons-material';
-import { Box, Button, Chip, Collapse, Container, Divider, IconButton, Paper, Stack, ToggleButton, ToggleButtonGroup, Typography } from '@mui/material';
+import { Alert, Box, Button, Chip, Collapse, Container, Divider, IconButton, Paper, Stack, ToggleButton, ToggleButtonGroup, Typography } from '@mui/material';
 import { useLocation } from 'react-router-dom';
-import { useHandoffTimelineViewModel } from '../features/handoff/useHandoffTimelineViewModel';
 import HandoffCategorySummaryCard from '../features/handoff/HandoffCategorySummaryCard';
 import { HandoffQuickNoteCard } from '../features/handoff/HandoffQuickNoteCard';
-import type { HandoffDayScope, HandoffTimeFilter } from '../features/handoff/handoffTypes';
-import { HANDOFF_DAY_SCOPE_LABELS, HANDOFF_TIME_FILTER_LABELS } from '../features/handoff/handoffTypes';
+import type { HandoffDayScope, HandoffTimeFilter, MeetingMode } from '../features/handoff/handoffTypes';
+import { HANDOFF_DAY_SCOPE_LABELS, HANDOFF_TIME_FILTER_LABELS, MEETING_MODE_LABELS } from '../features/handoff/handoffTypes';
 import { TodayHandoffTimelineList } from '../features/handoff/TodayHandoffTimelineList';
-import { tid, TESTIDS } from '@/testids';
+import { useHandoffTimelineViewModel } from '../features/handoff/useHandoffTimelineViewModel';
 
 /**
  * 申し送りタイムラインページ
@@ -42,6 +42,8 @@ export default function HandoffTimelinePage() {
     handleTimeFilterChange,
     openQuickNote,
     closeQuickNote,
+    meetingMode,
+    handleMeetingModeChange,
   } = useHandoffTimelineViewModel({ navState });
 
   return (
@@ -116,7 +118,36 @@ export default function HandoffTimelinePage() {
               午後〜夕方
             </ToggleButton>
           </ToggleButtonGroup>
+
+          {/* ミーティングモード切り替え */}
+          <ToggleButtonGroup
+            value={meetingMode}
+            exclusive
+            onChange={handleMeetingModeChange}
+            size="small"
+            color="primary"
+          >
+            {(Object.keys(MEETING_MODE_LABELS) as MeetingMode[]).map(mode => (
+              <ToggleButton key={mode} value={mode}>
+                {MEETING_MODE_LABELS[mode]}
+              </ToggleButton>
+            ))}
+          </ToggleButtonGroup>
         </Box>
+
+        {/* モード別サブヘッダー */}
+        {meetingMode !== 'normal' && (
+          <Alert
+            severity="info"
+            sx={{ mt: 1.5 }}
+            icon={meetingMode === 'evening' ? <EveningIcon /> : <MorningIcon />}
+          >
+            {meetingMode === 'evening'
+              ? '🌆 夕会モード: 未対応の申し送りを確認し、「確認済」「明日へ」「完了」を選択してください'
+              : '🌅 朝会モード: 昨日からの持越事項を確認し、処理完了したら「完了」を押してください'
+            }
+          </Alert>
+        )}
 
         {handoffStats && (
           <Box
@@ -217,6 +248,7 @@ export default function HandoffTimelinePage() {
           <TodayHandoffTimelineList
             timeFilter={timeFilter}
             dayScope={dayScope}
+            meetingMode={meetingMode}
             onStatsChange={setHandoffStats}
           />
         </Box>


### PR DESCRIPTION
## 概要
夕会→朝会の業務フローとして申し送りを昇格。既存UI3層分離・Fortress思想を維持。

## 状態遷移
```
[新規] → 未対応 → 確認済 → 明日へ持越 → 完了 (夕会→朝会フロー)
              ↘ 対応中 → 対応済           (従来フロー)
              確認済 → 完了               (その場で解決)
```

## 変更内容

### Type層 (`handoffTypes.ts`)
- 6ステータス: 未対応/対応中/対応済/確認済/明日へ持越/完了
- `MeetingMode`: normal / evening / morning
- `getAllowedActions(status, mode)`: 単一関数でUI分岐を制御
- `isTerminalStatus()`: 対応済 || 完了
- `formatYmdLocal()` / `getYesterdayYmd()`: JST安全日付

### API層
- `useHandoffTimeline`: `updateHandoffStatus` → `HandoffStatusUpdate` (carryOverDate同時セット)
- `handoffApi`: `CarryOverDateStore` (SP列未追加期間のローカル補完)
- `useHandoffSummary`: 6ステータス対応 + `isTerminalStatus` ベースの criticalCount

### ViewModel層 (`useHandoffTimelineViewModel.ts`)
- `meetingMode` state + `handleMeetingModeChange`
- ワークフローアクション: `markReviewed`, `markCarryOver`, `markClosed` (全てガード付き)

### UI層
- `HandoffTimelinePage`: MeetingMode ToggleButtonGroup + モード別Alertサブヘッダー
- `TodayHandoffTimelineList`: モード別アクションボタン + stats拡張 (reviewed/carryOver)

## テスト
- `handoffWorkflow.spec.ts`: **20/20** ✅ (getAllowedActions全パターン、isTerminalStatus、getNextStatus退行)
- `useHandoffTimelineViewModel.spec.ts`: **9/9** ✅ (meetingMode初期値/切替、ワークフローアクションガード)
- TypeCheck: 新規エラーなし

## 次セッション
- E2Eテスト: 夕会→朝会 happy path