### PR TITLE
feat: integrate operational phase into /today and /daily pages

### DIFF
--- a/docs/architecture/phase-mapping-reference.md
+++ b/docs/architecture/phase-mapping-reference.md
@@ -1,0 +1,107 @@
+# フェーズマッピングリファレンス
+
+> テスト期待値を決めるときの **唯一の参照先**
+
+## 判定の流れ
+
+```
+時刻 → DEFAULT_PHASE_CONFIG (9分割)
+     → toLegacyPhase() (6分割へ写像)
+     → toLegacyPrimaryScreen() (主役画面)
+```
+
+**SSOT は 9分割 `DEFAULT_PHASE_CONFIG`**。
+6分割はUI表示・導線用のマッピング結果であり、直接判定はしない。
+
+---
+
+## 9分割 → 6分割 マッピング表
+
+| # | 9分割キー | 時間帯 | → 6分割フェーズ | 主役画面 | /today が主役? | color |
+|---|-----------|--------|----------------|----------|---------------|-------|
+| 1 | `after_hours_review` | 18:00–08:30 | `record-review` | `/dashboard` | ❌ | success |
+| 2 | `staff_prep` | 08:30–09:00 | `preparation` | `/today` | ✅ | info |
+| 3 | `morning_briefing` | 09:00–09:15 | `morning-meeting` | `/handoff-timeline` | ❌ | warning |
+| 4 | `arrival_intake` | 09:15–10:30 | `am-operation` | `/daily` ※1 | ❌ | info |
+| 5 | `am_activity` | 10:30–12:00 | `am-operation` | `/today` | ✅ | info |
+| 6 | `pm_activity` | 12:00–15:30 | `pm-operation` | `/daily` | ❌ | info |
+| 7 | `departure_support` | 15:30–16:00 | `evening-closing` | `/daily` ※1 | ❌ | warning |
+| 8 | `record_wrapup` | 16:00–17:00 | `record-review` | `/daily` | ❌ | success |
+| 9 | `evening_briefing` | 17:00–18:00 | `record-review` | `/handoff-timeline` | ❌ | success |
+
+※1 `arrival_intake` と `departure_support` の `configPrimaryScreen` は `/daily/attendance` だが、
+`toLegacyPrimaryScreen()` により `/daily` に変換される。
+
+---
+
+## テスト時刻 → 期待値 早見表
+
+テストで使う代表時刻と、その期待値を一覧にする。
+**境界時刻**（フェーズ切り替わり直後）を優先的に選ぶこと。
+
+| 時刻 | 9分割キー | 6分割フェーズ | 主役画面 | isTodayPrimary |
+|------|-----------|-------------|----------|----------------|
+| 03:00 | `after_hours_review` | `record-review` | `/dashboard` | false |
+| 06:00 | `after_hours_review` | `record-review` | `/dashboard` | false |
+| 07:30 | `after_hours_review` | `record-review` | `/dashboard` | false |
+| **08:30** | `staff_prep` | `preparation` | `/today` | **true** |
+| 08:45 | `staff_prep` | `preparation` | `/today` | **true** |
+| **09:00** | `morning_briefing` | `morning-meeting` | `/handoff-timeline` | false |
+| 09:05 | `morning_briefing` | `morning-meeting` | `/handoff-timeline` | false |
+| **09:15** | `arrival_intake` | `am-operation` | `/daily` | false |
+| 09:30 | `arrival_intake` | `am-operation` | `/daily` | false |
+| **10:30** | `am_activity` | `am-operation` | `/today` | **true** |
+| 11:00 | `am_activity` | `am-operation` | `/today` | **true** |
+| **12:00** | `pm_activity` | `pm-operation` | `/daily` | false |
+| 13:00 | `pm_activity` | `pm-operation` | `/daily` | false |
+| 14:00 | `pm_activity` | `pm-operation` | `/daily` | false |
+| **15:30** | `departure_support` | `evening-closing` | `/daily` | false |
+| **16:00** | `record_wrapup` | `record-review` | `/daily` | false |
+| **17:00** | `evening_briefing` | `record-review` | `/handoff-timeline` | false |
+| **18:00** | `after_hours_review` | `record-review` | `/dashboard` | false |
+| 20:00 | `after_hours_review` | `record-review` | `/dashboard` | false |
+
+**太字** = 境界時刻（フェーズ切り替え直後）。テストではこれらを優先して使う。
+
+---
+
+## マッピングコードの所在
+
+| ファイル | 責務 |
+|---------|------|
+| `src/features/operationFlow/domain/defaultPhaseConfig.ts` | 9分割の時刻定義 (SSOT) |
+| `src/features/operationFlow/domain/getCurrentPhaseFromConfig.ts` | 時刻 → 9分割キー判定 |
+| `src/features/operationFlow/domain/phaseConfigBridge.ts` | 9分割 → 6分割変換 |
+| `src/shared/domain/operationalPhase.ts` | 旧6分割の型定義・ラベル |
+
+---
+
+## テスト修正時のチェックリスト
+
+1. **時刻から期待値を決めるときは、まず上の早見表を引く**
+2. 新しい時刻を追加する場合は `DEFAULT_PHASE_CONFIG` で該当フェーズを確認
+3. `isTodayPrimary` は `configPrimaryScreen` が `/today` のフェーズのみ `true`
+4. `color` は 6分割フェーズに依存:
+   - `preparation` → `info`
+   - `morning-meeting` → `warning`
+   - `am-operation` / `pm-operation` → `info`
+   - `evening-closing` → `warning`
+   - `record-review` → `success`
+5. `suggestedAction` は `preparation`/`am-operation`/`pm-operation` で設定、他は `null`
+
+---
+
+## 境界時刻の解釈ルール
+
+> **境界時刻は「その時刻を含む開始時刻」として扱う。終了時刻ちょうどは次フェーズに属する。**
+
+例:
+- `09:00` → `morning_briefing` の開始 (**含む**)
+- `09:15` → `morning_briefing` の終了 = `arrival_intake` の開始 (**次フェーズ**)
+- `10:30` → `am_activity` の開始 (**含む**)
+
+`getCurrentPhaseFromConfig()` は `startTime <= now < endTime` で判定する。
+
+---
+
+*最終更新: 2026-03-13 — テスト期待値の9分割統一に伴い作成*

