### PR TITLE
feat: モニタリングタブに行動タグ分析ダッシュボードを追加 (Phase 2)

### DIFF
--- a/src/features/daily/infra/dailyTableRepository.ts
+++ b/src/features/daily/infra/dailyTableRepository.ts
@@ -7,6 +7,7 @@ export interface DailyTableRecord {
   activities: { am?: string; pm?: string };
   lunchIntake?: LunchIntake;
   problemBehaviors?: ProblemBehaviorType[]; // 種別配列
+  behaviorTags?: string[];                  // 行動タグキー配列（BehaviorTagKey）
   notes?: string;
   submittedAt: string;         // ISO
   authorName?: string;

--- a/src/features/monitoring/components/MonitoringDailyDashboard.tsx
+++ b/src/features/monitoring/components/MonitoringDailyDashboard.tsx
@@ -13,6 +13,7 @@
  */
 import AssessmentIcon from '@mui/icons-material/Assessment';
 import ContentCopyRoundedIcon from '@mui/icons-material/ContentCopyRounded';
+import LocalOfferIcon from '@mui/icons-material/LocalOffer';
 import RestaurantIcon from '@mui/icons-material/Restaurant';
 import TrendingDownIcon from '@mui/icons-material/TrendingDown';
 import TrendingFlatIcon from '@mui/icons-material/TrendingFlat';
@@ -30,6 +31,7 @@ import React from 'react';
 
 import type {
   ActivityRank,
+  BehaviorTagSummary,
   DailyMonitoringSummary,
 } from '../domain/monitoringDailyAnalytics';
 
@@ -63,6 +65,13 @@ const TREND_LABEL: Record<string, string> = {
   flat: '横ばい',
 };
 
+const TAG_CATEGORY_COLORS: Record<string, 'primary' | 'secondary' | 'success' | 'info'> = {
+  behavior: 'secondary',
+  communication: 'info',
+  dailyLiving: 'primary',
+  positive: 'success',
+};
+
 // ─── サブコンポーネント ──────────────────────────────────
 
 const SectionTitle: React.FC<{ children: React.ReactNode }> = ({ children }) => (
@@ -87,6 +96,91 @@ const ActivityList: React.FC<{ label: string; items: ActivityRank[] }> = ({ labe
             variant="outlined"
           />
         ))}
+      </Stack>
+    </Box>
+  );
+};
+
+const BehaviorTagSection: React.FC<{ tagSummary: BehaviorTagSummary }> = ({ tagSummary }) => {
+  const TrendIcon =
+    tagSummary.usageTrend === 'up'
+      ? TrendingUpIcon
+      : tagSummary.usageTrend === 'down'
+        ? TrendingDownIcon
+        : TrendingFlatIcon;
+
+  return (
+    <Box>
+      <SectionTitle>
+        <LocalOfferIcon sx={{ fontSize: 16, mr: 0.5, verticalAlign: 'text-bottom' }} />
+        行動タグ分析
+      </SectionTitle>
+
+      {/* Top タグ */}
+      <Stack direction="row" spacing={0.5} flexWrap="wrap" rowGap={0.5} sx={{ mt: 0.5 }}>
+        {tagSummary.topTags.map((t) => (
+          <Chip
+            key={t.key}
+            label={`${t.label} (${t.count}回)`}
+            size="small"
+            color={TAG_CATEGORY_COLORS[t.category ?? ''] ?? 'default'}
+            variant="outlined"
+          />
+        ))}
+      </Stack>
+
+      {/* 付与率 */}
+      <Box sx={{ mt: 1 }}>
+        <Stack direction="row" alignItems="center" spacing={1}>
+          <Typography variant="caption" color="text.secondary" sx={{ minWidth: 80 }}>
+            タグ付与率
+          </Typography>
+          <LinearProgress
+            variant="determinate"
+            value={tagSummary.tagUsageRate}
+            sx={{ flex: 1 }}
+          />
+          <Typography variant="caption" sx={{ fontWeight: 600, minWidth: 45 }}>
+            {tagSummary.tagUsageRate}%
+          </Typography>
+        </Stack>
+        <Typography variant="caption" color="text.secondary" sx={{ mt: 0.3, display: 'block' }}>
+          {tagSummary.taggedRecords}件 / 平均{tagSummary.avgTagsPerRecord}タグ/日
+        </Typography>
+      </Box>
+
+      {/* カテゴリ分布 */}
+      {tagSummary.categoryDistribution.length > 0 && (
+        <Box sx={{ mt: 1 }}>
+          <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600 }}>
+            カテゴリ別
+          </Typography>
+          <Stack direction="row" spacing={0.5} flexWrap="wrap" rowGap={0.5} sx={{ mt: 0.3 }}>
+            {tagSummary.categoryDistribution.map((c) => {
+              const pct = tagSummary.totalRecords > 0
+                ? Math.round((c.count / tagSummary.totalRecords) * 100)
+                : 0;
+              return (
+                <Chip
+                  key={c.category}
+                  label={`${c.label} ${pct}%`}
+                  size="small"
+                  color={TAG_CATEGORY_COLORS[c.category] ?? 'default'}
+                  variant="filled"
+                  sx={{ fontSize: '0.7rem' }}
+                />
+              );
+            })}
+          </Stack>
+        </Box>
+      )}
+
+      {/* トレンド */}
+      <Stack direction="row" alignItems="center" spacing={0.5} sx={{ mt: 0.5 }}>
+        <TrendIcon fontSize="small" color={tagSummary.usageTrend === 'up' ? 'success' : 'inherit'} />
+        <Typography variant="caption" color="text.secondary">
+          {TREND_LABEL[tagSummary.usageTrend] || '横ばい'}
+        </Typography>
       </Stack>
     </Box>
   );
