### PR TITLE
feat(severe-addon): Phase C — 週次観察・配置資格データ接続

### DIFF
--- a/src/domain/regulatory/assignmentQualificationChecker.ts
+++ b/src/domain/regulatory/assignmentQualificationChecker.ts
@@ -1,0 +1,87 @@
+/**
+ * 配置資格チェック — 純粋ドメイン関数
+ *
+ * 加算対象者に配置されている職員が、必要な資格（基礎研修以上）を
+ * 保持しているかを判定する。
+ *
+ * 判定ロジック:
+ *   - 対象利用者にアクティブ配置されている職員のうち、
+ *     主担当（primary）が基礎研修未修了であれば「資格なし配置」と判定
+ *   - 配置がない利用者はチェックしない（未配置は別の問題）
+ *
+ * @see qualificationAssignment.ts — QualificationAssignment 型
+ * @see severeAddonFindings.ts — usersWithoutAssignmentQualification フィールド
+ */
+
+// ---------------------------------------------------------------------------
+// 最小インターフェース（OOM対策: 元の型をimportしない）
+// ---------------------------------------------------------------------------
+
+export interface AssignmentMinimal {
+  staffId: string;
+  userId: string;
+  assignedFrom: string;
+  assignedTo?: string;
+  assignmentType: string;
+}
+
+export interface StaffCertMinimal {
+  staffId: string;
+  certifications: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Core Function
+// ---------------------------------------------------------------------------
+
+/**
+ * 配置に必要な資格を持たない職員が配置されている利用者を特定する。
+ *
+ * @param targetUserIds — チェック対象の利用者ID一覧（加算候補者のみ渡せばよい）
+ * @param assignments — 全配置履歴
+ * @param staffCerts — 職員の資格情報（staffId → certifications）
+ * @param today — 基準日 (YYYY-MM-DD)
+ */
+export function findUsersWithUnqualifiedAssignment(
+  targetUserIds: string[],
+  assignments: AssignmentMinimal[],
+  staffCerts: Map<string, string[]>,
+  today: string,
+): string[] {
+  if (targetUserIds.length === 0) return [];
+
+  const result: string[] = [];
+
+  for (const userId of targetUserIds) {
+    // この利用者にアクティブ配置されている primary 職員を取得
+    const activeAssignments = assignments.filter(a =>
+      a.userId === userId &&
+      a.assignmentType === 'primary' &&
+      isActive(a, today),
+    );
+
+    // 配置がなければスキップ（未配置は別問題）
+    if (activeAssignments.length === 0) continue;
+
+    // primary 配置されている職員のうち、基礎研修が未修了の者がいるか
+    const hasUnqualified = activeAssignments.some(a => {
+      const certs = staffCerts.get(a.staffId) ?? [];
+      return !certs.some(c => c.includes('基礎研修') || c.includes('実践研修'));
+    });
+
+    if (hasUnqualified) {
+      result.push(userId);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * 配置がアクティブかを判定する（軽量版）
+ */
+function isActive(assignment: AssignmentMinimal, today: string): boolean {
+  if (assignment.assignedFrom > today) return false;
+  if (!assignment.assignedTo) return true;
+  return assignment.assignedTo >= today;
+}

--- a/src/domain/regulatory/weeklyObservationChecker.ts
+++ b/src/domain/regulatory/weeklyObservationChecker.ts
@@ -1,0 +1,59 @@
+/**
+ * 週次観察充足チェック — 純粋ドメイン関数
+ *
+ * 利用者ごとに直近の一定期間内に週次観察が実施されているかを判定する。
+ * 「週次観察不足」の利用者 ID リストを返す。
+ *
+ * 判定ロジック:
+ *   - 直近 lookbackDays（デフォルト30日）以内に1件以上の観察記録がなければ不足
+ *   - 観察記録の構造上、userId フィールドで利用者を特定
+ *
+ * @see weeklyObservation.ts — WeeklyObservationRecord 型
+ * @see severeAddonFindings.ts — usersWithoutWeeklyObservation フィールド
+ */
+
+// ---------------------------------------------------------------------------
+// 最小インターフェース（OOM対策: 元の型をimportしない）
+// ---------------------------------------------------------------------------
+
+export interface ObservationRecordMinimal {
+  userId: string;
+  observationDate: string;
+}
+
+// ---------------------------------------------------------------------------
+// Core Function
+// ---------------------------------------------------------------------------
+
+/**
+ * 直近の観察が不足している利用者を特定する。
+ *
+ * @param targetUserIds — チェック対象の利用者ID一覧（加算候補者のみ渡せばよい）
+ * @param observations — 全観察記録（listByUser で取得した結果をフラットにまとめたもの）
+ * @param today — 基準日 (YYYY-MM-DD)
+ * @param lookbackDays — 遡り日数（デフォルト30日。週1回要件なので30日あれば十分）
+ */
+export function findUsersWithoutRecentObservation(
+  targetUserIds: string[],
+  observations: ObservationRecordMinimal[],
+  today: string,
+  lookbackDays = 30,
+): string[] {
+  if (targetUserIds.length === 0) return [];
+
+  const todayDate = new Date(today);
+  const cutoffDate = new Date(todayDate);
+  cutoffDate.setDate(cutoffDate.getDate() - lookbackDays);
+  const cutoff = cutoffDate.toISOString().slice(0, 10);
+
+  // 利用者ごとに「cutoff 以降の観察があるか」を判定
+  const usersWithObservation = new Set<string>();
+
+  for (const obs of observations) {
+    if (obs.observationDate >= cutoff && obs.observationDate <= today) {
+      usersWithObservation.add(obs.userId);
+    }
+  }
+
+  return targetUserIds.filter(id => !usersWithObservation.has(id));
+}

--- a/src/features/regulatory/__tests__/assignmentQualificationChecker.spec.ts
+++ b/src/features/regulatory/__tests__/assignmentQualificationChecker.spec.ts
@@ -1,0 +1,146 @@
+/**
+ * assignmentQualificationChecker — 純粋関数の単体テスト
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  findUsersWithUnqualifiedAssignment,
+  type AssignmentMinimal,
+} from '@/domain/regulatory/assignmentQualificationChecker';
+
+const makeAssignment = (
+  overrides: Partial<AssignmentMinimal> = {},
+): AssignmentMinimal => ({
+  staffId: 'STF001',
+  userId: 'U001',
+  assignedFrom: '2025-01-01',
+  assignmentType: 'primary',
+  ...overrides,
+});
+
+const TODAY = '2026-03-14';
+
+describe('findUsersWithUnqualifiedAssignment', () => {
+
+  it('対象者が空の場合、空を返す', () => {
+    const result = findUsersWithUnqualifiedAssignment([], [], new Map(), TODAY);
+    expect(result).toEqual([]);
+  });
+
+  it('基礎研修修了職員が配置されている場合、不足なし', () => {
+    const assignments = [
+      makeAssignment({ staffId: 'STF001', userId: 'U001' }),
+    ];
+    const certs = new Map<string, string[]>([
+      ['STF001', ['基礎研修']],
+    ]);
+    const result = findUsersWithUnqualifiedAssignment(
+      ['U001'],
+      assignments,
+      certs,
+      TODAY,
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('実践研修修了職員も適格とみなす', () => {
+    const assignments = [
+      makeAssignment({ staffId: 'STF001', userId: 'U001' }),
+    ];
+    const certs = new Map<string, string[]>([
+      ['STF001', ['実践研修']],
+    ]);
+    const result = findUsersWithUnqualifiedAssignment(
+      ['U001'],
+      assignments,
+      certs,
+      TODAY,
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('資格なし主担当がいる場合、不足を検出する', () => {
+    const assignments = [
+      makeAssignment({ staffId: 'STF001', userId: 'U001' }),
+    ];
+    const certs = new Map<string, string[]>([
+      ['STF001', ['ヘルパー2級']],
+    ]);
+    const result = findUsersWithUnqualifiedAssignment(
+      ['U001'],
+      assignments,
+      certs,
+      TODAY,
+    );
+    expect(result).toEqual(['U001']);
+  });
+
+  it('副担当（sub）は資格チェック対象外', () => {
+    const assignments = [
+      makeAssignment({ staffId: 'STF001', userId: 'U001', assignmentType: 'sub' }),
+    ];
+    const certs = new Map<string, string[]>([
+      ['STF001', []],  // 資格なし
+    ]);
+    const result = findUsersWithUnqualifiedAssignment(
+      ['U001'],
+      assignments,
+      certs,
+      TODAY,
+    );
+    // primary 配置がないのでスキップ
+    expect(result).toEqual([]);
+  });
+
+  it('配置終了済みの職員は除外する', () => {
+    const assignments = [
+      makeAssignment({
+        staffId: 'STF001',
+        userId: 'U001',
+        assignedTo: '2025-12-31',  // 終了済み
+      }),
+    ];
+    const certs = new Map<string, string[]>([
+      ['STF001', []],  // 資格なし
+    ]);
+    const result = findUsersWithUnqualifiedAssignment(
+      ['U001'],
+      assignments,
+      certs,
+      TODAY,
+    );
+    // 配置がないのでスキップ
+    expect(result).toEqual([]);
+  });
+
+  it('複数利用者を個別に判定する', () => {
+    const assignments = [
+      makeAssignment({ staffId: 'STF001', userId: 'U001' }),
+      makeAssignment({ staffId: 'STF002', userId: 'U002' }),
+    ];
+    const certs = new Map<string, string[]>([
+      ['STF001', ['基礎研修']],    // OK
+      ['STF002', ['ヘルパー2級']],  // NG
+    ]);
+    const result = findUsersWithUnqualifiedAssignment(
+      ['U001', 'U002'],
+      assignments,
+      certs,
+      TODAY,
+    );
+    expect(result).toEqual(['U002']);
+  });
+
+  it('資格情報がない職員は不足扱い', () => {
+    const assignments = [
+      makeAssignment({ staffId: 'STF001', userId: 'U001' }),
+    ];
+    const certs = new Map<string, string[]>();  // 登録なし
+    const result = findUsersWithUnqualifiedAssignment(
+      ['U001'],
+      assignments,
+      certs,
+      TODAY,
+    );
+    expect(result).toEqual(['U001']);
+  });
+});

--- a/src/features/regulatory/__tests__/weeklyObservationChecker.spec.ts
+++ b/src/features/regulatory/__tests__/weeklyObservationChecker.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * weeklyObservationChecker — 純粋関数の単体テスト
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  findUsersWithoutRecentObservation,
+  type ObservationRecordMinimal,
+} from '@/domain/regulatory/weeklyObservationChecker';
+
+const makeObs = (userId: string, observationDate: string): ObservationRecordMinimal => ({
+  userId,
+  observationDate,
+});
+
+describe('findUsersWithoutRecentObservation', () => {
+
+  const TODAY = '2026-03-14';
+
+  it('対象者が空の場合、空を返す', () => {
+    const result = findUsersWithoutRecentObservation([], [], TODAY);
+    expect(result).toEqual([]);
+  });
+
+  it('直近30日以内に観察がある利用者は不足なし', () => {
+    const observations = [
+      makeObs('U001', '2026-03-10'),
+      makeObs('U002', '2026-03-01'),
+    ];
+    const result = findUsersWithoutRecentObservation(
+      ['U001', 'U002'],
+      observations,
+      TODAY,
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('直近30日以内に観察がない利用者を検出する', () => {
+    const observations = [
+      makeObs('U001', '2026-03-10'),
+      makeObs('U002', '2026-01-01'),  // 30日以上前
+    ];
+    const result = findUsersWithoutRecentObservation(
+      ['U001', 'U002'],
+      observations,
+      TODAY,
+    );
+    expect(result).toEqual(['U002']);
+  });
+
+  it('観察記録が全くない利用者を検出する', () => {
+    const result = findUsersWithoutRecentObservation(
+      ['U001', 'U002'],
+      [],
+      TODAY,
+    );
+    expect(result).toEqual(['U001', 'U002']);
+  });
+
+  it('対象外の利用者の観察は無視する', () => {
+    const observations = [
+      makeObs('U099', '2026-03-10'),  // 対象外
+    ];
+    const result = findUsersWithoutRecentObservation(
+      ['U001'],
+      observations,
+      TODAY,
+    );
+    expect(result).toEqual(['U001']);
+  });
+
+  it('lookbackDays をカスタマイズできる', () => {
+    const observations = [
+      makeObs('U001', '2026-03-07'),  // 7日前 → lookback=5 だと範囲外
+    ];
+    const result = findUsersWithoutRecentObservation(
+      ['U001'],
+      observations,
+      TODAY,
+      5,
+    );
+    expect(result).toEqual(['U001']);
+  });
+
+  it('境界値: ちょうど30日前の観察は不足なし', () => {
+    const observations = [
+      makeObs('U001', '2026-02-12'),  // ちょうど30日前
+    ];
+    const result = findUsersWithoutRecentObservation(
+      ['U001'],
+      observations,
+      TODAY,
+      30,
+    );
+    expect(result).toEqual([]);
+  });
+});

--- a/src/features/regulatory/hooks/useSevereAddonRealData.ts
+++ b/src/features/regulatory/hooks/useSevereAddonRealData.ts
@@ -1,5 +1,5 @@
 /**
- * 重度障害者支援加算 — 実データ収集 hook (Phase A + B)
+ * 重度障害者支援加算 — 実データ収集 hook (Phase A + B + C)
  *
  * ## Phase A の範囲（既存 SP フィールドのみ）
  *
@@ -21,12 +21,20 @@
  *   - UserCode → 利用者紐付け
  *   → lastReassessmentMap（userId → 最終再評価日）を構築
  *
- * 🟡 Phase C（未実装 → 空配列）
- *   - 週次観察: usersWithoutWeeklyObservation → []
- *   - 配置チェック: usersWithoutAssignmentQualification → []
+ * ## Phase C の範囲（週次観察・配置資格チェック）
+ *
+ * ✅ WeeklyObservation (listByUser)
+ *   - observationDate → 利用者ごとの直近観察有無を判定
+ *   → usersWithoutWeeklyObservation
+ *
+ * ✅ QualificationAssignment (getAll)
+ *   - primary 配置の職員資格チェック
+ *   → usersWithoutAssignmentQualification
  *
  * @see severeAddonFindings.ts — SevereAddonBulkInput 型定義
  * @see planningSheetReassessment.ts — 再評価ドメインロジック
+ * @see weeklyObservationChecker.ts — 週次観察判定
+ * @see assignmentQualificationChecker.ts — 配置資格判定
  */
 
 import { useMemo, useEffect, useState, useCallback } from 'react';
@@ -36,10 +44,22 @@ import type { Staff } from '@/types';
 import type { SevereAddonBulkInput, SevereAddonCheckInput } from '@/domain/regulatory/severeAddonFindings';
 import type { PlanningSheetListItem } from '@/domain/isp/schema';
 import type { PlanningSheetRepository } from '@/domain/isp/port';
+import type {
+  WeeklyObservationRepository,
+  QualificationAssignmentRepository,
+} from '@/domain/regulatory/staffQualificationRepository';
 import {
   buildLastReassessmentMap,
   buildPlanningSheetIdsByUser,
 } from '@/domain/regulatory/reassessmentMapBuilder';
+import {
+  findUsersWithoutRecentObservation,
+  type ObservationRecordMinimal,
+} from '@/domain/regulatory/weeklyObservationChecker';
+import {
+  findUsersWithUnqualifiedAssignment,
+  type AssignmentMinimal,
+} from '@/domain/regulatory/assignmentQualificationChecker';
 
 // Re-export for backward compatibility (テストからの直接 import)
 export { buildLastReassessmentMap };
@@ -133,6 +153,8 @@ export interface SevereAddonRealDataResult {
  * @param isLoading - データ読み込み中かどうか
  * @param error - データ取得エラー
  * @param planningSheetRepo - PlanningSheetRepository（Phase B: 再評価日取得用）
+ * @param weeklyObsRepo - WeeklyObservationRepository（Phase C: 週次観察取得用）
+ * @param assignmentRepo - QualificationAssignmentRepository（Phase C: 配置資格取得用）
  */
 export function useSevereAddonRealData(
   users: IUserMaster[],
@@ -140,6 +162,8 @@ export function useSevereAddonRealData(
   isLoading: boolean,
   error: Error | null,
   planningSheetRepo?: PlanningSheetRepository | null,
+  weeklyObsRepo?: WeeklyObservationRepository | null,
+  assignmentRepo?: QualificationAssignmentRepository | null,
 ): SevereAddonRealDataResult {
 
   // ── Phase B: 支援計画シートの再評価日を非同期に取得 ──
@@ -195,9 +219,90 @@ export function useSevereAddonRealData(
     fetchPlanningSheets();
   }, [fetchPlanningSheets]);
 
+  // ── Phase C: 週次観察データを非同期に取得 ──
+  const [allObservations, setAllObservations] = useState<ObservationRecordMinimal[]>([]);
+  const [obsLoading, setObsLoading] = useState(false);
+  const [obsError, setObsError] = useState<Error | null>(null);
+
+  const fetchObservations = useCallback(async () => {
+    if (!weeklyObsRepo || activeUserIds.length === 0) {
+      setAllObservations([]);
+      return;
+    }
+
+    setObsLoading(true);
+    setObsError(null);
+
+    try {
+      const results: ObservationRecordMinimal[] = [];
+
+      const promises = activeUserIds.map(async (userId) => {
+        try {
+          const records = await weeklyObsRepo.listByUser(userId);
+          for (const r of records) {
+            results.push({ userId: r.userId, observationDate: r.observationDate });
+          }
+        } catch (err) {
+          console.warn(`[useSevereAddonRealData] Failed to fetch observations for ${userId}:`, err);
+        }
+      });
+
+      await Promise.all(promises);
+      setAllObservations(results);
+    } catch (err) {
+      const e = err instanceof Error ? err : new Error(String(err));
+      setObsError(e);
+      console.warn('[useSevereAddonRealData] Observation fetch failed:', e.message);
+    } finally {
+      setObsLoading(false);
+    }
+  }, [weeklyObsRepo, activeUserIds]);
+
+  useEffect(() => {
+    fetchObservations();
+  }, [fetchObservations]);
+
+  // ── Phase C: 配置データを非同期に取得 ──
+  const [allAssignments, setAllAssignments] = useState<AssignmentMinimal[]>([]);
+  const [assignLoading, setAssignLoading] = useState(false);
+  const [assignError, setAssignError] = useState<Error | null>(null);
+
+  const fetchAssignments = useCallback(async () => {
+    if (!assignmentRepo || activeUserIds.length === 0) {
+      setAllAssignments([]);
+      return;
+    }
+
+    setAssignLoading(true);
+    setAssignError(null);
+
+    try {
+      const records = await assignmentRepo.getAll();
+      setAllAssignments(
+        records.map(r => ({
+          staffId: r.staffId,
+          userId: r.userId,
+          assignedFrom: r.assignedFrom,
+          assignedTo: r.assignedTo,
+          assignmentType: r.assignmentType,
+        })),
+      );
+    } catch (err) {
+      const e = err instanceof Error ? err : new Error(String(err));
+      setAssignError(e);
+      console.warn('[useSevereAddonRealData] Assignment fetch failed:', e.message);
+    } finally {
+      setAssignLoading(false);
+    }
+  }, [assignmentRepo, activeUserIds]);
+
+  useEffect(() => {
+    fetchAssignments();
+  }, [fetchAssignments]);
+
   // ── メイン BulkInput 構築 ──
-  const combinedLoading = isLoading || sheetsLoading;
-  const combinedError = error || sheetsError;
+  const combinedLoading = isLoading || sheetsLoading || obsLoading || assignLoading;
+  const combinedError = error || sheetsError || obsError || assignError;
 
   const input = useMemo<SevereAddonBulkInput | null>(() => {
     if (combinedLoading || combinedError) return null;
@@ -219,22 +324,44 @@ export function useSevereAddonRealData(
         return toAddonCheckInput(u, sheetIds);
       });
 
+    // 候補者のユーザーID
+    const candidateUserIds = addonUsers.map(u => u.userId);
+
     // 作成者要件: 実践研修修了者がいなければ全候補者が対象
     const usersWithoutAuthoringQualification: string[] = staffMetrics.hasPracticalTrainedStaff
       ? []
-      : addonUsers.map(u => u.userId);
+      : candidateUserIds;
+
+    // Phase C: 週次観察不足の利用者を判定
+    const usersWithoutWeeklyObservation = weeklyObsRepo
+      ? findUsersWithoutRecentObservation(candidateUserIds, allObservations, today)
+      : [];
+
+    // Phase C: 配置資格不足の利用者を判定
+    // staffCerts: staffId → certifications のマップ
+    const staffCerts = new Map<string, string[]>();
+    for (const s of staff) {
+      const id = s.staffId ?? s.id ?? '';
+      if (id) {
+        staffCerts.set(id, s.certifications ?? []);
+      }
+    }
+
+    const usersWithoutAssignmentQualification = assignmentRepo
+      ? findUsersWithUnqualifiedAssignment(candidateUserIds, allAssignments, staffCerts, today)
+      : [];
 
     return {
       users: addonUsers,
       totalLifeSupportStaff: staffMetrics.totalLifeSupportStaff,
       basicTrainingCompletedCount: staffMetrics.basicTrainingCompletedCount,
-      usersWithoutWeeklyObservation: [],  // Phase C で実装
+      usersWithoutWeeklyObservation,
       lastReassessmentMap,
       usersWithoutAuthoringQualification,
-      usersWithoutAssignmentQualification: [],  // Phase C で実装
+      usersWithoutAssignmentQualification,
       today,
     };
-  }, [users, staff, combinedLoading, combinedError, sheetsByUser]);
+  }, [users, staff, combinedLoading, combinedError, sheetsByUser, allObservations, allAssignments, weeklyObsRepo, assignmentRepo]);
 
   return {
     input,

--- a/src/pages/RegulatoryDashboardPage.tsx
+++ b/src/pages/RegulatoryDashboardPage.tsx
@@ -76,6 +76,10 @@ import { useSevereAddonRealData } from '@/features/regulatory/hooks/useSevereAdd
 import { useUsers } from '@/features/users/useUsers';
 import { useStaff } from '@/stores/useStaff';
 import { usePlanningSheetRepositories } from '@/features/planning-sheet/hooks/usePlanningSheetRepositories';
+import {
+  localWeeklyObservationRepository,
+  localQualificationAssignmentRepository,
+} from '@/infra/localStorage/localStaffQualificationRepository';
 
 // ─────────────────────────────────────────────
 // デモデータ
@@ -719,6 +723,8 @@ const RegulatoryDashboardPage: React.FC = () => {
     usersStatus === 'loading' || staffLoading,
     usersError ? (usersError instanceof Error ? usersError : new Error(String(usersError))) : staffError,
     planningSheetRepo,
+    localWeeklyObservationRepository,
+    localQualificationAssignmentRepository,
   );
   const addonFindings = useMemo(() => {
     if (realAddonInput) {


### PR DESCRIPTION
## Phase C: Connect Observations & Assignment Qualifications

### ドメイン層（純粋関数）

| ファイル | 関数 | 責務 |
|---------|------|------|
| `weeklyObservationChecker.ts` | `findUsersWithoutRecentObservation()` | 直近30日以内に週次観察がない利用者を検出 |
| `assignmentQualificationChecker.ts` | `findUsersWithUnqualifiedAssignment()` | primary配置の職員が基礎研修/実践研修未修了なら不足判定 |

### Hook拡張

- `useSevereAddonRealData` に追加引数:
  - `weeklyObsRepo?: WeeklyObservationRepository`
  - `assignmentRepo?: QualificationAssignmentRepository`
- **後方互換**: 両リポジトリは optional (null可)。未提供時は空配列

### ページ接続

- `RegulatoryDashboardPage` に localStorage ベース repos を接続

### テスト

- 21 tests passed (744ms)
- TypeScript 0 errors
- lint 通過

### Phase A → B → C の完成度

| Phase | 範囲 | 状態 |
|-------|------|------|
| A | 候補者判定・基礎研修比率・作成者要件 | ✅ |
| B | 3か月再評価（PlanningSheet reviewedAt） | ✅ |
| **C** | **週次観察・配置資格チェック** | **✅ 本PR** |

これで加算判定のデータ接続は全フェーズ完了です。