### PR TITLE
feat: MonitoringTab に日次記録分析ダッシュボードを追加

### DIFF
--- a/src/features/monitoring/components/MonitoringDailyDashboard.tsx
+++ b/src/features/monitoring/components/MonitoringDailyDashboard.tsx
@@ -1,0 +1,311 @@
+/**
+ * @fileoverview モニタリング集計ダッシュボード
+ * @description
+ * DailyMonitoringSummary を受け取り、
+ * - 記録状況サマリー
+ * - 活動頻度
+ * - 問題行動推移
+ * - 昼食傾向
+ * - 所見ドラフト
+ * を5ブロックで表示する。
+ *
+ * 既存の引用セクション（MonitoringEvidenceSection）の**前段**に配置する。
+ */
+import AssessmentIcon from '@mui/icons-material/Assessment';
+import ContentCopyRoundedIcon from '@mui/icons-material/ContentCopyRounded';
+import RestaurantIcon from '@mui/icons-material/Restaurant';
+import TrendingDownIcon from '@mui/icons-material/TrendingDown';
+import TrendingFlatIcon from '@mui/icons-material/TrendingFlat';
+import TrendingUpIcon from '@mui/icons-material/TrendingUp';
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import Divider from '@mui/material/Divider';
+import LinearProgress from '@mui/material/LinearProgress';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import React from 'react';
+
+import type {
+  ActivityRank,
+  DailyMonitoringSummary,
+} from '../domain/monitoringDailyAnalytics';
+
+// ─── 定数 ────────────────────────────────────────────────
+
+const LUNCH_LABELS: Record<string, string> = {
+  full: '完食',
+  '80': '8割',
+  half: '半分',
+  small: '少量',
+  none: 'なし',
+};
+
+const LUNCH_COLORS: Record<string, 'success' | 'warning' | 'error' | 'default' | 'info'> = {
+  full: 'success',
+  '80': 'success',
+  half: 'warning',
+  small: 'error',
+  none: 'error',
+};
+
+const TREND_ICON: Record<string, React.ReactNode> = {
+  up: <TrendingUpIcon fontSize="small" color="error" />,
+  down: <TrendingDownIcon fontSize="small" color="success" />,
+  flat: <TrendingFlatIcon fontSize="small" color="action" />,
+};
+
+const TREND_LABEL: Record<string, string> = {
+  up: '増加傾向',
+  down: '減少傾向',
+  flat: '横ばい',
+};
+
+// ─── サブコンポーネント ──────────────────────────────────
+
+const SectionTitle: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <Typography variant="subtitle2" color="text.secondary" sx={{ fontWeight: 600, mb: 0.5 }}>
+    {children}
+  </Typography>
+);
+
+const ActivityList: React.FC<{ label: string; items: ActivityRank[] }> = ({ label, items }) => {
+  if (items.length === 0) return null;
+  return (
+    <Box>
+      <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600 }}>
+        {label}
+      </Typography>
+      <Stack direction="row" spacing={0.5} flexWrap="wrap" sx={{ mt: 0.5 }}>
+        {items.map((a) => (
+          <Chip
+            key={a.label}
+            label={`${a.label} (${a.count}回)`}
+            size="small"
+            variant="outlined"
+          />
+        ))}
+      </Stack>
+    </Box>
+  );
+};
+
+// ─── メインコンポーネント ────────────────────────────────
+
+export interface MonitoringDailyDashboardProps {
+  summary: DailyMonitoringSummary | null;
+  insightLines: string[];
+  recordCount: number;
+  onAppendInsight: (text: string) => void;
+  isAdmin: boolean;
+}
+
+const MonitoringDailyDashboard: React.FC<MonitoringDailyDashboardProps> = ({
+  summary,
+  insightLines,
+  recordCount: _recordCount,
+  onAppendInsight,
+  isAdmin,
+}) => {
+  if (!summary) {
+    return (
+      <Box sx={{ mt: 1, mb: 2 }}>
+        <Paper variant="outlined" sx={{ p: 2, bgcolor: 'action.hover', borderStyle: 'dashed', textAlign: 'center' }}>
+          <Typography variant="body2" color="text.secondary">
+            日次記録がありません。一覧入力テーブルにデータを入力すると、モニタリング集計が表示されます。
+          </Typography>
+        </Paper>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ mt: 1, mb: 2 }}>
+      <Paper variant="outlined" sx={{ p: 2, bgcolor: 'action.hover', borderStyle: 'dashed' }}>
+        <Stack spacing={2}>
+          {/* ヘッダー */}
+          <Stack direction="row" justifyContent="space-between" alignItems="center">
+            <Stack direction="row" spacing={1} alignItems="center">
+              <AssessmentIcon fontSize="small" color="primary" />
+              <Typography variant="subtitle2" component="span" color="primary">
+                モニタリング集計 ({summary.period.from} 〜 {summary.period.to})
+              </Typography>
+            </Stack>
+            <Button
+              size="small"
+              variant="contained"
+              color="primary"
+              startIcon={<ContentCopyRoundedIcon />}
+              onClick={() => onAppendInsight(insightLines.join('\n'))}
+              disabled={!isAdmin || insightLines.length === 0}
+              data-testid="monitoring-insight-append"
+            >
+              所見を引用
+            </Button>
+          </Stack>
+
+          {/* 1. 記録状況 */}
+          <Box>
+            <SectionTitle>📊 記録状況</SectionTitle>
+            <Stack direction="row" spacing={2} alignItems="center">
+              <Typography variant="body2">
+                {summary.period.recordedDays}日 / {summary.period.totalDays}日中
+              </Typography>
+              <Box sx={{ flexGrow: 1, maxWidth: 200 }}>
+                <LinearProgress
+                  variant="determinate"
+                  value={summary.period.recordRate}
+                  sx={{ height: 8, borderRadius: 4 }}
+                />
+              </Box>
+              <Typography variant="caption" color="text.secondary">
+                記録率 {summary.period.recordRate}%
+              </Typography>
+            </Stack>
+          </Box>
+
+          <Divider />
+
+          {/* 2. 活動頻度 */}
+          <Box>
+            <SectionTitle>🏃 活動頻度</SectionTitle>
+            <Stack spacing={1}>
+              <ActivityList label="午前" items={summary.activity.topAm} />
+              <ActivityList label="午後" items={summary.activity.topPm} />
+              {summary.activity.topAm.length === 0 && summary.activity.topPm.length === 0 && (
+                <Typography variant="caption" color="text.secondary">
+                  活動記録なし
+                </Typography>
+              )}
+            </Stack>
+          </Box>
+
+          <Divider />
+
+          {/* 3. 問題行動 */}
+          <Box>
+            <SectionTitle>
+              <Stack direction="row" spacing={0.5} alignItems="center" component="span">
+                <WarningAmberIcon fontSize="inherit" />
+                <span>問題行動</span>
+              </Stack>
+            </SectionTitle>
+            {summary.behavior.totalDays === 0 ? (
+              <Typography variant="body2" color="success.main">
+                期間中の問題行動記録なし ✓
+              </Typography>
+            ) : (
+              <Stack spacing={1}>
+                <Stack direction="row" spacing={1} alignItems="center">
+                  <Typography variant="body2">
+                    発生 {summary.behavior.totalDays}日（発生率 {summary.behavior.rate}%）
+                  </Typography>
+                  <Stack direction="row" spacing={0.5} alignItems="center">
+                    {TREND_ICON[summary.behavior.recentChange]}
+                    <Typography variant="caption" color="text.secondary">
+                      {TREND_LABEL[summary.behavior.recentChange]}
+                      {summary.behavior.changeRate !== 0 &&
+                        ` (${summary.behavior.changeRate > 0 ? '+' : ''}${summary.behavior.changeRate}%)`}
+                    </Typography>
+                  </Stack>
+                </Stack>
+                <Stack direction="row" spacing={0.5} flexWrap="wrap">
+                  {summary.behavior.byType.map((b) => (
+                    <Chip
+                      key={b.type}
+                      label={`${b.label} ${b.count}件`}
+                      size="small"
+                      color="warning"
+                      variant="outlined"
+                    />
+                  ))}
+                </Stack>
+              </Stack>
+            )}
+          </Box>
+
+          <Divider />
+
+          {/* 4. 昼食傾向 */}
+          <Box>
+            <SectionTitle>
+              <Stack direction="row" spacing={0.5} alignItems="center" component="span">
+                <RestaurantIcon fontSize="inherit" />
+                <span>昼食傾向</span>
+              </Stack>
+            </SectionTitle>
+            {summary.lunch.totalWithData === 0 ? (
+              <Typography variant="caption" color="text.secondary">
+                昼食記録なし
+              </Typography>
+            ) : (
+              <Stack spacing={1}>
+                <Stack direction="row" spacing={0.5} flexWrap="wrap">
+                  {Object.entries(summary.lunch.ratios)
+                    .filter(([, r]) => (r ?? 0) > 0)
+                    .sort((a, b) => (b[1] ?? 0) - (a[1] ?? 0))
+                    .map(([key, r]) => (
+                      <Chip
+                        key={key}
+                        label={`${LUNCH_LABELS[key] ?? key} ${r}%`}
+                        size="small"
+                        color={LUNCH_COLORS[key] ?? 'default'}
+                        variant="outlined"
+                      />
+                    ))}
+                </Stack>
+                <Stack direction="row" spacing={1} alignItems="center">
+                  <Typography variant="caption" color="text.secondary">
+                    安定度
+                  </Typography>
+                  <Box sx={{ flexGrow: 1, maxWidth: 120 }}>
+                    <LinearProgress
+                      variant="determinate"
+                      value={summary.lunch.stableScore}
+                      color={summary.lunch.stableScore >= 70 ? 'success' : summary.lunch.stableScore >= 40 ? 'warning' : 'error'}
+                      sx={{ height: 6, borderRadius: 3 }}
+                    />
+                  </Box>
+                  <Typography variant="caption" color="text.secondary">
+                    {summary.lunch.stableScore}%
+                  </Typography>
+                </Stack>
+              </Stack>
+            )}
+          </Box>
+
+          {/* 5. 所見ドラフト */}
+          {insightLines.length > 0 && (
+            <>
+              <Divider />
+              <Box>
+                <SectionTitle>📝 所見ドラフト（自動生成）</SectionTitle>
+                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
+                  ※ 下記は日次記録データから自動生成された下書きです。内容を確認・修正のうえご活用ください。
+                </Typography>
+                <Box
+                  sx={{
+                    bgcolor: 'background.paper',
+                    borderRadius: 1,
+                    p: 1.5,
+                    border: '1px solid',
+                    borderColor: 'divider',
+                    whiteSpace: 'pre-wrap',
+                    fontSize: '0.8rem',
+                    lineHeight: 1.6,
+                  }}
+                >
+                  {insightLines.join('\n')}
+                </Box>
+              </Box>
+            </>
+          )}
+        </Stack>
+      </Paper>
+    </Box>
+  );
+};
+
+export default React.memo(MonitoringDailyDashboard);

