### PR TITLE
fix(attendance): 退所ボタンのグレーアウト修正 & 16:00自動退所バッチ処理

### DIFF
--- a/src/features/attendance/__tests__/attendance.logic.spec.ts
+++ b/src/features/attendance/__tests__/attendance.logic.spec.ts
@@ -6,10 +6,12 @@
 
 import { describe, expect, it } from 'vitest';
 import {
+    buildServiceEndTimestamp,
     canCheckOut,
     computeAbsenceEligibility,
     diffMinutes,
     formatTime,
+    getAutoCheckOutTargets,
     getDiscrepancyCount,
     isBeforeCloseTime,
     type AttendanceUser,
@@ -227,5 +229,58 @@ describe('canCheckOut', () => {
 
     expect(canCheckOut(checkedOutVisit)).toBe(false);
     expect(canCheckOut(undefined)).toBe(false);
+  });
+});
+
+describe('getAutoCheckOutTargets', () => {
+  const visits: Pick<AttendanceVisit, 'userCode' | 'status'>[] = [
+    { userCode: 'U001', status: '通所中' },
+    { userCode: 'U002', status: '退所済' },
+    { userCode: 'U003', status: '通所中' },
+    { userCode: 'U004', status: '未' },
+    { userCode: 'U005', status: '当日欠席' },
+  ];
+
+  it('returns empty before service end time', () => {
+    const before = new Date('2025-11-17T15:59:00');
+    expect(getAutoCheckOutTargets(visits, before, '16:00')).toEqual([]);
+  });
+
+  it('returns 通所中 user codes at exactly service end time', () => {
+    const exactly = new Date('2025-11-17T16:00:00');
+    expect(getAutoCheckOutTargets(visits, exactly, '16:00')).toEqual(['U001', 'U003']);
+  });
+
+  it('returns 通所中 user codes after service end time', () => {
+    const after = new Date('2025-11-17T17:30:00');
+    expect(getAutoCheckOutTargets(visits, after, '16:00')).toEqual(['U001', 'U003']);
+  });
+
+  it('returns empty when no 通所中 users exist after service end', () => {
+    const noActive: Pick<AttendanceVisit, 'userCode' | 'status'>[] = [
+      { userCode: 'U001', status: '退所済' },
+      { userCode: 'U002', status: '未' },
+    ];
+    const after = new Date('2025-11-17T17:00:00');
+    expect(getAutoCheckOutTargets(noActive, after, '16:00')).toEqual([]);
+  });
+
+  it('returns empty for empty visits array', () => {
+    const after = new Date('2025-11-17T17:00:00');
+    expect(getAutoCheckOutTargets([], after, '16:00')).toEqual([]);
+  });
+});
+
+describe('buildServiceEndTimestamp', () => {
+  it('builds correct JST ISO timestamp for 16:00', () => {
+    const iso = buildServiceEndTimestamp('2025-11-17', '16:00');
+    // 16:00 JST = 07:00 UTC
+    expect(iso).toBe('2025-11-17T07:00:00.000Z');
+  });
+
+  it('builds correct JST ISO timestamp for 18:00', () => {
+    const iso = buildServiceEndTimestamp('2025-11-17', '18:00');
+    // 18:00 JST = 09:00 UTC
+    expect(iso).toBe('2025-11-17T09:00:00.000Z');
   });
 });

--- a/src/features/attendance/attendance.logic.ts
+++ b/src/features/attendance/attendance.logic.ts
@@ -249,3 +249,39 @@ export function formatTime(iso?: string | null): string {
     timeZone: 'Asia/Tokyo',
   });
 }
