### PR TITLE
feat: /today ⇄ /dailysupport 双方向ナビゲーション

### DIFF
--- a/src/app/links/__tests__/navigationLinks.test.ts
+++ b/src/app/links/__tests__/navigationLinks.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import {
+    buildDailyHubFromTodayUrl,
+    buildTodayReturnUrl,
+    parseNavQuery,
+} from '../navigationLinks';
+
+// ---------------------------------------------------------------------------
+// navigationLinks — ユニットテスト
+// ---------------------------------------------------------------------------
+
+describe('buildDailyHubFromTodayUrl', () => {
+  it('日付なしで from=today のみ', () => {
+    expect(buildDailyHubFromTodayUrl()).toBe('/dailysupport?from=today');
+  });
+
+  it('日付ありで from + date を付与', () => {
+    expect(buildDailyHubFromTodayUrl('2026-02-28')).toBe(
+      '/dailysupport?from=today&date=2026-02-28',
+    );
+  });
+
+  it('空文字の date は無視される', () => {
+    expect(buildDailyHubFromTodayUrl('  ')).toBe('/dailysupport?from=today');
+  });
+});
+
+describe('buildTodayReturnUrl', () => {
+  it('日付なしではクエリなし', () => {
+    expect(buildTodayReturnUrl()).toBe('/today');
+  });
+
+  it('日付ありで date を付与', () => {
+    expect(buildTodayReturnUrl('2026-02-28')).toBe('/today?date=2026-02-28');
+  });
+
+  it('空文字の date は無視される', () => {
+    expect(buildTodayReturnUrl('')).toBe('/today');
+  });
+});
+
+describe('parseNavQuery', () => {
+  it('from=today & date を正しくパースする', () => {
+    const params = new URLSearchParams('from=today&date=2026-02-28');
+    expect(parseNavQuery(params)).toEqual({
+      from: 'today',
+      date: '2026-02-28',
+    });
+  });
+
+  it('空のパラメータは undefined を返す', () => {
+    const params = new URLSearchParams('');
+    expect(parseNavQuery(params)).toEqual({
+      from: undefined,
+      date: undefined,
+    });
+  });
+
+  it('許可リスト外の from は undefined にする', () => {
+    const params = new URLSearchParams('from=unknown&date=2026-02-28');
+    expect(parseNavQuery(params)).toEqual({
+      from: undefined,
+      date: '2026-02-28',
+    });
+  });
+
+  it('date のみ（from なし）', () => {
+    const params = new URLSearchParams('date=2026-02-28');
+    expect(parseNavQuery(params)).toEqual({
+      from: undefined,
+      date: '2026-02-28',
+    });
+  });
+});

--- a/src/app/links/dailyLinks.ts
+++ b/src/app/links/dailyLinks.ts
@@ -1,0 +1,19 @@
+// ---------------------------------------------------------------------------
+// dailyLinks — /daily/* 系 URL の一元管理
+//
+// ルーティング変更に耐性を持たせるため、ハードコード navigate を避け
+// このモジュール経由でパスを参照する。
+// ---------------------------------------------------------------------------
+
+export const dailyPaths = {
+  hub:              '/dailysupport',
+  activity:         '/daily/activity',
+  table:            '/daily/table',
+  attendance:       '/daily/attendance',
+  support:          '/daily/support',
+  supportChecklist: '/daily/support-checklist',
+  timeBased:        '/daily/time-based',
+  health:           '/daily/health',
+} as const;
+
+export type DailyPathKey = keyof typeof dailyPaths;

