### PR TITLE
feat: connect today next-action schedule deep link to week filters

### DIFF
--- a/src/features/today/widgets/NextActionCard.spec.tsx
+++ b/src/features/today/widgets/NextActionCard.spec.tsx
@@ -242,3 +242,36 @@ describe('NextActionCard — overdue 表示 (#852)', () => {
     expect(screen.getByText(/あと 15分/)).toBeInTheDocument();
   });
 });
+
+// ─── Today → Schedule 導線 ─────────────────────────────────
+
+describe('NextActionCard — Schedule deep link', () => {
+  it('calls onNavigate with scheduleDetailHref when 予定表で確認 is clicked', () => {
+    const handleNavigate = vi.fn();
+    const href = '/schedules/week?date=2026-03-12&tab=day&cat=User';
+    render(
+      <NextActionCard
+        nextAction={makeProps()}
+        scheduleDetailHref={href}
+        onNavigate={handleNavigate}
+      />,
+    );
+
+    const link = screen.getByTestId('next-action-schedule-link');
+    expect(link).toBeInTheDocument();
+    expect(link.tagName).toBe('BUTTON');
+    link.click();
+    expect(handleNavigate).toHaveBeenCalledWith(href);
+  });
+
+  it('does not render schedule link when onNavigate is not provided', () => {
+    render(
+      <NextActionCard
+        nextAction={makeProps()}
+        scheduleDetailHref="/schedules/week?date=2026-03-12"
+      />,
+    );
+
+    expect(screen.queryByTestId('next-action-schedule-link')).not.toBeInTheDocument();
+  });
+});

--- a/src/features/today/widgets/NextActionCard.tsx
+++ b/src/features/today/widgets/NextActionCard.tsx
@@ -349,15 +349,20 @@ export const NextActionCard: React.FC<NextActionCardProps> = ({
             )}
           </Box>
 
-          {/* 予定表への補助導線 */}
-          {scheduleDetailHref && (
+          {/* 予定表への補助導線 (SPA navigate — telemetry 経路統一) */}
+          {scheduleDetailHref && onNavigate && (
             <Box sx={{ mt: 1, textAlign: 'right' }}>
               <Typography
-                component="a"
-                href={scheduleDetailHref}
+                component="button"
+                type="button"
                 variant="caption"
                 data-testid="next-action-schedule-link"
+                onClick={() => onNavigate(scheduleDetailHref)}
                 sx={{
+                  background: 'none',
+                  border: 'none',
+                  padding: 0,
+                  font: 'inherit',
                   color: 'text.secondary',
                   textDecoration: 'none',
                   '&:hover': { color: 'primary.main', textDecoration: 'underline' },


### PR DESCRIPTION
## Summary

Wires the "📅 予定表で確認" link in NextActionCard to use SPA navigation instead of a raw `<a href>`, completing the Today → Schedule deep link pipeline.

## What changed

### `NextActionCard.tsx` (2 changes)
1. Replaced `<Typography component="a" href={...}>` with `<Typography component="button" onClick={() => onNavigate(href)}>`
2. Requires both `scheduleDetailHref` and `onNavigate` to render the link (prevents dangling `<a>`)

### `NextActionCard.spec.tsx` (2 new tests)
1. Verifies `onNavigate` is called with `scheduleDetailHref` when clicked
2. Verifies link is not rendered when `onNavigate` is absent

## Key finding

The schedules-side `cat` query param reception was **already implemented** in `useWeekPageRouteState.ts`:
```ts
const category = parseCategoryParam(laneParam ?? searchParams.get('cat'));
```
And `ScheduleLaneCategory` (`'User' | 'Staff' | 'Org'`) matches `ScheduleCategory` exactly.

So the only missing piece was the SPA navigate on the Today side.

## Done checklist
- [x] NextAction → Schedules SPA transition
- [x] cat-based initial filter (already working via useWeekPageRouteState)
- [x] Telemetry path unified through onNavigate
- [x] Existing behavior non-breaking
- [x] 2 tests added for this pathway

## PR size
- 2 files changed
- 42 insertions, 4 deletions
