### PR TITLE
feat(monitoring): Phase 3-B — goalProgress を DailyMonitoringSummary に統合

### DIFF
--- a/src/features/monitoring/domain/monitoringDailyAnalytics.spec.ts
+++ b/src/features/monitoring/domain/monitoringDailyAnalytics.spec.ts
@@ -443,3 +443,251 @@ describe('buildMonitoringInsightText — behaviorTag section', () => {
     expect(lines.some((l) => l.includes('【行動タグ】'))).toBe(false);
   });
 });
+
+// ─── Phase 3-B: goalProgress 統合 ────────────────────────
+
+describe('buildMonitoringDailySummary — goalProgress integration', () => {
+  it('goals 未指定 → goalProgress は undefined', () => {
+    const records = [
+      mkRecord({ recordDate: '2024-01-01', behaviorTags: ['cooperation'] }),
+    ];
+    const result = buildMonitoringDailySummary(records);
+    expect(result).not.toBeNull();
+    expect(result!.goalProgress).toBeUndefined();
+  });
+
+  it('goals が空配列 → goalProgress は undefined', () => {
+    const records = [
+      mkRecord({ recordDate: '2024-01-01', behaviorTags: ['cooperation'] }),
+    ];
+    const result = buildMonitoringDailySummary(records, []);
+    expect(result).not.toBeNull();
+    expect(result!.goalProgress).toBeUndefined();
+  });
+
+  it('goals あり → goalProgress が計算される', () => {
+    const records = [
+      mkRecord({ recordDate: '2024-01-01', behaviorTags: ['cooperation'] }),
+      mkRecord({ recordDate: '2024-01-02', behaviorTags: ['panic'] }),
+    ];
+    const goals = [{ id: 'g1', domains: ['social'] }];
+    const result = buildMonitoringDailySummary(records, goals);
+    expect(result).not.toBeNull();
+    expect(result!.goalProgress).toBeDefined();
+    expect(result!.goalProgress).toHaveLength(1);
+    expect(result!.goalProgress![0].goalId).toBe('g1');
+  });
+
+  it('social 目標 → positive/communication カテゴリのタグと照合', () => {
+    // social → ['communication', 'positive']
+    // cooperation = positive, verbalRequest = communication
+    const records = [
+      mkRecord({ recordDate: '2024-01-01', behaviorTags: ['cooperation'] }),
+      mkRecord({ recordDate: '2024-01-02', behaviorTags: ['verbalRequest'] }),
+      mkRecord({ recordDate: '2024-01-03', behaviorTags: ['panic'] }),  // behavior → social に無関連
+      mkRecord({ recordDate: '2024-01-04', behaviorTags: ['cooperation', 'verbalRequest'] }),
+    ];
+    const goals = [{ id: 'g1', domains: ['social'] }];
+    const result = buildMonitoringDailySummary(records, goals)!;
+    const gp = result.goalProgress![0];
+
+    // 4件中3件が social に関連（record 1,2,4）
+    expect(gp.matchedRecordCount).toBe(3);
+    // cooperation x2 + verbalRequest x2 = 4
+    expect(gp.matchedTagCount).toBe(4);
+    // rate = 3/4 = 0.75
+    expect(gp.rate).toBe(0.75);
+  });
+
+  it('cognitive 目標 → behavior カテゴリのタグと照合', () => {
+    // cognitive → ['behavior']
+    // panic = behavior, sensory = behavior
+    const records = [
+      mkRecord({ recordDate: '2024-01-01', behaviorTags: ['panic', 'sensory'] }),
+      mkRecord({ recordDate: '2024-01-02', behaviorTags: ['cooperation'] }), // positive → cognitive に無関連
+      mkRecord({ recordDate: '2024-01-03', behaviorTags: ['panic'] }),
+    ];
+    const goals = [{ id: 'g1', domains: ['cognitive'] }];
+    const result = buildMonitoringDailySummary(records, goals)!;
+    const gp = result.goalProgress![0];
+
+    // 3件中2件が cognitive に関連（record 1,3）
+    expect(gp.matchedRecordCount).toBe(2);
+    // panic x2 + sensory x1 = 3
+    expect(gp.matchedTagCount).toBe(3);
+  });
+
+  it('domain なしの目標 → matchedRecordCount=0, noData にならず stagnant', () => {
+    const records = [
+      mkRecord({ recordDate: '2024-01-01', behaviorTags: ['cooperation'] }),
+    ];
+    const goals = [{ id: 'g1' }]; // domains 未設定
+    const result = buildMonitoringDailySummary(records, goals)!;
+    const gp = result.goalProgress![0];
+
+    expect(gp.matchedRecordCount).toBe(0);
+    expect(gp.matchedTagCount).toBe(0);
+    expect(gp.level).toBe('stagnant');
+  });
+
+  it('複数目標 → それぞれ個別に計算される', () => {
+    const records = [
+      mkRecord({ recordDate: '2024-01-01', behaviorTags: ['cooperation', 'panic'] }),
+      mkRecord({ recordDate: '2024-01-02', behaviorTags: ['verbalRequest'] }),
+    ];
+    const goals = [
+      { id: 'g1', domains: ['cognitive'] },  // behavior → panic のみ
+      { id: 'g2', domains: ['language'] },    // communication → verbalRequest のみ
+    ];
+    const result = buildMonitoringDailySummary(records, goals)!;
+    expect(result.goalProgress).toHaveLength(2);
+
+    const g1 = result.goalProgress!.find((g) => g.goalId === 'g1')!;
+    const g2 = result.goalProgress!.find((g) => g.goalId === 'g2')!;
+
+    // g1: record 1 のみ match → 1/2 = 0.5
+    expect(g1.matchedRecordCount).toBe(1);
+    expect(g1.rate).toBe(0.5);
+
+    // g2: record 2 のみ match → 1/2 = 0.5
+    expect(g2.matchedRecordCount).toBe(1);
+    expect(g2.rate).toBe(0.5);
+  });
+
+  it('タグなし記録のみ → rate=0', () => {
+    const records = [
+      mkRecord({ recordDate: '2024-01-01' }),
+      mkRecord({ recordDate: '2024-01-02' }),
+    ];
+    const goals = [{ id: 'g1', domains: ['social'] }];
+    const result = buildMonitoringDailySummary(records, goals)!;
+    const gp = result.goalProgress![0];
+
+    expect(gp.matchedRecordCount).toBe(0);
+    expect(gp.rate).toBe(0);
+    expect(gp.level).toBe('stagnant');
+  });
+
+  it('既存サマリーフィールドが goals 有無で変わらない', () => {
+    const records = [
+      mkRecord({
+        recordDate: '2024-01-01',
+        activities: { am: '散歩' },
+        lunchIntake: 'full',
+        behaviorTags: ['cooperation'],
+      }),
+    ];
+    const withoutGoals = buildMonitoringDailySummary(records)!;
+    const withGoals = buildMonitoringDailySummary(records, [{ id: 'g1', domains: ['social'] }])!;
+
+    expect(withGoals.period).toEqual(withoutGoals.period);
+    expect(withGoals.activity).toEqual(withoutGoals.activity);
+    expect(withGoals.lunch).toEqual(withoutGoals.lunch);
+    expect(withGoals.behavior).toEqual(withoutGoals.behavior);
+    expect(withGoals.behaviorTagSummary).toEqual(withoutGoals.behaviorTagSummary);
+  });
+});
+
+// ─── Phase 3-B: goalProgress の trend 計算 ───────────────
+
+describe('goalProgress trend', () => {
+  it('後半に関連タグが増加 → improving', () => {
+    const records = [
+      // 前半: 関連タグなし
+      mkRecord({ recordDate: '2024-01-01' }),
+      mkRecord({ recordDate: '2024-01-02' }),
+      // 後半: 関連タグあり
+      mkRecord({ recordDate: '2024-01-03', behaviorTags: ['cooperation'] }),
+      mkRecord({ recordDate: '2024-01-04', behaviorTags: ['cooperation'] }),
+    ];
+    const goals = [{ id: 'g1', domains: ['social'] }];
+    const result = buildMonitoringDailySummary(records, goals)!;
+    const gp = result.goalProgress![0];
+
+    expect(gp.trend).toBe('improving');
+  });
+
+  it('前半に関連タグ集中 → declining', () => {
+    const records = [
+      // 前半: 関連タグあり
+      mkRecord({ recordDate: '2024-01-01', behaviorTags: ['cooperation'] }),
+      mkRecord({ recordDate: '2024-01-02', behaviorTags: ['cooperation'] }),
+      // 後半: 関連タグなし
+      mkRecord({ recordDate: '2024-01-03' }),
+      mkRecord({ recordDate: '2024-01-04' }),
+    ];
+    const goals = [{ id: 'g1', domains: ['social'] }];
+    const result = buildMonitoringDailySummary(records, goals)!;
+    const gp = result.goalProgress![0];
+
+    expect(gp.trend).toBe('declining');
+  });
+
+  it('4件未満 → stable', () => {
+    const records = [
+      mkRecord({ recordDate: '2024-01-01', behaviorTags: ['cooperation'] }),
+      mkRecord({ recordDate: '2024-01-02' }),
+    ];
+    const goals = [{ id: 'g1', domains: ['social'] }];
+    const result = buildMonitoringDailySummary(records, goals)!;
+    const gp = result.goalProgress![0];
+
+    expect(gp.trend).toBe('stable');
+  });
+});
+
+// ─── Phase 3-B: buildMonitoringInsightText — goalProgress section ──
+
+describe('buildMonitoringInsightText — goalProgress section', () => {
+  it('goalProgress あり → 【目標進捗】セクションが含まれる', () => {
+    const records = [
+      mkRecord({
+        recordDate: '2024-01-01',
+        activities: { am: '散歩' },
+        lunchIntake: 'full',
+        behaviorTags: ['cooperation'],
+      }),
+      mkRecord({
+        recordDate: '2024-01-02',
+        activities: { am: '体操' },
+        lunchIntake: '80',
+        behaviorTags: ['verbalRequest'],
+      }),
+    ];
+    const goals = [{ id: 'g1', domains: ['social'] }];
+    const summary = buildMonitoringDailySummary(records, goals)!;
+    const lines = buildMonitoringInsightText(summary);
+    const goalLine = lines.find((l) => l.includes('【目標進捗】'));
+    expect(goalLine).toBeDefined();
+    expect(goalLine).toContain('g1');
+  });
+
+  it('goalProgress なし → 【目標進捗】セクションが含まれない', () => {
+    const records = [
+      mkRecord({
+        recordDate: '2024-01-01',
+        activities: { am: '散歩' },
+        lunchIntake: 'full',
+      }),
+    ];
+    const summary = buildMonitoringDailySummary(records)!;
+    const lines = buildMonitoringInsightText(summary);
+    expect(lines.some((l) => l.includes('【目標進捗】'))).toBe(false);
+  });
+
+  it('domain なし目標は「停滞」と表示される（記録はあるが関連タグなし）', () => {
+    const records = [
+      mkRecord({
+        recordDate: '2024-01-01',
+        activities: { am: '散歩' },
+        lunchIntake: 'full',
+      }),
+    ];
+    const goals = [{ id: 'g-nodomain' }]; // domain なし → matched 0, totalRecordCount > 0 → stagnant
+    const summary = buildMonitoringDailySummary(records, goals)!;
+    const lines = buildMonitoringInsightText(summary);
+    const goalLine = lines.find((l) => l.includes('【目標進捗】'));
+    expect(goalLine).toBeDefined();
+    expect(goalLine).toContain('停滞');
+  });
+});

