### PR TITLE
feat(daily): モニタリング会議カウントダウン & LastAssessmentDate追加

### DIFF
--- a/src/features/daily/__tests__/MonitoringCountdown.spec.ts
+++ b/src/features/daily/__tests__/MonitoringCountdown.spec.ts
@@ -1,0 +1,82 @@
+import { computeMonitoringCycle } from '../components/MonitoringCountdown';
+
+describe('computeMonitoringCycle（利用者別アセスメント起点）', () => {
+  it('アセスメント日 2026-01-15 → 次回 2026-04-15', () => {
+    const assessment = new Date(2026, 0, 15); // 2026-01-15
+    const now = new Date(2026, 2, 10);        // 2026-03-10
+    const result = computeMonitoringCycle(assessment, now);
+
+    expect(result.prevDate).toEqual(new Date(2026, 0, 15));
+    expect(result.nextDate).toEqual(new Date(2026, 3, 15)); // 2026-04-15
+    // 1/15 → 3/10 = 54日
+    expect(result.elapsed).toBe(54);
+    // 3/10 → 4/15 = 36日
+    expect(result.remaining).toBe(36);
+  });
+
+  it('アセスメント日 2026-02-10 → 次回 2026-05-10', () => {
+    const assessment = new Date(2026, 1, 10); // 2026-02-10
+    const now = new Date(2026, 2, 10);        // 2026-03-10
+    const result = computeMonitoringCycle(assessment, now);
+
+    expect(result.prevDate).toEqual(new Date(2026, 1, 10));
+    expect(result.nextDate).toEqual(new Date(2026, 4, 10)); // 2026-05-10
+    expect(result.elapsed).toBe(28); // 2/10 → 3/10
+    expect(result.remaining).toBe(61); // 3/10 → 5/10
+  });
+
+  it('次回を過ぎていたら自動的に次のサイクルへ進む', () => {
+    const assessment = new Date(2025, 5, 1);  // 2025-06-01
+    const now = new Date(2026, 2, 10);        // 2026-03-10
+
+    // サイクル: 6/1 → 9/1 → 12/1 → 3/1 → 6/1
+    // now=3/10 は 3/1~6/1 のサイクル内
+    const result = computeMonitoringCycle(assessment, now);
+    expect(result.prevDate).toEqual(new Date(2026, 2, 1));  // 2026-03-01
+    expect(result.nextDate).toEqual(new Date(2026, 5, 1));  // 2026-06-01
+    expect(result.elapsed).toBe(9); // 3/1 → 3/10
+  });
+
+  it('現在日がアセスメント日より前の場合', () => {
+    const assessment = new Date(2026, 5, 1);  // 2026-06-01
+    const now = new Date(2026, 2, 10);        // 2026-03-10
+
+    const result = computeMonitoringCycle(assessment, now);
+    expect(result.elapsed).toBe(0);
+    expect(result.prevDate).toEqual(new Date(2026, 5, 1));
+    expect(result.nextDate).toEqual(new Date(2026, 8, 1)); // 2026-09-01
+  });
+
+  it('ちょうどサイクル境界日の場合', () => {
+    const assessment = new Date(2026, 0, 15); // 2026-01-15
+    const now = new Date(2026, 3, 15);        // 2026-04-15 = 次回会議日と同日
+
+    const result = computeMonitoringCycle(assessment, now);
+    // 4/15 は次のサイクルの開始 → prevDate = 4/15, nextDate = 7/15
+    expect(result.prevDate).toEqual(new Date(2026, 3, 15));
+    expect(result.nextDate).toEqual(new Date(2026, 6, 15));
+    expect(result.elapsed).toBe(0);
+  });
+
+  it('progress は 0-100 の範囲内', () => {
+    const assessment = new Date(2026, 0, 1);
+    const start = computeMonitoringCycle(assessment, new Date(2026, 0, 1));
+    expect(start.progress).toBeGreaterThanOrEqual(0);
+    expect(start.progress).toBeLessThanOrEqual(100);
+
+    const mid = computeMonitoringCycle(assessment, new Date(2026, 1, 14));
+    expect(mid.progress).toBeGreaterThan(30);
+    expect(mid.progress).toBeLessThan(70);
+  });
+
+  it('月末日のアセスメント日も正しく処理される（1/31 → 4/30）', () => {
+    const assessment = new Date(2026, 0, 31); // 2026-01-31
+    const now = new Date(2026, 2, 15);        // 2026-03-15
+    const result = computeMonitoringCycle(assessment, now);
+
+    expect(result.prevDate).toEqual(new Date(2026, 0, 31));
+    // 1/31 + 3ヶ月 = 4/30（4月は30日まで）
+    expect(result.nextDate.getMonth()).toBe(3); // April
+    expect(result.nextDate.getDate()).toBe(30);
+  });
+});