--- a/src/features/monitoring/domain/monitoringDailyAnalytics.spec.ts
+++ b/src/features/monitoring/domain/monitoringDailyAnalytics.spec.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect } from 'vitest';
+import {
+  aggregateActivities,
+  aggregateLunch,
+  aggregateBehaviors,
+  buildMonitoringDailySummary,
+  buildMonitoringInsightText,
+} from './monitoringDailyAnalytics';
+import type { DailyTableRecord } from '@/features/daily/infra/dailyTableRepository';
+
+// ─── テストデータファクトリ ──────────────────────────────
+
+const mkRecord = (
+  overrides: Partial<DailyTableRecord> & { recordDate: string },
+): DailyTableRecord => ({
+  userId: 'u1',
+  activities: {},
+  submittedAt: '2024-01-01T00:00:00Z',
+  ...overrides,
+});
+
+// ─── aggregateActivities ─────────────────────────────────
+
+describe('aggregateActivities', () => {
+  it('空配列 → 空結果', () => {
+    const result = aggregateActivities([]);
+    expect(result.amCounts).toEqual({});
+    expect(result.pmCounts).toEqual({});
+    expect(result.topAm).toEqual([]);
+    expect(result.topPm).toEqual([]);
+  });
+
+  it('単一レコード → AM/PM 各1件', () => {
+    const records = [
+      mkRecord({ recordDate: '2024-01-01', activities: { am: '散歩', pm: '室内作業' } }),
+    ];
+    const result = aggregateActivities(records);
+    expect(result.amCounts).toEqual({ 散歩: 1 });
+    expect(result.pmCounts).toEqual({ 室内作業: 1 });
+    expect(result.topAm).toEqual([{ label: '散歩', count: 1 }]);
+    expect(result.topPm).toEqual([{ label: '室内作業', count: 1 }]);
+  });
+
+  it('Top 活動が降順ソートされる', () => {
+    const records = [
+      mkRecord({ recordDate: '2024-01-01', activities: { am: '散歩' } }),
+      mkRecord({ recordDate: '2024-01-02', activities: { am: '散歩' } }),
+      mkRecord({ recordDate: '2024-01-03', activities: { am: '室内作業' } }),
+      mkRecord({ recordDate: '2024-01-04', activities: { am: '散歩' } }),
+      mkRecord({ recordDate: '2024-01-05', activities: { am: '園芸' } }),
+      mkRecord({ recordDate: '2024-01-06', activities: { am: '園芸' } }),
+    ];
+    const result = aggregateActivities(records);
+    expect(result.topAm[0]).toEqual({ label: '散歩', count: 3 });
+    expect(result.topAm[1]).toEqual({ label: '園芸', count: 2 });
+    expect(result.topAm[2]).toEqual({ label: '室内作業', count: 1 });
+  });
+
+  it('AM 空文字 → カウントしない', () => {
+    const records = [
+      mkRecord({ recordDate: '2024-01-01', activities: { am: '', pm: '作業' } }),
+    ];
+    const result = aggregateActivities(records);
+    expect(result.amCounts).toEqual({});
+    expect(result.pmCounts).toEqual({ 作業: 1 });
+  });
+});
+
+// ─── aggregateLunch ──────────────────────────────────────
+
+describe('aggregateLunch', () => {
+  it('空配列 → 安定度0', () => {
+    const result = aggregateLunch([]);
+    expect(result.totalWithData).toBe(0);
+    expect(result.stableScore).toBe(0);
+  });
+
+  it('lunchIntake 未設定 → カウントしない', () => {
+    const records = [mkRecord({ recordDate: '2024-01-01' })];
+    const result = aggregateLunch(records);
+    expect(result.totalWithData).toBe(0);
+  });
+
+  it('安定度計算: 完食+8割 の割合', () => {
+    const records = [
+      mkRecord({ recordDate: '2024-01-01', lunchIntake: 'full' }),
+      mkRecord({ recordDate: '2024-01-02', lunchIntake: 'full' }),
+      mkRecord({ recordDate: '2024-01-03', lunchIntake: '80' }),
+      mkRecord({ recordDate: '2024-01-04', lunchIntake: 'half' }),
+    ];
+    const result = aggregateLunch(records);
+    // 完食2 + 8割1 = 3 安定 / 4件 = 75%
+    expect(result.stableScore).toBe(75);
+    expect(result.ratios.full).toBe(50);
+    expect(result.ratios['80']).toBe(25);
+    expect(result.ratios.half).toBe(25);
+  });
+
+  it('昼食不安定パターン: 少量+なし中心', () => {
+    const records = [
+      mkRecord({ recordDate: '2024-01-01', lunchIntake: 'small' }),
+      mkRecord({ recordDate: '2024-01-02', lunchIntake: 'none' }),
+      mkRecord({ recordDate: '2024-01-03', lunchIntake: 'small' }),
+      mkRecord({ recordDate: '2024-01-04', lunchIntake: 'full' }),
+    ];
+    const result = aggregateLunch(records);
+    // 安定: full=1 / 4件 = 25%
+    expect(result.stableScore).toBe(25);
+  });
+});
+
+// ─── aggregateBehaviors ──────────────────────────────────
+
+describe('aggregateBehaviors', () => {
+  it('空配列 → 問題行動なし', () => {
+    const result = aggregateBehaviors([]);
+    expect(result.totalDays).toBe(0);
+    expect(result.rate).toBe(0);
+    expect(result.byType).toEqual([]);
+  });
+
+  it('問題行動なしのレコード → totalDays=0', () => {
+    const records = [
+      mkRecord({ recordDate: '2024-01-01', problemBehaviors: [] }),
+      mkRecord({ recordDate: '2024-01-02' }),
+    ];
+    const result = aggregateBehaviors(records);
+    expect(result.totalDays).toBe(0);
+    expect(result.rate).toBe(0);
+  });
+
+  it('種別カウントと降順ソート', () => {
+    const records = [
+      mkRecord({ recordDate: '2024-01-01', problemBehaviors: ['shouting', 'selfHarm'] }),
+      mkRecord({ recordDate: '2024-01-02', problemBehaviors: ['shouting'] }),
+      mkRecord({ recordDate: '2024-01-03', problemBehaviors: ['otherInjury'] }),
+    ];
+    const result = aggregateBehaviors(records);
+    expect(result.totalDays).toBe(3);
+    expect(result.byType[0]).toEqual({ type: 'shouting', label: '大声', count: 2 });
+    expect(result.byType[1].type).toBe('selfHarm');
+    expect(result.byType[2].type).toBe('otherInjury');
+  });
+
+  it('発生率の計算', () => {
+    const records = [
+      mkRecord({ recordDate: '2024-01-01', problemBehaviors: ['shouting'] }),
+      mkRecord({ recordDate: '2024-01-02' }),
+      mkRecord({ recordDate: '2024-01-03' }),
+      mkRecord({ recordDate: '2024-01-04', problemBehaviors: ['selfHarm'] }),
+    ];
+    const result = aggregateBehaviors(records);
+    expect(result.totalDays).toBe(2);
+    expect(result.rate).toBe(50); // 2/4
+  });
+
+  it('recentChange: 後半増加 → up', () => {
+    // 前半1件 (W1) → 後半4件 (W3,W4) で明確に増加
+    const records = [
+      mkRecord({ recordDate: '2024-01-02', problemBehaviors: ['shouting'] }),
+      // 2週目は問題行動なし
+      mkRecord({ recordDate: '2024-01-08' }),
+      // 後半: 集中して発生
+      mkRecord({ recordDate: '2024-01-15', problemBehaviors: ['shouting'] }),
+      mkRecord({ recordDate: '2024-01-16', problemBehaviors: ['shouting'] }),
+      mkRecord({ recordDate: '2024-01-22', problemBehaviors: ['shouting'] }),
+      mkRecord({ recordDate: '2024-01-23', problemBehaviors: ['shouting'] }),
+    ];
+    const result = aggregateBehaviors(records);
+    expect(result.recentChange).toBe('up');
+  });
+});
+
+// ─── buildMonitoringDailySummary ─────────────────────────
+
+describe('buildMonitoringDailySummary', () => {
+  it('空配列 → null', () => {
+    expect(buildMonitoringDailySummary([])).toBeNull();
+  });
+
+  it('単一レコード → 有効なサマリー', () => {
+    const records = [
+      mkRecord({
+        recordDate: '2024-01-15',
+        activities: { am: '散歩', pm: '作業' },
+        lunchIntake: 'full',
+      }),
+    ];
+    const result = buildMonitoringDailySummary(records);
+    expect(result).not.toBeNull();
+    expect(result!.period.from).toBe('2024-01-15');
+    expect(result!.period.to).toBe('2024-01-15');
+    expect(result!.period.recordedDays).toBe(1);
+    expect(result!.period.recordRate).toBe(100);
+    expect(result!.activity.topAm).toHaveLength(1);
+    expect(result!.lunch.stableScore).toBe(100);
+  });
+
+  it('複数日 → 記録率を正しく算出', () => {
+    const records = [
+      mkRecord({ recordDate: '2024-01-01' }),
+      mkRecord({ recordDate: '2024-01-03' }),
+      mkRecord({ recordDate: '2024-01-05' }),
+    ];
+    const result = buildMonitoringDailySummary(records);
+    expect(result).not.toBeNull();
+    // 1/1〜1/5 = 5日間、3日記録 → 60%
+    expect(result!.period.totalDays).toBe(5);
+    expect(result!.period.recordedDays).toBe(3);
+    expect(result!.period.recordRate).toBe(60);
+  });
+});
+
+// ─── buildMonitoringInsightText ──────────────────────────
+
+describe('buildMonitoringInsightText', () => {
+  it('サマリーから所見文を生成できる', () => {
+    const records = [
+      mkRecord({
+        recordDate: '2024-01-01',
+        activities: { am: '散歩', pm: '室内作業' },
+        lunchIntake: 'full',
+        problemBehaviors: ['shouting'],
+      }),
+      mkRecord({
+        recordDate: '2024-01-02',
+        activities: { am: '散歩', pm: '園芸' },
+        lunchIntake: 'full',
+      }),
+      mkRecord({
+        recordDate: '2024-01-03',
+        activities: { am: '体操', pm: '室内作業' },
+        lunchIntake: '80',
+        problemBehaviors: ['shouting', 'selfHarm'],
+      }),
+    ];
+    const summary = buildMonitoringDailySummary(records)!;
+    const lines = buildMonitoringInsightText(summary);
+
+    expect(lines.length).toBeGreaterThanOrEqual(3);
+    expect(lines[0]).toContain('モニタリング期間');
+    expect(lines[0]).toContain('記録率');
+    expect(lines.some((l) => l.includes('散歩'))).toBe(true);
+    expect(lines.some((l) => l.includes('完食'))).toBe(true);
+    expect(lines.some((l) => l.includes('大声'))).toBe(true);
+  });
+
+  it('問題行動なし → 「記録はなかった」', () => {
+    const records = [
+      mkRecord({
+        recordDate: '2024-01-01',
+        activities: { am: '散歩' },
+        lunchIntake: 'full',
+      }),
+    ];
+    const summary = buildMonitoringDailySummary(records)!;
+    const lines = buildMonitoringInsightText(summary);
+    expect(lines.some((l) => l.includes('記録はなかった'))).toBe(true);
+  });
+});

