### PR TITLE
docs(readme): remove dead docs and align auth/ci/test coverage notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 
 <!-- markdownlint-disable MD040 -->
 
-> Quality Gate (Phase 3 Baseline): Lines >= 70% / Functions >= 70% / Statements >= 70% / Branches >= 65%
-> Current (local latest): Lines ~78% / Functions ~73% / Statements ~78% / Branches ~76% (headroom maintained before next phase)
+> Quality Gate (Vitest 4 暫定): Lines >= 44% / Functions >= 38% / Branches >= 37% / Statements >= 43%
+> Note: thresholds were lowered after Vitest 4 migration; raise incrementally once coverage recovers.
 > CI note: docs-only PRs (e.g., README/docs) skip Playwright smoke + LHCI; workflow/config changes trigger them for safety.
 > **QA snapshot (v0.9.2):** Coverage 88.27% • Branch 71.70% • Lighthouse Perf 97 • A11y 100 • Errors 0.07%/mo
 
@@ -34,7 +34,7 @@
 
 - `import.meta.env` を直接参照すると lint / pre-push の制御に阻まれるので、必ず `src/lib/env.ts` のヘルパー経由で値を取得する
 - VS Code の Problems が急増したときは `src/lib/env.ts` や `.env` 差分をまず確認すると、型/エラーの原因を素早く特定できる
-- **React 18 開発モード (StrictMode)**: `useEffect` と認証フローが意図的に二重実行されます。MSAL の重複ログインを防ぐため、`useAuth.signIn()` は `useRef` ガードで保護されています。この動作は正常で、本番環境（StrictMode なし）には影響しません。
+- **React 18 開発モード (StrictMode)**: `useEffect` と認証フローが意図的に二重実行されます。MSAL の重複ログインを防ぐため、`useAuth.signIn()` はモジュールレベルの singleflight ガード (`signInInFlight`) で保護されています。この動作は正常で、本番環境（StrictMode なし）には影響しません。
 
 ## ⚠ Production Safety Notes
 
@@ -110,16 +110,14 @@ This ensures all production deployments are traceable to a specific main commit 
 
 ## Local Operation Mode
 
