### PR TITLE
feat(today): /today 改修フェーズ1 — 朝の確認3本柱 (Issue 1-3)

### DIFF
--- a/src/features/dashboard/sections/types.ts
+++ b/src/features/dashboard/sections/types.ts
@@ -54,6 +54,8 @@ export type DashboardSectionDef = {
  * - 欠席が3件 → { type: 'absent', severity: 'error', count: 3 }
  * - 重要申し送り2件待ち → { type: 'urgent_handover', severity: 'warning', count: 2 }
  */
+export type BriefingTag = '新規' | '重要' | '継続' | '今週の変更';
+
 export type BriefingAlert = {
   id: string;  // 'absent' | 'late' | 'urgent_handover' | 'critical_safety' | 'fever_alert' | 'evening_followup'
   type: 'absent' | 'late' | 'urgent_handover' | 'critical_safety' | 'health_concern' | 'fever_alert' | 'evening_followup';
@@ -64,4 +66,8 @@ export type BriefingAlert = {
   description?: string;  // 追加説明（「田中、山田」など）
   /** Per-user items for actionable alerts (Today Execution Layer) */
   items?: { userId: string; userName: string }[];
+  /** Section classification for Today two-layer display */
+  section?: 'today' | 'ongoing';
+  /** Visual tags for context (新規, 重要, 継続, etc.) */
+  tags?: BriefingTag[];
 };

--- a/src/features/dashboard/selectors/__tests__/useAttendanceAnalytics.spec.ts
+++ b/src/features/dashboard/selectors/__tests__/useAttendanceAnalytics.spec.ts
@@ -47,6 +47,8 @@ describe('useAttendanceAnalytics — 発熱アラート', () => {
     expect(alert!.label).toBe('発熱');
     expect(alert!.count).toBe(1);
     expect(alert!.items).toEqual([{ userId: 'U001', userName: '田中太郎' }]);
+    expect(alert!.section).toBe('today');
+    expect(alert!.tags).toEqual(['重要']);
   });
 
   it('ちょうど37.5℃でもアラートを生成する (境界値)', () => {
@@ -110,6 +112,8 @@ describe('useAttendanceAnalytics — 夕方フォロー未完了', () => {
     expect(alert!.severity).toBe('warning');
     expect(alert!.label).toBe('夕方フォロー未完了');
     expect(alert!.count).toBe(1);
+    expect(alert!.section).toBe('ongoing');
+    expect(alert!.tags).toEqual(['継続']);
   });
 
   it('欠席者で eveningChecked=undefined でもアラートを生成する (デフォルト未チェック)', () => {
@@ -191,5 +195,58 @@ describe('useAttendanceAnalytics — 複合ケース', () => {
     expect(briefingAlerts.find((a) => a.type === 'late')).toBeDefined();
     // evening follow-up は完了済みなのでアラートなし
     expect(briefingAlerts.find((a) => a.type === 'evening_followup')).toBeUndefined();
+  });
+});
+
+describe('useAttendanceAnalytics — section/tags 分類', () => {
+  it('absent は section=today, tags=[重要] を持つ', () => {
+    const visits = {
+      U001: makeVisit({ userCode: 'U001', status: '当日欠席' }),
+    };
+    const { briefingAlerts } = run(visits);
+    const alert = briefingAlerts.find((a) => a.type === 'absent');
+    expect(alert!.section).toBe('today');
+    expect(alert!.tags).toEqual(['重要']);
+  });
+
+  it('late は section=today, tags=[新規] を持つ', () => {
+    const visits = {
+      U001: makeVisit({ userCode: 'U001', status: '通所中', isEarlyLeave: true }),
+    };
+    const { briefingAlerts } = run(visits);
+    const alert = briefingAlerts.find((a) => a.type === 'late');
+    expect(alert!.section).toBe('today');
+    expect(alert!.tags).toEqual(['新規']);
+  });
+
+  it('fever_alert は section=today, tags=[重要] を持つ', () => {
+    const visits = {
+      U001: makeVisit({ userCode: 'U001', temperature: 38.0 }),
+    };
+    const { briefingAlerts } = run(visits);
+    const alert = briefingAlerts.find((a) => a.type === 'fever_alert');
+    expect(alert!.section).toBe('today');
+    expect(alert!.tags).toEqual(['重要']);
+  });
+
+  it('evening_followup は section=ongoing, tags=[継続] を持つ', () => {
+    const visits = {
+      U001: makeVisit({ userCode: 'U001', status: '当日欠席', eveningChecked: false }),
+    };
+    const { briefingAlerts } = run(visits);
+    const alert = briefingAlerts.find((a) => a.type === 'evening_followup');
+    expect(alert!.section).toBe('ongoing');
+    expect(alert!.tags).toEqual(['継続']);
+  });
+
+  it('today と ongoing のアラートが同時に生成される', () => {
+    const visits = {
+      U001: makeVisit({ userCode: 'U001', status: '当日欠席', eveningChecked: false, temperature: 38.0 }),
+    };
+    const { briefingAlerts } = run(visits);
+    const todayAlerts = briefingAlerts.filter((a) => a.section === 'today');
+    const ongoingAlerts = briefingAlerts.filter((a) => a.section === 'ongoing');
+    expect(todayAlerts.length).toBeGreaterThan(0);
+    expect(ongoingAlerts.length).toBeGreaterThan(0);
   });
 });

--- a/src/features/dashboard/selectors/useAttendanceAnalytics.ts
+++ b/src/features/dashboard/selectors/useAttendanceAnalytics.ts
@@ -57,6 +57,34 @@ export function useAttendanceAnalytics(
     );
     const absenceCount = absenceVisits.length;
 
+    // ── 欠席内訳: 当日欠席 / 事前欠席 ──
+    const sameDayAbsenceVisits = absenceVisits.filter((visit) => visit.status === '当日欠席');
+    const priorAbsenceVisits = absenceVisits.filter((visit) => visit.status === '事前欠席');
+    const sameDayAbsenceCount = sameDayAbsenceVisits.length;
+    const priorAbsenceCount = priorAbsenceVisits.length;
+    const sameDayAbsenceNames = Array.from(
+      new Set(
+        sameDayAbsenceVisits
+          .map((visit) => userCodeMap.get(visit.userCode))
+          .filter((name): name is string => Boolean(name))
+      )
+    );
+    const priorAbsenceNames = Array.from(
+      new Set(
+        priorAbsenceVisits
+          .map((visit) => userCodeMap.get(visit.userCode))
+          .filter((name): name is string => Boolean(name))
+      )
+    );
+    const sameDayAbsenceItems = sameDayAbsenceVisits.map((v) => ({
+      userId: v.userCode,
+      userName: userCodeMap.get(v.userCode) ?? v.userCode,
+    }));
+    const priorAbsenceItems = priorAbsenceVisits.map((v) => ({
+      userId: v.userCode,
+      userName: userCodeMap.get(v.userCode) ?? v.userCode,
+    }));
+
     const onDutyStaff = attendanceCounts.onDuty;
     const staffCount = staff.length || 0;
     const estimatedOnDutyStaff = Math.max(0, Math.round(staffCount * 0.6));
@@ -108,12 +136,22 @@ export function useAttendanceAnalytics(
       userName: userCodeMap.get(v.userCode) ?? v.userCode,
     }));
 
+    // 予定人数
+    const scheduledCount = users.length;
+
     return {
+      scheduledCount,
       facilityAttendees,
       lateOrEarlyLeave,
       lateOrEarlyNames,
       absenceCount,
       absenceNames,
+      sameDayAbsenceCount,
+      sameDayAbsenceNames,
+      sameDayAbsenceItems,
+      priorAbsenceCount,
+      priorAbsenceNames,
+      priorAbsenceItems,
       onDutyStaff: finalOnDutyStaff,
       lateOrShiftAdjust,
       absenceItems,
@@ -140,6 +178,8 @@ export function useAttendanceAnalytics(
         targetAnchorId: 'sec-attendance',
         description: attendanceSummary.absenceNames?.slice(0, 3).join('、'),
         items: attendanceSummary.absenceItems,
+        section: 'today',
+        tags: ['重要'],
       });
     }
 
@@ -153,6 +193,8 @@ export function useAttendanceAnalytics(
         targetAnchorId: 'sec-attendance',
         description: attendanceSummary.lateOrEarlyNames?.slice(0, 3).join('、'),
         items: attendanceSummary.lateOrEarlyItems,
+        section: 'today',
+        tags: ['新規'],
       });
     }
 
