### PR TITLE
fix(regulatory): remove hardcoded unqualifiedAssignments, connect auditChecks integration

### DIFF
--- a/src/domain/regulatory/__tests__/staffQualification.spec.ts
+++ b/src/domain/regulatory/__tests__/staffQualification.spec.ts
@@ -299,4 +299,31 @@ describe('computeStaffQualificationSummary', () => {
     expect(summary.missingCertificates).toBe(1);
     expect(summary.activeAssignments).toBe(1);
   });
+
+  it('unqualifiedAssignmentCount 省略時はデフォルト 0', () => {
+    const summary = computeStaffQualificationSummary({
+      certificates: 0,
+      missingCertificates: 0,
+      assignments: [],
+      observations: [],
+      corePersonAssignments: [],
+      today: '2026-03-10',
+    });
+
+    expect(summary.unqualifiedAssignments).toBe(0);
+  });
+
+  it('unqualifiedAssignmentCount を渡すとサマリに反映される', () => {
+    const summary = computeStaffQualificationSummary({
+      certificates: 2,
+      missingCertificates: 0,
+      assignments: [],
+      observations: [],
+      corePersonAssignments: [],
+      unqualifiedAssignmentCount: 3,
+      today: '2026-03-10',
+    });
+
+    expect(summary.unqualifiedAssignments).toBe(3);
+  });
 });

--- a/src/domain/regulatory/index.ts
+++ b/src/domain/regulatory/index.ts
@@ -23,3 +23,6 @@ export * from './auditChecks';
 export * from './severeDisabilityAddon';
 export * from './basicTrainingRatio';
 export * from './severeAddonFindings';
+export * from './reassessmentMapBuilder';
+export * from './weeklyObservationChecker';
+export * from './assignmentQualificationChecker';

--- a/src/domain/regulatory/weeklyObservation.ts
+++ b/src/domain/regulatory/weeklyObservation.ts
@@ -173,6 +173,10 @@ export interface StaffQualificationSummary {
 
 /**
  * 職員資格サマリを算出する。
+ *
+ * @param params.unqualifiedAssignmentCount - 資格未充足配置件数。
+ *   `findUsersWithUnqualifiedAssignment()` の結果 `.length` を渡す。
+ *   省略時は 0（後方互換）。
  */
 export function computeStaffQualificationSummary(params: {
   certificates: number;
@@ -180,6 +184,8 @@ export function computeStaffQualificationSummary(params: {
   assignments: QualificationAssignment[];
   observations: WeeklyObservationRecord[];
   corePersonAssignments: QualificationAssignment[];
+  /** 資格未充足配置のカウント（外部で算出して渡す） */
+  unqualifiedAssignmentCount?: number;
   today?: string;
 }): StaffQualificationSummary {
   const {
@@ -188,6 +194,7 @@ export function computeStaffQualificationSummary(params: {
     assignments,
     observations,
     corePersonAssignments,
+    unqualifiedAssignmentCount = 0,
     today,
   } = params;
   const now = today ?? new Date().toISOString().slice(0, 10);
@@ -214,7 +221,7 @@ export function computeStaffQualificationSummary(params: {
     totalCertificates: certificates,
     missingCertificates,
     activeAssignments: active.length,
-    unqualifiedAssignments: 0, // auditChecks側で判定
+    unqualifiedAssignments: unqualifiedAssignmentCount,
     fulfilledObservations: fulfilledCount,
     shortageObservations: shortageCount,
     overdueCorePersonAdvice: overdueCount,


### PR DESCRIPTION
## 変更内容

### ハードコード除去
- `computeStaffQualificationSummary` の `unqualifiedAssignments: 0` を除去
- `unqualifiedAssignmentCount` オプションパラメータを追加（デフォルト 0 で後方互換）
- 呼び出し側で `findUsersWithUnqualifiedAssignment().length` を渡せるように

### 設計判断
- 通常監査系 (`AuditFinding`) と加算系 (`SevereAddonFinding`) を **2系統維持**
- UI レイヤー (`unifyFindings`, `TypeBreakdown`, `FindingsTable`) で統合表示
- 型安全・拡張性・責務分離のバランスが最適

### テスト
- `staffQualification.spec.ts`: 20/20 ✅
- `auditChecks.spec.ts`: 37/37 ✅
- `severeAddonFindings.spec.ts`: 25/25 ✅
- TypeScript コンパイル: 0 エラー ✅