### PR TITLE
fix(test): add Link stub to react-router-dom mock in SupportPlanPermissions

### DIFF
--- a/tests/unit/SupportPlanPermissions.spec.tsx
+++ b/tests/unit/SupportPlanPermissions.spec.tsx
@@ -29,6 +29,8 @@ vi.mock('@/hydration/features', () => ({
 vi.mock('react-router-dom', () => ({
   useLocation: () => ({ pathname: '/support-plan-guide', search: '' }),
   useNavigate: () => vi.fn(),
+  // muiLink.ts imports `Link` — provide a stub to prevent unhandled import error
+  Link: vi.fn().mockImplementation(({ children, ..._props }: Record<string, unknown>) => children),
 }));
 
 // Mock MUI components or hooks that might cause issues in JSDOM


### PR DESCRIPTION
## Summary

`muiLink.ts` imports `Link` from `react-router-dom`. When `vi.mock` does not export `Link`, the test suite fails with an unhandled import error:

```
Error: [vitest] No "Link" export is defined on the "react-router-dom" mock.
```

This adds a simple stub `Link` to the mock to prevent the crash.

## Changes
- Added `Link` export to `react-router-dom` mock in `SupportPlanPermissions.spec.tsx`
- This is a pre-existing CI flake unrelated to #872