### PR TITLE
fix: normalize UserID format across pending/attendance pipelines (#630)

### DIFF
--- a/src/features/dashboard/selectors/__tests__/getPendingUserOrder.spec.ts
+++ b/src/features/dashboard/selectors/__tests__/getPendingUserOrder.spec.ts
@@ -57,4 +57,70 @@ describe('getPendingUserOrder', () => {
 
     expect(result).toEqual(['U-001', 'U-002', 'U-003']);
   });
+
+  // =========================================================================
+  // #630: UserID format normalization tests
+  // =========================================================================
+
+  it('matches UserIDs across format variants (U-001 vs U001)', () => {
+    // pendingUserIds use hyphenated format (from user master)
+    const pendingUserIds = ['U-003', 'U-001', 'U-002'];
+    // attendanceOrderUserIds use non-hyphenated format (from attendance system)
+    const attendanceOrderUserIds = ['U002', 'U003', 'U001'];
+
+    const result = getPendingUserOrder({
+      users,
+      pendingUserIds,
+      policy: 'attendanceToday',
+      attendanceOrderUserIds
+    });
+
+    // Should match despite format difference: attendance order preserved, original IDs returned
+    expect(result).toEqual(['U-002', 'U-003', 'U-001']);
+  });
+
+  it('handles mixed format variants in attendance order (some hyphenated, some not)', () => {
+    const pendingUserIds = ['U-003', 'U-001', 'U-002', 'U-004'];
+    const attendanceOrderUserIds = ['U003', 'U-001']; // Mixed formats
+
+    const result = getPendingUserOrder({
+      users,
+      pendingUserIds,
+      policy: 'attendanceToday',
+      attendanceOrderUserIds
+    });
+
+    // U-003 and U-001 matched, U-002 and U-004 as sorted leftovers
+    expect(result).toEqual(['U-003', 'U-001', 'U-002', 'U-004']);
+  });
+
+  it('handles lowercase format variants', () => {
+    const pendingUserIds = ['U-001', 'U-002'];
+    const attendanceOrderUserIds = ['u002', 'u001']; // Lowercase
+
+    const result = getPendingUserOrder({
+      users,
+      pendingUserIds,
+      policy: 'attendanceToday',
+      attendanceOrderUserIds
+    });
+
+    expect(result).toEqual(['U-002', 'U-001']);
+  });
+
+  it('returns original pending IDs (not normalized) in the result', () => {
+    const pendingUserIds = ['U-001', 'U-002'];
+    const attendanceOrderUserIds = ['U001'];
+
+    const result = getPendingUserOrder({
+      users,
+      pendingUserIds,
+      policy: 'attendanceToday',
+      attendanceOrderUserIds
+    });
+
+    // Should return "U-001" (original), not "U001" (normalized)
+    expect(result).toEqual(['U-001', 'U-002']);
+    expect(result[0]).toBe('U-001');
+  });
 });

--- a/src/features/dashboard/selectors/getPendingUserOrder.ts
+++ b/src/features/dashboard/selectors/getPendingUserOrder.ts
@@ -1,4 +1,6 @@
 