@@ -249,6 +343,14 @@ const MonitoringDailyDashboard: React.FC<MonitoringDailyDashboardProps> = ({
           </Box>
 
           <Divider />
+
+          {/* 3.5. 行動タグ分析 */}
+          {summary.behaviorTagSummary && (
+            <>
+              <BehaviorTagSection tagSummary={summary.behaviorTagSummary} />
+              <Divider />
+            </>
+          )}
 
           {/* 4. 昼食傾向 */}
           <Box>

--- a/src/features/monitoring/domain/monitoringDailyAnalytics.spec.ts
+++ b/src/features/monitoring/domain/monitoringDailyAnalytics.spec.ts
@@ -3,6 +3,7 @@ import {
   aggregateActivities,
   aggregateLunch,
   aggregateBehaviors,
+  aggregateBehaviorTags,
   buildMonitoringDailySummary,
   buildMonitoringInsightText,
 } from './monitoringDailyAnalytics';
@@ -256,5 +257,152 @@ describe('buildMonitoringInsightText', () => {
     const summary = buildMonitoringDailySummary(records)!;
     const lines = buildMonitoringInsightText(summary);
     expect(lines.some((l) => l.includes('記録はなかった'))).toBe(true);
+  });
+});
+
+// ─── aggregateBehaviorTags ───────────────────────────────
+
+describe('aggregateBehaviorTags', () => {
+  it('空配列 → null', () => {
+    expect(aggregateBehaviorTags([])).toBeNull();
+  });
+
+  it('タグなしのレコードのみ → null', () => {
+    const records = [
+      mkRecord({ recordDate: '2024-01-01' }),
+      mkRecord({ recordDate: '2024-01-02', behaviorTags: [] }),
+    ];
+    expect(aggregateBehaviorTags(records)).toBeNull();
+  });
+
+  it('Top タグが降順ソートされる', () => {
+    const records = [
+      mkRecord({ recordDate: '2024-01-01', behaviorTags: ['cooperation', 'panic'] }),
+      mkRecord({ recordDate: '2024-01-02', behaviorTags: ['cooperation', 'sensory'] }),
+      mkRecord({ recordDate: '2024-01-03', behaviorTags: ['cooperation'] }),
+      mkRecord({ recordDate: '2024-01-04', behaviorTags: ['panic'] }),
+    ];
+    const result = aggregateBehaviorTags(records);
+    expect(result).not.toBeNull();
+    expect(result!.topTags[0].key).toBe('cooperation');
+    expect(result!.topTags[0].count).toBe(3);
+    expect(result!.topTags[1].key).toBe('panic');
+    expect(result!.topTags[1].count).toBe(2);
+  });
+
+  it('カテゴリ分布が正しい', () => {
+    const records = [
+      mkRecord({ recordDate: '2024-01-01', behaviorTags: ['cooperation', 'panic'] }),
+      mkRecord({ recordDate: '2024-01-02', behaviorTags: ['selfRegulation', 'verbalRequest'] }),
+    ];
+    const result = aggregateBehaviorTags(records);
+    expect(result).not.toBeNull();
+    const cats = result!.categoryDistribution.map((c) => c.category);
+    expect(cats).toContain('positive');
+    expect(cats).toContain('behavior');
+    expect(cats).toContain('communication');
+  });
+
+  it('付与率と平均タグ数の算出', () => {
+    const records = [
+      mkRecord({ recordDate: '2024-01-01', behaviorTags: ['cooperation', 'panic'] }),
+      mkRecord({ recordDate: '2024-01-02', behaviorTags: [] }),
+      mkRecord({ recordDate: '2024-01-03', behaviorTags: ['cooperation'] }),
+      mkRecord({ recordDate: '2024-01-04' }),
+    ];
+    const result = aggregateBehaviorTags(records);
+    expect(result).not.toBeNull();
+    // タグ付き2件 / 全4件 = 50%
+    expect(result!.tagUsageRate).toBe(50);
+    expect(result!.taggedRecords).toBe(2);
+    // 合計3タグ / 全4件 = 0.8
+    expect(result!.avgTagsPerRecord).toBe(0.8);
+  });
+
+  it('トレンド: 後半増加 → up', () => {
+    const records = [
+      mkRecord({ recordDate: '2024-01-01' }),
+      mkRecord({ recordDate: '2024-01-02' }),
+      mkRecord({ recordDate: '2024-01-03', behaviorTags: ['cooperation'] }),
+      mkRecord({ recordDate: '2024-01-04', behaviorTags: ['cooperation'] }),
+      mkRecord({ recordDate: '2024-01-05', behaviorTags: ['panic'] }),
+      mkRecord({ recordDate: '2024-01-06', behaviorTags: ['cooperation'] }),
+    ];
+    const result = aggregateBehaviorTags(records);
+    expect(result).not.toBeNull();
+    expect(result!.usageTrend).toBe('up');
+  });
+
+  it('トレンド: 4件未満 → flat', () => {
+    const records = [
+      mkRecord({ recordDate: '2024-01-01', behaviorTags: ['cooperation'] }),
+      mkRecord({ recordDate: '2024-01-02', behaviorTags: ['panic'] }),
+    ];
+    const result = aggregateBehaviorTags(records);
+    expect(result).not.toBeNull();
+    expect(result!.usageTrend).toBe('flat');
+  });
+});
+
+// ─── buildMonitoringDailySummary — behaviorTagSummary ────
+
+describe('buildMonitoringDailySummary — behaviorTag integration', () => {
+  it('タグなし → behaviorTagSummary が null', () => {
+    const records = [mkRecord({ recordDate: '2024-01-01' })];
+    const result = buildMonitoringDailySummary(records);
+    expect(result).not.toBeNull();
+    expect(result!.behaviorTagSummary).toBeNull();
+  });
+
+  it('タグあり → behaviorTagSummary が有効', () => {
+    const records = [
+      mkRecord({ recordDate: '2024-01-01', behaviorTags: ['cooperation', 'panic'] }),
+      mkRecord({ recordDate: '2024-01-02', behaviorTags: ['cooperation'] }),
+    ];
+    const result = buildMonitoringDailySummary(records);
+    expect(result).not.toBeNull();
+    expect(result!.behaviorTagSummary).not.toBeNull();
+    expect(result!.behaviorTagSummary!.topTags[0].key).toBe('cooperation');
+  });
+});
+
+// ─── buildMonitoringInsightText — 行動タグ ───────────────
+
+describe('buildMonitoringInsightText — behaviorTag section', () => {
+  it('タグありの場合、所見に【行動タグ】セクションが含まれる', () => {
+    const records = [
+      mkRecord({
+        recordDate: '2024-01-01',
+        activities: { am: '散歩' },
+        lunchIntake: 'full',
+        behaviorTags: ['cooperation', 'panic'],
+      }),
+      mkRecord({
+        recordDate: '2024-01-02',
+        activities: { am: '体操' },
+        lunchIntake: '80',
+        behaviorTags: ['cooperation'],
+      }),
+    ];
+    const summary = buildMonitoringDailySummary(records)!;
+    const lines = buildMonitoringInsightText(summary);
+    const tagLine = lines.find((l) => l.includes('【行動タグ】'));
+    expect(tagLine).toBeDefined();
+    expect(tagLine).toContain('協力行動');
+    expect(tagLine).toContain('付与率');
+    expect(tagLine).toContain('カテゴリ別');
+  });
+
+  it('タグなしの場合、【行動タグ】セクションが含まれない', () => {
+    const records = [
+      mkRecord({
+        recordDate: '2024-01-01',
+        activities: { am: '散歩' },
+        lunchIntake: 'full',
+      }),
+    ];
+    const summary = buildMonitoringDailySummary(records)!;
+    const lines = buildMonitoringInsightText(summary);
+    expect(lines.some((l) => l.includes('【行動タグ】'))).toBe(false);
   });
 });

