### PR TITLE
feat(today): DayPhase pure function + useCurrentPhase hook (#822)

### DIFF
--- a/src/features/today/hooks/useCurrentPhase.ts
+++ b/src/features/today/hooks/useCurrentPhase.ts
@@ -1,0 +1,22 @@
+/**
+ * useCurrentPhase — React hook wrapping resolvePhase
+ *
+ * #822 useTimeSlot — Phase 2 時間帯連動 #1
+ *
+ * Returns the current operational DayPhase based on the system clock.
+ *
+ * NOTE: No interval/timer — the phase is resolved once per render.
+ * Page navigations and re-mounts naturally refresh the value.
+ * If real-time transitions are needed later, add a useEffect + setInterval.
+ *
+ * 将来拡張メモ: mode: 'auto' | 'manual' で手動フェーズ切替に対応
+ */
+
+import { resolvePhase, type DayPhase } from '../lib/resolvePhase';
+
+export { type DayPhase } from '../lib/resolvePhase';
+
+export function useCurrentPhase(): DayPhase {
+  const now = new Date();
+  return resolvePhase(now.getHours());
+}

--- a/src/features/today/lib/__tests__/resolvePhase.spec.ts
+++ b/src/features/today/lib/__tests__/resolvePhase.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { resolvePhase } from '../resolvePhase';
+
+describe('resolvePhase', () => {
+  it.each([
+    // 深夜・早朝 → morning
+    [0, 'morning'],
+    [3, 'morning'],
+    [6, 'morning'],
+
+    // 朝の運用
+    [7, 'morning'],
+    [10, 'morning'],
+
+    // 境界: midday 開始
+    [11, 'midday'],
+    [13, 'midday'],
+    [15, 'midday'],
+
+    // 境界: evening 開始
+    [16, 'evening'],
+    [19, 'evening'],
+    [23, 'evening'],
+  ] as const)('resolvePhase(%i) → %s', (hour, expected) => {
+    expect(resolvePhase(hour)).toBe(expected);
+  });
+});

--- a/src/features/today/lib/resolvePhase.ts
+++ b/src/features/today/lib/resolvePhase.ts
@@ -1,0 +1,50 @@
+/**
+ * resolvePhase — Pure function to determine the current operational phase
+ *
+ * #822 useTimeSlot — Phase 2 時間帯連動 #1
+ *
+ * NOTE: Named `DayPhase` instead of `TimeSlot` to avoid collision with
+ * the existing `TimeSlot` type in `src/domain/support/step-templates.ts`
+ * which represents concrete schedule slots like '09:30-10:30'.
+ * `DayPhase` represents the high-level operational phase of the day.
+ */
+
+// ─── Types ───────────────────────────────────────────────────────────────
+
+/** Operational phase of the day */
+export type DayPhase = 'morning' | 'midday' | 'evening';
+
+// ─── Constants ───────────────────────────────────────────────────────────
+
+/** Phase boundary hours (inclusive start) */
+export const PHASE_BOUNDARIES = {
+  midday: 11,  // 11:00–15:59
+  evening: 16, // 16:00–23:59 (19:01+ も evening — 班長判断)
+} as const;
+
+// ─── Pure Function ───────────────────────────────────────────────────────
+
+/**
+ * Resolve operational phase from hour of day.
+ *
+ * | hour   | phase    | 説明                         |
+ * |--------|----------|------------------------------|
+ * | 0–6    | morning  | 深夜・早朝 → morning 扱い    |
+ * | 7–10   | morning  | 朝の運用                     |
+ * | 11–15  | midday   | 昼の運用                     |
+ * | 16–23  | evening  | 夕方（19:01+ 含む、班長判断） |
+ *
+ * @param hour - Hour of day (0–23)
+ * @returns DayPhase
+ *
+ * 将来拡張メモ: mode: 'auto' | 'manual' で手動フェーズ切替に対応
+ */
+export function resolvePhase(hour: number): DayPhase {
+  if (hour >= PHASE_BOUNDARIES.midday && hour < PHASE_BOUNDARIES.evening) {
+    return 'midday';
+  }
+  if (hour >= PHASE_BOUNDARIES.evening) {
+    return 'evening';
+  }
+  return 'morning';
+}


### PR DESCRIPTION
## Summary

Implements **#822 useTimeSlot** — a pure function and React hook that resolve the current operational phase of the day.

### Why `DayPhase` instead of `TimeSlot`?

The existing `TimeSlot` type in `src/domain/support/step-templates.ts` represents **concrete schedule slots** like `'09:30-10:30'`. This new type represents the **high-level operational phase** (`morning` / `midday` / `evening`), so we use `DayPhase` to avoid collision.

## Changes

### New files

| File | Role |
|------|------|
| `src/features/today/lib/resolvePhase.ts` | Pure function: `resolvePhase(hour) → DayPhase` |
| `src/features/today/lib/__tests__/resolvePhase.spec.ts` | 11 test cases covering all boundaries |
| `src/features/today/hooks/useCurrentPhase.ts` | Thin React hook wrapping `resolvePhase` |

### Phase boundaries

| hour | phase | 説明 |
|------|-------|------|
| 0–10 | morning | 深夜・早朝 → morning 扱い |
| 11–15 | midday | 昼の運用 |
| 16–23 | evening | 夕方（19:01+ 含む、班長判断） |

## Testing

- ✅ 11 unit tests passing (`resolvePhase.spec.ts`)
- ✅ TypeCheck clean
- ✅ Lint clean

## Future integration points

- `TodayEngine` — phase-based task filtering
- `TodayTasksCard` — phase-based section display
- Hero banner — phase-based greeting message

Closes #822