### PR TITLE
feat(transport): Phase 3.5 — IsTransportTarget実データ接続 + syncToAttendanceDaily (#635)

### DIFF
--- a/src/features/today/transport/__tests__/transportRepo.spec.ts
+++ b/src/features/today/transport/__tests__/transportRepo.spec.ts
@@ -8,8 +8,9 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { loadTransportLogs, saveTransportLog, type SaveTransportLogInput } from '../transportRepo';
+import { loadTransportLogs, saveTransportLog, syncToAttendanceDaily, type SaveTransportLogInput, type SyncToAttendanceDailyInput } from '../transportRepo';
 import { TRANSPORT_LOG_FIELDS } from '@/sharepoint/fields/transportFields';
+import { ATTENDANCE_DAILY_FIELDS } from '@/sharepoint/fields/attendanceFields';
 
 // ─── Mock spClient ──────────────────────────────────────────────────────────
 
@@ -232,6 +233,109 @@ describe('transportRepo', () => {
 
       // Restore
       Object.defineProperty(envModule, 'isWriteEnabled', { value: true, writable: true });
+    });
+  });
+
+  // ─── syncToAttendanceDaily ────────────────────────────────────────────────
+
+  describe('syncToAttendanceDaily', () => {
+    const baseSync: SyncToAttendanceDailyInput = {
+      userCode: 'U001',
+      recordDate: '2026-03-13',
+      direction: 'to',
+      status: 'arrived',
+      method: 'office_shuttle',
+    };
+
+    it('should patch TransportTo + TransportToMethod for direction=to', async () => {
+      (client.listItems as ReturnType<typeof vi.fn>).mockResolvedValueOnce([{ Id: 99 }]);
+
+      await syncToAttendanceDaily(client, baseSync);
+
+      expect(client.updateItem).toHaveBeenCalledWith(
+        'AttendanceDaily',
+        99,
+        expect.objectContaining({
+          [ATTENDANCE_DAILY_FIELDS.transportTo]: true, // office_shuttle → true
+          [ATTENDANCE_DAILY_FIELDS.transportToMethod]: 'office_shuttle',
+        }),
+      );
+    });
+
+    it('should patch TransportFrom + TransportFromMethod for direction=from', async () => {
+      (client.listItems as ReturnType<typeof vi.fn>).mockResolvedValueOnce([{ Id: 100 }]);
+
+      await syncToAttendanceDaily(client, { ...baseSync, direction: 'from' });
+
+      expect(client.updateItem).toHaveBeenCalledWith(
+        'AttendanceDaily',
+        100,
+        expect.objectContaining({
+          [ATTENDANCE_DAILY_FIELDS.transportFrom]: true,
+          [ATTENDANCE_DAILY_FIELDS.transportFromMethod]: 'office_shuttle',
+        }),
+      );
+    });
+
+    it('should set transport boolean to false for non-shuttle methods', async () => {
+      (client.listItems as ReturnType<typeof vi.fn>).mockResolvedValueOnce([{ Id: 101 }]);
+
+      await syncToAttendanceDaily(client, { ...baseSync, method: 'self' });
+
+      expect(client.updateItem).toHaveBeenCalledWith(
+        'AttendanceDaily',
+        101,
+        expect.objectContaining({
+          [ATTENDANCE_DAILY_FIELDS.transportTo]: false, // self → false
+          [ATTENDANCE_DAILY_FIELDS.transportToMethod]: 'self',
+        }),
+      );
+    });
+
+    it('should skip sync for non-arrived statuses', async () => {
+      await syncToAttendanceDaily(client, { ...baseSync, status: 'in-progress' });
+      await syncToAttendanceDaily(client, { ...baseSync, status: 'pending' });
+
+      expect(client.listItems).not.toHaveBeenCalled();
+      expect(client.updateItem).not.toHaveBeenCalled();
+    });
+
+    it('should skip when no AttendanceDaily record exists', async () => {
+      (client.listItems as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
+
+      await syncToAttendanceDaily(client, baseSync);
+
+      expect(client.updateItem).not.toHaveBeenCalled();
+    });
+
+    it('should handle 404 when AttendanceDaily list does not exist', async () => {
+      const error404 = new Error('List does not exist');
+      Object.assign(error404, { status: 404 });
+      (client.listItems as ReturnType<typeof vi.fn>).mockRejectedValueOnce(error404);
+
+      await expect(syncToAttendanceDaily(client, baseSync)).resolves.toBeUndefined();
+    });
+
+    it('should not throw on non-404 errors (logs but swallows)', async () => {
+      const error500 = new Error('Server Error');
+      Object.assign(error500, { status: 500 });
+      (client.listItems as ReturnType<typeof vi.fn>).mockRejectedValueOnce(error500);
+
+      // syncToAttendanceDaily swallows non-404 errors (secondary sync)
+      await expect(syncToAttendanceDaily(client, baseSync)).resolves.toBeUndefined();
+    });
+
+    it('should use correct Key format: {UserCode}_{Date}', async () => {
+      (client.listItems as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
+
+      await syncToAttendanceDaily(client, baseSync);
+
+      expect(client.listItems).toHaveBeenCalledWith(
+        'AttendanceDaily',
+        expect.objectContaining({
+          filter: expect.stringContaining("Key eq 'U001_2026-03-13'"),
+        }),
+      );
     });
   });
 });

