### PR TITLE
perf(build): split vendor-reports 1.87MB → 3 lazy chunks under 900KB

### DIFF
--- a/src/features/users/UsersPanel/hooks/useUsersPanelExport.ts
+++ b/src/features/users/UsersPanel/hooks/useUsersPanelExport.ts
@@ -2,12 +2,12 @@
  * useUsersPanelExport
  *
  * PDF・Excel 出力ハンドラ
+ *
+ * Heavy report libraries (@react-pdf/renderer, xlsx) are loaded lazily
+ * via dynamic import() so they stay out of the initial bundle.
  */
 import { useDailyRecordRepository } from '@/features/daily/repositoryFactory';
-import { AchievementRecordPDF } from '@/features/reports/achievement/AchievementRecordPDF';
 import { useAchievementPDF } from '@/features/reports/achievement/useAchievementPDF';
-import { exportMonthlySummary } from '@/features/reports/monthly/MonthlySummaryExcel';
-import { pdf } from '@react-pdf/renderer';
 import { endOfMonth, format, parseISO, startOfMonth } from 'date-fns';
 import React, { useCallback } from 'react';
 import type { IUserMaster } from '../../types';
@@ -30,6 +30,12 @@ export function useUsersPanelExport(
     if (!pdfData) return;
 
     try {
+      // Lazy-load heavy PDF libs only when user clicks export
+      const [{ pdf }, { AchievementRecordPDF }] = await Promise.all([
+        import('@react-pdf/renderer'),
+        import('@/features/reports/achievement/AchievementRecordPDF'),
+      ]);
+
       const blob = await pdf(
         React.createElement(AchievementRecordPDF, pdfData) as unknown as React.ReactElement
       ).toBlob();
@@ -60,6 +66,11 @@ export function useUsersPanelExport(
           endDate: format(end, 'yyyy-MM-dd'),
         },
       });
+
+      // Lazy-load xlsx only when user clicks export
+      const { exportMonthlySummary } = await import(
+        '@/features/reports/monthly/MonthlySummaryExcel'
+      );
 
       exportMonthlySummary({
         month: targetMonth,

--- a/src/pages/IBDDemoPage.tsx
+++ b/src/pages/IBDDemoPage.tsx
@@ -41,7 +41,7 @@ import {
 } from '@/features/ibd/core/ibdStore';
 import type { ABCRecord, SupervisionLog, SupportScene } from '@/features/ibd/core/ibdTypes';
 import { PDCA_RECOMMENDATION_LABELS, SUPPORT_CATEGORY_CONFIG } from '@/features/ibd/core/ibdTypes';
-import { AuditEvidenceReportPDF } from '@/features/ibd/core/reports/AuditEvidenceReportPDF';
+
 import { useAuditEvidenceReport } from '@/features/ibd/core/reports/useAuditEvidenceReport';
 
 // ---------------------------------------------------------------------------
@@ -496,7 +496,10 @@ const IBDDemoPage = () => {
                 onClick={async () => {
                   setPdfLoading(true);
                   try {
-                    const { pdf } = await import('@react-pdf/renderer');
+                    const [{ pdf }, { AuditEvidenceReportPDF }] = await Promise.all([
+                      import('@react-pdf/renderer'),
+                      import('@/features/ibd/core/reports/AuditEvidenceReportPDF'),
+                    ]);
                     const reportData = prepareReportData('デモ管理者');
                     const blob = await pdf(<AuditEvidenceReportPDF data={reportData} />).toBlob();
                     const url = URL.createObjectURL(blob);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -213,12 +213,17 @@ export default defineConfig(({ mode }) => {
               return 'recharts';
             }
             // ── Heavy report libs: lazy-loaded on export ──
+            if (normalized.includes('/xlsx/')) {
+              return 'vendor-xlsx';
+            }
+            if (normalized.includes('/@react-pdf/pdfkit/')) {
+              return 'vendor-pdfkit';
+            }
             if (
-              normalized.includes('/xlsx/') ||
               normalized.includes('/@react-pdf/') ||
               normalized.includes('/react-pdf/')
             ) {
-              return 'vendor-reports';
+              return 'vendor-pdf';
             }
             // ── Data / validation libs ──
             if (normalized.includes('/zod/')) {


### PR DESCRIPTION
## Summary

Split the oversized \endor-reports\ chunk (1,865 kB) into 3 lazy-loaded chunks, all under the 900 kB warning limit.

### Changes

**Dynamic imports (code-splitting)**
- \useUsersPanelExport.ts\: Convert \@react-pdf/renderer\, \AchievementRecordPDF\, and \MonthlySummaryExcel\ from static to dynamic \import()\
- \IBDDemoPage.tsx\: Convert \AuditEvidenceReportPDF\ from static to dynamic \import()\

**Vite chunk splitting**
- Split \endor-reports\ → \endor-xlsx\ + \endor-pdf\ + \endor-pdfkit\

### Before / After

| Chunk | Before | After |
|---|---|---|
| \endor-reports\ | **1,865.75 kB** ⚠️ | _(removed)_ |
| \endor-xlsx\ | — | **282.92 kB** ✅ |
| \endor-pdf\ | — | **742.85 kB** ✅ |
| \endor-pdfkit\ | — | **829.27 kB** ✅ |

**Result**: Zero chunk size warnings. Report libs are only loaded when user clicks an export button.