--- a/src/features/daily/components/MonitoringCountdown.tsx
+++ b/src/features/daily/components/MonitoringCountdown.tsx
@@ -1,0 +1,249 @@
+/**
+ * MonitoringCountdown — 利用者別モニタリング会議カウントダウン
+ *
+ * 利用者ごとのアセスメント会議実施日を起点に、
+ * 三ヶ月後の次回モニタリング会議までのカウントダウンを
+ * ヘッダースペースにコンパクトに表示するウィジェット。
+ *
+ * - 利用者未選択: 非表示
+ * - アセスメント日未設定: 「未設定」表示
+ * - 次回会議日を過ぎている場合: 自動的に次のサイクルを計算
+ */
+import EventIcon from '@mui/icons-material/Event';
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import LinearProgress from '@mui/material/LinearProgress';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import React, { useMemo } from 'react';
+
+/* ------------------------------------------------------------------ */
+/*  純粋ロジック（テスト可能）                                          */
+/* ------------------------------------------------------------------ */
+
+const MONITORING_INTERVAL_MONTHS = 3;
+const MS_PER_DAY = 86_400_000;
+
+export interface MonitoringCycleResult {
+  /** 前回モニタリング会議日（= 直近のサイクル起点） */
+  prevDate: Date;
+  /** 次回モニタリング会議日 */
+  nextDate: Date;
+  /** 前回会議からの経過日数 */
+  elapsed: number;
+  /** 次回会議までの残り日数 */
+  remaining: number;
+  /** サイクル全体の日数 */
+  totalDays: number;
+  /** 進捗 (0-100) */
+  progress: number;
+}
+
+/**
+ * アセスメント会議実施日を起点に、三ヶ月ごとのモニタリングサイクルを計算する。
+ *
+ * アセスメント日から3ヶ月ごとに会議が繰り返される前提で、
+ * 現在日に対して「直近の過去の会議日」と「次の会議日」を特定する。
+ *
+ * @param assessmentDate アセスメント会議実施日
+ * @param now 現在日時（テスト用に差し替え可能）
+ */
+export function computeMonitoringCycle(
+  assessmentDate: Date,
+  now: Date,
+): MonitoringCycleResult {
+  // assessmentDate を起点に MONITORING_INTERVAL_MONTHS ごとのサイクルを刻む
+  // 「今日」が含まれるサイクルの [prevDate, nextDate) を見つける
+  let prevDate = new Date(assessmentDate);
+  let nextDate = addMonths(prevDate, MONITORING_INTERVAL_MONTHS);
+
+  // now がアセスメント日より前 → 最初のサイクルをそのまま返す
+  if (now < prevDate) {
+    const elapsed = 0;
+    const totalDays = Math.round((nextDate.getTime() - prevDate.getTime()) / MS_PER_DAY);
+    return {
+      prevDate,
+      nextDate,
+      elapsed,
+      remaining: totalDays,
+      totalDays,
+      progress: 0,
+    };
+  }
+
+  // now が nextDate 以降なら、prevDate を進める
+  while (nextDate.getTime() <= now.getTime()) {
+    prevDate = new Date(nextDate);
+    nextDate = addMonths(prevDate, MONITORING_INTERVAL_MONTHS);
+  }
+
+  const elapsed = Math.floor((now.getTime() - prevDate.getTime()) / MS_PER_DAY);
+  const remaining = Math.ceil((nextDate.getTime() - now.getTime()) / MS_PER_DAY);
+  const totalDays = Math.round((nextDate.getTime() - prevDate.getTime()) / MS_PER_DAY);
+  const progress = Math.min(Math.max((elapsed / totalDays) * 100, 0), 100);
+
+  return { prevDate, nextDate, elapsed, remaining, totalDays, progress };
+}
+
+/** 月を加算する（日付は同日。月末の場合は月末に丸める） */
+function addMonths(date: Date, months: number): Date {
+  const result = new Date(date);
+  const targetMonth = result.getMonth() + months;
+  result.setMonth(targetMonth);
+  // 月をまたぐとき日がずれる場合の補正（31日→28日 等）
+  if (result.getDate() !== date.getDate()) {
+    result.setDate(0); // 前月末に戻す
+  }
+  return result;
+}
+
+/* ------------------------------------------------------------------ */
+/*  コンポーネント                                                      */
+/* ------------------------------------------------------------------ */
+
+const formatDate = (d: Date) =>
+  `${d.getFullYear()}/${String(d.getMonth() + 1).padStart(2, '0')}/${String(d.getDate()).padStart(2, '0')}`;
+
+export type MonitoringCountdownProps = {
+  /** 選択中の利用者名 */
+  userName?: string;
+  /** アセスメント会議実施日 (ISO 文字列 or null) */
+  lastAssessmentDate?: string | null;
+  /** テスト用に「今日」を差し替え可能 */
+  today?: Date;
+};
+
+export const MonitoringCountdown: React.FC<MonitoringCountdownProps> = ({
+  userName,
+  lastAssessmentDate,
+  today,
+}) => {
+  const now = useMemo(() => today ?? new Date(), [today]);
+
+  // 利用者未選択 → 非表示
+  if (!userName) return null;
+
+  // アセスメント日未設定 → 「未設定」表示
+  if (!lastAssessmentDate) {
+    return (
+      <Tooltip title="この利用者のアセスメント会議実施日が未設定です" arrow placement="bottom">
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 0.5,
+            px: 1,
+            py: 0.5,
+            borderRadius: 2,
+            bgcolor: 'action.hover',
+            cursor: 'default',
+            flexShrink: 0,
+          }}
+          data-testid="monitoring-countdown"
+        >
+          <WarningAmberIcon sx={{ fontSize: '0.9rem', color: 'text.disabled' }} />
+          <Typography variant="caption" color="text.disabled" sx={{ fontSize: '0.7rem', whiteSpace: 'nowrap' }}>
+            会議日未設定
+          </Typography>
+        </Box>
+      </Tooltip>
+    );
+  }
+
+  return <MonitoringCountdownInner assessmentDateStr={lastAssessmentDate} now={now} />;
+};
+
+/** 内部コンポーネント — アセスメント日が確定している場合 */
+const MonitoringCountdownInner: React.FC<{ assessmentDateStr: string; now: Date }> = ({
+  assessmentDateStr,
+  now,
+}) => {
+  const cycle = useMemo(() => {
+    const assessmentDate = new Date(`${assessmentDateStr}T00:00:00`);
+    return computeMonitoringCycle(assessmentDate, now);
+  }, [assessmentDateStr, now]);
+
+  // 残り日数による色分け
+  const urgencyColor = cycle.remaining <= 14 ? 'error' : cycle.remaining <= 30 ? 'warning' : 'primary';
+  const urgencyLabel =
+    cycle.remaining <= 7 ? '会議間近' : cycle.remaining <= 14 ? 'もうすぐ' : '';
+
+  return (
+    <Tooltip
+      title={
+        <Box sx={{ p: 0.5 }}>
+          <Typography variant="body2" fontWeight="bold" gutterBottom>
+            モニタリング会議（三ヶ月ごと）
+          </Typography>
+          <Typography variant="caption" component="div">
+            前回会議日：{formatDate(cycle.prevDate)}（{cycle.elapsed}日前）
+          </Typography>
+          <Typography variant="caption" component="div">
+            次回会議日：{formatDate(cycle.nextDate)}（あと{cycle.remaining}日）
+          </Typography>
+          <Typography variant="caption" component="div" sx={{ mt: 0.5 }}>
+            サイクル進捗：{Math.round(cycle.progress)}%（{cycle.elapsed}/{cycle.totalDays}日）
+          </Typography>
+        </Box>
+      }
+      arrow
+      placement="bottom"
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 0.75,
+          px: 1.5,
+          py: 0.5,
+          borderRadius: 2,
+          bgcolor: 'action.hover',
+          cursor: 'default',
+          minWidth: 'fit-content',
+          flexShrink: 0,
+        }}
+        data-testid="monitoring-countdown"
+      >
+        <EventIcon
+          fontSize="small"
+          color={urgencyColor as 'error' | 'warning' | 'primary'}
+          sx={{ fontSize: '1rem' }}
+        />
+
+        <Box sx={{ display: 'flex', flexDirection: 'column', minWidth: 80, gap: 0.25 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+            <Typography
+              variant="caption"
+              fontWeight="bold"
+              color={`${urgencyColor}.main`}
+              sx={{ fontSize: '0.7rem', lineHeight: 1.2, whiteSpace: 'nowrap' }}
+            >
+              次回会議まで {cycle.remaining}日
+            </Typography>
+            {urgencyLabel && (
+              <Chip
+                label={urgencyLabel}
+                size="small"
+                color={urgencyColor as 'error' | 'warning'}
+                sx={{ height: 16, fontSize: '0.6rem', '& .MuiChip-label': { px: 0.5 } }}
+              />
+            )}
+          </Box>
+
+          <LinearProgress
+            variant="determinate"
+            value={cycle.progress}
+            color={urgencyColor as 'primary' | 'warning' | 'error'}
+            sx={{
+              height: 3,
+              borderRadius: 1.5,
+              bgcolor: 'grey.300',
+              '& .MuiLinearProgress-bar': { borderRadius: 1.5 },
+            }}
+          />
+        </Box>
+      </Box>
+    </Tooltip>
+  );
+};

