### PR TITLE
chore: eliminate all as-any from production code (#839 Phase 1)

### DIFF
--- a/src/features/schedules/repositoryFactory.ts
+++ b/src/features/schedules/repositoryFactory.ts
@@ -5,8 +5,14 @@ import {
     isTestMode,
     shouldSkipLogin,
 } from '@/lib/env';
+import { isE2E } from '@/env';
 import { hasSpfxContext } from '@/lib/runtime';
 import { useMemo } from 'react';
+
+/** Debug-only window extension for tracking repository changes in E2E */
+interface WindowWithDebug extends Window {
+  __LAST_REPO__?: unknown;
+}
 
 import { useAuth } from '@/auth/useAuth';
 import type { ScheduleRepository } from './domain/ScheduleRepository';
@@ -40,10 +46,9 @@ let overrideKind: ScheduleRepositoryKind | null = null;
 const shouldUseDemoRepository = (): boolean => {
   const { isDev } = getAppConfig();
   const spfxContextAvailable = hasSpfxContext();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const isE2E = (typeof window !== 'undefined' && (window as any).__ENV__?.VITE_E2E === '1');
+  const e2eActive = isE2E;
 
-  if (isE2E) return false;
+  if (e2eActive) return false;
 
   return (
     isDev ||
@@ -182,18 +187,14 @@ export const useScheduleRepository = (): ScheduleRepository => {
     return getScheduleRepository({ acquireToken });
   }, [acquireToken]);
 
-  // eslint-disable-next-line no-console
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  if (typeof window !== 'undefined' && (window as any).__ENV__?.VITE_E2E === '1') {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (window as any).__LAST_REPO__ = (window as any).__LAST_REPO__ || null;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const changed = (window as any).__LAST_REPO__ !== repo;
+  if (typeof window !== 'undefined' && isE2E) {
+    const w = window as WindowWithDebug;
+    w.__LAST_REPO__ = w.__LAST_REPO__ || null;
+    const changed = w.__LAST_REPO__ !== repo;
     if (changed) {
       // eslint-disable-next-line no-console
       console.log('[schedules] [useScheduleRepository] repository instance CHANGED');
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (window as any).__LAST_REPO__ = repo;
+      w.__LAST_REPO__ = repo;
     }
   }
 

--- a/src/hooks/useDaily.ts
+++ b/src/hooks/useDaily.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import { useCallback } from 'react';
 import { useSP } from '@/lib/spClient';
 import type { DailyUpsert, SpDailyItem } from '@/types';
@@ -9,12 +9,9 @@ export type DailyWithEtag = {
   etag: string | null;
 };
 
-const sanitizeEnvValue = (value: unknown): string => {
-  if (typeof value !== 'string') return '';
-  return value.trim();
-};
+import { get as getEnv } from '@/env';
 
-const DEFAULT_DAILY_LIST_TITLE = sanitizeEnvValue((import.meta as any)?.env?.VITE_SP_LIST_DAILY) || 'SupportRecord_Daily';
+const DEFAULT_DAILY_LIST_TITLE = getEnv('VITE_SP_LIST_DAILY', 'SupportRecord_Daily').trim() || 'SupportRecord_Daily';
 
 export function useDaily() {
   const sp = useSP();

--- a/src/infra/sharepoint/repos/schedulesRepo.ts
+++ b/src/infra/sharepoint/repos/schedulesRepo.ts
@@ -183,8 +183,7 @@ export async function querySchedules(
   args: QuerySchedulesArgs,
   client: ReturnType<typeof useSP>
 ): Promise<RepoSchedule[]> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const listIdentifier = ((FIELD_MAP as any).Schedules?.title ?? 'Schedules');
+  const listIdentifier = FIELD_MAP.Schedules.title;
 
   const select = [
     'Id',
@@ -255,9 +254,9 @@ export type UpdateScheduleInput = Partial<Omit<CreateScheduleInput, 'rowKey'>> &
   // rowKey は原則不変
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const pickEtag = (v: any): string | undefined => {
-  return v?.etag ?? v?.ETag ?? v?.__metadata?.etag ?? v?.headers?.etag ?? v?.headers?.ETag;
+const pickEtag = (v: SpScheduleRow | Record<string, unknown> | undefined | null): string | undefined => {
+  if (!v) return undefined;
+  return (v.etag ?? v.ETag ?? v.__metadata?.etag ?? v.headers?.etag ?? v.headers?.ETag) as string | undefined;
 };
 
 /**
@@ -360,8 +359,7 @@ export async function createSchedule(
   const payload = buildCreateBody(input);
 
   // Step 1: POST to create item (may return incomplete data)
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const created: any = await client.addListItemByTitle(listId, payload);
+  const created = await client.addListItemByTitle(listId, payload) as SpScheduleRow | undefined;
   
   // Step 2: Extract ID from response
   const createdId = Number(created?.Id ?? created?.d?.Id ?? created?.data?.Id);
@@ -441,15 +439,13 @@ export async function updateSchedule(
   const listId = getSchedulesListTitle();
 
   // NOTE: spClient.updateItem(listId, id, body, { ifMatch }) 前提
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const updated: any = await client.updateItem(listId, id, buildUpdateBody(input), { ifMatch: etag });
+  const updated = await client.updateItem(listId, id, buildUpdateBody(input), { ifMatch: etag }) as SpScheduleRow | undefined;
 
   const nextEtag = pickEtag(updated) ?? etag;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const row: any = updated?.data ?? updated;
+  const row = (updated?.data ?? updated) as SpScheduleRow | undefined;
 
   try {
-    return mapSpToRepoSchedule(row, nextEtag);
+    return mapSpToRepoSchedule(row!, nextEtag);
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : String(err);
     const errorStack = err instanceof Error ? err.stack : undefined;

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,4 +1,4 @@
-﻿import { getRuntimeEnv, isDev as runtimeIsDev } from '@/env';
+import { getRuntimeEnv, isDev as runtimeIsDev } from '@/env';
 import { z } from 'zod';
 import { envSchema as AppEnvSchema } from './env.schema';
 
@@ -150,8 +150,7 @@ const getEnvValue = (key: string, envOverride?: EnvRecord): Primitive => {
 const resolveIsDev = (envOverride?: EnvRecord): boolean => {
   // Use a slightly obfuscated access to bypass simple regex-based architecture guards
   // that prevent direct import.meta.env usage in feature code.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const metaEnv = (import.meta as any).env;
+  const metaEnv = (import.meta as ImportMeta).env;
   if (metaEnv && metaEnv.DEV) {
     return true;
   }

--- a/tests/unit/Home.spec.tsx
+++ b/tests/unit/Home.spec.tsx
@@ -29,6 +29,16 @@ vi.mock('@/lib/env', async () => {
   };
 });
 
+vi.mock('@/env', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/env')>();
+  return {
+    ...actual,
+    isE2E: false,
+    isE2eMsalMock: false,
+    isE2eForceSchedulesWrite: false,
+  };
+});
+
 const renderHome = () =>
   renderWithAppProviders(
     <FeatureFlagsProvider value={{ ...featureFlagsState }}>

--- a/tests/unit/repositoryFactory.spec.ts
+++ b/tests/unit/repositoryFactory.spec.ts
@@ -38,6 +38,16 @@ vi.mock('@/lib/runtime', () => ({
   hasSpfxContext: () => mockState.hasSpfxContext,
 }));
 
+vi.mock('@/env', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/env')>();
+  return {
+    ...actual,
+    isE2E: false,
+    isE2eMsalMock: false,
+    isE2eForceSchedulesWrite: false,
+  };
+});
+
 vi.mock('@/lib/audit', () => ({
   pushAudit: vi.fn(),
 }));

--- a/tests/unit/schedules/schedules.no-direct-sp.spec.ts
+++ b/tests/unit/schedules/schedules.no-direct-sp.spec.ts
@@ -31,6 +31,16 @@ vi.mock('@/lib/runtime', () => ({
   hasSpfxContext: vi.fn(() => false),
 }));
 
+vi.mock('@/env', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/env')>();
+  return {
+    ...actual,
+    isE2E: false,
+    isE2eMsalMock: false,
+    isE2eForceSchedulesWrite: false,
+  };
+});
+
 // Break transitive import chain
 vi.mock('@/features/schedules/infra/SharePointScheduleRepository', () => ({
   SharePointScheduleRepository: vi.fn(),

--- a/tests/unit/schedules/schedules.repositoryFactory.spec.ts
+++ b/tests/unit/schedules/schedules.repositoryFactory.spec.ts
@@ -49,6 +49,16 @@ vi.mock('@/lib/runtime', () => ({
   hasSpfxContext: vi.fn(() => false),
 }));
 
+vi.mock('@/env', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/env')>();
+  return {
+    ...actual,
+    isE2E: false,
+    isE2eMsalMock: false,
+    isE2eForceSchedulesWrite: false,
+  };
+});
+
 // Break transitive import chain: SharePointScheduleRepository → fetchSp → msal
 vi.mock('@/features/schedules/infra/SharePointScheduleRepository', () => ({
   SharePointScheduleRepository: MockSPRepo,
@@ -71,6 +81,7 @@ import {
     resetScheduleRepository,
 } from '@/features/schedules/repositoryFactory';
 
+// eslint-disable-next-line no-restricted-imports -- test needs direct env mock access
 import * as envModule from '@/lib/env';
 import * as runtimeModule from '@/lib/runtime';
 


### PR DESCRIPTION
## 目的

Issue #839 Phase 1: プロダクションコードの `as any` を全廃する。

## 主な変更

### Production code (`as any` 10 → 0)

| ファイル | 変更内容 |
|----------|----------|
| `schedulesRepo.ts` | `FIELD_MAP` 型安全アクセス、`pickEtag/create/update` に `SpScheduleRow` 型適用 |
| `repositoryFactory.ts` | `(window as any).__ENV__` → `isE2E` import + `WindowWithDebug` 型 |
| `useDaily.ts` | `(import.meta as any)` → `get()` from `@/env` |
| `lib/env.ts` | `(import.meta as any)` → `(import.meta as ImportMeta)` |

### テスト修正

`.env.test.local` で `VITE_E2E=true` が設定されているため、`isE2E` を `@/env` import 経由で使うと Vitest で E2E パスに入る問題を修正。4テストファイルに `@/env` mock を追加。

## 検証

- `tsc --noEmit`: ✅
- 関係テスト 42/42: ✅
- lint + pre-commit hooks: ✅

Closes #839 (Phase 1 only)