### PR TITLE
feat: ISP three-layer regulatory audit engine (Issue 4)

### DIFF
--- a/src/app/navigation/diagnostics/pathUtils.ts
+++ b/src/app/navigation/diagnostics/pathUtils.ts
@@ -106,6 +106,7 @@ export const ORPHAN_ALLOWLIST_DETAILS: AllowlistRoute[] = [
   { path: '/admin/debug/opening-verification', category: 'Dev', reason: '開発用テナント検証ツール' },
   { path: '/admin/debug/smoke-test', category: 'Dev', reason: '開発用スモークテスト画面' },
   { path: '/admin/data-integrity', category: 'Admin', reason: '管理者用データ整合性確認画面' },
+  { path: '/admin/regulatory-dashboard', category: 'Admin', reason: '制度適合ダッシュボード（AdminHubからリンク経由）' },
 ].map(item => ({ ...item, path: normalizeRouterPath(item.path) }));
 
 export const ORPHAN_ALLOWLIST = new Set(ORPHAN_ALLOWLIST_DETAILS.map(d => d.path));


### PR DESCRIPTION
## 概要
ISP 三層モデル（個別支援計画 → 支援計画シート → 支援手順書兼記録）に基づく制度判定・監査エンジンを実装。

## 新規追加

### ドメイン層
- **ISP 三層 Zod スキーマ** (src/domain/isp/schema.ts): ISP、支援計画シート、支援手順実施記録の完全なバリデーション
- **ISP 型定義** (src/domain/isp/types.ts): 監査証跡・版管理・状態遷移を含む型体系
- **ISP ポート** (src/domain/isp/port.ts): Repository Port インターフェース
- **制度判定** (src/domain/regulatory/): 利用者・職員の制度適合性チェック

### データ層
- **SharePoint ISP リポジトリ** (3本): ISP、支援計画シート、支援手順記録の CRUD
- **SP行マッパー** (src/data/isp/sharepoint/mapper.ts): SharePoint ↔ ドメインモデル変換
- **SP フィールド定義** (src/sharepoint/fields/ispThreeLayerFields.ts)

### UI
- **RegulatoryDashboardPage** (src/pages/RegulatoryDashboardPage.tsx): 制度適合ダッシュボード
- **AdminHubPage** にリンク追加
- **ルーティング** (dminRoutes, lazyPages, ppRoutePaths)

### ドキュメント
- ADR-005: ISP三層分離アーキテクチャ決定記録
- AI プロトコル・規制ガードレール・SharePointリスト定義

### テスト
- スキーマバリデーション: 1,319行 (262テスト)
- 監査チェック: 424行
- リポジトリ: 475行
- マッパー: 426行

## 検証結果
- [x] 	sc --noEmit 通過
- [x] eslint --max-warnings=0 通過
- [x] itest run 全 262 テスト通過
- [x] ite build 通過