--- a/src/app/links/navigationLinks.ts
+++ b/src/app/links/navigationLinks.ts
@@ -1,0 +1,78 @@
+// ---------------------------------------------------------------------------
+// navigationLinks — Hub 間遷移用の URL ビルダー
+//
+// /today (Ops Hub) ⇄ /dailysupport (Records Hub) の双方向導線で使う。
+// query を手書きで散らさず、このモジュール経由で URL を組み立てる。
+//
+// ⚠️ Hub間遷移（/today ⇄ /dailysupport）でのみ使用。
+//    通常のページ遷移は dailyPaths（dailyLinks.ts）を使うこと。
+//
+// パターンは dailySupportLinks.ts と同一。
+// ---------------------------------------------------------------------------
+
+import { dailyPaths } from './dailyLinks';
+
+// ─── Query Key 定数 ────────────────────────────────────────────────────
+export const NAV_QUERY = {
+  from: 'from',
+  date: 'date',
+} as const;
+
+/** 許可された遷移元。union を拡張するには allowedFrom にも追加すること。 */
+export type NavFrom = 'today';
+
+const allowedFrom = new Set<NavFrom>(['today']);
+
+// ─── Builders ──────────────────────────────────────────────────────────
+
+/**
+ * /dailysupport?from=today&date=YYYY-MM-DD を生成する。
+ * /today → /dailysupport への導線で使用。
+ */
+export function buildDailyHubFromTodayUrl(date?: string): string {
+  const base = dailyPaths.hub;
+  const search = new URLSearchParams();
+  search.set(NAV_QUERY.from, 'today');
+
+  const trimmed = date?.trim();
+  if (trimmed) {
+    search.set(NAV_QUERY.date, trimmed);
+  }
+
+  return `${base}?${search.toString()}`;
+}
+
+/**
+ * /today?date=YYYY-MM-DD を生成する。
+ * /dailysupport → /today への戻り導線で使用。
+ */
+export function buildTodayReturnUrl(date?: string): string {
+  const base = '/today';
+  const trimmed = date?.trim();
+  if (!trimmed) return base;
+
+  const search = new URLSearchParams();
+  search.set(NAV_QUERY.date, trimmed);
+  return `${base}?${search.toString()}`;
+}
+
+// ─── Parser ────────────────────────────────────────────────────────────
+
+/**
+ * URLSearchParams から from / date を安全にパースする。
+ * 許可リスト外の from は undefined として扱う。
+ */
+export function parseNavQuery(params: URLSearchParams): {
+  from: NavFrom | undefined;
+  date: string | undefined;
+} {
+  const rawFrom = params.get(NAV_QUERY.from);
+  const from = rawFrom && allowedFrom.has(rawFrom as NavFrom)
+    ? (rawFrom as NavFrom)
+    : undefined;
+
+  const rawDate = params.get(NAV_QUERY.date)?.trim();
+  const date = rawDate || undefined;
+
+  return { from, date };
+}

--- a/src/features/today/layouts/TodayOpsLayout.tsx
+++ b/src/features/today/layouts/TodayOpsLayout.tsx
@@ -20,6 +20,7 @@ type HeroProps = {
   approvalPendingCount: number;
   onOpenUnfilled: () => void;
   onOpenApproval: () => void;
+  onOpenMenu?: () => void;
 };
 
 type TransportUser = { userId: string; name: string };
@@ -46,6 +47,7 @@ export const TodayOpsLayout: React.FC<TodayOpsProps> = ({
         unfilledCount={hero.unfilledCount}
         approvalPendingCount={hero.approvalPendingCount}
         onClickPrimary={hero.onOpenUnfilled}
+        onClickSecondary={hero.onOpenMenu}
         sticky={true}
       />
 

--- a/src/features/today/widgets/HeroUnfinishedBanner.spec.tsx
+++ b/src/features/today/widgets/HeroUnfinishedBanner.spec.tsx
@@ -65,4 +65,32 @@ describe('HeroUnfinishedBanner', () => {
     // 関数が正しく呼び出されたか
     expect(handleClick).toHaveBeenCalledTimes(1);
   });
+
+  it('renders secondary button when onClickSecondary is provided', () => {
+    const handleSecondary = vi.fn();
+    render(
+      <HeroUnfinishedBanner
+        unfilledCount={2}
+        onClickPrimary={() => {}}
+        onClickSecondary={handleSecondary}
+      />
+    );
+
+    const menuBtn = screen.getByRole('button', { name: /記録メニュー/ });
+    expect(menuBtn).toBeInTheDocument();
+
+    fireEvent.click(menuBtn);
+    expect(handleSecondary).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render secondary button when onClickSecondary is omitted (backward compat)', () => {
+    render(
+      <HeroUnfinishedBanner
+        unfilledCount={2}
+        onClickPrimary={() => {}}
+      />
+    );
+
+    expect(screen.queryByRole('button', { name: /記録メニュー/ })).not.toBeInTheDocument();
+  });
 });

--- a/src/features/today/widgets/HeroUnfinishedBanner.tsx
+++ b/src/features/today/widgets/HeroUnfinishedBanner.tsx
@@ -5,6 +5,8 @@ export type HeroUnfinishedBannerProps = {
   unfilledCount: number;
   approvalPendingCount?: number;
   onClickPrimary: () => void;
+  /** 「記録メニュー」への導線。undefined なら非表示（後方互換）。 */
+  onClickSecondary?: () => void;
   sticky?: boolean;
 };
 