+
+// ── Auto-checkout (batch discharge) ──────────────────────────
+
+/** サービス提供終了時刻（利用者の退所基準時刻） */
+export const SERVICE_END_TIME = '16:00';
+
+/**
+ * 自動退所の対象となる利用者コードを返す。
+ * 現在時刻が SERVICE_END_TIME を過ぎており、ステータスが '通所中' のユーザーが対象。
+ */
+export function getAutoCheckOutTargets(
+  visits: Pick<AttendanceVisit, 'userCode' | 'status'>[],
+  now: Date,
+  serviceEndTime: string = SERVICE_END_TIME,
+): string[] {
+  // まだサービス終了時刻前なら対象なし
+  if (isBeforeCloseTime(now, serviceEndTime)) return [];
+
+  return visits
+    .filter((v) => v.status === '通所中')
+    .map((v) => v.userCode);
+}
+
+/**
+ * サービス終了時刻の ISO タイムスタンプを構築する。
+ * recordDate (YYYY-MM-DD) + serviceEndTime (HH:mm) → JST ISO 文字列。
+ * 退所タイムスタンプとして使用（実際の操作時刻ではなくサービス終了時刻を記録）。
+ */
+export function buildServiceEndTimestamp(
+  recordDate: string,
+  serviceEndTime: string = SERVICE_END_TIME,
+): string {
+  const [hh, mm] = serviceEndTime.split(':').map((v) => parseInt(v, 10));
+  const padded = `${String(hh).padStart(2, '0')}:${String(mm).padStart(2, '0')}`;
+  return new Date(`${recordDate}T${padded}:00+09:00`).toISOString();
+}

