### PR TITLE
polish(monitoring): behavior tag insights の表示品質を改善

### DIFF
--- a/src/features/monitoring/components/MonitoringDailyDashboard.tsx
+++ b/src/features/monitoring/components/MonitoringDailyDashboard.tsx
@@ -125,6 +125,7 @@ const BehaviorTagSection: React.FC<{ tagSummary: BehaviorTagSummary }> = ({ tagS
             size="small"
             color={TAG_CATEGORY_COLORS[t.category ?? ''] ?? 'default'}
             variant="outlined"
+            sx={{ maxWidth: 200 }}
           />
         ))}
       </Stack>
@@ -145,7 +146,10 @@ const BehaviorTagSection: React.FC<{ tagSummary: BehaviorTagSummary }> = ({ tagS
           </Typography>
         </Stack>
         <Typography variant="caption" color="text.secondary" sx={{ mt: 0.3, display: 'block' }}>
-          {tagSummary.taggedRecords}件 / 平均{tagSummary.avgTagsPerRecord}タグ/日
+          {tagSummary.taggedRecords}件の記録にタグ付与あり（全{tagSummary.totalRecords}件中）、平均{tagSummary.avgTagsPerRecord}タグ/日
+        </Typography>
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', fontSize: '0.65rem' }}>
+          ※ 日次記録で行動タグがどれだけ活用されているかの指標です
         </Typography>
       </Box>
 
@@ -153,25 +157,23 @@ const BehaviorTagSection: React.FC<{ tagSummary: BehaviorTagSummary }> = ({ tagS
       {tagSummary.categoryDistribution.length > 0 && (
         <Box sx={{ mt: 1 }}>
           <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600 }}>
-            カテゴリ別
+            カテゴリ別分布
           </Typography>
           <Stack direction="row" spacing={0.5} flexWrap="wrap" rowGap={0.5} sx={{ mt: 0.3 }}>
-            {tagSummary.categoryDistribution.map((c) => {
-              const pct = tagSummary.totalRecords > 0
-                ? Math.round((c.count / tagSummary.totalRecords) * 100)
-                : 0;
-              return (
-                <Chip
-                  key={c.category}
-                  label={`${c.label} ${pct}%`}
-                  size="small"
-                  color={TAG_CATEGORY_COLORS[c.category] ?? 'default'}
-                  variant="filled"
-                  sx={{ fontSize: '0.7rem' }}
-                />
-              );
-            })}
+            {tagSummary.categoryDistribution.map((c) => (
+              <Chip
+                key={c.category}
+                label={`${c.label} ${c.percentage}%`}
+                size="small"
+                color={TAG_CATEGORY_COLORS[c.category] ?? 'default'}
+                variant="filled"
+                sx={{ fontSize: '0.7rem', maxWidth: 180 }}
+              />
+            ))}
           </Stack>
+          <Typography variant="caption" color="text.secondary" sx={{ mt: 0.3, display: 'block', fontSize: '0.65rem' }}>
+            ※ 全タグ付与数に対する各カテゴリの割合
+          </Typography>
         </Box>
       )}
 
@@ -180,6 +182,10 @@ const BehaviorTagSection: React.FC<{ tagSummary: BehaviorTagSummary }> = ({ tagS
         <TrendIcon fontSize="small" color={tagSummary.usageTrend === 'up' ? 'success' : 'inherit'} />
         <Typography variant="caption" color="text.secondary">
           {TREND_LABEL[tagSummary.usageTrend] || '横ばい'}
+          {tagSummary.usageTrendRate !== 0 && ` (${tagSummary.usageTrendRate > 0 ? '+' : ''}${tagSummary.usageTrendRate}%)`}
+        </Typography>
+        <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.6rem', ml: 0.5 }}>
+          ※ 前半/後半比較
         </Typography>
       </Stack>
     </Box>

--- a/src/features/monitoring/domain/monitoringDailyAnalytics.spec.ts
+++ b/src/features/monitoring/domain/monitoringDailyAnalytics.spec.ts
@@ -303,6 +303,41 @@ describe('aggregateBehaviorTags', () => {
     expect(cats).toContain('communication');
   });
 
+  it('categoryDistribution に percentage が含まれる', () => {
+    const records = [
+      mkRecord({ recordDate: '2024-01-01', behaviorTags: ['cooperation', 'cooperation', 'panic'] }),
+      mkRecord({ recordDate: '2024-01-02', behaviorTags: ['selfRegulation'] }),
+    ];
+    const result = aggregateBehaviorTags(records);
+    expect(result).not.toBeNull();
+    // 全タグ: cooperation(2) + cooperation(overlap counted once per tag instance) + panic(1) + selfRegulation(1) = 4
+    // このテストでは behaviorTags は flat なので cooperation=2, panic=1, selfRegulation=1 = total 4
+    // positive(cooperation=2, selfRegulation=1) = 3/4 = 75%
+    // behavior(panic=1) = 1/4 = 25%
+    for (const cat of result!.categoryDistribution) {
+      expect(cat).toHaveProperty('percentage');
+      expect(cat.percentage).toBeGreaterThanOrEqual(0);
+      expect(cat.percentage).toBeLessThanOrEqual(100);
+    }
+    const total = result!.categoryDistribution.reduce((s, c) => s + c.percentage, 0);
+    expect(total).toBeGreaterThanOrEqual(90); // 丸め誤差許容
+    expect(total).toBeLessThanOrEqual(110);
+  });
+
+  it('同率タグは key の辞書順で安定ソートされる', () => {
+    const records = [
+      mkRecord({ recordDate: '2024-01-01', behaviorTags: ['panic', 'cooperation'] }),
+      mkRecord({ recordDate: '2024-01-02', behaviorTags: ['verbalRequest'] }),
+    ];
+    const result = aggregateBehaviorTags(records);
+    expect(result).not.toBeNull();
+    // panic=1, cooperation=1, verbalRequest=1 — 全て同率
+    // 辞書順: cooperation < panic < verbalRequest
+    expect(result!.topTags[0].key).toBe('cooperation');
+    expect(result!.topTags[1].key).toBe('panic');
+    expect(result!.topTags[2].key).toBe('verbalRequest');
+  });
+
   it('付与率と平均タグ数の算出', () => {
     const records = [
       mkRecord({ recordDate: '2024-01-01', behaviorTags: ['cooperation', 'panic'] }),
@@ -391,6 +426,8 @@ describe('buildMonitoringInsightText — behaviorTag section', () => {
     expect(tagLine).toContain('協力行動');
     expect(tagLine).toContain('付与率');
     expect(tagLine).toContain('カテゴリ別');
+    // Phase 2.5: percentage が含まれる
+    expect(tagLine).toMatch(/%/);
   });
 
   it('タグなしの場合、【行動タグ】セクションが含まれない', () => {

--- a/src/features/monitoring/domain/monitoringDailyAnalytics.ts
+++ b/src/features/monitoring/domain/monitoringDailyAnalytics.ts
@@ -88,7 +88,7 @@ export interface BehaviorTagSummary {
   /** タグが1つ以上ある記録の割合（0–100 整数%） */
   tagUsageRate: number;
   /** カテゴリ別の出現回数 */
-  categoryDistribution: { category: string; label: string; count: number }[];
+  categoryDistribution: { category: string; label: string; count: number; percentage: number }[];
   /** 計算対象の記録数 */
   totalRecords: number;
   /** タグが1つ以上ある記録数 */
@@ -328,9 +328,9 @@ export function aggregateBehaviorTags(
     }
   }
 
-  // Top タグ（最大5件）
+  // Top タグ（最大5件）— 同率時は key の辞書順で安定ソート
   const topTags: BehaviorTagRank[] = [...freq.entries()]
-    .sort((a, b) => b[1] - a[1])
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
     .slice(0, MAX_TOP_TAGS)
     .map(([key, count]) => {
       const def = BEHAVIOR_TAGS[key as BehaviorTagKey];
@@ -344,13 +344,14 @@ export function aggregateBehaviorTags(
       };
     });
 
-  // カテゴリ分布
+  // カテゴリ分布（割合付き）
   const categoryDistribution = [...categoryFreq.entries()]
-    .sort((a, b) => b[1] - a[1])
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
     .map(([cat, count]) => ({
       category: cat,
       label: BEHAVIOR_TAG_CATEGORIES[cat as BehaviorTagCategory] ?? cat,
       count,
+      percentage: totalTags > 0 ? Math.round((count / totalTags) * 100) : 0,
     }));
 
   // 指標
@@ -506,7 +507,7 @@ export function buildMonitoringInsightText(
       .map((t) => `${t.label}(${t.count}回)`)
       .join('・');
     const catText = ts.categoryDistribution
-      .map((c) => `${c.label}${c.count}件`)
+      .map((c) => `${c.label}${c.count}件(${c.percentage}%)`)
       .join('・');
     const trendLabel =
       ts.usageTrend === 'up'


### PR DESCRIPTION
## 概要
MonitoringDailyDashboard の behaviorTags 分析表示について、
ロジック変更を最小限に抑えつつ、表示品質と解釈しやすさを改善する。

## 背景
PR #928 で以下を実装済み:
- `aggregateBehaviorTags()` の追加
- `BehaviorTagSection` の表示
- 29 tests pass

## 変更内容

### Domain (`monitoringDailyAnalytics.ts`)
- `categoryDistribution` に `percentage` フィールドを追加
- Top tags の同率ソートを key 辞書順で安定化
- カテゴリ分布のソートも安定化
- 所見テキストにカテゴリ別割合(%)を含める

### UI (`MonitoringDailyDashboard.tsx`)
- 付与率の補助説明テキストを追加
- カテゴリ分布の割合表示を domain から直接取得（ローカル計算を排除）
- トレンドの算出期間（前半/後半比較）を UI に明示
- トレンド変化率をパーセンテージ表示
- Chip の maxWidth を設定し長いタグ名の overflow を防止

### テスト (`monitoringDailyAnalytics.spec.ts`)
- `categoryDistribution` に `percentage` が含まれるテスト追加
- 同率タグの安定ソートテスト追加
- 所見テキストに `%` が含まれる検証追加
- **31 tests pass**

## 確認結果
- `tsc --noEmit`: 0 errors
- `vitest run`: 31/31 pass
- lint: pass

## 次フェーズ
Phase 3-A で `goalProgressTypes.ts` を追加し、
`GoalItem.domains → BehaviorTag.category` の推論に着手する。

Closes #929