### PR TITLE
refactor: extract path helpers to lib/sp/helpers.ts (spClient Phase 3)

### DIFF
--- a/src/lib/sp/helpers.ts
+++ b/src/lib/sp/helpers.ts
@@ -1,0 +1,112 @@
+/**
+ * SharePoint Path & Error Helpers
+ *
+ * spClient.ts から抽出。リストパス構築、エラーレスポンス解析。
+ */
+import { getAppConfig } from '@/lib/env';
+import { trimGuidBraces } from '@/lib/sp/types';
+
+// ─── GUID / Path helpers ─────────────────────────────────────────
+
+export const normalizeGuidCandidate = (value: string): string =>
+  trimGuidBraces(value.replace(/^guid:/i, ''));
+
+const GUID_REGEX = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+export const buildListItemsPath = (listTitle: string, select: string[], top: number): string => {
+  const queryParts: string[] = [];
+  if (select.length) queryParts.push(`$select=${select.join(',')}`);
+  if (Number.isFinite(top) && top > 0) queryParts.push(`$top=${top}`);
+  const query = queryParts.length ? `?${queryParts.join('&')}` : '';
+  const guidCandidate = normalizeGuidCandidate(listTitle);
+  if (GUID_REGEX.test(guidCandidate)) {
+    return `/lists(guid'${guidCandidate}')/items${query}`;
+  }
+  return `/lists/getbytitle('${encodeURIComponent(listTitle)}')/items${query}`;
+};
+
+export const resolveListPath = (identifier: string): string => {
+  const raw = (identifier ?? '').trim();
+  if (!raw) {
+    throw new Error('SharePoint list identifier is required');
+  }
+  if (/^\//.test(raw)) {
+    return raw;
+  }
+  if (/^(lists|web)\//i.test(raw) || /^lists\(/i.test(raw)) {
+    return `/${raw}`;
+  }
+  const guidCandidate = normalizeGuidCandidate(raw);
+  if (GUID_REGEX.test(guidCandidate)) {
+    return `/lists(guid'${guidCandidate}')`;
+  }
+  return `/lists/getbytitle('${encodeURIComponent(raw)}')`;
+};
+
+export const buildItemPath = (identifier: string, id?: number, select?: string[]): string => {
+  const base = resolveListPath(identifier);
+  const suffix = typeof id === 'number' ? `/items(${id})` : '/items';
+  const params = new URLSearchParams();
+  if (select?.length) {
+    params.append('$select', select.join(','));
+  }
+  const query = params.toString();
+  return query ? `${base}${suffix}?${query}` : `${base}${suffix}`;
+};
+
+// ─── Error response parsing ──────────────────────────────────────
+
+export const readErrorPayload = async (res: Response): Promise<string> => {
+  const text = await res.text().catch(() => '');
+  if (!text) return '';
+  try {
+    const data = JSON.parse(text) as {
+      error?: { message?: { value?: string } };
+      'odata.error'?: { message?: { value?: string } };
+      message?: { value?: string };
+    };
+    return (
+      data.error?.message?.value ??
+      data['odata.error']?.message?.value ??
+      data.message?.value ??
+      text
+    );
+  } catch {
+    return text;
+  }
+};
+
+export const raiseHttpError = async (
+  res: Response,
+  ctx?: { url?: string; method?: string }
+): Promise<never> => {
+  const detail = await readErrorPayload(res);
+  const AUDIT_DEBUG = getAppConfig().VITE_AUDIT_DEBUG;
+
+  // 必ず1行はエラーとして残す（詳細なし）
+  console.error('[SP ERROR]', {
+    status: res.status,
+    statusText: res.statusText,
+    method: ctx?.method,
+    url: ctx?.url ? ctx.url.split('?')[0] : undefined,
+  });
+
+  // 詳細は AUDIT_DEBUG 時のみ
+  if (AUDIT_DEBUG) {
+    console.error('[SP ERROR][detail]', {
+      status: res.status,
+      statusText: res.statusText,
+      method: ctx?.method,
+      url: ctx?.url,
+      detailPreview: typeof detail === 'string' ? detail.slice(0, 800) : detail,
+    });
+  }
+
+  const base = `APIリクエストに失敗しました (${res.status} ${res.statusText ?? ''})`;
+  const error: Error & { status?: number; statusText?: string } = new Error(detail || base);
+  error.status = res.status;
+  if (res.statusText) {
+    error.statusText = res.statusText;
+  }
+  throw error;
+};

