### PR TITLE
feat(analysis): Phase 4-A/B1 — reverse trace for ABC evidence

### DIFF
--- a/src/domain/isp/__tests__/reverseTrace.spec.ts
+++ b/src/domain/isp/__tests__/reverseTrace.spec.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from 'vitest';
+
+import type { EvidenceLinkMap } from '@/domain/isp/evidenceLink';
+import { createEmptyEvidenceLinkMap } from '@/domain/isp/evidenceLink';
+import {
+  getStrategyUsagesForAbcRecord,
+  getStrategyUsagesForPdcaItem,
+  STRATEGY_LABELS,
+} from '@/domain/isp/reverseTrace';
+
+// ── Helpers ──
+
+function makeLinkMap(overrides: Partial<EvidenceLinkMap> = {}): EvidenceLinkMap {
+  return { ...createEmptyEvidenceLinkMap(), ...overrides };
+}
+
+function abcLink(refId: string) {
+  return { type: 'abc' as const, referenceId: refId, label: `ABC-${refId}`, linkedAt: '2026-03-15T10:00:00' };
+}
+
+function pdcaLink(refId: string) {
+  return { type: 'pdca' as const, referenceId: refId, label: `PDCA-${refId}`, linkedAt: '2026-03-15T10:00:00' };
+}
+
+// ── getStrategyUsagesForAbcRecord ──
+
+describe('getStrategyUsagesForAbcRecord', () => {
+  it('returns empty summary when no evidence link maps exist', () => {
+    const result = getStrategyUsagesForAbcRecord('abc-1', {});
+    expect(result.totalUsageCount).toBe(0);
+    expect(result.relatedSheetCount).toBe(0);
+    expect(result.usages).toEqual([]);
+    expect(result.byStrategy.antecedentStrategies).toBe(0);
+    expect(result.byStrategy.teachingStrategies).toBe(0);
+    expect(result.byStrategy.consequenceStrategies).toBe(0);
+  });
+
+  it('returns empty summary when ABC record is not referenced', () => {
+    const allMaps: Record<string, EvidenceLinkMap> = {
+      sheet1: makeLinkMap({
+        antecedentStrategies: [abcLink('abc-other')],
+      }),
+    };
+    const result = getStrategyUsagesForAbcRecord('abc-1', allMaps);
+    expect(result.totalUsageCount).toBe(0);
+    expect(result.relatedSheetCount).toBe(0);
+    expect(result.usages).toEqual([]);
+  });
+
+  it('finds single usage in one strategy', () => {
+    const allMaps: Record<string, EvidenceLinkMap> = {
+      sheet1: makeLinkMap({
+        antecedentStrategies: [abcLink('abc-1')],
+      }),
+    };
+
+    const result = getStrategyUsagesForAbcRecord('abc-1', allMaps);
+    expect(result.totalUsageCount).toBe(1);
+    expect(result.relatedSheetCount).toBe(1);
+    expect(result.byStrategy.antecedentStrategies).toBe(1);
+    expect(result.usages).toHaveLength(1);
+    expect(result.usages[0]).toEqual({
+      planningSheetId: 'sheet1',
+      strategy: 'antecedentStrategies',
+      strategyLabel: '先行事象戦略',
+      count: 1,
+    });
+  });
+
+  it('finds usages across multiple strategies in same sheet', () => {
+    const allMaps: Record<string, EvidenceLinkMap> = {
+      sheet1: makeLinkMap({
+        antecedentStrategies: [abcLink('abc-1')],
+        teachingStrategies: [abcLink('abc-1')],
+      }),
+    };
+
+    const result = getStrategyUsagesForAbcRecord('abc-1', allMaps);
+    expect(result.totalUsageCount).toBe(2);
+    expect(result.relatedSheetCount).toBe(1);
+    expect(result.byStrategy.antecedentStrategies).toBe(1);
+    expect(result.byStrategy.teachingStrategies).toBe(1);
+    expect(result.usages).toHaveLength(2);
+  });
+
+  it('finds usages across multiple sheets', () => {
+    const allMaps: Record<string, EvidenceLinkMap> = {
+      sheet1: makeLinkMap({
+        antecedentStrategies: [abcLink('abc-1')],
+      }),
+      sheet2: makeLinkMap({
+        consequenceStrategies: [abcLink('abc-1')],
+      }),
+    };
+
+    const result = getStrategyUsagesForAbcRecord('abc-1', allMaps);
+    expect(result.totalUsageCount).toBe(2);
+    expect(result.relatedSheetCount).toBe(2);
+    expect(result.byStrategy.antecedentStrategies).toBe(1);
+    expect(result.byStrategy.consequenceStrategies).toBe(1);
+    expect(result.usages).toHaveLength(2);
+  });
+
+  it('counts duplicates within same strategy correctly', () => {
+    const allMaps: Record<string, EvidenceLinkMap> = {
+      sheet1: makeLinkMap({
+        antecedentStrategies: [abcLink('abc-1'), abcLink('abc-1')],
+      }),
+    };
+
+    const result = getStrategyUsagesForAbcRecord('abc-1', allMaps);
+    expect(result.totalUsageCount).toBe(2);
+    expect(result.relatedSheetCount).toBe(1);
+    expect(result.usages[0].count).toBe(2);
+  });
+
+  it('ignores PDCA links when searching for ABC', () => {
+    const allMaps: Record<string, EvidenceLinkMap> = {
+      sheet1: makeLinkMap({
+        antecedentStrategies: [abcLink('abc-1'), pdcaLink('abc-1')],
+      }),
+    };
+
+    const result = getStrategyUsagesForAbcRecord('abc-1', allMaps);
+    expect(result.totalUsageCount).toBe(1);
+  });
+
+  it('sorts usages by count descending', () => {
+    const allMaps: Record<string, EvidenceLinkMap> = {
+      sheet1: makeLinkMap({
+        antecedentStrategies: [abcLink('abc-1')],
+      }),
+      sheet2: makeLinkMap({
+        teachingStrategies: [abcLink('abc-1'), abcLink('abc-1'), abcLink('abc-1')],
+      }),
+      sheet3: makeLinkMap({
+        consequenceStrategies: [abcLink('abc-1'), abcLink('abc-1')],
+      }),
+    };
+
+    const result = getStrategyUsagesForAbcRecord('abc-1', allMaps);
+    expect(result.usages[0].count).toBe(3);
+    expect(result.usages[1].count).toBe(2);
+    expect(result.usages[2].count).toBe(1);
+  });
+});
+
+// ── getStrategyUsagesForPdcaItem ──
+
+describe('getStrategyUsagesForPdcaItem', () => {
+  it('returns empty summary when no evidence link maps exist', () => {
+    const result = getStrategyUsagesForPdcaItem('pdca-1', {});
+    expect(result.totalUsageCount).toBe(0);
+    expect(result.relatedSheetCount).toBe(0);
+    expect(result.usages).toEqual([]);
+  });
+
+  it('finds PDCA usage across sheets', () => {
+    const allMaps: Record<string, EvidenceLinkMap> = {
+      sheet1: makeLinkMap({
+        antecedentStrategies: [pdcaLink('pdca-1')],
+      }),
+      sheet2: makeLinkMap({
+        consequenceStrategies: [pdcaLink('pdca-1'), pdcaLink('pdca-1')],
+      }),
+    };
+
+    const result = getStrategyUsagesForPdcaItem('pdca-1', allMaps);
+    expect(result.totalUsageCount).toBe(3);
+    expect(result.relatedSheetCount).toBe(2);
+    expect(result.byStrategy.antecedentStrategies).toBe(1);
+    expect(result.byStrategy.consequenceStrategies).toBe(2);
+  });
+
+  it('ignores ABC links when searching for PDCA', () => {
+    const allMaps: Record<string, EvidenceLinkMap> = {
+      sheet1: makeLinkMap({
+        antecedentStrategies: [pdcaLink('pdca-1'), abcLink('pdca-1')],
+      }),
+    };
+
+    const result = getStrategyUsagesForPdcaItem('pdca-1', allMaps);
+    expect(result.totalUsageCount).toBe(1);
+  });
+});
+
+// ── STRATEGY_LABELS ──
+
+describe('STRATEGY_LABELS', () => {
+  it('has Japanese labels for all strategies', () => {
+    expect(STRATEGY_LABELS.antecedentStrategies).toBe('先行事象戦略');
+    expect(STRATEGY_LABELS.teachingStrategies).toBe('教授戦略');
+    expect(STRATEGY_LABELS.consequenceStrategies).toBe('後続事象戦略');
+  });
+});

