### PR TITLE
feat: connect Iceberg analysis to Support Planning Sheet via planningSheetId

### DIFF
--- a/src/domain/isp/schema.ts
+++ b/src/domain/isp/schema.ts
@@ -669,6 +669,10 @@ export interface SupportPlanBundle {
   isp: IndividualSupportPlan;
   planningSheets: SupportPlanningSheet[];
   recentProcedureRecords: SupportProcedureRecord[];
+  /** 支援計画シートごとの Iceberg 分析件数（planningSheetId → count） */
+  icebergCountBySheet?: Record<string, number>;
+  /** 直近のモニタリング結果 */
+  latestMonitoring?: { date: string; planChangeRequired: boolean } | null;
 }
 
 // ─────────────────────────────────────────────

--- a/src/features/ibd/analysis/__tests__/icebergPlanningSheetLink.spec.ts
+++ b/src/features/ibd/analysis/__tests__/icebergPlanningSheetLink.spec.ts
@@ -1,0 +1,232 @@
+/**
+ * Iceberg planningSheetId 接続テスト
+ *
+ * 6-A: IcebergSession / icebergSnapshotSchema に planningSheetId が追加されたことを検証
+ * 6-B: IcebergPdcaItem / CreatePdcaInput に planningSheetId が追加されたことを検証
+ * 6-C: SupportPlanBundle に icebergCountBySheet / latestMonitoring が追加されたことを検証
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  icebergSnapshotSchema,
+  type IcebergSession,
+} from '@/features/ibd/analysis/iceberg/icebergTypes';
+import type { IcebergPdcaItem } from '@/features/ibd/analysis/pdca/types';
+import type { CreatePdcaInput, PdcaListQuery, UpdatePdcaInput } from '@/features/ibd/analysis/pdca/domain/pdcaRepository';
+import type { SupportPlanBundle } from '@/domain/isp/schema';
+
+// ---------- helpers ----------
+
+function makeValidSnapshot(overrides: Record<string, unknown> = {}) {
+  return {
+    schemaVersion: 1 as const,
+    sessionId: 'sess-001',
+    userId: 'user-001',
+    title: 'Test Session',
+    updatedAt: '2026-03-13T00:00:00Z',
+    nodes: [],
+    links: [],
+    ...overrides,
+  };
+}
+
+// =============================
+// 6-A: IcebergSession + snapshot
+// =============================
+
+describe('6-A: IcebergSession planningSheetId', () => {
+  it('IcebergSession accepts planningSheetId', () => {
+    const session: IcebergSession = {
+      id: 'sess-001',
+      targetUserId: 'user-001',
+      planningSheetId: 'ps-001',
+      title: 'Test',
+      createdAt: '2026-03-13T00:00:00Z',
+      updatedAt: '2026-03-13T00:00:00Z',
+      nodes: [],
+      links: [],
+    };
+    expect(session.planningSheetId).toBe('ps-001');
+  });
+
+  it('IcebergSession allows planningSheetId to be undefined (backward compat)', () => {
+    const session: IcebergSession = {
+      id: 'sess-002',
+      targetUserId: 'user-001',
+      title: 'Legacy Session',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+      nodes: [],
+      links: [],
+    };
+    expect(session.planningSheetId).toBeUndefined();
+  });
+});
+
+describe('6-A: icebergSnapshotSchema planningSheetId', () => {
+  it('accepts snapshot with planningSheetId', () => {
+    const input = makeValidSnapshot({ planningSheetId: 'ps-001' });
+    const result = icebergSnapshotSchema.safeParse(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.planningSheetId).toBe('ps-001');
+    }
+  });
+
+  it('accepts snapshot without planningSheetId (backward compat)', () => {
+    const input = makeValidSnapshot();
+    const result = icebergSnapshotSchema.safeParse(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.planningSheetId).toBeUndefined();
+    }
+  });
+
+  it('rejects empty string planningSheetId', () => {
+    const input = makeValidSnapshot({ planningSheetId: '' });
+    const result = icebergSnapshotSchema.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts snapshot with both userId and planningSheetId', () => {
+    const input = makeValidSnapshot({
+      userId: 'user-abc',
+      planningSheetId: 'ps-xyz',
+    });
+    const result = icebergSnapshotSchema.safeParse(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.userId).toBe('user-abc');
+      expect(result.data.planningSheetId).toBe('ps-xyz');
+    }
+  });
+
+  it('round-trips planningSheetId through parse', () => {
+    const input = makeValidSnapshot({ planningSheetId: 'ps-round-trip' });
+    const parsed = icebergSnapshotSchema.parse(input);
+    const reparsed = icebergSnapshotSchema.parse(JSON.parse(JSON.stringify(parsed)));
+    expect(reparsed.planningSheetId).toBe('ps-round-trip');
+  });
+});
+
+// =============================
+// 6-B: IcebergPdcaItem + inputs
+// =============================
+
+describe('6-B: IcebergPdcaItem planningSheetId', () => {
+  it('IcebergPdcaItem accepts planningSheetId', () => {
+    const item: IcebergPdcaItem = {
+      id: 'pdca-001',
+      userId: 'user-001',
+      planningSheetId: 'ps-001',
+      title: 'PDCA cycle',
+      summary: 'Test',
+      phase: 'PLAN',
+      createdAt: '2026-03-13T00:00:00Z',
+      updatedAt: '2026-03-13T00:00:00Z',
+    };
+    expect(item.planningSheetId).toBe('ps-001');
+  });
+
+  it('IcebergPdcaItem allows planningSheetId to be undefined', () => {
+    const item: IcebergPdcaItem = {
+      id: 'pdca-002',
+      userId: 'user-001',
+      title: 'Legacy PDCA',
+      summary: '',
+      phase: 'DO',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    };
+    expect(item.planningSheetId).toBeUndefined();
+  });
+});
+
+describe('6-B: CreatePdcaInput planningSheetId', () => {
+  it('accepts planningSheetId', () => {
+    const input: CreatePdcaInput = {
+      userId: 'user-001',
+      planningSheetId: 'ps-001',
+      title: 'New PDCA',
+    };
+    expect(input.planningSheetId).toBe('ps-001');
+  });
+
+  it('works without planningSheetId', () => {
+    const input: CreatePdcaInput = {
+      userId: 'user-001',
+      title: 'Legacy PDCA',
+    };
+    expect(input.planningSheetId).toBeUndefined();
+  });
+});
+
+describe('6-B: UpdatePdcaInput planningSheetId', () => {
+  it('accepts planningSheetId', () => {
+    const input: UpdatePdcaInput = {
+      id: 'pdca-001',
+      planningSheetId: 'ps-002',
+    };
+    expect(input.planningSheetId).toBe('ps-002');
+  });
+});
+
+describe('6-B: PdcaListQuery planningSheetId', () => {
+  it('accepts planningSheetId for filtering', () => {
+    const query: PdcaListQuery = {
+      userId: 'user-001',
+      planningSheetId: 'ps-001',
+    };
+    expect(query.planningSheetId).toBe('ps-001');
+  });
+
+  it('works with only userId (backward compat)', () => {
+    const query: PdcaListQuery = { userId: 'user-001' };
+    expect(query.planningSheetId).toBeUndefined();
+  });
+});
+
+// =============================
+// 6-C: SupportPlanBundle extensions
+// =============================
+
+describe('6-C: SupportPlanBundle extensions', () => {
+  it('accepts icebergCountBySheet', () => {
+    const bundle: Partial<SupportPlanBundle> = {
+      icebergCountBySheet: {
+        'ps-001': 3,
+        'ps-002': 1,
+      },
+    };
+    expect(bundle.icebergCountBySheet?.['ps-001']).toBe(3);
+  });
+
+  it('accepts latestMonitoring', () => {
+    const bundle: Partial<SupportPlanBundle> = {
+      latestMonitoring: {
+        date: '2026-02-15',
+        planChangeRequired: true,
+      },
+    };
+    expect(bundle.latestMonitoring?.planChangeRequired).toBe(true);
+  });
+
+  it('accepts latestMonitoring as null', () => {
+    const bundle: Partial<SupportPlanBundle> = {
+      latestMonitoring: null,
+    };
+    expect(bundle.latestMonitoring).toBeNull();
+  });
+
+  it('accepts empty icebergCountBySheet', () => {
+    const bundle: Partial<SupportPlanBundle> = {
+      icebergCountBySheet: {},
+    };
+    expect(Object.keys(bundle.icebergCountBySheet!)).toHaveLength(0);
+  });
+
+  it('all new fields are optional (backward compat)', () => {
+    const bundle: Partial<SupportPlanBundle> = {};
+    expect(bundle.icebergCountBySheet).toBeUndefined();
+    expect(bundle.latestMonitoring).toBeUndefined();
+  });
+});

--- a/src/features/ibd/analysis/iceberg/icebergTypes.ts
+++ b/src/features/ibd/analysis/iceberg/icebergTypes.ts
@@ -29,6 +29,8 @@ export type HypothesisLink = {
 export type IcebergSession = {
   id: string;
   targetUserId: string;
+  /** 紐づく支援計画シートID（optional: 旧データ互換） */
+  planningSheetId?: string;
   title: string;
   createdAt: string;
   updatedAt: string;
