### PR TITLE
fix(handoff): changedBy をアカウントと表示名に分離

### DIFF
--- a/src/auth/useAuth.ts
+++ b/src/auth/useAuth.ts
@@ -31,6 +31,8 @@ function debugLog(...args: unknown[]) {
 type BasicAccountInfo = {
   username?: string;
   homeAccountId?: string;
+  /** 表示名（MSAL AccountInfo.name に対応） */
+  name?: string;
 };
 
 const ensureActiveAccount = (instance: IPublicClientApplication) => {

--- a/src/features/handoff/__tests__/handoffAuditTypes.spec.ts
+++ b/src/features/handoff/__tests__/handoffAuditTypes.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * handoffAuditTypes のユニットテスト
+ *
+ * changedBy（表示名）と changedByAccount（UPN）の分離が正しく機能することを検証。
+ * Issue #804
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { HandoffAuditLog, NewAuditLogInput, SpHandoffAuditLogItem } from '../handoffAuditTypes';
+import {
+  formatAuditDescription,
+  formatStatusTransition,
+  fromSpAuditLogItem,
+  toSpAuditLogCreatePayload,
+} from '../handoffAuditTypes';
+
+// ── helpers ──
+
+const makeAuditLog = (overrides: Partial<HandoffAuditLog> = {}): HandoffAuditLog => ({
+  id: 1,
+  handoffId: 100,
+  action: 'created',
+  changedBy: '田中太郎',
+  changedByAccount: 'tanaka@example.com',
+  changedAt: '2026-03-13T10:00:00.000Z',
+  ...overrides,
+});
+
+// ────────────────────────────────────────────────────────────
+// formatAuditDescription
+// ────────────────────────────────────────────────────────────
+
+describe('formatAuditDescription', () => {
+  it('created アクションで changedBy（表示名）を使う', () => {
+    const log = makeAuditLog({ action: 'created', changedBy: '田中太郎' });
+    const description = formatAuditDescription(log);
+
+    expect(description).toContain('田中太郎');
+    expect(description).not.toContain('tanaka@example.com');
+    expect(description).toContain('作成しました');
+  });
+
+  it('status_changed アクションで changedBy（表示名）を使う', () => {
+    const log = makeAuditLog({
+      action: 'status_changed',
+      changedBy: '佐藤花子',
+      changedByAccount: 'sato@example.com',
+      fieldName: 'status',
+      oldValue: '未対応',
+      newValue: '対応中',
+    });
+    const description = formatAuditDescription(log);
+
+    expect(description).toContain('佐藤花子');
+    expect(description).not.toContain('sato@example.com');
+    expect(description).toContain('ステータス');
+    expect(description).toContain('未対応');
+    expect(description).toContain('対応中');
+  });
+
+  it('field_updated アクションで changedBy（表示名）を使う', () => {
+    const log = makeAuditLog({
+      action: 'field_updated',
+      changedBy: '鈴木一郎',
+      fieldName: 'message',
+    });
+    const description = formatAuditDescription(log);
+
+    expect(description).toContain('鈴木一郎');
+    expect(description).toContain('本文');
+  });
+
+  it('comment_added アクションで changedBy（表示名）を使う', () => {
+    const log = makeAuditLog({
+      action: 'comment_added',
+      changedBy: '高橋次郎',
+    });
+    const description = formatAuditDescription(log);
+
+    expect(description).toContain('高橋次郎');
+    expect(description).toContain('コメント');
+  });
+
+  it('changedByAccount は formatAuditDescription には含まれない', () => {
+    const log = makeAuditLog({
+      changedBy: '田中太郎',
+      changedByAccount: 'tanaka@example.com',
+    });
+    const description = formatAuditDescription(log);
+
+    expect(description).not.toContain('tanaka@example.com');
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// fromSpAuditLogItem
+// ────────────────────────────────────────────────────────────
+
+describe('fromSpAuditLogItem', () => {
+  it('ChangedBy と ChangedByAccount を正しくマッピングする', () => {
+    const spItem: SpHandoffAuditLogItem = {
+      Id: 42,
+      HandoffId: 100,
+      Action: 'status_changed',
+      FieldName: 'status',
+      OldValue: '未対応',
+      NewValue: '対応中',
+      ChangedBy: '山田太郎',
+      ChangedByAccount: 'yamada@example.com',
+      Created: '2026-03-13T12:00:00.000Z',
+    };
+
+    const result = fromSpAuditLogItem(spItem);
+
+    expect(result.changedBy).toBe('山田太郎');
+    expect(result.changedByAccount).toBe('yamada@example.com');
+    expect(result.id).toBe(42);
+    expect(result.action).toBe('status_changed');
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// toSpAuditLogCreatePayload
+// ────────────────────────────────────────────────────────────
+
+describe('toSpAuditLogCreatePayload', () => {
+  it('changedBy と changedByAccount を SP フィールドに変換する', () => {
+    const input: NewAuditLogInput = {
+      handoffId: 200,
+      action: 'created',
+      changedBy: '佐藤花子',
+      changedByAccount: 'sato@example.com',
+    };
+
+    const payload = toSpAuditLogCreatePayload(input);
+
+    expect(payload.ChangedBy).toBe('佐藤花子');
+    expect(payload.ChangedByAccount).toBe('sato@example.com');
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// formatStatusTransition
+// ────────────────────────────────────────────────────────────
+
+describe('formatStatusTransition', () => {
+  it('両方指定: old → new', () => {
+    expect(formatStatusTransition('未対応', '対応中')).toBe('未対応 → 対応中');
+  });
+
+  it('old のみ: old →', () => {
+    expect(formatStatusTransition('未対応', undefined)).toBe('未対応 →');
+  });
+
+  it('new のみ: → new', () => {
+    expect(formatStatusTransition(undefined, '対応中')).toBe('→ 対応中');
+  });
+});

--- a/src/features/handoff/useHandoffTimeline.ts
+++ b/src/features/handoff/useHandoffTimeline.ts
@@ -96,11 +96,13 @@ export function useHandoffTimeline(
         }));
 
         // 監査ログ記録（fire-and-forget）
-        const changedByAccount = account?.username ?? 'unknown';
+        // changedBy = 表示名（UI用）, changedByAccount = UPN（監査証跡用）
+        const displayName = account?.name ?? account?.username ?? 'unknown';
+        const accountId = account?.username ?? 'unknown';
         auditRepo.recordCreation(
           newRecord.id,
-          changedByAccount,
-          changedByAccount,
+          displayName,
+          accountId,
         ).catch(e => {
           logAuditPersistFailed({
             handoffId: newRecord.id,
@@ -114,7 +116,7 @@ export function useHandoffTimeline(
           id: newRecord.id,
           category: newRecord.category,
           severity: newRecord.severity,
-          changedByAccount: account?.username ?? 'unknown',
+          changedByAccount: accountId,
           source: 'useHandoffTimeline',
         });
       } catch {
@@ -151,13 +153,15 @@ export function useHandoffTimeline(
         await repo.updateStatus(id, newStatus, dayScope, carryOverDate);
 
         // 監査ログ記録（fire-and-forget）
-        const changedByAccount = account?.username ?? 'unknown';
+        // changedBy = 表示名（UI用）, changedByAccount = UPN（監査証跡用）
+        const displayName = account?.name ?? account?.username ?? 'unknown';
+        const accountId = account?.username ?? 'unknown';
         auditRepo.recordStatusChange(
           id,
           oldStatus ?? '不明',
           newStatus,
-          changedByAccount,
-          changedByAccount,
+          displayName,
+          accountId,
         ).catch(e => {
           logAuditPersistFailed({
             handoffId: id,
@@ -172,7 +176,7 @@ export function useHandoffTimeline(
           oldStatus: oldStatus ?? '不明',
           newStatus,
           meetingMode: 'unknown',
-          changedByAccount: account?.username ?? 'unknown',
+          changedByAccount: accountId,
           source: 'useHandoffTimeline',
         });
       } catch {


### PR DESCRIPTION
## 概要

Issue #804 対応。申し送り監査ログの `changedBy` フィールドをアカウント識別子（UPN）と表示名に正しく分離します。

## 変更内容

### 1. `useAuth.ts` — `BasicAccountInfo` 型拡張
- `name` プロパティを追加（MSAL `AccountInfo.name` に対応）
- これによりフック利用側で `account.name`（表示名）にアクセス可能に

### 2. `useHandoffTimeline.ts` — 監査ログ記録の修正
- `changedBy` に `account.name`（表示名）を設定（UI表示用）
- `changedByAccount` に `account.username`（UPN）を設定（監査証跡用）
- `name` が未設定の場合は `username` にフォールバック
- `createHandoff` と `updateHandoffStatus` の両方を修正

### 3. テスト追加
- `handoffAuditTypes.spec.ts`（新規10件）
  - `formatAuditDescription` が表示名を使い、メールアドレスを漏らさないことを検証
  - `fromSpAuditLogItem` / `toSpAuditLogCreatePayload` の変換テスト
  - `formatStatusTransition` のテスト

## Before / After

| 項目 | Before | After |
|---|---|---|
| UI表示 | `tanaka@example.com が作成しました` | `田中太郎 が作成しました` |
| 監査ログ | `changedByAccount: tanaka@...` | `changedByAccount: tanaka@...` (変更なし) |
| SP `ChangedBy` 列 | `tanaka@example.com` | `田中太郎` |

## テスト

- `npx tsc --noEmit` ✅
- 全 handoff テスト (241件) ✅
- 新規 handoffAuditTypes テスト (10件) ✅

Closes #804