### PR TITLE
P2-2: Staff Attendance Write UI Enhancement (port-backed CRUD)

### DIFF
--- a/src/features/staff/attendance/StaffAttendanceInput.tsx
+++ b/src/features/staff/attendance/StaffAttendanceInput.tsx
@@ -1,101 +1,323 @@
-import { useStaffAttendanceStore } from './store';
-import type { StaffAttendanceStatus } from './types';
-import { canAccess } from '@/auth/roles';
-import { useUserAuthz } from '@/auth/useUserAuthz';
+/**
+ * StaffAttendanceInput — Write UI
+ *
+ * P2-2: 同期ストア + ポーリングを削除し、
+ * useStaffAttendanceWrite (async port-backed) に全面移行。
+ *
+ * - 表示: hook の items
+ * - 更新: hook の upsertOne
+ * - 編集: StaffAttendanceEditDialog
+ * - 一括: StaffAttendanceBulkInputDrawer + useStaffAttendanceBulk
+ */
+import { useMemo, useState } from 'react';
+
+import EditIcon from '@mui/icons-material/Edit';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import {
+    Alert,
+    Box,
+    Button,
+    Checkbox,
+    CircularProgress,
+    Stack,
+    Table,
+    TableBody,
+    TableCell,
+    TableContainer,
+    TableHead,
+    TableRow,
+    ToggleButton,
+    ToggleButtonGroup,
+    Typography,
+} from '@mui/material';
+
 import { useStaff } from '@/stores/useStaff';