@@ -75,6 +77,8 @@ export const icebergSnapshotSchema = z.object({
   schemaVersion: z.literal(1),
   sessionId: z.string().min(1, 'Session ID required'),
   userId: z.string().min(1, 'User ID required'),
+  /** 紐づく支援計画シートID（optional: 旧データ互換） */
+  planningSheetId: z.string().min(1).optional(),
   title: z.string().min(1, 'Title required'),
   updatedAt: z.string().datetime('Must be ISO datetime'),
   nodes: z.array(icebergNodeSchema),

--- a/src/features/ibd/analysis/pdca/domain/pdcaRepository.ts
+++ b/src/features/ibd/analysis/pdca/domain/pdcaRepository.ts
@@ -2,6 +2,8 @@ import type { IcebergPdcaItem, IcebergPdcaPhase } from './pdca';
 
 export type CreatePdcaInput = {
   userId: string;
+  /** 紐づく支援計画シートID（optional: 旧データ互換） */
+  planningSheetId?: string;
   title: string;
   summary?: string;
   phase?: IcebergPdcaPhase;
@@ -14,6 +16,8 @@ export type UpdatePdcaInput = {
   phase?: IcebergPdcaPhase;
   etag?: string;
   userId?: string;
+  /** 紐づく支援計画シートID */
+  planningSheetId?: string;
 };
 
 export type DeletePdcaInput = {
@@ -23,6 +27,8 @@ export type DeletePdcaInput = {
 
 export type PdcaListQuery = {
   userId?: string;
+  /** 支援計画シートでフィルタ */
+  planningSheetId?: string;
 };
 
 export interface PdcaRepository {

--- a/src/features/ibd/analysis/pdca/types.ts
+++ b/src/features/ibd/analysis/pdca/types.ts
@@ -3,6 +3,8 @@ export type IcebergPdcaPhase = 'PLAN' | 'DO' | 'CHECK' | 'ACT';
 export type IcebergPdcaItem = {
   id: string;
   userId: string;
+  /** 紐づく支援計画シートID（optional: 旧データ互換） */
+  planningSheetId?: string;
   title: string;
   summary: string;
   phase: IcebergPdcaPhase;


### PR DESCRIPTION
## 概要

Iceberg 分析を支援計画シートに正式接続する構造変更。
ドメインマップ v2 の設計方針に基づき、Iceberg を「ISP 直結の分析ツール」から「**支援計画シートの仮説形成・再分析を支える専門分析レイヤー**」として型レベルで位置づけ直す。

## 変更内容

### 6-A: IcebergSession + icebergSnapshotSchema
- `IcebergSession` に `planningSheetId?: string` を追加
- `icebergSnapshotSchema` に `planningSheetId` (optional, min(1)) を追加
- 旧データ互換のため optional 維持

### 6-B: PDCA サイクル
- `IcebergPdcaItem` に `planningSheetId?: string` を追加
- `CreatePdcaInput` / `UpdatePdcaInput` / `PdcaListQuery` すべてに `planningSheetId` を追加

### 6-C: SupportPlanBundle
- `icebergCountBySheet?: Record<string, number>` 追加（シートごとの分析件数）
- `latestMonitoring?: { date: string; planChangeRequired: boolean } | null` 追加

### テスト
- 新規テスト「icebergPlanningSheetLink.spec.ts」(19テスト)
  - 型互換性テスト（新規 + 旧データ undefined）
  - Zod スキーマパース + ラウンドトリップ
  - 空文字列拒否

## 設計意図

```text
ISP → Support Planning Sheet → Iceberg → Monitoring → Procedure Record
```text

この ID 接続により:
- Iceberg 分析が「どの支援計画シートのための分析か」を型レベルで表現
- 監査証跡チェーンが一本の線で繋がる
- SupportPlanGuidePage の統合ビュー化の土台が完成

## 検証
- [x] `tsc --noEmit` 通過
- [x] 新規テスト 19件 通過
- [x] 既存 InMemoryPdcaRepository テスト 12件 通過
- [x] pre-commit hooks (lint + typecheck) 通過