### PR TITLE
fix(today): guard recordLanding against invalid Firestore instance

### DIFF
--- a/src/features/today/telemetry/recordLanding.ts
+++ b/src/features/today/telemetry/recordLanding.ts
@@ -28,9 +28,18 @@ export function recordLanding(event: LandingEvent): void {
     clientTs: new Date().toISOString(),
   };
 
-  addDoc(collection(db, 'telemetry'), payload).catch((err) => {
-    // Fire-and-forget: ログだけ残して握りつぶす
+  try {
+    // Guard: db may be a noop Proxy (E2E / unconfigured Firebase)
+    // Firebase SDK's collection() validates the first arg with instanceof —
+    // a Proxy object will fail this check and throw a FirebaseError.
+    addDoc(collection(db, 'telemetry'), payload).catch((err) => {
+      // Fire-and-forget: ログだけ残して握りつぶす
+      // eslint-disable-next-line no-console
+      console.warn('[todayops:landing] telemetry write failed', err);
+    });
+  } catch (err) {
+    // Synchronous throw from collection() when db is invalid (noop Proxy, undefined, etc.)
     // eslint-disable-next-line no-console
-    console.warn('[todayops:landing] telemetry write failed', err);
-  });
+    console.warn('[todayops:landing] telemetry skipped (db not ready)', err);
+  }
 }


### PR DESCRIPTION
## 問題

本番環境で TodayOps ページアクセス時に以下のエラーが発生:

```
FirebaseError: Expected first argument to collection() to be a CollectionReference, a DocumentReference or FirebaseFirestore
```

## 原因

`recordLanding()` が Firebase SDK の `collection(db, 'telemetry')` を呼ぶ際、`db` が noop Proxy（E2E/未設定環境）や初期化不完全な Firestore インスタンスの場合、Firebase SDK 内部の `instanceof` チェックが失敗して同期的に throw する。

既存の `.catch()` は非同期エラーのみを捕捉するため、同期的な throw はキャッチされずにページクラッシュを引き起こしていた。

## 修正

- `collection()` 呼び出しを `try-catch` で囲み、同期的なエラーも fire-and-forget で処理
- UI をブロックしない telemetry の契約を維持

## テスト

- `tsc --noEmit` ✅
- ESLint ✅
- 変更は 1 ファイル (recordLanding.ts) のみ