### PR TITLE
refactor: fetchSp を spFetch の互換レイヤーに変換 (Phase 3-A)

### DIFF
--- a/src/lib/fetchSp.ts
+++ b/src/lib/fetchSp.ts
@@ -1,33 +1,78 @@
+/**
+ * fetchSp — SharePoint fetch 互換ラッパー
+ *
+ * @deprecated Phase 3-B で spClient.spFetch 直利用に移行予定。
+ *   新規コードでは import { useSP } from '@/lib/spClient' を使うこと。
+ *
+ * 内部実装は spFetch (createSpFetch) に完全委譲し、
+ * リトライ・mock・認証を SSOT で処理する。
+ * throwOnError: false により、従来通り Response を返す。
+ * (呼び出し側が response.ok を自前でチェックする既存パターンを維持)
+ */
 import { acquireSpAccessToken, getSharePointScopes } from '@/lib/msal';
+import { ensureConfig } from '@/lib/sp/config';
+import { createNormalizePath, createSpFetch } from '@/lib/sp/spFetch';
+import { getAppConfig, readEnv, type EnvRecord } from '@/lib/env';
 
-const DEFAULT_ACCEPT = 'application/json;odata=nometadata';
-const SHAREPOINT_SCOPES = getSharePointScopes();
+// ── Singleton (lazily initialized) ──────────────────────────────────────────
 
-const applyHeaders = (init: RequestInit): RequestInit => {
-  const headers = new Headers(init.headers ?? {});
-  if (!headers.has('Accept')) {
-    headers.set('Accept', DEFAULT_ACCEPT);
-  }
-  return { ...init, headers };
-};
+let _cachedFetch: ((path: string, init?: RequestInit) => Promise<Response>) | null = null;
 
+function getOrCreateSpFetch(): (path: string, init?: RequestInit) => Promise<Response> {
+  if (_cachedFetch) return _cachedFetch;
+
+  const { baseUrl } = ensureConfig();
+  const config = getAppConfig();
+  const envRecord: EnvRecord = { ...config } as EnvRecord;
+  const spSiteLegacy = readEnv('VITE_SP_SITE', '', envRecord);
+
+  const retrySettings = {
+    maxAttempts: Number(config.VITE_SP_RETRY_MAX) || 4,
+    baseDelay: Number(config.VITE_SP_RETRY_BASE_MS) || 400,
+    capDelay: Number(config.VITE_SP_RETRY_MAX_DELAY_MS) || 5000,
+  } as const;
+
+  const debugEnabled = !!config.VITE_AUDIT_DEBUG;
+
+  const normalizePath = createNormalizePath(envRecord, spSiteLegacy, baseUrl);
+
+  const scopes = getSharePointScopes();
+  const acquireToken = async (): Promise<string | null> => {
+    try {
+      return await acquireSpAccessToken(scopes.length ? scopes : getSharePointScopes());
+    } catch {
+      return null;
+    }
+  };
+
+  const rawSpFetch = createSpFetch({
+    acquireToken,
+    baseUrl,
+    config: envRecord,
+    retrySettings,
+    debugEnabled,
+    spSiteLegacy,
+    throwOnError: false, // ← 互換: Response をそのまま返す
+  });
+
+  // spClient と同じ normalizePath → rawSpFetch パイプライン
+  _cachedFetch = async (path: string, init: RequestInit = {}): Promise<Response> => {
+    return rawSpFetch(normalizePath(path), init);
+  };
+
+  return _cachedFetch;
+}
+
+// ── Public API (signature unchanged) ────────────────────────────────────────
+
+/**
+ * @deprecated Use `useSP().spFetch()` or `createSpClient()` instead.
+ *
+ * SharePoint REST API fetch。フルURL・相対パスの両方を受け付ける。
+ * リトライ (429/5xx)・mock (dev/demo)・認証は createSpFetch に委譲。
+ * !response.ok 時は例外を投げず、呼び出し側で response.ok をチェックする。
+ */
 export const fetchSp = async (url: string, init: RequestInit = {}): Promise<Response> => {
-  if (typeof window === 'undefined') {
-    // eslint-disable-next-line no-restricted-globals -- 旧 SP fetch ラッパー SSOT（Phase 4 で spFetch に統合予定）
-    return fetch(url, init);
-  }
-
-  const scopes = SHAREPOINT_SCOPES.length ? SHAREPOINT_SCOPES : getSharePointScopes();
-  try {
-    const accessToken = await acquireSpAccessToken(scopes);
-    const requestInit = applyHeaders(init);
-    const headers = new Headers(requestInit.headers);
-    headers.set('Authorization', `Bearer ${accessToken}`);
-
-    // eslint-disable-next-line no-restricted-globals -- 旧 SP fetch ラッパー SSOT（Phase 4 で spFetch に統合予定）
-    return fetch(url, { ...requestInit, headers });
-  } catch (error) {
-    console.error('[fetchSp] SharePoint request failed', error);
-    throw error;
-  }
+  const spFetch = getOrCreateSpFetch();
+  return spFetch(url, init);
 };