--- a/src/domain/isp/reverseTrace.ts
+++ b/src/domain/isp/reverseTrace.ts
@@ -1,0 +1,140 @@
+/**
+ * reverseTrace — Evidence Reverse Trace (Phase 4)
+ *
+ * ABC記録やPDCA項目から「どの支援計画の、どの戦略で採用されているか」を
+ * 逆引きする pure functions。
+ *
+ * 双方向トレーサビリティの基盤:
+ *   ABC/PDCA → 採用戦略の逆引き
+ *   支援計画 → 根拠の順引き（既存: evidenceLink.ts）
+ *
+ * @module domain/isp/reverseTrace
+ */
+
+import type { EvidenceLinkMap, StrategyEvidenceKey } from './evidenceLink';
+
+// ─────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────
+
+/** 逆引き結果1件: どの planningSheet の、どの戦略で採用されているか */
+export interface StrategyUsage {
+  /** 支援計画シート ID */
+  planningSheetId: string;
+  /** 戦略キー */
+  strategy: StrategyEvidenceKey;
+  /** 戦略の日本語ラベル */
+  strategyLabel: string;
+  /** 同一シート×同一戦略での採用回数 */
+  count: number;
+}
+
+/** 逆引きサマリー: 戦略別の合計 + 詳細リスト */
+export interface StrategyUsageSummary {
+  /** 採用されている戦略ごとの合計件数 */
+  byStrategy: Record<StrategyEvidenceKey, number>;
+  /** 関連する支援計画シートの件数 */
+  relatedSheetCount: number;
+  /** 全採用回数の合計 */
+  totalUsageCount: number;
+  /** 詳細: planningSheet × strategy ごとの採用情報（count 降順） */
+  usages: StrategyUsage[];
+}
+
+// ─────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────
+
+const STRATEGY_KEYS: StrategyEvidenceKey[] = [
+  'antecedentStrategies',
+  'teachingStrategies',
+  'consequenceStrategies',
+];
+
+export const STRATEGY_LABELS: Record<StrategyEvidenceKey, string> = {
+  antecedentStrategies: '先行事象戦略',
+  teachingStrategies: '教授戦略',
+  consequenceStrategies: '後続事象戦略',
+};
+
+// ─────────────────────────────────────────────
+// Core functions
+// ─────────────────────────────────────────────
+
+/**
+ * 指定された ABC 記録 ID がどの支援計画の、どの戦略で採用されているかを逆引きする。
+ *
+ * @param abcRecordId - 逆引き対象の ABC 記録 ID
+ * @param allEvidenceLinkMaps - 全 planningSheet の EvidenceLinkMap（key = planningSheetId）
+ * @returns 戦略別の合計 + 詳細リスト
+ */
+export function getStrategyUsagesForAbcRecord(
+  abcRecordId: string,
+  allEvidenceLinkMaps: Record<string, EvidenceLinkMap>,
+): StrategyUsageSummary {
+  return getStrategyUsages(abcRecordId, 'abc', allEvidenceLinkMaps);
+}
+
+/**
+ * 指定された PDCA 項目 ID がどの支援計画の、どの戦略で採用されているかを逆引きする。
+ *
+ * @param pdcaItemId - 逆引き対象の PDCA 項目 ID
+ * @param allEvidenceLinkMaps - 全 planningSheet の EvidenceLinkMap（key = planningSheetId）
+ * @returns 戦略別の合計 + 詳細リスト
+ */
+export function getStrategyUsagesForPdcaItem(
+  pdcaItemId: string,
+  allEvidenceLinkMaps: Record<string, EvidenceLinkMap>,
+): StrategyUsageSummary {
+  return getStrategyUsages(pdcaItemId, 'pdca', allEvidenceLinkMaps);
+}
+
+// ─────────────────────────────────────────────
+// Internal
+// ─────────────────────────────────────────────
+
+/**
+ * 内部実装: referenceId + type で逆引きを実行する汎用関数
+ */
+function getStrategyUsages(
+  referenceId: string,
+  type: 'abc' | 'pdca',
+  allEvidenceLinkMaps: Record<string, EvidenceLinkMap>,
+): StrategyUsageSummary {
+  const usages: StrategyUsage[] = [];
+  const byStrategy: Record<StrategyEvidenceKey, number> = {
+    antecedentStrategies: 0,
+    teachingStrategies: 0,
+    consequenceStrategies: 0,
+  };
+  const relatedSheets = new Set<string>();
+
+  for (const [sheetId, linkMap] of Object.entries(allEvidenceLinkMaps)) {
+    for (const strategyKey of STRATEGY_KEYS) {
+      const matchCount = linkMap[strategyKey].filter(
+        link => link.type === type && link.referenceId === referenceId
+      ).length;
+
+      if (matchCount > 0) {
+        usages.push({
+          planningSheetId: sheetId,
+          strategy: strategyKey,
+          strategyLabel: STRATEGY_LABELS[strategyKey],
+          count: matchCount,
+        });
+        byStrategy[strategyKey] += matchCount;
+        relatedSheets.add(sheetId);
+      }
+    }
+  }
+
+  // count 降順でソート
+  usages.sort((a, b) => b.count - a.count);
+
+  return {
+    byStrategy,
+    relatedSheetCount: relatedSheets.size,
+    totalUsageCount: usages.reduce((sum, u) => sum + u.count, 0),
+    usages,
+  };
+}