--- a/src/features/monitoring/domain/monitoringDailyAnalytics.ts
+++ b/src/features/monitoring/domain/monitoringDailyAnalytics.ts
@@ -19,6 +19,8 @@ import type {
   ProblemBehaviorType,
 } from '@/features/daily/infra/dailyTableRepository';
 
+import { BEHAVIOR_TAGS, type BehaviorTagKey, BEHAVIOR_TAG_CATEGORIES, type BehaviorTagCategory } from '@/features/daily/domain/behaviorTag';
+
 // ─── 型定義 ──────────────────────────────────────────────
 
 export interface PeriodSummary {
@@ -70,16 +72,46 @@ export interface BehaviorSummary {
   changeRate: number;
 }
 
+export interface BehaviorTagRank {
+  key: string;
+  label: string;
+  category: string;
+  categoryLabel: string;
+  count: number;
+}
+
+export interface BehaviorTagSummary {
+  /** 使用頻度 Top タグ（最大5件） */
+  topTags: BehaviorTagRank[];
+  /** 1記録あたりの平均タグ数（小数1桁） */
+  avgTagsPerRecord: number;
+  /** タグが1つ以上ある記録の割合（0–100 整数%） */
+  tagUsageRate: number;
+  /** カテゴリ別の出現回数 */
+  categoryDistribution: { category: string; label: string; count: number }[];
+  /** 計算対象の記録数 */
+  totalRecords: number;
+  /** タグが1つ以上ある記録数 */
+  taggedRecords: number;
+  /** 直近半分 vs 前半のタグ使用増減 */
+  usageTrend: 'up' | 'down' | 'flat';
+  /** 増減率（%） */
+  usageTrendRate: number;
+}
+
 export interface DailyMonitoringSummary {
   period: PeriodSummary;
   activity: ActivitySummary;
   lunch: LunchSummary;
   behavior: BehaviorSummary;
+  /** Phase 2: 行動タグ集計（タグ付き記録がない場合は null） */
+  behaviorTagSummary: BehaviorTagSummary | null;
 }
 
 // ─── 定数 ────────────────────────────────────────────────
 
 const MAX_TOP_ACTIVITIES = 5;
+const MAX_TOP_TAGS = 5;
 
 const LUNCH_LABELS: Record<LunchIntake, string> = {
   full: '完食',
@@ -265,6 +297,121 @@ function computeRecentChange(
   return { recentChange: 'flat', changeRate };
 }
 
+// ─── 行動タグ集計 ────────────────────────────────────────
+
+export function aggregateBehaviorTags(
+  records: DailyTableRecord[],
+): BehaviorTagSummary | null {
+  if (records.length === 0) return null;
+
+  // タグ付き記録数
+  const taggedRecords = records.filter(
+    (r) => (r.behaviorTags ?? []).length > 0,
+  ).length;
+  if (taggedRecords === 0) return null;
+
+  // 全タグをフラット化して頻度カウント
+  const freq = new Map<string, number>();
+  const categoryFreq = new Map<string, number>();
+  let totalTags = 0;
+
+  for (const r of records) {
+    for (const tag of r.behaviorTags ?? []) {
+      freq.set(tag, (freq.get(tag) ?? 0) + 1);
+      totalTags++;
+
+      const def = BEHAVIOR_TAGS[tag as BehaviorTagKey];
+      if (def) {
+        const cat = def.category;
+        categoryFreq.set(cat, (categoryFreq.get(cat) ?? 0) + 1);
+      }
+    }
+  }
+
+  // Top タグ（最大5件）
+  const topTags: BehaviorTagRank[] = [...freq.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, MAX_TOP_TAGS)
+    .map(([key, count]) => {
+      const def = BEHAVIOR_TAGS[key as BehaviorTagKey];
+      return {
+        key,
+        label: def?.label ?? key,
+        category: def?.category ?? 'unknown',
+        categoryLabel:
+          BEHAVIOR_TAG_CATEGORIES[def?.category as BehaviorTagCategory] ?? '不明',
+        count,
+      };
+    });
+
+  // カテゴリ分布
+  const categoryDistribution = [...categoryFreq.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([cat, count]) => ({
+      category: cat,
+      label: BEHAVIOR_TAG_CATEGORIES[cat as BehaviorTagCategory] ?? cat,
+      count,
+    }));
+
+  // 指標
+  const avgTagsPerRecord = Math.round((totalTags / records.length) * 10) / 10;
+  const tagUsageRate = Math.round((taggedRecords / records.length) * 100);
+
+  // 使用頻度の前半/後半比較
+  const { usageTrend, usageTrendRate } = computeTagUsageTrend(records);
+
+  return {
+    topTags,
+    avgTagsPerRecord,
+    tagUsageRate,
+    categoryDistribution,
+    totalRecords: records.length,
+    taggedRecords,
+    usageTrend,
+    usageTrendRate,
+  };
+}
+
+function computeTagUsageTrend(
+  records: DailyTableRecord[],
+): { usageTrend: 'up' | 'down' | 'flat'; usageTrendRate: number } {
+  if (records.length < 4) return { usageTrend: 'flat', usageTrendRate: 0 };
+
+  const sorted = [...records].sort((a, b) =>
+    a.recordDate.localeCompare(b.recordDate),
+  );
+  const mid = Math.floor(sorted.length / 2);
+  const firstHalf = sorted.slice(0, mid);
+  const secondHalf = sorted.slice(mid);
+
+  const firstTagged = firstHalf.filter(
+    (r) => (r.behaviorTags ?? []).length > 0,
+  ).length;
+  const secondTagged = secondHalf.filter(
+    (r) => (r.behaviorTags ?? []).length > 0,
+  ).length;
+
+  // 件数ベースで比較（割合ではなく密度）
+  const firstRate =
+    firstHalf.length > 0 ? firstTagged / firstHalf.length : 0;
+  const secondRate =
+    secondHalf.length > 0 ? secondTagged / secondHalf.length : 0;
+
+  if (firstRate === 0 && secondRate === 0)
+    return { usageTrend: 'flat', usageTrendRate: 0 };
+  if (firstRate === 0)
+    return { usageTrend: 'up', usageTrendRate: 100 };
+
+  const changeRate = Math.round(
+    ((secondRate - firstRate) / firstRate) * 100,
+  );
+
+  if (changeRate > 10) return { usageTrend: 'up', usageTrendRate: changeRate };
+  if (changeRate < -10)
+    return { usageTrend: 'down', usageTrendRate: changeRate };
+  return { usageTrend: 'flat', usageTrendRate: changeRate };
+}
+
 // ─── メイン集計 ──────────────────────────────────────────
 
 export function buildMonitoringDailySummary(
@@ -286,6 +433,7 @@ export function buildMonitoringDailySummary(
     activity: aggregateActivities(records),
     lunch: aggregateLunch(records),
     behavior: aggregateBehaviors(records),
+    behaviorTagSummary: aggregateBehaviorTags(records),
   };
 }
 
@@ -349,6 +497,27 @@ export function buildMonitoringInsightText(
     );
   } else {
     lines.push('【問題行動】期間中、問題行動の記録はなかった。');
+  }
+
+  // 行動タグ
+  if (summary.behaviorTagSummary) {
+    const ts = summary.behaviorTagSummary;
+    const topText = ts.topTags
+      .map((t) => `${t.label}(${t.count}回)`)
+      .join('・');
+    const catText = ts.categoryDistribution
+      .map((c) => `${c.label}${c.count}件`)
+      .join('・');
+    const trendLabel =
+      ts.usageTrend === 'up'
+        ? '活用が増加傾向にある'
+        : ts.usageTrend === 'down'
+          ? '活用が減少傾向にある'
+          : '一定の活用がみられる';
+    lines.push(
+      `【行動タグ】${ts.taggedRecords}件の記録にタグ付与あり（付与率 ${ts.tagUsageRate}%、平均 ${ts.avgTagsPerRecord}個/記録）。` +
+        `頻出タグ: ${topText}。カテゴリ別: ${catText}。${trendLabel}。`,
+    );
   }
 
   return lines;


### PR DESCRIPTION
## 概要
モニタリングダッシュボードに行動タグ（behaviorTags）の分析・可視化機能を追加する。

## 背景
PR #925（Phase 1）で構築した日次記録分析ダッシュボードに、行動タグの集計機能を統合する。
これにより、モニタリング時に「どの行動特性がどの頻度で観察されたか」を客観的に把握できる。

## 変更内容

### Domain（純関数）
- `BehaviorTagRank`, `BehaviorTagSummary` 型を追加
- `aggregateBehaviorTags()` 関数を追加
  - Top 5 タグランキング（カテゴリ付き）
  - カテゴリ別分布
  - タグ付与率・平均タグ数/記録
  - 前半/後半のトレンド検出（up/down/flat）
- `DailyMonitoringSummary` に `behaviorTagSummary` フィールドを追加
- `buildMonitoringInsightText()` に【行動タグ】セクションを追加

### Data
- `DailyTableRecord` インターフェースに `behaviorTags?: string[]` を追加

### UI
- `BehaviorTagSection` コンポーネント新設
  - カテゴリ色付き Chip（Top タグ表示）
  - 付与率プログレスバー
  - カテゴリ別分布 Chip
  - トレンドインジケーター
- 問題行動セクションと昼食セクションの間に条件付きレンダリング

### テスト
- 11 テスト追加（計 29 テスト全パス）
  - aggregateBehaviorTags: 空配列、タグなし、ソート、カテゴリ、使用率、トレンド
  - buildMonitoringDailySummary: タグ統合テスト
  - buildMonitoringInsightText: タグセクション生成テスト

## 技術的判断
- `aggregateBehaviorTags` は純関数で副作用なし
- タグ付き記録がない場合は null を返し、UI も条件付きで描画（既存UIへの影響ゼロ）
- `BEHAVIOR_TAGS` 定義を daily domain から参照し、ラベル・カテゴリのSSoTを維持

## テスト結果
```
Tests: 29 passed (29)
tsc --noEmit: 0 errors
```