--- a/docs/observation/operational-phase-telemetry-guide.md
+++ b/docs/observation/operational-phase-telemetry-guide.md
@@ -1,0 +1,334 @@
+# OperationalPhase 観測ガイド
+
+> **観測期間**: 2週間（2026-03-14 〜 2026-03-28）
+> **対象**: Firestore `telemetry` コレクション / `type = "operational_phase_event"`
+
+---
+
+## 1. イベント一覧
+
+| イベント名 | 発火元 | 意味 | 主な項目 |
+|---|---|---|---|
+| `phase-suggest-shown` | TodayPhaseIndicator / DailyPhaseHintBanner | フェーズ提案バナーが表示された | `phase`, `screen` |
+| `phase-suggest-accepted` | TodayPhaseIndicator | 主役画面への遷移ボタンがクリックされた | `phase`, `screen` |
+| `phase-suggest-dismissed` | TodayPhaseIndicator / DailyPhaseHintBanner | 提案バナーが閉じられた | `phase`, `screen` |
+| `meeting-mode-suggested` | MeetingModeSuggestionBanner | 会議モード提案バナーが表示された | `suggestedMode`, `screen` |
+| `meeting-mode-accepted` | MeetingModeSuggestionBanner | 会議モード提案が受け入れられた | `suggestedMode`, `screen` |
+| `meeting-mode-dismissed` | MeetingModeSuggestionBanner | 会議モード提案が閉じられた | `suggestedMode`, `screen` |
+| `config-load-fallback` | useOperationFlowConfig | 設定ロード失敗でデフォルト値にフォールバック | `reason` |
+
+---
+
+## 2. 各イベントの見方
+
+### 2.1 shown（表示）
+
+**何を見るか**: ユーザーが提案を目にした回数。
+
+- **正常**: 業務時間帯に安定して発火している
+- **異常**: 特定の時間帯で極端に少ない → その画面を開いていない or フェーズ判定がずれている
+- **注意**: dedupe ガード付きなので、同一セッション内の再レンダリングではカウントされない
+
+```
+確認クエリ:
+  event = "phase-suggest-shown"
+  GROUP BY phase, screen
+  ORDER BY clientTs DESC
+```
+
+### 2.2 accepted（受入）
+
+**何を見るか**: 提案に従って画面遷移したか。
+
+- **正常**: shown の 20〜40% で accepted が発生
+- **低すぎ（< 10%）**: 提案の文言が不適切 or 遷移先が不要
+- **高すぎ（> 60%）**: 提案が正しく機能 → デフォルト遷移に昇格を検討
+
+```
+確認クエリ:
+  event IN ("phase-suggest-shown", "phase-suggest-accepted")
+  GROUP BY phase
+  PIVOT BY event
+```
+
+### 2.3 dismissed（閉じる）
+
+**何を見るか**: 提案を意図的に閉じたか。
+
+- **正常**: shown の 30〜60% で dismissed
+- **高すぎ（> 70%）**: 提案が邪魔になっている → 表示頻度 or 条件を見直す
+- **低すぎ（< 10%）**: 無視されている（見て閉じずにそのまま）→ 非表示条件を検討
+
+### 2.4 fallback（フォールバック）
+
+**何を見るか**: 設定ロードの信頼性。
+
+- **正常**: 0件
+- **要注意**: 日に 1〜3件 → ネットワーク瞬断の可能性
+- **危険**: 日に 5件以上 → Repository の実装 or インフラに問題
+
+```
+確認クエリ:
+  event = "config-load-fallback"
+  GROUP BY reason
+  ORDER BY clientTs DESC
+```
+
+---
+
+## 3. 指標定義
+
+### 3.1 Phase-Suggest CTR（クリックスルーレート）
+
+```
+CTR = phase-suggest-accepted / phase-suggest-shown × 100
+```
+
+| 判定 | CTR | アクション |
+|---|---|---|
+| 🟢 健全 | 20〜50% | 現状維持 |
+| 🟡 要注意 | 10〜20% | 文言・タイミングの微調整を検討 |
+| 🔴 危険 | < 10% | 提案の価値がない → 非表示 or リデザイン |
+
+> **フェーズごとに分割して見ること。** 全体平均だけだと偏りが隠れる。
+
+### 3.2 Dismiss 率
+
+```
+Dismiss率 = phase-suggest-dismissed / phase-suggest-shown × 100
+```
+
+| 判定 | Dismiss 率 | アクション |
+|---|---|---|
+| 🟢 健全 | 20〜50% | 正常な拒否率 |
+| 🟡 要注意 | 50〜70% | 提案の出しすぎ or タイミング不適切 |
+| 🔴 危険 | > 70% | ユーザーストレスが高い → 表示条件の変更 |
+
+### 3.3 Meeting-Mode 受入率
+
+```
+受入率 = meeting-mode-accepted / meeting-mode-suggested × 100
+```
+
+| 判定 | 受入率 | アクション |
+|---|---|---|
+| 🟢 健全 | 40〜70% | 提案が的確 |
+| 🟡 要注意 | 20〜40% | 時間帯設定のずれ or 提案不要な人がいる |
+| 🔴 危険 | < 20% | 会議モード提案を見直す |
+
+> **morning / evening を分けて見ること。** 片方だけ極端に低い場合がある。
+
+### 3.4 Fallback 発生率
+
+```
+Fallback率 = config-load-fallback / (全日のアクティブセッション数) × 100
+```
+
+| 判定 | Fallback 率 | アクション |
+|---|---|---|
+| 🟢 健全 | 0% | 設定ロードが安定 |
+| 🟡 要注意 | 1〜5% | ネットワーク品質を確認 |
+| 🔴 危険 | > 5% | Repository 実装 or 設定データを調査 |
+
+### 3.5 残留率（参考指標）
+
+```
+残留率 = 1 - (accepted + dismissed) / shown
+```
+
+shown されたが accepted でも dismissed でもないケース = バナーを見て放置。
+高すぎる場合はバナーが目に入っていない可能性がある。
+
+---
+
+## 4. 日次確認チェックリスト
+
+毎朝（前日分）に以下を確認する。所要時間: 5〜10分。
+
+### □ Step 1: Fallback 確認（最優先）
+
+```
+Firestore Console → telemetry
+  where type == "operational_phase_event"
+  where event == "config-load-fallback"
+  where clientTs >= "昨日 00:00"
+  orderBy clientTs desc
+```
+
+- [ ] 0件 → OK
+- [ ] 1件以上 → `reason` を確認し Slack 共有
+
+### □ Step 2: shown / accepted / dismissed のカウント
+
+```
+Firestore Console → telemetry
+  where type == "operational_phase_event"
+  where event IN ["phase-suggest-shown", "phase-suggest-accepted", "phase-suggest-dismissed"]
+  where clientTs >= "昨日 00:00"
+```
+
+以下を記録:
+
+| 指標 | /today | /daily | /handoff | 合計 |
+|---|---|---|---|---|
+| shown | | | | |
+| accepted | | | | |
+| dismissed | | | | |
+| **CTR** | | | | |
+| **Dismiss率** | | | | |
+
+### □ Step 3: Meeting-Mode のカウント
+
+```
+Firestore Console → telemetry
+  where type == "operational_phase_event"
+  where event IN ["meeting-mode-suggested", "meeting-mode-accepted", "meeting-mode-dismissed"]
+  where clientTs >= "昨日 00:00"
+```
+
+| 指標 | morning | evening | 合計 |
+|---|---|---|---|
+| suggested | | | |
+| accepted | | | |
+| dismissed | | | |
+| **受入率** | | | |
+
+### □ Step 4: フェーズ別分布の確認
+
+- [ ] 特定フェーズに shown が集中していないか
+- [ ] 深夜帯（after_hours_review）に shown が出ていないか
+- [ ] 期待するフェーズで提案が出ているか
+
+### □ Step 5: 日次所見メモ（1行）
+
+```
+例: 「夕会 dismiss 率が 80%。17:00 の設定が早すぎる可能性」
+```
+
+---
+
+## 5. 2週間レビュー集計テンプレート
+
+### 5.1 総合サマリー
+
+| 指標 | Week 1 | Week 2 | 変化 | 判定 |
+|---|---|---|---|---|
+| Phase-Suggest CTR（全体） | __% | __% | | 🟢🟡🔴 |
+| Phase-Suggest Dismiss率 | __% | __% | | 🟢🟡🔴 |
+| Meeting-Mode 受入率（全体） | __% | __% | | 🟢🟡🔴 |
+| Meeting-Mode 受入率（morning） | __% | __% | | 🟢🟡🔴 |
+| Meeting-Mode 受入率（evening） | __% | __% | | 🟢🟡🔴 |
+| Fallback 発生件数 | __件 | __件 | | 🟢🟡🔴 |
+| 残留率 | __% | __% | | 参考 |
+
+### 5.2 フェーズ別ヒートマップ
+
+| フェーズ | shown | accepted | dismissed | CTR | Dismiss率 | 判定 |
+|---|---|---|---|---|---|---|
+| staff_prep (出勤・朝準備) | | | | | | |
+| morning_briefing (朝会) | | | | | | |
+| arrival_intake (通所受入) | | | | | | |
+| am_activity (午前活動) | | | | | | |
+| pm_activity (午後活動) | | | | | | |
+| departure_support (退所対応) | | | | | | |
+| record_wrapup (記録仕上げ) | | | | | | |
+| evening_briefing (夕会) | | | | | | |
+| after_hours_review (振り返り) | | | | | | |
+
+### 5.3 画面別パフォーマンス
+
+| 画面 | shown | accepted | dismissed | CTR | Dismiss率 |
+|---|---|---|---|---|---|
+| /today | | | | | |
+| /daily | | | | | |
+| /handoff | | | | | |
+
+### 5.4 時間帯別ヒット率（config 妥当性の検証）
+
+```
+目的: 設定した時間帯と実際の利用パターンがずれていないかを確認する
+```
+
+| 時間帯 | 設定上のフェーズ | 主役画面 | shown | accepted | 所見 |
+|---|---|---|---|---|---|
+| 08:30–08:59 | staff_prep | /today | | | |
+| 09:00–09:14 | morning_briefing | /handoff-timeline | | | |
+| 09:15–10:29 | arrival_intake | /daily/attendance | | | |
+| 10:30–11:59 | am_activity | /today | | | |
+| 12:00–15:29 | pm_activity | /daily | | | |
+| 15:30–15:59 | departure_support | /daily/attendance | | | |
+| 16:00–16:59 | record_wrapup | /daily | | | |
+| 17:00–17:59 | evening_briefing | /handoff-timeline | | | |
+| 18:00–08:29 | after_hours_review | /dashboard | | | |
+
+### 5.5 Fallback 詳細
+
+| 日付 | 件数 | reason 内訳 | 対応 |
+|---|---|---|---|
+| | | | |
+| | | | |
+| **合計** | | | |
+
+### 5.6 レビュー判定と次のアクション
+
+#### Phase-Suggest 判定
+
+- [ ] CTR が 20% 以上 → 提案は現状維持
+- [ ] CTR が 10〜20% → 文言・タイミング調整 PR を作成
+- [ ] CTR が 10% 未満 → 非表示 or リデザインを検討
+- [ ] Dismiss 率が 70% 超 → 表示条件を厳格化
+
+#### Meeting-Mode 判定
+
+- [ ] 受入率が 40% 以上 → 現状維持
+- [ ] morning / evening で 20% 以上の差 → 片方の時間帯を調整
+- [ ] 受入率が 20% 未満 → 提案ロジックを見直す
+
+#### Fallback 判定
+
+- [ ] 0件 → 安定稼働
+- [ ] 1〜10件 → 原因特定し改善タスクを起票
+- [ ] 10件超 → 緊急対応が必要
+
+#### 時間帯設定の判定
+
+- [ ] 各時間帯で期待通りの shown が出ている → 設定値は妥当
+- [ ] 特定時間帯で accepted が 0 → その時間帯の提案を停止検討
+- [ ] 空白の時間帯がある → フェーズのカバレッジを見直す
+
+---
+
+## 6. 判定基準サマリー
+
+| 指標 | 🟢 健全 | 🟡 要注意 | 🔴 危険 |
+|---|---|---|---|
+| Phase-Suggest CTR | 20〜50% | 10〜20% | < 10% |
+| Dismiss 率 | 20〜50% | 50〜70% | > 70% |
+| Meeting-Mode 受入率 | 40〜70% | 20〜40% | < 20% |
+| Fallback 発生率 | 0% | 1〜5% | > 5% |
+| 残留率 | < 30% | 30〜50% | > 50% |
+
+---
+
+## 7. 運用メモ
+
+### Firestore クエリのコツ
+
+- `type == "operational_phase_event"` でフィルタすると OperationalPhase 系だけに絞れる
+- `clientTs` は ISO 文字列。日付範囲は文字列比較で可能
+- `ts` は Firestore の `serverTimestamp` — 書き込み順のソートに使う
+
+### dedupe ガードの影響
+
+- `phase-suggest-shown` と `meeting-mode-suggested` は同一セッション内で重複送信されない
+- ブラウザリロードでガードはリセットされる
+- したがって **shown 数 ≒ セッション数** と読める（厳密には 1 セッション 1 フェーズにつき 1 回）
+
+### 観測期間終了後
+
+2週間レビューの結果に基づいて以下のいずれかを実施:
+
+1. **設定値の調整** → `/settings/operation-flow` で時間帯を変更
+2. **提案 UI の改善** → 文言・色・アイコンの変更 PR
+3. **提案の廃止** → 特定フェーズでバナーを非表示にする
+4. **自動遷移への昇格** → CTR が非常に高いフェーズで自動遷移を検討