@@ -167,6 +209,8 @@ export function useAttendanceAnalytics(
         targetAnchorId: 'sec-attendance',
         description: attendanceSummary.feverNames?.slice(0, 3).join('、'),
         items: attendanceSummary.feverItems,
+        section: 'today',
+        tags: ['重要'],
       });
     }
 
@@ -181,6 +225,8 @@ export function useAttendanceAnalytics(
         targetAnchorId: 'sec-attendance',
         description: attendanceSummary.eveningPendingNames?.slice(0, 3).join('、'),
         items: attendanceSummary.eveningPendingItems,
+        section: 'ongoing',
+        tags: ['継続'],
       });
     }
 

--- a/src/features/today/domain/index.ts
+++ b/src/features/today/domain/index.ts
@@ -1,1 +1,2 @@
+export type { DayCareStructure, DecisionSupportStructure, LifeSupportStructure, ServiceStructure } from './serviceStructure.types';
 export { useTodaySummary, type TodaySummary } from './useTodaySummary';

--- a/src/features/today/domain/serviceStructure.types.ts
+++ b/src/features/today/domain/serviceStructure.types.ts
@@ -1,0 +1,44 @@
+/**
+ * ServiceStructure — 今日の業務体制データ型
+ *
+ * 「担当表」ではなく「業務体制」を表現する。
+ * 生活介護 / 生活支援 / 判断窓口 の3区分で現場の配置を可視化。
+ *
+ * @see Issue 3: TodayServiceStructureCard
+ */
+
+/** 生活介護: 集団対応の配置・役割 */
+export type DayCareStructure = {
+  floorWatchStaff: string[];
+  activityLeadStaff: string[];
+  mealSupportStaff: string[];
+  recordCheckStaff: string[];
+  returnAcceptStaff: string[];
+};
+
+/** 生活支援: ショートステイ・一時ケアの受け入れ体制 */
+export type LifeSupportStructure = {
+  shortStayCount: number;
+  temporaryCareCount: number;
+  intakeDeskStaff: string[];
+  supportStaff: string[];
+  coordinatorStaff: string[];
+  notes: string[];
+};
+
+/** 判断窓口: 所長・サビ管・ナースの在席 */
+export type DecisionSupportStructure = {
+  directorPresent: boolean;
+  serviceManagerPresent: boolean;
+  nursePresent: boolean;
+  directorNames: string[];
+  serviceManagerNames: string[];
+  nurseNames: string[];
+};
+
+/** 業務体制の全体構造 */
+export type ServiceStructure = {
+  dayCare: DayCareStructure;
+  lifeSupport: LifeSupportStructure;
+  decisionSupport: DecisionSupportStructure;
+};

--- a/src/features/today/domain/useTodaySummary.ts
+++ b/src/features/today/domain/useTodaySummary.ts
@@ -12,13 +12,44 @@ import { useAttendanceStore } from '@/features/attendance';
 import { useDashboardSummary } from '@/features/dashboard';
 import { useStaffStore } from '@/features/staff';
 import { useUsersDemo } from '@/features/users/usersStoreDemo';
-import { useMemo } from 'react';
 import { toLocalDateISO } from '@/utils/getNow';
+import { useMemo } from 'react';
+import type { ServiceStructure } from './serviceStructure.types';
 
 // ─── Internal: Dashboard-irrelevant defaults ────────────────────────────
 const generateMockActivityRecords = () => [];
 const mockAttendanceCounts = { onDuty: 0, out: 0, absent: 0, total: 0 };
 const mockSpSyncStatus = { loading: false, error: null, itemCount: 0, source: 'demo' as const };
+
+/** 業務体制モック — staff 名からデモ配置を生成 */
+function buildMockServiceStructure(staffNames: string[]): ServiceStructure {
+  const s = (i: number) => staffNames[i % staffNames.length] ?? '未定';
+  return {
+    dayCare: {
+      floorWatchStaff: [s(0), s(1)],
+      activityLeadStaff: [s(2)],
+      mealSupportStaff: [s(3)],
+      recordCheckStaff: [s(4)],
+      returnAcceptStaff: [s(5)],
+    },
+    lifeSupport: {
+      shortStayCount: 1,
+      temporaryCareCount: 2,
+      intakeDeskStaff: [s(1)],
+      supportStaff: [s(3), s(5)],
+      coordinatorStaff: [s(4)],
+      notes: ['送迎時間確認あり'],
+    },
+    decisionSupport: {
+      directorPresent: true,
+      serviceManagerPresent: true,
+      nursePresent: true,
+      directorNames: [s(0)],
+      serviceManagerNames: [s(4)],
+      nurseNames: [s(2)],
+    },
+  };
+}
 
 /**
  * Today Summary Facade
@@ -48,7 +79,16 @@ export function useTodaySummary() {
     spSyncStatus: mockSpSyncStatus,
   });
 
-  // ─── 3. Pick-only: Today のデータ契約 ───
+  // ─── 3. Service Structure (Today-only: facade 内で生成) ───
+  const serviceStructure = useMemo(
+    () => {
+      const staffNames = staff.map((s) => s.name ?? `職員${staff.indexOf(s) + 1}`);
+      return buildMockServiceStructure(staffNames);
+    },
+    [staff],
+  );
+
+  // ─── 4. Pick-only: Today のデータ契約 ───
   // ⚠ このリストを拡張する場合は ADR-002 を参照し、
   //   dashboard domain 側に追加してから pick すること。
   return useMemo(
@@ -61,6 +101,8 @@ export function useTodaySummary() {
       briefingAlerts: full.briefingAlerts,
       // 当日スケジュールレーン（NextAction 導出に使用）
       scheduleLanesToday: full.scheduleLanesToday,
+      // 業務体制（Today-only）
+      serviceStructure,
 
       // ─── Passthrough: TodayOpsPage の UI マッピングで必要 ───
       users,
@@ -71,6 +113,7 @@ export function useTodaySummary() {
       full.dailyRecordStatus,
       full.briefingAlerts,
       full.scheduleLanesToday,
+      serviceStructure,
       users,
       visits,
     ],

--- a/src/features/today/layouts/TodayBentoLayout.tsx
+++ b/src/features/today/layouts/TodayBentoLayout.tsx
@@ -25,6 +25,7 @@
  */
 import { BentoCard, BentoContainer } from '@/components/ui/BentoGrid';
 import type { BriefingAlert } from '@/features/dashboard/sections/types';