--- a/src/pages/AbcRecordPage.tsx
+++ b/src/pages/AbcRecordPage.tsx
@@ -37,6 +37,7 @@ import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 
 // ── Icons ──
+import AccountTreeRoundedIcon from '@mui/icons-material/AccountTreeRounded';
 import AddCircleOutlineRoundedIcon from '@mui/icons-material/AddCircleOutlineRounded';
 import ArrowBackRoundedIcon from '@mui/icons-material/ArrowBackRounded';
 import BubbleChartRoundedIcon from '@mui/icons-material/BubbleChartRounded';
@@ -51,6 +52,9 @@ import type { AbcRecord, AbcRecordCreateInput } from '@/domain/abc/abcRecord';
 import { ABC_INTENSITY_VALUES, ABC_INTENSITY_DISPLAY } from '@/domain/abc/abcRecord';
 import type { AbcIntensity } from '@/domain/abc/abcRecord';
 import { localAbcRecordRepository } from '@/infra/localStorage/localAbcRecordRepository';
+import { localEvidenceLinkRepository } from '@/infra/localStorage/localEvidenceLinkRepository';
+import { getStrategyUsagesForAbcRecord } from '@/domain/isp/reverseTrace';
+import type { StrategyUsageSummary } from '@/domain/isp/reverseTrace';
 import { useUsersDemo } from '@/features/users/usersStoreDemo';
 import { useAuth } from '@/auth/useAuth';
 
