### PR TITLE
test(today): add resolveNextUser + useQuickRecord tests (#628)

### DIFF
--- a/src/features/schedules/hooks/__tests__/useSchedulesToday.spec.ts
+++ b/src/features/schedules/hooks/__tests__/useSchedulesToday.spec.ts
@@ -104,6 +104,7 @@ describe('useSchedulesToday (Repository integration)', () => {
       id: 1,
       title: '朝のミーティング',
       startText: '09:00',
+      endText: '09:00',
       status: 'Planned',
       allDay: false,
     });

--- a/src/features/today/records/__tests__/resolveNextUser.spec.ts
+++ b/src/features/today/records/__tests__/resolveNextUser.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { resolveNextUser } from '../resolveNextUser';
+
+describe('resolveNextUser', () => {
+  it('returns the next user when current user is in the middle of the queue', () => {
+    const result = resolveNextUser('U002', ['U001', 'U002', 'U003']);
+    expect(result).toBe('U003');
+  });
+
+  it('returns the next user when current user is first in the queue', () => {
+    const result = resolveNextUser('U001', ['U001', 'U002', 'U003']);
+    expect(result).toBe('U002');
+  });
+
+  it('returns undefined when current user is the last in the queue (end-of-queue)', () => {
+    const result = resolveNextUser('U003', ['U001', 'U002', 'U003']);
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when pending list is empty', () => {
+    const result = resolveNextUser('U001', []);
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when currentUserId is null and pending list is empty', () => {
+    const result = resolveNextUser(null, []);
+    expect(result).toBeUndefined();
+  });
+
+  it('returns first pending user when currentUserId is null', () => {
+    const result = resolveNextUser(null, ['U005', 'U006']);
+    expect(result).toBe('U005');
+  });
+
+  it('fail-safes to first pending user when current user is NOT in the list (concurrent edit)', () => {
+    const result = resolveNextUser('U999', ['U001', 'U002']);
+    expect(result).toBe('U001');
+  });
+
+  it('returns undefined when only one user and it is the current user', () => {
+    const result = resolveNextUser('U001', ['U001']);
+    expect(result).toBeUndefined();
+  });
+
+  it('handles single pending user when current user is not in list', () => {
+    const result = resolveNextUser('U999', ['U001']);
+    expect(result).toBe('U001');
+  });
+});

--- a/src/features/today/records/__tests__/useQuickRecord.spec.tsx
+++ b/src/features/today/records/__tests__/useQuickRecord.spec.tsx
@@ -1,0 +1,210 @@
+// ---------------------------------------------------------------------------
+// useQuickRecord – URL state + localStorage テスト (#628)
+// ---------------------------------------------------------------------------
+import { act, renderHook } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useQuickRecord } from '../useQuickRecord';
+
+// Router wrapper（useSearchParams を使うため）
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <MemoryRouter>{children}</MemoryRouter>;
+}
+
+function wrapperWithParams(initialEntries: string[]) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>;
+  };
+}
+
+const AUTO_NEXT_KEY = 'ams_quick_auto_next';
+
+describe('useQuickRecord', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  // -----------------------------------------------------------------------
+  // 初期状態
+  // -----------------------------------------------------------------------
+  it('starts with drawer closed and autoNext enabled by default', () => {
+    const { result } = renderHook(() => useQuickRecord(), { wrapper });
+
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.mode).toBeNull();
+    expect(result.current.userId).toBeNull();
+    expect(result.current.autoNextEnabled).toBe(true);
+  });
+
+  // -----------------------------------------------------------------------
+  // openUnfilled
+  // -----------------------------------------------------------------------
+  it('openUnfilled sets mode and userId', () => {
+    const { result } = renderHook(() => useQuickRecord(), { wrapper });
+
+    act(() => {
+      result.current.openUnfilled('U001');
+    });
+
+    expect(result.current.isOpen).toBe(true);
+    expect(result.current.mode).toBe('unfilled');
+    expect(result.current.userId).toBe('U001');
+  });
+
+  it('openUnfilled without targetUserId opens in unfilled mode', () => {
+    const { result } = renderHook(() => useQuickRecord(), { wrapper });
+
+    act(() => {
+      result.current.openUnfilled();
+    });
+
+    expect(result.current.isOpen).toBe(true);
+    expect(result.current.mode).toBe('unfilled');
+    expect(result.current.userId).toBeNull();
+  });
+
+  // -----------------------------------------------------------------------
+  // openUser
+  // -----------------------------------------------------------------------
+  it('openUser sets mode=user and userId', () => {
+    const { result } = renderHook(() => useQuickRecord(), { wrapper });
+
+    act(() => {
+      result.current.openUser('U042');
+    });
+
+    expect(result.current.isOpen).toBe(true);
+    expect(result.current.mode).toBe('user');
+    expect(result.current.userId).toBe('U042');
+  });
+
+  // -----------------------------------------------------------------------
+  // close
+  // -----------------------------------------------------------------------
+  it('close removes mode and userId', () => {
+    const { result } = renderHook(() => useQuickRecord(), { wrapper });
+
+    act(() => {
+      result.current.openUnfilled('U001');
+    });
+    expect(result.current.isOpen).toBe(true);
+
+    act(() => {
+      result.current.close();
+    });
+
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.mode).toBeNull();
+    expect(result.current.userId).toBeNull();
+  });
+
+  // -----------------------------------------------------------------------
+  // autoNext toggle
+  // -----------------------------------------------------------------------
+  it('setAutoNextEnabled persists to localStorage', () => {
+    const { result } = renderHook(() => useQuickRecord(), { wrapper });
+
+    act(() => {
+      result.current.setAutoNextEnabled(false);
+    });
+
+    expect(result.current.autoNextEnabled).toBe(false);
+    expect(localStorage.getItem(AUTO_NEXT_KEY)).toBe('0');
+  });
+
+  it('setAutoNextEnabled(true) writes 1 to localStorage', () => {
+    const { result } = renderHook(() => useQuickRecord(), { wrapper });
+
+    act(() => {
+      result.current.setAutoNextEnabled(false);
+    });
+    act(() => {
+      result.current.setAutoNextEnabled(true);
+    });
+
+    expect(result.current.autoNextEnabled).toBe(true);
+    expect(localStorage.getItem(AUTO_NEXT_KEY)).toBe('1');
+  });
+
+  // -----------------------------------------------------------------------
+  // localStorage fallback
+  // -----------------------------------------------------------------------
+  it('reads autoNext from localStorage when URL has no autoNext param', () => {
+    localStorage.setItem(AUTO_NEXT_KEY, '0');
+
+    const { result } = renderHook(() => useQuickRecord(), { wrapper });
+
+    expect(result.current.autoNextEnabled).toBe(false);
+  });
+
+  it('defaults autoNext to true when localStorage is empty', () => {
+    localStorage.removeItem(AUTO_NEXT_KEY);
+
+    const { result } = renderHook(() => useQuickRecord(), { wrapper });
+
+    expect(result.current.autoNextEnabled).toBe(true);
+  });
+
+  // -----------------------------------------------------------------------
+  // URL param restoration (reload simulation)
+  // -----------------------------------------------------------------------
+  it('restores state from URL params on mount (reload scenario)', () => {
+    const Wrapper = wrapperWithParams(['/today?mode=unfilled&userId=U005&autoNext=1']);
+
+    const { result } = renderHook(() => useQuickRecord(), { wrapper: Wrapper });
+
+    expect(result.current.isOpen).toBe(true);
+    expect(result.current.mode).toBe('unfilled');
+    expect(result.current.userId).toBe('U005');
+    expect(result.current.autoNextEnabled).toBe(true);
+  });
+
+  it('restores autoNext=0 from URL params', () => {
+    const Wrapper = wrapperWithParams(['/today?mode=unfilled&userId=U005&autoNext=0']);
+
+    const { result } = renderHook(() => useQuickRecord(), { wrapper: Wrapper });
+
+    expect(result.current.autoNextEnabled).toBe(false);
+  });
+
+  // -----------------------------------------------------------------------
+  // localStorage error resilience
+  // -----------------------------------------------------------------------
+  it('does not crash when localStorage throws on read', () => {
+    const original = Storage.prototype.getItem;
+    Storage.prototype.getItem = () => {
+      throw new Error('SecurityError');
+    };
+
+    const { result } = renderHook(() => useQuickRecord(), { wrapper });
+
+    // Default fallback: true
+    expect(result.current.autoNextEnabled).toBe(true);
+
+    Storage.prototype.getItem = original;
+  });
+
+  it('does not crash when localStorage throws on write', () => {
+    const original = Storage.prototype.setItem;
+    Storage.prototype.setItem = () => {
+      throw new Error('QuotaExceeded');
+    };
+
+    const { result } = renderHook(() => useQuickRecord(), { wrapper });
+
+    expect(() => {
+      act(() => {
+        result.current.setAutoNextEnabled(false);
+      });
+    }).not.toThrow();
+
+    Storage.prototype.setItem = original;
+  });
+});