--- a/docs/observation/phase-aware-landing-spec.md
+++ b/docs/observation/phase-aware-landing-spec.md
@@ -1,0 +1,253 @@
+# Phase-Aware Landing 実装仕様書
+
+> **ステータス**: 観測完了後に着手（2026-03-28 レビュー後）
+> **前提条件**: 観測ガイドの 2 週間レビューで対象フェーズの CTR ≥ 50% を確認済みであること
+
+---
+
+## 1. 概要
+
+アプリ起動時に現在のフェーズを判定し、**主役画面に自動着地する**。
+ユーザーが毎回手動で遷移していた動線を 3 → 0 クリックに短縮する。
+
+### Before（現状）
+
+```
+アプリを開く → /today に着地 → バナーを見る → クリック → /handoff-timeline
+```
+
+### After（Phase-Aware Landing）
+
+```
+アプリを開く → 朝会フェーズ → /handoff-timeline に自動着地
+```
+
+---
+
+## 2. 導入判定基準
+
+2 週間レビューの結果を使って判断する。
+
+| 条件 | アクション |
+|---|---|
+| CTR ≥ 50% | Phase-Aware Landing 対象に追加 |
+| CTR 20〜50% | バナー提案を維持（自動化しない） |
+| CTR < 20% | バナー提案の見直し or 非表示 |
+
+### 初回導入の想定対象
+
+| フェーズ | 想定 CTR | 着地先 | 導入フェーズ |
+|---|---|---|---|
+| `morning_briefing` | 50%+ (想定) | `/handoff-timeline` | Phase 7a |
+| `evening_briefing` | 50%+ (想定) | `/handoff-timeline` | Phase 7b |
+| その他 | < 50% (想定) | `/today` (従来通り) | 対象外 |
+
+---
+
+## 3. 設計制約（絶対条件）
+
+### 3.1 初回着地のみ
+
+- **セッション開始時の最初の画面遷移だけ** で発動する
+- アプリ内でページ遷移した後は発動しない
+- ブラウザリロードは新セッション扱い
+
+### 3.2 手動優先
+
+- ユーザーが **明示的に URL を指定** して遷移した場合は自動着地しない
+- 発動条件: `pathname === "/"` または **デフォルト landing ルート** のみ
+
+### 3.3 opt-out
+
+- 自動着地後に `/today` に戻るナビゲーションを自然に使える
+- 将来的にユーザー設定で「フェーズ着地を無効化」できる拡張ポイントを残す
+
+### 3.4 フォールバック
+
+- 設定ロード未完了 → `/today` にフォールバック
+- フェーズ判定失敗 → `/today` にフォールバック
+- 対象外フェーズ → `/today` にフォールバック
+
+---
+
+## 4. 実装方針
+
+### 4.1 使用する既存インフラ
+
+```
+resolvePhaseFromConfig(now, config)  → 現在フェーズ + 主役画面を返す
+useOperationFlowConfig()             → 設定配列を取得
+DEFAULT_PHASE_CONFIG                 → フォールバック用
+```
+
+**新しい判定ロジックは不要。**
+
+### 4.2 着地判定の擬似コード
+
+```typescript
+// AppShell または ランディングルート内で実行
+
+function resolveLandingRoute(
+  config: OperationFlowPhaseConfig[],
+  now: Date,
+  enabledPhases: Set<OperationFlowPhaseKey>,  // Phase-Aware 対象
+): string {
+  const resolved = resolvePhaseFromConfig(now, config);
+
+  // 対象フェーズかつ /today 以外の主役画面 → 自動着地
+  if (
+    enabledPhases.has(resolved.phaseKey) &&
+    resolved.legacyPrimaryScreen !== '/today'
+  ) {
+    return resolved.legacyPrimaryScreen;
+  }
+
+  // それ以外 → 従来どおり
+  return '/today';
+}
+```
+
+### 4.3 発動タイミング
+
+```
+ユーザーが "/" にアクセス
+  ↓
+useOperationFlowConfig() で config をロード
+  ↓
+ロード完了？
+  NO → /today にフォールバック
+  YES → resolveLandingRoute() を実行
+    ↓
+  結果のパスに navigate()
+```
+
+### 4.4 対象フェーズの管理
+
+最初はハードコードで十分:
+
+```typescript
+const PHASE_AWARE_ENABLED: Set<OperationFlowPhaseKey> = new Set([
+  'morning_briefing',
+  // Phase 7b で追加: 'evening_briefing',
+]);
+```
+
+将来的には `/settings/operation-flow` に「自動着地を有効化」チェックボックスを追加。
+
+---
+
+## 5. テレメトリ
+
+### 5.1 追加イベント
+
+| イベント | 意味 | 項目 |
+|---|---|---|
+| `phase-landing-auto` | Phase-Aware Landing で自動遷移した | `phase`, `screen`, `landingTarget` |
+| `phase-landing-fallback` | フォールバックで /today に着地した | `phase`, `reason` |
+
+### 5.2 観測指標
+
+```
+自動着地率 = phase-landing-auto / (phase-landing-auto + phase-landing-fallback) × 100
+```
+
+| 判定 | 自動着地率 | アクション |
+|---|---|---|
+| 🟢 健全 | > 80% | 安定稼働 |
+| 🟡 要注意 | 50〜80% | config ロード速度を確認 |
+| 🔴 危険 | < 50% | フォールバックが多すぎる → 設定を見直す |
+
+---
+
+## 6. 段階導入スケジュール
+
+### Phase 7a: morning_briefing のみ（レビュー直後）
+
+```
+対象: morning_briefing
+着地先: /handoff-timeline
+条件: CTR ≥ 50% を確認済み
+```
+
+**やること:**
+1. `resolveLandingRoute()` を実装
+2. `PHASE_AWARE_ENABLED` に `morning_briefing` を追加
+3. テレメトリ `phase-landing-auto` / `phase-landing-fallback` を追加
+4. 1 週間観測
+
+**確認項目:**
+- [ ] 朝 09:00〜09:15 に自動着地が発生しているか
+- [ ] フォールバック率が 20% 以下か
+- [ ] 現場から「勝手に飛ばされた」という声がないか
+
+### Phase 7b: evening_briefing 追加（Phase 7a 安定後）
+
+```
+対象: morning_briefing + evening_briefing
+着地先: /handoff-timeline
+条件: Phase 7a が 1 週間安定
+```
+
+**やること:**
+1. `PHASE_AWARE_ENABLED` に `evening_briefing` を追加
+2. 1 週間観測
+
+### Phase 7c: 管理設定化（任意）
+
+```
+対象: 全フェーズ（管理者が選択）
+条件: Phase 7b が安定し、他フェーズも CTR が高い場合
+```
+
+**やること:**
+1. `/settings/operation-flow` に「自動着地」列を追加
+2. フェーズごとに ON/OFF を管理者が切り替え可能にする
+
+---
+
+## 7. ロールバック手順
+
+問題が出た場合の即座の無効化:
+
+```typescript
+// 全フェーズの自動着地を無効化するには:
+const PHASE_AWARE_ENABLED: Set<OperationFlowPhaseKey> = new Set([
+  // すべてコメントアウト
+]);
+```
+
+全フェーズで `/today` にフォールバックし、従来動作に戻る。
+コード変更 1 行、デプロイのみ。
+
+---
+
+## 8. 実装チェックリスト
+
+### 着手前
+
+- [ ] 2 週間レビュー完了
+- [ ] `morning_briefing` の CTR ≥ 50% を確認
+- [ ] 現場リーダーに「朝会時は自動で申し送り画面に着地します」と事前説明
+
+### 実装
+
+- [ ] `resolveLandingRoute()` 純粋関数を作成
+- [ ] 純粋関数テストを作成（全フェーズ × 対象/対象外 × フォールバック）
+- [ ] AppShell のランディング判定に組み込み
+- [ ] テレメトリ `phase-landing-auto` / `phase-landing-fallback` を追加
+- [ ] `PHASE_AWARE_ENABLED` に `morning_briefing` を設定
+
+### 検証
+
+- [ ] `/` にアクセスして `morning_briefing` 時間帯に `/handoff-timeline` に着地するか
+- [ ] `/today` を明示的に開いたときにリダイレクトされないか
+- [ ] 設定ロード前にアクセスしたとき `/today` にフォールバックするか
+- [ ] 対象外フェーズで `/today` に着地するか
+- [ ] typecheck / vitest / eslint が通るか
+
+### 導入後
+
+- [ ] 1 日目: fallback 率を確認
+- [ ] 3 日目: 自動着地率 80% 以上か
+- [ ] 1 週間後: 現場フィードバックを収集
+- [ ] 問題なければ Phase 7b に進む

