### PR TITLE
chore: プレリリース全メニュー開放

### DIFF
--- a/src/app/config/navigationConfig.ts
+++ b/src/app/config/navigationConfig.ts
@@ -261,9 +261,9 @@ export function createNavItems(config: CreateNavItemsConfig): NavItem[] {
     icebergPdcaEnabled: _icebergPdcaEnabled,
     staffAttendanceEnabled,
     todayOpsEnabled,
-    isAdmin,
+    isAdmin: _isAdmin, // TODO: プレリリース中は未使用
     authzReady,
-    navAudience,
+    navAudience: _navAudience, // TODO: プレリリース中は未使用。復元時に rename すること
     skipLogin = false,
   } = config;
 
@@ -504,7 +504,8 @@ export function createNavItems(config: CreateNavItemsConfig): NavItem[] {
     });
   }
 
-  if (isAdmin && (authzReady || skipLogin)) {
+  // TODO: プレリリース中は isAdmin チェックを無効化。正式リリース時に `isAdmin &&` を復元すること。
+  if (authzReady || skipLogin) {
     items.push(
       {
         label: '支援手順マスタ',
@@ -634,11 +635,13 @@ export function createNavItems(config: CreateNavItemsConfig): NavItem[] {
   }
 
   // Filter by audience
-  const isNavVisible = (item: NavItem): boolean => {
-    const audienceList = Array.isArray(item.audience) ? item.audience : [item.audience ?? 'all'];
-    if (audienceList.includes('all')) return true;
-    if (navAudience === 'admin') return true; // admin sees everything (including staff/reception stuff if needed)
-    return audienceList.includes(navAudience);
+  const isNavVisible = (_item: NavItem): boolean => {
+    // TODO: プレリリース期間中は全メニュー表示。正式リリース時に audience フィルタを復元すること。
+    return true;
+    // const audienceList = Array.isArray(item.audience) ? item.audience : [item.audience ?? 'all'];
+    // if (audienceList.includes('all')) return true;
+    // if (navAudience === 'admin') return true;
+    // return audienceList.includes(navAudience);
   };
 
   return items.filter(isNavVisible);


### PR DESCRIPTION
プレリリース期間中、全職員が全メニューにアクセスできるよう audience/isAdmin 制限を一時無効化。正式リリース時にTODOコメントに従い復元すること。