--- a/src/features/today/records/resolveNextUser.ts
+++ b/src/features/today/records/resolveNextUser.ts
@@ -1,0 +1,39 @@
+/**
+ * Determine the next pending user to navigate to after saving a record.
+ *
+ * Design rationale (Issue #628):
+ * - If currentUserId is in pendingUserIds, return the next one in the list.
+ * - If currentUserId is NOT in pendingUserIds (e.g. concurrent staff editing),
+ *   fail-safe to the first pending user.
+ * - If no pending users remain, return undefined (signals end-of-queue).
+ *
+ * This is a pure function extracted from TodayOpsPage's handleSaveSuccess
+ * to enable deterministic unit testing without React lifecycle mocking.
+ */
+export function resolveNextUser(
+  currentUserId: string | null,
+  pendingUserIds: string[],
+): string | undefined {
+  if (pendingUserIds.length === 0) {
+    return undefined;
+  }
+
+  if (!currentUserId) {
+    return pendingUserIds[0];
+  }
+
+  const idx = pendingUserIds.indexOf(currentUserId);
+
+  // Current user found → return next in queue
+  if (idx >= 0 && idx + 1 < pendingUserIds.length) {
+    return pendingUserIds[idx + 1];
+  }
+
+  // Current user is last in queue → end-of-queue
+  if (idx >= 0 && idx + 1 >= pendingUserIds.length) {
+    return undefined;
+  }
+
+  // Current user not in pending list (concurrent edit) → fail-safe to first
+  return pendingUserIds[0];
+}