--- a/src/features/monitoring/domain/monitoringDailyAnalytics.ts
+++ b/src/features/monitoring/domain/monitoringDailyAnalytics.ts
@@ -1,0 +1,355 @@
+/**
+ * @fileoverview モニタリング用日次記録集計（pure function）
+ * @description
+ * DailyTableRecord[] を入力に、ISPモニタリングに必要な客観指標を算出する。
+ *
+ * Phase 1 スコープ:
+ * - 期間サマリー（記録日数・記録率）
+ * - 活動頻度（AM/PM 別 Top 活動）
+ * - 昼食傾向（摂取量分布・安定度）
+ * - 問題行動推移（種別件数・週次推移・直近変化）
+ * - 所見ドラフト文の自動生成
+ *
+ * 副作用なし。UI 非依存。テスト容易。
+ */ // contract:allow-interface
+
+import type {
+  DailyTableRecord,
+  LunchIntake,
+  ProblemBehaviorType,
+} from '@/features/daily/infra/dailyTableRepository';
+
+// ─── 型定義 ──────────────────────────────────────────────
+
+export interface PeriodSummary {
+  from: string;
+  to: string;
+  /** 期間内の暦日数 */
+  totalDays: number;
+  /** 記録が存在する日数 */
+  recordedDays: number;
+  /** 記録率 (0–100 整数%) */
+  recordRate: number;
+}
+
+export interface ActivityRank {
+  label: string;
+  count: number;
+}
+
+export interface ActivitySummary {
+  amCounts: Record<string, number>;
+  pmCounts: Record<string, number>;
+  topAm: ActivityRank[];
+  topPm: ActivityRank[];
+}
+
+export interface LunchSummary {
+  counts: Partial<Record<LunchIntake, number>>;
+  ratios: Partial<Record<LunchIntake, number>>;
+  totalWithData: number;
+  /** 安定度スコア（0–100）: 完食+8割の割合 */
+  stableScore: number;
+}
+
+export interface BehaviorWeek {
+  week: string; // 'YYYY-Www' or 'MM/DD〜'
+  count: number;
+}
+
+export interface BehaviorSummary {
+  /** 問題行動が1つ以上記録された日数 */
+  totalDays: number;
+  /** 全記録日に対する問題行動発生率 */
+  rate: number;
+  byType: { type: ProblemBehaviorType; label: string; count: number }[];
+  weeklyTrend: BehaviorWeek[];
+  /** 直近2週間と前2週間の比較 */
+  recentChange: 'up' | 'down' | 'flat';
+  /** 変化率（%、符号付き） */
+  changeRate: number;
+}
+
+export interface DailyMonitoringSummary {
+  period: PeriodSummary;
+  activity: ActivitySummary;
+  lunch: LunchSummary;
+  behavior: BehaviorSummary;
+}
+
+// ─── 定数 ────────────────────────────────────────────────
+
+const MAX_TOP_ACTIVITIES = 5;
+
+const LUNCH_LABELS: Record<LunchIntake, string> = {
+  full: '完食',
+  '80': '8割',
+  half: '半分',
+  small: '少量',
+  none: 'なし',
+};
+
+const BEHAVIOR_LABELS: Record<ProblemBehaviorType, string> = {
+  selfHarm: '自傷',
+  otherInjury: '他傷',
+  shouting: '大声',
+  pica: '異食',
+  other: 'その他',
+};
+
+const STABLE_INTAKES: LunchIntake[] = ['full', '80'];
+
+// ─── ヘルパー ────────────────────────────────────────────
+
+const clean = (s: unknown): string => {
+  const t = String(s ?? '').trim();
+  return t || '';
+};
+
+/** YYYY-MM-DD 間の暦日数（inclusive） */
+function daysBetween(from: string, to: string): number {
+  const a = new Date(from + 'T00:00:00');
+  const b = new Date(to + 'T00:00:00');
+  const diff = b.getTime() - a.getTime();
+  return Math.max(1, Math.floor(diff / 86_400_000) + 1);
+}
+
+/** YYYY-MM-DD → 週番号文字列（月曜起点） */
+function toWeekKey(ymd: string): string {
+  const d = new Date(ymd + 'T00:00:00');
+  const day = d.getDay();
+  // 月曜起点に補正
+  const monday = new Date(d);
+  monday.setDate(d.getDate() - ((day + 6) % 7));
+  const mm = String(monday.getMonth() + 1).padStart(2, '0');
+  const dd = String(monday.getDate()).padStart(2, '0');
+  return `${mm}/${dd}〜`;
+}
+
+function topN(counts: Record<string, number>, n: number): ActivityRank[] {
+  return Object.entries(counts)
+    .filter(([, c]) => c > 0)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, n)
+    .map(([label, count]) => ({ label, count }));
+}
+
+// ─── 集計関数 ────────────────────────────────────────────
+
+export function aggregateActivities(records: DailyTableRecord[]): ActivitySummary {
+  const amCounts: Record<string, number> = {};
+  const pmCounts: Record<string, number> = {};
+
+  for (const r of records) {
+    const am = clean(r.activities?.am);
+    const pm = clean(r.activities?.pm);
+    if (am) amCounts[am] = (amCounts[am] ?? 0) + 1;
+    if (pm) pmCounts[pm] = (pmCounts[pm] ?? 0) + 1;
+  }
+
+  return {
+    amCounts,
+    pmCounts,
+    topAm: topN(amCounts, MAX_TOP_ACTIVITIES),
+    topPm: topN(pmCounts, MAX_TOP_ACTIVITIES),
+  };
+}
+
+export function aggregateLunch(records: DailyTableRecord[]): LunchSummary {
+  const counts: Partial<Record<LunchIntake, number>> = {};
+  let totalWithData = 0;
+
+  for (const r of records) {
+    if (!r.lunchIntake) continue;
+    totalWithData++;
+    counts[r.lunchIntake] = (counts[r.lunchIntake] ?? 0) + 1;
+  }
+
+  const ratios: Partial<Record<LunchIntake, number>> = {};
+  for (const [key, count] of Object.entries(counts)) {
+    ratios[key as LunchIntake] = totalWithData > 0
+      ? Math.round((count / totalWithData) * 100)
+      : 0;
+  }
+
+  const stableCount = STABLE_INTAKES.reduce(
+    (sum, key) => sum + (counts[key] ?? 0),
+    0,
+  );
+  const stableScore = totalWithData > 0
+    ? Math.round((stableCount / totalWithData) * 100)
+    : 0;
+
+  return { counts, ratios, totalWithData, stableScore };
+}
+
+export function aggregateBehaviors(records: DailyTableRecord[]): BehaviorSummary {
+  const typeCounts: Record<string, number> = {};
+  const weekCounts: Record<string, number> = {};
+  let totalDays = 0;
+
+  // 問題行動があるレコードのみ集計
+  const pbRecords: DailyTableRecord[] = [];
+
+  for (const r of records) {
+    const pbs = r.problemBehaviors ?? [];
+    if (pbs.length === 0) continue;
+    totalDays++;
+    pbRecords.push(r);
+
+    for (const pb of pbs) {
+      typeCounts[pb] = (typeCounts[pb] ?? 0) + 1;
+    }
+
+    const wk = toWeekKey(r.recordDate);
+    weekCounts[wk] = (weekCounts[wk] ?? 0) + 1;
+  }
+
+  const byType = Object.entries(typeCounts)
+    .sort((a, b) => b[1] - a[1])
+    .map(([type, count]) => ({
+      type: type as ProblemBehaviorType,
+      label: BEHAVIOR_LABELS[type as ProblemBehaviorType] ?? type,
+      count,
+    }));
+
+  const weeklyTrend = Object.entries(weekCounts)
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([week, count]) => ({ week, count }));
+
+  // 直近変化: 全レコード期間の中間日を基準に前半/後半で比較
+  const { recentChange, changeRate } = computeRecentChange(pbRecords, records);
+
+  const recordedDays = records.length;
+  const rate = recordedDays > 0 ? Math.round((totalDays / recordedDays) * 100) : 0;
+
+  return { totalDays, rate, byType, weeklyTrend, recentChange, changeRate };
+}
+
+/**
+ * 全レコードの日付範囲の中間日を基準に前半/後半の問題行動件数を比較する。
+ */
+function computeRecentChange(
+  pbRecords: DailyTableRecord[],
+  allRecords: DailyTableRecord[],
+): { recentChange: 'up' | 'down' | 'flat'; changeRate: number } {
+  if (pbRecords.length < 2) return { recentChange: 'flat', changeRate: 0 };
+  if (allRecords.length < 2) return { recentChange: 'flat', changeRate: 0 };
+
+  // 全レコード期間の中間日を算出
+  const sortedDates = allRecords.map((r) => r.recordDate).sort();
+  const from = sortedDates[0];
+  const to = sortedDates[sortedDates.length - 1];
+  const fromMs = new Date(from + 'T00:00:00').getTime();
+  const toMs = new Date(to + 'T00:00:00').getTime();
+  const midMs = fromMs + (toMs - fromMs) / 2;
+  const midDate = new Date(midMs).toISOString().slice(0, 10);
+
+  let olderCount = 0;
+  let recentCount = 0;
+  for (const r of pbRecords) {
+    if (r.recordDate <= midDate) {
+      olderCount++;
+    } else {
+      recentCount++;
+    }
+  }
+
+  if (olderCount === 0 && recentCount === 0) return { recentChange: 'flat', changeRate: 0 };
+  if (olderCount === 0) return { recentChange: 'up', changeRate: 100 };
+
+  const changeRate = Math.round(((recentCount - olderCount) / olderCount) * 100);
+
+  if (changeRate > 10) return { recentChange: 'up', changeRate };
+  if (changeRate < -10) return { recentChange: 'down', changeRate };
+  return { recentChange: 'flat', changeRate };
+}
+
+// ─── メイン集計 ──────────────────────────────────────────
+
+export function buildMonitoringDailySummary(
+  records: DailyTableRecord[],
+): DailyMonitoringSummary | null {
+  if (records.length === 0) return null;
+
+  // 期間を recordDate の min/max から算出
+  const dates = records.map((r) => r.recordDate).sort();
+  const from = dates[0];
+  const to = dates[dates.length - 1];
+  const totalDays = daysBetween(from, to);
+  const uniqueDates = new Set(dates);
+  const recordedDays = uniqueDates.size;
+  const recordRate = totalDays > 0 ? Math.round((recordedDays / totalDays) * 100) : 0;
+
+  return {
+    period: { from, to, totalDays, recordedDays, recordRate },
+    activity: aggregateActivities(records),
+    lunch: aggregateLunch(records),
+    behavior: aggregateBehaviors(records),
+  };
+}
+
+// ─── 所見ドラフト文生成 ──────────────────────────────────
+
+/**
+ * 集計サマリーから人が読める所見ドラフト文を生成する。
+ * 示唆であり断定ではない。あくまで下書き。
+ */
+export function buildMonitoringInsightText(
+  summary: DailyMonitoringSummary,
+): string[] {
+  const lines: string[] = [];
+
+  // 期間
+  lines.push(
+    `【モニタリング期間】${summary.period.from} 〜 ${summary.period.to}（${summary.period.recordedDays}日分 / ${summary.period.totalDays}日中 → 記録率 ${summary.period.recordRate}%）`,
+  );
+
+  // 活動
+  const { topAm, topPm } = summary.activity;
+  if (topAm.length > 0 || topPm.length > 0) {
+    const amText = topAm.length > 0
+      ? `午前は${topAm.map((a) => `${a.label}(${a.count}回)`).join('・')}が中心`
+      : '午前活動の記録なし';
+    const pmText = topPm.length > 0
+      ? `午後は${topPm.map((a) => `${a.label}(${a.count}回)`).join('・')}が中心`
+      : '午後活動の記録なし';
+    lines.push(`【活動状況】${amText}、${pmText}。`);
+  }
+
+  // 昼食
+  if (summary.lunch.totalWithData > 0) {
+    const entries = Object.entries(summary.lunch.ratios)
+      .filter(([, r]) => (r ?? 0) > 0)
+      .sort((a, b) => (b[1] ?? 0) - (a[1] ?? 0))
+      .map(([key, r]) => `${LUNCH_LABELS[key as LunchIntake] ?? key} ${r}%`);
+    const stabilityText = summary.lunch.stableScore >= 70
+      ? '摂取状況は概ね安定していた'
+      : summary.lunch.stableScore >= 40
+        ? '摂取量にばらつきがみられた'
+        : '摂取量の不安定さがみられた';
+    lines.push(`【昼食摂取】${entries.join('・')}。${stabilityText}。`);
+  }
+
+  // 問題行動
+  if (summary.behavior.totalDays > 0) {
+    const typeText = summary.behavior.byType
+      .map((b) => `${b.label} ${b.count}件`)
+      .join('・');
+    const trendLabel = summary.behavior.recentChange === 'down'
+      ? '減少傾向がみられた'
+      : summary.behavior.recentChange === 'up'
+        ? '増加傾向がみられた'
+        : '大きな変動はみられなかった';
+    const changeText = summary.behavior.changeRate !== 0
+      ? `（前半比 ${summary.behavior.changeRate > 0 ? '+' : ''}${summary.behavior.changeRate}%）`
+      : '';
+    lines.push(
+      `【問題行動】期間中 ${summary.behavior.totalDays}日で発生（発生率 ${summary.behavior.rate}%）。内訳: ${typeText}。直近では${trendLabel}${changeText}。`,
+    );
+  } else {
+    lines.push('【問題行動】期間中、問題行動の記録はなかった。');
+  }
+
+  return lines;
+}

