### PR TITLE
fix: resolve OOM worker crash in useSchedulesToday.spec.ts

### DIFF
--- a/src/features/schedules/hooks/__tests__/useSchedulesToday.spec.ts
+++ b/src/features/schedules/hooks/__tests__/useSchedulesToday.spec.ts
@@ -4,8 +4,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ScheduleRepositoryListParams } from '../../domain/ScheduleRepository';
 
 // vi.hoisted lets us define the spy BEFORE vi.mock hoisting
-const { mockList } = vi.hoisted(() => ({
-  mockList: vi.fn(async (_params: ScheduleRepositoryListParams) => [
+const { mockList, mockRepository } = vi.hoisted(() => {
+  const list = vi.fn(async (_params: ScheduleRepositoryListParams) => [
     {
       id: '1',
       title: '朝のミーティング',
@@ -15,9 +15,20 @@ const { mockList } = vi.hoisted(() => ({
       status: 'Planned',
       etag: '',
     },
-  ]),
-}));
+  ]);
+  return {
+    mockList: list,
+    // Stable reference — returned by useScheduleRepository on every call
+    mockRepository: {
+      list,
+      create: vi.fn(),
+      update: vi.fn(),
+      remove: vi.fn(),
+    },
+  };
+});
 
+// ── Lightweight mocks ────────────────────────────────────────────────
 // Mock env — must come before hook import
 vi.mock('@/lib/env', () => ({
   isSchedulesFeatureEnabled: vi.fn(() => true),
@@ -27,14 +38,6 @@ vi.mock('@/lib/env', () => ({
   isForceDemoEnabled: vi.fn(() => true),
   isTestMode: vi.fn(() => true),
   shouldSkipLogin: vi.fn(() => true),
-}));
-
-vi.mock('@/lib/runtime', () => ({
-  hasSpfxContext: vi.fn(() => false),
-}));
-
-vi.mock('@/auth/useAuth', () => ({
-  useAuth: vi.fn(() => ({ acquireToken: vi.fn(async () => null) })),
 }));
 
 vi.mock('@/hydration/features', () => ({
@@ -52,19 +55,20 @@ vi.mock('@/lib/tz', () => ({
   formatInTimeZone: vi.fn((_date: Date, _tz: string, _fmt: string) => '09:00'),
 }));
 
-// Break the transitive import chain: SharePointScheduleRepository → fetchSp → msal
-vi.mock('@/features/schedules/infra/SharePointScheduleRepository', () => ({
-  SharePointScheduleRepository: vi.fn(),
-}));
-
-// Spy on InMemoryScheduleRepository (used by factory in demo mode)
-vi.mock('@/features/schedules/infra/InMemoryScheduleRepository', () => ({
-  inMemoryScheduleRepository: {
-    list: mockList,
-    create: vi.fn(),
-    update: vi.fn(),
-    remove: vi.fn(),
-  },
+// ── KEY FIX: Mock repositoryFactory directly ─────────────────────────
+// Previously, individual infra modules (SharePointScheduleRepository,
+// InMemoryScheduleRepository) were mocked, but repositoryFactory itself
+// was NOT mocked, causing Vitest to resolve the full transitive import
+// chain: repositoryFactory → @/env → import.meta, and
+// repositoryFactory → SharePointScheduleRepository → fetchSp → spClient
+// → msal, which exhausted worker memory (OOM).
+//
+// By mocking the factory at the boundary, we cut off the entire heavy
+// dependency graph. This matches the pattern used by useAttendance.spec.ts
+// and useTableDailyRecordViewModel.spec.ts.
+vi.mock('../../repositoryFactory', () => ({
+  useScheduleRepository: vi.fn(() => mockRepository),
+  getCurrentScheduleRepositoryKind: vi.fn(() => 'demo'),
 }));
 
 import { useSchedulesToday } from '../useSchedulesToday';


### PR DESCRIPTION
## 原因

`useSchedulesToday.spec.ts` は `SharePointScheduleRepository` と `InMemoryScheduleRepository` を個別にモックしていたが、**`repositoryFactory` 自体はモックしていなかった**。

そのため Vitest ワーカーは以下の重い推移的依存チェーンを解決する必要があり、メモリが枯渇して OOM クラッシュが発生していた：

```
repositoryFactory.ts
  → @/env (import.meta.env)
  → @/auth/useAuth
  → SharePointScheduleRepository
      → @/infra/sharepoint/repos/schedulesRepo
      → @/lib/fetchSp → @/lib/spClient → MSAL
```

## 修正

1. **`repositoryFactory` をバウンダリ境界で直接モック化**
   - `useScheduleRepository` / `getCurrentScheduleRepositoryKind` をファクトリレベルでモック
   - 重い依存チェーン全体を切断

2. **不要なリーフモックを削除** (7個 → 5個)
   - `@/lib/runtime`, `@/auth/useAuth`, `SharePointScheduleRepository`, `InMemoryScheduleRepository` の個別モックは不要に

3. **安定したオブジェクト参照** (`vi.hoisted`)
   - `mockRepository` を一度だけ作成し、`useScheduleRepository` が毎回同じ参照を返すことで React hook の無限再レンダリングループを防止

## 効果

| 指標 | 修正前 | 修正後 |
|------|--------|--------|
| **実行時間** | 39.59s → クラッシュ | **891ms** |
| **ステータス** | ❌ OOM Worker crash | ✅ 4/4 pass |
| **モック数** | 7個（リーフレベル） | 5個（バウンダリレベル） |

## 設計ルール（横展開）

- UI / hook テストでは `repositoryFactory` をモック
- infra 実装は UI テストで直接モックしない
- factory が返すオブジェクトは stable reference を保つ
- env / auth / MSAL を跨ぐ依存は unit test に持ち込まない

Matches existing patterns: `useAttendance.spec.ts`, `useTableDailyRecordViewModel.spec.ts`