--- a/src/pages/TodayOpsPage.tsx
+++ b/src/pages/TodayOpsPage.tsx
@@ -20,6 +20,7 @@ import { useNextAction } from '@/features/today/hooks/useNextAction';
 import { TodayBentoLayout } from '@/features/today/layouts/TodayBentoLayout';
 import { recordAutoNextComplete, recordAutoNextSave } from '@/features/today/records/autoNextCounters';
 import { QuickRecordDrawer } from '@/features/today/records/QuickRecordDrawer';
+import { resolveNextUser } from '@/features/today/records/resolveNextUser';
 import { useQuickRecord } from '@/features/today/records/useQuickRecord';
 import { useTransportStatus } from '@/features/today/transport';
 import { ApprovalDialog } from '@/features/today/widgets/ApprovalDialog';
@@ -157,16 +158,7 @@ export const TodayOpsPage: React.FC = () => {
     recordAutoNextSave();
 
     const pendingUserIds = summary?.dailyRecordStatus?.pendingUserIds || [];
-    const currentUserId = quickRecord.userId;
-
-    const idx = currentUserId ? pendingUserIds.indexOf(currentUserId) : -1;
-    let nextUserId: string | undefined;
-
-    if (idx >= 0 && idx + 1 < pendingUserIds.length) {
-      nextUserId = pendingUserIds[idx + 1];
-    } else if (idx === -1 && pendingUserIds.length > 0) {
-      nextUserId = pendingUserIds[0];
-    }
+    const nextUserId = resolveNextUser(quickRecord.userId, pendingUserIds);
 
     if (nextUserId) {
       setTimeout(() => {


### PR DESCRIPTION
## 概要
Issue #628「/today 連続入力フロー本番検証」の Day-1 バリデーション。
連続入力（auto-next）のコアロジックにテストを追加し、リファクタリングでテスト容易性を向上。

## 変更内容

### ロジック抽出（リファクタリング）
- `resolveNextUser.ts`: `TodayOpsPage` の `handleSaveSuccess` 内のインライン算術を純粋関数に抽出
- `TodayOpsPage.tsx`: `resolveNextUser` 呼び出しに置換（動作変更なし）

### 新規テスト（+22 tests）
- `resolveNextUser.spec.ts` (9 tests): mid-queue, end-of-queue, null userId, concurrent edit fail-safe
- `useQuickRecord.spec.tsx` (13 tests): URL params, localStorage fallback, reload restore, error resilience

### バグ修正
- `useSchedulesToday.spec.ts`: 先行PR で追加された `endText` フィールドの assertion 追加

## テスト
- `npx vitest run` ✅ (全3010テスト pass)
- typecheck ✅
- lint ✅

Closes #628