--- a/src/features/attendance/components/AttendanceRow.tsx
+++ b/src/features/attendance/components/AttendanceRow.tsx
@@ -176,9 +176,9 @@ export function AttendanceRow({
 
         <Button
           variant={canCheckOut ? 'contained' : 'outlined'}
-          disabled={isSaving || !canCheckOut || isAbsent || isRunMode}
+          disabled={isSaving || !canCheckOut || isAbsent}
           onClick={onCheckOut}
-          sx={{ minHeight: 44, minWidth: 92, fontWeight: 700, ...secondarySx }}
+          sx={{ minHeight: 44, minWidth: 92, fontWeight: 700, ...(isRunMode && !canCheckOut ? secondarySx : {}) }}
         >
           {visit.checkOutAtText && isDone ? `退所 ${visit.checkOutAtText}` : '退所'}
           {isSaving && canCheckOut ? savingSpinner : null}

--- a/src/features/attendance/useAttendance.ts
+++ b/src/features/attendance/useAttendance.ts
@@ -7,13 +7,14 @@ import type { ObservationListItem } from '@/features/nurse/sp/map';
 import type { AbsentSupportLog } from '@/features/service-provision/domain/absentSupportLog';
 import type { IUserMaster } from '@/features/users/types';
 
+import { toLocalDateISO } from '@/utils/getNow';
+import { buildServiceEndTimestamp, getAutoCheckOutTargets, isBeforeCloseTime, SERVICE_END_TIME } from './attendance.logic';
 import type { ObservationTemperatureItem } from './domain/AttendanceRepository';
 import { classifyAttendanceError, type AttendanceErrorCode } from './hooks/useAttendanceActions';
 import type { AttendanceDailyItem } from './infra/attendanceDailyRepository';
 import { useAttendanceRepository } from './repositoryFactory';
 import { methodImpliesShuttle } from './transportMethod';
 import type { AttendanceFilter, AttendanceHookStatus, AttendanceInputMode, AttendanceRowVM } from './types';
-import { toLocalDateISO } from '@/utils/getNow';
 
 const todayIso = (): string => toLocalDateISO();
 
@@ -340,6 +341,9 @@ export function useAttendance(): UseAttendanceReturn {
   const [notification, setNotification] = useState<AttendanceNotification>(NOTIFICATION_CLOSED);
   const dismissNotification = useCallback(() => setNotification(NOTIFICATION_CLOSED), []);
 
+  // ── Auto-checkout guard (tracks which date has been auto-checked-out) ──
+  const autoCheckOutDoneRef = useRef<string>('');
+
   const refresh = useCallback(async () => {
     setStatus('loading');
     try {
@@ -347,7 +351,8 @@ export function useAttendance(): UseAttendanceReturn {
         repository.getActiveUsers(),
         repository.getDailyByDate({ recordDate: filters.date }),
       ]);
-      setRowsRaw(mergeRows(users, dailyItems, filters.date));
+      const merged = mergeRows(users, dailyItems, filters.date);
+      setRowsRaw(merged);
       setStatus('success');
 
       // Load saved temperatures (non-blocking, failures are silent)
@@ -361,6 +366,45 @@ export function useAttendance(): UseAttendanceReturn {
       } catch (e) {
         console.error('useAttendance: temperature load failed (non-fatal)', e);
       }
+
+      // ── Auto-checkout: 16:00 過ぎに「通所中」→「退所済」を一括処理 ──
+      const today = todayIso();
+      if (filters.date === today && autoCheckOutDoneRef.current !== today) {
+        const targets = getAutoCheckOutTargets(merged, new Date());
+        if (targets.length > 0) {
+          autoCheckOutDoneRef.current = today;
+          const checkOutIso = buildServiceEndTimestamp(today);
+          const checkedOutRows = merged.map((row) =>
+            targets.includes(row.userCode)
+              ? getNextStatusRow(row, '退所済', checkOutIso)
+              : row,
+          );
+          setRowsRaw(checkedOutRows);
+
+          try {
+            await Promise.all(
+              checkedOutRows
+                .filter((r) => targets.includes(r.userCode))
+                .map((r) => repository.upsertDailyByKey(toDailyItem(r, filters.date))),
+            );
+            const names = checkedOutRows
+              .filter((r) => targets.includes(r.userCode))
+              .map((r) => r.FullName ?? r.userCode)
+              .join('、');
+            setNotification({
+              open: true,
+              severity: 'info',
+              message: `${targets.length}名を自動退所しました（${names}）`,
+            });
+          } catch (error) {
+            console.error('useAttendance: autoCheckOut persist failed', error);
+            autoCheckOutDoneRef.current = ''; // allow retry on next refresh
+          }
+        } else if (!isBeforeCloseTime(new Date(), SERVICE_END_TIME)) {
+          // Past service end but no targets → mark as done
+          autoCheckOutDoneRef.current = today;
+        }
+      }
     } catch (error) {
       console.error('useAttendance.refresh failed', error);
       setStatus('error');
@@ -369,6 +413,26 @@ export function useAttendance(): UseAttendanceReturn {
   useEffect(() => {
     void refresh();
   }, [refresh]);
+
+  // ── Timer: 16:00 到達時に refresh を発火して自動退所をトリガー ──
+  useEffect(() => {
+    const today = todayIso();
+    if (filters.date !== today) return;
+    if (autoCheckOutDoneRef.current === today) return;
+
+    const now = new Date();
+    if (!isBeforeCloseTime(now, SERVICE_END_TIME)) return; // already past
+
+    const [hh, mm] = SERVICE_END_TIME.split(':').map((v) => parseInt(v, 10));
+    const target = new Date(now.getTime());
+    target.setHours(hh, mm, 0, 0);
+    const delay = target.getTime() - now.getTime() + 2000; // +2s buffer
+
+    const timer = setTimeout(() => {
+      void refresh();
+    }, delay);
+    return () => clearTimeout(timer);
+  }, [filters.date, refresh]);
 
   // Ref to always call the latest updateStatus from undo callbacks
   const updateStatusRef = useRef<(userCode: string, status: AttendanceRowVM['status']) => Promise<void>>();


### PR DESCRIPTION
## 変更概要

### 1. 退所ボタンのグレーアウト修正
- **問題**: checkInRun（通所連続）モードで通所ボタンを押した後も退所ボタンがグレーアウトしたまま
- **原因**: 退所ボタンの `disabled` 条件に `isRunMode` が含まれており、通所連続モード中は無条件で退所不可
- **修正**: `disabled` から `isRunMode` を除外、通所済みユーザーは操作可能に

### 2. 16:00自動退所バッチ処理
- **要件**: PM 16:00（サービス終了時刻）を過ぎても `通所中` のままの利用者を自動で `退所済` に変更
- **実装**:
  - `getAutoCheckOutTargets()`: 自動退所対象ユーザーを判定する純粋関数
  - `buildServiceEndTimestamp()`: 退所タイムスタンプ（16:00 JST）を生成
  - `refresh()` 内でデータロード後にバッチ処理実行
  - 16:00到達時にタイマーで `refresh()` を自動トリガー
  - 二重処理防止の `autoCheckOutDoneRef` ガード

### テスト
- 既存テスト 96 件 → 103 件（+7 件の新規テスト）
- 全テスト合格、TypeScript コンパイルエラーなし