--- a/src/lib/spClient.ts
+++ b/src/lib/spClient.ts
@@ -204,104 +204,14 @@ const USERS_OPTIONAL_FIELDS = ['FullNameKana', 'Furigana', 'Email', 'Phone', 'Bi
 const STAFF_BASE_FIELDS = ['Id', 'StaffID', 'StaffName', 'Role', 'Phone', 'Email'] as const;
 const STAFF_OPTIONAL_FIELDS = ['StaffID', 'AttendanceDays', 'Certifications', 'Department', 'Notes'] as const;
 
-const normalizeGuidCandidate = (value: string): string => trimGuidBraces(value.replace(/^guid:/i, ''));
+// ─── Path & error helpers imported from @/lib/sp/helpers (SSOT) ─────────────
+import {
+    buildItemPath,
+    buildListItemsPath,
+    raiseHttpError,
+    resolveListPath
+} from '@/lib/sp/helpers';
 
-
-const buildListItemsPath = (listTitle: string, select: string[], top: number): string => {
-  const queryParts: string[] = [];
-  if (select.length) queryParts.push(`$select=${select.join(',')}`);
-  if (Number.isFinite(top) && top > 0) queryParts.push(`$top=${top}`);
-  const query = queryParts.length ? `?${queryParts.join('&')}` : '';
-  const guidCandidate = normalizeGuidCandidate(listTitle);
-  if (/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(guidCandidate)) {
-    return `/lists(guid'${guidCandidate}')/items${query}`;
-  }
-  return `/lists/getbytitle('${encodeURIComponent(listTitle)}')/items${query}`;
-};
-
-const resolveListPath = (identifier: string): string => {
-  const raw = (identifier ?? '').trim();
-  if (!raw) {
-    throw new Error('SharePoint list identifier is required');
-  }
-  if (/^\//.test(raw)) {
-    return raw;
-  }
-  if (/^(lists|web)\//i.test(raw) || /^lists\(/i.test(raw)) {
-    return `/${raw}`;
-  }
-  const guidCandidate = normalizeGuidCandidate(raw);
-  if (/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(guidCandidate)) {
-    return `/lists(guid'${guidCandidate}')`;
-  }
-  return `/lists/getbytitle('${encodeURIComponent(raw)}')`;
-};
-
-const buildItemPath = (identifier: string, id?: number, select?: string[]): string => {
-  const base = resolveListPath(identifier);
-  const suffix = typeof id === 'number' ? `/items(${id})` : '/items';
-  const params = new URLSearchParams();
-  if (select?.length) {
-    params.append('$select', select.join(','));
-  }
-  const query = params.toString();
-  return query ? `${base}${suffix}?${query}` : `${base}${suffix}`;
-};
-
-const readErrorPayload = async (res: Response): Promise<string> => {
-  const text = await res.text().catch(() => '');
-  if (!text) return '';
-  try {
-    const data = JSON.parse(text) as {
-      error?: { message?: { value?: string } };
-      'odata.error'?: { message?: { value?: string } };
-      message?: { value?: string };
-    };
-    return (
-      data.error?.message?.value ??
-      data['odata.error']?.message?.value ??
-      data.message?.value ??
-      text
-    );
-  } catch {
-    return text;
-  }
-};
-
-const raiseHttpError = async (
-  res: Response,
-  ctx?: { url?: string; method?: string }
-): Promise<never> => {
-  const detail = await readErrorPayload(res);
-  const AUDIT_DEBUG = getAppConfig().VITE_AUDIT_DEBUG;
-
-  // 必ず1行はエラーとして残す（詳細なし）
-  console.error('[SP ERROR]', {
-    status: res.status,
-    statusText: res.statusText,
-    method: ctx?.method,
-    url: ctx?.url ? ctx.url.split('?')[0] : undefined,
-  });
-
-  // 詳細は AUDIT_DEBUG 時のみ
-  if (AUDIT_DEBUG) {
-    console.error('[SP ERROR][detail]', {
-      status: res.status,
-      statusText: res.statusText,
-      method: ctx?.method,
-      url: ctx?.url,
-      detailPreview: typeof detail === 'string' ? detail.slice(0, 800) : detail,
-    });
-  }
-
-  const base = `APIリクエストに失敗しました (${res.status} ${res.statusText ?? ''})`;
-  const error: Error & { status?: number; statusText?: string } = new Error(detail || base);
-  error.status = res.status;
-  if (res.statusText) {
-    error.statusText = res.statusText;
-  }
-  throw error;
-};
 
 const fetchListItemsWithFallback = async <TRow>(
   client: Pick<ReturnType<typeof createSpClient>, 'spFetch'>,


### PR DESCRIPTION
## 概要

`spClient.ts` God File 分割の **Phase 3**: パス構築・エラーハンドリングを `src/lib/sp/helpers.ts` に抽出。

Phase 1 (PR #721, merged) で型定義、Phase 2 (PR #722, merged) でキャッシュロジックを分離済み。

## 新規: `src/lib/sp/helpers.ts` (110行)
- パス構築: `normalizeGuidCandidate`, `buildListItemsPath`, `resolveListPath`, `buildItemPath`
- エラー処理: `readErrorPayload`, `raiseHttpError`
- GUID正規化の共通 regex (DRY化)

## 修正: `src/lib/spClient.ts` (1,384 → 1,294行, -90行)
- 上記関数を `@/lib/sp/helpers` からインポートに置換

## 累計効果 (Phase 1-3)

| ファイル | 元 | Phase 1 | Phase 2 | Phase 3 |
|----------|-----|---------|---------|---------|
| `spClient.ts` | 1,629 | 1,508 | 1,384 | **1,294 (-21%)** |
| `sp/types.ts` | — | 187 | 187 | 187 |
| `sp/fieldCache.ts` | — | — | 150 | 150 |
| `sp/helpers.ts` | — | — | — | **110 (新規)** |

## 検証
- `tsc --noEmit`: エラー 0
- contract テスト: 14/14 パス
- spClient 関連テスト: 5ファイル全パス
- ESLint + pre-commit hooks: 全パス
