### PR TITLE
chore(sharepoint): P1 audit remediation — index runbook, PdfOutput_Log, field definitions

### DIFF
--- a/docs/runbooks/sharepoint-index-check.md
+++ b/docs/runbooks/sharepoint-index-check.md
@@ -1,0 +1,176 @@
+# SharePoint インデックス列 確認・追加手順
+
+> **目的**: 5,000件ビューしきい値超過を防止するため、高増加リストのフィルター列にインデックスを設定する
+> **作成日**: 2026-03-16
+> **由来**: SharePoint 構成監査 P1-1
+
+---
+
+## 1. 対象リスト
+
+| リスト名 | 年間想定件数 | 必須インデックス列 | 優先度 |
+|---|---|---|---|
+| DailyActivityRecords | ~60,000 | `UserCode`, `RecordDate` | 🔴 最優先 |
+| SupportRecord_Daily | ~7,500 | `cr013_personId`, `cr013_date` | 🟡 |
+| AttendanceDaily | ~7,500 | `UserCode`, `RecordDate`, `Key` | 🟡 |
+| ServiceProvisionRecords | ~7,500 | `EntryKey`, `UserCode`, `RecordDate` | 🟡 |
+| Transport_Log | ~15,000 | `UserCode`, `RecordDate`, `Title` | 🟡 |
+| SupportProcedureRecord_Daily | 可変 | `UserCode`, `RecordDate` | 🟡 |
+| Schedules | 可変 | `Date`, `MonthKey`, `ServiceType` | 🟢 |
+
+---
+
+## 2. 確認手順（PnP PowerShell）
+
+### 前提
+
+```powershell
+# PnP PowerShell モジュールのインストール（未インストールの場合）
+Install-Module PnP.PowerShell -Scope CurrentUser
+
+# サイトに接続
+Connect-PnPOnline -Url "https://<tenant>.sharepoint.com/sites/<site>" -Interactive
+```
+
+### 全対象リストのインデックス列を一括確認
+
+```powershell
+$targetLists = @(
+  @{ Name = 'DailyActivityRecords'; RequiredIndexes = @('UserCode', 'RecordDate') },
+  @{ Name = 'SupportRecord_Daily';  RequiredIndexes = @('cr013_personId', 'cr013_date') },
+  @{ Name = 'AttendanceDaily';      RequiredIndexes = @('UserCode', 'RecordDate', 'Key') },
+  @{ Name = 'ServiceProvisionRecords'; RequiredIndexes = @('EntryKey', 'UserCode', 'RecordDate') },
+  @{ Name = 'Transport_Log';        RequiredIndexes = @('UserCode', 'RecordDate', 'Title') },
+  @{ Name = 'SupportProcedureRecord_Daily'; RequiredIndexes = @('UserCode', 'RecordDate') },
+  @{ Name = 'Schedules';            RequiredIndexes = @('Date', 'MonthKey', 'ServiceType') }
+)
+
+foreach ($list in $targetLists) {
+  Write-Host "`n=== $($list.Name) ===" -ForegroundColor Cyan
+
+  try {
+    $fields = Get-PnPField -List $list.Name -ErrorAction Stop
+    $indexedFields = $fields | Where-Object { $_.Indexed -eq $true }
+
+    if ($indexedFields) {
+      Write-Host "  ✅ Indexed columns:" -ForegroundColor Green
+      $indexedFields | ForEach-Object {
+        Write-Host "    - $($_.InternalName) ($($_.Title))"
+      }
+    } else {
+      Write-Host "  ⚠️ No indexed columns found" -ForegroundColor Yellow
+    }
+
+    # 不足チェック
+    foreach ($required in $list.RequiredIndexes) {
+      $field = $fields | Where-Object { $_.InternalName -eq $required }
+      if (-not $field) {
+        Write-Host "  ❌ Column '$required' not found in list" -ForegroundColor Red
+      } elseif (-not $field.Indexed) {
+        Write-Host "  ⚠️ Column '$required' exists but NOT indexed" -ForegroundColor Yellow
+      }
+    }
+  } catch {
+    Write-Host "  ❌ List not found or access denied: $_" -ForegroundColor Red
+  }
+}
+```
+
+---
+
+## 3. インデックス追加手順
+
+### 個別追加
+
+```powershell
+# 例: DailyActivityRecords にインデックスを追加
+Set-PnPField -List "DailyActivityRecords" -Identity "UserCode" -Values @{Indexed=$true}
+Set-PnPField -List "DailyActivityRecords" -Identity "RecordDate" -Values @{Indexed=$true}
+```
+
+### 全対象リストに一括追加
+
+```powershell
+foreach ($list in $targetLists) {
+  Write-Host "`n=== $($list.Name) ===" -ForegroundColor Cyan
+
+  foreach ($fieldName in $list.RequiredIndexes) {
+    try {
+      $field = Get-PnPField -List $list.Name -Identity $fieldName -ErrorAction Stop
+
+      if (-not $field.Indexed) {
+        Set-PnPField -List $list.Name -Identity $fieldName -Values @{Indexed=$true}
+        Write-Host "  ✅ Indexed: $fieldName" -ForegroundColor Green
+      } else {
+        Write-Host "  ✅ Already indexed: $fieldName" -ForegroundColor DarkGreen
+      }
+    } catch {
+      Write-Host "  ⚠️ Skipped: $fieldName — $_" -ForegroundColor Yellow
+    }
+  }
+}
+```
+
+---
+
+## 4. Users_Master.UserID ユニーク制約（P1-4）
+
+### 確認
+
+```powershell
+$field = Get-PnPField -List "Users_Master" -Identity "UserID"
+Write-Host "UserID.EnforceUniqueValues = $($field.EnforceUniqueValues)"
+Write-Host "UserID.Indexed = $($field.Indexed)"
+```
+
+### 追加（重複データがないことを確認後）
+
+```powershell
+# ⚠️ 既存データに重複がある場合はエラーになります
+# 先に重複確認を行ってください
+
+# 重複確認
+$items = Get-PnPListItem -List "Users_Master" -Fields "UserID"
+$duplicates = $items | Group-Object { $_["UserID"] } | Where-Object { $_.Count -gt 1 }
+if ($duplicates) {
+  Write-Host "❌ Duplicate UserIDs found:" -ForegroundColor Red
+  $duplicates | ForEach-Object { Write-Host "  - $($_.Name): $($_.Count) items" }
+  Write-Host "Resolve duplicates before adding unique constraint" -ForegroundColor Yellow
+} else {
+  Write-Host "✅ No duplicates found. Adding unique constraint..." -ForegroundColor Green
+  Set-PnPField -List "Users_Master" -Identity "UserID" -Values @{
+    EnforceUniqueValues = $true
+    Indexed = $true
+  }
+  Write-Host "✅ Unique constraint added" -ForegroundColor Green
+}
+```
+
+---
+
+## 5. 確認後のチェックリスト
+
+- [ ] DailyActivityRecords: `UserCode` indexed
+- [ ] DailyActivityRecords: `RecordDate` indexed
+- [ ] SupportRecord_Daily: `cr013_personId` indexed
+- [ ] SupportRecord_Daily: `cr013_date` indexed
+- [ ] AttendanceDaily: `UserCode` indexed
+- [ ] AttendanceDaily: `RecordDate` indexed
+- [ ] AttendanceDaily: `Key` indexed
+- [ ] ServiceProvisionRecords: `EntryKey` indexed
+- [ ] ServiceProvisionRecords: `UserCode` indexed
+- [ ] ServiceProvisionRecords: `RecordDate` indexed
+- [ ] Transport_Log: `UserCode` indexed
+- [ ] Transport_Log: `RecordDate` indexed
+- [ ] SupportProcedureRecord_Daily: `UserCode` indexed
+- [ ] SupportProcedureRecord_Daily: `RecordDate` indexed
+- [ ] Users_Master: `UserID` EnforceUniqueValues + Indexed
+
+---
+
+## 6. 注意事項
+
+- インデックスは **列あたり最大20個** まで（SharePoint の制限）
+- ユニーク制約追加時、既存データに重複がある場合は **エラーになる**
+- インデックス追加後も既存の Filter Query は正常動作する（パフォーマンスが向上するのみ）
+- 5,000件を超えたリストで **非インデックス列をフィルターすると 400/500 エラー** が発生する

--- a/src/lib/env.schema.ts
+++ b/src/lib/env.schema.ts
@@ -88,6 +88,7 @@ export const envSchema = z.object({
   VITE_SP_LIST_ICEBERG_ANALYSIS: z.string().optional().default('Iceberg_Analysis'),
   VITE_SP_LIST_BILLING_ORDERS: z.string().optional(),
   VITE_SP_LIST_HOLIDAY_MASTER: z.string().optional().default('Holiday_Master'),
+  VITE_SP_LIST_PDF_OUTPUT_LOG: z.string().optional().default('PdfOutput_Log'),
   VITE_SP_HANDOFF_LIST_ID: z.string().optional(),
   VITE_SCHEDULES_LIST_TITLE: z.string().optional().default('Schedules'),
   VITE_SP_TENANT: z.string().optional(),

--- a/src/sharepoint/fields/dailyAttendanceFields.ts
+++ b/src/sharepoint/fields/dailyAttendanceFields.ts
@@ -1,0 +1,43 @@
+/**
+ * SharePoint フィールド定義 — Daily_Attendance
+ *
+ * 日次出欠記録リスト（読み取り専用）。
+ * 出欠管理の集約ビューとして、他リスト (AttendanceDaily 等) から参照されるマスタ的なリスト。
+ *
+ * 監査 P1-3 追加
+ *
+ * ⚠️ 実際の SP リスト列を PnP PowerShell で確認し、
+ *   下記の推定フィールドを実際の内部名に合わせて修正してください。
+ *
+ * ```powershell
+ * Get-PnPField -List "Daily_Attendance" | Format-Table InternalName, Title, TypeAsString -AutoSize
+ * ```
+ */
+
+export const DAILY_ATTENDANCE_LIST_TITLE = 'Daily_Attendance' as const;
+
+export const DAILY_ATTENDANCE_FIELDS = {
+  id: 'Id',
+  title: 'Title',
+  userCode: 'UserCode',
+  recordDate: 'RecordDate',
+  status: 'Status',           // Choice: present | absent | late | early-leave
+  checkInTime: 'CheckInTime',
+  checkOutTime: 'CheckOutTime',
+  note: 'Note',
+  created: 'Created',
+  modified: 'Modified',
+} as const;
+
+export const DAILY_ATTENDANCE_SELECT_FIELDS = [
+  DAILY_ATTENDANCE_FIELDS.id,
+  DAILY_ATTENDANCE_FIELDS.title,
+  DAILY_ATTENDANCE_FIELDS.userCode,
+  DAILY_ATTENDANCE_FIELDS.recordDate,
+  DAILY_ATTENDANCE_FIELDS.status,
+  DAILY_ATTENDANCE_FIELDS.checkInTime,
+  DAILY_ATTENDANCE_FIELDS.checkOutTime,
+  DAILY_ATTENDANCE_FIELDS.note,
+  DAILY_ATTENDANCE_FIELDS.created,
+  DAILY_ATTENDANCE_FIELDS.modified,
+] as const;

--- a/src/sharepoint/fields/index.ts
+++ b/src/sharepoint/fields/index.ts
@@ -125,6 +125,21 @@ export {
     buildTransportLogTitle, TRANSPORT_LOG_FIELDS, TRANSPORT_LOG_LIST_TITLE, TRANSPORT_LOG_SELECT_FIELDS
 } from './transportFields';
 
+// ── PdfOutput_Log (監査 P1-2 追加) ──
+export {
+    buildPdfOutputLogTitle, PDF_OUTPUT_LOG_FIELDS, PDF_OUTPUT_LOG_LIST_TITLE, PDF_OUTPUT_LOG_SELECT_FIELDS
+} from './pdfOutputLogFields';
+
+// ── NurseObservations (監査 P1-3 追加) ──
+export {
+    NURSE_OBSERVATIONS_FIELDS, NURSE_OBSERVATIONS_LIST_TITLE, NURSE_OBSERVATIONS_SELECT_FIELDS
+} from './nurseObservationFields';
+
+// ── Daily_Attendance (監査 P1-3 追加) ──
+export {
+    DAILY_ATTENDANCE_FIELDS, DAILY_ATTENDANCE_LIST_TITLE, DAILY_ATTENDANCE_SELECT_FIELDS
+} from './dailyAttendanceFields';
+
 // ──────────────────────────────────────────────────────────────
 // 統合 FIELD_MAP（後方互換用）
 //

--- a/src/sharepoint/fields/listRegistry.ts
+++ b/src/sharepoint/fields/listRegistry.ts
@@ -29,6 +29,10 @@ export enum ListKeys {
   PlanningSheetMaster = 'SupportPlanningSheet_Master',
   ProcedureRecordDaily = 'SupportProcedureRecord_Daily',
   HolidayMaster = 'Holiday_Master',
+  // ── P1-2/P1-3 追加 ──
+  PdfOutputLog = 'PdfOutput_Log',
+  NurseObservations = 'NurseObservations',
+  DailyAttendance = 'Daily_Attendance',
 }
 
 export const LIST_CONFIG: Record<ListKeys, { title: string }> = {
@@ -55,4 +59,8 @@ export const LIST_CONFIG: Record<ListKeys, { title: string }> = {
   [ListKeys.PlanningSheetMaster]: { title: 'SupportPlanningSheet_Master' },
   [ListKeys.ProcedureRecordDaily]: { title: 'SupportProcedureRecord_Daily' },
   [ListKeys.HolidayMaster]: { title: 'Holiday_Master' },
+  // ── P1-2/P1-3 追加 ──
+  [ListKeys.PdfOutputLog]: { title: 'PdfOutput_Log' },
+  [ListKeys.NurseObservations]: { title: 'NurseObservations' },
+  [ListKeys.DailyAttendance]: { title: 'Daily_Attendance' },
 };

--- a/src/sharepoint/fields/nurseObservationFields.ts
+++ b/src/sharepoint/fields/nurseObservationFields.ts
@@ -1,0 +1,55 @@
+/**
+ * SharePoint フィールド定義 — NurseObservations
+ *
+ * 看護観察記録リスト。バイタルサイン・食事量・排泄・特記事項を記録。
+ * オフラインキュー + IdempotencyKey による冪等性 upsert 対応。
+ *
+ * 監査 P1-3 追加
+ *
+ * @see src/features/nurse/sp/map.ts — ObservationListItem 型
+ */
+
+export const NURSE_OBSERVATIONS_LIST_TITLE = 'NurseObservations' as const;
+
+export const NURSE_OBSERVATIONS_FIELDS = {
+  id: 'Id',
+  title: 'Title',
+  userLookupId: 'UserLookupId',    // Lookup ID → Users_Master
+  observedAt: 'ObservedAt',         // ISO datetime
+  temperature: 'Temperature',       // number (℃)
+  pulse: 'Pulse',                   // number (bpm)
+  systolic: 'Systolic',             // number (mmHg) 収縮期血圧
+  diastolic: 'Diastolic',           // number (mmHg) 拡張期血圧
+  spo2: 'SpO2',                     // number (%)
+  weight: 'Weight',                 // number (kg)
+  memo: 'Memo',                     // text
+  tags: 'Tags',                     // text (comma-separated)
+  idempotencyKey: 'IdempotencyKey', // text (upsert 冪等キー)
+  source: 'Source',                 // text (app | offline-sync)
+  localTimeZone: 'LocalTimeZone',   // text (e.g. 'Asia/Tokyo')
+  createdBy: 'CreatedBy',           // text (UPN)
+  deviceId: 'DeviceId',             // text
+  vitalsJson: 'VitalsJson',         // text (JSON payload)
+  created: 'Created',
+  modified: 'Modified',
+} as const;
+
+export const NURSE_OBSERVATIONS_SELECT_FIELDS = [
+  NURSE_OBSERVATIONS_FIELDS.id,
+  NURSE_OBSERVATIONS_FIELDS.title,
+  NURSE_OBSERVATIONS_FIELDS.userLookupId,
+  NURSE_OBSERVATIONS_FIELDS.observedAt,
+  NURSE_OBSERVATIONS_FIELDS.temperature,
+  NURSE_OBSERVATIONS_FIELDS.pulse,
+  NURSE_OBSERVATIONS_FIELDS.systolic,
+  NURSE_OBSERVATIONS_FIELDS.diastolic,
+  NURSE_OBSERVATIONS_FIELDS.spo2,
+  NURSE_OBSERVATIONS_FIELDS.weight,
+  NURSE_OBSERVATIONS_FIELDS.memo,
+  NURSE_OBSERVATIONS_FIELDS.tags,
+  NURSE_OBSERVATIONS_FIELDS.idempotencyKey,
+  NURSE_OBSERVATIONS_FIELDS.source,
+  NURSE_OBSERVATIONS_FIELDS.vitalsJson,
+  NURSE_OBSERVATIONS_FIELDS.created,
+  NURSE_OBSERVATIONS_FIELDS.modified,
+] as const;

--- a/src/sharepoint/fields/pdfOutputLogFields.ts
+++ b/src/sharepoint/fields/pdfOutputLogFields.ts
@@ -1,0 +1,57 @@
+/**
+ * SharePoint フィールド定義 — PdfOutput_Log
+ *
+ * 帳票出力（PDF/Excel）の監査証跡を記録するリスト。
+ * Power Automate から自動記録、または手動出力時にアプリから記録。
+ *
+ * Title (複合キー): {OutputType}_{UserCode}_{TargetPeriod}
+ *   例: monthly-report_U001_2026-03
+ *
+ * 監査 P1-2 追加
+ */
+
+export const PDF_OUTPUT_LOG_LIST_TITLE = 'PdfOutput_Log' as const;
+
+export const PDF_OUTPUT_LOG_FIELDS = {
+  id: 'Id',
+  title: 'Title',              // composite key: {OutputType}_{UserCode}_{TargetPeriod}
+  outputType: 'OutputType',     // Choice: monthly-report | service-provision | isp | billing | attendance
+  userCode: 'UserCode',         // 対象利用者コード (Users_Master.UserID)
+  outputDate: 'OutputDate',     // 出力日 (ISO date)
+  targetPeriod: 'TargetPeriod', // 対象期間 (e.g. '2026-03')
+  fileName: 'FileName',         // 出力ファイル名
+  fileUrl: 'FileUrl',           // SharePoint ファイル URL
+  outputBy: 'OutputBy',         // 出力実行者 (UPN or StaffId)
+  status: 'Status',             // Choice: success | failed | pending
+  errorMessage: 'ErrorMessage', // エラー時のメッセージ
+  source: 'Source',             // Choice: power-automate | manual | scheduled
+  created: 'Created',
+  modified: 'Modified',
+} as const;
+
+export const PDF_OUTPUT_LOG_SELECT_FIELDS = [
+  PDF_OUTPUT_LOG_FIELDS.id,
+  PDF_OUTPUT_LOG_FIELDS.title,
+  PDF_OUTPUT_LOG_FIELDS.outputType,
+  PDF_OUTPUT_LOG_FIELDS.userCode,
+  PDF_OUTPUT_LOG_FIELDS.outputDate,
+  PDF_OUTPUT_LOG_FIELDS.targetPeriod,
+  PDF_OUTPUT_LOG_FIELDS.fileName,
+  PDF_OUTPUT_LOG_FIELDS.fileUrl,
+  PDF_OUTPUT_LOG_FIELDS.outputBy,
+  PDF_OUTPUT_LOG_FIELDS.status,
+  PDF_OUTPUT_LOG_FIELDS.source,
+  PDF_OUTPUT_LOG_FIELDS.created,
+  PDF_OUTPUT_LOG_FIELDS.modified,
+] as const;
+
+/**
+ * PdfOutput_Log の Title キーを生成する
+ */
+export function buildPdfOutputLogTitle(
+  outputType: string,
+  userCode: string,
+  targetPeriod: string,
+): string {
+  return `${outputType}_${userCode}_${targetPeriod}`;
+}

--- a/src/sharepoint/spListRegistry.ts
+++ b/src/sharepoint/spListRegistry.ts
@@ -1,5 +1,5 @@
 /**
- * SharePoint リスト レジストリ — 全32リストの Single Source of Truth
+ * SharePoint リスト レジストリ — 全33リストの Single Source of Truth
  *
  * 各エントリは以下を保持:
  * - key: プログラム内で使用するユニーク識別子
@@ -121,7 +121,7 @@ export const SP_LIST_REGISTRY: readonly SpListEntry[] = [
   {
     key: 'daily_attendance',
     displayName: '日次出欠',
-    resolve: () => envOr('VITE_SP_LIST_ATTENDANCE', 'Daily_Attendance'),
+    resolve: () => envOr('VITE_SP_LIST_ATTENDANCE', fromConfig(ListKeys.DailyAttendance)),
     operations: ['R'],
     category: 'attendance',
   },
@@ -278,7 +278,7 @@ export const SP_LIST_REGISTRY: readonly SpListEntry[] = [
   {
     key: 'nurse_observations',
     displayName: '看護観察記録',
-    resolve: () => envOr('VITE_SP_LIST_NURSE_OBSERVATION', 'NurseObservations'),
+    resolve: () => envOr('VITE_SP_LIST_NURSE_OBSERVATION', fromConfig(ListKeys.NurseObservations)),
     operations: ['R', 'W'],
     category: 'other',
   },
@@ -297,6 +297,13 @@ export const SP_LIST_REGISTRY: readonly SpListEntry[] = [
       return envVal ? `guid:${envVal}` : 'guid:00000000-0000-0000-0000-000000000003';
     },
     operations: ['R'],
+    category: 'other',
+  },
+  {
+    key: 'pdf_output_log',
+    displayName: '帳票出力ログ',
+    resolve: () => envOr('VITE_SP_LIST_PDF_OUTPUT_LOG', fromConfig(ListKeys.PdfOutputLog)),
+    operations: ['R', 'W'],
     category: 'other',
   },
 ] as const;


### PR DESCRIPTION
## SharePoint 構成監査 P1 是正

P0 是正 (PR #968) に続く P1 チケット4件の実装です。

### 変更内容

| チケット | 内容 | ファイル |
|---|---|---|
| **P1-1** | 高増加リスト7つのインデックス確認・追加の PnP PowerShell Runbook | `docs/runbooks/sharepoint-index-check.md` |
| **P1-2** | PdfOutput_Log フィールド定義 + レジストリ登録 + 環境変数追加 | `pdfOutputLogFields.ts` 他 |
| **P1-3** | NurseObservations / Daily_Attendance フィールド定義追加 | `nurseObservationFields.ts`, `dailyAttendanceFields.ts` |
| **P1-4** | Users_Master.UserID ユニーク制約確認手順 | P1-1 Runbook に含む |

### 追加された成果物

**新規ファイル:**
- `docs/runbooks/sharepoint-index-check.md` — インデックス確認 + ユニーク制約確認の手順書
- `src/sharepoint/fields/pdfOutputLogFields.ts` — 帳票出力ログのフィールド定義
- `src/sharepoint/fields/nurseObservationFields.ts` — 看護観察のフィールド定義
- `src/sharepoint/fields/dailyAttendanceFields.ts` — 日次出欠のフィールド定義

**変更ファイル:**
- `listRegistry.ts` — ListKeys 3件追加 (PdfOutputLog, NurseObservations, DailyAttendance)
- `spListRegistry.ts` — 1エントリ追加 (pdf_output_log) + nurse/attendance を fromConfig() 化
- `env.schema.ts` — VITE_SP_LIST_PDF_OUTPUT_LOG 追加
- `fields/index.ts` — re-export 3件追加

### レジストリ変更
- 登録リスト数: 32 → **33**

### テスト
- `src/sharepoint/` + `src/lib/` + `src/data/isp/` テスト: ✅ 13ファイル全件 passed
- typecheck: ✅ 新規エラーなし

### SP 管理画面での作業（別途必要）
- [ ] 各リストのインデックス列設定（Runbook の手順に従う）
- [ ] Users_Master.UserID のユニーク制約設定
- [ ] PdfOutput_Log リストの新規作成