### PR TITLE
docs(todayops): roadmap, runbook + feat(worker): allow runtime feature flag

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -65,6 +65,7 @@ const RUNTIME_ENV_ALLOWLIST = new Set([
   'VITE_RECEPTION_GROUP_ID',
   'VITE_AAD_ADMIN_GROUP_ID',
   'VITE_ADMIN_GROUP_ID',
+  'VITE_FEATURE_TODAY_OPS',
 ]);
 
 const pickRuntimeEnvFromBindings = (env: Env): Record<string, string> => {


### PR DESCRIPTION
## Summary

- **docs**: Add TodayOps roadmap, layout spec, trial review runbook, and rollout runbook
- **feat(worker)**: Add `VITE_FEATURE_TODAY_OPS` to `RUNTIME_ENV_ALLOWLIST`

## Why the Worker change matters

Without this change, setting `VITE_FEATURE_TODAY_OPS=true` in Cloudflare Dashboard has **no effect** — the Worker doesn't inject it into `window.__ENV__`, so `readBool()` always returns `false`.

With this change:
- Cloudflare Dashboard variable changes take effect **immediately** (no rebuild needed)
- Rollback is instant: set `VITE_FEATURE_TODAY_OPS=false` in Dashboard
- Meets the <5 minute rollback requirement for the trial period

## After merge

1. Deploy (`npm run deploy:cf`)
2. Set `VITE_FEATURE_TODAY_OPS=true` in Cloudflare Dashboard
3. 4-point smoke test (staff→/today, admin→/dashboard, SP Connected, cards OK)
4. Begin 1-week observation period