--- a/src/features/monitoring/hooks/useMonitoringDailyAnalytics.ts
+++ b/src/features/monitoring/hooks/useMonitoringDailyAnalytics.ts
@@ -1,0 +1,61 @@
+/**
+ * @fileoverview モニタリング集計 React Hook
+ * @description
+ * MonitoringTab から呼ばれ、指定ユーザーの日次記録を期間指定で集計する。
+ * pure function (monitoringDailyAnalytics) をラップし、
+ * useMemo で再計算を最小限にする。
+ */
+
+import { useMemo } from 'react';
+
+import { getDailyTableRecords } from '@/features/daily/infra/dailyTableRepository';
+import {
+  buildMonitoringDailySummary,
+  buildMonitoringInsightText,
+  type DailyMonitoringSummary,
+} from '../domain/monitoringDailyAnalytics';
+
+const DEFAULT_LOOKBACK_DAYS = 60;
+
+function computeDateRange(lookbackDays: number): { from: string; to: string } {
+  const to = new Date();
+  const from = new Date();
+  from.setDate(from.getDate() - lookbackDays);
+  return {
+    from: from.toISOString().slice(0, 10),
+    to: to.toISOString().slice(0, 10),
+  };
+}
+
+export interface UseMonitoringDailyAnalyticsResult {
+  summary: DailyMonitoringSummary | null;
+  insightLines: string[];
+  /** 所見全文（改行区切り） */
+  insightText: string;
+  /** 元データの件数 */
+  recordCount: number;
+}
+
+/**
+ * モニタリング集計 Hook
+ * @param userId 対象ユーザーID
+ * @param lookbackDays 遡り日数 (default: 60)
+ */
+export function useMonitoringDailyAnalytics(
+  userId: string,
+  lookbackDays = DEFAULT_LOOKBACK_DAYS,
+): UseMonitoringDailyAnalyticsResult {
+  return useMemo(() => {
+    if (!userId) {
+      return { summary: null, insightLines: [], insightText: '', recordCount: 0 };
+    }
+
+    const range = computeDateRange(lookbackDays);
+    const records = getDailyTableRecords(userId, range);
+    const summary = buildMonitoringDailySummary(records);
+    const insightLines = summary ? buildMonitoringInsightText(summary) : [];
+    const insightText = insightLines.join('\n');
+
+    return { summary, insightLines, insightText, recordCount: records.length };
+  }, [userId, lookbackDays]);
+}

