### PR TITLE
feat(today): PR-3 Tabs layout + NextAction sticky + transport Accordion

### DIFF
--- a/src/features/today/hooks/deriveUrgency.spec.ts
+++ b/src/features/today/hooks/deriveUrgency.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { deriveUrgency } from './useNextAction';
+
+describe('deriveUrgency', () => {
+  // Boundary: exactly 10 → high
+  it('returns high when minutesUntil <= 10', () => {
+    expect(deriveUrgency(0)).toBe('high');
+    expect(deriveUrgency(5)).toBe('high');
+    expect(deriveUrgency(10)).toBe('high');
+  });
+
+  // Boundary: 11 → medium
+  it('returns medium when minutesUntil is 11-30', () => {
+    expect(deriveUrgency(11)).toBe('medium');
+    expect(deriveUrgency(20)).toBe('medium');
+    expect(deriveUrgency(30)).toBe('medium');
+  });
+
+  // Boundary: 31 → low
+  it('returns low when minutesUntil > 30', () => {
+    expect(deriveUrgency(31)).toBe('low');
+    expect(deriveUrgency(60)).toBe('low');
+    expect(deriveUrgency(120)).toBe('low');
+  });
+
+  // Edge: negative (past item, shouldn't happen but safe)
+  it('returns high for negative minutesUntil', () => {
+    expect(deriveUrgency(-1)).toBe('high');
+  });
+});

--- a/src/features/today/hooks/useNextAction.ts
+++ b/src/features/today/hooks/useNextAction.ts
@@ -24,11 +24,21 @@ export type NextActionItem = {
   minutesUntil: number;
 };
 
+export type Urgency = 'low' | 'medium' | 'high';
+
+/** minutesUntil → urgency 境界値（B層ロジック） */
+export function deriveUrgency(minutesUntil: number): Urgency {
+  if (minutesUntil <= 10) return 'high';
+  if (minutesUntil <= 30) return 'medium';
+  return 'low';
+}
+
 export type NextActionWithProgress = {
   item: NextActionItem | null;
   progress: NextActionProgress | null;
   progressKey: string | null;
   status: 'idle' | 'started' | 'done';
+  urgency: Urgency;
   elapsedMinutes: number | null;  // minutes since start (null if not started)
   actions: {
     start: () => void;
@@ -159,11 +169,15 @@ export function useNextAction(
     },
   }), [progressKey, progressStore]);
 
+  // Urgency: derived from minutesUntil (B層 pure logic)
+  const urgency: Urgency = nextItem ? deriveUrgency(nextItem.minutesUntil) : 'low';
+
   return {
     item: nextItem,
     progress,
     progressKey,
     status,
+    urgency,
     elapsedMinutes,
     actions,
   };

--- a/src/features/today/layouts/TodayOpsLayout.tsx
+++ b/src/features/today/layouts/TodayOpsLayout.tsx
@@ -1,19 +1,53 @@
 /**
  * TodayOpsLayout — 「今日の業務」画面レイアウト
  *
- * 左カラム: Hero → 出席サマリー → ブリーフィングアラート → 利用者一覧
- * 右カラム: 次のアクション → 送迎状況(P1)
+ * 左カラム: Hero(常時表示) → Tabs(出席 / ブリーフィング / 利用者)
+ * 右カラム: 次のアクション(sticky) → 送迎状況(Accordion)
+ *
+ * Layout state は view-only（tab index）に限定。
+ * データ集約・副作用は追加しない。
+ *
+ * @see docs/adr/ADR-002-today-execution-layer-guardrails.md
  */
 import type { BriefingAlert } from '@/features/dashboard/sections/types';
-import { Box, Container, Grid, Paper, Stack, Typography } from '@mui/material';
-import React from 'react';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import {
+    Accordion,
+    AccordionDetails,
+    AccordionSummary,
+    Box,
+    Container,
+    Grid,
+    Stack,
+    Tab,
+    Tabs,
+    Typography,
+} from '@mui/material';
+import React, { useState } from 'react';
 import type { NextActionWithProgress } from '../hooks/useNextAction';
 import type { AttendanceSummaryCardProps } from '../widgets/AttendanceSummaryCard';
 import { AttendanceSummaryCard } from '../widgets/AttendanceSummaryCard';
 import { BriefingActionList } from '../widgets/BriefingActionList';
 import { HeroUnfinishedBanner } from '../widgets/HeroUnfinishedBanner';