-import Box from '@mui/material/Box';
-import Paper from '@mui/material/Paper';
-import Stack from '@mui/material/Stack';
-import ToggleButton from '@mui/material/ToggleButton';
-import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
-import Typography from '@mui/material/Typography';
-import { useEffect, useState } from 'react';
+import { StaffAttendanceBulkInputDrawer } from './components/StaffAttendanceBulkInputDrawer';
+import { StaffAttendanceEditDialog } from './components/StaffAttendanceEditDialog';
+import { useStaffAttendanceBulk } from './hooks/useStaffAttendanceBulk';
+import { useStaffAttendanceWrite } from './hooks/useStaffAttendanceWrite';
+import type { StaffAttendance, StaffAttendanceStatus } from './types';
+
+const STATUS_OPTIONS: StaffAttendanceStatus[] = ['出勤', '欠勤', '外出中'];
+
+/**
+ * ISO datetime → "HH:MM" (JST)
+ */
+function formatTimeLike(v?: string | null): string {
+  if (!v) return '';
+  try {
+    const d = new Date(v);
+    if (Number.isNaN(d.getTime())) return String(v);
+    return d.toLocaleTimeString('ja-JP', {
+      hour: '2-digit',
+      minute: '2-digit',
+      timeZone: 'Asia/Tokyo',
+    });
+  } catch {
+    return String(v);
+  }
+}
 
 export const StaffAttendanceInput: React.FC = () => {
+  const today = useMemo(() => new Date().toISOString().slice(0, 10), []);
   const { staff } = useStaff();
-  const { role, ready } = useUserAuthz();
-  const today = new Date().toISOString().slice(0, 10);
-  const canUpdateAttendance = ready && canAccess(role, 'reception');
 
-  const [attendances, setAttendances] = useState(() => {
-    const store = useStaffAttendanceStore();
-    return store.listByDate(today);
-  });
+  const {
+    items,
+    isLoading,
+    error,
+    reload,
+    saving,
+    upsertOne,
+    writeEnabled,
+    readOnlyReason,
+    port,
+  } = useStaffAttendanceWrite(today);
 
-  const handleStatusChange = (staffId: string, status: StaffAttendanceStatus) => {
-    if (!canUpdateAttendance) {
-      return;
-    }
-    const store = useStaffAttendanceStore();
-    store.upsert({ staffId, recordDate: today, status });
-    setAttendances(store.listByDate(today));
+  // ── Merged rows: staff master × attendance items ──
+  // 全職員を表示し、attendance がある場合は status を埋める
+  const rows = useMemo(() => {
+    const attendanceMap = new Map(items.map((a) => [a.staffId, a]));
+
+    return staff.map((s): StaffAttendance & { staffName: string } => {
+      const att = attendanceMap.get(s.staffId);
+      return {
+        staffId: s.staffId,
+        recordDate: today,
+        status: att?.status ?? '出勤',
+        checkInAt: att?.checkInAt,
+        checkOutAt: att?.checkOutAt,
+        lateMinutes: att?.lateMinutes,
+        note: att?.note,
+        isFinalized: att?.isFinalized,
+        finalizedAt: att?.finalizedAt,
+        finalizedBy: att?.finalizedBy,
+        staffName: s.name,
+      };
+    });
+  }, [items, staff, today]);
+
+  // ── Edit dialog ──
+  const [editOpen, setEditOpen] = useState(false);
+  const [editItem, setEditItem] = useState<StaffAttendance | null>(null);
+
+  const openEdit = (row: StaffAttendance) => {
+    setEditItem(row);
+    setEditOpen(true);
   };
 
-  // 他のコンポーネントからの変更を反映（1秒ごとにポーリング）
-  useEffect(() => {
-    const interval = setInterval(() => {
-      const store = useStaffAttendanceStore();
-      setAttendances(store.listByDate(today));
-    }, 1000);
-    return () => clearInterval(interval);
-  }, [today]);
+  const closeEdit = () => {
+    setEditOpen(false);
+    setEditItem(null);
+  };
+
+  const handleEditSave = async (next: StaffAttendance) => {
+    await upsertOne(next);
+    closeEdit();
+  };
+
+  // ── Bulk input ──
+  const refetch = async () => {
+    await reload();
+  };
+  const bulk = useStaffAttendanceBulk({
+    port,
+    recordDate: today,
+    items,
+    refetch,
+    writeEnabled,
+    readOnlyReason,
+  });
+
+  // ── Status toggle ──
+  const handleChangeStatus = async (row: StaffAttendance, nextStatus: string | null) => {
+    if (!nextStatus) return;
+    await upsertOne({ ...row, status: nextStatus as StaffAttendanceStatus });
+  };
 
   return (
-    <Paper sx={{ p: 3 }}>
-      <Typography variant="h6" sx={{ mb: 2, fontWeight: 700 }}>
-        職員勤怠入力（{today}）
-      </Typography>
-      <Stack spacing={2}>
-        {staff.map((s) => {
-          const att = attendances.find((a) => a.staffId === s.staffId);
-          return (
-            <Box
-              key={s.id}
-              sx={{
-                display: 'flex',
-                gap: 2,
-                alignItems: 'center',
-                flexWrap: 'wrap',
-              }}
+    <Stack spacing={2} data-testid="staff-attendance-input-write">
+      {/* Header */}
+      <Box display="flex" alignItems="center" justifyContent="space-between" gap={2} flexWrap="wrap">
+        <Stack spacing={0.5}>
+          <Typography variant="h6" sx={{ fontWeight: 700 }}>
+            職員勤怠入力（{today}）
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            件数: {rows.length}
+          </Typography>
+        </Stack>
+
+        <Box display="flex" gap={1}>
+          <Button
+            startIcon={<RefreshIcon />}
+            onClick={() => void reload()}
+            disabled={isLoading || saving}
+            data-testid="staff-attendance-write-reload"
+          >
+            再読み込み
+          </Button>
+
+          <Button
+            variant={bulk.bulkMode ? 'contained' : 'outlined'}
+            onClick={bulk.toggleBulkMode}
+            disabled={!writeEnabled || isLoading}
+            data-testid="staff-attendance-write-bulk-toggle"
+          >
+            {bulk.bulkMode ? '選択解除' : '一括入力'}
+          </Button>
+
+          {bulk.bulkMode && bulk.selectedCount > 0 && (
+            <Button
+              variant="contained"
+              onClick={bulk.openDrawer}
+              disabled={!writeEnabled}
+              data-testid="staff-attendance-write-bulk-open"
             >
-              <Typography sx={{ minWidth: 120, fontWeight: 600 }}>
-                {s.name}
-              </Typography>
-              <ToggleButtonGroup
-                value={att?.status || ''}
-                exclusive
-                size="small"
-                onChange={(_, val) => val && handleStatusChange(s.staffId, val)}
-                disabled={!canUpdateAttendance}
-                aria-label={`${s.name}の勤怠状態`}
-                data-testid={`staff-attendance-toggle-${s.staffId}`}
-              >
-                <ToggleButton
-                  value="出勤"
-                  aria-label="出勤"
-                  data-testid={`staff-attendance-status-${s.staffId}-present`}
-                >
-                  出勤
-                </ToggleButton>
-                <ToggleButton
-                  value="欠勤"
-                  aria-label="欠勤"
-                  data-testid={`staff-attendance-status-${s.staffId}-absent`}
-                >
-                  欠勤
-                </ToggleButton>
-                <ToggleButton
-                  value="外出中"
-                  aria-label="外出中"
-                  data-testid={`staff-attendance-status-${s.staffId}-away`}
-                >
-                  外出
-                </ToggleButton>
-              </ToggleButtonGroup>
-            </Box>
-          );
-        })}
-      </Stack>
-    </Paper>
+              適用（{bulk.selectedCount}件）
+            </Button>
+          )}
+        </Box>
+      </Box>
+
+      {/* Alerts */}
+      {!writeEnabled && (
+        <Alert severity="info" data-testid="staff-attendance-write-readonly">
+          {readOnlyReason ?? '読み取り専用モードです。'}
+        </Alert>
+      )}
+
+      {error && (
+        <Alert severity="error" data-testid="staff-attendance-write-error">
+          {error}
+        </Alert>
+      )}
+
+      {/* Loading */}
+      {isLoading ? (
+        <Box display="flex" justifyContent="center" py={4} data-testid="staff-attendance-write-loading">
+          <CircularProgress size={32} />
+        </Box>
+      ) : (
+        /* Table */
+        <TableContainer data-testid="staff-attendance-write-table">
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                {bulk.bulkMode && <TableCell padding="checkbox" />}
+                <TableCell sx={{ fontWeight: 700 }}>職員名</TableCell>
+                <TableCell sx={{ fontWeight: 700 }}>ステータス</TableCell>
+                <TableCell sx={{ fontWeight: 700 }}>出勤時刻</TableCell>
+                <TableCell sx={{ fontWeight: 700 }}>メモ</TableCell>
+                <TableCell sx={{ fontWeight: 700 }} align="right">操作</TableCell>
+              </TableRow>
+            </TableHead>
+
+            <TableBody>
+              {rows.map((row) => (
+                <TableRow key={row.staffId} data-testid={`staff-attendance-write-row-${row.staffId}`}>
+                  {bulk.bulkMode && (
+                    <TableCell padding="checkbox">
+                      <Checkbox
+                        checked={bulk.selectedIds.has(row.staffId)}
+                        onChange={() => bulk.toggleSelect(row.staffId)}
+                        data-testid={`staff-attendance-write-check-${row.staffId}`}
+                      />
+                    </TableCell>
+                  )}
+
+                  <TableCell>
+                    <Stack>
+                      <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                        {row.staffName || row.staffId}
+                      </Typography>
+                      {row.staffName && (
+                        <Typography variant="caption" color="text.secondary">
+                          {row.staffId}
+                        </Typography>
+                      )}
+                    </Stack>
+                  </TableCell>
+
+                  <TableCell>
+                    <ToggleButtonGroup
+                      size="small"
+                      exclusive
+                      value={row.status}
+                      onChange={(_, next) => void handleChangeStatus(row, next)}
+                      disabled={!writeEnabled || saving}
+                      aria-label={`${row.staffName ?? row.staffId}の勤怠状態`}
+                      data-testid={`staff-attendance-toggle-${row.staffId}`}
+                    >
+                      {STATUS_OPTIONS.map((opt) => (
+                        <ToggleButton key={opt} value={opt} aria-label={opt}>
+                          {opt}
+                        </ToggleButton>
+                      ))}
+                    </ToggleButtonGroup>
+                  </TableCell>
+
+                  <TableCell>
+                    <Typography variant="body2" color="text.secondary">
+                      {formatTimeLike(row.checkInAt)}
+                    </Typography>
+                  </TableCell>
+
+                  <TableCell
+                    sx={{
+                      maxWidth: 200,
+                      whiteSpace: 'nowrap',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                    }}
+                    title={row.note ?? ''}
+                  >
+                    <Typography variant="body2" color="text.secondary" noWrap>
+                      {row.note || '—'}
+                    </Typography>
+                  </TableCell>
+
+                  <TableCell align="right">
+                    <Button
+                      size="small"
+                      startIcon={<EditIcon />}
+                      onClick={() => openEdit(row)}
+                      disabled={!writeEnabled || saving}
+                      data-testid={`staff-attendance-edit-${row.staffId}`}
+                    >
+                      編集
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+
+      {/* Edit Dialog */}
+      <StaffAttendanceEditDialog
+        open={editOpen}
+        recordDate={today}
+        initial={editItem}
+        onClose={closeEdit}
+        onSave={handleEditSave}
+        saving={saving}
+        writeEnabled={writeEnabled}
+      />
+
+      {/* Bulk Input Drawer */}
+      <StaffAttendanceBulkInputDrawer
+        open={bulk.drawerOpen}
+        selectedCount={bulk.selectedCount}
+        saving={bulk.saving}
+        error={bulk.error}
+        onClose={bulk.closeDrawer}
+        writeEnabled={writeEnabled}
+        value={bulk.value}
+        onChange={bulk.setValue}
+        onSave={bulk.bulkSave}
+      />
+    </Stack>
   );
 };

--- a/src/features/staff/attendance/__tests__/useStaffAttendanceWrite.spec.ts
+++ b/src/features/staff/attendance/__tests__/useStaffAttendanceWrite.spec.ts
@@ -1,0 +1,164 @@
+import { result } from '@/shared/result';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { StaffAttendance } from '../types';
+
+// ── Mocks ──
+
+const mockListByDate = vi.fn();
+const mockUpsert = vi.fn();
+
+vi.mock('../storage', () => ({
+  getStaffAttendancePort: () => ({
+    listByDate: mockListByDate,
+    upsert: mockUpsert,
+    remove: vi.fn(),
+    getByKey: vi.fn(),
+    listByDateRange: vi.fn(),
+    countByDate: vi.fn(),
+    finalizeDay: vi.fn(),
+    unfinalizeDay: vi.fn(),
+    getDayFinalizedState: vi.fn(),
+  }),
+  getStaffAttendanceStorageKind: () => 'local',
+  getStaffAttendanceWriteEnabled: () => true,
+}));
+
+// Import AFTER mocks
+import { useStaffAttendanceWrite } from '../hooks/useStaffAttendanceWrite';
+
+const mkAtt = (staffId: string, status: StaffAttendance['status'] = '出勤'): StaffAttendance => ({
+  staffId,
+  recordDate: '2026-03-01',
+  status,
+});
+
+describe('useStaffAttendanceWrite', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: empty success
+    mockListByDate.mockResolvedValue(result.ok([]));
+    mockUpsert.mockResolvedValue(result.ok(undefined));
+  });
+
+  it('initial load: returns items from port.listByDate', async () => {
+    const items = [mkAtt('S001', '出勤'), mkAtt('S002', '欠勤')];
+    mockListByDate.mockResolvedValue(result.ok(items));
+
+    const { result: hookResult } = renderHook(() => useStaffAttendanceWrite('2026-03-01'));
+
+    expect(hookResult.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(hookResult.current.isLoading).toBe(false);
+    });
+
+    expect(hookResult.current.items).toEqual(items);
+    expect(hookResult.current.error).toBeNull();
+    expect(hookResult.current.storageKind).toBe('local');
+  });
+
+  it('upsertOne: calls port.upsert then reloads', async () => {
+    const initial = [mkAtt('S001', '出勤')];
+    mockListByDate.mockResolvedValue(result.ok(initial));
+
+    const { result: hookResult } = renderHook(() => useStaffAttendanceWrite('2026-03-01'));
+
+    await waitFor(() => {
+      expect(hookResult.current.isLoading).toBe(false);
+    });
+
+    const updated = [mkAtt('S001', '欠勤')];
+    mockListByDate.mockResolvedValue(result.ok(updated));
+
+    await act(async () => {
+      await hookResult.current.upsertOne({ ...initial[0], status: '欠勤' });
+    });
+
+    expect(mockUpsert).toHaveBeenCalledTimes(1);
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ staffId: 'S001', status: '欠勤' }),
+    );
+    // After upsert, reload was called (initial load + reload after upsert = at least 2)
+    expect(mockListByDate.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('saving: true while upsert is in-flight', async () => {
+    mockListByDate.mockResolvedValue(result.ok([mkAtt('S001')]));
+    mockUpsert.mockImplementation(
+      () => new Promise((resolve) => setTimeout(() => resolve(result.ok(undefined)), 50)),
+    );
+
+    const { result: hookResult } = renderHook(() => useStaffAttendanceWrite('2026-03-01'));
+
+    await waitFor(() => {
+      expect(hookResult.current.isLoading).toBe(false);
+    });
+
+    // Fire upsert but don't await (to observe saving=true)
+    let upsertPromise: Promise<void>;
+    act(() => {
+      upsertPromise = hookResult.current.upsertOne(mkAtt('S001', '欠勤'));
+    });
+
+    // saving should be true during flight
+    await waitFor(() => {
+      expect(hookResult.current.saving).toBe(true);
+    });
+
+    // Wait for completion
+    await act(async () => {
+      await upsertPromise!;
+    });
+
+    await waitFor(() => {
+      expect(hookResult.current.saving).toBe(false);
+    });
+  });
+
+  it('writeEnabled reflects config', async () => {
+    mockListByDate.mockResolvedValue(result.ok([]));
+
+    const { result: hookResult } = renderHook(() => useStaffAttendanceWrite('2026-03-01'));
+
+    await waitFor(() => {
+      expect(hookResult.current.isLoading).toBe(false);
+    });
+
+    expect(hookResult.current.writeEnabled).toBe(true);
+    expect(hookResult.current.readOnlyReason).toBeNull();
+  });
+
+  it('returns error on port.listByDate failure', async () => {
+    mockListByDate.mockResolvedValue(
+      result.forbidden('アクセス権限がありません。'),
+    );
+
+    const { result: hookResult } = renderHook(() => useStaffAttendanceWrite('2026-03-01'));
+
+    await waitFor(() => {
+      expect(hookResult.current.isLoading).toBe(false);
+    });
+
+    expect(hookResult.current.items).toEqual([]);
+    expect(hookResult.current.error).toBe('アクセス権限がありません。');
+  });
+
+  it('returns error on upsert failure', async () => {
+    mockListByDate.mockResolvedValue(result.ok([mkAtt('S001')]));
+
+    const { result: hookResult } = renderHook(() => useStaffAttendanceWrite('2026-03-01'));
+
+    await waitFor(() => {
+      expect(hookResult.current.isLoading).toBe(false);
+    });
+
+    mockUpsert.mockResolvedValueOnce(result.unknown('保存に失敗しました'));
+
+    await act(async () => {
+      await hookResult.current.upsertOne(mkAtt('S001', '欠勤'));
+    });
+
+    expect(hookResult.current.error).toBeTruthy();
+  });
+});

--- a/src/features/staff/attendance/hooks/useStaffAttendanceWrite.ts
+++ b/src/features/staff/attendance/hooks/useStaffAttendanceWrite.ts
@@ -1,0 +1,139 @@
+/**
+ * useStaffAttendanceWrite
+ *
+ * Read + Write façade for staff attendance.
+ * - Read side: port.listByDate() (same pattern as useStaffAttendanceDay)
+ * - Write side: port.upsert() → auto-reload
+ *
+ * UI は port を直接触らず、この hook 経由で全 CRUD を行う。
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import type { StaffAttendancePort } from '../port';
+import { getStaffAttendancePort, getStaffAttendanceStorageKind, getStaffAttendanceWriteEnabled } from '../storage';
+import type { StaffAttendance } from '../types';
+
+export type UseStaffAttendanceWriteReturn = {
+  items: StaffAttendance[];
+  isLoading: boolean;
+  error: string | null;
+  reload: () => void;
+  storageKind: string;
+
+  saving: boolean;
+  upsertOne: (next: StaffAttendance) => Promise<void>;
+
+  writeEnabled: boolean;
+  readOnlyReason: string | null;
+
+  /** Port instance — useStaffAttendanceBulk が直接必要とする */
+  port: StaffAttendancePort;
+};
+
+/**
+ * Classify ResultError.kind → user-facing message (ja)
+ */
+const classifyError = (error: { kind: string; message?: string }): string => {
+  switch (error.kind) {
+    case 'forbidden':
+      return error.message || 'アクセス権限がありません。管理者に連絡してください。';
+    case 'not_found':
+      return error.message || 'データが見つかりません。';
+    case 'validation':
+      return error.message || '入力データに問題があります。';
+    case 'network':
+      return error.message || 'ネットワーク接続に問題があります。再試行してください。';
+    default:
+      return error.message || '予期しないエラーが発生しました。';
+  }
+};
+
+export function useStaffAttendanceWrite(date: string): UseStaffAttendanceWriteReturn {
+  const storageKind = getStaffAttendanceStorageKind();
+  const port = useMemo(() => getStaffAttendancePort(), []);
+
+  const writeEnabled = useMemo(() => getStaffAttendanceWriteEnabled(), []);
+  const readOnlyReason = useMemo(() => {
+    if (writeEnabled) return null;
+    return '書き込みが無効です（環境設定 / 権限 / 機能フラグをご確認ください）';
+  }, [writeEnabled]);
+
+  // ── Read state ──
+  const [items, setItems] = useState<StaffAttendance[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const res = await port.listByDate(date);
+
+      if (res.isOk) {
+        setItems(res.value);
+      } else {
+        setItems([]);
+        setError(classifyError(res.error));
+      }
+    } catch (e) {
+      setItems([]);
+      setError(e instanceof Error ? e.message : '予期しないエラーが発生しました。');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [date, port]);
+
+  // 初回 + date 変更時に自動取得
+  useEffect(() => {
+    void fetchData();
+  }, [fetchData]);
+
+  // ── Saving state ──
+  const inflight = useRef(0);
+  const [saving, setSaving] = useState(false);
+
+  const bumpSaving = useCallback((delta: 1 | -1) => {
+    inflight.current += delta;
+    setSaving(inflight.current > 0);
+  }, []);
+
+  // ── Write ──
+  const upsertOne = useCallback(
+    async (next: StaffAttendance) => {
+      if (!writeEnabled) return;
+
+      bumpSaving(1);
+      try {
+        const res = await port.upsert(next);
+        if (!res.isOk) {
+          setError(classifyError(res.error));
+          return;
+        }
+        // 書き込み成功 → 再取得
+        await fetchData();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : '保存中にエラーが発生しました。');
+      } finally {
+        bumpSaving(-1);
+      }
+    },
+    [bumpSaving, fetchData, port, writeEnabled],
+  );
+
+  return {
+    items,
+    isLoading,
+    error,
+    reload: fetchData,
+    storageKind,
+
+    saving,
+    upsertOne,
+
+    writeEnabled,
+    readOnlyReason,
+
+    port,
+  };
+}