--- a/src/features/support-plan-guide/components/tabs/MonitoringTab.tsx
+++ b/src/features/support-plan-guide/components/tabs/MonitoringTab.tsx
@@ -5,6 +5,7 @@
  * プレゼンテーショナルコンポーネント（状態・副作用なし）。
  *
  * 他のセクションタブと異なり、MonitoringEvidenceSection を条件付きで描画する。
+ * Phase 1: MonitoringDailyDashboard を前段に配置し、客観指標を可視化する。
  */
 import AutoStoriesIcon from '@mui/icons-material/AutoStories';
 import BubbleChartIcon from '@mui/icons-material/BubbleChart';
@@ -25,6 +26,8 @@ import { buildIcebergPdcaUrl } from '@/app/links/navigationLinks';
 import { buildIcebergEvidence } from '@/features/ibd/analysis/pdca/icebergEvidenceAdapter';
 import { useIcebergPdcaList } from '@/features/ibd/analysis/pdca/queries';
 import { buildMonitoringEvidence } from '@/features/ibd/plans/support-plan/monitoringEvidenceAdapter';
+import MonitoringDailyDashboard from '@/features/monitoring/components/MonitoringDailyDashboard';
+import { useMonitoringDailyAnalytics } from '@/features/monitoring/hooks/useMonitoringDailyAnalytics';
 import type { MonitoringEvidenceSectionProps, ToastState } from '../../types';
 import { findSection, minusDaysYmd, todayYmd } from '../../utils/helpers';
 import FieldCard from './FieldCard';
