### PR TITLE
feat(planning-sheet): implement tokusei bridge core patch/candidate/provenance pipeline (PR2)

### DIFF
--- a/src/features/planning-sheet/__tests__/tokuseiToPlanningBridge.spec.ts
+++ b/src/features/planning-sheet/__tests__/tokuseiToPlanningBridge.spec.ts
@@ -284,3 +284,607 @@ describe('emptyNormalized', () => {
     }
   });
 });
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PR2: Builder Functions & Entry Point Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+import {
+  tokuseiToPlanningBridge,
+} from '../tokuseiToPlanningBridge';
+import type { TokuseiBridgeInput } from '../tokuseiToPlanningBridge';
+import {
+  buildAssessmentPatches,
+  buildAudit,
+  buildCandidates,
+  buildFormPatches,
+  buildIntakePatches,
+  buildProvenance,
+  summarizeTokuseiBridge,
+} from '../tokuseiBridgeBuilders';
+import type { ExtractedSignals } from '../tokuseiBridgeBuilders';
+import {
+  extractBehaviorSignals,
+  extractChangeRigiditySignals,
+  extractCommunicationSignals,
+  extractMedicalSignals,
+  extractSensorySignals,
+} from '../tokuseiSignalExtractors';
+
+// ---------------------------------------------------------------------------
+// Test Fixtures
+// ---------------------------------------------------------------------------
+
+/** 全フィールドが埋まった raw row */
+const RICH_RAW_ROW: SpTokuseiRawRow = {
+  Id: 1,
+  Hearing: '大きな音が苦手。イヤーマフを使用している',
+  Vision: '蛍光灯のちらつきが辛い',
+  Touch: 'タグ付きの服が着られない',
+  Smell: '',
+  Taste: '',
+  SensoryMultiSelect: '聴覚,触覚',
+  SensoryFreeText: '静かな環境を好む。サングラスも使用',
+  DifficultyWithChanges: '予定変更で泣いてしまう',
+  FixedHabits: '朝の準備は毎日同じ順番でないと混乱する',
+  RepetitiveBehaviors: '手をひらひらさせる',
+  InterestInParts: 'ミニカーのタイヤに注目する',
+  RelationalDifficulties: '初対面で緊張が強い',
+  SituationalUnderstanding: '言語指示だけでは理解しにくい',
+  ComprehensionDifficulty: '複雑な指示は伝わりにくい。絵カードなら理解できる',
+  ExpressionDifficulty: '言葉で気持ちを伝えるのが難しい。指差しで伝える',
+  InteractionDifficulty: '1対1なら落ち着いて話せる',
+  BehaviorMultiSelect: '自傷,他害,離席',
+  BehaviorEpisodes: '休憩の終わりに離席を拒否して壁を叩く。スケジュール提示で落ち着く',
+  Strengths: '手先が器用。パズルが得意',
+  Notes: 'てんかんの既往あり。服薬中。アレルギー（卵）あり',
+};
+
+/** 全signal を一括抽出するヘルパー */
+function extractAllSignals(normalized: ReturnType<typeof normalizeTokuseiFromRaw>): ExtractedSignals {
+  return {
+    sensory: extractSensorySignals(normalized),
+    communication: extractCommunicationSignals(normalized),
+    behavior: extractBehaviorSignals(normalized),
+    changeRigidity: extractChangeRigiditySignals(normalized),
+    medical: extractMedicalSignals(normalized),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// tokuseiToPlanningBridge (entry function)
+// ---------------------------------------------------------------------------
+
+describe('tokuseiToPlanningBridge (entry function)', () => {
+  it('should return empty result for all-empty input', () => {
+    const input: TokuseiBridgeInput = {
+      kind: 'raw',
+      row: { Id: 99 },
+      responseId: 'EMPTY-001',
+    };
+    const result = tokuseiToPlanningBridge(input);
+
+    expect(result.formPatches).toEqual({});
+    expect(result.intakePatches).toEqual({});
+    expect(result.assessmentPatches).toEqual({});
+    expect(result.candidates.targetBehaviors).toEqual([]);
+    expect(result.candidates.hypotheses).toEqual([]);
+    expect(result.candidates.abcEvents).toEqual([]);
+    expect(result.summary.icebergFieldsFilled).toBe(0);
+    expect(result.audit.sourceResponseId).toBe('EMPTY-001');
+  });
+
+  it('should process raw input and return full result', () => {
+    const input: TokuseiBridgeInput = {
+      kind: 'raw',
+      row: RICH_RAW_ROW,
+      responseId: 'RAW-001',
+      updatedAt: '2026-03-15T00:00:00Z',
+    };
+    const result = tokuseiToPlanningBridge(input);
+
+    // formPatches が入っている
+    expect(Object.keys(result.formPatches).length).toBeGreaterThan(0);
+    // intakePatches が入っている
+    expect(Object.keys(result.intakePatches).length).toBeGreaterThan(0);
+    // candidates が入っている
+    expect(result.candidates.targetBehaviors.length).toBeGreaterThan(0);
+    expect(result.candidates.hypotheses.length).toBeGreaterThan(0);
+    // provenance が入っている
+    expect(result.provenance.length).toBeGreaterThan(0);
+    // summary が集計されている
+    expect(result.summary.icebergFieldsFilled).toBeGreaterThan(0);
+    // audit の sourceResponseId
+    expect(result.audit.sourceResponseId).toBe('RAW-001');
+    expect(result.audit.sourceUpdatedAt).toBe('2026-03-15T00:00:00Z');
+    expect(result.audit.fieldsTouched.length).toBeGreaterThan(0);
+  });
+
+  it('should process aggregated input and include fallback warning', () => {
+    const input: TokuseiBridgeInput = {
+      kind: 'aggregated',
+      response: {
+        id: 1,
+        responseId: 'AGG-001',
+        responderName: 'テスト',
+        fillDate: '2026-03-15',
+        targetUserName: 'Aさん',
+        createdAt: '2026-03-15',
+        sensoryFeatures: '【聴覚】大きな音がパニックの原因',
+        behaviorFeatures: '【変化への対応困難】予定変更で泣く',
+        strengths: 'パズルが得意',
+        notes: 'てんかんあり',
+      },
+      responseId: 'AGG-001',
+    };
+    const result = tokuseiToPlanningBridge(input);
+
+    // aggregated fallback warning
+    expect(result.audit.warnings).toContain('集約データからの再分解のため、精度が限定的です');
+    // formPatches に何か入っている
+    expect(Object.keys(result.formPatches).length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildFormPatches
+// ---------------------------------------------------------------------------
+
+describe('buildFormPatches', () => {
+  it('should map hearing hypersensitivity to environmentFactors', () => {
+    const normalized = normalizeTokuseiFromRaw({
+      Id: 1,
+      Hearing: '大きな音が苦手',
+    });
+    const signals = extractAllSignals(normalized);
+    const patches = buildFormPatches(normalized, signals);
+
+    expect(patches.environmentFactors).toContain('聴覚');
+    expect(patches.environmentFactors).toContain('過敏');
+  });
+
+  it('should map difficultyWithChanges to triggers', () => {
+    const normalized = normalizeTokuseiFromRaw({
+      Id: 1,
+      DifficultyWithChanges: '予定変更で泣いてしまう',
+    });
+    const signals = extractAllSignals(normalized);
+    const patches = buildFormPatches(normalized, signals);
+
+    expect(patches.triggers).toContain('予定変更');
+  });
+
+  it('should map sensoryFreeText to environmentalAdjustment', () => {
+    const normalized = normalizeTokuseiFromRaw({
+      Id: 1,
+      Hearing: '音が苦手でイヤーマフ使用',
+      SensoryFreeText: '静かな環境を好む',
+    });
+    const signals = extractAllSignals(normalized);
+    const patches = buildFormPatches(normalized, signals);
+
+    expect(patches.environmentalAdjustment).toContain('感覚詳細');
+    expect(patches.environmentalAdjustment).toContain('静かな環境');
+  });
+
+  it('should map notes to teamConsensusNote', () => {
+    const normalized = normalizeTokuseiFromRaw({
+      Id: 1,
+      Notes: '保護者の希望あり',
+    });
+    const signals = extractAllSignals(normalized);
+    const patches = buildFormPatches(normalized, signals);
+
+    expect(patches.teamConsensusNote).toContain('保護者の希望');
+  });
+
+  it('should map strengths to reinforcementMethod', () => {
+    const normalized = normalizeTokuseiFromRaw({
+      Id: 1,
+      Strengths: '手先が器用',
+      InterestInParts: 'ミニカーのタイヤ',
+    });
+    const signals = extractAllSignals(normalized);
+    const patches = buildFormPatches(normalized, signals);
+
+    expect(patches.reinforcementMethod).toContain('得意なこと');
+    expect(patches.reinforcementMethod).toContain('手先が器用');
+    expect(patches.reinforcementMethod).toContain('興味の対象');
+  });
+
+  it('should return empty object for empty input', () => {
+    const normalized = emptyNormalized();
+    const signals = extractAllSignals(normalized);
+    const patches = buildFormPatches(normalized, signals);
+
+    expect(patches).toEqual({});
+  });
+
+  it('should map relationalDifficulties to emotions', () => {
+    const normalized = normalizeTokuseiFromRaw({
+      Id: 1,
+      RelationalDifficulties: '初対面で緊張が強い',
+    });
+    const signals = extractAllSignals(normalized);
+    const patches = buildFormPatches(normalized, signals);
+
+    expect(patches.emotions).toContain('対人関係');
+  });
+
+  it('should map situationalUnderstanding to cognition', () => {
+    const normalized = normalizeTokuseiFromRaw({
+      Id: 1,
+      SituationalUnderstanding: '言語指示だけでは理解しにくい',
+    });
+    const signals = extractAllSignals(normalized);
+    const patches = buildFormPatches(normalized, signals);
+
+    expect(patches.cognition).toContain('状況理解');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildIntakePatches
+// ---------------------------------------------------------------------------
+
+describe('buildIntakePatches', () => {
+  it('should extract sensoryTriggers from hypersensitivity', () => {
+    const normalized = normalizeTokuseiFromRaw({
+      Id: 1,
+      Hearing: '大きな音が苦手',
+      Touch: 'タグ付きの服が着られない',
+    });
+    const signals = extractAllSignals(normalized);
+    const patches = buildIntakePatches(normalized, signals);
+
+    expect(patches.sensoryTriggers).toContain('聴覚過敏');
+    expect(patches.sensoryTriggers).toContain('触覚過敏');
+  });
+
+  it('should extract communicationModes from difficulties', () => {
+    const normalized = normalizeTokuseiFromRaw({
+      Id: 1,
+      ComprehensionDifficulty: '絵カードなら理解できる',
+      ExpressionDifficulty: '指差しで伝える',
+    });
+    const signals = extractAllSignals(normalized);
+    const patches = buildIntakePatches(normalized, signals);
+
+    expect(patches.communicationModes).toContain('視覚支援（絵カード）');
+    expect(patches.communicationModes).toContain('ジェスチャー（指差し）');
+  });
+
+  it('should extract presentingProblem from behavior labels', () => {
+    const normalized = normalizeTokuseiFromRaw({
+      Id: 1,
+      BehaviorMultiSelect: '自傷,他害,離席',
+    });
+    const signals = extractAllSignals(normalized);
+    const patches = buildIntakePatches(normalized, signals);
+
+    expect(patches.presentingProblem).toContain('自傷');
+    expect(patches.presentingProblem).toContain('他害');
+    expect(patches.presentingProblem).toContain('離席');
+  });
+
+  it('should extract medicalFlags from medical keywords', () => {
+    const normalized = normalizeTokuseiFromRaw({
+      Id: 1,
+      Notes: 'てんかんの既往あり。服薬中。アレルギーあり',
+    });
+    const signals = extractAllSignals(normalized);
+    const patches = buildIntakePatches(normalized, signals);
+
+    expect(patches.medicalFlags).toContain('てんかん');
+    expect(patches.medicalFlags).toContain('服薬');
+    expect(patches.medicalFlags).toContain('アレルギー');
+  });
+
+  it('should deduplicate communicationModes', () => {
+    const normalized = normalizeTokuseiFromRaw({
+      Id: 1,
+      ComprehensionDifficulty: '絵カードの提示',
+      ExpressionDifficulty: '絵カードで選ぶ',
+    });
+    const signals = extractAllSignals(normalized);
+    const patches = buildIntakePatches(normalized, signals);
+
+    const count = patches.communicationModes?.filter((m) => m === '視覚支援（絵カード）').length;
+    expect(count).toBe(1);
+  });
+
+  it('should return empty for empty signals', () => {
+    const normalized = emptyNormalized();
+    const signals = extractAllSignals(normalized);
+    const patches = buildIntakePatches(normalized, signals);
+
+    expect(Object.keys(patches)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildAssessmentPatches
+// ---------------------------------------------------------------------------
+
+describe('buildAssessmentPatches', () => {
+  it('should extract healthFactors from medical signals', () => {
+    const normalized = normalizeTokuseiFromRaw({
+      Id: 1,
+      Notes: 'てんかんの既往あり。アレルギー（卵）あり',
+    });
+    const signals = extractAllSignals(normalized);
+    const patches = buildAssessmentPatches(normalized, signals);
+
+    expect(patches.healthFactors).toBeDefined();
+    expect(patches.healthFactors!.length).toBeGreaterThan(0);
+    expect(patches.healthFactors!.some((f) => f.includes('てんかん'))).toBe(true);
+  });
+
+  it('should return empty for no medical signals', () => {
+    const normalized = normalizeTokuseiFromRaw({
+      Id: 1,
+      Hearing: '大きな音が苦手',
+    });
+    const signals = extractAllSignals(normalized);
+    const patches = buildAssessmentPatches(normalized, signals);
+
+    expect(Object.keys(patches)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildCandidates
+// ---------------------------------------------------------------------------
+
+describe('buildCandidates', () => {
+  it('should generate targetBehavior candidates from behavior episode', () => {
+    const normalized = normalizeTokuseiFromRaw({
+      Id: 1,
+      BehaviorMultiSelect: '自傷,他害',
+      BehaviorEpisodes: '休憩の終わりに壁を叩く。原因はスケジュール変更',
+    });
+    const signals = extractAllSignals(normalized);
+    const candidates = buildCandidates(normalized, signals);
+
+    expect(candidates.targetBehaviors.length).toBeGreaterThan(0);
+    expect(candidates.targetBehaviors.some((c) => c.name === '自傷')).toBe(true);
+    expect(candidates.targetBehaviors.some((c) => c.name === '他害')).toBe(true);
+  });
+
+  it('should generate hypotheses from communication difficulty', () => {
+    const normalized = normalizeTokuseiFromRaw({
+      Id: 1,
+      ComprehensionDifficulty: '複雑な指示は伝わりにくい',
+    });
+    const signals = extractAllSignals(normalized);
+    const candidates = buildCandidates(normalized, signals);
+
+    expect(candidates.hypotheses.length).toBeGreaterThan(0);
+    expect(candidates.hypotheses.some((h) => h.function.includes('コミュニケーション'))).toBe(true);
+  });
+
+  it('should generate hypotheses from sensory avoidance', () => {
+    const normalized = normalizeTokuseiFromRaw({
+      Id: 1,
+      Hearing: '大きな音が苦手でパニックになる',
+    });
+    const signals = extractAllSignals(normalized);
+    const candidates = buildCandidates(normalized, signals);
+
+    expect(candidates.hypotheses.some((h) => h.function.includes('聴覚過敏'))).toBe(true);
+  });
+
+  it('should generate abcEvent candidates from change difficulty', () => {
+    const normalized = normalizeTokuseiFromRaw({
+      Id: 1,
+      DifficultyWithChanges: '予定変更で泣いてしまう',
+    });
+    const signals = extractAllSignals(normalized);
+    const candidates = buildCandidates(normalized, signals);
+
+    expect(candidates.abcEvents.length).toBeGreaterThan(0);
+    expect(candidates.abcEvents[0].antecedent).toContain('予定変更');
+    expect(candidates.abcEvents[0].confidence).toBe('low');
+  });
+
+  it('should not include low confidence in patches', () => {
+    const normalized = normalizeTokuseiFromRaw({
+      Id: 1,
+      BehaviorEpisodes: '壁を叩く',
+    });
+    const signals = extractAllSignals(normalized);
+
+    // form patches should NOT include behavior episodes (low confidence)
+    const formPatches = buildFormPatches(normalized, signals);
+    expect(formPatches).not.toHaveProperty('targetBehavior');
+    expect(formPatches).not.toHaveProperty('targetBehaviors');
+
+    // but candidates should have it
+    const candidates = buildCandidates(normalized, signals);
+    expect(candidates.targetBehaviors.length).toBeGreaterThan(0);
+  });
+
+  it('should deduplicate candidates', () => {
+    const normalized = normalizeTokuseiFromRaw({
+      Id: 1,
+      BehaviorMultiSelect: '自傷,自傷,他害',
+    });
+    const signals = extractAllSignals(normalized);
+    const candidates = buildCandidates(normalized, signals);
+
+    const selfInjury = candidates.targetBehaviors.filter((c) => c.name === '自傷');
+    expect(selfInjury.length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildProvenance
+// ---------------------------------------------------------------------------
+
+describe('buildProvenance', () => {
+  it('should create provenance entries for touched fields', () => {
+    const normalized = normalizeTokuseiFromRaw(RICH_RAW_ROW);
+    const signals = extractAllSignals(normalized);
+    const formPatches = buildFormPatches(normalized, signals);
+    const intakePatches = buildIntakePatches(normalized, signals);
+    const assessmentPatches = buildAssessmentPatches(normalized, signals);
+    const candidates = buildCandidates(normalized, signals);
+
+    const provenance = buildProvenance(
+      formPatches,
+      intakePatches,
+      assessmentPatches,
+      candidates,
+      'TEST-001',
+      TOKUSEI_FIELD_MAP,
+    );
+
+    expect(provenance.length).toBeGreaterThan(0);
+    // All entries should have tokusei_survey source
+    for (const entry of provenance) {
+      expect(entry.source).toBe('tokusei_survey');
+    }
+    // formPatches keys should appear in provenance
+    const formFieldNames = provenance
+      .filter((p) => p.field.startsWith('formPatches.'))
+      .map((p) => p.field.replace('formPatches.', ''));
+    expect(formFieldNames).toContain('environmentFactors');
+  });
+
+  it('should include candidate provenance when candidates exist', () => {
+    const normalized = normalizeTokuseiFromRaw({
+      Id: 1,
+      BehaviorMultiSelect: '自傷',
+      BehaviorEpisodes: '壁を叩く',
+    });
+    const signals = extractAllSignals(normalized);
+    const candidates = buildCandidates(normalized, signals);
+    const provenance = buildProvenance({}, {}, {}, candidates, 'TEST', TOKUSEI_FIELD_MAP);
+
+    expect(provenance.some((p) => p.field === 'candidates.targetBehaviors')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// summarizeTokuseiBridge
+// ---------------------------------------------------------------------------
+
+describe('summarizeTokuseiBridge', () => {
+  it('should count iceberg fields correctly', () => {
+    const formPatches = {
+      environmentFactors: 'test',
+      triggers: 'test',
+      emotions: 'test',
+    };
+    const intakePatches = { sensoryTriggers: ['聴覚過敏'] };
+    const candidates = { targetBehaviors: [{ name: 'a', operationalDefinition: '', sourceText: '', confidence: 'low' as const }], hypotheses: [], abcEvents: [] };
+
+    const summary = summarizeTokuseiBridge(formPatches, intakePatches, candidates);
+
+    expect(summary.icebergFieldsFilled).toBe(3);
+    expect(summary.sensoryTriggersAdded).toBe(1);
+    expect(summary.targetBehaviorCandidates).toBe(1);
+    expect(summary.hypothesesGenerated).toBe(0);
+  });
+
+  it('should return zeros for empty patches', () => {
+    const summary = summarizeTokuseiBridge({}, {}, { targetBehaviors: [], hypotheses: [], abcEvents: [] });
+
+    expect(summary.icebergFieldsFilled).toBe(0);
+    expect(summary.sensoryTriggersAdded).toBe(0);
+    expect(summary.hypothesesGenerated).toBe(0);
+    expect(summary.targetBehaviorCandidates).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildAudit
+// ---------------------------------------------------------------------------
+
+describe('buildAudit', () => {
+  it('should include aggregated fallback warning', () => {
+    const normalized = emptyNormalized();
+    const audit = buildAudit(
+      'TEST', undefined, normalized, {}, {}, {},
+      { targetBehaviors: [], hypotheses: [], abcEvents: [] },
+      true,
+    );
+
+    expect(audit.warnings).toContain('集約データからの再分解のため、精度が限定的です');
+  });
+
+  it('should include warning when only low confidence candidates exist', () => {
+    const normalized = emptyNormalized();
+    const audit = buildAudit(
+      'TEST', undefined, normalized, {}, {}, {},
+      {
+        targetBehaviors: [{ name: 'a', operationalDefinition: '', sourceText: '', confidence: 'low' }],
+        hypotheses: [],
+        abcEvents: [],
+      },
+      false,
+    );
+
+    expect(audit.warnings).toContain('low confidence 候補のみで patch が空です');
+  });
+
+  it('should track touched fields', () => {
+    const normalized = normalizeTokuseiFromRaw(RICH_RAW_ROW);
+    const signals = extractAllSignals(normalized);
+    const formPatches = buildFormPatches(normalized, signals);
+    const intakePatches = buildIntakePatches(normalized, signals);
+    const assessmentPatches = buildAssessmentPatches(normalized, signals);
+    const candidates = buildCandidates(normalized, signals);
+
+    const audit = buildAudit(
+      'RAW-001', '2026-03-15',
+      normalized,
+      formPatches,
+      intakePatches,
+      assessmentPatches,
+      candidates,
+      false,
+    );
+
+    expect(audit.sourceResponseId).toBe('RAW-001');
+    expect(audit.fieldsTouched.length).toBeGreaterThan(0);
+    expect(audit.fieldsTouched.some((f) => f.startsWith('formPatches.'))).toBe(true);
+    expect(audit.fieldsTouched.some((f) => f.startsWith('intakePatches.'))).toBe(true);
+  });
+
+  it('should track skipped (empty) fields', () => {
+    const normalized = normalizeTokuseiFromRaw({
+      Id: 1,
+      Hearing: '音が苦手',
+      // 他は全部空
+    });
+    const audit = buildAudit(
+      'TEST', undefined, normalized, {}, {}, {},
+      { targetBehaviors: [], hypotheses: [], abcEvents: [] },
+      false,
+    );
+
+    // smell, taste, etc. should be skipped
+    expect(audit.skippedFields.length).toBeGreaterThan(0);
+    expect(audit.skippedFields).toContain('smell');
+    expect(audit.skippedFields).toContain('taste');
+    expect(audit.skippedFields).not.toContain('hearing');
+  });
+
+  it('should include operational definition warning', () => {
+    const normalized = normalizeTokuseiFromRaw({
+      Id: 1,
+      BehaviorMultiSelect: '自傷',
+      BehaviorEpisodes: '叩く',
+    });
+    const signals = extractAllSignals(normalized);
+    const candidates = buildCandidates(normalized, signals);
+
+    const audit = buildAudit(
+      'TEST', undefined, normalized, {}, {}, {}, candidates, false,
+    );
+
+    expect(audit.warnings.some((w) => w.includes('操作的定義は未確定'))).toBe(true);
+  });
+});
+

--- a/src/features/planning-sheet/tokuseiBridgeBuilders.ts
+++ b/src/features/planning-sheet/tokuseiBridgeBuilders.ts
@@ -1,0 +1,609 @@
+/**
+ * tokuseiBridgeBuilders.ts — 特性アンケート → 支援計画シート builder 群
+ *
+ * PR1 の signal extractors が返す「素材」を、
+ * 支援計画シートの各セクションに適した patch / candidate / provenance に変換する。
+ *
+ * 設計原則:
+ *  - 全関数が pure function（副作用なし）
+ *  - low confidence は patch に入れず candidate 側に寄せる
+ *  - 文字列結合は deterministic（安定順序）
+ *  - 重複除去を徹底する
+ *  - UI merge policy の実適用は行わない（audit/provenance で表現）
+ *
+ * @module
+ */
+import type { PlanningAssessment, PlanningIntake } from '@/domain/isp/schema';
+import type { TOKUSEI_FIELD_MAP } from './tokuseiFieldMap';
+import type {
+  AbcEventCandidate,
+  BehaviorHypothesisCandidate,
+  BridgeConfidence,
+  TargetBehaviorCandidate,
+  TokuseiBridgeAudit,
+  TokuseiBridgeResult,
+  TokuseiBridgeSummary,
+  TokuseiProvenanceEntry,
+  TokuseiSourceNormalized,
+} from './tokuseiToPlanningBridge';
+import type {
+  BehaviorSignal,
+  ChangeRigiditySignal,
+  CommunicationSignal,
+  MedicalSignal,
+  SensorySignal,
+} from './tokuseiSignalExtractors';
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Internal Types
+// ═══════════════════════════════════════════════════════════════════════════
+
+/** 全 signal を束ねた入力型 */
+export interface ExtractedSignals {
+  sensory: SensorySignal[];
+  communication: CommunicationSignal[];
+  behavior: BehaviorSignal | null;
+  changeRigidity: ChangeRigiditySignal[];
+  medical: MedicalSignal[];
+}
+
+/** TOKUSEI_FIELD_MAP の型参照用 */
+type FieldMapType = typeof TOKUSEI_FIELD_MAP;
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Internal Helpers
+// ═══════════════════════════════════════════════════════════════════════════
+
+/** 安定順序で重複除去した配列を返す */
+const dedupe = (arr: string[]): string[] => [...new Set(arr)];
+
+/** 空文字・undefined をフィルターする */
+const nonEmpty = (arr: (string | undefined)[]): string[] =>
+  arr.filter((v): v is string => !!v && v.trim().length > 0).map((v) => v.trim());
+
+/** 安定順序で文字列を結合（改行区切り、空行なし） */
+const joinLines = (lines: string[]): string =>
+  dedupe(nonEmpty(lines)).join('\n');
+
+/** 感覚レベルの日本語ラベル */
+const LEVEL_LABEL: Record<string, string> = {
+  hypersensitive: '過敏',
+  hyposensitive: '鈍麻',
+  typical: '標準',
+};
+
+/** 感覚の日本語名 */
+const SENSE_LABEL: Record<string, string> = {
+  hearing: '聴覚',
+  vision: '視覚',
+  touch: '触覚',
+  smell: '嗅覚',
+  taste: '味覚',
+};
+
+/** コミュニケーション種別の日本語名 */
+const COMM_LABEL: Record<string, string> = {
+  comprehension: '理解',
+  expression: '表出',
+  interaction: 'やり取り',
+};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 1. buildFormPatches
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * FormState (PlanningSheetFormValues) 向けのパッチを構築する。
+ *
+ * 出力は Record<string, string> 形式。
+ * UI 側で empty-only / append を適用する。
+ */
+export function buildFormPatches(
+  normalized: TokuseiSourceNormalized,
+  signals: ExtractedSignals,
+): Record<string, string> {
+  const patches: Record<string, string> = {};
+
+  // ── environmentFactors: 感覚過敏/鈍麻 ──
+  const envFactorLines: string[] = [];
+  for (const sig of signals.sensory) {
+    const label = SENSE_LABEL[sig.sense] ?? sig.sense;
+    const levelLabel = LEVEL_LABEL[sig.level] ?? '';
+    if (levelLabel) {
+      envFactorLines.push(`【${label}${levelLabel}】${sig.rawText}`);
+    } else if (sig.rawText) {
+      envFactorLines.push(`【${label}】${sig.rawText}`);
+    }
+  }
+  const envFactors = joinLines(envFactorLines);
+  if (envFactors) patches.environmentFactors = envFactors;
+
+  // ── triggers: 変化困難・固執 ──
+  const triggerLines: string[] = [];
+  for (const sig of signals.changeRigidity) {
+    if (sig.confidence !== 'low') {
+      const prefix = sig.kind === 'change-difficulty' ? '【予定変更等】' : '【こだわり】';
+      triggerLines.push(`${prefix}${sig.rawText}`);
+    }
+  }
+  const triggers = joinLines(triggerLines);
+  if (triggers) patches.triggers = triggers;
+
+  // ── emotions: 対人関係の難しさ ──
+  if (normalized.relationalDifficulties) {
+    patches.emotions = `【対人関係】${normalized.relationalDifficulties}`;
+  }
+
+  // ── cognition: 状況理解 ──
+  if (normalized.situationalUnderstanding) {
+    patches.cognition = `【状況理解】${normalized.situationalUnderstanding}`;
+  }
+
+  // ── behaviorFunctionDetail: コミュニケーション困難 ──
+  const bfdLines: string[] = [];
+  for (const sig of signals.communication) {
+    const kindLabel = COMM_LABEL[sig.kind] ?? sig.kind;
+    bfdLines.push(`【${kindLabel}の困難】${sig.rawText}`);
+  }
+  const bfd = joinLines(bfdLines);
+  if (bfd) patches.behaviorFunctionDetail = bfd;
+
+  // ── environmentalAdjustment: 感覚対処法 + sensoryFreeText ──
+  const adjLines: string[] = [];
+  for (const sig of signals.sensory) {
+    if (sig.copingStrategies.length > 0) {
+      const label = SENSE_LABEL[sig.sense] ?? sig.sense;
+      adjLines.push(`【${label}対処】${sig.copingStrategies.join('、')}`);
+    }
+  }
+  if (normalized.sensoryFreeText) {
+    adjLines.push(`【感覚詳細】${normalized.sensoryFreeText}`);
+  }
+  const adj = joinLines(adjLines);
+  if (adj) patches.environmentalAdjustment = adj;
+
+  // ── visualSupport: 繰り返し行動 → 見通し支援素材 ──
+  const vsLines: string[] = [];
+  for (const sig of signals.changeRigidity) {
+    if (sig.kind === 'repetitive-behavior' && sig.rawText) {
+      vsLines.push(`【繰り返し行動からの支援手がかり】${sig.rawText}`);
+    }
+  }
+  const vs = joinLines(vsLines);
+  if (vs) patches.visualSupport = vs;
+
+  // ── reinforcementMethod: 得意なこと・強み + 物の一部への興味 ──
+  const rmLines: string[] = [];
+  if (normalized.strengths) {
+    rmLines.push(`【得意なこと・強み】${normalized.strengths}`);
+  }
+  for (const sig of signals.changeRigidity) {
+    if (sig.kind === 'interest-in-parts' && sig.rawText) {
+      rmLines.push(`【興味の対象】${sig.rawText}`);
+    }
+  }
+  const rm = joinLines(rmLines);
+  if (rm) patches.reinforcementMethod = rm;
+
+  // ── teamConsensusNote: notes ──
+  if (normalized.notes) {
+    patches.teamConsensusNote = `【特性アンケート特記事項】${normalized.notes}`;
+  }
+
+  return patches;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 2. buildIntakePatches
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * PlanningIntake 向けのパッチを構築する。
+ * append-first 前提。追加候補として自然な値にする。
+ */
+export function buildIntakePatches(
+  _normalized: TokuseiSourceNormalized,
+  signals: ExtractedSignals,
+): Partial<PlanningIntake> {
+  const patches: Partial<PlanningIntake> = {};
+
+  // ── sensoryTriggers: 感覚過敏/鈍麻 ──
+  const triggers: string[] = [];
+  for (const sig of signals.sensory) {
+    if (sig.level === 'hypersensitive' || sig.level === 'hyposensitive') {
+      const label = SENSE_LABEL[sig.sense] ?? sig.sense;
+      const levelLabel = LEVEL_LABEL[sig.level] ?? '';
+      triggers.push(`${label}${levelLabel}`);
+    }
+  }
+  if (triggers.length > 0) {
+    patches.sensoryTriggers = dedupe(triggers);
+  }
+
+  // ── communicationModes: コミュニケーションモード ──
+  const modes: string[] = [];
+  for (const sig of signals.communication) {
+    modes.push(...sig.inferredModes);
+  }
+  const deduped = dedupe(modes);
+  if (deduped.length > 0) {
+    patches.communicationModes = deduped;
+  }
+
+  // ── presentingProblem: 行動ラベル要約 ──
+  if (signals.behavior && signals.behavior.labels.length > 0) {
+    patches.presentingProblem =
+      `【特性アンケート主訴】${dedupe(signals.behavior.labels).join('、')}`;
+  }
+
+  // ── medicalFlags: 医療キーワード ──
+  const flags: string[] = [];
+  for (const sig of signals.medical) {
+    flags.push(sig.keyword);
+  }
+  if (flags.length > 0) {
+    patches.medicalFlags = dedupe(flags);
+  }
+
+  return patches;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 3. buildAssessmentPatches
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * PlanningAssessment 向けのパッチを構築する。
+ *
+ * 原則として多くは candidate に寄せ、ここは限定的。
+ * 医療情報は高確度なので healthFactors に入れてよい。
+ */
+export function buildAssessmentPatches(
+  _normalized: TokuseiSourceNormalized,
+  signals: ExtractedSignals,
+): Partial<PlanningAssessment> {
+  const patches: Partial<PlanningAssessment> = {};
+
+  // ── healthFactors: 医療キーワード（高確度） ──
+  const healthFactors: string[] = [];
+  for (const sig of signals.medical) {
+    if (sig.confidence === 'high') {
+      healthFactors.push(`${sig.keyword}（${sig.context}）`);
+    }
+  }
+  if (healthFactors.length > 0) {
+    patches.healthFactors = dedupe(healthFactors);
+  }
+
+  return patches;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 4. buildCandidates
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * 確度 low / medium で解釈を伴う候補を構築する。
+ * UI で明示選択して初めて確定するデータ。
+ */
+export function buildCandidates(
+  _normalized: TokuseiSourceNormalized,
+  signals: ExtractedSignals,
+): TokuseiBridgeResult['candidates'] {
+  const targetBehaviors: TargetBehaviorCandidate[] = [];
+  const hypotheses: BehaviorHypothesisCandidate[] = [];
+  const abcEvents: AbcEventCandidate[] = [];
+
+  // ── targetBehaviors: 行動エピソード → 対象行動候補 ──
+  if (signals.behavior) {
+    const { labels, rawEpisode, operationalHints, confidence } = signals.behavior;
+
+    for (const label of dedupe(labels)) {
+      targetBehaviors.push({
+        name: label,
+        operationalDefinition: operationalHints.length > 0
+          ? operationalHints[0]
+          : '（操作的定義の補完が必要）',
+        sourceText: rawEpisode ?? label,
+        confidence,
+      });
+    }
+
+    // エピソード自体が操作的定義のヒントになる
+    if (rawEpisode && labels.length === 0) {
+      targetBehaviors.push({
+        name: '（行動エピソードからの候補）',
+        operationalDefinition: operationalHints.join('。'),
+        sourceText: rawEpisode,
+        confidence: 'low',
+      });
+    }
+  }
+
+  // ── hypotheses: コミュニケーション困難 → 仮説候補 ──
+  for (const sig of signals.communication) {
+    const kindLabel = COMM_LABEL[sig.kind] ?? sig.kind;
+    hypotheses.push({
+      function: `コミュニケーション（${kindLabel}）の困難による要求・回避`,
+      evidence: sig.rawText,
+      sourceText: sig.rawText,
+      confidence: sig.confidence,
+    });
+  }
+
+  // ── hypotheses: 感覚回避 → 仮説候補 ──
+  for (const sig of signals.sensory) {
+    if (sig.level === 'hypersensitive') {
+      const label = SENSE_LABEL[sig.sense] ?? sig.sense;
+      hypotheses.push({
+        function: `${label}過敏による感覚回避`,
+        evidence: sig.rawText,
+        sourceText: sig.rawText,
+        confidence: sig.confidence,
+      });
+    }
+  }
+
+  // ── abcEvents: 変化困難 → ABC テンプレート候補 ──
+  for (const sig of signals.changeRigidity) {
+    if (sig.kind === 'change-difficulty') {
+      abcEvents.push({
+        antecedent: `予定変更・環境変化: ${sig.rawText}`,
+        behavior: '（行動の特定が必要）',
+        consequence: '（結果の観察が必要）',
+        sourceText: sig.rawText,
+        confidence: 'low',
+      });
+    }
+  }
+
+  // 重複除去（name ベース）
+  const dedupeTargets = dedupeByKey(targetBehaviors, (c) => c.name);
+  const dedupeHypotheses = dedupeByKey(hypotheses, (c) => c.function);
+  const dedupeAbcEvents = dedupeByKey(abcEvents, (c) => c.antecedent);
+
+  return {
+    targetBehaviors: dedupeTargets,
+    hypotheses: dedupeHypotheses,
+    abcEvents: dedupeAbcEvents,
+  };
+}
+
+/** キーで重複除去するヘルパー */
+function dedupeByKey<T>(items: T[], keyFn: (item: T) => string): T[] {
+  const seen = new Set<string>();
+  return items.filter((item) => {
+    const key = keyFn(item);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 5. buildProvenance
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * 変換根拠の一覧を構築する。
+ * touched field ごとに provenance entry を作る。
+ */
+export function buildProvenance(
+  formPatches: Record<string, string>,
+  intakePatches: Partial<PlanningIntake>,
+  assessmentPatches: Partial<PlanningAssessment>,
+  candidates: TokuseiBridgeResult['candidates'],
+  sourceId: string,
+  fieldMap: FieldMapType,
+): TokuseiProvenanceEntry[] {
+  const now = new Date().toISOString();
+  const entries: TokuseiProvenanceEntry[] = [];
+
+  // form patches
+  for (const [field, value] of Object.entries(formPatches)) {
+    entries.push({
+      field: `formPatches.${field}`,
+      source: 'tokusei_survey',
+      sourceLabel: `特性アンケート`,
+      reason: buildReason(field, fieldMap),
+      value: truncate(value, 80),
+      confidence: getConfidenceForField(field, fieldMap),
+      importedAt: now,
+    });
+  }
+
+  // intake patches
+  for (const [field, value] of Object.entries(intakePatches)) {
+    const display = Array.isArray(value) ? (value as string[]).join(', ') : String(value);
+    entries.push({
+      field: `intakePatches.${field}`,
+      source: 'tokusei_survey',
+      sourceLabel: `特性アンケート`,
+      reason: `特性アンケートの回答から${field}を抽出`,
+      value: truncate(display, 80),
+      confidence: 'medium',
+      importedAt: now,
+    });
+  }
+
+  // assessment patches
+  for (const [field, value] of Object.entries(assessmentPatches)) {
+    const display = Array.isArray(value) ? (value as string[]).join(', ') : String(value);
+    entries.push({
+      field: `assessmentPatches.${field}`,
+      source: 'tokusei_survey',
+      sourceLabel: `特性アンケート`,
+      reason: `特性アンケートの回答から${field}を抽出`,
+      value: truncate(display, 80),
+      confidence: 'high',
+      importedAt: now,
+    });
+  }
+
+  // candidate fields
+  if (candidates.targetBehaviors.length > 0) {
+    entries.push({
+      field: 'candidates.targetBehaviors',
+      source: 'tokusei_survey',
+      sourceLabel: '特性アンケート',
+      reason: '行動エピソード・選択肢から対象行動候補を生成',
+      value: `${candidates.targetBehaviors.length}件の候補`,
+      confidence: 'low',
+      importedAt: now,
+    });
+  }
+  if (candidates.hypotheses.length > 0) {
+    entries.push({
+      field: 'candidates.hypotheses',
+      source: 'tokusei_survey',
+      sourceLabel: '特性アンケート',
+      reason: 'コミュニケーション困難・感覚回避から仮説候補を生成',
+      value: `${candidates.hypotheses.length}件の候補`,
+      confidence: 'low',
+      importedAt: now,
+    });
+  }
+  if (candidates.abcEvents.length > 0) {
+    entries.push({
+      field: 'candidates.abcEvents',
+      source: 'tokusei_survey',
+      sourceLabel: '特性アンケート',
+      reason: '変化困難からABCテンプレート候補を生成',
+      value: `${candidates.abcEvents.length}件の候補`,
+      confidence: 'low',
+      importedAt: now,
+    });
+  }
+
+  return entries;
+}
+
+/** フィールド名から変換理由を構築 */
+function buildReason(field: string, fieldMap: FieldMapType): string {
+  // fieldMap のエントリから sourceLabel を探す
+  for (const [, entry] of Object.entries(fieldMap)) {
+    if (entry.target === field) {
+      return `特性アンケート「${entry.sourceLabel}」から${field}へ転記`;
+    }
+  }
+  return `特性アンケートの回答から${field}を抽出`;
+}
+
+/** フィールド名から confidence を取得 */
+function getConfidenceForField(field: string, fieldMap: FieldMapType): BridgeConfidence {
+  for (const [, entry] of Object.entries(fieldMap)) {
+    if (entry.target === field) {
+      return entry.confidence;
+    }
+  }
+  return 'medium';
+}
+
+/** 文字列を指定長に切り詰める */
+function truncate(text: string, maxLen: number): string {
+  if (text.length <= maxLen) return text;
+  return text.slice(0, maxLen - 1) + '…';
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 6. summarizeTokuseiBridge
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * UI 表示用のサマリーを構築する。
+ */
+export function summarizeTokuseiBridge(
+  formPatches: Record<string, string>,
+  intakePatches: Partial<PlanningIntake>,
+  candidates: TokuseiBridgeResult['candidates'],
+): TokuseiBridgeSummary {
+  // §3 氷山分析フィールド
+  const icebergFields = [
+    'environmentFactors',
+    'triggers',
+    'emotions',
+    'cognition',
+  ];
+  const icebergFieldsFilled = icebergFields.filter((f) => f in formPatches).length;
+
+  const sensoryTriggersAdded = intakePatches.sensoryTriggers?.length ?? 0;
+
+  return {
+    icebergFieldsFilled,
+    sensoryTriggersAdded,
+    hypothesesGenerated: candidates.hypotheses.length,
+    targetBehaviorCandidates: candidates.targetBehaviors.length,
+  };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 7. buildAudit
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * 監査・ログ用の詳細情報を構築する。
+ */
+export function buildAudit(
+  sourceResponseId: string,
+  sourceUpdatedAt: string | undefined,
+  normalized: TokuseiSourceNormalized,
+  formPatches: Record<string, string>,
+  intakePatches: Partial<PlanningIntake>,
+  assessmentPatches: Partial<PlanningAssessment>,
+  candidates: TokuseiBridgeResult['candidates'],
+  isAggregatedFallback: boolean,
+): TokuseiBridgeAudit {
+  const fieldsTouched = [
+    ...Object.keys(formPatches).map((k) => `formPatches.${k}`),
+    ...Object.keys(intakePatches).map((k) => `intakePatches.${k}`),
+    ...Object.keys(assessmentPatches).map((k) => `assessmentPatches.${k}`),
+  ];
+
+  // スキップ判定: normalized で空だったフィールド
+  const allFields = Object.keys(normalized) as (keyof TokuseiSourceNormalized)[];
+  const skippedFields = allFields.filter((f) => !normalized[f]);
+
+  const warnings: string[] = [];
+
+  // 警告 1: aggregated fallback
+  if (isAggregatedFallback) {
+    warnings.push('集約データからの再分解のため、精度が限定的です');
+  }
+
+  // 警告 2: patch が空で候補のみ
+  if (Object.keys(formPatches).length === 0 && Object.keys(intakePatches).length === 0) {
+    if (
+      candidates.targetBehaviors.length > 0 ||
+      candidates.hypotheses.length > 0 ||
+      candidates.abcEvents.length > 0
+    ) {
+      warnings.push('low confidence 候補のみで patch が空です');
+    }
+  }
+
+  // 警告 3: 医療語検出あるが文脈不十分
+  const medicalInAssessment = assessmentPatches.healthFactors ?? [];
+  for (const hf of medicalInAssessment) {
+    if (hf.length < 10) {
+      warnings.push(`医療語は検出しましたが文脈が不十分: ${hf}`);
+    }
+  }
+
+  // 警告 4: 行動エピソードあるが操作的定義未確定
+  if (normalized.behaviorEpisodes && candidates.targetBehaviors.length > 0) {
+    const hasUndefined = candidates.targetBehaviors.some(
+      (c) => c.operationalDefinition.includes('操作的定義の補完'),
+    );
+    if (hasUndefined) {
+      warnings.push('行動エピソードはありますが操作的定義は未確定です');
+    }
+  }
+
+  return {
+    sourceResponseId,
+    sourceUpdatedAt,
+    fieldsTouched,
+    skippedFields: skippedFields.map(String),
+    warnings,
+  };
+}

--- a/src/features/planning-sheet/tokuseiToPlanningBridge.ts
+++ b/src/features/planning-sheet/tokuseiToPlanningBridge.ts
@@ -20,6 +20,24 @@ import type {
   PlanningIntake,
 } from '@/domain/isp/schema';
 import type { ProvenanceSource } from './assessmentBridge';
+import { TOKUSEI_FIELD_MAP } from './tokuseiFieldMap';
+import {
+  buildAssessmentPatches,
+  buildAudit,
+  buildCandidates,
+  buildFormPatches,
+  buildIntakePatches,
+  buildProvenance,
+  summarizeTokuseiBridge,
+} from './tokuseiBridgeBuilders';
+import type { ExtractedSignals } from './tokuseiBridgeBuilders';
+import {
+  extractBehaviorSignals,
+  extractChangeRigiditySignals,
+  extractCommunicationSignals,
+  extractMedicalSignals,
+  extractSensorySignals,
+} from './tokuseiSignalExtractors';
 
 // ---------------------------------------------------------------------------
 // Core Types
@@ -331,5 +349,86 @@ export function emptyBridgeResult(sourceResponseId = ''): TokuseiBridgeResult {
       skippedFields: [],
       warnings: [],
     },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Bridge Entry Point
+// ---------------------------------------------------------------------------
+
+/** ブリッジへの入力（raw / aggregated を自動判別） */
+export type TokuseiBridgeInput =
+  | { kind: 'raw'; row: SpTokuseiRawRow; responseId: string; updatedAt?: string }
+  | { kind: 'aggregated'; response: TokuseiSurveyResponse; responseId: string; updatedAt?: string };
+
+/**
+ * 特性アンケート → 支援計画シート データブリッジ エントリ関数。
+ *
+ * 1. 入力を正規化
+ * 2. signal extractors を実行
+ * 3. builder 群を実行
+ * 4. summary / provenance / audit を束ねて TokuseiBridgeResult を返す
+ *
+ * raw / aggregated の両経路をサポートする。
+ */
+export function tokuseiToPlanningBridge(input: TokuseiBridgeInput): TokuseiBridgeResult {
+  // 1. 正規化
+  const isAggregatedFallback = input.kind === 'aggregated';
+  const normalized = input.kind === 'raw'
+    ? normalizeTokuseiFromRaw(input.row)
+    : normalizeTokuseiFromAggregated(input.response);
+
+  // 全フィールド空チェック
+  const allEmpty = (Object.values(normalized) as string[]).every((v) => !v);
+  if (allEmpty) {
+    return emptyBridgeResult(input.responseId);
+  }
+
+  // 2. signal extractors 実行
+  const signals: ExtractedSignals = {
+    sensory: extractSensorySignals(normalized),
+    communication: extractCommunicationSignals(normalized),
+    behavior: extractBehaviorSignals(normalized),
+    changeRigidity: extractChangeRigiditySignals(normalized),
+    medical: extractMedicalSignals(normalized),
+  };
+
+  // 3. builder 群実行
+  const formPatches = buildFormPatches(normalized, signals);
+  const intakePatches = buildIntakePatches(normalized, signals);
+  const assessmentPatches = buildAssessmentPatches(normalized, signals);
+  const candidates = buildCandidates(normalized, signals);
+
+  // 4. 束ねる
+  const provenance = buildProvenance(
+    formPatches,
+    intakePatches,
+    assessmentPatches,
+    candidates,
+    input.responseId,
+    TOKUSEI_FIELD_MAP,
+  );
+
+  const summary = summarizeTokuseiBridge(formPatches, intakePatches, candidates);
+
+  const audit = buildAudit(
+    input.responseId,
+    input.updatedAt,
+    normalized,
+    formPatches,
+    intakePatches,
+    assessmentPatches,
+    candidates,
+    isAggregatedFallback,
+  );
+
+  return {
+    formPatches,
+    intakePatches,
+    assessmentPatches,
+    candidates,
+    provenance,
+    summary,
+    audit,
   };
 }


### PR DESCRIPTION
## 概要

PR1 (型・辞書・正規化・シグナル抽出) を土台にして、特性アンケート → 支援計画シート bridge 本体を実装。

## 追加ファイル

### `tokuseiBridgeBuilders.ts` (新規: 610行)
7つの pure builder 関数:
- **buildFormPatches()** — 感覚/変化困難/対人/認知 → 氷山分析+支援計画フィールド
- **buildIntakePatches()** — 感覚トリガー/コミュニケーションモード/主訴/医療フラグ
- **buildAssessmentPatches()** — 高確度医療情報 → healthFactors
- **buildCandidates()** — 低〜中確度データ → 対象行動/仮説/ABC候補 (ユーザー選択前提)
- **buildProvenance()** — 全 touched field のトレーサビリティ
- **summarizeTokuseiBridge()** — UI 表示用メトリクス集計
- **buildAudit()** — 監査ログ (touched/skipped/warnings)

### `tokuseiToPlanningBridge.ts` (更新)
- エントリ関数 `tokuseiToPlanningBridge()` を追加
- `TokuseiBridgeInput` 型 (raw/aggregated 自動判別)
- 正規化 → signal 抽出 → builder 実行 → 結果束ね の一括処理

### テスト (36 テスト追加, 合計 53 テスト)
- エントリ関数: 空入力 / raw 入力 / aggregated fallback
- buildFormPatches: 8 テスト (感覚→環境因子, 変化困難→トリガー, 対処法→環境調整, etc.)
- buildIntakePatches: 6 テスト (重複除去, 空入力, 医療フラグ)
- buildAssessmentPatches: 2 テスト
- buildCandidates: 6 テスト (重複除去, low confidence 分離)
- buildProvenance: 2 テスト
- summarizeTokuseiBridge: 2 テスト
- buildAudit: 5 テスト (aggregated warning, skipped fields, 操作的定義 warning)

## 設計原則

| 原則 | 実装 |
|------|------|
| 候補値優先 | low confidence → candidates, high のみ patch |
| pure function | 全関数が副作用なし |
| 重複除去 | dedupe / dedupeByKey で一貫 |
| トレーサビリティ | 全 touched field に provenance entry |
| 非破壊 | 既存 assessmentBridge.ts 変更なし |

## 今回やらないこと
- [ ] UI 統合 (TokuseiImportPreview.tsx)
- [ ] ImportAssessmentDialog 拡張
- [ ] Provenance badge

## 検証結果
- `tsc --noEmit` ✅
- `vitest run` 53/53 pass ✅
- lint + pre-commit hooks pass ✅
- 既存テスト 5914 pass (既存 failure 4件は無関係)