### PR DESCRIPTION
## Summary

StaffAttendanceInput を同期 in-memory store + 1s polling から撤去し、port-backed CRUD（localStorage / SharePoint）に接続した書き込み UI に刷新。既存の EditDialog / BulkDrawer を配線し、ドメイン項目 checkInAt, note をテーブルに露出。

## Changes

- **[NEW]** `hooks/useStaffAttendanceWrite.ts`
  - read（port.listByDate）+ write（port.upsert）+ reload() を統合
  - saving / writeEnabled / readOnlyReason を提供
  - port が Result\<T\> 返却のため classifyError によりエラー統一
- **[REWRITE]** `StaffAttendanceInput.tsx`
  - useStaffAttendanceStore() 呼び出しと setInterval(..., 1000) polling を完全削除
  - Table UI: 職員名 | ステータス | 出勤時刻 | メモ | 操作
  - ステータス変更は upsertOne() 経由で永続化（refresh でも残る）
  - StaffAttendanceEditDialog / StaffAttendanceBulkInputDrawer を既存 props のまま配線
- **[NEW]** `__tests__/useStaffAttendanceWrite.spec.ts`（6 tests）

## Verification

- `tsc --noEmit` ✅
- `npx vitest run src/features/staff/attendance/__tests__/ --reporter=verbose` ✅
- 既存 13 + 新規 6 = **19 tests all pass**
- Manual (feature flag):
  - `localStorage.setItem('feature:staffAttendance', 'true'); location.reload();`
  - テーブル列が増えている（出勤時刻/メモ/操作）
  - Toggle / 編集 / 一括入力が保存され、ページ再読み込みでも保持される

## Why

- React のデータフロー外で同期 store を呼ぶアンチパターンと 1s polling を排除し、永続化と UI の一貫性を確保。
- 既存「完成済みコンポーネント」を配線して、欠けていた主要機能（edit / bulk / checkInAt / note）を実運用レベルに引き上げ。