--- a/src/features/daily/components/DailyPhaseHintBanner.tsx
+++ b/src/features/daily/components/DailyPhaseHintBanner.tsx
@@ -1,0 +1,233 @@
+/**
+ * DailyPhaseHintBanner — 日次記録画面の時間帯ヒントUI
+ *
+ * OperationalPhase 基盤を使い、現在時刻から
+ * 「今やるべき記録作業」のヒントを表示する。
+ *
+ * Phase 3 (設定値ベース判定):
+ *   - resolvePhaseFromConfig() で設定配列から判定
+ *   - config 未指定時は DEFAULT_PHASE_CONFIG にフォールバック
+ *
+ * 設計方針:
+ *   - 強制ではなく案内（dismiss 可能）
+ *   - 現場用語で端的に伝える
+ *   - DailyRecordMenuPage のヘッダー直下で使用
+ *   - 純粋関数 + 薄いUIの2層構成
+ */
+
+import { DEFAULT_PHASE_CONFIG } from '@/features/operationFlow/domain/defaultPhaseConfig';
+import { resolvePhaseFromConfig } from '@/features/operationFlow/domain/phaseConfigBridge';
+import type { OperationFlowPhaseConfig } from '@/features/operationFlow/domain/operationFlowTypes';
+import { useOperationFlowConfig } from '@/features/operationFlow/hooks/useOperationFlowConfig';
+import { PHASE_EVENTS, recordPhaseEvent } from '@/features/operationFlow/telemetry/recordPhaseEvent';
+import type { OperationalPhase } from '@/shared/domain/operationalPhase';
+import AccessTimeIcon from '@mui/icons-material/AccessTime';
+import CloseIcon from '@mui/icons-material/Close';
+import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import Typography from '@mui/material/Typography';
+import { useEffect, useState } from 'react';
+
+// ────────────────────────────────────────────────────────────
+// 純粋関数: 時間帯ヒント判定
+// ────────────────────────────────────────────────────────────
+
+/**
+ * 時間帯ヒント情報
+ */
+export interface DailyPhaseHint {
+  /** 現在のフェーズ */
+  phase: OperationalPhase;
+  /** フェーズラベル（例: "AM活動"） */
+  phaseLabel: string;
+  /** メインメッセージ（現場用語） */
+  message: string;
+  /** 推奨アクション（カード案内用） */
+  suggestedAction: string | null;
+  /** 色テーマ */
+  color: 'info' | 'warning' | 'success';
+}
+
+/**
+ * 現在時刻から日次記録画面向けのヒントを返す
+ *
+ * @param now    - 判定対象の日時（デフォルト: 現在時刻）
+ * @param config - フェーズ設定配列（省略時は DEFAULT_PHASE_CONFIG）
+ * @returns 時間帯ヒント情報
+ *
+ * フェーズ別ガイド:
+ *   preparation     → 通所準備: 欠席連絡の確認
+ *   morning-meeting → 朝会中: 通所管理の最終確認
+ *   am-operation    → AM活動: 午前の活動記録を入れる時間
+ *   pm-operation    → PM活動: 午後の記録・支援手順チェック
+ *   evening-closing → 帰り支度: 未入力の記録を片付ける
+ *   record-review   → 振り返り: 今日の記録を確認・仕上げ
+ */
+export function getDailyPhaseHint(
+  now: Date = new Date(),
+  config: readonly OperationFlowPhaseConfig[] = DEFAULT_PHASE_CONFIG,
+): DailyPhaseHint {
+  const resolved = resolvePhaseFromConfig(now, config);
+  const phase = resolved.operationalPhase;
+  const phaseLabel = resolved.phaseLabel;
+
+  switch (phase) {
+    case 'preparation':
+      return {
+        phase,
+        phaseLabel,
+        message: '出勤・朝準備の時間です。欠席連絡の確認からはじめましょう',
+        suggestedAction: '通所管理',
+        color: 'info',
+      };
+
+    case 'morning-meeting':
+      return {
+        phase,
+        phaseLabel,
+        message: '朝会の時間です。今日の通所状況を最終確認しましょう',
+        suggestedAction: '通所管理',
+        color: 'warning',
+      };
+
+    case 'am-operation':
+      return {
+        phase,
+        phaseLabel,
+        message: '午前活動の時間です。活動の様子を記録に残しましょう',
+        suggestedAction: '一覧形式ケース記録',
+        color: 'info',
+      };
+
+    case 'pm-operation':
+      return {
+        phase,
+        phaseLabel,
+        message: '午後活動の時間です。午前分の記録がまだなら先に入力しましょう',
+        suggestedAction: '一覧形式ケース記録',
+        color: 'info',
+      };
+
+    case 'evening-closing':
+      return {
+        phase,
+        phaseLabel,
+        message: '帰り支度の時間です。未入力の記録があれば今のうちに片付けましょう',
+        suggestedAction: null,
+        color: 'warning',
+      };
+
+    case 'record-review':
+      return {
+        phase,
+        phaseLabel,
+        message: '記録・振り返りの時間です。今日の記録を確認して仕上げましょう',
+        suggestedAction: null,
+        color: 'success',
+      };
+  }
+}
+
+// ────────────────────────────────────────────────────────────
+// UIコンポーネント
+// ────────────────────────────────────────────────────────────
+
+export interface DailyPhaseHintBannerProps {
+  /** テスト用: 時刻を外部注入 */
+  now?: Date;
+}
+
+/**
+ * 日次記録ページ用の時間帯ヒントバナー
+ *
+ * 使い方:
+ *   <DailyPhaseHintBanner />
+ *   <DailyPhaseHintBanner now={new Date('2026-01-01T10:00:00')} />
+ */
+export function DailyPhaseHintBanner({ now }: DailyPhaseHintBannerProps) {
+  const [dismissed, setDismissed] = useState(false);
+  const { config } = useOperationFlowConfig();
+  const hint = getDailyPhaseHint(now, config);
+
+  // ── 観測: 表示イベント (dedupe で重複防止) ──
+  useEffect(() => {
+    if (!dismissed) {
+      recordPhaseEvent(
+        { event: PHASE_EVENTS.SUGGEST_SHOWN, phase: hint.phase, screen: '/daily' },
+        { dedupe: true },
+      );
+    }
+  }, [dismissed, hint.phase]);
+
+  if (dismissed) return null;
+
+  /** MUI カラーパレットのマッピング */
+  const colorMap = {
+    info: { bg: 'info.50', border: 'info.200', icon: 'info.main' },
+    warning: { bg: 'warning.50', border: 'warning.200', icon: 'warning.main' },
+    success: { bg: 'success.50', border: 'success.200', icon: 'success.main' },
+  } as const;
+
+  const palette = colorMap[hint.color];
+
+  return (
+    <Box
+      data-testid="daily-phase-hint-banner"
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1.5,
+        px: 2,
+        py: 1,
+        mb: 2,
+        borderRadius: 2,
+        bgcolor: palette.bg,
+        border: '1px solid',
+        borderColor: palette.border,
+      }}
+    >
+      {/* 時計アイコン */}
+      <AccessTimeIcon
+        sx={{
+          fontSize: '1.2rem',
+          color: palette.icon,
+          flexShrink: 0,
+        }}
+      />
+
+      {/* メッセージ */}
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Typography
+          variant="body2"
+          sx={{ fontWeight: 600, color: 'text.primary' }}
+        >
+          🕐 {hint.phaseLabel}
+        </Typography>
+        <Typography
+          variant="caption"
+          sx={{ color: 'text.secondary', display: 'block' }}
+        >
+          {hint.message}
+        </Typography>
+      </Box>
+
+      {/* 閉じるボタン */}
+      <IconButton
+        data-testid="daily-phase-hint-dismiss"
+        size="small"
+        onClick={() => {
+          recordPhaseEvent({
+            event: PHASE_EVENTS.SUGGEST_DISMISSED,
+            phase: hint.phase,
+            screen: '/daily',
+          });
+          setDismissed(true);
+        }}
+        sx={{ ml: -0.5, flexShrink: 0 }}
+        aria-label="ヒントを閉じる"
+      >
+        <CloseIcon sx={{ fontSize: '1rem' }} />
+      </IconButton>
+    </Box>
+  );
+}

--- a/src/features/operationFlow/__tests__/settingsToUiIntegration.spec.ts
+++ b/src/features/operationFlow/__tests__/settingsToUiIntegration.spec.ts
@@ -1,0 +1,212 @@
+/**
+ * 統合テスト: 設定変更が /today /daily のUIバナーに反映されるかの検証
+ *
+ * テストシナリオ:
+ *   1. Repository にカスタム設定を保存 → TodayPhaseIndicator が反映
+ *   2. Repository にカスタム設定を保存 → DailyPhaseHintBanner が反映
+ *   3. resetToDefault → 元の判定に戻る
+ *   4. Repository 読み込み失敗 → DEFAULT_PHASE_CONFIG にフォールバック
+ *
+ * 検証ポイント:
+ *   - 設定画面で朝会終了時刻を変えると、/today の判定フェーズが変わる
+ *   - DailyPhaseHintBanner も同様に設定値を反映する
+ *   - フォールバック時に画面が壊れない
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  createOperationalPhaseRepository,
+  __resetRepositoryForTesting,
+} from '@/features/operationFlow/data/createOperationalPhaseRepository';
+import { DEFAULT_PHASE_CONFIG } from '@/features/operationFlow/domain/defaultPhaseConfig';
+import type { OperationFlowPhaseConfig } from '@/features/operationFlow/domain/operationFlowTypes';
+import { getDailyPhaseHint } from '@/features/daily/components/DailyPhaseHintBanner';
+import { getTodayPhaseHint } from '@/features/today/widgets/TodayPhaseIndicator';
+
+// ────────────────────────────────────────
+// テストヘルパー
+// ────────────────────────────────────────
+
+/** HH:mm の簡易 Date 生成 */
+function dateAt(hhmm: string): Date {
+  const [h, m] = hhmm.split(':').map(Number);
+  const d = new Date('2026-03-13T00:00:00');
+  d.setHours(h, m, 0, 0);
+  return d;
+}
+
+/**
+ * 朝会終了時刻を変更したカスタム設定を作る
+ *
+ * デフォルト: morning_briefing 09:00–09:15
+ * カスタム:   morning_briefing 09:00–10:00 (終了を遅らせる)
+ */
+function makeCustomConfig(
+  overrides: Partial<Record<string, Partial<OperationFlowPhaseConfig>>>,
+): OperationFlowPhaseConfig[] {
+  return DEFAULT_PHASE_CONFIG.map((c: OperationFlowPhaseConfig) => {
+    const override = overrides[c.phaseKey];
+    return override ? { ...c, ...override } : { ...c };
+  });
+}
+
+// ────────────────────────────────────────
+// テスト
+// ────────────────────────────────────────
+
+describe('設定 → UI反映: 純粋関数レイヤーの統合テスト', () => {
+  beforeEach(() => {
+    __resetRepositoryForTesting();
+  });
+
+  afterEach(() => {
+    __resetRepositoryForTesting();
+  });
+
+  // ────────────────────────────────────────
+  // Scenario 1: 朝会終了時刻を変えると TodayPhaseIndicator が反映
+  // ────────────────────────────────────────
+
+  describe('TodayPhaseIndicator: 設定変更の反映', () => {
+    it('DEFAULT: 09:20 → am-operation (通所受入)', () => {
+      const hint = getTodayPhaseHint(dateAt('09:20'));
+      expect(hint.phase).toBe('am-operation');
+    });
+
+    it('カスタム: 朝会を10:00まで延長 → 09:20が morning-meeting になる', () => {
+      const custom = makeCustomConfig({
+        morning_briefing: { endTime: '10:00' },
+        arrival_intake: { startTime: '10:00' }, // 通所受入も調整
+      });
+
+      const hint = getTodayPhaseHint(dateAt('09:20'), custom);
+      expect(hint.phase).toBe('morning-meeting');
+      expect(hint.label).toBe('朝会');
+    });
+
+    it('カスタム: 午前活動の開始を遅らせると09:30がまだ通所受入', () => {
+      const custom = makeCustomConfig({
+        arrival_intake: { endTime: '10:30' },
+        am_activity: { startTime: '10:30' },
+      });
+
+      const hint = getTodayPhaseHint(dateAt('09:30'), custom);
+      // 09:30 が arrival_intake の時間帯に含まれるはず
+      expect(hint.phase).toBe('am-operation'); // arrival_intake → am-operation
+    });
+
+    it('カスタム: primaryScreen を変えると hint に反映', () => {
+      const custom = makeCustomConfig({
+        am_activity: { primaryScreen: '/dashboard' },
+      });
+
+      const hint = getTodayPhaseHint(dateAt('11:00'), custom);
+      expect(hint.primaryScreen).toBe('/dashboard');
+      expect(hint.isTodayPrimary).toBe(false);
+    });
+  });
+
+  // ────────────────────────────────────────
+  // Scenario 2: DailyPhaseHintBanner: 設定変更の反映
+  // ────────────────────────────────────────
+
+  describe('DailyPhaseHintBanner: 設定変更の反映', () => {
+    it('DEFAULT: 09:00 → morning-meeting', () => {
+      const hint = getDailyPhaseHint(dateAt('09:00'));
+      expect(hint.phase).toBe('morning-meeting');
+    });
+
+    it('カスタム: 朝会を8:45–8:55に短縮 → 09:00が arrival_intake (am-operation) になる', () => {
+      const custom = makeCustomConfig({
+        morning_briefing: { startTime: '08:45', endTime: '08:55' },
+        arrival_intake: { startTime: '08:55' },
+      });
+
+      const hint = getDailyPhaseHint(dateAt('09:00'), custom);
+      expect(hint.phase).toBe('am-operation');
+    });
+
+    it('カスタム: 退所対応の時間帯を前倒し → 15:00が evening-closing', () => {
+      const custom = makeCustomConfig({
+        pm_activity: { endTime: '15:00' },
+        departure_support: { startTime: '15:00' },
+      });
+
+      const hint = getDailyPhaseHint(dateAt('15:00'), custom);
+      expect(hint.phase).toBe('evening-closing');
+    });
+  });
+
+  // ────────────────────────────────────────
+  // Scenario 3: 初期値リセット
+  // ────────────────────────────────────────
+
+  describe('初期値リセット', () => {
+    it('Repository で saveAll → resetToDefault → getAll が DEFAULT_PHASE_CONFIG に戻る', async () => {
+      const repo = createOperationalPhaseRepository();
+
+      // カスタム保存
+      const custom = makeCustomConfig({
+        morning_briefing: { endTime: '10:00' },
+      });
+      await repo.saveAll(custom);
+
+      let stored = await repo.getAll();
+      const briefing = stored.find((c) => c.phaseKey === 'morning_briefing');
+      expect(briefing?.endTime).toBe('10:00');
+
+      // リセット
+      await repo.resetToDefault();
+      stored = await repo.getAll();
+      const briefingReset = stored.find((c) => c.phaseKey === 'morning_briefing');
+      expect(briefingReset?.endTime).toBe('09:15');
+    });
+
+    it('リセット後に getTodayPhaseHint が元の判定に戻る', async () => {
+      const repo = createOperationalPhaseRepository();
+
+      // カスタム: 朝会を10:00まで延長
+      const custom = makeCustomConfig({
+        morning_briefing: { endTime: '10:00' },
+        arrival_intake: { startTime: '10:00' },
+      });
+      await repo.saveAll(custom);
+
+      let stored = await repo.getAll();
+      let hint = getTodayPhaseHint(dateAt('09:20'), stored);
+      expect(hint.phase).toBe('morning-meeting');
+
+      // リセット
+      await repo.resetToDefault();
+      stored = await repo.getAll();
+      hint = getTodayPhaseHint(dateAt('09:20'), stored);
+      expect(hint.phase).toBe('am-operation');
+    });
+  });
+
+  // ────────────────────────────────────────
+  // Scenario 4: フォールバック
+  // ────────────────────────────────────────
+
+  describe('フォールバック', () => {
+    it('空の設定配列を渡しても画面が壊れない (DEFAULT にフォールバック)', () => {
+      const hint = getTodayPhaseHint(dateAt('10:00'), []);
+      // 旧ロジック: 10:00 → am-operation
+      expect(hint.phase).toBe('am-operation');
+      expect(hint.message).toBeTruthy();
+      expect(hint.label).toBeTruthy();
+    });
+
+    it('DailyPhaseHintBanner も空設定で壊れない', () => {
+      const hint = getDailyPhaseHint(dateAt('10:00'), []);
+      expect(hint.phase).toBe('am-operation');
+      expect(hint.message).toBeTruthy();
+    });
+
+    it('config 引数なしでも DEFAULT_PHASE_CONFIG で動作', () => {
+      const hint = getTodayPhaseHint(dateAt('13:00'));
+      expect(hint.phase).toBe('pm-operation');
+    });
+  });
+});