--- a/src/features/users/constants.ts
+++ b/src/features/users/constants.ts
@@ -12,6 +12,7 @@ export const DEMO_USERS: IUserMaster[] = [
     IsSupportProcedureTarget: true,
     ServiceEndDate: null,
     AttendanceDays: ['月', '火', '水', '木', '金'],
+    LastAssessmentDate: '2026-01-15',
   },
   {
     Id: 2,
@@ -23,6 +24,7 @@ export const DEMO_USERS: IUserMaster[] = [
     IsSupportProcedureTarget: true,
     ServiceEndDate: null,
     AttendanceDays: ['月', '水', '金'],
+    LastAssessmentDate: '2026-02-10',
   },
   {
     Id: 3,
@@ -34,6 +36,7 @@ export const DEMO_USERS: IUserMaster[] = [
     IsSupportProcedureTarget: true,
     ServiceEndDate: null,
     AttendanceDays: ['火', '木', '金'],
+    LastAssessmentDate: '2025-12-20',
   },
   // 通常利用者（29名）- 支援記録（ケース記録）のみ
   {

--- a/src/pages/DailyRecordMenuPage.tsx
+++ b/src/pages/DailyRecordMenuPage.tsx
@@ -393,7 +393,7 @@ const DailyRecordMenuPage: React.FC = () => {
                   <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                     <AssignmentIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
                     <Typography variant="body2" color="text.secondary">
-                      対象：強度行動障害者（{intensiveSupportUsers}名）
+                      対象：強度行動障害支援対象者（{intensiveSupportUsers}名）
                     </Typography>
                     <Chip
                       label="⚑ 特別支援"

--- a/src/pages/TimeBasedSupportRecordPage.tsx
+++ b/src/pages/TimeBasedSupportRecordPage.tsx
@@ -1,6 +1,6 @@
 ﻿import { useInterventionStore } from '@/features/analysis/stores/interventionStore';
 import { FullScreenDailyDialogPage } from '@/features/daily/components/FullScreenDailyDialogPage';
-
+import { MonitoringCountdown } from '@/features/daily/components/MonitoringCountdown';
 import { ProcedureEditor } from '@/features/daily/components/procedure/ProcedureEditor';
 import { RecentRecordsDialog } from '@/features/daily/components/split-stream/RecentRecordsDialog';
 import { PlanSelectionStep } from '@/features/daily/components/wizard/PlanSelectionStep';
@@ -242,7 +242,12 @@ const TimeBasedSupportRecordPage: React.FC = () => {
       title="支援手順兼記録"
       backTo="/dashboard"
       testId="daily-support-page"
-
+      headerActions={
+        <MonitoringCountdown
+          userName={selectedUser?.FullName}
+          lastAssessmentDate={selectedUser?.LastAssessmentDate}
+        />
+      }
     >
       <Container
         maxWidth="xl"

--- a/src/sharepoint/fields/userFields.ts
+++ b/src/sharepoint/fields/userFields.ts
@@ -53,6 +53,9 @@ export interface IUserMaster {
 
   // 取得レベルマーカー（Repository から付与、UI 側で表示判定に使用可）
   __selectMode?: UserSelectMode;
+
+  // アセスメント会議実施日（モニタリング会議カウントダウンの起点）
+  LastAssessmentDate?: string | null;
 }
 
 export interface IUserMasterCreateDto {
@@ -89,6 +92,9 @@ export interface IUserMasterCreateDto {
   TransportAdditionType?: string | null;
   MealAddition?: string | null;
   CopayPaymentMethod?: string | null;
+
+  // アセスメント会議実施日
+  LastAssessmentDate?: string | null;
 }
 
 export const USERS_MASTER_FIELD_MAP = {
@@ -123,6 +129,7 @@ export const USERS_MASTER_FIELD_MAP = {
   transportAdditionType: 'TransportAdditionType',
   mealAddition: 'MealAddition',
   copayPaymentMethod: 'CopayPaymentMethod',
+  lastAssessmentDate: 'LastAssessmentDate',
 } as const;
 
 // ── CORE: 一覧表示用（軽量 / 20列） ──
@@ -147,6 +154,7 @@ export const USERS_SELECT_FIELDS_CORE = [
   USERS_MASTER_FIELD_MAP.recipientCertExpiry,
   USERS_MASTER_FIELD_MAP.modified,
   USERS_MASTER_FIELD_MAP.created,
+  USERS_MASTER_FIELD_MAP.lastAssessmentDate,
 ] as const;
 
 // ── DETAIL: 詳細画面用（CORE + 支給決定情報） ──


### PR DESCRIPTION
## 概要
支援記録画面にモニタリング会議までのカウントダウン表示を追加。

## 変更内容
- `MonitoringCountdown` コンポーネントを新規作成（次回モニタリングまでの日数表示）
- カウントダウンのユニットテストを追加
- `IUserMaster` に `LastAssessmentDate` フィールドを追加
- DEMO_USERS に `LastAssessmentDate` を設定
- 支援記録画面ヘッダーに `MonitoringCountdown` を統合
- テキスト修正: 強度行動障害者→支援対象者

## 依存
- #841 (fix/wizard-back-navigation) をベースにしています