### PR TITLE
security: add RequireAudience guard to /handoff-timeline

### DIFF
--- a/src/app/routes/recordRoutes.tsx
+++ b/src/app/routes/recordRoutes.tsx
@@ -64,7 +64,14 @@ export const recordRoutes: RouteObject[] = [
       </RequireAudience>
     ),
   },
-  { path: 'handoff-timeline', element: <SuspendedHandoffTimelinePage /> },
+  {
+    path: 'handoff-timeline',
+    element: (
+      <RequireAudience requiredRole="viewer">
+        <SuspendedHandoffTimelinePage />
+      </RequireAudience>
+    ),
+  },
   { path: 'meeting-minutes', element: MeetingMinutesRoutes.List },
   { path: 'meeting-minutes/new', element: MeetingMinutesRoutes.New },
   { path: 'meeting-minutes/:id', element: MeetingMinutesRoutes.Detail },


### PR DESCRIPTION
## Background

構造調査レポート (2026-03-13) の Step 1.2 で、`/handoff-timeline` が `recordRoutes` 内で唯一 `RequireAudience` ガードを持たないことが判明。

## Changes

`recordRoutes.tsx` の `/handoff-timeline` ルートに `RequireAudience(requiredRole="viewer")` を追加。

```diff
- { path: 'handoff-timeline', element: <SuspendedHandoffTimelinePage /> },
+ {
+   path: 'handoff-timeline',
+   element: (
+     <RequireAudience requiredRole="viewer">
+       <SuspendedHandoffTimelinePage />
+     </RequireAudience>
+   ),
+ },
```

## Why `viewer`?

- `navigationConfig` で `audience: NAV_AUDIENCE.all`（= 全認証ユーザー）
- 同ドメインの `/records`, `/records/journal` も `viewer`
- 申し送りは全スタッフが使う日常業務機能
- `viewer` は RBAC 階層の最低レベル（認証済み = アクセス可能）

## Verification

- [x] `tsc --noEmit` — 0 errors
- [x] `vitest run` — 437 files passed, 4129 tests passed
- [x] lint / typecheck pre-commit hook passed
- [x] `navigationConfig.ts` の `audience` と整合確認済み

## Impact

- 認証済みユーザー: **挙動の変化なし**
- 未認証ユーザー: ProtectedRoute → RequireAudience のダブルガード
- E2E テスト: `shouldSkipLogin` 環境ではバイパス（既存ルートと同一挙動）