--- a/src/lib/sp/spFetch.ts
+++ b/src/lib/sp/spFetch.ts
@@ -22,6 +22,11 @@ export type SpFetchDeps = {
   debugEnabled: boolean;
   spSiteLegacy: string;
   onRetry?: SpClientOptions['onRetry'];
+  /**
+   * true (default): !response.ok 時に raiseHttpError で例外を投げる
+   * false: Response をそのまま返す（互換レイヤー用）
+   */
+  throwOnError?: boolean;
 };
 
 // ─── normalizePath (extracted as standalone) ────────────────────────────────
@@ -123,7 +128,7 @@ function computeDelay(attempt: number, res: Response, baseDelay: number, capDela
 // ─── Factory ────────────────────────────────────────────────────────────────
 
 export function createSpFetch(deps: SpFetchDeps) {
-  const { acquireToken, baseUrl, config, retrySettings, debugEnabled, onRetry } = deps;
+  const { acquireToken, baseUrl, config, retrySettings, debugEnabled, onRetry, throwOnError = true } = deps;
   const _e2eMsalMockFlag = config.VITE_E2E_MSAL_MOCK;
   const tokenMetricsCarrier = globalThis as { __TOKEN_METRICS__?: Record<string, unknown> };
 
@@ -277,7 +282,7 @@ export function createSpFetch(deps: SpFetchDeps) {
       }
     }
 
-    if (!response.ok) {
+    if (!response.ok && throwOnError) {
       await raiseHttpError(response, { url: resolveUrl(resolvedPath), method: init.method ?? 'GET' });
     }
     return response;


### PR DESCRIPTION
## 概要

既存 `fetchSp` の内部実装を `spFetch` に委譲し、
**差分最小で SP 通信の出口を一本化** しました。

## 変更内容

### `src/lib/sp/spFetch.ts`
- `throwOnError` オプションを追加 (default: `true`)
- `false` の場合、`raiseHttpError` をスキップし `Response` をそのまま返却

### `src/lib/fetchSp.ts`
- 元の生 `fetch` ベースの実装を完全に置換
- `createSpFetch({ throwOnError: false })` のシングルトンラッパーに変換
- 既存7箇所は import 変更なしで恩恵を享受:
  - リトライ (指数バックオフ + Retry-After)
  - Mock 対応 (E2E/デモ)
  - トークン自動更新
  - 監査ログ

## 設計判断
- `throwOnError: false` により既存の `response.ok` チェックとの互換性を維持
- 移行コストを後ろに逃がしつつ、基盤品質だけ先に上げる戦略

## 検証
- [x] TypeScript (`tsc --noEmit`)
- [x] ESLint (0 warnings)
- [x] Vitest (6206 tests passed)