### PR TITLE
fix(monitoring): SharePoint API パス二重プレフィックス修正

### DIFF
--- a/src/features/monitoring/data/SharePointIspDecisionRepository.ts
+++ b/src/features/monitoring/data/SharePointIspDecisionRepository.ts
@@ -93,7 +93,8 @@ type SpResponse<T> = { value?: T[] };
 
 const buildListPath = (baseUrl: string): string => {
   const title = getListTitle();
-  return `${baseUrl}/_api/web/lists/GetByTitle('${encodeURIComponent(title)}')`;
+  // NOTE: ensureConfig().baseUrl already ends with "/_api/web"
+  return `${baseUrl}/lists/GetByTitle('${encodeURIComponent(title)}')`;
 };
 
 const readSpErrorMessage = async (response: Response): Promise<string> => {


### PR DESCRIPTION
## 問題

ensureConfig().baseUrl は既に /_api/web で終了しているが、buildListPath が再度 /_api/web を付与していた。

結果: .../_api/web/_api/web/lists/... → 404 エラー

## 修正

buildListPath から /_api/web プレフィックスを除去。

## テスト

- 163テスト全通過
- tsc / ESLint クリア
- 影響範囲: SharePointIspDecisionRepository.ts の1行のみ