@@ -155,6 +158,25 @@ const IcebergEvidenceSection: React.FC<{
 const MonitoringTab: React.FC<MonitoringTabProps> = ({ userId, setToast, ...sectionProps }) => {
   const navigate = useNavigate();
   const section = findSection('monitoring');
+
+  const userIdStr = userId ? String(userId) : '';
+  const { summary, insightLines, recordCount } = useMonitoringDailyAnalytics(userIdStr);
+
+  /** monitoringPlan フィールドへの追記共通ヘルパー */
+  const appendToMonitoringPlan = React.useCallback(
+    (text: string, duplicateMsg: string, successMsg: string) => {
+      const currentVal = sectionProps.form.monitoringPlan || '';
+      const headerLine = text.split('\n')[0];
+      if (currentVal.includes(headerLine)) {
+        setToast({ open: true, message: duplicateMsg, severity: 'info' });
+        return;
+      }
+      sectionProps.onFieldChange('monitoringPlan', (currentVal ? currentVal + '\n\n' : '') + text);
+      setToast({ open: true, message: successMsg, severity: 'success' });
+    },
+    [sectionProps, setToast],
+  );
+
   if (!section) return null;
 
   return (
@@ -165,37 +187,50 @@ const MonitoringTab: React.FC<MonitoringTabProps> = ({ userId, setToast, ...sect
         </Typography>
       ) : null}
 
+      {/* Phase 1: 集計ダッシュボード（新規） */}
+      {userIdStr && (
+        <MonitoringDailyDashboard
+          summary={summary}
+          insightLines={insightLines}
+          recordCount={recordCount}
+          isAdmin={sectionProps.isAdmin}
+          onAppendInsight={(text) =>
+            appendToMonitoringPlan(
+              text,
+              'この期間の所見は既に引用されています。',
+              '所見ドラフトを引用しました。内容を調整してください。',
+            )
+          }
+        />
+      )}
+
+      {/* 既存: 日次記録エビデンス（生データ引用） */}
       {userId && (
         <MonitoringEvidenceSection
           userId={String(userId)}
           isAdmin={sectionProps.isAdmin}
-          onAppend={(text) => {
-            const currentVal = sectionProps.form.monitoringPlan || '';
-            const headerLine = text.split('\n')[0];
-            if (currentVal.includes(headerLine)) {
-              setToast({ open: true, message: 'この期間のエビデンスは既に引用されています。', severity: 'info' });
-              return;
-            }
-            sectionProps.onFieldChange('monitoringPlan', (currentVal ? currentVal + '\n\n' : '') + text);
-            setToast({ open: true, message: 'エビデンスを引用しました。内容を調整してください。', severity: 'success' });
-          }}
+          onAppend={(text) =>
+            appendToMonitoringPlan(
+              text,
+              'この期間のエビデンスは既に引用されています。',
+              'エビデンスを引用しました。内容を調整してください。',
+            )
+          }
         />
       )}
 
+      {/* 既存: Iceberg PDCA 引用 */}
       {userId && (
         <IcebergEvidenceSection
           userId={String(userId)}
           isAdmin={sectionProps.isAdmin}
-          onAppend={(text) => {
-            const currentVal = sectionProps.form.monitoringPlan || '';
-            const headerLine = text.split('\n')[0];
-            if (currentVal.includes(headerLine)) {
-              setToast({ open: true, message: 'Iceberg分析結果は既に引用されています。', severity: 'info' });
-              return;
-            }
-            sectionProps.onFieldChange('monitoringPlan', (currentVal ? currentVal + '\n\n' : '') + text);
-            setToast({ open: true, message: 'Iceberg分析結果を引用しました。内容を調整してください。', severity: 'success' });
-          }}
+          onAppend={(text) =>
+            appendToMonitoringPlan(
+              text,
+              'Iceberg分析結果は既に引用されています。',
+              'Iceberg分析結果を引用しました。内容を調整してください。',
+            )
+          }
         />
       )}
 


### PR DESCRIPTION
## 概要
MonitoringTab に日次記録テーブル（`/daily/table`）由来の集計ダッシュボードを追加し、
モニタリング所見の客観的根拠を可視化できるようにしました。

## 追加ファイル
| ファイル | 役割 |
|---|---|
| `monitoring/domain/monitoringDailyAnalytics.ts` | 純関数の集計レイヤー（期間/活動/昼食/行動/所見テキスト） |
| `monitoring/domain/monitoringDailyAnalytics.spec.ts` | ユニットテスト 18件 |
| `monitoring/hooks/useMonitoringDailyAnalytics.ts` | React フック（useMemo 最適化） |
| `monitoring/components/MonitoringDailyDashboard.tsx` | 5ブロック構成のダッシュボード UI |

## 変更ファイル
| ファイル | 変更内容 |
|---|---|
| `MonitoringTab.tsx` | ダッシュボードを既存エビデンスセクションの前段に配置、appendToMonitoringPlan 共通化 |

## 表示内容
- 📊 記録率（プログレスバー付き）
- 🏃 活動頻度（午前/午後の上位活動）
- ⚠️ 問題行動の件数・発生率・推移トレンド
- 🍽️ 昼食傾向（摂取割合・安定度スコア）
- 📝 所見ドラフト（自動生成 → 引用ボタンで追記）

## 技術的ポイント
- 集計ロジックは pure function に完全分離（テスタブル・再利用可能）
- UI は hook 経由で useMemo 最適化
- 既存の monitoringPlan 追記導線はそのまま維持
- 既存の MonitoringEvidenceSection / IcebergEvidenceSection の前段に配置

## 検証
- `tsc --noEmit` ✅
- `eslint --max-warnings=0` ✅
- ユニットテスト 18件 pass ✅
- pre-commit / pre-push フック通過 ✅

## 次フェーズ
- Phase 2: behaviorTags を使った行動タグ分析統合
- Phase 3: ISP goal との進捗連携・所見ドラフト高度化