+import type { ServiceStructure } from '@/features/today/domain/serviceStructure.types';
 import {
     Box,
     Typography,
@@ -38,6 +39,7 @@ import { BriefingActionList } from '../widgets/BriefingActionList';
 import { HeroUnfinishedBanner } from '../widgets/HeroUnfinishedBanner';
 import type { NextActionCardProps } from '../widgets/NextActionCard';
 import { NextActionCard } from '../widgets/NextActionCard';
+import { TodayServiceStructureCard } from '../widgets/TodayServiceStructureCard';
 import { UserCompactList, type UserRow } from '../widgets/UserCompactList';
 
 // ─── Types ───────────────────────────────────────────────────
@@ -56,6 +58,7 @@ export type TodayBentoProps = {
   hero: HeroProps;
   attendance: AttendanceSummaryCardProps;
   briefingAlerts: BriefingAlert[];
+  serviceStructure?: ServiceStructure;
   nextAction: NextActionWithProgress;
   nextActionEmptyAction?: NextActionCardProps['onEmptyAction'];
   transport: { pending: TransportUser[]; inProgress: TransportUser[]; onArrived: (id: string) => void };
@@ -91,6 +94,7 @@ export const TodayBentoLayout: React.FC<TodayBentoProps> = ({
   hero,
   attendance,
   briefingAlerts,
+  serviceStructure,
   nextAction,
   nextActionEmptyAction,
   transportCard,
@@ -178,6 +182,17 @@ export const TodayBentoLayout: React.FC<TodayBentoProps> = ({
           <SectionLabel emoji="📋" text="申し送り" />
           <BriefingActionList alerts={briefingAlerts} />
         </BentoCard>
+
+        {/* ── Row 3: Service Structure (full-width) ── */}
+        {serviceStructure && (
+          <BentoCard
+            colSpan={{ xs: 1, sm: 2, md: 4 }}
+            testId="bento-service-structure"
+          >
+            <SectionLabel emoji="🏢" text="業務体制" />
+            <TodayServiceStructureCard serviceStructure={serviceStructure} />
+          </BentoCard>
+        )}
       </BentoContainer>
     </Box>
   );

--- a/src/features/today/widgets/AttendanceSummaryCard.spec.tsx
+++ b/src/features/today/widgets/AttendanceSummaryCard.spec.tsx
@@ -3,45 +3,95 @@ import { describe, expect, it } from 'vitest';
 import { AttendanceSummaryCard } from './AttendanceSummaryCard';
 
 describe('AttendanceSummaryCard', () => {
-  it('displays attendance counts', () => {
+  it('displays attendance counts with absence breakdown', () => {
     render(
       <AttendanceSummaryCard
+        scheduledCount={20}
         facilityAttendees={12}
-        absenceCount={2}
-        absenceNames={['田中', '山田']}
+        sameDayAbsenceCount={2}
+        sameDayAbsenceNames={['田中', '山田']}
+        priorAbsenceCount={1}
+        priorAbsenceNames={['佐藤']}
         lateOrEarlyLeave={1}
-        lateOrEarlyNames={['佐藤']}
+        lateOrEarlyNames={['鈴木']}
       />
     );
 
-    expect(screen.getByText(/通所中 12名/)).toBeInTheDocument();
-    expect(screen.getByText(/欠席 2名/)).toBeInTheDocument();
+    expect(screen.getByText(/予定 20名/)).toBeInTheDocument();
+    expect(screen.getByText(/通所済 12名/)).toBeInTheDocument();
+    expect(screen.getByText(/当日欠席 2名/)).toBeInTheDocument();
+    expect(screen.getByText(/事前欠席 1名/)).toBeInTheDocument();
     expect(screen.getByText(/遅刻・早退 1名/)).toBeInTheDocument();
     expect(screen.getByText(/田中、山田/)).toBeInTheDocument();
+    expect(screen.getByText(/佐藤/)).toBeInTheDocument();
   });
 
-  it('hides absence chip when count is 0', () => {
+  it('shows 記録重要 label for same-day absence', () => {
     render(
       <AttendanceSummaryCard
-        facilityAttendees={15}
-        absenceCount={0}
-        absenceNames={[]}
+        scheduledCount={15}
+        facilityAttendees={10}
+        sameDayAbsenceCount={3}
+        sameDayAbsenceNames={['田中', '山田', '鈴木']}
+        priorAbsenceCount={0}
+        priorAbsenceNames={[]}
         lateOrEarlyLeave={0}
         lateOrEarlyNames={[]}
       />
     );
 
-    expect(screen.getByText(/通所中 15名/)).toBeInTheDocument();
-    expect(screen.queryByText(/欠席/)).not.toBeInTheDocument();
+    expect(screen.getByTestId('same-day-absence-important')).toBeInTheDocument();
+    expect(screen.getByText('⚠ 記録重要')).toBeInTheDocument();
+  });
+
+  it('hides 記録重要 when only prior absences exist', () => {
+    render(
+      <AttendanceSummaryCard
+        scheduledCount={15}
+        facilityAttendees={12}
+        sameDayAbsenceCount={0}
+        sameDayAbsenceNames={[]}
+        priorAbsenceCount={2}
+        priorAbsenceNames={['佐藤', '高橋']}
+        lateOrEarlyLeave={0}
+        lateOrEarlyNames={[]}
+      />
+    );
+
+    expect(screen.queryByTestId('same-day-absence-important')).not.toBeInTheDocument();
+    expect(screen.getByText(/事前欠席 2名/)).toBeInTheDocument();
+    expect(screen.getByText(/佐藤、高橋/)).toBeInTheDocument();
+  });
+
+  it('hides absence & late chips when counts are 0', () => {
+    render(
+      <AttendanceSummaryCard
+        scheduledCount={15}
+        facilityAttendees={15}
+        sameDayAbsenceCount={0}
+        sameDayAbsenceNames={[]}
+        priorAbsenceCount={0}
+        priorAbsenceNames={[]}
+        lateOrEarlyLeave={0}
+        lateOrEarlyNames={[]}
+      />
+    );
+
+    expect(screen.getByText(/通所済 15名/)).toBeInTheDocument();
+    expect(screen.queryByText(/当日欠席/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/事前欠席/)).not.toBeInTheDocument();
     expect(screen.queryByText(/遅刻/)).not.toBeInTheDocument();
   });
 
   it('has data-testid for integration testing', () => {
     render(
       <AttendanceSummaryCard
+        scheduledCount={10}
         facilityAttendees={10}
-        absenceCount={0}
-        absenceNames={[]}
+        sameDayAbsenceCount={0}
+        sameDayAbsenceNames={[]}
+        priorAbsenceCount={0}
+        priorAbsenceNames={[]}
         lateOrEarlyLeave={0}
         lateOrEarlyNames={[]}
       />
@@ -53,9 +103,12 @@ describe('AttendanceSummaryCard', () => {
   it('shows empty state when all counts are 0', () => {
     render(
       <AttendanceSummaryCard
+        scheduledCount={0}
         facilityAttendees={0}
-        absenceCount={0}
-        absenceNames={[]}
+        sameDayAbsenceCount={0}
+        sameDayAbsenceNames={[]}
+        priorAbsenceCount={0}
+        priorAbsenceNames={[]}
         lateOrEarlyLeave={0}
         lateOrEarlyNames={[]}
       />
@@ -63,7 +116,6 @@ describe('AttendanceSummaryCard', () => {
 
     expect(screen.getByTestId('today-empty-attendance')).toBeInTheDocument();
     expect(screen.getByText('出席データがありません')).toBeInTheDocument();
-    // testid for card wrapper should still be present
     expect(screen.getByTestId('today-attendance-card')).toBeInTheDocument();
   });
 });

--- a/src/features/today/widgets/AttendanceSummaryCard.tsx
+++ b/src/features/today/widgets/AttendanceSummaryCard.tsx
@@ -1,7 +1,8 @@
 /**
  * AttendanceSummaryCard — 出席状況サマリー
  *
- * 通所中/欠席/早退の件数をチップ形式で表示。
+ * 予定人数 / 通所済み / 当日欠席(記録重要) / 事前欠席 / 遅刻・早退を表示。
+ * 当日欠席は欠席加算に直結するため「記録重要」ラベルで強調する。
  */
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import { Box, Chip, Paper, Typography } from '@mui/material';
@@ -9,21 +10,28 @@ import React from 'react';
 import { EmptyStateBlock } from './EmptyStateBlock';
 
 export type AttendanceSummaryCardProps = {
+  scheduledCount: number;
   facilityAttendees: number;
-  absenceCount: number;
-  absenceNames: string[];
+  sameDayAbsenceCount: number;
+  sameDayAbsenceNames: string[];
+  priorAbsenceCount: number;
+  priorAbsenceNames: string[];
   lateOrEarlyLeave: number;
   lateOrEarlyNames: string[];
 };
 
 export const AttendanceSummaryCard: React.FC<AttendanceSummaryCardProps> = ({
+  scheduledCount,
   facilityAttendees,
-  absenceCount,
-  absenceNames,
+  sameDayAbsenceCount,
+  sameDayAbsenceNames,
+  priorAbsenceCount,
+  priorAbsenceNames,
   lateOrEarlyLeave,
   lateOrEarlyNames,
 }) => {
-  const hasAnyData = facilityAttendees > 0 || absenceCount > 0 || lateOrEarlyLeave > 0;
+  const totalAbsence = sameDayAbsenceCount + priorAbsenceCount;
+  const hasAnyData = facilityAttendees > 0 || totalAbsence > 0 || lateOrEarlyLeave > 0;
 
   if (!hasAnyData) {
     return (
@@ -43,23 +51,45 @@ export const AttendanceSummaryCard: React.FC<AttendanceSummaryCardProps> = ({
 
   return (
     <Paper data-testid="today-attendance-card" sx={{ p: 2, mb: 3 }}>
-      <Typography variant="subtitle2" fontWeight="bold" gutterBottom>
-        📊 出席状況
-      </Typography>
+      {/* Header: タイトル + 予定人数 */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+        <Typography variant="subtitle2" fontWeight="bold">
+          📊 出席状況
+        </Typography>
+        {scheduledCount > 0 && (
+          <Chip
+            label={`予定 ${scheduledCount}名`}
+            size="small"
+            variant="outlined"
+            sx={{ fontWeight: 600, fontSize: '0.7rem' }}
+          />
+        )}
+      </Box>
 
-      <Box sx={{ display: 'flex', gap: 1.5, flexWrap: 'wrap', mb: 1 }}>
+      {/* Chips Row */}
+      <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mb: 1 }}>
         <Chip
-          label={`通所中 ${facilityAttendees}名`}
+          label={`通所済 ${facilityAttendees}名`}
           color="success"
           size="small"
           variant="filled"
         />
-        {absenceCount > 0 && (
+        {sameDayAbsenceCount > 0 && (
           <Chip
-            label={`欠席 ${absenceCount}名`}
+            label={`🔴 当日欠席 ${sameDayAbsenceCount}名`}
             color="error"
             size="small"
             variant="filled"
+            data-testid="chip-same-day-absence"
+          />
+        )}
+        {priorAbsenceCount > 0 && (
+          <Chip
+            label={`事前欠席 ${priorAbsenceCount}名`}
+            color="default"
+            size="small"
+            variant="outlined"
+            data-testid="chip-prior-absence"
           />
         )}
         {lateOrEarlyLeave > 0 && (
@@ -72,17 +102,40 @@ export const AttendanceSummaryCard: React.FC<AttendanceSummaryCardProps> = ({
         )}
       </Box>
 
-      {absenceCount > 0 && absenceNames.length > 0 && (
-        <Typography variant="caption" color="text.secondary">
-          欠席: {absenceNames.join('、')}
+      {/* 当日欠席: 記録重要 + 名前リスト */}
+      {sameDayAbsenceCount > 0 && (
+        <Box sx={{ mb: 0.5 }}>
+          <Typography
+            variant="caption"
+            data-testid="same-day-absence-important"
+            sx={{
+              color: 'error.main',
+              fontWeight: 700,
+              fontSize: '0.7rem',
+            }}
+          >
+            ⚠ 記録重要
+          </Typography>
+          {sameDayAbsenceNames.length > 0 && (
+            <Typography variant="caption" color="text.secondary" sx={{ ml: 1 }}>
+              {sameDayAbsenceNames.join('、')}
+            </Typography>
+          )}
+        </Box>
+      )}
+
+      {/* 事前欠席: 名前リスト */}
+      {priorAbsenceCount > 0 && priorAbsenceNames.length > 0 && (
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
+          事前欠席: {priorAbsenceNames.join('、')}
         </Typography>
       )}
+
+      {/* 遅刻・早退: 名前リスト */}
       {lateOrEarlyLeave > 0 && lateOrEarlyNames.length > 0 && (
-        <Box>
-          <Typography variant="caption" color="text.secondary">
-            遅刻・早退: {lateOrEarlyNames.join('、')}
-          </Typography>
-        </Box>
+        <Typography variant="caption" color="text.secondary">
+          遅刻・早退: {lateOrEarlyNames.join('、')}
+        </Typography>
       )}
     </Paper>
   );

--- a/src/features/today/widgets/BriefingActionList.spec.tsx
+++ b/src/features/today/widgets/BriefingActionList.spec.tsx
@@ -1,6 +1,47 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import type { BriefingAlert } from '@/features/dashboard/sections/types';
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 import { BriefingActionList } from './BriefingActionList';
+
+// Mock useAuth (needed by useAlertActionState)
+vi.mock('@/auth/useAuth', () => ({
+  useAuth: () => ({ account: { username: 'test@example.com' } }),
+}));
+
+// ── Test Helpers ──
+
+const makeTodayAlert = (overrides: Partial<BriefingAlert> = {}): BriefingAlert => ({
+  id: 'test-absent',
+  type: 'absent',
+  severity: 'error',
+  label: '本日欠席',
+  count: 2,
+  targetAnchorId: 'sec-attendance',
+  section: 'today',
+  tags: ['重要'],
+  items: [
+    { userId: 'U001', userName: '田中 太郎' },
+    { userId: 'U002', userName: '山田 花子' },
+  ],
+  ...overrides,
+});
+
+const makeOngoingAlert = (overrides: Partial<BriefingAlert> = {}): BriefingAlert => ({
+  id: 'test-evening',
+  type: 'evening_followup',
+  severity: 'warning',
+  label: '夕方フォロー未完了',
+  count: 1,
+  targetAnchorId: 'sec-attendance',
+  section: 'ongoing',
+  tags: ['継続'],
+  items: [
+    { userId: 'U003', userName: '鈴木 次郎' },
+  ],
+  ...overrides,
+});
+
+// ── Tests ──
 
 describe('BriefingActionList', () => {
   it('shows empty state when alerts is empty', () => {
@@ -13,20 +54,7 @@ describe('BriefingActionList', () => {
   });
 
   it('renders accordion when alerts exist', () => {
-    const alerts = [
-      {
-        id: 'test-absence',
-        type: 'absent' as const,
-        severity: 'warning' as const,
-        label: '本日欠席',
-        count: 2,
-        targetAnchorId: 'sec-attendance',
-        items: [
-          { userId: 'U001', userName: '田中 太郎' },
-          { userId: 'U002', userName: '山田 花子' },
-        ],
-      },
-    ];
+    const alerts = [makeTodayAlert()];
 
     render(<BriefingActionList alerts={alerts} />);
 
@@ -34,6 +62,78 @@ describe('BriefingActionList', () => {
     expect(screen.queryByTestId('today-empty-briefing')).not.toBeInTheDocument();
     // Should show the accordion
     expect(screen.getByTestId('today-accordion-briefing')).toBeInTheDocument();
+    expect(screen.getByText('本日欠席 (2件)')).toBeInTheDocument();
+  });
+});
+
+describe('BriefingActionList — 2-section 表示', () => {
+  it('today アラートが「今日の共有事項」セクションに表示される', () => {
+    render(<BriefingActionList alerts={[makeTodayAlert()]} />);
+
+    expect(screen.getByText(/今日の共有事項/)).toBeInTheDocument();
+    expect(screen.getByText('本日欠席 (2件)')).toBeInTheDocument();
+  });
+
+  it('ongoing アラートが「最近の引き継ぎ要点」セクションに表示される', () => {
+    render(<BriefingActionList alerts={[makeOngoingAlert()]} />);
+
+    expect(screen.getByText(/最近の引き継ぎ要点/)).toBeInTheDocument();
+    expect(screen.getByText('夕方フォロー未完了 (1件)')).toBeInTheDocument();
+  });
+
+  it('today と ongoing の両方がある場合、両セクションが表示される', () => {
+    render(
+      <BriefingActionList alerts={[makeTodayAlert(), makeOngoingAlert()]} />,
+    );
+
+    expect(screen.getByText(/今日の共有事項/)).toBeInTheDocument();
+    expect(screen.getByText(/最近の引き継ぎ要点/)).toBeInTheDocument();
+    expect(screen.getByText('本日欠席 (2件)')).toBeInTheDocument();
+    expect(screen.getByText('夕方フォロー未完了 (1件)')).toBeInTheDocument();
+  });
+
+  it('全件 today の場合、ongoing セクションに空メッセージが出る', () => {
+    render(<BriefingActionList alerts={[makeTodayAlert()]} />);
+
+    expect(screen.getByText('最近の引き継ぎ要点はありません')).toBeInTheDocument();
+  });
+
+  it('全件 ongoing の場合、today セクションに空メッセージが出る', () => {
+    render(<BriefingActionList alerts={[makeOngoingAlert()]} />);
+
+    expect(screen.getByText('今日の共有事項はありません')).toBeInTheDocument();
+  });
+});
+
+describe('BriefingActionList — タグ chip', () => {
+  it('重要タグが表示される', () => {
+    render(<BriefingActionList alerts={[makeTodayAlert({ tags: ['重要'] })]} />);
+
+    const actions = screen.getByTestId('today-briefing-actions');
+    expect(within(actions).getByText('重要')).toBeInTheDocument();
+  });
+
+  it('継続タグが表示される', () => {
+    render(<BriefingActionList alerts={[makeOngoingAlert({ tags: ['継続'] })]} />);
+
+    const actions = screen.getByTestId('today-briefing-actions');
+    expect(within(actions).getByText('継続')).toBeInTheDocument();
+  });
+
+  it('新規タグが表示される', () => {
+    render(
+      <BriefingActionList
+        alerts={[makeTodayAlert({ id: 'late', type: 'late', label: '遅刻・早退', tags: ['新規'] })]}
+      />,
+    );
+
+    const actions = screen.getByTestId('today-briefing-actions');
+    expect(within(actions).getByText('新規')).toBeInTheDocument();
+  });
+
+  it('タグなしのアラートでも表示が壊れない', () => {
+    render(<BriefingActionList alerts={[makeTodayAlert({ tags: undefined })]} />);
+
     expect(screen.getByText('本日欠席 (2件)')).toBeInTheDocument();
   });
 });

--- a/src/features/today/widgets/BriefingActionList.tsx
+++ b/src/features/today/widgets/BriefingActionList.tsx
@@ -1,17 +1,19 @@
 /**
- * BriefingActionList — アクション型朝会アラート（Execution Layer）
+ * BriefingActionList — 二層型朝会ブリーフィング（Execution Layer）
+ *
+ * 「今日の共有事項」と「最近の引き継ぎ要点」を分離表示。
+ * 常勤/非常勤どちらにも分かりやすい共有構造を提供する。
  *
  * H-3 ガードレール準拠:
- * - MUI <Accordion> を使用（Collapse 置換）
- * - 複数同時展開OK（排他禁止）
- * - 未完了ありなら expanded=true がデフォルト（ユーザー操作で折りたたみ可能）
- * - ヘッダー: 「ブリーフィング」+ 未完了数バッジ
- * - ヘッダー内に複数CTAを置かない
+ * - MUI <Accordion> を使用
+ * - 未完了ありなら expanded=true がデフォルト
+ * - セクション内で完了チェック体験を維持
  *
  * @see docs/adr/ADR-002-today-execution-layer-guardrails.md
  */
 import { motionTokens } from '@/app/theme';
-import type { BriefingAlert } from '@/features/dashboard/sections/types';
+import type { BriefingAlert, BriefingTag } from '@/features/dashboard/sections/types';
+import { toLocalDateISO } from '@/utils/getNow';
 import AssignmentTurnedInIcon from '@mui/icons-material/AssignmentTurnedIn';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import {
@@ -35,7 +37,6 @@ import {
     type ActionStatus,
 } from '../actions';
 import { EmptyStateBlock } from './EmptyStateBlock';
-import { toLocalDateISO } from '@/utils/getNow';
 
 export type BriefingActionListProps = {
   alerts: BriefingAlert[];
@@ -48,9 +49,209 @@ const STATUS_CHIP: Record<ActionStatus, { label: string; color: 'default' | 'war
   snoozed: { label: '後で', color: 'info' },
 };
 
+const TAG_CHIP: Record<BriefingTag, { color: 'error' | 'warning' | 'info' | 'default'; variant: 'filled' | 'outlined' }> = {
+  '重要': { color: 'error', variant: 'filled' },
+  '新規': { color: 'info', variant: 'filled' },
+  '継続': { color: 'warning', variant: 'outlined' },
+  '今週の変更': { color: 'default', variant: 'outlined' },
+};
+
+// ─── Section Renderer ────────────────────────────────────────
+
+function AlertSection({
+  title,
+  emoji,
+  alerts,
+  getState,
+  setState,
+  completionStats,
+  ymd,
+}: {
+  title: string;
+  emoji: string;
+  alerts: BriefingAlert[];
+  getState: (key: string) => ActionStatus;
+  setState: (key: string, status: ActionStatus) => void;
+  completionStats: (keys: string[]) => { done: number; total: number };
+  ymd: string;
+}) {
+  if (alerts.length === 0) {
+    return (
+      <Box sx={{ py: 1.5, px: 1 }}>
+        <Typography variant="caption" color="text.secondary" sx={{ fontStyle: 'italic' }}>
+          {title}はありません
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      <Typography
+        variant="overline"
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 0.5,
+          fontWeight: 700,
+          letterSpacing: '0.06em',
+          color: 'text.secondary',
+          fontSize: '0.65rem',
+          mb: 0.5,
+        }}
+      >
+        {emoji} {title}
+      </Typography>
+      <Stack spacing={1.5}>
+        {alerts.map((alert) => {
+          const items = alert.items ?? [];
+          const alertKeys = items.map((item) =>
+            buildAlertKey(alert.type, item.userId, ymd),
+          );
+          const stats = completionStats(alertKeys);
+          const actionDefs = ALERT_ACTION_DEFS[alert.type] ?? [];
+
+          return (
+            <Box key={alert.id}>
+              {/* Group Header */}
+              <Alert
+                severity={alert.severity}
+                variant="outlined"
+                sx={{ py: 0.25, mb: 0.5 }}
+                action={
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                    {/* Tags */}
+                    {alert.tags?.map((tag) => {
+                      const config = TAG_CHIP[tag];
+                      return (
+                        <Chip
+                          key={tag}
+                          size="small"
+                          label={tag}
+                          color={config.color}
+                          variant={config.variant}
+                          sx={{ fontSize: '0.6rem', height: 18, '& .MuiChip-label': { px: 0.75 } }}
+                        />
+                      );
+                    })}
+                    {items.length > 0 && (
+                      <Chip
+                        size="small"
+                        label={`${stats.done}/${stats.total} 完了`}
+                        color={stats.done === stats.total && stats.total > 0 ? 'success' : 'default'}
+                        variant="outlined"
+                      />
+                    )}
+                  </Box>
+                }
+              >
+                <Typography variant="body2" fontWeight={600}>
+                  {alert.label}
+                  {alert.count > 0 && ` (${alert.count}件)`}
+                </Typography>
+              </Alert>
+
+              {/* Per-user Action Rows */}
+              {items.length > 0 && (
+                <Stack spacing={0.5} sx={{ pl: 2 }}>
+                  {items.map((item) => {
+                    const key = buildAlertKey(alert.type, item.userId, ymd);
+                    const status = getState(key);
+                    const chipConfig = STATUS_CHIP[status];
+
+                    return (
+                      <Box
+                        key={key}
+                        data-testid={`alert-action-row-${item.userId}`}
+                        sx={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 1,
+                          py: 0.5,
+                          px: 1,
+                          borderRadius: 1,
+                          bgcolor: status === 'done' ? 'action.hover' : 'transparent',
+                          opacity: status === 'done' ? 0.7 : 1,
+                          transition: motionTokens.transition.hoverAll,
+                        }}
+                      >
+                        <Typography
+                          variant="body2"
+                          sx={{
+                            flex: 1,
+                            textDecoration: status === 'done' ? 'line-through' : 'none',
+                          }}
+                        >
+                          {item.userName}
+                        </Typography>
+
+                        <Chip
+                          size="small"
+                          label={chipConfig.label}
+                          color={chipConfig.color}
+                          variant="filled"
+                          sx={{ minWidth: 56 }}
+                        />
+
+                        {actionDefs.map((action) => (
+                          <Button
+                            key={action.id}
+                            size="small"
+                            variant={action.primary ? 'contained' : 'text'}
+                            disabled={status === 'done'}
+                            onClick={() => setState(key, 'done')}
+                            sx={{
+                              textTransform: 'none',
+                              fontSize: '0.75rem',
+                              minWidth: 'auto',
+                              px: 1,
+                            }}
+                          >
+                            {action.label}
+                          </Button>
+                        ))}
+                      </Box>
+                    );
+                  })}
+                </Stack>
+              )}
+
+              {/* Fallback: no items (backward compat) */}
+              {items.length === 0 && alert.description && (
+                <Typography variant="caption" color="text.secondary" sx={{ pl: 2 }}>
+                  {alert.description}
+                </Typography>
+              )}
+            </Box>
+          );
+        })}
+      </Stack>
+    </Box>
+  );
+}
+
+// ─── Main Component ──────────────────────────────────────────
+
 export const BriefingActionList: React.FC<BriefingActionListProps> = ({ alerts }) => {
   const { getState, setState, completionStats } = useAlertActionState();
   const ymd = toLocalDateISO();
+
+  // Split into today vs ongoing sections
+  const { todayAlerts, ongoingAlerts } = useMemo(() => {
+    const today: BriefingAlert[] = [];
+    const ongoing: BriefingAlert[] = [];
+
+    alerts.forEach((alert) => {
+      if (alert.section === 'ongoing') {
+        ongoing.push(alert);
+      } else {
+        // Default to 'today' for backward compatibility
+        today.push(alert);
+      }
+    });
+
+    return { todayAlerts: today, ongoingAlerts: ongoing };
+  }, [alerts]);
 
   // Pending count across all alerts (for badge display)
   const pendingCount = useMemo(() => {
@@ -108,113 +309,33 @@ export const BriefingActionList: React.FC<BriefingActionListProps> = ({ alerts }
       </AccordionSummary>
 
       <AccordionDetails data-testid="today-briefing-actions" sx={{ pt: 0, px: 2, pb: 2 }}>
-        <Stack spacing={2}>
-          {alerts.map((alert) => {
-            const items = alert.items ?? [];
-            const alertKeys = items.map((item) =>
-              buildAlertKey(alert.type, item.userId, ymd),
-            );
-            const stats = completionStats(alertKeys);
-            const actionDefs = ALERT_ACTION_DEFS[alert.type] ?? [];
+        <Stack spacing={2.5}>
+          {/* Section A: 今日の共有事項 */}
+          <AlertSection
+            title="今日の共有事項"
+            emoji="📌"
+            alerts={todayAlerts}
+            getState={getState}
+            setState={setState}
+            completionStats={completionStats}
+            ymd={ymd}
+          />
 
-            return (
-              <Box key={alert.id}>
-                {/* Group Header */}
-                <Alert
-                  severity={alert.severity}
-                  variant="outlined"
-                  sx={{ py: 0.25, mb: 1 }}
-                  action={
-                    items.length > 0 ? (
-                      <Chip
-                        size="small"
-                        label={`${stats.done}/${stats.total} 完了`}
-                        color={stats.done === stats.total && stats.total > 0 ? 'success' : 'default'}
-                        variant="outlined"
-                      />
-                    ) : undefined
-                  }
-                >
-                  <Typography variant="body2" fontWeight={600}>
-                    {alert.label}
-                    {alert.count > 0 && ` (${alert.count}件)`}
-                  </Typography>
-                </Alert>
+          {/* Divider between sections (only if both have content) */}
+          {todayAlerts.length > 0 && ongoingAlerts.length > 0 && (
+            <Box sx={{ borderTop: 1, borderColor: 'divider' }} />
+          )}
 
-                {/* Per-user Action Rows */}
-                {items.length > 0 && (
-                  <Stack spacing={0.5} sx={{ pl: 2 }}>
-                    {items.map((item) => {
-                      const key = buildAlertKey(alert.type, item.userId, ymd);
-                      const status = getState(key);
-                      const chipConfig = STATUS_CHIP[status];
-
-                      return (
-                        <Box
-                          key={key}
-                          data-testid={`alert-action-row-${item.userId}`}
-                          sx={{
-                            display: 'flex',
-                            alignItems: 'center',
-                            gap: 1,
-                            py: 0.5,
-                            px: 1,
-                            borderRadius: 1,
-                            bgcolor: status === 'done' ? 'action.hover' : 'transparent',
-                            opacity: status === 'done' ? 0.7 : 1,
-                            transition: motionTokens.transition.hoverAll,
-                          }}
-                        >
-                          <Typography
-                            variant="body2"
-                            sx={{
-                              flex: 1,
-                              textDecoration: status === 'done' ? 'line-through' : 'none',
-                            }}
-                          >
-                            {item.userName}
-                          </Typography>
-
-                          <Chip
-                            size="small"
-                            label={chipConfig.label}
-                            color={chipConfig.color}
-                            variant="filled"
-                            sx={{ minWidth: 56 }}
-                          />
-
-                          {actionDefs.map((action) => (
-                            <Button
-                              key={action.id}
-                              size="small"
-                              variant={action.primary ? 'contained' : 'text'}
-                              disabled={status === 'done'}
-                              onClick={() => setState(key, 'done')}
-                              sx={{
-                                textTransform: 'none',
-                                fontSize: '0.75rem',
-                                minWidth: 'auto',
-                                px: 1,
-                              }}
-                            >
-                              {action.label}
-                            </Button>
-                          ))}
-                        </Box>
-                      );
-                    })}
-                  </Stack>
-                )}
-
-                {/* Fallback: no items (backward compat) */}
-                {items.length === 0 && alert.description && (
-                  <Typography variant="caption" color="text.secondary" sx={{ pl: 2 }}>
-                    {alert.description}
-                  </Typography>
-                )}
-              </Box>
-            );
-          })}
+          {/* Section B: 最近の引き継ぎ要点 */}
+          <AlertSection
+            title="最近の引き継ぎ要点"
+            emoji="🔄"
+            alerts={ongoingAlerts}
+            getState={getState}
+            setState={setState}
+            completionStats={completionStats}
+            ymd={ymd}
+          />
         </Stack>
       </AccordionDetails>
     </Accordion>

--- a/src/features/today/widgets/TodayServiceStructureCard.spec.tsx
+++ b/src/features/today/widgets/TodayServiceStructureCard.spec.tsx
@@ -1,0 +1,135 @@
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { ServiceStructure } from '../domain/serviceStructure.types';
+import { TodayServiceStructureCard } from './TodayServiceStructureCard';
+
+// ── Test Helpers ──
+
+const fullStructure: ServiceStructure = {
+  dayCare: {
+    floorWatchStaff: ['山田', '佐藤'],
+    activityLeadStaff: ['鈴木'],
+    mealSupportStaff: ['田中'],
+    recordCheckStaff: ['村上'],
+    returnAcceptStaff: ['中村'],
+  },
+  lifeSupport: {
+    shortStayCount: 1,
+    temporaryCareCount: 2,
+    intakeDeskStaff: ['佐藤'],
+    supportStaff: ['高橋', '伊藤'],
+    coordinatorStaff: ['田中'],
+    notes: ['送迎時間確認あり'],
+  },
+  decisionSupport: {
+    directorPresent: true,
+    serviceManagerPresent: true,
+    nursePresent: true,
+    directorNames: ['山田'],
+    serviceManagerNames: ['佐藤'],
+    nurseNames: ['鈴木'],
+  },
+};
+
+const emptyLifeSupport: ServiceStructure = {
+  ...fullStructure,
+  lifeSupport: {
+    shortStayCount: 0,
+    temporaryCareCount: 0,
+    intakeDeskStaff: [],
+    supportStaff: [],
+    coordinatorStaff: [],
+    notes: [],
+  },
+};
+
+const partialPresence: ServiceStructure = {
+  ...fullStructure,
+  decisionSupport: {
+    directorPresent: true,
+    serviceManagerPresent: false,
+    nursePresent: true,
+    directorNames: ['山田'],
+    serviceManagerNames: [],
+    nurseNames: ['鈴木'],
+  },
+};
+
+// ── Tests ──
+
+describe('TodayServiceStructureCard — 生活介護', () => {
+  it('生活介護の配置・役割が表示される', () => {
+    render(<TodayServiceStructureCard serviceStructure={fullStructure} />);
+
+    const section = within(screen.getByTestId('section-daycare'));
+    expect(section.getByText('フロア見守り')).toBeInTheDocument();
+    expect(section.getByText('山田、佐藤')).toBeInTheDocument();
+    expect(section.getByText('活動進行')).toBeInTheDocument();
+    expect(section.getByText('鈴木')).toBeInTheDocument();
+  });
+});
+
+describe('TodayServiceStructureCard — 生活支援', () => {
+  it('受け入れ件数・窓口・対応職員が表示される', () => {
+    render(<TodayServiceStructureCard serviceStructure={fullStructure} />);
+
+    expect(screen.getByTestId('section-life-support')).toBeInTheDocument();
+    expect(screen.getByText('ショートステイ 1件')).toBeInTheDocument();
+    expect(screen.getByText('一時ケア 2件')).toBeInTheDocument();
+    expect(screen.getByText('受け入れ窓口')).toBeInTheDocument();
+    expect(screen.getByText('高橋、伊藤')).toBeInTheDocument();
+  });
+
+  it('注意事項が表示される', () => {
+    render(<TodayServiceStructureCard serviceStructure={fullStructure} />);
+
+    expect(screen.getByText(/送迎時間確認あり/)).toBeInTheDocument();
+  });
+
+  it('件数が0のとき空状態メッセージが表示される', () => {
+    render(<TodayServiceStructureCard serviceStructure={emptyLifeSupport} />);
+
+    expect(screen.getByTestId('empty-life-support')).toBeInTheDocument();
+    expect(screen.getByText('本日の生活支援受け入れ予定はありません')).toBeInTheDocument();
+  });
+});
+
+describe('TodayServiceStructureCard — 判断窓口', () => {
+  it('所長・サビ管・ナース在席が表示される', () => {
+    render(<TodayServiceStructureCard serviceStructure={fullStructure} />);
+
+    expect(screen.getByTestId('section-decision-support')).toBeInTheDocument();
+    expect(screen.getByText('所長')).toBeInTheDocument();
+    expect(screen.getByText('サビ管')).toBeInTheDocument();
+    expect(screen.getByText('ナース')).toBeInTheDocument();
+    // All present
+    const chips = screen.getAllByText('在席');
+    expect(chips.length).toBe(3);
+  });
+
+  it('一部不在でも表示が壊れない', () => {
+    render(<TodayServiceStructureCard serviceStructure={partialPresence} />);
+
+    expect(screen.getByText('所長')).toBeInTheDocument();
+    expect(screen.getByText('サビ管')).toBeInTheDocument();
+    // serviceManager is absent
+    expect(screen.getByText('不在')).toBeInTheDocument();
+    // director and nurse are present
+    const presentChips = screen.getAllByText('在席');
+    expect(presentChips.length).toBe(2);
+  });
+});
+
+describe('TodayServiceStructureCard — 全体', () => {
+  it('data-testid が設定されている', () => {
+    render(<TodayServiceStructureCard serviceStructure={fullStructure} />);
+
+    expect(screen.getByTestId('today-service-structure-card')).toBeInTheDocument();
+  });
+
+  it('タイトルが表示される', () => {
+    render(<TodayServiceStructureCard serviceStructure={fullStructure} />);
+
+    expect(screen.getByText(/今日の業務体制/)).toBeInTheDocument();
+  });
+});

--- a/src/features/today/widgets/TodayServiceStructureCard.tsx
+++ b/src/features/today/widgets/TodayServiceStructureCard.tsx
@@ -1,0 +1,213 @@
+/**
+ * TodayServiceStructureCard — 今日の業務体制
+ *
+ * 「担当表」ではなく「業務体制」を可視化する。
+ * 3セクション: 生活介護 / 生活支援 / 判断窓口
+ *
+ * - 生活介護: 集団対応の配置・役割
+ * - 生活支援: ショートステイ・一時ケア受け入れ体制
+ * - 判断窓口: 所長・サビ管・ナースの在席
+ *
+ * @see Issue 3: /today に TodayServiceStructureCard を追加
+ */
+import BusinessCenterIcon from '@mui/icons-material/BusinessCenter';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import RemoveCircleOutlineIcon from '@mui/icons-material/RemoveCircleOutline';
+import {
+    Box,
+    Chip,
+    Divider,
+    Paper,
+    Stack,
+    Typography,
+} from '@mui/material';
+import React from 'react';
+import type { ServiceStructure } from '../domain/serviceStructure.types';
+import { EmptyStateBlock } from './EmptyStateBlock';
+
+// ─── Props ───────────────────────────────────────────────────
+
+export type TodayServiceStructureCardProps = {
+  serviceStructure: ServiceStructure;
+};
+
+// ─── Helpers ─────────────────────────────────────────────────
+
+function RoleRow({ label, names }: { label: string; names: string[] }) {
+  if (names.length === 0) return null;
+  return (
+    <Box sx={{ display: 'flex', gap: 1, alignItems: 'baseline', py: 0.25 }}>
+      <Typography
+        variant="caption"
+        sx={{ color: 'text.secondary', minWidth: 90, flexShrink: 0, fontSize: '0.7rem' }}
+      >
+        {label}
+      </Typography>
+      <Typography variant="body2" sx={{ fontSize: '0.8rem' }}>
+        {names.join('、')}
+      </Typography>
+    </Box>
+  );
+}
+
+function PresenceIndicator({ label, present, names }: { label: string; present: boolean; names: string[] }) {
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 0.25 }}>
+      {present ? (
+        <CheckCircleIcon sx={{ fontSize: 16, color: 'success.main' }} />
+      ) : (
+        <RemoveCircleOutlineIcon sx={{ fontSize: 16, color: 'text.disabled' }} />
+      )}
+      <Typography variant="body2" sx={{ fontSize: '0.8rem', minWidth: 48 }}>
+        {label}
+      </Typography>
+      <Chip
+        size="small"
+        label={present ? '在席' : '不在'}
+        color={present ? 'success' : 'default'}
+        variant={present ? 'filled' : 'outlined'}
+        sx={{ fontSize: '0.65rem', height: 20, '& .MuiChip-label': { px: 0.75 } }}
+      />
+      {present && names.length > 0 && (
+        <Typography variant="caption" color="text.secondary">
+          {names.join('、')}
+        </Typography>
+      )}
+    </Box>
+  );
+}
+
+function SectionHeader({ emoji, title }: { emoji: string; title: string }) {
+  return (
+    <Typography
+      variant="overline"
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 0.5,
+        fontWeight: 700,
+        letterSpacing: '0.06em',
+        color: 'text.secondary',
+        fontSize: '0.65rem',
+        mb: 0.5,
+      }}
+    >
+      {emoji} {title}
+    </Typography>
+  );
+}
+
+// ─── Main Component ──────────────────────────────────────────
+
+export const TodayServiceStructureCard: React.FC<TodayServiceStructureCardProps> = ({
+  serviceStructure,
+}) => {
+  const { dayCare, lifeSupport, decisionSupport } = serviceStructure;
+
+  const hasDayCareStaff =
+    dayCare.floorWatchStaff.length > 0 ||
+    dayCare.activityLeadStaff.length > 0 ||
+    dayCare.mealSupportStaff.length > 0 ||
+    dayCare.recordCheckStaff.length > 0 ||
+    dayCare.returnAcceptStaff.length > 0;
+
+  const hasLifeSupport = lifeSupport.shortStayCount > 0 || lifeSupport.temporaryCareCount > 0;
+
+  return (
+    <Paper
+      data-testid="today-service-structure-card"
+      sx={{ p: 2, mb: 3 }}
+    >
+      <Typography variant="subtitle2" fontWeight="bold" sx={{ mb: 1.5 }}>
+        🏢 今日の業務体制
+      </Typography>
+
+      <Stack spacing={2}>
+        {/* ── A. 生活介護 ── */}
+        <Box>
+          <SectionHeader emoji="🟢" title="生活介護" />
+          {hasDayCareStaff ? (
+            <Box data-testid="section-daycare">
+              <RoleRow label="フロア見守り" names={dayCare.floorWatchStaff} />
+              <RoleRow label="活動進行" names={dayCare.activityLeadStaff} />
+              <RoleRow label="食事対応" names={dayCare.mealSupportStaff} />
+              <RoleRow label="記録確認" names={dayCare.recordCheckStaff} />
+              <RoleRow label="送迎戻り受入" names={dayCare.returnAcceptStaff} />
+            </Box>
+          ) : (
+            <EmptyStateBlock
+              icon={<BusinessCenterIcon />}
+              title="配置情報はありません"
+              description="スケジュール登録後に表示されます。"
+              testId="empty-daycare"
+            />
+          )}
+        </Box>
+
+        <Divider />
+
+        {/* ── B. 生活支援（ショートステイ・一時ケア） ── */}
+        <Box>
+          <SectionHeader emoji="🔵" title="生活支援（ショートステイ・一時ケア）" />
+          {hasLifeSupport ? (
+            <Box data-testid="section-life-support">
+              <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mb: 0.5 }}>
+                {lifeSupport.shortStayCount > 0 && (
+                  <Chip
+                    size="small"
+                    label={`ショートステイ ${lifeSupport.shortStayCount}件`}
+                    color="primary"
+                    variant="outlined"
+                  />
+                )}
+                {lifeSupport.temporaryCareCount > 0 && (
+                  <Chip
+                    size="small"
+                    label={`一時ケア ${lifeSupport.temporaryCareCount}件`}
+                    color="secondary"
+                    variant="outlined"
+                  />
+                )}
+              </Box>
+              <RoleRow label="受け入れ窓口" names={lifeSupport.intakeDeskStaff} />
+              <RoleRow label="対応職員" names={lifeSupport.supportStaff} />
+              <RoleRow label="調整確認" names={lifeSupport.coordinatorStaff} />
+              {lifeSupport.notes.length > 0 && (
+                <Box sx={{ mt: 0.5 }}>
+                  {lifeSupport.notes.map((note, i) => (
+                    <Typography
+                      key={i}
+                      variant="caption"
+                      sx={{ display: 'block', color: 'warning.main', fontSize: '0.7rem' }}
+                    >
+                      ⚠ {note}
+                    </Typography>
+                  ))}
+                </Box>
+              )}
+            </Box>
+          ) : (
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{ fontStyle: 'italic', py: 0.5, display: 'block' }}
+              data-testid="empty-life-support"
+            >
+              本日の生活支援受け入れ予定はありません
+            </Typography>
+          )}
+        </Box>
+
+        <Divider />
+
+        {/* ── C. 判断窓口 ── */}
+        <Box data-testid="section-decision-support">
+          <SectionHeader emoji="🟡" title="判断窓口" />
+          <PresenceIndicator label="所長" present={decisionSupport.directorPresent} names={decisionSupport.directorNames} />
+          <PresenceIndicator label="サビ管" present={decisionSupport.serviceManagerPresent} names={decisionSupport.serviceManagerNames} />
+          <PresenceIndicator label="ナース" present={decisionSupport.nursePresent} names={decisionSupport.nurseNames} />
+        </Box>
+      </Stack>
+    </Paper>
+  );
+};

--- a/src/pages/TodayOpsPage.tsx
+++ b/src/pages/TodayOpsPage.tsx
@@ -98,13 +98,17 @@ export const TodayOpsPage: React.FC = () => {
         },
       },
       attendance: {
+        scheduledCount: summary.users?.length ?? 0,
         facilityAttendees: summary?.attendanceSummary?.facilityAttendees ?? 0,
-        absenceCount: summary?.attendanceSummary?.absenceCount ?? 0,
-        absenceNames: summary?.attendanceSummary?.absenceNames ?? [],
+        sameDayAbsenceCount: summary?.attendanceSummary?.sameDayAbsenceCount ?? 0,
+        sameDayAbsenceNames: summary?.attendanceSummary?.sameDayAbsenceNames ?? [],
+        priorAbsenceCount: summary?.attendanceSummary?.priorAbsenceCount ?? 0,
+        priorAbsenceNames: summary?.attendanceSummary?.priorAbsenceNames ?? [],
         lateOrEarlyLeave: summary?.attendanceSummary?.lateOrEarlyLeave ?? 0,
         lateOrEarlyNames: summary?.attendanceSummary?.lateOrEarlyNames ?? [],
       },
       briefingAlerts: summary?.briefingAlerts ?? [],
+      serviceStructure: summary?.serviceStructure,
       nextAction,
       transport: {
         pending: transport.isReady


### PR DESCRIPTION
## 概要

`/today` ページに**朝の確認に必要な3本柱**を追加。Execution Layer (ADR-002) の原則を維持したまま、現場の朝会・確認業務に耐える画面に強化。

## 変更内容

### Issue 1: 出席状況の実務精度向上
- 当日欠席 / 事前欠席の分離（欠席加算に直結する当日欠席を「🔴 記録重要」で強調）
- 遅刻・早退の可視化
- 各区分に名前リスト表示
- `EmptyStateBlock` による空状態ガイド

### Issue 2: 共有事項の二層分離
- 「📌 今日の共有事項」と「🔁 最近の引き継ぎ要点」を分離
- アクション追跡（未対応 / 対応中 / 確認済）
- セクション別進捗カウンタ
- カテゴリ Chip 表示

### Issue 3: 業務体制の可視化
- `TodayServiceStructureCard` 新規追加
- 🟢 生活介護 / 🔵 生活支援 / 🟡 判断窓口 の3セクション
- 型定義 (`serviceStructure.types.ts`)
- Bento Layout (Row 3, full-width) に統合

## 現場価値

**常勤**: 朝会前に出欠・体制・申し送りを一画面で確認。当日欠席の記録漏れ防止。
**非常勤**: 「今日の共有事項」を起点に当日必要な情報へ短時間でアクセス可能。

## テスト

全ウィジェット **39 tests / 5 spec files — All passing** ✅

| Spec | Tests |
|------|-------|
| AttendanceSummaryCard | 6 |
| BriefingActionList | 11 |
| TodayServiceStructureCard | 8 |
| NextActionCard | 8 |
| HeroUnfinishedBanner | 6 |

TypeScript: 今回の `/today` 改修スコープに関する新規エラーなし。

## Execution Layer 維持

- データフローは `useTodaySummary` facade 経由 ✅
- ページに集約ロジックなし ✅
- 新規データは dashboard domain → pick パターン ✅
- ADR-002 準拠 ✅

## 次フェーズ

次は現場確認を通じて、情報密度・表示順・Bento 配置の微調整を行う。