--- a/src/features/today/transport/transportRepo.ts
+++ b/src/features/today/transport/transportRepo.ts
@@ -23,7 +23,12 @@ import {
   TRANSPORT_LOG_FIELDS,
   TRANSPORT_LOG_SELECT_FIELDS,
 } from '@/sharepoint/fields/transportFields';
+import {
+  ATTENDANCE_DAILY_FIELDS,
+  ATTENDANCE_DAILY_LIST_TITLE,
+} from '@/sharepoint/fields/attendanceFields';
 import { LIST_CONFIG, ListKeys } from '@/sharepoint/fields/listRegistry';
+import { methodImpliesShuttle } from '@/features/attendance/transportMethod';
 import type { TransportLogEntry } from './transportStatusLogic';
 import type { TransportDirection, TransportLegStatus } from './transportTypes';
 import type { TransportMethod } from '@/features/attendance/transportMethod';
@@ -204,5 +209,88 @@ export async function saveTransportLog(
 
     console.error(`${LOG} Failed to save transport log (${titleKey}):`, err);
     throw err;
+  }
+}
+
+// ─── Sync to AttendanceDaily ────────────────────────────────────────────────
+
+/**
+ * Sync transport confirmation to AttendanceDaily.
+ *
+ * When a leg reaches 'arrived' status, we patch the corresponding
+ * AttendanceDaily record with:
+ *   - TransportTo/TransportFrom = true/false (derived from method)
+ *   - TransportToMethod/TransportFromMethod = the method enum value
+ *
+ * Design:
+ * - Key format: {UserCode}_{yyyy-MM-dd} (matches AttendanceDaily.Key)
+ * - Only syncs when status === 'arrived'
+ * - Graceful degradation: list/record not found → no-op
+ * - Write gate: requires VITE_WRITE_ENABLED=1
+ *
+ * Phase 3.5 of Issue #635.
+ */
+export type SyncToAttendanceDailyInput = {
+  userCode: string;
+  recordDate: string;     // yyyy-MM-dd
+  direction: TransportDirection;
+  status: TransportLegStatus;
+  method?: TransportMethod;
+};
+
+export async function syncToAttendanceDaily(
+  client: ReturnType<typeof useSP>,
+  input: SyncToAttendanceDailyInput,
+): Promise<void> {
+  // Only sync when arrived
+  if (input.status !== 'arrived') return;
+
+  assertWriteEnabled('syncToAttendanceDaily');
+
+  const listTitle = ATTENDANCE_DAILY_LIST_TITLE;
+  const dailyKey = `${input.userCode}_${input.recordDate}`;
+  const isShuttle = input.method ? methodImpliesShuttle(input.method) : false;
+
+  // Build partial patch payload (only transport fields for this direction)
+  const patch: Record<string, unknown> = {};
+  if (input.direction === 'to') {
+    patch[ATTENDANCE_DAILY_FIELDS.transportTo] = isShuttle;
+    if (input.method) patch[ATTENDANCE_DAILY_FIELDS.transportToMethod] = input.method;
+  } else {
+    patch[ATTENDANCE_DAILY_FIELDS.transportFrom] = isShuttle;
+    if (input.method) patch[ATTENDANCE_DAILY_FIELDS.transportFromMethod] = input.method;
+  }
+
+  try {
+    // Look up existing daily record by Key
+    const existing = await client.listItems<{ Id: number }>(listTitle, {
+      select: ['Id'],
+      filter: `${ATTENDANCE_DAILY_FIELDS.key} eq '${dailyKey}'`,
+      top: 1,
+    });
+
+    if (!existing || existing.length === 0) {
+      // No AttendanceDaily record yet — skip sync
+      // This is normal during early morning before check-in
+      console.debug(`${LOG} AttendanceDaily not found for key=${dailyKey}, skipping sync`);
+      return;
+    }
+
+    const recordId = Number(existing[0].Id);
+    if (!Number.isFinite(recordId)) return;
+
+    await client.updateItem(listTitle, recordId, patch);
+    console.debug(`${LOG} Synced transport ${input.direction} to AttendanceDaily: key=${dailyKey}`);
+  } catch (err: unknown) {
+    const status = (err as { status?: number })?.status;
+    const message = err instanceof Error ? err.message : String(err);
+
+    if (status === 404 || message.includes('does not exist')) {
+      console.warn(`${LOG} AttendanceDaily list not found, skipping sync.`);
+      return;
+    }
+
+    // Log but don't throw — this is a secondary sync, should not break the main flow
+    console.error(`${LOG} Failed to sync to AttendanceDaily (key=${dailyKey}):`, err);
   }
 }