+import type { NextActionCardProps } from '../widgets/NextActionCard';
 import { NextActionCard } from '../widgets/NextActionCard';
 import { UserCompactList, type UserRow } from '../widgets/UserCompactList';
+
+// ─── a11y helper: tab/tabpanel id binding ───────────────────────────
+function a11yTabProps(index: number) {
+  return {
+    id: `today-tab-${index}`,
+    'aria-controls': `today-tabpanel-${index}`,
+  };
+}
+
+function a11yTabPanelProps(index: number) {
+  return {
+    id: `today-tabpanel-${index}`,
+    'aria-labelledby': `today-tab-${index}`,
+    role: 'tabpanel' as const,
+  };
+}
 
 type HeroProps = {
   unfilledCount: number;
@@ -30,8 +64,9 @@ export type TodayOpsProps = {
   attendance: AttendanceSummaryCardProps;
   briefingAlerts: BriefingAlert[];
   nextAction: NextActionWithProgress;
+  nextActionEmptyAction?: NextActionCardProps['onEmptyAction'];
   transport: { pending: TransportUser[]; inProgress: TransportUser[]; onArrived: (id: string) => void };
-  users: { items: UserRow[]; onOpenQuickRecord: (id: string) => void; onOpenISP?: (id: string) => void };
+  users: { items: UserRow[]; onOpenQuickRecord: (id: string) => void; onOpenISP?: (id: string) => void; onEmptyAction?: () => void };
 };
 
 export const TodayOpsLayout: React.FC<TodayOpsProps> = ({
@@ -39,10 +74,15 @@ export const TodayOpsLayout: React.FC<TodayOpsProps> = ({
   attendance,
   briefingAlerts,
   nextAction,
+  nextActionEmptyAction,
   users,
 }) => {
+  // view-only state: tab index のみ
+  const [tab, setTab] = useState(0);
+
   return (
     <Box sx={{ minHeight: '100dvh', bgcolor: 'background.default', pb: 8 }}>
+      {/* Hero — Tabs 外で常時表示 */}
       <HeroUnfinishedBanner
         unfilledCount={hero.unfilledCount}
         approvalPendingCount={hero.approvalPendingCount}
@@ -53,36 +93,102 @@ export const TodayOpsLayout: React.FC<TodayOpsProps> = ({
 
       <Container maxWidth="lg" sx={{ mt: 3 }}>
         <Grid container spacing={3}>
-          {/* 左：主動線 */}
+          {/* 左：主動線 — Tabs で出席/ブリーフィング/利用者を切替 */}
           <Grid size={{ xs: 12, md: 8 }}>
-            <AttendanceSummaryCard {...attendance} />
+            <Tabs
+              data-testid="today-tabs"
+              value={tab}
+              onChange={(_, v) => setTab(v)}
+              aria-label="今日の業務セクション"
+              sx={{
+                mb: 2,
+                borderBottom: 1,
+                borderColor: 'divider',
+                '& .MuiTab-root': {
+                  fontWeight: 'bold',
+                  textTransform: 'none',
+                  minHeight: 48,
+                },
+              }}
+            >
+              <Tab label="📊 出席" {...a11yTabProps(0)} />
+              <Tab label="📋 ブリーフィング" {...a11yTabProps(1)} />
+              <Tab label="👥 利用者" {...a11yTabProps(2)} />
+            </Tabs>
 
-            <BriefingActionList alerts={briefingAlerts} />
+            {/* TabPanel 0: 出席 — 常時マウント / hidden + display 切替 */}
+            <Box
+              {...a11yTabPanelProps(0)}
+              data-testid="today-tabpanel-attendance"
+              hidden={tab !== 0}
+              sx={{ display: tab === 0 ? 'block' : 'none' }}
+            >
+              <AttendanceSummaryCard {...attendance} />
+            </Box>
 
-            <Typography variant="h6" gutterBottom fontWeight="bold">
-              👥 今日の利用者
-            </Typography>
+            {/* TabPanel 1: ブリーフィング — 常時マウント / hidden + display 切替 */}
+            <Box
+              {...a11yTabPanelProps(1)}
+              data-testid="today-tabpanel-briefing"
+              hidden={tab !== 1}
+              sx={{ display: tab === 1 ? 'block' : 'none' }}
+            >
+              <BriefingActionList alerts={briefingAlerts} />
+            </Box>
 
-            <UserCompactList
-              items={users.items}
-              onOpenQuickRecord={users.onOpenQuickRecord}
-              onOpenISP={users.onOpenISP}
-            />
+            {/* TabPanel 2: 利用者 — 常時マウント / hidden + display 切替 */}
+            <Box
+              {...a11yTabPanelProps(2)}
+              data-testid="today-tabpanel-users"
+              hidden={tab !== 2}
+              sx={{ display: tab === 2 ? 'block' : 'none' }}
+            >
+              <Typography variant="h6" gutterBottom fontWeight="bold">
+                👥 今日の利用者
+              </Typography>
+              <UserCompactList
+                items={users.items}
+                onOpenQuickRecord={users.onOpenQuickRecord}
+                onOpenISP={users.onOpenISP}
+                onEmptyAction={users.onEmptyAction}
+              />
+            </Box>
           </Grid>
 
           {/* 右：補助線 */}
           <Grid size={{ xs: 12, md: 4 }}>
             <Stack spacing={3}>
-              <NextActionCard nextAction={nextAction} />
+              <NextActionCard nextAction={nextAction} onEmptyAction={nextActionEmptyAction} />
 
-              <Paper sx={{ p: 2 }}>
-                <Typography variant="subtitle2" fontWeight="bold" gutterBottom>
-                  🚚 送迎状況
-                </Typography>
-                <Typography variant="body2" color="text.secondary">
-                  P1で実データ接続予定
-                </Typography>
-              </Paper>
+              {/* 送迎プレースホルダ — Accordion で折りたたみ */}
+              <Accordion
+                data-testid="today-accordion-transport"
+                defaultExpanded={false}
+                disableGutters
+                sx={{
+                  '&::before': { display: 'none' },
+                  boxShadow: 1,
+                  borderRadius: 1,
+                  overflow: 'hidden',
+                }}
+              >
+                <AccordionSummary
+                  expandIcon={<ExpandMoreIcon />}
+                  sx={{
+                    minHeight: 48,
+                    '& .MuiAccordionSummary-content': { my: 1 },
+                  }}
+                >
+                  <Typography variant="subtitle2" fontWeight="bold">
+                    🚚 送迎状況
+                  </Typography>
+                </AccordionSummary>
+                <AccordionDetails>
+                  <Typography variant="body2" color="text.secondary">
+                    P1で実データ接続予定
+                  </Typography>
+                </AccordionDetails>
+              </Accordion>
             </Stack>
           </Grid>
         </Grid>

--- a/src/features/today/widgets/EmptyStateBlock.tsx
+++ b/src/features/today/widgets/EmptyStateBlock.tsx
@@ -1,0 +1,105 @@
+/**
+ * EmptyStateBlock — /today 統一 Empty State コンポーネント
+ *
+ * H-1 ガードレール準拠:
+ * - 構造: icon + heading + description + optional CTA の4要素（統一）
+ * - 種類: success / zero-users / nextAction-null は同一パターンで表現
+ * - CTA方針: 必ず1つは "次の行動" を置く（弱いCTAでもOK）
+ * - testid: 接頭辞 today-empty-* を統一
+ * - 禁止: フォーム入力/複雑操作は入れない
+ */
+import { Box, Button, Typography } from '@mui/material';
+import React from 'react';
+
+export type EmptyStateAction = {
+  label: string;
+  onClick: () => void;
+  testId?: string;
+};
+
+export type EmptyStateBlockProps = {
+  /** MUI icon element */
+  icon: React.ReactNode;
+  /** 見出し */
+  title: string;
+  /** 補足説明 */
+  description?: string;
+  /** CTA（弱い導線でもOK） */
+  primaryAction?: EmptyStateAction;
+  /** data-testid（today-empty-* 接頭辞ルール） */
+  testId?: string;
+  /** compact=inline表示 / hero=大きめ表示 */
+  variant?: 'compact' | 'hero';
+};
+
+export const EmptyStateBlock: React.FC<EmptyStateBlockProps> = ({
+  icon,
+  title,
+  description,
+  primaryAction,
+  testId,
+  variant = 'compact',
+}) => {
+  const isHero = variant === 'hero';
+
+  return (
+    <Box
+      data-testid={testId}
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        textAlign: 'center',
+        py: isHero ? 4 : 3,
+        px: 2,
+        gap: 1,
+      }}
+    >
+      {/* Icon */}
+      <Box
+        sx={{
+          color: isHero ? 'success.main' : 'text.secondary',
+          fontSize: isHero ? 48 : 36,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          '& .MuiSvgIcon-root': {
+            fontSize: 'inherit',
+          },
+        }}
+      >
+        {icon}
+      </Box>
+
+      {/* Heading */}
+      <Typography
+        variant={isHero ? 'h6' : 'subtitle1'}
+        fontWeight="bold"
+        color={isHero ? 'success.main' : 'text.primary'}
+      >
+        {title}
+      </Typography>
+
+      {/* Description */}
+      {description ? (
+        <Typography variant="body2" color="text.secondary">
+          {description}
+        </Typography>
+      ) : null}
+
+      {/* CTA */}
+      {primaryAction ? (
+        <Button
+          data-testid={primaryAction.testId}
+          variant="outlined"
+          size="small"
+          onClick={primaryAction.onClick}
+          sx={{ mt: 1, minHeight: 44 }}
+        >
+          {primaryAction.label}
+        </Button>
+      ) : null}
+    </Box>
+  );
+};

--- a/src/features/today/widgets/EmptyStateHero.tsx
+++ b/src/features/today/widgets/EmptyStateHero.tsx
@@ -1,0 +1,38 @@
+/**
+ * EmptyStateHero — Hero完了分岐のサブコンポーネント
+ *
+ * HeroUnfinishedBanner の isComplete === true 時に表示。
+ * EmptyStateBlock の hero variant をラップし、
+ * 既存 today-hero-banner の testid は親が維持している。
+ */
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import React from 'react';
+import { EmptyStateBlock } from './EmptyStateBlock';
+
+export type EmptyStateHeroProps = {
+  /** 「記録メニュー」等への導線 */
+  onClickMenu?: () => void;
+};
+
+export const EmptyStateHero: React.FC<EmptyStateHeroProps> = ({
+  onClickMenu,
+}) => {
+  return (
+    <EmptyStateBlock
+      icon={<CheckCircleOutlineIcon />}
+      title="本日の対応は完了しました"
+      description="お疲れさまでした。次の準備に進めます。"
+      primaryAction={
+        onClickMenu
+          ? {
+              label: '📋 記録メニューを開く',
+              onClick: onClickMenu,
+              testId: 'today-empty-hero-cta',
+            }
+          : undefined
+      }
+      testId="today-empty-hero"
+      variant="hero"
+    />
+  );
+};

--- a/src/features/today/widgets/HeroUnfinishedBanner.spec.tsx
+++ b/src/features/today/widgets/HeroUnfinishedBanner.spec.tsx
@@ -12,8 +12,9 @@ describe('HeroUnfinishedBanner', () => {
       />
     );
 
-    // ✅ 本日完了 のテキストが表示されること
-    expect(screen.getByText(/本日完了/)).toBeInTheDocument();
+    // EmptyStateHero が表示されること
+    expect(screen.getByText(/本日の対応は完了しました/)).toBeInTheDocument();
+    expect(screen.getByTestId('today-empty-hero')).toBeInTheDocument();
 
     // 今すぐ入力 ボタンが表示されないこと
     expect(screen.queryByRole('button', { name: /今すぐ入力/ })).not.toBeInTheDocument();

--- a/src/features/today/widgets/HeroUnfinishedBanner.tsx
+++ b/src/features/today/widgets/HeroUnfinishedBanner.tsx
@@ -1,5 +1,6 @@
 import { Box, Button, Typography } from '@mui/material';
 import React from 'react';
+import { EmptyStateHero } from './EmptyStateHero';
 
 export type HeroUnfinishedBannerProps = {
   unfilledCount: number;
@@ -19,6 +20,28 @@ export const HeroUnfinishedBanner: React.FC<HeroUnfinishedBannerProps> = ({
 }) => {
   const isComplete = unfilledCount === 0 && approvalPendingCount === 0;
 
+  if (isComplete) {
+    return (
+      <Box
+        data-testid="today-hero-banner"
+        sx={[
+          {
+            bgcolor: 'success.main',
+            color: 'common.white',
+            boxShadow: 2,
+          },
+          sticky && {
+            position: 'sticky',
+            top: 0,
+            zIndex: 1100,
+          },
+        ]}
+      >
+        <EmptyStateHero onClickMenu={onClickSecondary} />
+      </Box>
+    );
+  }
+
   return (
     <Box
       data-testid="today-hero-banner"
@@ -26,7 +49,7 @@ export const HeroUnfinishedBanner: React.FC<HeroUnfinishedBannerProps> = ({
         {
           px: 2,
           py: 1.5,
-          bgcolor: isComplete ? 'success.main' : 'error.main',
+          bgcolor: 'error.main',
           color: 'common.white',
           display: 'flex',
           gap: 2,
@@ -37,56 +60,48 @@ export const HeroUnfinishedBanner: React.FC<HeroUnfinishedBannerProps> = ({
         sticky && {
           position: 'sticky',
           top: 0,
-          zIndex: 1100, // AppShellV2 の header よりも前面、Dialog等よりは背面
-        }
+          zIndex: 1100,
+        },
       ]}
     >
-      {isComplete ? (
-        <Typography variant="subtitle1" fontWeight="bold">
-          ✅ 本日完了
-        </Typography>
-      ) : (
-        <Typography variant="subtitle1" fontWeight="bold">
-          🔴 未記録 {unfilledCount}件
-          {approvalPendingCount > 0 && ` / 🟡 承認待ち ${approvalPendingCount}件`}
-        </Typography>
-      )}
+      <Typography variant="subtitle1" fontWeight="bold">
+        🔴 未記録 {unfilledCount}件
+        {approvalPendingCount > 0 && ` / 🟡 承認待ち ${approvalPendingCount}件`}
+      </Typography>
 
-      {!isComplete && (
-        <Box sx={{ display: 'flex', gap: 1 }}>
+      <Box sx={{ display: 'flex', gap: 1 }}>
+        <Button
+          data-testid="today-hero-cta"
+          variant="contained"
+          color="inherit"
+          onClick={onClickPrimary}
+          sx={{
+            color: 'error.main',
+            fontWeight: 'bold',
+            minHeight: 44,
+            px: 2,
+          }}
+        >
+          今すぐ入力
+        </Button>
+
+        {onClickSecondary && (
           <Button
-            data-testid="today-hero-cta"
-            variant="contained"
+            data-testid="today-hero-menu"
+            variant="outlined"
             color="inherit"
-            onClick={onClickPrimary}
+            onClick={onClickSecondary}
             sx={{
-              color: 'error.main',
               fontWeight: 'bold',
               minHeight: 44,
               px: 2,
+              borderColor: 'rgba(255,255,255,0.5)',
             }}
           >
-            今すぐ入力
+            📋 記録メニュー
           </Button>
-
-          {onClickSecondary && (
-            <Button
-              data-testid="today-hero-menu"
-              variant="outlined"
-              color="inherit"
-              onClick={onClickSecondary}
-              sx={{
-                fontWeight: 'bold',
-                minHeight: 44,
-                px: 2,
-                borderColor: 'rgba(255,255,255,0.5)',
-              }}
-            >
-              📋 記録メニュー
-            </Button>
-          )}
-        </Box>
-      )}
+        )}
+      </Box>
     </Box>
   );
 };

--- a/src/features/today/widgets/NextActionCard.spec.tsx
+++ b/src/features/today/widgets/NextActionCard.spec.tsx
@@ -18,6 +18,7 @@ function makeProps(overrides: Partial<NextActionWithProgress> = {}): NextActionW
     progress: null,
     progressKey: 'test-key',
     status: 'idle',
+    urgency: 'medium',
     elapsedMinutes: null,
     actions: { start: noop, done: noop, reset: noop },
     ...overrides,
@@ -118,7 +119,8 @@ describe('NextActionCard', () => {
       />
     );
 
-    expect(screen.getByText(/本日の予定はすべて完了しました/)).toBeInTheDocument();
+    expect(screen.getByText(/次の予定はありません/)).toBeInTheDocument();
+    expect(screen.getByTestId('today-empty-next-action')).toBeInTheDocument();
   });
 
   it('has data-testid', () => {

--- a/src/features/today/widgets/NextActionCard.tsx
+++ b/src/features/today/widgets/NextActionCard.tsx
@@ -3,15 +3,21 @@
  *
  * P0: 表示のみ
  * P1-A: Start/Done ボタン + 経過時間 + 完了状態
+ * PR-3: sticky 化 + urgency に応じた左ボーダー/背景色
  */
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import EventAvailableIcon from '@mui/icons-material/EventAvailable';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import { Box, Button, Chip, Paper, Typography } from '@mui/material';
+import { alpha, useTheme } from '@mui/material/styles';
 import React from 'react';
-import type { NextActionWithProgress } from '../hooks/useNextAction';
+import type { NextActionWithProgress, Urgency } from '../hooks/useNextAction';
+import { EmptyStateBlock } from './EmptyStateBlock';
 
 export type NextActionCardProps = {
   nextAction: NextActionWithProgress;
+  /** 空状態CTAクリック時の導線（スケジュール確認等） */
+  onEmptyAction?: () => void;
 };
 
 function formatMinutesUntil(minutes: number): string {
@@ -28,95 +34,142 @@ function formatElapsed(minutes: number): string {
   return m > 0 ? `${h}時間${m}分経過` : `${h}時間経過`;
 }
 
-export const NextActionCard: React.FC<NextActionCardProps> = ({ nextAction }) => {
-  const { item, status, elapsedMinutes, actions } = nextAction;
+const URGENCY_COLOR: Record<Urgency, string> = {
+  low: 'text.secondary',
+  medium: 'warning.main',
+  high: 'error.main',
+};
+
+const URGENCY_BORDER_COLOR: Record<Urgency, string> = {
+  low: 'grey.300',
+  medium: 'warning.main',
+  high: 'error.main',
+};
+
+export const NextActionCard: React.FC<NextActionCardProps> = ({ nextAction, onEmptyAction }) => {
+  const { item, status, urgency, elapsedMinutes, actions } = nextAction;
+  const theme = useTheme();
+
+  // Empty state: early return — no sticky Paper wrapper
+  if (!item) {
+    return (
+      <Paper data-testid="today-next-action-card" sx={{ p: 2 }}>
+        <Typography variant="subtitle2" fontWeight="bold" gutterBottom>
+          ⏭️ 次のアクション
+        </Typography>
+        <EmptyStateBlock
+          icon={<EventAvailableIcon />}
+          title="次の予定はありません"
+          description="本日の予定はすべて完了しています。"
+          primaryAction={
+            onEmptyAction
+              ? { label: 'スケジュールを見る', onClick: onEmptyAction, testId: 'today-empty-next-action-cta' }
+              : undefined
+          }
+          testId="today-empty-next-action"
+        />
+      </Paper>
+    );
+  }
+
+  // urgency-based background using alpha() — theme-agnostic
+  const urgencyBg =
+    urgency === 'high'
+      ? alpha(theme.palette.error.main, 0.06)
+      : urgency === 'medium'
+        ? alpha(theme.palette.warning.main, 0.06)
+        : theme.palette.background.paper;
 
   return (
-    <Paper data-testid="today-next-action-card" sx={{ p: 2 }}>
+    <Paper
+      data-testid="today-next-action-card"
+      sx={{
+        p: 2,
+        position: 'sticky',
+        top: theme.spacing(1),
+        zIndex: 10,
+        borderLeft: 4,
+        borderColor: URGENCY_BORDER_COLOR[urgency],
+        bgcolor: urgencyBg,
+        transition: 'border-color 0.3s, background-color 0.3s',
+      }}
+    >
       <Typography variant="subtitle2" fontWeight="bold" gutterBottom>
         ⏭️ 次のアクション
       </Typography>
 
-      {item ? (
-        <>
-          {/* Time + Title */}
-          <Typography variant="h5" fontWeight="bold" color="primary.main">
-            {item.time}
-          </Typography>
-          <Typography variant="body1" sx={{ mt: 0.5 }}>
-            {item.title}
-          </Typography>
-          {item.owner && (
-            <Typography variant="caption" color="text.secondary">
-              {item.owner}
-            </Typography>
-          )}
-
-          {/* Status line */}
-          <Box sx={{ mt: 1.5, display: 'flex', alignItems: 'center', gap: 1 }}>
-            {status === 'idle' && (
-              <>
-                <Typography
-                  variant="caption"
-                  color="text.secondary"
-                  sx={{ fontStyle: 'italic', flex: 1 }}
-                >
-                  {formatMinutesUntil(item.minutesUntil)}
-                </Typography>
-                <Button
-                  data-testid="next-action-start"
-                  variant="contained"
-                  size="small"
-                  startIcon={<PlayArrowIcon />}
-                  onClick={actions.start}
-                  sx={{ minHeight: 44 }}
-                >
-                  開始
-                </Button>
-              </>
-            )}
-
-            {status === 'started' && (
-              <>
-                <Chip
-                  label={elapsedMinutes !== null ? formatElapsed(elapsedMinutes) : '実行中'}
-                  color="info"
-                  size="small"
-                  variant="outlined"
-                  sx={{ flex: '0 0 auto' }}
-                />
-                <Box sx={{ flex: 1 }} />
-                <Button
-                  data-testid="next-action-done"
-                  variant="contained"
-                  color="success"
-                  size="small"
-                  startIcon={<CheckCircleIcon />}
-                  onClick={actions.done}
-                  sx={{ minHeight: 44 }}
-                >
-                  完了
-                </Button>
-              </>
-            )}
-
-            {status === 'done' && (
-              <Chip
-                data-testid="next-action-done-chip"
-                icon={<CheckCircleIcon />}
-                label="完了"
-                color="success"
-                size="small"
-                variant="filled"
-              />
-            )}
-          </Box>
-        </>
-      ) : (
-        <Typography variant="body2" color="text.secondary">
-          本日の予定はすべて完了しました 🎉
+      {/* Time + Title */}
+      <Typography variant="h5" fontWeight="bold" color="primary.main">
+        {item.time}
+      </Typography>
+      <Typography variant="body1" sx={{ mt: 0.5 }}>
+        {item.title}
+      </Typography>
+      {item.owner && (
+        <Typography variant="caption" color="text.secondary">
+          {item.owner}
         </Typography>
       )}
+
+      {/* Status line */}
+      <Box sx={{ mt: 1.5, display: 'flex', alignItems: 'center', gap: 1 }}>
+        {status === 'idle' && (
+          <>
+            <Typography
+              variant="caption"
+              color={URGENCY_COLOR[urgency]}
+              sx={{ fontStyle: 'italic', flex: 1, fontWeight: urgency !== 'low' ? 'bold' : undefined }}
+            >
+              {formatMinutesUntil(item.minutesUntil)}
+            </Typography>
+            <Button
+              data-testid="next-action-start"
+              variant="contained"
+              size="small"
+              startIcon={<PlayArrowIcon />}
+              onClick={actions.start}
+              sx={{ minHeight: 44 }}
+            >
+              開始
+            </Button>
+          </>
+        )}
+
+        {status === 'started' && (
+          <>
+            <Chip
+              label={elapsedMinutes !== null ? formatElapsed(elapsedMinutes) : '実行中'}
+              color="info"
+              size="small"
+              variant="outlined"
+              sx={{ flex: '0 0 auto' }}
+            />
+            <Box sx={{ flex: 1 }} />
+            <Button
+              data-testid="next-action-done"
+              variant="contained"
+              color="success"
+              size="small"
+              startIcon={<CheckCircleIcon />}
+              onClick={actions.done}
+              sx={{ minHeight: 44 }}
+            >
+              完了
+            </Button>
+          </>
+        )}
+
+        {status === 'done' && (
+          <Chip
+            data-testid="next-action-done-chip"
+            icon={<CheckCircleIcon />}
+            label="完了"
+            color="success"
+            size="small"
+            variant="filled"
+          />
+        )}
+      </Box>
     </Paper>
   );
 };

--- a/src/features/today/widgets/UserCompactList.tsx
+++ b/src/features/today/widgets/UserCompactList.tsx
@@ -1,7 +1,9 @@
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import EditNoteIcon from '@mui/icons-material/EditNote';
+import GroupOffIcon from '@mui/icons-material/GroupOff';
 import { Box, Button, IconButton, Paper, Stack, Tooltip, Typography } from '@mui/material';
 import React from 'react';
+import { EmptyStateBlock } from './EmptyStateBlock';
 
 export type UserRow = {
   userId: string;
@@ -14,6 +16,8 @@ export type UserCompactListProps = {
   items: UserRow[];
   onOpenQuickRecord: (id: string) => void;
   onOpenISP?: (id: string) => void;
+  /** zero-users 時の弱いCTA（スケジュール確認等） */
+  onEmptyAction?: () => void;
 };
 
 // rerender-memo: memoized row to avoid full-list re-renders
@@ -93,12 +97,20 @@ const UserCompactRow = React.memo<{
   );
 });
 
-export const UserCompactList: React.FC<UserCompactListProps> = ({ items, onOpenQuickRecord, onOpenISP }) => {
+export const UserCompactList: React.FC<UserCompactListProps> = ({ items, onOpenQuickRecord, onOpenISP, onEmptyAction }) => {
   if (items.length === 0) {
     return (
-      <Typography color="text.secondary" sx={{ py: 2 }}>
-        利用予定はありません
-      </Typography>
+      <EmptyStateBlock
+        icon={<GroupOffIcon />}
+        title="本日の通所予定はありません"
+        description="共有事項や明日の予定を確認できます。"
+        primaryAction={
+          onEmptyAction
+            ? { label: 'スケジュールを確認', onClick: onEmptyAction, testId: 'today-empty-users-cta' }
+            : undefined
+        }
+        testId="today-empty-users"
+      />
     );
   }
 

--- a/src/pages/TodayOpsPage.tsx
+++ b/src/pages/TodayOpsPage.tsx
@@ -108,7 +108,9 @@ export const TodayOpsPage: React.FC = () => {
           : sortedUserItems,
         onOpenQuickRecord: quickRecord.openUser,
         onOpenISP: (userId: string) => navigate(`/isp-editor/${userId}`),
+        onEmptyAction: () => navigate('/schedules'),
       },
+      nextActionEmptyAction: () => navigate('/schedules'),
     };
   }, [summary, nextAction, quickRecord.openUnfilled, quickRecord.openUser]);
 


### PR DESCRIPTION
## Summary

`/today` の情報設計を確定。左カラムに **3タブ常時マウント**（出席/ブリーフィング/利用者）、右カラムに **sticky NextAction** + **送迎 Accordion** を配置。

## Changes

### TodayOpsLayout.tsx — Tabs 導入
- 左カラムの 3 セクションを MUI `<Tabs>` + 常時マウント TabPanel に分割
- `hidden` + `sx={{ display }}` 二重ガードで state 消失回避・a11y安定化
- `a11yTabProps()` / `a11yTabPanelProps()` helper で `id` / `aria-controls` / `aria-labelledby` を機械生成
- Hero は Tabs **外**で常時表示を維持
- Layout state は **view-only（tab index のみ）**— データ集約・副作用は追加しない

### NextActionCard.tsx — sticky + urgency 視覚強調
- `position: sticky`, `top: theme.spacing(1)`, `zIndex: 10`（Hero 高さ依存なし）
- urgency に応じた左ボーダー + `alpha()` 背景色（theme 拡張に非依存）
- Empty state は早期 return で sticky Paper の外に分離（レイアウトノイズ削減）

### 送迎プレースホルダ — Accordion 化
- `defaultExpanded={false}` でプレースホルダを折りたたみ
- `AccordionSummary` の `content.my: 1` でタッチ領域安定化

## Design Decisions

| 決定事項 | 理由 |
|---|---|
| 常時マウント（`hidden`+`display`）| ブリーフィング action state 消失回避 + E2E 安定性 |
| `alpha()` for urgency colors | `warning.lighter` 等の theme 拡張に非依存 |
| `theme.spacing(1)` for sticky top | Hero 高さ依存を排除、レイアウト変更に耐性 |
| Tab children に fetch なし | `useEffect` 二重実行リスクなし（確認済み） |

## Verification

- [x] TypeScript compile — exit 0
- [x] ESLint — 0 warnings
- [x] vitest — 7 files / 46 tests all passed
- [x] Browser: 3 タブ切替、sticky 追従、送迎 Accordion 展開
- [x] Pre-commit hooks (lint + typecheck) passed
- [x] Tab children に `useEffect` なし（double-fetch リスク排除）

## Reviewer Notes

- TabPanel 常時マウントは dashboard の `RoomManagementTabs.tsx`（unmount 方式）とは意図的に異なる設計
- `a11yTabProps(index)` の prefix は `"today"` 固定。将来ページ内に複数 Tabs が増える場合は prefix 引数化を検討
- urgency 色は item がある場合のみ適用、Empty state は neutral