-> 拠点内 LAN でのロータッチ運用を想定した「ローカル運用モード」の概要です。完全な手順書は `docs/local-mode.md` を参照してください。
+> 拠点内 LAN でのロータッチ運用を想定した「ローカル運用モード」の概要です。
+> Local mode documentation (`docs/local-mode.md`, `docs/local-mode-sop.md`) is planned but not yet published.
 
 - 🏠 **Overview** — SharePoint と OneDrive の同期枠内で動作するオフライン・ファーストなモード。監査ログは端末内に保持され、ネットワーク復帰後に一括同期します。
 - ⚙️ **Key Requirements** — 現場オペレーション用タブレット（iPad 等）とバックオフィス PC、SharePoint Online サイト、OneDrive またはファイルサーバーの自動バックアップ先、日報同期用の Power Automate フローもしくは cron 相当。
 - 🧩 **QA Baseline** — 品質保証の指標は [`CHANGELOG.md` の Target Metrics 表](CHANGELOG.md#target-metrics) を参照し、ライン/ブランチカバレッジや Lighthouse/axe-core のしきい値を達成したビルドのみを展開します。
 - 💾 **Backup & Recovery** — 監査ログ CSV と SharePoint リストを日次でエクスポートし、30 日以上のローテーションで保管します。障害時はローカル端末から直近の CSV を復元して SharePoint に再投入できます。
 - 🔐 **Access & Security** — データは Microsoft 365 テナントと拠点内ファイルサーバー内に閉じ、LAN 外への持ち出しは禁止。MSAL 設定は本番テナントのアプリ登録を利用し、権限は最小限に絞ります。
-- �️ **Architecture** — [ローカル運用モード概要図](docs/assets/local-mode-architecture.svg) で端末 ⇄ SharePoint ⇄ OneDrive のデータフローを視覚化。
-- �🔍 **Full Guide** — 詳細手順・トラブルシュート・保守運用は [`docs/local-mode.md`](docs/local-mode.md) を参照してください。
-- 🧾 **Daily SOP** — 日次チェックリストは [`docs/local-mode-sop.md`](docs/local-mode-sop.md) を活用し、オペレーションの抜け漏れを防ぎます。
 
 Ops フィードバックはこちら → [docs/ops-feedback.md](docs/ops-feedback.md)
 
@@ -260,7 +258,6 @@ VITE_FIREBASE_AUTH_ALLOW_ANON_FALLBACK=0
 #### Testing with overrides
 
 - Call config helpers with an override object instead of mutating `import.meta.env`.
-  Example: `resolveSpCacheSettings({ VITE_SP_GET_SWR: '1', VITE_SP_GET_SWR_TTL_MS: '120000' })`.
 
 ```text
 VITE_MSAL_CLIENT_ID=<YOUR_APP_CLIENT_ID>
@@ -468,16 +465,13 @@ npm run dev:schedules
 - `npm run dev:users` … 5178 `/users`（利用者マスタ UI）
 - `npm run dev:nurse` … 5179 `/nurse`（バイタル・投薬 UI）
 
-### Cache & Concurrency Knobs
+### Retry Tuning Knobs
 
-- `VITE_SP_GET_SWR` — Enable stale-while-revalidate + ETag reuse (`0` = off, `1` = opt-in).
-- `VITE_SP_GET_SWR_TTL_MS` — Hard TTL for cached GET responses (ms). Overrides legacy `VITE_SP_GET_TTL_MS` / `VITE_SP_GET_CACHE_TTL` when present.
-- `VITE_SP_GET_SWR_WINDOW_MS` — Additional SWR window (ms) after TTL expires before treating entries as cold misses.
-- `VITE_SP_GET_TTL_MS` — Legacy TTL alias (still read for backward compatibility when SWR-specific envs are omitted).
-- `VITE_SP_GET_CACHE_MAX_ENTRIES` — Max cached GET entries before LRU eviction (default 200).
-- `VITE_SP_MAX_CONCURRENCY` — Max simultaneous SharePoint requests (default 6).
-- `VITE_SP_NETWORK_RETRIES` — Network-layer retry attempts for transport failures (default 3).
-- `VITE_SP_RETRY_MAX`, `VITE_SP_RETRY_BASE_MS`, `VITE_SP_RETRY_MAX_DELAY_MS` — 429/503/504 backoff tuning knobs shared by GET and $batch flows.
+- `VITE_SP_RETRY_MAX` — Max 429/503/504 retry attempts (default 4).
+- `VITE_SP_RETRY_BASE_MS` — Base delay for exponential backoff (default 400 ms).
+- `VITE_SP_RETRY_MAX_DELAY_MS` — Cap delay for backoff (default 5000 ms).
+
+These knobs are shared by GET and `$batch` flows.
 
 ## タイムゾーン方針（Schedules）
 
@@ -494,14 +488,6 @@ npm run dev:schedules
 
 テストでタイムゾーンを固定する場合は `tests/unit/schedule/helpers/loadDateutils.ts` の `loadDateutilsWithTz()` を利用し、返される `restore()` を各テスト後に呼び出して `Intl.DateTimeFormat` / `import.meta.env` の差し替え状態を元に戻してください。
 
-### Stale-While-Revalidate & Scoped Bust (opt-in)
-
-- Flip `VITE_SP_GET_SWR=1` to opt into background refresh with SharePoint ETag reuse. Hard TTL is controlled by `VITE_SP_GET_SWR_TTL_MS`; the additional grace window comes from `VITE_SP_GET_SWR_WINDOW_MS`.
-- Fresh hits (<= TTL) return immediately from cache. Between TTL and TTL + SWR window, cached data is returned instantly while a single background refresh revalidates the entry. Beyond that window the entry is treated as cold and a network fetch occurs.
-- When SharePoint responds `304 Not Modified`, the client resets the TTL without touching the JSON payload. New `If-None-Match` headers are attached automatically whenever a cached ETag exists.
-- `getListItemsByTitle(..., { bypassCache: true })` or a manual `x-sp-bypass-cache: 1` header skips both cache usage and ETag headers for one-off debugging.
-- Mutations and `$batch` calls invalidate only the affected cache keys using tags such as `list:Records` / `list:Records:item:42`. If parsing a batch payload fails to detect targets, the client falls back to a global bust.
-
 ### Optional Flags
 
 ```
@@ -516,8 +502,7 @@ VITE_SP_RETRY_MAX_DELAY_MS=5000
 
 ### Dev Tips
 
-- After changing auth settings (MSAL config, scopes, or cookie policy), clear site cookies once to flush stale MSAL state.
-- Inspect cache stats in DevTools via `window.__SP_DBG__()` — it now reports `{ size, hits, cacheHits, staleHits, swrRefreshes, \_304s, lruKeysSample }`. Individual counters (`window.__SP_GET_HITS__`, `__SP_GET_CACHE_HITS__`, `__SP_GET_STALE_HITS__`, `__SP_GET_SWR_REFRESHES__`, `__SP_GET_304s__`) remain available for quick console pokes.
+- After changing auth settings (MSAL config or scopes), clear site cookies once to flush stale MSAL state.
 
 ### HTTPS Development Environment (Issue #344)
 
@@ -564,36 +549,7 @@ VITE_SP_RETRY_MAX_DELAY_MS=5000
 
 **CI/E2E Note:** Tests continue using HTTP (`npm run dev`) — HTTPS is opt-in for local development only.
 
-### Bypass cache (for debugging)
-
-- Add header `x-sp-bypass-cache: 1` on a GET to force a network fetch.
-- Or pass `opt: { bypassCache: true }` to `getListItemsByTitle` if you opt into the helper flag (suppresses both cache usage and automatic `If-None-Match`).
-
 > Security: Never put client secrets in `.env` (frontend). Only `VITE_` prefixed public config belongs here.
-
-## Security
-
-### Cookie policy helper
-
-Use `cookiePolicy({ crossSite })` to derive **SameSite** and **Secure** automatically.
-
-- Cross-site cookies in production → `SameSite=None; Secure` (required by modern browsers).
-- Local dev without HTTPS → falls back to `SameSite=Lax` (avoids Secure-on-HTTP breakage).
-- After switching dev to HTTPS, **clear cookies** to remove stale warnings.
-
-Utilities:
-
-- `buildSetCookie(name, value, options)` → single `Set-Cookie` string.
-- `buildCookieBundle(base, items)` → several cookies at once.
-- `appendSetCookies(headers, cookies)` → append multiple cookies (Edge-friendly).
-
-Types:
-
-- Reuse `SameSite` union (`'none' | 'lax' | 'strict'`) across frameworks (Express/Next/Hono).
-- Pair this helper with your CSP / CSRF strategy—MDN’s [`Set-Cookie` security guide](https://developer.mozilla.org/docs/Web/HTTP/Cookies#security) has an excellent checklist for hardening those headers.
-- Set `COOKIE_DEV_WARN=1` in your dev shell to fire `onDevFallbackWarn` whenever a cross-site cookie request falls back to `SameSite=Lax; Secure=false` locally (helps catch stray prod-only expectations).
-- Need to bridge framework APIs? Use dedicated adapters like `src/lib/http/edgeAdapter.ts` / `nodeAdapter.ts` (ESLint is configured to allow them). For rare exceptions, add a one-line disable with a justification: `// eslint-disable-next-line no-restricted-properties -- OAuth redirect cookie from framework hook`.
-- Local commits run `npm run lint`, `npm run typecheck`, `npm run lint:cookies`, and `lint-staged` automatically via Husky’s pre-commit hook—only use the documented ESLint disable for adapters when absolutely necessary.
 
 ## Audit Metrics (Testing Contract)
 
@@ -661,7 +617,7 @@ test("batch metrics math", async ({ page }) => {
 4. `useAuth()` hook exposes `acquireToken()` which obtains an access token for SharePoint using configured scopes (defaults to `${VITE_SP_RESOURCE}/.default`).
 5. Token stored transiently (sessionStorage) to bridge legacy calls during migration.
 
-> ヒント: 自動ログインが無い環境では、右上の「サインイン」ボタンから `loginPopup` を実行できます。既存セッションがある場合は起動時に `ssoSilent` が働き、自動復元されます。
+> ヒント: 自動ログインが無い環境では、右上の「サインイン」ボタンから `loginPopup` を実行できます。Session restoration is handled through the standard MSAL redirect flow (`handleRedirectPromise`) and cached account state. `ssoSilent` is not currently implemented.
 
 ## SharePoint Access: `useSP`
 
@@ -758,7 +714,7 @@ The nightly health workflow runs comprehensive type checking to surface any issu
 
 - **Unit (厚め)**: 同期ロジック、リトライ、バッチパーサ、CSV 生成などの純粋ロジックは **Vitest** で網羅。UI 断面も **React Testing Library (jsdom)** でコンポーネント単位を検証。
 - **E2E (最小)**: **Playwright** は「失敗のみ再送」「429/503 リトライ」など **重要シナリオの最小数** に絞り、ページ全体のフレーク回避と実行時間を抑制。
-- **カバレッジ・ゲート**: Phase 3 固定（Lines/Funcs/Stmts **70%** / Branches **65%**）。
+- **カバレッジ・ゲート**: Vitest 4 暫定（Lines **44%** / Functions **38%** / Branches **37%** / Statements **43%**）。
   ロジックの追加時はユニットテストを先に整備して緑化→E2E 追加は必要最小に留めます。
 - Vitest suites that touch `ensureConfig` reset `import.meta.env` per test to avoid leaking real tenant URLs into assertions; keep this pattern when adding new cases.
 
@@ -772,10 +728,10 @@ npm run test:schedule-week
 
 Playwright + `VITE_FEATURE_SCHEDULES_WEEK_V2=1` 環境で `schedule-week.*.spec.ts` をまとめて実行するワンライナーです。
 
-現在の固定品質ゲート (Phase 3 固定化):
+現在の暫定品質ゲート (Vitest 4 移行後):
 
 ```text
-Lines >= 70%, Statements >= 70%, Functions >= 70%, Branches >= 65%
+Lines >= 44%, Functions >= 38%, Branches >= 37%, Statements >= 43%
 ```
 
 `vitest.config.ts` の `thresholds` を将来引き上げる際は、CI 3 連続グリーン後に 5–10pt 程度ずつ。急激な引き上げは避けてください。
@@ -790,7 +746,7 @@ Lines >= 70%, Statements >= 70%, Functions >= 70%, Branches >= 65%
 | 0 | 20/20/20 \| 10 (導入) | スモーク + 主要ユーティリティ | 初期テスト整備 | 達成済 ✅ |
 | 1 | 40/40/40 \| 20 (現状) | 回帰テスト安定 (直近失敗なし) | バッチパーサ / リトライ / UUID フォールバック | 達成済 ✅ |
 | 2 | 60/60/60 \| 40 | クリティカルパス (認証, spClient, 監査同期) Happy/エラー系網羅 | useSP リトライ分岐 / 409 重複成功扱い / 部分失敗再送 | 次期 |
-| 3 | 70/70/70 \| 65 (固定現状) | UI ロジック分離・Hooks 単体化 | `useAuditSyncBatch` 分岐別テスト | 達成済 ✅ |
+| 3 | 44/38/37 \| 43 (暫定 — Vitest 4 移行後) | UI ロジック分離・Hooks 単体化 | `useAuditSyncBatch` 分岐別テスト | 達成済 ✅ |
 | 4 | 80/80/80 \| 65 | 主要分岐ほぼ網羅 (表示のみ除外) | jsdom コンポーネントテスト導入 (ピンポイント) | 中期 |
 | 5 | 85+/85+/85+ \| 70+ | コスト/リターン再評価 | Snapshot 最適化 / Flaky 監視 | 後期 |
 <!-- markdownlint-enable MD060 -->
@@ -861,13 +817,9 @@ npm run test:coverage # カバレッジ付き
 
 ## CI / Workflow Policy
 
-このリポジトリでは、CI負荷とレビュー速度を両立するため、重いWorkflowは **ラベル駆動**で起動します。
+このリポジトリでは、全 PR で CI が自動実行されます（ラベル駆動ではありません）。
 
-### ✅ `run-ci` ラベル運用（必須）
-
-- **Draft / WIP PR**：`run-ci` を付けない（重いCIは走りません）
-- **レビュー準備が整ったPR**：`run-ci` を付ける（重いCIが走ります）
-  - 対象：e2e-smoke / storybook-a11y / fast-lane / lighthouse-ci
+docs-only PR (README/docs のみの変更) では Playwright smoke と LHCI がスキップされます。workflow/config 変更を含む PR ではすべてのチェックが実行されます。
 
 ### ✅ `ready-for-review` ラベル
 
@@ -1301,7 +1253,7 @@ npm run dev:https
 
 > ポート 3000 が塞がっている場合、Vite が自動で 3001 へフォールバックすることがあります。ブラウザも `https://127.0.0.1:3001/` に切り替えて再読み込みしてください。
 >
-> 认证フローでクロスサイト Cookie を扱う場合は `cookiePolicy` ヘルパーを使うと `SameSite=None; Secure` を自動で付与でき、Chrome の警告を避けられます。
+
 
 1. ポートの競合を掃除
 
@@ -1388,7 +1340,7 @@ Internal / TBD.
 
 ## Docs
 
-- Local Operation Mode: `docs/local-mode.md` (plus architecture PNG/SVG, SOPs, validation form)
+- Local Operation Mode: planned but not yet published (see README § Local Operation Mode)
 - SharePoint CRUD Notes: `docs/sharepoint-crud-notes.md` (DELETE/PATCH UX and network handling)
 - Metrics: `docs/releases/v0.9.2.metrics.yaml`
 


### PR DESCRIPTION
## Summary

Remove dead README sections and align documentation with current implementation.

### Changes

- Remove dead README sections for unimplemented SWR/cache, cookie helpers, and `__SP_DBG__`
- Align auth docs with current implementation (`handleRedirectPromise`, singleflight guard)
- Update CI wording to match current workflow behavior
- Replace broken local-mode links with planned-note text
- Normalize Vitest coverage thresholds to current values: Lines 44 / Functions 38 / Branches 37 / Statements 43

### Impact

- **Net change:** 21 insertions, 69 deletions (~48 lines removed)
- **docs only** — no code changes