### PR TITLE
feat: モニタリング向け目標進捗の型・推論・判定ロジックを追加

### DIFF
--- a/src/features/monitoring/domain/goalProgressTypes.ts
+++ b/src/features/monitoring/domain/goalProgressTypes.ts
@@ -1,0 +1,101 @@
+/**
+ * @fileoverview ISP 目標と行動タグの紐付け・進捗判定の型定義
+ * @description
+ * Phase 3-A:
+ *   GoalItem.domains → BehaviorTagCategory への推論と、
+ *   記録データを用いた進捗レベル判定に必要な型を定義する。
+ *
+ * SSOT:
+ *   - GoalDomainId は goalTypes.ts の DOMAINS.id と一致させる
+ *   - BehaviorTagCategory は behaviorTag.ts から再エクスポートする
+ */
+
+import type { BehaviorTagCategory } from '../../daily/domain/behaviorTag';
+
+// ─── Goal 側の型 ────────────────────────────────────────
+
+/**
+ * DOMAINS 定数の id をリテラル型化。
+ * goalTypes.ts の DOMAINS 配列と同期させること。
+ */
+export type GoalDomainId =
+  | 'health'
+  | 'motor'
+  | 'cognitive'
+  | 'language'
+  | 'social';
+
+/**
+ * inferGoalTagLinks の入力用。
+ * GoalItem から必要なフィールドだけ抜いた最小形。
+ */
+export type GoalLike = {
+  id: string;
+  domains?: string[];
+};
+
+// ─── 推論結果 ───────────────────────────────────────────
+
+/** Goal と BehaviorTag カテゴリの紐付け結果 */
+export type GoalTagLink = {
+  goalId: string;
+  /** domains から推論されたカテゴリ一覧 */
+  inferredCategories: BehaviorTagCategory[];
+  /** 将来の個別タグ指定用（Phase 3-A では空配列） */
+  inferredTags: string[];
+  /** 推論元の追跡 */
+  source: 'domain-inference' | 'manual';
+};
+
+// ─── 進捗判定 ───────────────────────────────────────────
+
+export type ProgressTrend = 'improving' | 'stable' | 'declining';
+
+export type ProgressLevel =
+  | 'achieved'
+  | 'progressing'
+  | 'stagnant'
+  | 'regressing'
+  | 'noData';
+
+/** assessGoalProgress の入力 */
+export type GoalProgressInput = {
+  goalId: string;
+  linkedCategories: BehaviorTagCategory[];
+  matchedRecordCount: number;
+  matchedTagCount: number;
+  totalRecordCount: number;
+  trend: ProgressTrend;
+};
+
+/** assessGoalProgress の出力 */
+export type GoalProgressSummary = {
+  goalId: string;
+  level: ProgressLevel;
+  /** matchedRecordCount / totalRecordCount */
+  rate: number;
+  trend: ProgressTrend;
+  matchedRecordCount: number;
+  matchedTagCount: number;
+  linkedCategories: BehaviorTagCategory[];
+  /** 判定根拠テキスト（所見ドラフト用） */
+  note?: string;
+};
+
+// ─── 判定レベルの表示定数 ────────────────────────────────
+
+export const PROGRESS_LEVEL_LABELS: Record<ProgressLevel, string> = {
+  achieved:    '達成',
+  progressing: '進捗あり',
+  stagnant:    '停滞',
+  regressing:  '後退',
+  noData:      'データなし',
+};
+
+export const PROGRESS_LEVEL_COLORS: Record<ProgressLevel, string> = {
+  achieved:    '#10b981',
+  progressing: '#3b82f6',
+  stagnant:    '#f59e0b',
+  regressing:  '#ef4444',
+  noData:      '#9ca3af',
+};