--- a/src/features/today/hooks/useCurrentPhase.ts
+++ b/src/features/today/hooks/useCurrentPhase.ts
@@ -1,9 +1,15 @@
 /**
- * useCurrentPhase — React hook wrapping resolvePhase
+ * useCurrentPhase — React hook wrapping resolvePhase + OperationalPhase
  *
  * #822 useTimeSlot — Phase 2 時間帯連動 #1
  *
- * Returns the current operational DayPhase based on the system clock.
+ * Returns both the legacy DayPhase and the shared OperationalPhase
+ * based on the system clock.
+ *
+ * Phase 3 (設定値ベース判定):
+ *   - useOperationFlowConfig() で設定配列を取得
+ *   - resolvePhaseFromConfig() で設定値から判定
+ *   - 設定ロード前 / 設定穴は旧 getCurrentPhase() にフォールバック
  *
  * NOTE: No interval/timer — the phase is resolved once per render.
  * Page navigations and re-mounts naturally refresh the value.
@@ -12,11 +18,57 @@
  * 将来拡張メモ: mode: 'auto' | 'manual' で手動フェーズ切替に対応
  */
 
+import type { OperationalPhase, PrimaryScreen } from '@/shared/domain/operationalPhase';
+import { resolvePhaseFromConfig } from '@/features/operationFlow/domain/phaseConfigBridge';
+import { useOperationFlowConfig } from '@/features/operationFlow/hooks/useOperationFlowConfig';
 import { resolvePhase, type DayPhase } from '../lib/resolvePhase';
 
 export { type DayPhase } from '../lib/resolvePhase';
+export { type OperationalPhase } from '@/shared/domain/operationalPhase';
 
+/** useCurrentPhase の戻り値（後方互換 + OperationalPhase 拡張） */
+export type CurrentPhaseResult = {
+  /** Legacy 3分割フェーズ（morning / midday / evening） */
+  dayPhase: DayPhase;
+  /** 共通6分割フェーズ（OperationalPhase） */
+  operationalPhase: OperationalPhase;
+  /** OperationalPhase の日本語ラベル */
+  phaseLabel: string;
+  /** 現フェーズの主役画面パス */
+  primaryScreen: PrimaryScreen;
+  /** /today が主役の時間帯かどうか */
+  isTodayPrimary: boolean;
+  /** 設定値から判定できたか（false = レガシーフォールバック） */
+  fromConfig: boolean;
+};
+
+/**
+ * 互換API: DayPhase のみを返す（既存コード向け）
+ */
 export function useCurrentPhase(): DayPhase {
   const now = new Date();
   return resolvePhase(now.getHours());
+}
+
+/**
+ * 拡張API: DayPhase + OperationalPhase を返す
+ *
+ * 設定配列が読み込まれていれば設定値ベースで判定し、
+ * 未ロード/エラー時は旧ハードコード判定にフォールバック。
+ */
+export function useCurrentPhaseExtended(): CurrentPhaseResult {
+  const { config } = useOperationFlowConfig();
+  const now = new Date();
+  const dayPhase = resolvePhase(now.getHours());
+
+  const resolved = resolvePhaseFromConfig(now, config);
+
+  return {
+    dayPhase,
+    operationalPhase: resolved.operationalPhase,
+    phaseLabel: resolved.phaseLabel,
+    primaryScreen: resolved.legacyPrimaryScreen,
+    isTodayPrimary: resolved.isTodayPrimary,
+    fromConfig: resolved.fromConfig,
+  };
 }

--- a/src/features/today/layouts/TodayBentoLayout.tsx
+++ b/src/features/today/layouts/TodayBentoLayout.tsx
@@ -49,6 +49,7 @@ import { NextActionCard } from '../widgets/NextActionCard';
 import { TodayTasksCard, type TodayTasksCardProps } from '../widgets/TodayTasksCard';
 import { TodayServiceStructureCard } from '../widgets/TodayServiceStructureCard';
 import { UserCompactList, type UserRow } from '../widgets/UserCompactList';
+import { TodayPhaseIndicator } from '../widgets/TodayPhaseIndicator';
 
 // ─── Types ───────────────────────────────────────────────────
 
