### PR TITLE
fix(P0): 未保存ガード + 削除確認ダイアログ追加

### DIFF
--- a/src/features/daily/DailyRecordList.tsx
+++ b/src/features/daily/DailyRecordList.tsx
@@ -11,9 +11,15 @@ import RestaurantIcon from '@mui/icons-material/Restaurant';
 import WarningIcon from '@mui/icons-material/Warning';
 import Avatar from '@mui/material/Avatar';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Chip from '@mui/material/Chip';
+import MuiDialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
 import Divider from '@mui/material/Divider';
 import IconButton from '@mui/material/IconButton';
 import Menu from '@mui/material/Menu';
@@ -59,6 +65,8 @@ export function DailyRecordList({
 }: DailyRecordListProps) {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const [selectedRecord, setSelectedRecord] = React.useState<PersonDaily | null>(null);
+  // P0防波堤: 削除確認ダイアログ用
+  const [deleteConfirmRecord, setDeleteConfirmRecord] = React.useState<PersonDaily | null>(null);
 
   // Utility function for meal amount formatting
   const formatMealAmount = (amount: PersonDaily['data']['mealAmount']) => {
@@ -83,11 +91,23 @@ export function DailyRecordList({
     handleMenuClose();
   };
 
+  // P0防波堤: 削除メニュークリック時は確認ダイアログを表示
   const handleDelete = () => {
     if (selectedRecord) {
-      onDelete(selectedRecord.id);
+      setDeleteConfirmRecord(selectedRecord);
     }
     handleMenuClose();
+  };
+
+  const handleConfirmDelete = () => {
+    if (deleteConfirmRecord) {
+      onDelete(deleteConfirmRecord.id);
+    }
+    setDeleteConfirmRecord(null);
+  };
+
+  const handleCancelDelete = () => {
+    setDeleteConfirmRecord(null);
   };
 
   const handleOpenAttendance = () => {
@@ -406,6 +426,38 @@ export function DailyRecordList({
           削除
         </MenuItem>
       </Menu>
+
+      {/* P0防波堤: 削除確認ダイアログ */}
+      <MuiDialog
+        open={deleteConfirmRecord !== null}
+        onClose={handleCancelDelete}
+        data-testid="delete-confirm-dialog"
+        aria-labelledby="delete-confirm-title"
+      >
+        <DialogTitle id="delete-confirm-title">記録の削除</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            {deleteConfirmRecord?.personName}さんの記録（{deleteConfirmRecord?.date}）を削除します。
+            この操作は取り消せません。
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={handleCancelDelete}
+            data-testid="delete-cancel-button"
+          >
+            キャンセル
+          </Button>
+          <Button
+            onClick={handleConfirmDelete}
+            color="error"
+            variant="contained"
+            data-testid="delete-confirm-button"
+          >
+            削除する
+          </Button>
+        </DialogActions>
+      </MuiDialog>
     </>
   );
 }

--- a/src/features/daily/__tests__/DailyRecordList.test.tsx
+++ b/src/features/daily/__tests__/DailyRecordList.test.tsx
@@ -180,7 +180,7 @@ describe('DailyRecordList', () => {
       expect(mockProps.onEdit).toHaveBeenCalledWith(record);
     });
 
-    it('calls onDelete when delete menu item is clicked', () => {
+    it('calls onDelete when delete is confirmed via dialog', () => {
       const record = createMockRecord({ id: 18 });
       render(<DailyRecordList {...mockProps} records={[record]} />);
 
@@ -190,7 +190,33 @@ describe('DailyRecordList', () => {
       const deleteMenuItem = screen.getByTestId('delete-record-menu-item-18');
       fireEvent.click(deleteMenuItem);
 
+      // P0防波堤: 確認ダイアログが表示される
+      expect(screen.getByTestId('delete-confirm-dialog')).toBeInTheDocument();
+      expect(screen.getByText(/テスト太郎さんの記録/)).toBeInTheDocument();
+      expect(screen.getByText(/この操作は取り消せません/)).toBeInTheDocument();
+
+      // 「削除する」をクリック
+      const confirmButton = screen.getByTestId('delete-confirm-button');
+      fireEvent.click(confirmButton);
+
       expect(mockProps.onDelete).toHaveBeenCalledWith(18);
+    });
+
+    it('does not call onDelete when delete is cancelled', () => {
+      const record = createMockRecord({ id: 20 });
+      render(<DailyRecordList {...mockProps} records={[record]} />);
+
+      const menuButton = screen.getByTestId('menu-button-20');
+      fireEvent.click(menuButton);
+
+      const deleteMenuItem = screen.getByTestId('delete-record-menu-item-20');
+      fireEvent.click(deleteMenuItem);
+
+      // 確認ダイアログの「キャンセル」をクリック
+      const cancelButton = screen.getByTestId('delete-cancel-button');
+      fireEvent.click(cancelButton);
+
+      expect(mockProps.onDelete).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## 概要

UI憲章監査で特定されたP0リスク2件を最小差分で実装:

### 1. 未保存ガード（P0-4）
- DailyRecordForm.tsx: isDirty判定 + window.confirm + beforeunload
- TimeBasedSupportRecordForm.tsx: 同上
- StaffForm.tsx の既存パターンに準拠

### 2. 削除確認ダイアログ（P0-3）
- DailyRecordList.tsx: MUI Dialog で確認（利用者名+日付+不可逆警告）

## テスト
- 19/19 テスト合格
- tsc --noEmit 成功（変更ファイルに型エラーなし）

## 変更ファイル
- src/features/daily/DailyRecordForm.tsx
- src/features/daily/DailyRecordList.tsx
- src/features/daily/__tests__/DailyRecordList.test.tsx
- src/features/support/TimeBasedSupportRecordForm.tsx