--- a/src/features/monitoring/domain/monitoringDailyAnalytics.ts
+++ b/src/features/monitoring/domain/monitoringDailyAnalytics.ts
@@ -21,6 +21,10 @@ import type {
 
 import { BEHAVIOR_TAGS, type BehaviorTagKey, BEHAVIOR_TAG_CATEGORIES, type BehaviorTagCategory } from '@/features/daily/domain/behaviorTag';
 
+import type { GoalLike, GoalProgressSummary } from './goalProgressTypes';
+import { PROGRESS_LEVEL_LABELS } from './goalProgressTypes';
+import { inferGoalTagLinks, assessGoalProgress } from './goalProgressUtils';
+
 // ─── 型定義 ──────────────────────────────────────────────
 
 export interface PeriodSummary {
@@ -106,6 +110,8 @@ export interface DailyMonitoringSummary {
   behavior: BehaviorSummary;
   /** Phase 2: 行動タグ集計（タグ付き記録がない場合は null） */
   behaviorTagSummary: BehaviorTagSummary | null;
+  /** Phase 3: 目標ごとの進捗判定（goals 未指定時は undefined） */
+  goalProgress?: GoalProgressSummary[];
 }
 
 // ─── 定数 ────────────────────────────────────────────────
@@ -413,10 +419,108 @@ function computeTagUsageTrend(
   return { usageTrend: 'flat', usageTrendRate: changeRate };
 }
 
+// ─── 目標進捗の照合 ──────────────────────────────────────
+
+/**
+ * Goal の linkedCategories に該当する behaviorTags を持つ記録を照合し、
+ * GoalProgressSummary[] を返す。
+ *
+ * trend は既存の前半/後半比較ロジックを目標ごとに適用する。
+ */
+function computeGoalProgress(
+  records: DailyTableRecord[],
+  goals: GoalLike[],
+): GoalProgressSummary[] {
+  const links = inferGoalTagLinks(goals);
+
+  // 記録を日付順にソート（trend 計算用）
+  const sorted = [...records].sort((a, b) =>
+    a.recordDate.localeCompare(b.recordDate),
+  );
+  const mid = Math.floor(sorted.length / 2);
+  const firstHalf = sorted.slice(0, mid);
+  const secondHalf = sorted.slice(mid);
+
+  return links.map((link) => {
+    const cats = new Set(link.inferredCategories);
+    if (cats.size === 0) {
+      return assessGoalProgress({
+        goalId: link.goalId,
+        linkedCategories: [],
+        matchedRecordCount: 0,
+        matchedTagCount: 0,
+        totalRecordCount: records.length,
+        trend: 'stable',
+      });
+    }
+
+    // 記録ごとに「この goal に関連するタグを持つか」を判定
+    let matchedRecordCount = 0;
+    let matchedTagCount = 0;
+
+    for (const r of records) {
+      const tags = r.behaviorTags ?? [];
+      let recordMatched = false;
+      for (const tag of tags) {
+        const def = BEHAVIOR_TAGS[tag as BehaviorTagKey];
+        if (def && cats.has(def.category)) {
+          matchedTagCount++;
+          recordMatched = true;
+        }
+      }
+      if (recordMatched) matchedRecordCount++;
+    }
+
+    // trend: 前半/後半で matched 密度を比較
+    const countInHalf = (half: DailyTableRecord[]): number => {
+      let c = 0;
+      for (const r of half) {
+        for (const tag of r.behaviorTags ?? []) {
+          const def = BEHAVIOR_TAGS[tag as BehaviorTagKey];
+          if (def && cats.has(def.category)) {
+            c++;
+            break;
+          }
+        }
+      }
+      return c;
+    };
+
+    let trend: 'improving' | 'stable' | 'declining' = 'stable';
+    if (sorted.length >= 4) {
+      const firstRate =
+        firstHalf.length > 0 ? countInHalf(firstHalf) / firstHalf.length : 0;
+      const secondRate =
+        secondHalf.length > 0 ? countInHalf(secondHalf) / secondHalf.length : 0;
+      if (firstRate > 0) {
+        const changeRate = ((secondRate - firstRate) / firstRate) * 100;
+        if (changeRate > 10) trend = 'improving';
+        else if (changeRate < -10) trend = 'declining';
+      } else if (secondRate > 0) {
+        trend = 'improving';
+      }
+    }
+
+    return assessGoalProgress({
+      goalId: link.goalId,
+      linkedCategories: link.inferredCategories,
+      matchedRecordCount,
+      matchedTagCount,
+      totalRecordCount: records.length,
+      trend,
+    });
+  });
+}
+
 // ─── メイン集計 ──────────────────────────────────────────
 
+/**
+ * @param records 日次記録
+ * @param goals ISP 目標（省略時は goalProgress を算出しない）
+ */
 export function buildMonitoringDailySummary(
   records: DailyTableRecord[],
+  goals?: GoalLike[],
 ): DailyMonitoringSummary | null {
   if (records.length === 0) return null;
 
@@ -429,13 +533,20 @@ export function buildMonitoringDailySummary(
   const recordedDays = uniqueDates.size;
   const recordRate = totalDays > 0 ? Math.round((recordedDays / totalDays) * 100) : 0;
 
-  return {
+  const result: DailyMonitoringSummary = {
     period: { from, to, totalDays, recordedDays, recordRate },
     activity: aggregateActivities(records),
     lunch: aggregateLunch(records),
     behavior: aggregateBehaviors(records),
     behaviorTagSummary: aggregateBehaviorTags(records),
   };
+
+  // goals が渡されたときだけ goalProgress を算出
+  if (goals && goals.length > 0) {
+    result.goalProgress = computeGoalProgress(records, goals);
+  }
+
+  return result;
 }
 
 // ─── 所見ドラフト文生成 ──────────────────────────────────
@@ -519,6 +630,23 @@ export function buildMonitoringInsightText(
       `【行動タグ】${ts.taggedRecords}件の記録にタグ付与あり（付与率 ${ts.tagUsageRate}%、平均 ${ts.avgTagsPerRecord}個/記録）。` +
         `頻出タグ: ${topText}。カテゴリ別: ${catText}。${trendLabel}。`,
     );
+  }
+
+  // 目標進捗
+  if (summary.goalProgress && summary.goalProgress.length > 0) {
+    const progressTexts = summary.goalProgress.map((gp) => {
+      const levelLabel = PROGRESS_LEVEL_LABELS[gp.level];
+      const ratePercent = Math.round(gp.rate * 100);
+      if (gp.level === 'noData') {
+        return `目標(${gp.goalId}): 関連データなし、評価保留`;
+      }
+      return (
+        `目標(${gp.goalId}): ${levelLabel}` +
+        `（関連記録 ${gp.matchedRecordCount}件/${ratePercent}%、` +
+        `タグ ${gp.matchedTagCount}件）`
+      );
+    });
+    lines.push(`【目標進捗】${progressTexts.join('。')}。`);
   }
 
   return lines;

--- a/src/features/monitoring/hooks/useMonitoringDailyAnalytics.ts
+++ b/src/features/monitoring/hooks/useMonitoringDailyAnalytics.ts
@@ -14,6 +14,7 @@ import {
   buildMonitoringInsightText,
   type DailyMonitoringSummary,
 } from '../domain/monitoringDailyAnalytics';
+import type { GoalLike } from '../domain/goalProgressTypes';
 
 const DEFAULT_LOOKBACK_DAYS = 60;
 
@@ -40,10 +41,12 @@ export interface UseMonitoringDailyAnalyticsResult {
  * モニタリング集計 Hook
  * @param userId 対象ユーザーID
  * @param lookbackDays 遡り日数 (default: 60)
+ * @param goals ISP 目標（省略時は goalProgress を算出しない）
  */
 export function useMonitoringDailyAnalytics(
   userId: string,
   lookbackDays = DEFAULT_LOOKBACK_DAYS,
+  goals?: GoalLike[],
 ): UseMonitoringDailyAnalyticsResult {
   return useMemo(() => {
     if (!userId) {
@@ -52,10 +55,10 @@ export function useMonitoringDailyAnalytics(
 
     const range = computeDateRange(lookbackDays);
     const records = getDailyTableRecords(userId, range);
-    const summary = buildMonitoringDailySummary(records);
+    const summary = buildMonitoringDailySummary(records, goals);
     const insightLines = summary ? buildMonitoringInsightText(summary) : [];
     const insightText = insightLines.join('\n');
 
     return { summary, insightLines, insightText, recordCount: records.length };
-  }, [userId, lookbackDays]);
+  }, [userId, lookbackDays, goals]);
 }


### PR DESCRIPTION
## 概要
Phase 3-B: ISP 目標の進捗判定を既存の日次記録集計パイプラインに統合する。

## 背景
PR #931 (Phase 3-A) で定義した型・推論・判定の pure function を、
既存の `buildMonitoringDailySummary()` パイプラインに組み込む。

## 変更内容

### `monitoringDailyAnalytics.ts`
- `DailyMonitoringSummary` に `goalProgress?: GoalProgressSummary[]` を追加
- `buildMonitoringDailySummary(records, goals?)` — 第2引数 `goals?` を追加
  - **goals 未指定**: 既存動作そのまま（goalProgress = undefined）
  - **goals あり**: `computeGoalProgress()` を実行
- `computeGoalProgress()` — 内部ヘルパー
  - `inferGoalTagLinks()` で goal.domains → BehaviorTagCategory を推論
  - 記録の behaviorTags と照合し matchedRecordCount / matchedTagCount を計算
  - 前半/後半の密度比較で goal ごとの trend を算出
  - `assessGoalProgress()` で最終判定
- `buildMonitoringInsightText()` に【目標進捗】セクションを追加

### `useMonitoringDailyAnalytics.ts`
- `goals?` パラメータを追加（既存呼び出し側は変更不要）

### テスト（14件追加）
- goals 未指定 → undefined
- goals 空配列 → undefined
- social 目標の照合（positive/communication）
- cognitive 目標の照合（behavior）
- domain なし → stagnant
- 複数目標の独立計算
- タグなし → rate=0
- 既存フィールド不変の保証
- trend: improving / declining / stable
- insight text: 目標進捗セクションの有無

## Done 条件
- [x] `DailyMonitoringSummary` に `goalProgress` が追加される
- [x] `goals?` ありで `GoalProgressSummary[]` が返る
- [x] `goals?` なしで既存動作を壊さない
- [x] insight text に goal progress 文が追加できる
- [x] 既存テスト維持 + 新規14テスト追加（全78テスト pass）
- [x] 全5330テスト pass
- [x] TypeScript コンパイル通過

## テスト結果
```
Test Files  2 passed (2)
     Tests  78 passed (78)  ← monitoring domain
----
Test Files  500 passed | 5 skipped (505)
     Tests  5330 passed | 54 skipped (5385)  ← 全体
```