--- a/src/features/monitoring/domain/goalProgressUtils.spec.ts
+++ b/src/features/monitoring/domain/goalProgressUtils.spec.ts
@@ -1,0 +1,318 @@
+/**
+ * @fileoverview goalProgressUtils のユニットテスト
+ * Phase 3-A: 推論 + 判定ロジックの網羅テスト
+ */
+import { describe, expect, it } from 'vitest';
+
+import { assessGoalProgress, DOMAIN_CATEGORY_MAP, inferGoalTagLinks } from './goalProgressUtils';
+import type { GoalProgressInput, ProgressLevel, ProgressTrend } from './goalProgressTypes';
+
+// ═══════════════════════════════════════════════════════════
+// inferGoalTagLinks
+// ═══════════════════════════════════════════════════════════
+
+describe('inferGoalTagLinks', () => {
+  it('domain 1つ → 対応カテゴリを推論する', () => {
+    const result = inferGoalTagLinks([{ id: 'g1', domains: ['cognitive'] }]);
+    expect(result).toHaveLength(1);
+    expect(result[0].goalId).toBe('g1');
+    expect(result[0].inferredCategories).toEqual(['behavior']);
+    expect(result[0].source).toBe('domain-inference');
+  });
+
+  it('domain 複数 → カテゴリの union を返す', () => {
+    const result = inferGoalTagLinks([
+      { id: 'g1', domains: ['cognitive', 'language'] },
+    ]);
+    expect(result[0].inferredCategories).toEqual(
+      expect.arrayContaining(['behavior', 'communication']),
+    );
+    expect(result[0].inferredCategories).toHaveLength(2);
+  });
+
+  it('同じカテゴリに重なる domain → 重複除去', () => {
+    // health → [dailyLiving, positive], motor → [dailyLiving, positive]
+    const result = inferGoalTagLinks([
+      { id: 'g1', domains: ['health', 'motor'] },
+    ]);
+    expect(result[0].inferredCategories).toEqual(
+      expect.arrayContaining(['dailyLiving', 'positive']),
+    );
+    // 重複なし
+    expect(result[0].inferredCategories).toHaveLength(2);
+  });
+
+  it('social → communication + positive', () => {
+    const result = inferGoalTagLinks([{ id: 'g1', domains: ['social'] }]);
+    expect(result[0].inferredCategories).toEqual(
+      expect.arrayContaining(['communication', 'positive']),
+    );
+    expect(result[0].inferredCategories).toHaveLength(2);
+  });
+
+  it('domains undefined → 空 categories', () => {
+    const result = inferGoalTagLinks([{ id: 'g1' }]);
+    expect(result[0].inferredCategories).toEqual([]);
+    expect(result[0].source).toBe('domain-inference');
+  });
+
+  it('domains 空配列 → 空 categories', () => {
+    const result = inferGoalTagLinks([{ id: 'g1', domains: [] }]);
+    expect(result[0].inferredCategories).toEqual([]);
+  });
+
+  it('未知の domain ID → スキップ（エラーにならない）', () => {
+    const result = inferGoalTagLinks([
+      { id: 'g1', domains: ['unknown-domain'] },
+    ]);
+    expect(result[0].inferredCategories).toEqual([]);
+  });
+
+  it('goals 空配列 → 空配列', () => {
+    expect(inferGoalTagLinks([])).toEqual([]);
+  });
+
+  it('inferredTags は Phase 3-A では空配列', () => {
+    const result = inferGoalTagLinks([{ id: 'g1', domains: ['health'] }]);
+    expect(result[0].inferredTags).toEqual([]);
+  });
+
+  it('カテゴリはソート済みで安定', () => {
+    // social → [communication, positive] をソートで安定
+    const r1 = inferGoalTagLinks([{ id: 'g1', domains: ['social'] }]);
+    const r2 = inferGoalTagLinks([{ id: 'g1', domains: ['social'] }]);
+    expect(r1[0].inferredCategories).toEqual(r2[0].inferredCategories);
+    // アルファベット順: communication < positive
+    expect(r1[0].inferredCategories[0]).toBe('communication');
+    expect(r1[0].inferredCategories[1]).toBe('positive');
+  });
+
+  it('全5領域のマッピングが定義されている', () => {
+    const domainIds = ['health', 'motor', 'cognitive', 'language', 'social'];
+    for (const id of domainIds) {
+      expect(DOMAIN_CATEGORY_MAP).toHaveProperty(id);
+      expect(DOMAIN_CATEGORY_MAP[id as keyof typeof DOMAIN_CATEGORY_MAP].length).toBeGreaterThan(0);
+    }
+  });
+
+  it('複数 goal を一括で処理できる', () => {
+    const result = inferGoalTagLinks([
+      { id: 'g1', domains: ['health'] },
+      { id: 'g2', domains: ['cognitive'] },
+      { id: 'g3', domains: ['social'] },
+    ]);
+    expect(result).toHaveLength(3);
+    expect(result.map((r) => r.goalId)).toEqual(['g1', 'g2', 'g3']);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════
+// assessGoalProgress
+// ═══════════════════════════════════════════════════════════
+
+describe('assessGoalProgress', () => {
+  /** テスト用ヘルパー */
+  const mkInput = (
+    overrides: Partial<GoalProgressInput> = {},
+  ): GoalProgressInput => ({
+    goalId: 'g1',
+    linkedCategories: ['behavior'],
+    matchedRecordCount: 0,
+    matchedTagCount: 0,
+    totalRecordCount: 0,
+    trend: 'stable',
+    ...overrides,
+  });
+
+  // ── noData ──
+
+  it('totalRecordCount === 0 → noData', () => {
+    const result = assessGoalProgress(mkInput({ totalRecordCount: 0 }));
+    expect(result.level).toBe('noData');
+    expect(result.rate).toBe(0);
+    expect(result.trend).toBe('stable');
+    expect(result.note).toBe('記録データがありません');
+  });
+
+  // ── rate >= 0.5 ──
+
+  it('rate=0.6 + improving → achieved', () => {
+    const result = assessGoalProgress(
+      mkInput({ matchedRecordCount: 6, totalRecordCount: 10, trend: 'improving' }),
+    );
+    expect(result.level).toBe('achieved');
+    expect(result.rate).toBe(0.6);
+  });
+
+  it('rate=0.6 + stable → progressing', () => {
+    const result = assessGoalProgress(
+      mkInput({ matchedRecordCount: 6, totalRecordCount: 10, trend: 'stable' }),
+    );
+    expect(result.level).toBe('progressing');
+  });
+
+  it('rate=0.5 + declining → progressing', () => {
+    const result = assessGoalProgress(
+      mkInput({ matchedRecordCount: 5, totalRecordCount: 10, trend: 'declining' }),
+    );
+    expect(result.level).toBe('progressing');
+  });
+
+  // ── rate >= 0.3, < 0.5 ──
+
+  it('rate=0.35 + improving → progressing', () => {
+    const result = assessGoalProgress(
+      mkInput({ matchedRecordCount: 7, totalRecordCount: 20, trend: 'improving' }),
+    );
+    expect(result.level).toBe('progressing');
+  });
+
+  it('rate=0.35 + stable → progressing', () => {
+    const result = assessGoalProgress(
+      mkInput({ matchedRecordCount: 7, totalRecordCount: 20, trend: 'stable' }),
+    );
+    expect(result.level).toBe('progressing');
+  });
+
+  it('rate=0.35 + declining → stagnant', () => {
+    const result = assessGoalProgress(
+      mkInput({ matchedRecordCount: 7, totalRecordCount: 20, trend: 'declining' }),
+    );
+    expect(result.level).toBe('stagnant');
+  });
+
+  // ── rate >= 0.1, < 0.3 ──
+
+  it('rate=0.15 + improving → progressing', () => {
+    const result = assessGoalProgress(
+      mkInput({ matchedRecordCount: 3, totalRecordCount: 20, trend: 'improving' }),
+    );
+    expect(result.level).toBe('progressing');
+  });
+
+  it('rate=0.15 + stable → stagnant', () => {
+    const result = assessGoalProgress(
+      mkInput({ matchedRecordCount: 3, totalRecordCount: 20, trend: 'stable' }),
+    );
+    expect(result.level).toBe('stagnant');
+  });
+
+  it('rate=0.15 + declining → regressing', () => {
+    const result = assessGoalProgress(
+      mkInput({ matchedRecordCount: 3, totalRecordCount: 20, trend: 'declining' }),
+    );
+    expect(result.level).toBe('regressing');
+  });
+
+  // ── rate < 0.1 ──
+
+  it('rate=0.05 + improving → stagnant', () => {
+    const result = assessGoalProgress(
+      mkInput({ matchedRecordCount: 1, totalRecordCount: 20, trend: 'improving' }),
+    );
+    expect(result.level).toBe('stagnant');
+  });
+
+  it('rate=0.05 + stable → stagnant', () => {
+    const result = assessGoalProgress(
+      mkInput({ matchedRecordCount: 1, totalRecordCount: 20, trend: 'stable' }),
+    );
+    expect(result.level).toBe('stagnant');
+  });
+
+  it('rate=0.05 + declining → regressing', () => {
+    const result = assessGoalProgress(
+      mkInput({ matchedRecordCount: 1, totalRecordCount: 20, trend: 'declining' }),
+    );
+    expect(result.level).toBe('regressing');
+  });
+
+  // ── 出力フィールドの検証 ──
+
+  it('matchedRecordCount / matchedTagCount がそのまま返る', () => {
+    const result = assessGoalProgress(
+      mkInput({
+        matchedRecordCount: 8,
+        matchedTagCount: 15,
+        totalRecordCount: 10,
+        trend: 'improving',
+      }),
+    );
+    expect(result.matchedRecordCount).toBe(8);
+    expect(result.matchedTagCount).toBe(15);
+  });
+
+  it('linkedCategories がそのまま返る', () => {
+    const cats = ['behavior', 'communication'] as const;
+    const result = assessGoalProgress(
+      mkInput({
+        linkedCategories: [...cats],
+        matchedRecordCount: 5,
+        totalRecordCount: 10,
+      }),
+    );
+    expect(result.linkedCategories).toEqual([...cats]);
+  });
+
+  it('rate は小数2桁に丸められる', () => {
+    const result = assessGoalProgress(
+      mkInput({ matchedRecordCount: 1, totalRecordCount: 3, trend: 'improving' }),
+    );
+    // 1/3 = 0.333... → 0.33
+    expect(result.rate).toBe(0.33);
+  });
+
+  // ── 境界値テスト ──
+
+  it('rate=0.5 ちょうど + improving → achieved', () => {
+    const result = assessGoalProgress(
+      mkInput({ matchedRecordCount: 5, totalRecordCount: 10, trend: 'improving' }),
+    );
+    expect(result.level).toBe('achieved');
+  });
+
+  it('rate=0.3 ちょうど + declining → stagnant', () => {
+    const result = assessGoalProgress(
+      mkInput({ matchedRecordCount: 3, totalRecordCount: 10, trend: 'declining' }),
+    );
+    expect(result.level).toBe('stagnant');
+  });
+
+  it('rate=0.1 ちょうど + declining → regressing', () => {
+    const result = assessGoalProgress(
+      mkInput({ matchedRecordCount: 1, totalRecordCount: 10, trend: 'declining' }),
+    );
+    expect(result.level).toBe('regressing');
+  });
+
+  // ── 判定マトリクス網羅 ──
+
+  it('全12パターンの判定マトリクスが正しい', () => {
+    type Case = [number, number, ProgressTrend, ProgressLevel];
+    const cases: Case[] = [
+      // rate >= 0.5
+      [6, 10, 'improving', 'achieved'],
+      [6, 10, 'stable', 'progressing'],
+      [6, 10, 'declining', 'progressing'],
+      // rate >= 0.3
+      [4, 10, 'improving', 'progressing'],
+      [4, 10, 'stable', 'progressing'],
+      [4, 10, 'declining', 'stagnant'],
+      // rate >= 0.1
+      [2, 10, 'improving', 'progressing'],
+      [2, 10, 'stable', 'stagnant'],
+      [2, 10, 'declining', 'regressing'],
+      // rate < 0.1
+      [0, 10, 'improving', 'stagnant'],
+      [0, 10, 'stable', 'stagnant'],
+      [0, 10, 'declining', 'regressing'],
+    ];
+
+    for (const [matched, total, trend, expected] of cases) {
+      const result = assessGoalProgress(
+        mkInput({ matchedRecordCount: matched, totalRecordCount: total, trend }),
+      );
+      expect(result.level).toBe(expected);
+    }
+  });
+});

--- a/src/features/monitoring/domain/goalProgressUtils.ts
+++ b/src/features/monitoring/domain/goalProgressUtils.ts
@@ -1,0 +1,139 @@
+/**
+ * @fileoverview ISP 目標 × 行動タグの推論・進捗判定ロジック
+ * @description
+ * Phase 3-A:
+ *   - inferGoalTagLinks: GoalItem.domains → BehaviorTagCategory の自動推論
+ *   - assessGoalProgress: rate × trend → ProgressLevel の判定
+ *
+ * 全関数は pure function。副作用・外部依存なし。
+ */
+
+import type { BehaviorTagCategory } from '../../daily/domain/behaviorTag';
+import type {
+  GoalDomainId,
+  GoalLike,
+  GoalProgressInput,
+  GoalProgressSummary,
+  GoalTagLink,
+  ProgressLevel,
+} from './goalProgressTypes';
+
+// ─── 5領域 → 4カテゴリ マッピング ──────────────────────
+
+/**
+ * GoalItem.domains の各 ID から、関連する BehaviorTagCategory を推論する。
+ *
+ * 根拠:
+ *   - health  → 食事・排泄・睡眠(dailyLiving) + 自己調整(positive)
+ *   - motor   → 生活動作(dailyLiving) + 新スキル(positive)
+ *   - cognitive → パニック・感覚(behavior)
+ *   - language → 言語要求・ジェスチャー(communication)
+ *   - social  → 協力行動(positive) + コミュニケーション(communication)
+ */
+export const DOMAIN_CATEGORY_MAP: Record<GoalDomainId, BehaviorTagCategory[]> = {
+  health:    ['dailyLiving', 'positive'],
+  motor:     ['dailyLiving', 'positive'],
+  cognitive: ['behavior'],
+  language:  ['communication'],
+  social:    ['communication', 'positive'],
+};
+
+// ─── inferGoalTagLinks ─────────────────────────────────
+
+/**
+ * Goal の domains フィールドから BehaviorTagCategory を自動推論する。
+ *
+ * - domains がない/空の goal → inferredCategories は空配列
+ * - 未知の domain ID → スキップ（エラーにしない）
+ * - 重複カテゴリは除去
+ * - カテゴリの順序はソート済みで安定
+ *
+ * @param goals - GoalItem の最小形
+ * @returns 各 goal に対する GoalTagLink
+ */
+export function inferGoalTagLinks(goals: GoalLike[]): GoalTagLink[] {
+  return goals.map((goal) => {
+    const categories = Array.from(
+      new Set(
+        (goal.domains ?? []).flatMap(
+          (d) => DOMAIN_CATEGORY_MAP[d as GoalDomainId] ?? [],
+        ),
+      ),
+    ).sort() as BehaviorTagCategory[];
+
+    return {
+      goalId: goal.id,
+      inferredCategories: categories,
+      inferredTags: [], // Phase 3-A では未実装
+      source: 'domain-inference' as const,
+    };
+  });
+}
+
+// ─── assessGoalProgress ────────────────────────────────
+
+/**
+ * 判定マトリクス:
+ *
+ * | rate             | improving   | stable      | declining   |
+ * |------------------|-------------|-------------|-------------|
+ * | >= 0.5           | achieved    | progressing | progressing |
+ * | >= 0.3, < 0.5    | progressing | progressing | stagnant    |
+ * | >= 0.1, < 0.3    | progressing | stagnant    | regressing  |
+ * | < 0.1            | stagnant    | stagnant    | regressing  |
+ *
+ * totalRecordCount === 0 → noData（即 return）
+ */
+export function assessGoalProgress(
+  input: GoalProgressInput,
+): GoalProgressSummary {
+  const {
+    goalId,
+    linkedCategories,
+    matchedRecordCount,
+    matchedTagCount,
+    totalRecordCount,
+    trend,
+  } = input;
+
+  // ── データなし ──
+  if (totalRecordCount === 0) {
+    return {
+      goalId,
+      level: 'noData',
+      rate: 0,
+      trend: 'stable',
+      matchedRecordCount: 0,
+      matchedTagCount: 0,
+      linkedCategories,
+      note: '記録データがありません',
+    };
+  }
+
+  const rate = matchedRecordCount / totalRecordCount;
+
+  // ── 判定マトリクス ──
+  let level: ProgressLevel;
+
+  if (rate >= 0.5) {
+    level = trend === 'improving' ? 'achieved' : 'progressing';
+  } else if (rate >= 0.3) {
+    level = trend === 'declining' ? 'stagnant' : 'progressing';
+  } else if (rate >= 0.1) {
+    if (trend === 'declining') level = 'regressing';
+    else if (trend === 'stable') level = 'stagnant';
+    else level = 'progressing';
+  } else {
+    level = trend === 'declining' ? 'regressing' : 'stagnant';
+  }
+
+  return {
+    goalId,
+    level,
+    rate: Math.round(rate * 100) / 100, // 小数2桁に丸め
+    trend,
+    matchedRecordCount,
+    matchedTagCount,
+    linkedCategories,
+  };
+}


### PR DESCRIPTION
## 概要
Phase 3-A として、Monitoring の goal progress 算出に必要な
型定義・推論関数・判定ロジックを追加した。

## 背景
Phase 2.5 (PR #930) で行動タグ分析の表示品質を仕上げた。
次のステップとして、ISP 目標と行動タグの紐付けを domain レイヤーに追加する。

## 追加ファイル

### `goalProgressTypes.ts`
- `GoalDomainId`: DOMAINS 定数の ID リテラル型
- `GoalLike`: GoalItem の最小入力形
- `GoalTagLink`: 推論結果（categories + source）
- `GoalProgressInput`: 判定入力
- `GoalProgressSummary`: 判定出力
- `ProgressLevel` / `ProgressTrend`: 判定レベル

### `goalProgressUtils.ts`
- `DOMAIN_CATEGORY_MAP`: 5領域→4カテゴリのマッピング
- `inferGoalTagLinks()`: domains→categories の自動推論
- `assessGoalProgress()`: rate×trend→level の判定

## 判定マトリクス
| rate | improving | stable | declining |
|---|---|---|---|
| ≥ 0.5 | achieved | progressing | progressing |
| ≥ 0.3 | progressing | progressing | stagnant |
| ≥ 0.1 | progressing | stagnant | regressing |
| < 0.1 | stagnant | stagnant | regressing |

## 5領域→4カテゴリ マッピング
| GoalDomainId | → Categories |
|---|---|
| health | dailyLiving, positive |
| motor | dailyLiving, positive |
| cognitive | behavior |
| language | communication |
| social | communication, positive |

## 設計ポイント
- `GoalLike` で GoalItem への直接依存を回避
- `BehaviorTagCategory` は `behaviorTag.ts` SSOT から import
- `source: 'domain-inference'` で将来の manual override に対応
- `inferredTags` は空配列（Phase 3-B 以降で拡張）
- `rate` は小数2桁に丸め、UI でそのまま使えるよう整形

## 検証結果
- `tsc --noEmit`: 0 errors
- `vitest run`: 63/63 pass（新規32 + 既存31 に影響なし）
- lint: pass

## 次フェーズ
- Phase 3-B: `DailyMonitoringSummary` に `goalProgress` を統合
- Phase 3-C: `GoalProgressCard` UI を追加