+import { normalizeUserId } from '@/lib/normalizeUserId';
+
 export type PendingOrderPolicy = 'userId' | 'attendanceToday';
 
 export function getPendingUserOrder(args: {
@@ -14,14 +16,27 @@ export function getPendingUserOrder(args: {
     return [...pendingUserIds].sort();
   }
 
-  const pendingSet = new Set(pendingUserIds);
+  // Normalize to canonical form for comparison (e.g. "U-001" → "U001")
+  const pendingByNorm = new Map<string, string>();
+  for (const id of pendingUserIds) {
+    pendingByNorm.set(normalizeUserId(id), id);
+  }
 
-  const orderedFromAttendance = attendanceOrderUserIds.filter(id => pendingSet.has(id));
-  const orderedSet = new Set(orderedFromAttendance);
+  const orderedOriginals: string[] = [];
+  const matchedNorms = new Set<string>();
+
+  for (const attId of attendanceOrderUserIds) {
+    const norm = normalizeUserId(attId);
+    const original = pendingByNorm.get(norm);
+    if (original && !matchedNorms.has(norm)) {
+      orderedOriginals.push(original);
+      matchedNorms.add(norm);
+    }
+  }
 
   const leftovers = pendingUserIds
-    .filter(id => !orderedSet.has(id))
+    .filter(id => !matchedNorms.has(normalizeUserId(id)))
     .sort();
 
-  return [...orderedFromAttendance, ...leftovers];
+  return [...orderedOriginals, ...leftovers];
 }

--- a/src/features/dashboard/selectors/useActivitySummary.ts
+++ b/src/features/dashboard/selectors/useActivitySummary.ts
@@ -1,6 +1,7 @@
 import type { PersonDaily } from '@/domain/daily/types';
 import { calculateUsageFromDailyRecords } from '@/features/users/userMasterDashboardUtils';
 import { estimatePayloadSize, HYDRATION_FEATURES, startFeatureSpan } from '@/hydration/features';
+import { normalizeUserId } from '@/lib/normalizeUserId';
 import type { IUserMaster } from '@/sharepoint/fields';
 import { useMemo } from 'react';
 import { getPendingUserOrder } from './getPendingUserOrder';
@@ -118,12 +119,12 @@ export function useActivitySummary(
     const recordedUserIds = new Set(
       activityRecords
         .filter(r => r.status === '完了' || r.status === '作成中')
-        .map(r => String(r.personId))
+        .map(r => normalizeUserId(String(r.personId)))
     );
 
     const rawPendingUserIds = users
       .map(u => String(u.UserID))
-      .filter(id => !recordedUserIds.has(id));
+      .filter(id => !recordedUserIds.has(normalizeUserId(id)));
 
     const pendingUserIds = getPendingUserOrder({
       users,

--- a/src/features/schedules/data/createAdapters.ts
+++ b/src/features/schedules/data/createAdapters.ts
@@ -1,16 +1,17 @@
 import { fromZonedTime } from 'date-fns-tz';
 
 import { createSpClient, ensureConfig } from '@/lib/spClient';
-import type { CreateScheduleEventInput, SchedItem, ScheduleServiceType, ScheduleStatus, ScheduleVisibility, SchedulesPort } from './port';
 import { result } from '@/shared/result';
-import { getSchedulesListTitle, SCHEDULES_FIELDS, DEFAULT_SCHEDULE_VISIBILITY, OWNER_USER_ID_ME } from './spSchema';
-import { resolveSchedulesTz } from '@/utils/scheduleTz';
 import { normalizeServiceType as normalizeSharePointServiceType } from '@/sharepoint/serviceTypes';
+import { resolveSchedulesTz } from '@/utils/scheduleTz';
+import type { CreateScheduleEventInput, SchedItem, ScheduleServiceType, SchedulesPort, ScheduleStatus, ScheduleVisibility } from './port';
+import { DEFAULT_SCHEDULE_VISIBILITY, getSchedulesListTitle, OWNER_USER_ID_ME, SCHEDULES_FIELDS } from './spSchema';
 
 const DEFAULT_TITLE = '予定';
 const SCHEDULES_TZ = resolveSchedulesTz();
 
-export const normalizeUserId = (value: string): string => value.trim().toUpperCase().replace(/[^A-Z0-9]/g, '');
+import { normalizeUserId } from '@/lib/normalizeUserId';
+export { normalizeUserId };
 
 const trimText = (value?: string | null): string | undefined => {
   if (typeof value !== 'string') {

--- a/src/lib/normalizeUserId.ts
+++ b/src/lib/normalizeUserId.ts
@@ -1,0 +1,18 @@
+/**
+ * UserID の正規化関数（共通ユーティリティ）
+ *
+ * SharePointやシステム間で `U-001`, `U001`, `u-001` など表記ゆれが発生するため、
+ * 比較時は必ずこの関数を通す。
+ *
+ * 正規化ルール:
+ *  1. 前後の空白を除去
+ *  2. 大文字に統一
+ *  3. 英数字以外（ハイフン等）を除去
+ *
+ * @example
+ *   normalizeUserId('U-001')   // → 'U001'
+ *   normalizeUserId('u001')    // → 'U001'
+ *   normalizeUserId(' U-001 ') // → 'U001'
+ */
+export const normalizeUserId = (value: string): string =>
+  value.trim().toUpperCase().replace(/[^A-Z0-9]/g, '');

--- a/tests/unit/normalizeUserId.spec.ts
+++ b/tests/unit/normalizeUserId.spec.ts
@@ -1,0 +1,36 @@
+import { normalizeUserId } from '@/lib/normalizeUserId';
+
+describe('normalizeUserId', () => {
+  it('strips hyphens', () => {
+    expect(normalizeUserId('U-001')).toBe('U001');
+  });
+
+  it('uppercases lowercase input', () => {
+    expect(normalizeUserId('u001')).toBe('U001');
+    expect(normalizeUserId('u-001')).toBe('U001');
+  });
+
+  it('trims whitespace', () => {
+    expect(normalizeUserId('  U-001 ')).toBe('U001');
+  });
+
+  it('strips all non-alphanumeric characters', () => {
+    expect(normalizeUserId('U_001')).toBe('U001');
+    expect(normalizeUserId('U.001')).toBe('U001');
+    expect(normalizeUserId('U 001')).toBe('U001');
+  });
+
+  it('is idempotent', () => {
+    const first = normalizeUserId('U-001');
+    const second = normalizeUserId(first);
+    expect(first).toBe(second);
+  });
+
+  it('handles numeric-only IDs', () => {
+    expect(normalizeUserId('001')).toBe('001');
+  });
+
+  it('handles LOCAL-U format', () => {
+    expect(normalizeUserId('LOCAL-U-0001')).toBe('LOCALU0001');
+  });
+});


### PR DESCRIPTION
## 概要

Closes #630

`pendingUserIds`（ユーザーマスター由来: `U-001`）と `attendanceOrderUserIds`（出勤管理由来: `U001`）の **表記ゆれ** により、`Set` ベースのマッチングが失敗し、正しく出勤している利用者が `leftovers`（フォールバック順）に落ちてしまうバグを修正しました。

## 変更内容

### 1. 共通 `normalizeUserId()` の追加
- **`src/lib/normalizeUserId.ts`** (新規)
- ルール: `trim()` → `toUpperCase()` → 英数字以外を除去
- `U-001`, `u001`, `U_001` すべて → `U001` に正規化

### 2. `getPendingUserOrder.ts` の修正（バグ修正本体）
- 比較前に `normalizeUserId()` を適用
- 返却値は正規化前のオリジナルID（表示に影響しない）

### 3. `useActivitySummary.ts` の修正
- `recordedUserIds`（`personId` 由来）と `rawPendingUserIds`（`UserID` 由来）の比較にも正規化を適用

### 4. `schedules/data/createAdapters.ts` の統一
- 既存のローカル `normalizeUserId` 定義を `@/lib/normalizeUserId` の re-export に変更
- Single Source of Truth を確保

## テスト

- `normalizeUserId.spec.ts` — 7テスト追加（ハイフン除去、大小文字、冪等性、LOCAL-U形式等）
- `getPendingUserOrder.spec.ts` — 4テスト追加（フォーマット不一致、混在形式、小文字、オリジナルID返却）
- `createAdapters.spec.ts` — 既存テスト全パス
- **合計 19テスト / 3ファイル すべてパス**
- `npx tsc --noEmit` — エラー 0