@@ -12,6 +14,7 @@ export const HeroUnfinishedBanner: React.FC<HeroUnfinishedBannerProps> = ({
   unfilledCount,
   approvalPendingCount = 0,
   onClickPrimary,
+  onClickSecondary,
   sticky = true,
 }) => {
   const isComplete = unfilledCount === 0 && approvalPendingCount === 0;
@@ -50,20 +53,39 @@ export const HeroUnfinishedBanner: React.FC<HeroUnfinishedBannerProps> = ({
       )}
 
       {!isComplete && (
-        <Button
-          data-testid="today-hero-cta"
-          variant="contained"
-          color="inherit"
-          onClick={onClickPrimary}
-          sx={{
-            color: 'error.main',
-            fontWeight: 'bold',
-            minHeight: 44, // タッチデバイス向けの最小タップ領域
-            px: 2,
-          }}
-        >
-          今すぐ入力
-        </Button>
+        <Box sx={{ display: 'flex', gap: 1 }}>
+          <Button
+            data-testid="today-hero-cta"
+            variant="contained"
+            color="inherit"
+            onClick={onClickPrimary}
+            sx={{
+              color: 'error.main',
+              fontWeight: 'bold',
+              minHeight: 44,
+              px: 2,
+            }}
+          >
+            今すぐ入力
+          </Button>
+
+          {onClickSecondary && (
+            <Button
+              data-testid="today-hero-menu"
+              variant="outlined"
+              color="inherit"
+              onClick={onClickSecondary}
+              sx={{
+                fontWeight: 'bold',
+                minHeight: 44,
+                px: 2,
+                borderColor: 'rgba(255,255,255,0.5)',
+              }}
+            >
+              📋 記録メニュー
+            </Button>
+          )}
+        </Box>
       )}
     </Box>
   );

--- a/src/pages/TodayOpsPage.tsx
+++ b/src/pages/TodayOpsPage.tsx
@@ -13,6 +13,7 @@
  *
  * @see docs/adr/ADR-002-today-execution-layer-guardrails.md
  */
+import { buildDailyHubFromTodayUrl } from '@/app/links/navigationLinks';
 import { useTodaySummary } from '@/features/today/domain';
 import { useNextAction } from '@/features/today/hooks/useNextAction';
 import { TodayOpsLayout } from '@/features/today/layouts/TodayOpsLayout';