--- a/src/features/today/transport/useTransportStatus.ts
+++ b/src/features/today/transport/useTransportStatus.ts
@@ -1,7 +1,7 @@
 /**
  * useTransportStatus — React Hook for today's transport tracking
  *
- * Phase 3 of Issue #635 — SharePoint Connected.
+ * Phase 3.5 of Issue #635 — IsTransportTarget filtering + syncToAttendanceDaily.
  *
  * Responsibilities:
  * 1. Derive TransportLeg[] from useTodaySummary (users + visits)
@@ -38,7 +38,8 @@ import {
     type TransportUserInfo,
     type TransportVisitInfo,
 } from './transportStatusLogic';
-import { loadTransportLogs, saveTransportLog } from './transportRepo';
+import { loadTransportLogs, saveTransportLog, syncToAttendanceDaily } from './transportRepo';
+import { getActiveUsers, type AttendanceUserItem } from '@/features/attendance/infra/attendanceUsersRepository';
 import type {
     TodayTransportStatus,
     TransportDirection,
@@ -198,18 +199,24 @@ export function useTransportStatus(): UseTransportStatusReturn {
     const todayKey = getTodayKey();
 
     async function initLegs() {
-      // Load existing logs from SharePoint (graceful: returns [] if list missing)
-      let existingLogs: TransportLogEntry[] = [];
-      try {
-        existingLogs = await loadTransportLogs(sp, todayKey);
-      } catch {
-        // Graceful: SP unavailable → start with empty logs
-        console.warn('[useTransportStatus] Failed to load SP logs, starting fresh');
-      }
+      // Load existing transport logs and attendance users in parallel
+      // Both are graceful: failures return empty arrays
+      const [existingLogs, attendanceUsers] = await Promise.all([
+        loadTransportLogs(sp, todayKey).catch((err) => {
+          console.warn('[useTransportStatus] Failed to load SP logs, starting fresh', err);
+          return [] as TransportLogEntry[];
+        }),
+        getActiveUsers(sp).catch((err) => {
+          console.warn('[useTransportStatus] Failed to load AttendanceUsers, showing all users', err);
+          return [] as AttendanceUserItem[];
+        }),
+      ]);
 
       if (cancelled) return;
 
-      const users = adaptUsers(summary.users); // AttendanceUsers filtering: Phase 3.5
+      // Phase 3.5: Pass real AttendanceUsers for IsTransportTarget filtering
+      // If attendanceUsers is empty (list missing or error), adaptUsers falls back to showing all
+      const users = adaptUsers(summary.users, attendanceUsers);
       const visits = adaptVisits(summary.visits);
 
       const toLegs = deriveTransportLegs(users, visits, existingLogs, 'to');
@@ -220,7 +227,7 @@ export function useTransportStatus(): UseTransportStatusReturn {
 
     void initLegs();
     return () => { cancelled = true; };
-  }, [summary.users, summary.visits]);
+  }, [summary.users, summary.visits, sp]);
 
   // ─── Actions ──────────────────────────────────────────────────────────────
 
@@ -253,6 +260,20 @@ export function useTransportStatus(): UseTransportStatusReturn {
           actualTime: updated.actualTime,
           driverName: updated.driverName,
           notes: updated.notes,
+        }).then(() => {
+          // Phase 3.5: Sync to AttendanceDaily when arrived
+          // Fire-and-forget — sync failures should not affect transport log
+          if (updated.status === 'arrived') {
+            syncToAttendanceDaily(spRef.current, {
+              userCode: updated.userId,
+              recordDate: todayKey,
+              direction: updated.direction,
+              status: updated.status,
+              method: updated.method,
+            }).catch((syncErr) => {
+              console.warn('[useTransportStatus] AttendanceDaily sync failed (non-blocking):', syncErr);
+            });
+          }
         }).catch((err) => {
           console.error('[useTransportStatus] SP save failed, rolling back:', err);
           // Rollback: restore the previous leg state


### PR DESCRIPTION
## 概要

Transport Status Phase 3.5 — 送迎管理パネルの残り2機能を実装。

### 1. IsTransportTarget 実データ接続
- `AttendanceUsers` リストから `IsTransportTarget` を読み取り、送迎対象者のみをパネルに表示
- `getActiveUsers()` による並列ロード（`Transport_Log` と同時に取得）
- リスト未作成時は全ユーザー表示（graceful fallback）

### 2. syncToAttendanceDaily
- `arrived` ステータス到達時に `AttendanceDaily` の該当レコードを部分PATCH
- `TransportTo/From` (boolean) + `TransportToMethod/FromMethod` (enum) を同期
- `methodImpliesShuttle()` で `office_shuttle` → true, それ以外 → false を自動判定
- 日次レコード未作成時（朝のチェックイン前）はスキップ
- fire-and-forget チェーン: `saveTransportLog → syncToAttendanceDaily`

### Graceful Degradation
| シナリオ | 動作 |
|---------|------|
| AttendanceUsers リスト未作成 | 全ユーザー表示（フィルタなし） |
| AttendanceDaily レコード未作成 | sync スキップ |
| AttendanceDaily リスト未作成 (404) | console.warn で no-op |
| sync 時の非 404 エラー | ログ出力のみ、rollback なし |

### テスト
- syncToAttendanceDaily: 8テスト追加（合計18テスト）
- tsc --noEmit: 型エラー 0

### 変更ファイル (3ファイル)
| ファイル | 変更 |
|---------|------|
| `useTransportStatus.ts` | IsTransportTarget 接続 + syncToAttendanceDaily 呼び出し |
| `transportRepo.ts` | syncToAttendanceDaily 関数追加 |
| `transportRepo.spec.ts` | 8テスト追加 |

### アーキテクチャ到達状態

```
UI (TransportStatusCard)         ✅ Phase 1
  ↕
Hook (useTransportStatus)        ✅ Phase 2 + 3 + 3.5
  ↕
Pure Logic (transportStatusLogic) ✅ Phase 2
  ↕
Repository (transportRepo)       ✅ Phase 3 + 3.5
  ↕
SharePoint (Transport_Log)       ✅ Phase 3
  ↕
SharePoint (AttendanceUsers)     ✅ Phase 3.5 (read: IsTransportTarget)
  ↕
SharePoint (AttendanceDaily)     ✅ Phase 3.5 (write: transport sync)
```

Closes Phase 3.5 of Issue #635