### PR TITLE
refactor: 黒ノート → 運営状況/記録一覧 リネーム

### DIFF
--- a/docs/pilot-operation-constraints.md
+++ b/docs/pilot-operation-constraints.md
@@ -25,7 +25,7 @@
 |------|------|
 | **出席管理** (Attendance) | SP リスト `Daily_Attendance` 等が存在すれば動作 |
 | **日次記録** (Daily Records) | `/dailysupport` → 各記録画面。認証済みユーザーなら利用可能 |
-| **Dashboard（黒ノート）** | `/dashboard` — 管理者向け KPI 表示 |
+| **Dashboard（運営状況）** | `/dashboard` — 管理者向け KPI 表示 |
 | **TodayOps** | `/today` — `VITE_FEATURE_TODAY_OPS=1` 設定が必要 |
 | **ユーザー管理** (Users) | `/users` — admin ロール必要 |
 | **職員管理** (Staff) | `/staff` — admin ロール必要 |

--- a/src/app/AppShellSidebar.tsx
+++ b/src/app/AppShellSidebar.tsx
@@ -53,7 +53,7 @@ const NavItemRow: React.FC<{
 }> = React.memo(({ item, navCollapsed, currentPathname, currentSearch, onNavigate }) => {
   const { label, to, isActive, testId, icon: IconComponent, prefetchKey, prefetchKeys } = item;
   const active = isActive(currentPathname, currentSearch);
-  const isBlackNote = label.includes('黒ノート');
+  const isRecordSection = label.includes('運営状況') || label.includes('記録一覧');
   const showLabel = !navCollapsed;
 
   const handleClick = (e: React.MouseEvent) => {
@@ -69,7 +69,7 @@ const NavItemRow: React.FC<{
     'aria-current': active ? ('page' as const) : undefined,
     onClick: handleClick,
     sx: {
-      ...(isBlackNote && active ? {
+      ...(isRecordSection && active ? {
         borderLeft: 4,
         borderColor: 'primary.main',
         fontWeight: 700,

--- a/src/app/config/navigationConfig.helpers.ts
+++ b/src/app/config/navigationConfig.helpers.ts
@@ -84,7 +84,8 @@ export function pickGroup(item: NavItem, isAdmin: boolean): NavGroupKey {
     testId === TESTIDS.nav.schedules ||
     to.startsWith('/records') ||
     to.startsWith('/schedule') ||
-    label.includes('黒ノート') ||
+    label.includes('運営状況') ||
+    label.includes('記録一覧') ||
     label.includes('月次')
   ) {
     return 'record';

--- a/src/app/config/navigationConfig.ts
+++ b/src/app/config/navigationConfig.ts
@@ -161,7 +161,7 @@ export function createNavItems(config: CreateNavItemsConfig): NavItem[] {
       group: 'daily' as NavGroupKey,
     },
     {
-      label: '黒ノート',
+      label: '運営状況',
       to: '/dashboard',
       isActive: (pathname) => pathname === '/dashboard',
       icon: undefined,
@@ -170,7 +170,7 @@ export function createNavItems(config: CreateNavItemsConfig): NavItem[] {
       group: 'record' as NavGroupKey,
     },
     {
-      label: '黒ノート一覧',
+      label: '記録一覧',
       to: '/records',
       isActive: (pathname) => pathname.startsWith('/records'),
       icon: undefined,

--- a/src/app/config/routeGroups/recordRoutes.ts
+++ b/src/app/config/routeGroups/recordRoutes.ts
@@ -12,7 +12,7 @@ import { NAV_AUDIENCE } from '../navigationConfig.types';
 /** Unconditional record group items */
 export const RECORD_ROUTES_BASE: NavItem[] = [
   {
-    label: '黒ノート',
+    label: '運営状況',
     to: '/dashboard',
     isActive: (pathname) => pathname === '/dashboard',
     icon: undefined,
@@ -21,7 +21,7 @@ export const RECORD_ROUTES_BASE: NavItem[] = [
     group: 'record' as NavGroupKey,
   },
   {
-    label: '黒ノート一覧',
+    label: '記録一覧',
     to: '/records',
     isActive: (pathname) => pathname.startsWith('/records'),
     icon: undefined,

--- a/src/app/navIconMap.ts
+++ b/src/app/navIconMap.ts
@@ -25,7 +25,7 @@ export const navIconMap: Record<string, React.ElementType> = {
   '朝会（作成）': AddCircleOutlineIcon,
   '夕会（作成）': AddCircleOutlineIcon,
   '議事録アーカイブ': EditNoteIcon,
-  '黒ノート一覧': AssignmentTurnedInRoundedIcon,
+  '記録一覧': AssignmentTurnedInRoundedIcon,
   '月次記録': AssessmentRoundedIcon,
   '分析': InsightsIcon,
   '氷山分析': WorkspacesIcon,

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -69,7 +69,8 @@ const DashboardPage: React.FC<DashboardPageProps> = ({ audience = 'staff' }) => 
       <Box sx={{ py: { xs: 1.5, sm: 2, md: 2.5 } }}>
         {/* B) ヘッダー */}
         <PageHeader
-          title="黒ノート"
+          title="運営状況"
+          subtitle="出席・体制・申し送りの状況を一覧します"
           icon={<DashboardIcon />}
           actions={
             <DashboardHeaderActions

--- a/src/pages/DashboardPageTabs.tsx
+++ b/src/pages/DashboardPageTabs.tsx
@@ -43,7 +43,7 @@ const DashboardPageTabs: React.FC = () => {
         <Tabs
           value={tab.value}
           onChange={(_, v: BriefingTabValue) => tab.set(v)}
-          aria-label="黒ノート機能タブ"
+          aria-label="運営状況タブ"
           variant="scrollable"
           scrollButtons="auto"
           sx={{ mb: 3 }}

--- a/src/pages/ScheduleUnavailablePage.tsx
+++ b/src/pages/ScheduleUnavailablePage.tsx
@@ -51,9 +51,9 @@ const ScheduleUnavailablePage = () => (
           component={Link}
           to="/records"
           variant="outlined"
-          aria-label="黒ノート（月次・日次記録の画面）を開く"
+          aria-label="記録一覧（月次・日次記録の画面）を開く"
         >
-          黒ノートを開く
+          記録一覧を開く
         </Button>
       </Stack>
     </Stack>

--- a/src/testids.ts
+++ b/src/testids.ts
@@ -21,6 +21,7 @@ const NAV_TESTIDS = {
   navigationDiagnostics: 'nav-navigation-diagnostics',
   todayOps: 'nav-today-ops',
   roomManagement: 'nav-room-management',
+  operationFlowSettings: 'nav-operation-flow-settings',
 } as const;
 
 const FOOTER_TESTIDS = {
@@ -43,7 +44,7 @@ export const TESTIDS = {
   'meeting-guide': 'meeting-guide',
   'meeting-guide-page': 'meeting-guide-page',
   'dashboard-page': 'dashboard-page',
-  'dashboard-page-tabs': 'dashboard-page-tabs', // 🧪 黒ノート機能タブ専用（日次ダッシュボードと区別）
+  'dashboard-page-tabs': 'dashboard-page-tabs', // 🧪 運営状況タブ専用（日次ダッシュボードと区別）
   'dashboard-records': 'dashboard-records',
   'audit-heading': 'audit-heading',
   'iceberg-pdca-root': 'iceberg-pdca-root',
@@ -63,7 +64,7 @@ export const TESTIDS = {
   'pdca-weekly-leadtime-trend': 'pdca-weekly-leadtime-trend',
   'pdca-monthly-leadtime-trend': 'pdca-monthly-leadtime-trend',
 
-  // Dashboard Tabs (黒ノート機能個別タブ) 🌱 E2Eでタブ切替を細かく検査用
+  // Dashboard Tabs (運営状況機能個別タブ) 🌱 E2Eでタブ切替を細かく検査用
   'dashboard-tab-management': 'dashboard-tab-management',
   'dashboard-tab-timeline': 'dashboard-tab-timeline',
   'dashboard-tab-weekly': 'dashboard-tab-weekly',

--- a/tests/e2e/app-shell.aria-current.smoke.spec.ts
+++ b/tests/e2e/app-shell.aria-current.smoke.spec.ts
@@ -9,9 +9,9 @@ test.describe('AppShell sidebar aria-current', () => {
     const usersLink = page.getByRole('link', { name: '利用者' });
     await expect(usersLink).toHaveAttribute('aria-current', 'page');
 
-    // 3) 別リンクは aria-current を持たない（例：黒ノート一覧）
-    const blackNoteLink = page.getByRole('link', { name: '黒ノート一覧' });
-    await expect(blackNoteLink).not.toHaveAttribute('aria-current', 'page');
+    // 3) 別リンクは aria-current を持たない（例：記録一覧）
+    const recordListLink = page.getByRole('link', { name: '記録一覧' });
+    await expect(recordListLink).not.toHaveAttribute('aria-current', 'page');
   });
 
   test('marks /dashboard with aria-current="page" and non-current links without it', async ({ page }) => {
@@ -22,7 +22,7 @@ test.describe('AppShell sidebar aria-current', () => {
     const dashboardLink = page.getByRole('navigation', { name: /主要ナビゲーション/i }).locator('a[href="/dashboard"]');
     await expect(dashboardLink).toHaveAttribute('aria-current', 'page');
 
-    // a[href="/records"]（黒ノート一覧）が aria-current を持たない
+    // a[href="/records"]（記録一覧）が aria-current を持たない
     const recordsLink = page.getByRole('navigation', { name: /主要ナビゲーション/i }).locator('a[href="/records"]');
     await expect(recordsLink).not.toHaveAttribute('aria-current', 'page');
   });

--- a/tests/e2e/basic-smoke.spec.ts
+++ b/tests/e2e/basic-smoke.spec.ts
@@ -30,7 +30,7 @@ test.describe('Basic Dashboard', () => {
 
       // 認証なし/マウント失敗でも「HTMLが返っている」ことを確認する（CI安定化）
       await page.waitForLoadState('domcontentloaded');
-      await expect(page).toHaveTitle('黒ノート');
+      await expect(page).toHaveTitle('運営状況');
 
       // root 自体は存在すればOK（hidden でも落とさない）
       const reactRoot = page.locator('#root, [data-reactroot]');

--- a/tests/e2e/dashboard-minimal.spec.ts
+++ b/tests/e2e/dashboard-minimal.spec.ts
@@ -6,7 +6,7 @@ test.describe('Dashboard Phase II - Minimal E2E', () => {
     await page.waitForLoadState('networkidle');
 
     // 基本的なページロード確認
-    await expect(page).toHaveTitle(/黒ノート/);
+    await expect(page).toHaveTitle(/運営状況/);
 
     // Dashboard ページ要素の確認
     const dashboardPage = page.getByTestId('dashboard-page');
@@ -32,7 +32,7 @@ test.describe('Dashboard Phase II - Minimal E2E', () => {
 
     // 重要なキーワードが含まれていることを確認 - 実際のコンテンツに基づく
     const pageText = await page.textContent('body');
-    expect(pageText).toContain('黒ノート');
+    expect(pageText).toContain('運営状況');
 
     console.log('✅ Dashboard contains expected content');
   });

--- a/tests/e2e/dashboard-phase-ii.spec.ts
+++ b/tests/e2e/dashboard-phase-ii.spec.ts
@@ -9,7 +9,7 @@ test.describe('Dashboard Phase II - Mini E2E Tests', () => {
 
   test('Dashboard表示 - 基本コンポーネント検証', async ({ page }) => {
     // ページタイトル確認 - 実際のタイトルに合わせて修正
-    await expect(page).toHaveTitle(/黒ノート/);
+    await expect(page).toHaveTitle(/運営状況/);
 
     // Dashboard ページの基本要素確認
     const dashboardPage = page.getByTestId('dashboard-page');
@@ -18,7 +18,7 @@ test.describe('Dashboard Phase II - Mini E2E Tests', () => {
     console.log('Dashboard page loaded successfully');
 
     // ページ内に重要なテキストが含まれていることを確認
-    await expect(page.getByRole('heading', { name: '黒ノート' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: '運営状況' })).toBeVisible();
   });
 
   test('Safety HUD - アラート表示検証', async ({ page }) => {

--- a/tests/e2e/prefetch.navshell.spec.ts
+++ b/tests/e2e/prefetch.navshell.spec.ts
@@ -65,15 +65,15 @@ test.describe('Prefetch nav shell intents', () => {
 
     await expect.poll(async () => {
       const spans = await readPrefetchSpans(page);
-      return spans.some((span) => span.key === 'route:dashboard' && span.source === 'hover' && span.meta?.label === '黒ノート');
+      return spans.some((span) => span.key === 'route:dashboard' && span.source === 'hover' && span.meta?.label === '運営状況');
     }).toBe(true);
     await expect.poll(async () => {
       const spans = await readPrefetchSpans(page);
-      return spans.some((span) => span.key === 'mui:data' && span.source === 'hover' && span.meta?.label === '黒ノート');
+      return spans.some((span) => span.key === 'mui:data' && span.source === 'hover' && span.meta?.label === '運営状況');
     }).toBe(true);
     await expect.poll(async () => {
       const spans = await readPrefetchSpans(page);
-      return spans.some((span) => span.key === 'mui:feedback' && span.source === 'hover' && span.meta?.label === '黒ノート');
+      return spans.some((span) => span.key === 'mui:feedback' && span.source === 'hover' && span.meta?.label === '運営状況');
     }).toBe(true);
     await expect(hud).toContainText('mui:data');
     await expect(hud).toContainText('mui:feedback');

--- a/tests/unit/app/config/navigationConfig.spec.ts
+++ b/tests/unit/app/config/navigationConfig.spec.ts
@@ -74,7 +74,7 @@ describe('navigationConfig', () => {
 
     it('should classify records as record group', () => {
       const item: NavItem = {
-        label: '黒ノート一覧',
+        label: '記録一覧',
         to: '/records',
         isActive: () => false,
       };
@@ -193,7 +193,7 @@ describe('navigationConfig', () => {
       expect(items.length).toBeGreaterThan(0);
       expect(items.some((item) => item.label === '日次記録')).toBe(true);
       expect(items.some((item) => item.label === '健康記録')).toBe(true);
-      expect(items.some((item) => item.label === '黒ノート一覧')).toBe(true);
+      expect(items.some((item) => item.label === '記録一覧')).toBe(true);
       expect(items.some((item) => item.label === '利用者')).toBe(true);
     });
 
@@ -330,7 +330,7 @@ describe('navigationConfig', () => {
         isActive: () => false,
       },
       {
-        label: '黒ノート一覧',
+        label: '記録一覧',
         to: '/records',
         isActive: () => false,
       },
@@ -348,7 +348,7 @@ describe('navigationConfig', () => {
 
     it('should filter items by label (case-insensitive)', () => {
       const result = filterNavItems(sampleItems, '記録');
-      expect(result.length).toBe(2); // 日次記録, 健康記録
+      expect(result.length).toBe(3); // 日次記録, 健康記録, 記録一覧
       expect(result.every((item) => item.label.includes('記録'))).toBe(true);
     });
 
@@ -379,7 +379,7 @@ describe('navigationConfig', () => {
         testId: TESTIDS.nav.daily,
       },
       {
-        label: '黒ノート一覧',
+        label: '記録一覧',
         to: '/records',
         isActive: () => false,
       },
@@ -407,7 +407,7 @@ describe('navigationConfig', () => {
 
       expect(ORDER).toEqual(NAV_GROUP_ORDER);
       expect(map.get('daily')).toHaveLength(1);
-      expect(map.get('record')).toHaveLength(2); // 黒ノート + 自己点検 (non-admin default)
+      expect(map.get('record')).toHaveLength(2); // 記録一覧 + 自己点検 (non-admin default)
       expect(map.get('ibd')).toHaveLength(1);
       expect(map.get('master')).toHaveLength(1);
     });
@@ -416,7 +416,7 @@ describe('navigationConfig', () => {
       const { map } = groupNavItems(sampleItems, true);
 
       expect(map.get('admin')).toHaveLength(1); // 自己点検
-      expect(map.get('record')).toHaveLength(1); // 黒ノート only
+      expect(map.get('record')).toHaveLength(1); // 記録一覧 only
     });
 
     it('should maintain group order', () => {


### PR DESCRIPTION
## 概要
ナビゲーション・UI全体で「黒ノート」という内部呼称を、運用者にとって分かりやすい「運営状況」「記録一覧」に統一します。

## 変更内容
- ナビゲーションラベル変更（navigation config, sidebar, icon map）
- ダッシュボードページタイトル・コメント更新
- testids.ts のコメント更新 + operationFlowSettings testid 追加
- 全 E2E テスト・unit テストのラベル参照を更新
- ドキュメント（pilot-operation-constraints）の用語更新

## テスト
- `tsc --noEmit`: ✅ pass
- `navigationConfig.spec.ts`: ✅ 38/38 pass
- E2E テストのラベル参照を全て更新済み

## 影響範囲
- UIラベルの変更のみ（ロジック・データ変更なし）
- 16 files changed, 37 insertions(+), 34 deletions(-)