@@ -20,8 +21,11 @@ import { QuickRecordDrawer } from '@/features/today/records/QuickRecordDrawer';
 import { useQuickRecord } from '@/features/today/records/useQuickRecord';
 import { isE2E } from '@/lib/env';
 import React, { useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 export const TodayOpsPage: React.FC = () => {
+  const navigate = useNavigate();
+
   // 1. Data via Facade (Execution Layer はドメイン集約を持たない)
   const summary = useTodaySummary();
 
@@ -72,6 +76,10 @@ export const TodayOpsPage: React.FC = () => {
         onOpenApproval: () => {
           // eslint-disable-next-line no-console
           console.log('Open Approval Modal');
+        },
+        onOpenMenu: () => {
+          const today = new Date().toISOString().split('T')[0];
+          navigate(buildDailyHubFromTodayUrl(today));
         },
       },
       attendance: {

--- a/src/pages/__tests__/DailyRecordMenuPage.test.tsx
+++ b/src/pages/__tests__/DailyRecordMenuPage.test.tsx
@@ -1,0 +1,113 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// DailyRecordMenuPage — 回帰防止テスト
+//
+// 「件数表示が出る」「モック % が出ない」をガードする最小テスト。
+// ---------------------------------------------------------------------------
+
+// Mock react-router-dom
+const mockNavigate = vi.fn();
+let mockSearchParams = new URLSearchParams('');
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+  useSearchParams: () => [mockSearchParams],
+}));
+
+// Mock useAttendanceStore
+vi.mock('@/features/attendance/store', () => ({
+  useAttendanceStore: () => ({ visits: {} }),
+}));
+
+// Mock useUsersDemo with IsSupportProcedureTarget users
+vi.mock('@/features/users/usersStoreDemo', () => ({
+  useUsersDemo: () => ({
+    data: [
+      { Id: 1, UserID: 'U001', DisplayName: 'テスト太郎', IsSupportProcedureTarget: false },
+      { Id: 2, UserID: 'U002', DisplayName: 'テスト花子', IsSupportProcedureTarget: true },
+      { Id: 3, UserID: 'U003', DisplayName: 'テスト次郎', IsSupportProcedureTarget: true },
+    ],
+  }),
+}));
+
+// Suppress MUI container warnings
+vi.mock('@mui/material/Container', () => ({
+  default: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+    <div {...props}>{children}</div>
+  ),
+}));
+
+import DailyRecordMenuPage from '@/pages/DailyRecordMenuPage';
+
+describe('DailyRecordMenuPage — 統計パネル回帰防止', () => {
+  it('件数表示（件）がレンダされる', () => {
+    render(<DailyRecordMenuPage />);
+
+    const statsPanel = screen.getByTestId('daily-stats-summary');
+
+    // "件" 表記が統計パネル内に存在する
+    expect(statsPanel.textContent).toMatch(/\d+件/);
+  });
+
+  it('モック % 表示が存在しない', () => {
+    render(<DailyRecordMenuPage />);
+
+    const statsPanel = screen.getByTestId('daily-stats-summary');
+
+    // "% 完了" が統計パネル内に無い
+    expect(statsPanel.textContent).not.toContain('% 完了');
+  });
+
+  it('件数ラベルが正しい', () => {
+    render(<DailyRecordMenuPage />);
+
+    const statsPanel = screen.getByTestId('daily-stats-summary');
+
+    expect(statsPanel.textContent).toContain('未入力');
+    expect(statsPanel.textContent).toContain('要確認');
+    expect(statsPanel.textContent).toContain('未記入');
+  });
+
+  it('data-testid が各セクションに存在する', () => {
+    render(<DailyRecordMenuPage />);
+
+    expect(screen.getByTestId('daily-stats-activity')).toBeInTheDocument();
+    expect(screen.getByTestId('daily-stats-attendance')).toBeInTheDocument();
+    expect(screen.getByTestId('daily-stats-support')).toBeInTheDocument();
+  });
+});
+
+describe('DailyRecordMenuPage — /today からの戻り導線', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  it('from=today のとき「今日の運用へ戻る」ボタンが表示される', () => {
+    mockSearchParams = new URLSearchParams('from=today&date=2026-02-28');
+    render(<DailyRecordMenuPage />);
+
+    const returnBtn = screen.getByTestId('daily-hub-return-today');
+    expect(returnBtn).toBeInTheDocument();
+    expect(returnBtn.textContent).toContain('今日の運用へ戻る');
+  });
+
+  it('戻るボタンをクリックすると /today に navigate する', () => {
+    mockSearchParams = new URLSearchParams('from=today&date=2026-02-28');
+    render(<DailyRecordMenuPage />);
+
+    const returnBtn = screen.getByTestId('daily-hub-return-today');
+    fireEvent.click(returnBtn);
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith('/today?date=2026-02-28');
+  });
+
+  it('from が無いとき戻るボタンは表示されない', () => {
+    mockSearchParams = new URLSearchParams('');
+    render(<DailyRecordMenuPage />);
+
+    expect(screen.queryByTestId('daily-hub-return-today')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要

`/today`（Ops Hub）と `/dailysupport`（Records Hub）の間に、`from` + `date` query による双方向導線を追加。

### 設計方針
- `/today` は基本「その場で QuickRecord」で自己完結
- 例外として「記録の種類選択が必要なときだけ /dailysupport に逃がす」
- 逃がした場合は必ず `/today` に戻れる（`from` + `date` を保持）

## 変更内容

### PR-A: Link Builders
- `navigationLinks.ts`: Hub間遷移用URLビルダー + `parseNavQuery`（`allowedFrom` ガード付き）
- `dailyLinks.ts`: `/daily/*` パス定数（既存コード統合）

### PR-B: /today Hero Secondary Button
- `HeroUnfinishedBanner`: `onClickSecondary?` で「📋 記録メニュー」ボタン追加（後方互換）
- `TodayOpsLayout` / `TodayOpsPage`: `onOpenMenu` → `navigate(buildDailyHubFromTodayUrl)`

### PR-C: /dailysupport Return Button
- `DailyRecordMenuPage`: `from=today` 検知 → 「← 今日の運用へ戻る」条件付き表示
- `from` が無い通常導線（サイドバー等）では戻るボタンを出さない

## テスト

| File | Tests | Result |
|------|-------|--------|
| `navigationLinks.test.ts` | 10 | ✅ |
| `HeroUnfinishedBanner.spec.tsx` | 6 | ✅ |
| `DailyRecordMenuPage.test.tsx` | 7 | ✅ |
| **Total** | **23** | **All pass** |

## 安全性
- `allowedFrom` Set で未知の `from` を reject
- `date?.trim()` で空文字排除
- Hero Secondary は optional（後方互換）
- 戻るボタンは `from=today` のときだけ表示（挙動のブレ防止）