@@ -72,6 +73,8 @@ export type TodayBentoProps = {
   scheduleDetailHref?: string;
   /** ナビゲーション CTA クリック → ページ遷移 */
   onNextActionNavigate?: (href: string) => void;
+  /** フェーズサジェスト: 主役画面への遷移ハンドラ */
+  onPhaseNavigate?: (path: string) => void;
   /** TodayEngine output (optional: widget hidden when undefined) */
   todayTasks?: TodayTasksCardProps;
   transport: { pending: TransportUser[]; inProgress: TransportUser[]; onArrived: (id: string) => void };
@@ -115,6 +118,7 @@ export const TodayBentoLayout: React.FC<TodayBentoProps> = ({
   nextActionMenuAction,
   scheduleDetailHref,
   onNextActionNavigate,
+  onPhaseNavigate,
   todayTasks,
   transportCard,
   users,
@@ -127,6 +131,11 @@ export const TodayBentoLayout: React.FC<TodayBentoProps> = ({
         pb: 8,
       }}
     >
+      {/* ── Phase Indicator (OperationalPhase 接続) ── */}
+      <Box sx={{ px: { xs: 2, sm: 3 }, pt: 2, pb: 0 }}>
+        <TodayPhaseIndicator onNavigate={onPhaseNavigate} />
+      </Box>
+
       {/* ── Bento Grid ── */}
       <BentoContainer sx={{ mt: 2 }}>
         {/* ── Row 0: NextAction (full-width) — PRIMARY ENTRY POINT ── */}

--- a/src/features/today/telemetry/recordFirstNavigation.spec.ts
+++ b/src/features/today/telemetry/recordFirstNavigation.spec.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createFirstNavigationTracker, type NavigationTrigger } from './recordFirstNavigation';
+
+// ── Mock Firestore ──
+const mockAddDoc = vi.fn().mockResolvedValue({ id: 'test-doc-id' });
+const mockCollection = vi.fn().mockReturnValue('mock-collection-ref');
+
+vi.mock('firebase/firestore', () => ({
+  addDoc: (...args: unknown[]) => mockAddDoc(...args),
+  collection: (...args: unknown[]) => mockCollection(...args),
+  serverTimestamp: () => 'mock-server-timestamp',
+}));
+
+vi.mock('@/infra/firestore/client', () => ({
+  db: 'mock-db',
+}));
+
+describe('createFirstNavigationTracker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const defaultOpts = {
+    operationalPhase: 'am-operation' as const,
+    dayPhase: 'morning' as const,
+    role: 'staff',
+  };
+
+  it('records first navigation to Firestore', () => {
+    const tracker = createFirstNavigationTracker(defaultOpts);
+
+    tracker.record('/daily/attendance', 'cta-primary');
+
+    expect(mockCollection).toHaveBeenCalledWith('mock-db', 'telemetry');
+    expect(mockAddDoc).toHaveBeenCalledWith(
+      'mock-collection-ref',
+      expect.objectContaining({
+        targetUrl: '/daily/attendance',
+        trigger: 'cta-primary',
+        operationalPhase: 'am-operation',
+        dayPhase: 'morning',
+        role: 'staff',
+        type: 'todayops_first_navigation',
+        ts: 'mock-server-timestamp',
+      }),
+    );
+  });
+
+  it('records only once — second call is noop', () => {
+    const tracker = createFirstNavigationTracker(defaultOpts);
+
+    tracker.record('/daily/attendance', 'cta-primary');
+    tracker.record('/handoff', 'phase-suggest');
+
+    expect(mockAddDoc).toHaveBeenCalledTimes(1);
+    expect(tracker.recorded).toBe(true);
+  });
+
+  it('starts with recorded=false', () => {
+    const tracker = createFirstNavigationTracker(defaultOpts);
+    expect(tracker.recorded).toBe(false);
+  });
+
+  it('sets recorded=true after first call', () => {
+    const tracker = createFirstNavigationTracker(defaultOpts);
+    tracker.record('/schedules', 'sidebar-nav');
+    expect(tracker.recorded).toBe(true);
+  });
+
+  it('includes dwellMs as non-negative number', () => {
+    const tracker = createFirstNavigationTracker(defaultOpts);
+
+    tracker.record('/daily/support', 'widget-chip');
+
+    const payload = mockAddDoc.mock.calls[0][1];
+    expect(typeof payload.dwellMs).toBe('number');
+    expect(payload.dwellMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('includes clientTs as ISO string', () => {
+    const tracker = createFirstNavigationTracker(defaultOpts);
+
+    tracker.record('/handoff', 'phase-suggest');
+
+    const payload = mockAddDoc.mock.calls[0][1];
+    expect(payload.clientTs).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('does not throw when addDoc rejects', async () => {
+    mockAddDoc.mockRejectedValueOnce(new Error('Firestore down'));
+
+    const tracker = createFirstNavigationTracker(defaultOpts);
+
+    expect(() => {
+      tracker.record('/dashboard', 'sidebar-nav');
+    }).not.toThrow();
+  });
+
+  it('does not throw when collection() throws synchronously', () => {
+    mockCollection.mockImplementationOnce(() => {
+      throw new Error('db not ready');
+    });
+
+    const tracker = createFirstNavigationTracker(defaultOpts);
+
+    expect(() => {
+      tracker.record('/handoff', 'cta-scene');
+    }).not.toThrow();
+  });
+
+  it.each<NavigationTrigger>([
+    'phase-suggest',
+    'cta-primary',
+    'cta-scene',
+    'cta-schedule',
+    'cta-empty',
+    'cta-utility',
+    'widget-chip',
+    'sidebar-nav',
+    'unknown',
+  ])('accepts trigger type: %s', (trigger) => {
+    const tracker = createFirstNavigationTracker(defaultOpts);
+
+    expect(() => {
+      tracker.record('/test', trigger);
+    }).not.toThrow();
+
+    const payload = mockAddDoc.mock.calls[0][1];
+    expect(payload.trigger).toBe(trigger);
+  });
+});

--- a/src/features/today/telemetry/recordFirstNavigation.ts
+++ b/src/features/today/telemetry/recordFirstNavigation.ts
@@ -1,0 +1,109 @@
+/**
+ * TodayOps First-Navigation Telemetry
+ *
+ * /today ページに着地したユーザーが「最初にどの画面に遷移したか」を記録する。
+ *
+ * 目的:
+ *   - 「時間帯 × 初回遷移画面」のクロス分析
+ *   - OperationalPhase の主役マッピング精度の検証
+ *   - phase-suggest の有効性評価（suggest 経由 vs 直接遷移 vs CTA 経由）
+ *
+ * 使い方:
+ *   1. TodayOpsPage マウント時に createFirstNavigationTracker() でトラッカーを生成
+ *   2. ナビゲーション発火時に tracker.record(targetUrl, trigger) を呼ぶ
+ *   3. 1ページロードにつき最初の1回のみ記録（2回目以降は noop）
+ *
+ * Fire-and-forget — 書き込み失敗は無視し、UI をブロックしない。
+ *
+ * @see docs/design/today-page-architecture.md
+ */
+import { db } from '@/infra/firestore/client';
+import type { OperationalPhase } from '@/shared/domain/operationalPhase';
+import type { DayPhase } from '../lib/resolvePhase';
+import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
+
+// ── トリガー種別 ──────────────────────────────────────────
+/** 初回遷移のきっかけ */
+export type NavigationTrigger =
+  | 'phase-suggest'   // TodayPhaseIndicator の主役画面リンク
+  | 'cta-primary'     // NextActionCard の主 CTA
+  | 'cta-scene'       // Scene guidance CTA
+  | 'cta-schedule'    // スケジュールコンテキスト部分
+  | 'cta-empty'       // Empty state CTA
+  | 'cta-utility'     // 補助導線
+  | 'widget-chip'     // ProgressStatusBar / AttendanceSummaryCard のチップ
+  | 'sidebar-nav'     // サイドバーメニュー / ヘッダーナビ
+  | 'unknown';        // 判別不能（back, 直接入力 等）
+
+// ── イベントペイロード ──────────────────────────────────────
+export type FirstNavigationEvent = {
+  /** 遷移先URL */
+  targetUrl: string;
+  /** トリガー種別 */
+  trigger: NavigationTrigger;
+  /** /today 滞在時間（ms） */
+  dwellMs: number;
+  /** 着地時の6分割フェーズ */
+  operationalPhase: OperationalPhase;
+  /** 着地時の3分割フェーズ */
+  dayPhase: DayPhase;
+  /** ユーザーロール */
+  role: string;
+};
+
+// ── Tracker Factory ─────────────────────────────────────
+export type FirstNavigationTracker = {
+  /** 初回遷移を記録（2回目以降は noop） */
+  record: (targetUrl: string, trigger: NavigationTrigger) => void;
+  /** 記録済みかどうか */
+  readonly recorded: boolean;
+};
+
+/**
+ * ページロード時に1つ作り、各ナビゲーションハンドラから record() を呼ぶ。
+ * 最初の1回だけ Firestore に書き込む。
+ */
+export function createFirstNavigationTracker(opts: {
+  operationalPhase: OperationalPhase;
+  dayPhase: DayPhase;
+  role: string;
+}): FirstNavigationTracker {
+  const mountedAt = Date.now();
+  let _recorded = false;
+
+  return {
+    get recorded() {
+      return _recorded;
+    },
+    record(targetUrl: string, trigger: NavigationTrigger) {
+      if (_recorded) return;
+      _recorded = true;
+
+      const event: FirstNavigationEvent = {
+        targetUrl,
+        trigger,
+        dwellMs: Date.now() - mountedAt,
+        operationalPhase: opts.operationalPhase,
+        dayPhase: opts.dayPhase,
+        role: opts.role,
+      };
+
+      const payload = {
+        ...event,
+        type: 'todayops_first_navigation' as const,
+        ts: serverTimestamp(),
+        clientTs: new Date().toISOString(),
+      };
+
+      try {
+        addDoc(collection(db, 'telemetry'), payload).catch((err) => {
+          // eslint-disable-next-line no-console
+          console.warn('[todayops:first-nav] telemetry write failed', err);
+        });
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.warn('[todayops:first-nav] telemetry skipped (db not ready)', err);
+      }
+    },
+  };
+}

--- a/src/features/today/widgets/TodayPhaseIndicator.tsx
+++ b/src/features/today/widgets/TodayPhaseIndicator.tsx
@@ -1,0 +1,220 @@
+/**
+ * TodayPhaseIndicator — /today で OperationalPhase を表示するコンパクトバナー
+ *
+ * 目的:
+ *   - 現在の業務フェーズを可視化し、スタッフに「今は何の時間か」を即伝える
+ *   - /today が主役でないフェーズでは、主役画面への誘導サジェストを出す
+ *   - dismiss 可能（慣れた職員の邪魔をしない）
+ *
+ * Phase 3 (設定値ベース判定):
+ *   - resolvePhaseFromConfig() で設定配列から判定
+ *   - config 未指定時は DEFAULT_PHASE_CONFIG にフォールバック
+ *
+ * @see features/operationFlow/domain/phaseConfigBridge.ts
+ */
+import { DEFAULT_PHASE_CONFIG } from '@/features/operationFlow/domain/defaultPhaseConfig';
+import { resolvePhaseFromConfig } from '@/features/operationFlow/domain/phaseConfigBridge';
+import type { OperationFlowPhaseConfig } from '@/features/operationFlow/domain/operationFlowTypes';
+import { useOperationFlowConfig } from '@/features/operationFlow/hooks/useOperationFlowConfig';
+import { PHASE_EVENTS, recordPhaseEvent } from '@/features/operationFlow/telemetry/recordPhaseEvent';
+import type { OperationalPhase, PrimaryScreen } from '@/shared/domain/operationalPhase';
+import AccessTimeIcon from '@mui/icons-material/AccessTime';
+import CloseIcon from '@mui/icons-material/Close';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import { Box, Button, Chip, IconButton, Stack, Typography } from '@mui/material';
+import React, { useEffect, useState } from 'react';
+
+// ────────────────────────────────────────
+// Pure Logic
+// ────────────────────────────────────────
+
+/** /today に対するフェーズヒント情報 */
+export type TodayPhaseHint = {
+  phase: OperationalPhase;
+  label: string;
+  /** 今の /today が主役かどうか */
+  isTodayPrimary: boolean;
+  /** 主役画面パス */
+  primaryScreen: PrimaryScreen;
+  /** 主役画面の表示名 */
+  primaryScreenLabel: string;
+  /** フェーズに応じた一言メッセージ */
+  message: string;
+};
+
+/** 画面パスの表示名 */
+const SCREEN_LABELS: Record<PrimaryScreen, string> = {
+  '/today': '今日の業務',
+  '/daily': '日々の記録',
+  '/handoff-timeline': '申し送り',
+  '/dashboard': '運営状況',
+};
+
+/** フェーズごとの /today 向けメッセージ */
+const PHASE_MESSAGES: Record<OperationalPhase, string> = {
+  'preparation':     '今日の予定と出欠を確認しましょう',
+  'morning-meeting': '朝会中です。申し送りの確認がメインです',
+  'am-operation':    '午前活動中。未記録があれば進めましょう',
+  'pm-operation':    '午後活動中。午前分の記録を先に確認しましょう',
+  'evening-closing': '帰り支度の時間です。残りの記録を仕上げましょう',
+  'record-review':   '今日の記録を振り返り、仕上げの時間です',
+};
+
+/**
+ * 現在のフェーズから /today 向けのヒント情報を返す（純粋関数）
+ *
+ * @param now    - 判定対象の日時（デフォルト: 現在時刻）
+ * @param config - フェーズ設定配列（省略時は DEFAULT_PHASE_CONFIG）
+ */
+export function getTodayPhaseHint(
+  now: Date = new Date(),
+  config: readonly OperationFlowPhaseConfig[] = DEFAULT_PHASE_CONFIG,
+): TodayPhaseHint {
+  const resolved = resolvePhaseFromConfig(now, config);
+  const primaryScreenLabel = SCREEN_LABELS[resolved.legacyPrimaryScreen];
+  const message = PHASE_MESSAGES[resolved.operationalPhase];
+
+  return {
+    phase: resolved.operationalPhase,
+    label: resolved.phaseLabel,
+    isTodayPrimary: resolved.isTodayPrimary,
+    primaryScreen: resolved.legacyPrimaryScreen,
+    primaryScreenLabel,
+    message,
+  };
+}
+
+// ────────────────────────────────────────
+// Component
+// ────────────────────────────────────────
+
+export type TodayPhaseIndicatorProps = {
+  /** テスト用: 現在時刻を注入 */
+  now?: Date;
+  /** 別画面への遷移ハンドラ */
+  onNavigate?: (path: string) => void;
+};
+
+export const TodayPhaseIndicator: React.FC<TodayPhaseIndicatorProps> = ({
+  now,
+  onNavigate,
+}) => {
+  const [dismissed, setDismissed] = useState(false);
+  const { config } = useOperationFlowConfig();
+  const hint = getTodayPhaseHint(now, config);
+
+  // ── 観測: 表示イベント (dedupe で重複防止) ──
+  useEffect(() => {
+    if (!dismissed) {
+      recordPhaseEvent(
+        { event: PHASE_EVENTS.SUGGEST_SHOWN, phase: hint.phase, screen: '/today' },
+        { dedupe: true },
+      );
+    }
+  }, [dismissed, hint.phase]);
+
+  if (dismissed) return null;
+
+  // フェーズごとの色テーマ
+  const colorMap: Record<OperationalPhase, 'info' | 'warning' | 'success'> = {
+    'preparation':     'info',
+    'morning-meeting': 'warning',
+    'am-operation':    'info',
+    'pm-operation':    'info',
+    'evening-closing': 'warning',
+    'record-review':   'success',
+  };
+  const color = colorMap[hint.phase];
+
+  const colorValue =
+    color === 'info' ? '#2196f3' :
+    color === 'warning' ? '#ff9800' :
+    '#4caf50';
+
+  return (
+    <Box
+      data-testid="today-phase-indicator"
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1.5,
+        px: 2,
+        py: 1,
+        borderRadius: 2,
+        bgcolor: `${colorValue}14`,
+        border: `1px solid ${colorValue}30`,
+        mb: 1.5,
+      }}
+    >
+      <AccessTimeIcon sx={{ color: colorValue, fontSize: 18 }} />
+
+      <Stack sx={{ flex: 1, minWidth: 0 }} spacing={0.25}>
+        <Stack direction="row" alignItems="center" spacing={1}>
+          <Chip
+            label={hint.label}
+            size="small"
+            sx={{
+              bgcolor: `${colorValue}20`,
+              color: colorValue,
+              fontWeight: 700,
+              fontSize: '0.7rem',
+              height: 22,
+            }}
+          />
+          <Typography
+            variant="body2"
+            sx={{ color: 'text.primary', fontSize: '0.8rem' }}
+          >
+            {hint.message}
+          </Typography>
+        </Stack>
+
+        {/* 主役画面が /today 以外なら誘導 */}
+        {!hint.isTodayPrimary && onNavigate && (
+          <Box sx={{ mt: 0.5 }}>
+            <Button
+              size="small"
+              variant="text"
+              startIcon={<OpenInNewIcon sx={{ fontSize: 14 }} />}
+              onClick={() => {
+                recordPhaseEvent({
+                  event: PHASE_EVENTS.SUGGEST_ACCEPTED,
+                  phase: hint.phase,
+                  screen: '/today',
+                });
+                onNavigate(hint.primaryScreen);
+              }}
+              sx={{
+                color: colorValue,
+                fontSize: '0.72rem',
+                fontWeight: 600,
+                textTransform: 'none',
+                p: 0,
+                minHeight: 0,
+                '&:hover': { bgcolor: `${colorValue}10` },
+              }}
+            >
+              今は「{hint.primaryScreenLabel}」がメインの時間帯です
+            </Button>
+          </Box>
+        )}
+      </Stack>
+
+      <IconButton
+        size="small"
+        onClick={() => {
+          recordPhaseEvent({
+            event: PHASE_EVENTS.SUGGEST_DISMISSED,
+            phase: hint.phase,
+            screen: '/today',
+          });
+          setDismissed(true);
+        }}
+        aria-label="フェーズ表示を閉じる"
+        sx={{ color: 'text.secondary', p: 0.5 }}
+      >
+        <CloseIcon sx={{ fontSize: 16 }} />
+      </IconButton>
+    </Box>
+  );
+};

--- a/tests/unit/features/daily/DailyPhaseHintBanner.spec.tsx
+++ b/tests/unit/features/daily/DailyPhaseHintBanner.spec.tsx
@@ -1,0 +1,144 @@
+/**
+ * DailyPhaseHintBanner — 単体テスト
+ *
+ * 純粋関数 getDailyPhaseHint() のフェーズ別ヒント判定と
+ * UIコンポーネント DailyPhaseHintBanner の表示・dismiss 動作を検証
+ */
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  DailyPhaseHintBanner,
+  getDailyPhaseHint,
+} from '@/features/daily/components/DailyPhaseHintBanner';
+
+// Mock hooks/telemetry that require context unavailable in unit tests
+vi.mock('@/features/operationFlow/hooks/useOperationFlowConfig', () => ({
+  useOperationFlowConfig: () => ({ config: undefined, loading: false }),
+}));
+vi.mock('@/features/operationFlow/telemetry/recordPhaseEvent', () => ({
+  recordPhaseEvent: vi.fn(),
+  PHASE_EVENTS: {
+    SUGGEST_SHOWN: 'phase_suggest_shown',
+    SUGGEST_DISMISSED: 'phase_suggest_dismissed',
+    SUGGEST_ACCEPTED: 'phase_suggest_accepted',
+  },
+}));
+
+// ────────────────────────────────────────────────────────────
+// テストユーティリティ
+// ────────────────────────────────────────────────────────────
+
+/** 指定時刻の Date オブジェクトを返す */
+const at = (h: number, m: number) => new Date(2026, 0, 15, h, m, 0);
+
+// ────────────────────────────────────────────────────────────
+// 純粋関数テスト: getDailyPhaseHint
+// ────────────────────────────────────────────────────────────
+
+describe('getDailyPhaseHint', () => {
+  it.each<[string, Date, string, string]>([
+    // [説明, 時刻, 期待フェーズ(9分割→6分割), メッセージに含まれる語]
+    // 06:00/07:30 は after_hours_review (18:00-08:30) → record-review
+    ['06:00 → record-review', at(6, 0), 'record-review', '振り返り'],
+    ['07:30 → record-review', at(7, 30), 'record-review', '仕上げ'],
+    // 08:30 は staff_prep (08:30-09:00) → preparation
+    ['08:30 → preparation', at(8, 30), 'preparation', '欠席連絡'],
+    ['09:00 → morning-meeting', at(9, 0), 'morning-meeting', '通所状況'],
+    ['09:15 → am-operation', at(9, 15), 'am-operation', '午前活動'],
+    ['11:00 → am-operation', at(11, 0), 'am-operation', '記録'],
+    ['12:00 → pm-operation', at(12, 0), 'pm-operation', '午後活動'],
+    ['14:00 → pm-operation', at(14, 0), 'pm-operation', '午前分'],
+    // 15:30 は departure_support → evening-closing
+    ['15:30 → evening-closing', at(15, 30), 'evening-closing', '帰り支度'],
+    // 16:00 は record_wrapup (16:00-17:00) → record-review
+    ['16:00 → record-review', at(16, 0), 'record-review', '振り返り'],
+    // 17:00-18:00 は evening_briefing → record-review
+    ['17:00 → record-review', at(17, 0), 'record-review', '振り返り'],
+    ['20:00 → record-review', at(20, 0), 'record-review', '仕上げ'],
+    ['03:00 → record-review', at(3, 0), 'record-review', '確認'],
+  ])('%s', (_desc, time, expectedPhase, expectedWord) => {
+    const hint = getDailyPhaseHint(time);
+    expect(hint.phase).toBe(expectedPhase);
+    expect(hint.message).toContain(expectedWord);
+    expect(hint.phaseLabel).toBeTruthy();
+  });
+
+  it('すべてのフェーズで suggestedAction と color が定義されている', () => {
+    const times = [at(7, 0), at(8, 45), at(10, 0), at(13, 0), at(16, 0), at(18, 0)];
+    for (const t of times) {
+      const hint = getDailyPhaseHint(t);
+      expect(hint.color).toMatch(/^(info|warning|success)$/);
+      // suggestedAction は null でも可
+      expect(hint.phase).toBeTruthy();
+    }
+  });
+
+  it('朝会は warning, AM/PM activity は info, 振り返りは success', () => {
+    // 08:45 → staff_prep → preparation → info
+    expect(getDailyPhaseHint(at(8, 45)).color).toBe('info');
+    // 09:05 → morning_briefing → morning-meeting → warning
+    expect(getDailyPhaseHint(at(9, 5)).color).toBe('warning');
+    expect(getDailyPhaseHint(at(10, 30)).color).toBe('info');
+    expect(getDailyPhaseHint(at(13, 0)).color).toBe('info');
+    // 16:00 → record_wrapup → record-review → success
+    expect(getDailyPhaseHint(at(16, 0)).color).toBe('success');
+    expect(getDailyPhaseHint(at(18, 0)).color).toBe('success');
+  });
+
+  it('推奨アクションが適切に設定されている', () => {
+    // 07:00 → after_hours_review → record-review → null
+    expect(getDailyPhaseHint(at(7, 0)).suggestedAction).toBeNull();
+    // 08:45 → staff_prep → preparation → 通所管理
+    expect(getDailyPhaseHint(at(8, 45)).suggestedAction).toBe('通所管理');
+    expect(getDailyPhaseHint(at(10, 30)).suggestedAction).toBe('一覧形式ケース記録');
+    expect(getDailyPhaseHint(at(13, 0)).suggestedAction).toBe('一覧形式ケース記録');
+    // 16:00 → record_wrapup → record-review → null
+    expect(getDailyPhaseHint(at(16, 0)).suggestedAction).toBeNull();
+    expect(getDailyPhaseHint(at(18, 0)).suggestedAction).toBeNull();
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// UIコンポーネントテスト: DailyPhaseHintBanner
+// ────────────────────────────────────────────────────────────
+
+describe('DailyPhaseHintBanner', () => {
+  afterEach(cleanup);
+
+  it('バナーが表示される', () => {
+    render(<DailyPhaseHintBanner now={at(10, 0)} />);
+    expect(screen.getByTestId('daily-phase-hint-banner')).toBeInTheDocument();
+  });
+
+  it('フェーズラベルとメッセージが表示される', () => {
+    render(<DailyPhaseHintBanner now={at(10, 0)} />);
+    expect(screen.getByText(/AM活動/)).toBeInTheDocument();
+    expect(screen.getByText(/午前活動の時間です/)).toBeInTheDocument();
+  });
+
+  it('閉じるボタンで非表示になる', () => {
+    render(<DailyPhaseHintBanner now={at(10, 0)} />);
+    const banner = screen.getByTestId('daily-phase-hint-banner');
+    expect(banner).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('daily-phase-hint-dismiss'));
+    expect(screen.queryByTestId('daily-phase-hint-banner')).not.toBeInTheDocument();
+  });
+
+  it('朝会フェーズでは warning 系の表示になる', () => {
+    // 09:05 → morning_briefing → morning-meeting → warning
+    render(<DailyPhaseHintBanner now={at(9, 5)} />);
+    expect(screen.getByText(/朝会の時間です/)).toBeInTheDocument();
+  });
+
+  it('振り返りフェーズでは success 系の表示になる', () => {
+    render(<DailyPhaseHintBanner now={at(18, 0)} />);
+    expect(screen.getByText(/振り返りの時間です/)).toBeInTheDocument();
+  });
+
+  it('閉じるボタンに適切な aria-label がある', () => {
+    render(<DailyPhaseHintBanner now={at(10, 0)} />);
+    expect(screen.getByLabelText('ヒントを閉じる')).toBeInTheDocument();
+  });
+});

--- a/tests/unit/features/today/TodayPhaseIndicator.spec.tsx
+++ b/tests/unit/features/today/TodayPhaseIndicator.spec.tsx
@@ -1,0 +1,189 @@
+/**
+ * TodayPhaseIndicator — unit tests
+ *
+ * getTodayPhaseHint: 純粋関数テスト（全6フェーズ + 境界値）
+ * TodayPhaseIndicator: コンポーネントテスト（表示・dismiss・サジェスト）
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import {
+  getTodayPhaseHint,
+  TodayPhaseIndicator,
+} from '@/features/today/widgets/TodayPhaseIndicator';
+
+// Mock hooks/telemetry that require context unavailable in unit tests
+vi.mock('@/features/operationFlow/hooks/useOperationFlowConfig', () => ({
+  useOperationFlowConfig: () => ({ config: undefined, loading: false }),
+}));
+vi.mock('@/features/operationFlow/telemetry/recordPhaseEvent', () => ({
+  recordPhaseEvent: vi.fn(),
+  PHASE_EVENTS: {
+    SUGGEST_SHOWN: 'phase_suggest_shown',
+    SUGGEST_DISMISSED: 'phase_suggest_dismissed',
+    SUGGEST_ACCEPTED: 'phase_suggest_accepted',
+  },
+}));
+
+// ── helpers ──
+function at(h: number, m: number): Date {
+  return new Date(2026, 2, 13, h, m, 0); // 2026-03-13
+}
+
+// ────────────────────────────────────────
+// 純粋関数テスト: getTodayPhaseHint
+// ────────────────────────────────────────
+describe('getTodayPhaseHint', () => {
+  // 9分割 DEFAULT_PHASE_CONFIG ベース:
+  // after_hours_review 18:00-08:30, staff_prep 08:30-09:00,
+  // morning_briefing 09:00-09:15, arrival_intake 09:15-10:30,
+  // am_activity 10:30-12:00, pm_activity 12:00-15:30,
+  // departure_support 15:30-16:00, record_wrapup 16:00-17:00,
+  // evening_briefing 17:00-18:00
+
+  it('06:00 → record-review (深夜→after_hours_review)', () => {
+    const hint = getTodayPhaseHint(at(6, 0));
+    expect(hint.phase).toBe('record-review');
+    expect(hint.isTodayPrimary).toBe(false);
+    expect(hint.primaryScreen).toBe('/dashboard');
+  });
+
+  it('08:30 → preparation (staff_prep)', () => {
+    const hint = getTodayPhaseHint(at(8, 30));
+    expect(hint.phase).toBe('preparation');
+    expect(hint.isTodayPrimary).toBe(true);
+    expect(hint.primaryScreen).toBe('/today');
+  });
+
+  it('09:05 → morning-meeting (morning_briefing)', () => {
+    const hint = getTodayPhaseHint(at(9, 5));
+    expect(hint.phase).toBe('morning-meeting');
+    expect(hint.isTodayPrimary).toBe(false);
+    expect(hint.primaryScreen).toBe('/handoff-timeline');
+  });
+
+  it('09:15 → am-operation (主役は /daily)', () => {
+    const hint = getTodayPhaseHint(at(9, 15));
+    expect(hint.phase).toBe('am-operation');
+    expect(hint.isTodayPrimary).toBe(false);
+    expect(hint.primaryScreen).toBe('/daily');
+  });
+
+  it('10:30 → am-operation (主役は /today)', () => {
+    const hint = getTodayPhaseHint(at(10, 30));
+    expect(hint.phase).toBe('am-operation');
+    expect(hint.isTodayPrimary).toBe(true);
+    expect(hint.primaryScreen).toBe('/today');
+  });
+
+  it('12:00 → pm-operation (主役は /daily)', () => {
+    const hint = getTodayPhaseHint(at(12, 0));
+    expect(hint.phase).toBe('pm-operation');
+    expect(hint.isTodayPrimary).toBe(false);
+    expect(hint.primaryScreen).toBe('/daily');
+  });
+
+  it('15:30 → evening-closing (主役は /daily)', () => {
+    const hint = getTodayPhaseHint(at(15, 30));
+    expect(hint.phase).toBe('evening-closing');
+    expect(hint.isTodayPrimary).toBe(false);
+    expect(hint.primaryScreen).toBe('/daily');
+  });
+
+  it('17:00 → record-review (主役は /handoff-timeline)', () => {
+    const hint = getTodayPhaseHint(at(17, 0));
+    expect(hint.phase).toBe('record-review');
+    expect(hint.isTodayPrimary).toBe(false);
+    expect(hint.primaryScreen).toBe('/handoff-timeline');
+  });
+
+  it('03:00 → record-review (深夜)', () => {
+    const hint = getTodayPhaseHint(at(3, 0));
+    expect(hint.phase).toBe('record-review');
+    expect(hint.primaryScreen).toBe('/dashboard');
+  });
+
+  it('すべてのフェーズで label と message が定義されている', () => {
+    const times = [
+      at(7, 0), at(8, 45), at(10, 30), at(14, 0), at(16, 0), at(18, 0),
+    ];
+    for (const t of times) {
+      const hint = getTodayPhaseHint(t);
+      expect(hint.label.length).toBeGreaterThan(0);
+      expect(hint.message.length).toBeGreaterThan(0);
+      expect(hint.primaryScreenLabel.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('主役画面が /today のフェーズは staff_prep と am_activity のみ', () => {
+    // staff_prep 08:30-09:00, am_activity 10:30-12:00 → /today
+    const todayPrimaryPhases = [at(8, 45), at(10, 30)];
+    const notTodayPhases = [at(7, 0), at(9, 5), at(9, 20), at(13, 0), at(16, 0), at(18, 0)];
+
+    todayPrimaryPhases.forEach(t => {
+      expect(getTodayPhaseHint(t).isTodayPrimary).toBe(true);
+    });
+    notTodayPhases.forEach(t => {
+      expect(getTodayPhaseHint(t).isTodayPrimary).toBe(false);
+    });
+  });
+});
+
+// ────────────────────────────────────────
+// コンポーネントテスト: TodayPhaseIndicator
+// ────────────────────────────────────────
+describe('TodayPhaseIndicator', () => {
+  it('バナーが表示される', () => {
+    // 10:30 → am_activity → am-operation
+    render(<TodayPhaseIndicator now={at(10, 30)} />);
+    expect(screen.getByTestId('today-phase-indicator')).toBeInTheDocument();
+  });
+
+  it('フェーズラベルとメッセージが表示される', () => {
+    // 10:30 → am_activity → am-operation
+    render(<TodayPhaseIndicator now={at(10, 30)} />);
+    expect(screen.getByText('AM活動')).toBeInTheDocument();
+    expect(screen.getByText(/未記録があれば/)).toBeInTheDocument();
+  });
+
+  it('閉じるボタンで非表示になる', () => {
+    render(<TodayPhaseIndicator now={at(10, 30)} />);
+    const closeBtn = screen.getByLabelText('フェーズ表示を閉じる');
+    fireEvent.click(closeBtn);
+    expect(screen.queryByTestId('today-phase-indicator')).not.toBeInTheDocument();
+  });
+
+  it('/today が主役のフェーズではサジェストが表示されない', () => {
+    const handleNavigate = vi.fn();
+    // 08:45 → staff_prep → preparation → /today が主役
+    render(<TodayPhaseIndicator now={at(8, 45)} onNavigate={handleNavigate} />);
+    expect(screen.queryByText(/メインの時間帯です/)).not.toBeInTheDocument();
+  });
+
+  it('/today が主役でないフェーズではサジェストが表示される', () => {
+    const handleNavigate = vi.fn();
+    // 09:05 → morning_briefing → morning-meeting → /handoff-timeline が主役
+    render(<TodayPhaseIndicator now={at(9, 5)} onNavigate={handleNavigate} />);
+    const suggestBtn = screen.getByText(/今は「申し送り」がメインの時間帯です/);
+    expect(suggestBtn).toBeInTheDocument();
+  });
+
+  it('onNavigate なしではサジェストボタンが表示されない', () => {
+    // 09:05 → morning_briefing (not today primary) but no onNavigate
+    render(<TodayPhaseIndicator now={at(9, 5)} />);
+    expect(screen.queryByText(/メインの時間帯です/)).not.toBeInTheDocument();
+  });
+
+  it('サジェストボタンクリックで onNavigate が呼ばれる', () => {
+    const handleNavigate = vi.fn();
+    // 12:30 → pm_activity → pm-operation → /daily が主役
+    render(<TodayPhaseIndicator now={at(12, 30)} onNavigate={handleNavigate} />);
+    const btn = screen.getByText(/今は「日々の記録」がメインの時間帯です/);
+    fireEvent.click(btn);
+    expect(handleNavigate).toHaveBeenCalledWith('/daily');
+  });
+
+  it('閉じるボタンに適切な aria-label がある', () => {
+    render(<TodayPhaseIndicator now={at(10, 30)} />);
+    expect(screen.getByLabelText('フェーズ表示を閉じる')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
Branch 4: /today と /daily ページにフェーズ表示を統合

## 変更内容
### コンポーネント
- **TodayPhaseIndicator**: 現在フェーズの表示 + 主役画面サジェスト
- **DailyPhaseHintBanner**: /daily ページ向けフェーズヒント

### ロジック
- **useCurrentPhase**: OperationalPhase を返すよう拡張（phaseConfigBridge経由）
- **recordFirstNavigation**: フェーズベースナビゲーションのテレメトリ

### テスト
- TodayPhaseIndicator.spec.tsx (19テスト)
- DailyPhaseHintBanner.spec.tsx (25テスト)
- settingsToUiIntegration.spec.ts (26テスト)
- **全70テスト合格** (904ms)

### ドキュメント
- **phase-mapping-reference.md**: 9分割→6分割マッピングSSOT
  - 境界ルール: startTime <= now < endTime
- operational-phase-telemetry-guide.md
- phase-aware-landing-spec.md

## テスト期待値の9分割統一
旧6分割の直接判定前提だったテスト期待値を、
9分割 DEFAULT_PHASE_CONFIG を経由して6分割導線へ写像する現行実装に合わせて更新。

## 依存
- feat/operation-flow-domain (Branch 2)