@@ -459,6 +463,19 @@ const LogTab: React.FC<{
   const [editForm, setEditForm] = useState<Partial<AbcRecord>>({});
   const [editSaving, setEditSaving] = useState(false);
 
+  // ── Reverse Trace (Phase 4) ──
+  const [reverseTrace, setReverseTrace] = useState<StrategyUsageSummary | null>(null);
+
+  useEffect(() => {
+    if (detailRecord && !isEditing) {
+      const allMaps = localEvidenceLinkRepository.getAll();
+      const summary = getStrategyUsagesForAbcRecord(detailRecord.id, allMaps);
+      setReverseTrace(summary);
+    } else {
+      setReverseTrace(null);
+    }
+  }, [detailRecord, isEditing]);
+
   const allTags = useMemo(() => {
     const tagSet = new Set<string>();
     records.forEach(r => r.tags.forEach(t => tagSet.add(t)));
@@ -692,6 +709,104 @@ const LogTab: React.FC<{
                       <Typography variant="subtitle2" color="text.secondary">メモ</Typography>
                       <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>{detailRecord.notes}</Typography>
                     </Box>
+                  )}
+                  {/* ── Reverse Trace: このABCが使われている支援 ── */}
+                  {reverseTrace && reverseTrace.totalUsageCount > 0 && (
+                    <>
+                      <Divider />
+                      <Box>
+                        <Stack direction="row" spacing={0.75} alignItems="center" sx={{ mb: 1 }}>
+                          <AccountTreeRoundedIcon fontSize="small" color="primary" />
+                          <Typography variant="subtitle2" fontWeight={700} color="primary.main">
+                            このABCが使われている支援
+                          </Typography>
+                          <Chip
+                            label={`${reverseTrace.totalUsageCount}件`}
+                            size="small"
+                            color="primary"
+                            variant="outlined"
+                            sx={{ height: 20, fontSize: '0.65rem' }}
+                          />
+                        </Stack>
+                        <Stack spacing={0.75}>
+                          {reverseTrace.usages.map((usage, idx) => (
+                            <Paper
+                              key={`${usage.planningSheetId}-${usage.strategy}-${idx}`}
+                              variant="outlined"
+                              sx={{
+                                px: 1.5, py: 0.75,
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: 1,
+                                borderLeftWidth: 3,
+                                borderLeftColor: usage.strategy === 'antecedentStrategies'
+                                  ? 'info.main'
+                                  : usage.strategy === 'teachingStrategies'
+                                    ? 'success.main'
+                                    : 'warning.main',
+                              }}
+                            >
+                              <Chip
+                                label={usage.strategyLabel}
+                                size="small"
+                                variant="filled"
+                                color={
+                                  usage.strategy === 'antecedentStrategies'
+                                    ? 'info'
+                                    : usage.strategy === 'teachingStrategies'
+                                      ? 'success'
+                                      : 'warning'
+                                }
+                                sx={{ height: 22, fontSize: '0.7rem', fontWeight: 600 }}
+                              />
+                              <Typography variant="body2" color="text.secondary" sx={{ flex: 1 }}>
+                                支援計画シート: {usage.planningSheetId.slice(0, 12)}…
+                              </Typography>
+                              {usage.count > 1 && (
+                                <Chip
+                                  label={`×${usage.count}`}
+                                  size="small"
+                                  variant="outlined"
+                                  sx={{ height: 18, fontSize: '0.6rem' }}
+                                />
+                              )}
+                            </Paper>
+                          ))}
+                        </Stack>
+                        <Stack direction="row" spacing={1} sx={{ mt: 1 }}>
+                          {Object.entries(reverseTrace.byStrategy)
+                            .filter(([, count]) => count > 0)
+                            .map(([key, count]) => {
+                              const labels: Record<string, string> = {
+                                antecedentStrategies: '先行事象',
+                                teachingStrategies: '教授',
+                                consequenceStrategies: '後続事象',
+                              };
+                              return (
+                                <Typography key={key} variant="caption" color="text.secondary">
+                                  {labels[key]}（{count}件）
+                                </Typography>
+                              );
+                            })}
+                          <Typography variant="caption" color="text.secondary">
+                            関連支援計画: {reverseTrace.relatedSheetCount}件
+                          </Typography>
+                        </Stack>
+                      </Box>
+                    </>
+                  )}
+                  {reverseTrace && reverseTrace.totalUsageCount === 0 && (
+                    <>
+                      <Divider />
+                      <Box>
+                        <Stack direction="row" spacing={0.75} alignItems="center">
+                          <AccountTreeRoundedIcon fontSize="small" sx={{ color: 'text.disabled' }} />
+                          <Typography variant="body2" color="text.disabled">
+                            このABCはまだ支援計画に紐づけられていません
+                          </Typography>
+                        </Stack>
+                      </Box>
+                    </>
                   )}
                   <Typography variant="caption" color="text.secondary">
                     記録者: {detailRecord.recorderName} | 作成: {new Date(detailRecord.createdAt).toLocaleString('ja-JP')}


### PR DESCRIPTION
## Phase 4: Evidence Reverse Trace — A/B1

### 概要
ABC記録から**どの支援計画の、どの戦略で採用されているか**を逆引きする機能を追加。
これにより、根拠→設計の双方向トレーサビリティの基盤が完成。

### 変更内容

#### Pure Functions (everseTrace.ts)
- getStrategyUsagesForAbcRecord() — ABC → 採用戦略の逆引き
- getStrategyUsagesForPdcaItem() — PDCA → 採用戦略の逆引き（Phase 4-A2 で UI 接続予定）
- StrategyUsageSummary 型: 戦略別合計 + 詳細リスト

#### UI (AbcRecordPage.tsx)
- 詳細ダイアログに「このABCが使われている支援」セクション追加
- 色分けされた戦略 Chip（先行事象=info, 教授=success, 後続事象=warning）
- フッターに戦略別件数 + 関連支援計画シート数
- 未紐づけ時の空状態表示

#### テスト
- 12 テスト: 空マップ、未参照、単一使用、複数戦略、複数シート、重複カウント、型フィルタリング、ソート順

### Phase 4 ロードマップ
- [x] **A1/B1**: ABC逆引き pure functions + UI
- [ ] **A2/B2**: PDCA逆引き pure functions + IcebergPdcaPage UI
- [ ] **C**: 支援計画シート側のクリック導線（往復リンク）
