### PR TITLE
feat: monitoring-to-iceberg reanalysis link (Phase5 P1)

### DIFF
--- a/src/app/links/__tests__/navigationLinks.test.ts
+++ b/src/app/links/__tests__/navigationLinks.test.ts
@@ -153,6 +153,16 @@ describe('buildIcebergPdcaUrl', () => {
     expect(url).toContain('userId=user');
     expect(url).toMatch(/^\/analysis\/iceberg-pdca\?/);
   });
+
+  it('source オプションを指定すると URL に含まれる', () => {
+    expect(buildIcebergPdcaUrl('U001', { source: 'monitoring' })).toBe(
+      '/analysis/iceberg-pdca?userId=U001&source=monitoring',
+    );
+  });
+
+  it('source 未指定なら userId のみ（後方互換）', () => {
+    expect(buildIcebergPdcaUrl('U001')).toBe('/analysis/iceberg-pdca?userId=U001');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/app/links/navigationLinks.ts
+++ b/src/app/links/navigationLinks.ts
@@ -212,11 +212,18 @@ export function resolveOpsNavTarget(opsStep?: string): OpsNavTarget {
 
 /**
  * /analysis/iceberg-pdca?userId=xxx を生成する。
- * Daily Support → Iceberg PDCA への導線で使用。
+ * Daily Support / Monitoring → Iceberg PDCA への導線で使用。
+ * source を指定すると流入元追跡に利用できる。
  */
-export function buildIcebergPdcaUrl(userId: string): string {
+export function buildIcebergPdcaUrl(
+  userId: string,
+  options?: { source?: string },
+): string {
   const search = new URLSearchParams();
   search.set('userId', userId);
+  if (options?.source) {
+    search.set('source', options.source);
+  }
   return `/analysis/iceberg-pdca?${search.toString()}`;
 }
 

--- a/src/features/support-plan-guide/components/tabs/MonitoringTab.tsx
+++ b/src/features/support-plan-guide/components/tabs/MonitoringTab.tsx
@@ -18,6 +18,9 @@ import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { buildIcebergPdcaUrl } from '@/app/links/navigationLinks';
 
 import { buildIcebergEvidence } from '@/features/ibd/analysis/pdca/icebergEvidenceAdapter';
 import { useIcebergPdcaList } from '@/features/ibd/analysis/pdca/queries';
@@ -150,6 +153,7 @@ const IcebergEvidenceSection: React.FC<{
 };
 
 const MonitoringTab: React.FC<MonitoringTabProps> = ({ userId, setToast, ...sectionProps }) => {
+  const navigate = useNavigate();
   const section = findSection('monitoring');
   if (!section) return null;
 
@@ -193,6 +197,21 @@ const MonitoringTab: React.FC<MonitoringTabProps> = ({ userId, setToast, ...sect
             setToast({ open: true, message: 'Iceberg分析結果を引用しました。内容を調整してください。', severity: 'success' });
           }}
         />
+      )}
+
+      {userId && (
+        <Box sx={{ mt: 1 }}>
+          <Button
+            variant="outlined"
+            color="secondary"
+            size="small"
+            startIcon={<BubbleChartIcon />}
+            onClick={() => navigate(buildIcebergPdcaUrl(String(userId), { source: 'monitoring' }))}
+            data-testid="monitoring-reanalysis-link"
+          >
+            再分析する
+          </Button>
+        </Box>
       )}
 
       <Stack spacing={2}>


### PR DESCRIPTION
## Summary

Closes the PDCA improvement loop by adding a 're-analyze' navigation from Monitoring back to Iceberg PDCA.

### Before
\\\
Today → Schedules → Daily → Iceberg → Monitoring (dead end)
\\\

### After
\\\
Today → Schedules → Daily → Iceberg → Monitoring → Iceberg (loop)
\\\

## Changes

### 1. MonitoringTab — 're-analyze' button
- Added below IcebergEvidenceSection
- BubbleChart icon + secondary color (consistent with Iceberg branding)
- Navigates to \/analysis/iceberg-pdca?userId=xxx&source=monitoring\
- \data-testid='monitoring-reanalysis-link'\

### 2. buildIcebergPdcaUrl — optional \source\ param
- Backward compatible (source is optional, existing callers unaffected)
- Enables future telemetry tracking of navigation origin
- When \source='monitoring'\, URL becomes \?userId=xxx&source=monitoring\

### 3. Tests (+2)
- \source\ option included in URL
- \source\ omitted = backward compatible

## Connection Matrix (final)

\\\
         To →   Today   Schedules   Daily   Iceberg   Monitoring
From ↓
Today            —       ✅          ✅      ✅        ❌
Schedules        ❌      —           ✅      ❌        ❌
Daily            ❌      ❌          —       ✅        ❌
Iceberg          ❌      ❌          ❌      —         ✅
Monitoring       ❌      ❌          ❌      ✅ NEW    —
\\\

**PDCA improvement loop: COMPLETE** 🎉