### PR TITLE
feat(daily): migrate daily and monitoring flows to userId references

### DIFF
--- a/src/domain/daily/spMap.ts
+++ b/src/domain/daily/spMap.ts
@@ -11,7 +11,7 @@
  * Error handling strategy:
  * - Status normalization: English/Japanese synonyms → Zod validation → fallback to '未作成'
  * - JSON serialization: Size limits + custom error types for troubleshooting
- * - Person/Reporter resolution: Multiple fallback chains to prevent "unknown" records
+ * - User/Reporter resolution: Multiple fallback chains to prevent "unknown" records
  * - Type coercion: Safe parsing with sensible defaults throughout
  */
 
@@ -174,13 +174,13 @@ const coerceReporter = (item: SpDailyItem) => {
   return { name, ...(id ? { id } : {}) };
 };
 
-const coercePerson = (item: SpDailyItem) => {
+const coerceUser = (item: SpDailyItem) => {
   const id = typeof item[DAILY_FIELD_PERSON_ID] === 'string' && item[DAILY_FIELD_PERSON_ID] ? item[DAILY_FIELD_PERSON_ID].trim() : '';
   const name = typeof item.Title === 'string' && item.Title ? item.Title.trim() : '';
   return { id, name };
 };
 
-const coercePersonName = (item: SpDailyItem) => {
+const coerceUserName = (item: SpDailyItem) => {
   const name = typeof item.Title === 'string' && item.Title ? item.Title.trim() : '';
   return name || coerceReporter(item).name;
 };
@@ -212,12 +212,12 @@ export const fromSpItem = (item: SpDailyItem, argKind: 'A' | 'B'): AnyDaily => {
   const storedKind = typeof item[DAILY_FIELD_KIND] === 'string' ? item[DAILY_FIELD_KIND] : undefined;
   const kind: 'A' | 'B' = storedKind === 'A' || storedKind === 'B' ? storedKind : argKind;
 
-  const person = coercePerson(item);
+  const user = coerceUser(item);
 
   const base = {
     id: typeof item.Id === 'number' ? item.Id : Number(item.Id ?? 0) || 0,
-    personId: person.id,
-    personName: coercePersonName(item),
+    userId: user.id,
+    userName: coerceUserName(item),
     date: typeof item[DAILY_FIELD_DATE] === 'string' ? item[DAILY_FIELD_DATE] : '',
     status: coerceStatus(item[DAILY_FIELD_STATUS]),
     reporter: coerceReporter(item),
@@ -250,7 +250,7 @@ export const fromSpItem = (item: SpDailyItem, argKind: 'A' | 'B'): AnyDaily => {
  * - Input validation through AnyDailyZ parsing
  * - Safe JSON serialization of complex fields
  * - Proper null handling for optional reporter ID
- * - Title field population from personName
+ * - Title field population from userName
  *
  * @param daily - Validated domain object
  * @returns SharePoint field mapping ready for SP operations
@@ -260,8 +260,8 @@ export const toSpFields = (daily: AnyDaily): Record<string, unknown> => {
   const reporterId = 'reporter' in parsed && parsed.reporter && 'id' in parsed.reporter ? parsed.reporter.id : undefined;
   const reporterName = parsed.reporter?.name ?? '';
   return {
-    Title: parsed.personName,
-    [DAILY_FIELD_PERSON_ID]: parsed.personId,
+    Title: parsed.userName,
+    [DAILY_FIELD_PERSON_ID]: parsed.userId,
     [DAILY_FIELD_DATE]: parsed.date,
     [DAILY_FIELD_STATUS]: parsed.status,
     [DAILY_FIELD_REPORTER_NAME]: reporterName,
@@ -272,17 +272,17 @@ export const toSpFields = (daily: AnyDaily): Record<string, unknown> => {
   } satisfies Record<string, unknown>;
 };
 
-export const extractPersonFromItem = (item: SpDailyItem) => {
-  const { id, name } = coercePerson(item);
+export const extractUserFromItem = (item: SpDailyItem) => {
+  const { id, name } = coerceUser(item);
   return {
-    personId: id,
-    personName: name,
+    userId: id,
+    userName: name,
     group: typeof item[DAILY_FIELD_GROUP] === 'string' && item[DAILY_FIELD_GROUP] ? item[DAILY_FIELD_GROUP] : undefined,
   };
 };
 
 export const getFieldNames = () => ({
-  personId: DAILY_FIELD_PERSON_ID,
+  userId: DAILY_FIELD_PERSON_ID,
   date: DAILY_FIELD_DATE,
   status: DAILY_FIELD_STATUS,
   group: DAILY_FIELD_GROUP,

--- a/src/domain/daily/types.ts
+++ b/src/domain/daily/types.ts
@@ -66,8 +66,8 @@ export type Reporter = z.infer<typeof ReporterZ>;
 /** Base daily record fields shared across all record types */
 export const BaseDailyZ = z.object({
   id: z.number(),
-  personId: z.string(),
-  personName: z.string(),
+  userId: z.string(),
+  userName: z.string(),
   date: YmdString,
   status: DailyStatusZ,
   reporter: ReporterZ,

--- a/src/features/cross-module/__tests__/dailyUserSnapshot.test.ts
+++ b/src/features/cross-module/__tests__/dailyUserSnapshot.test.ts
@@ -67,6 +67,57 @@ describe('Cross-Module Integration: DailyUserSnapshot', () => {
       expect(snapshot.providedMinutes).toBe(150);
       expect(snapshot.standardMinutes).toBe(240);
     });
+
+    // ── Phase 4a: UserRef 統合テスト ──
+
+    it('UserRef が指定された場合、スナップショットに凍結保存される', () => {
+      const userRef = { userId: 'U001', userName: '田中太郎' };
+      const input: DailyUserSnapshotInput = {
+        userId: 'U001',
+        userName: '田中太郎',
+        date: '2024-01-15',
+        userRef,
+      };
+
+      const snapshot = buildDailyUserSnapshot(input);
+
+      expect(snapshot.userRef).toEqual({ userId: 'U001', userName: '田中太郎' });
+      // フラットフィールドも維持（後方互換）
+      expect(snapshot.userId).toBe('U001');
+      expect(snapshot.userName).toBe('田中太郎');
+    });
+
+    it('UserRef が未指定の場合、userRef フィールドは存在しない（後方互換）', () => {
+      const input: DailyUserSnapshotInput = {
+        userId: 'U002',
+        userName: '鈴木花子',
+        date: '2024-01-15',
+      };
+
+      const snapshot = buildDailyUserSnapshot(input);
+
+      expect(snapshot.userRef).toBeUndefined();
+      // フラットフィールドは正常に動作
+      expect(snapshot.userId).toBe('U002');
+      expect(snapshot.userName).toBe('鈴木花子');
+    });
+
+    it('UserRef はマスタ変更の影響を受けない不変コピーである', () => {
+      const mutableRef = { userId: 'U003', userName: '佐藤次郎' };
+      const input: DailyUserSnapshotInput = {
+        userId: 'U003',
+        userName: '佐藤次郎',
+        date: '2024-01-15',
+        userRef: { ...mutableRef },
+      };
+
+      const snapshot = buildDailyUserSnapshot(input);
+
+      // 元の参照を変更しても snapshot は影響を受けない
+      mutableRef.userName = '佐藤三郎（改名後）';
+
+      expect(snapshot.userRef!.userName).toBe('佐藤次郎');
+    });
   });
 
   describe('detectCrossModuleIssues', () => {

--- a/src/features/cross-module/dailyUserSnapshot.ts
+++ b/src/features/cross-module/dailyUserSnapshot.ts
@@ -1,3 +1,4 @@
+import type { UserRef } from '@/domain/user';
 import type { PersonDaily } from '@/features/daily';
 // Note: Dashboard is another feature, but it seems to be used as a public API here if available.
 // If not, we might need a barrel for dashboard too.
@@ -19,6 +20,8 @@ export function buildDailyUserSnapshot(input: DailyUserSnapshotInput): DailyUser
     userId: input.userId,
     userName: input.userName,
     date: input.date,
+    // Phase 4a: 利用者参照を凍結保存（指定時のみ）
+    ...(input.userRef ? { userRef: input.userRef } : {}),
     lastUpdated: new Date().toISOString(),
   };
 
@@ -74,6 +77,8 @@ export function buildDailyUserSnapshot(input: DailyUserSnapshotInput): DailyUser
 
 /**
  * 既存のデモデータからDailyUserSnapshotを生成
+ *
+ * @param userRef - Phase 4a: 利用者参照（指定時はスナップショットに凍結保存）
  */
 export function buildDailyUserSnapshotFromExistingData(
   userId: string,
@@ -81,12 +86,14 @@ export function buildDailyUserSnapshotFromExistingData(
   date: string,
   personDaily?: PersonDaily,
   attendanceUser?: AttendanceUser,
-  attendanceVisit?: AttendanceVisit
+  attendanceVisit?: AttendanceVisit,
+  userRef?: UserRef,
 ): DailyUserSnapshot {
   const input: DailyUserSnapshotInput = {
     userId,
     userName,
     date,
+    ...(userRef ? { userRef } : {}),
   };
 
   // PersonDaily から Activity データを抽出

--- a/src/features/cross-module/mockData.ts
+++ b/src/features/cross-module/mockData.ts
@@ -146,16 +146,16 @@ export function createMockDailySnapshotsFromExistingData(
   // 全ユーザーのベースリストを作成（attendance基準）
   const allUserIds = new Set([
     ...attendanceUsers.map(u => u.userCode),
-    ...personDailies.map(p => p.personId),
+    ...personDailies.map(p => p.userId),
   ]);
 
   allUserIds.forEach(userId => {
     // 対応するデータを検索
     const attendanceUser = attendanceUsers.find(u => u.userCode === userId);
     const attendanceVisit = attendanceVisits.find(v => v.userCode === userId);
-    const personDaily = personDailies.find(p => p.personId === userId && p.date === date);
+    const personDaily = personDailies.find(p => p.userId === userId && p.date === date);
 
-    const userName = attendanceUser?.fullName || personDaily?.personName || `利用者${userId}`;
+    const userName = attendanceUser?.fullName || personDaily?.userName || `利用者${userId}`;
 
     const snapshot = buildDailyUserSnapshotFromExistingData(
       userId,

--- a/src/features/cross-module/types.ts
+++ b/src/features/cross-module/types.ts
@@ -3,6 +3,8 @@
  * 利用者×日付をキーとした各モジュール情報の統合型定義
  */
 
+import type { UserRef } from '@/domain/user';
+
 // ========================================
 // Core Types
 // ========================================
@@ -36,6 +38,16 @@ export interface DailyUserSnapshot {
   userName: string;
   /** 対象日付 (ISO形式: YYYY-MM-DD) */
   date: string;
+
+  // ========================================
+  // User Reference (Phase 4a)
+  // ========================================
+  /**
+   * 作成時点の利用者参照（軽量版）。
+   * マスタ変更の影響を受けない不変コピー。
+   * Phase 4a で追加。既存レコードで undefined の場合は userId/userName にフォールバック。
+   */
+  userRef?: UserRef;
 
   // ========================================
   // Attendance Module Data
@@ -113,6 +125,8 @@ export interface DailyUserSnapshotInput {
   userId: string;
   userName: string;
   date: string;
+  /** 利用者参照（Phase 4a）。指定時は作成時点の UserRef を凍結保存する */
+  userRef?: UserRef;
   attendanceData?: {
     status: AttendanceStatus;
     providedMinutes?: number;

--- a/src/features/daily/__tests__/DailyRecordForm.test.tsx
+++ b/src/features/daily/__tests__/DailyRecordForm.test.tsx
@@ -37,15 +37,15 @@ const dailyUserOptions: DailyUserOption[] = [
 vi.mock('../forms/useDailyUserOptions', () => ({
   useDailyUserOptions: () => ({
     options: dailyUserOptions,
-    findByPersonId: (personId?: string | null) =>
-      dailyUserOptions.find((option) => option.id === personId),
+    findByUserId: (userId?: string | null) =>
+      dailyUserOptions.find((option) => option.id === userId),
   }),
 }));
 
 const mockRecord: PersonDaily = {
   id: 1,
-  personId: '001',
-  personName: '田中太郎',
+  userId: '001',
+  userName: '田中太郎',
   date: '2024-01-15',
   status: '作成中',
   reporter: { name: '山田花子' },
@@ -223,8 +223,8 @@ describe('DailyRecordForm', () => {
       fireEvent.click(saveButton);
 
       expect(mockOnSave).toHaveBeenCalledWith({
-        personId: '001',
-        personName: '田中太郎',
+        userId: '001',
+        userName: '田中太郎',
         date: '2024-01-15',
         status: '作成中',
         reporter: { name: '山田花子' },

--- a/src/features/daily/__tests__/DailyRecordList.test.tsx
+++ b/src/features/daily/__tests__/DailyRecordList.test.tsx
@@ -6,8 +6,8 @@ import { DailyRecordList } from '../lists/DailyRecordList';
 // Create a mock record with proper data structure
 const createMockRecord = (overrides = {}): PersonDaily => ({
   id: 1,
-  personId: 'P001',
-  personName: 'テスト太郎',
+  userId: 'P001',
+  userName: 'テスト太郎',
   date: '2025-01-01',
   status: '完了',
   reporter: {

--- a/src/features/daily/__tests__/useDailyRecordViewModel.spec.ts
+++ b/src/features/daily/__tests__/useDailyRecordViewModel.spec.ts
@@ -4,8 +4,8 @@ import { useDailyRecordViewModel } from '../lists/useDailyRecordViewModel';
 
 type PersonDaily = {
   id: number;
-  personName: string;
-  personId: string;
+  userName: string;
+  userId: string;
   status: string;
   date: string;
   draft: { isDraft: boolean };
@@ -15,9 +15,9 @@ function createDeps(
   overrides?: Partial<Parameters<typeof useDailyRecordViewModel<PersonDaily>>[0]>,
 ) {
   const records: PersonDaily[] = [
-    { id: 1, personName: '山田 太郎', personId: 'U001', status: 'open', date: '2026-02-07', draft: { isDraft: false } },
-    { id: 2, personName: '佐藤 花子', personId: 'U002', status: 'done', date: '2026-02-06', draft: { isDraft: false } },
-    { id: 3, personName: '鈴木 次郎', personId: 'U003', status: 'open', date: '2026-02-06', draft: { isDraft: true } },
+    { id: 1, userName: '山田 太郎', userId: 'U001', status: 'open', date: '2026-02-07', draft: { isDraft: false } },
+    { id: 2, userName: '佐藤 花子', userId: 'U002', status: 'done', date: '2026-02-06', draft: { isDraft: false } },
+    { id: 3, userName: '鈴木 次郎', userId: 'U003', status: 'open', date: '2026-02-06', draft: { isDraft: true } },
   ];
 
   const deps: Parameters<typeof useDailyRecordViewModel<PersonDaily>>[0] = {
@@ -35,8 +35,8 @@ function createDeps(
     mockUsers: ['山田 太郎', '佐藤 花子', '鈴木 次郎'],
     createMissingRecord: vi.fn((name, userId, date, index) => ({
       id: Date.now() + index,
-      personId: userId,
-      personName: name,
+      userId: userId,
+      userName: name,
       date,
       status: '未作成',
       draft: { isDraft: true },
@@ -71,6 +71,6 @@ describe('useDailyRecordViewModel', () => {
 
     const list = result.current.filteredRecords as PersonDaily[];
     expect(list).toHaveLength(1);
-    expect(list[0].personId).toBe('U002');
+    expect(list[0].userId).toBe('U002');
   });
 });

--- a/src/features/daily/adapters/useHandoffNotesForTable.ts
+++ b/src/features/daily/adapters/useHandoffNotesForTable.ts
@@ -146,7 +146,7 @@ function convertToImportantHandoff(
 
   return {
     id: handoff.id,
-    personId: handoff.userCode,
+    userId: handoff.userCode,
     personDisplayName: handoff.userDisplayName,
     date,
     time,

--- a/src/features/daily/components/time-flow/TimeFlowPage.tsx
+++ b/src/features/daily/components/time-flow/TimeFlowPage.tsx
@@ -198,7 +198,7 @@ const TimeFlowPage: React.FC = () => {
             />
 
             <MonitoringInfo
-              personName={s.currentDailyRecord.personName}
+              userName={s.currentDailyRecord.userName}
               currentDate={s.selectedDate}
             />
 

--- a/src/features/daily/components/time-flow/timeFlowTypes.ts
+++ b/src/features/daily/components/time-flow/timeFlowTypes.ts
@@ -10,8 +10,8 @@ import type { SupportStrategyStage } from '@/features/planDeployment/supportFlow
 export interface SupportRecord {
   id: number;
   supportPlanId: string;
-  personId: string;
-  personName: string;
+  userId: string;
+  userName: string;
   date: string;
   timeSlot?: string;
   userActivities: {
@@ -58,8 +58,8 @@ export interface SupportRecord {
 export interface DailySupportRecord {
   id: number;
   supportPlanId: string;
-  personId: string;
-  personName: string;
+  userId: string;
+  userName: string;
   date: string;
   records: SupportRecord[];
   summary: {

--- a/src/features/daily/components/time-flow/timeFlowUtils.ts
+++ b/src/features/daily/components/time-flow/timeFlowUtils.ts
@@ -140,8 +140,8 @@ export const generateMockTimeFlowDailyRecord = (
     return {
       id: Date.now() + index,
       supportPlanId: deployment?.planId ?? `plan-${user.id}`,
-      personId: user.id,
-      personName: user.name,
+      userId: user.id,
+      userName: user.name,
       date,
       timeSlot: `${activity.time} ${activity.title}`,
       activityKey: activity.time,
@@ -185,8 +185,8 @@ export const generateMockTimeFlowDailyRecord = (
   return {
     id: Date.now(),
     supportPlanId: deployment?.planId ?? `plan-${user.id}`,
-    personId: user.id,
-    personName: user.name,
+    userId: user.id,
+    userName: user.name,
     date,
     records: sampleRecords,
     summary: {

--- a/src/features/daily/components/time-flow/views/MonitoringInfo.tsx
+++ b/src/features/daily/components/time-flow/views/MonitoringInfo.tsx
@@ -10,11 +10,11 @@ import Typography from '@mui/material/Typography';
 import React, { useMemo } from 'react';
 
 interface MonitoringInfoProps {
-  personName: string;
+  userName: string;
   currentDate: string;
 }
 
-const MonitoringInfo: React.FC<MonitoringInfoProps> = ({ personName, currentDate }) => {
+const MonitoringInfo: React.FC<MonitoringInfoProps> = ({ userName, currentDate }) => {
   const currentMonitoringPeriod = useMemo(() => {
     const date = new Date(currentDate);
     const month = date.getMonth();
@@ -30,7 +30,7 @@ const MonitoringInfo: React.FC<MonitoringInfoProps> = ({ personName, currentDate
           📊 モニタリング情報
         </Typography>
         <Stack direction="row" spacing={2} sx={{ flexWrap: 'wrap' }}>
-          <Chip label={`対象者: ${personName}`} color="primary" variant="outlined" />
+          <Chip label={`対象者: ${userName}`} color="primary" variant="outlined" />
           <Chip label={`記録日: ${currentDate}`} color="info" variant="outlined" />
           <Chip label={`モニタリング周期: ${currentMonitoringPeriod}`} color="secondary" variant="outlined" />
           <Chip label="更新頻度: 三ヶ月ごと" color="default" variant="outlined" />

--- a/src/features/daily/components/time-flow/views/RecordSummaryCard.tsx
+++ b/src/features/daily/components/time-flow/views/RecordSummaryCard.tsx
@@ -24,7 +24,7 @@ const RecordSummaryCard: React.FC<RecordSummaryCardProps> = ({ record, date }) =
     <CardContent>
       <Typography variant="h6" gutterBottom display="flex" alignItems="center" gap={1}>
         <AssignmentIcon color="primary" />
-        記録サマリー - {record.personName} ({date})
+        記録サマリー - {record.userName} ({date})
       </Typography>
       <Divider sx={{ my: 2 }} />
 

--- a/src/features/daily/components/time-flow/views/TimeFlowSupportRecordList.tsx
+++ b/src/features/daily/components/time-flow/views/TimeFlowSupportRecordList.tsx
@@ -152,8 +152,8 @@ const TimeFlowSupportRecordList: React.FC<TimeFlowSupportRecordListProps> = ({
     const baseRecord: SupportRecord = existingRecord ?? {
       id: Date.now(),
       supportPlanId: dailyRecord.supportPlanId,
-      personId: dailyRecord.personId,
-      personName: dailyRecord.personName,
+      userId: dailyRecord.userId,
+      userName: dailyRecord.userName,
       date: dailyRecord.date,
       timeSlot: '',
       userActivities: { planned: '', actual: '', notes: '' },

--- a/src/features/daily/domain/dailyRecordLogic.ts
+++ b/src/features/daily/domain/dailyRecordLogic.ts
@@ -97,11 +97,11 @@ function isValidDateFormat(value: string): boolean {
 export function validateDailyRecord(record: DailyRecordWithoutId): DailyRecordValidationResult {
   const errors: string[] = [];
 
-  if (!record.personName || !record.personName.trim()) {
+  if (!record.userName || !record.userName.trim()) {
     errors.push('利用者名は必須です');
   }
 
-  if (!record.personId || !record.personId.trim()) {
+  if (!record.userId || !record.userId.trim()) {
     errors.push('利用者の選択は必須です');
   }
 
@@ -149,8 +149,8 @@ export function searchRecordsByName(records: PersonDaily[], query: string): Pers
   }
 
   return records.filter((record) => {
-    const nameHit = record.personName?.includes(trimmed);
-    const idHit = record.personId?.includes(trimmed);
+    const nameHit = record.userName?.includes(trimmed);
+    const idHit = record.userId?.includes(trimmed);
     return Boolean(nameHit || idHit);
   });
 }

--- a/src/features/daily/forms/DailyRecordForm.tsx
+++ b/src/features/daily/forms/DailyRecordForm.tsx
@@ -114,8 +114,8 @@ export function DailyRecordForm({ open, onClose, record, onSave }: DailyRecordFo
                       {...params}
                       label="利用者の選択"
                       placeholder="氏名で検索してください"
-                      helperText={s.errors.personId || '氏名から利用者を検索できます'}
-                      error={!!s.errors.personId}
+                      helperText={s.errors.userId || '氏名から利用者を検索できます'}
+                      error={!!s.errors.userId}
                     />
                   )}
                   data-testid="daily-record-user-picker"
@@ -146,7 +146,7 @@ export function DailyRecordForm({ open, onClose, record, onSave }: DailyRecordFo
           </Paper>
 
           {/* Related handoffs banner */}
-          {s.formData.personId && (
+          {s.formData.userId && (
             <>
               {s.loadingHandoffs && <Skeleton variant="rectangular" height={80} />}
 
@@ -258,7 +258,7 @@ export function DailyRecordForm({ open, onClose, record, onSave }: DailyRecordFo
             onProblemBehaviorChange={s.handleProblemBehaviorChange}
             onSeizureRecordChange={s.handleSeizureRecordChange}
             showSuggestion={
-              !!s.formData.personId &&
+              !!s.formData.userId &&
               !!s.formData.date &&
               !s.loadingHandoffs &&
               !s.handoffError &&

--- a/src/features/daily/forms/dailyRecordFormLogic.ts
+++ b/src/features/daily/forms/dailyRecordFormLogic.ts
@@ -77,8 +77,8 @@ export function isProblemBehaviorEmpty(pb: DailyAData['problemBehavior'] | undef
 
 export function createEmptyDailyRecord(): Omit<PersonDaily, 'id'> {
   return {
-    personId: '',
-    personName: '',
+    userId: '',
+    userName: '',
     date: toLocalDateISO(),
     status: '作成中',
     reporter: { name: '' },
@@ -120,8 +120,8 @@ export function todayYmdLocal(): string {
 
 export function validateDailyRecordForm(formData: Omit<PersonDaily, 'id'>): Record<string, string> {
   const newErrors: Record<string, string> = {};
-  if (!formData.personId) {
-    newErrors.personId = '利用者の選択は必須です';
+  if (!formData.userId) {
+    newErrors.userId = '利用者の選択は必須です';
   }
   if (!formData.date) {
     newErrors.date = '日付を入力してください';

--- a/src/features/daily/forms/useDailyRecordFormState.ts
+++ b/src/features/daily/forms/useDailyRecordFormState.ts
@@ -95,7 +95,7 @@ export function useDailyRecordFormState({
   onSave,
 }: DailyRecordFormStateParams): DailyRecordFormState {
   const navigate = useNavigate();
-  const { options: userOptions, findByPersonId } = useDailyUserOptions();
+  const { options: userOptions, findByUserId } = useDailyUserOptions();
   const confirmDialog = useConfirmDialog();
 
   const initialFormDataRef = useRef<string>('');
@@ -109,14 +109,14 @@ export function useDailyRecordFormState({
 
   // User selection
   const selectedUserValue = useMemo<DailyUserOption | null>(() => {
-    if (!formData.personId) return null;
-    const matched = findByPersonId(formData.personId);
+    if (!formData.userId) return null;
+    const matched = findByUserId(formData.userId);
     if (matched) return matched;
-    if (formData.personName) {
-      return { id: formData.personId, label: formData.personName, lookupId: undefined, furigana: null };
+    if (formData.userName) {
+      return { id: formData.userId, label: formData.userName, lookupId: undefined, furigana: null };
     }
     return null;
-  }, [findByPersonId, formData.personId, formData.personName]);
+  }, [findByUserId, formData.userId, formData.userName]);
 
   // Date scope for handoff lookup
   const todayYmd = todayYmdLocal();
@@ -128,7 +128,7 @@ export function useDailyRecordFormState({
     loading: loadingHandoffs,
     error: handoffError,
     count: handoffCount,
-  } = useImportantHandoffsForDaily(formData.personId, formData.date);
+  } = useImportantHandoffsForDaily(formData.userId, formData.date);
 
   // Problem behavior suggestion
   const problemSuggestion = useMemo(
@@ -145,8 +145,8 @@ export function useDailyRecordFormState({
   useEffect(() => {
     if (record) {
       const initial = {
-        personId: record.personId,
-        personName: record.personName,
+        userId: record.userId,
+        userName: record.userName,
         date: record.date,
         status: record.status,
         reporter: record.reporter,
@@ -187,7 +187,7 @@ export function useDailyRecordFormState({
     if (
       shouldAutoGenerateSpecialNotes(
         !record,
-        formData.personId,
+        formData.userId,
         formData.data.specialNotes || '',
         handoffCount,
       ) &&
@@ -206,7 +206,7 @@ export function useDailyRecordFormState({
         },
       }));
     }
-  }, [record, formData.personId, loadingHandoffs, importantHandoffs, handoffCount, handoffError]);
+  }, [record, formData.userId, loadingHandoffs, importantHandoffs, handoffCount, handoffError]);
 
   // ─── Handlers ───────────────────────────────────────────────────────────
 
@@ -289,10 +289,10 @@ export function useDailyRecordFormState({
   const handlePersonChange = (option: DailyUserOption | null) => {
     setFormData((prev) => ({
       ...prev,
-      personId: option?.id ?? '',
-      personName: option?.label ?? '',
+      userId: option?.id ?? '',
+      userName: option?.label ?? '',
     }));
-    if (errors.personId) setErrors((prev) => ({ ...prev, personId: '' }));
+    if (errors.userId) setErrors((prev) => ({ ...prev, userId: '' }));
   };
 
   const handleAddActivity = (period: 'AM' | 'PM') => {
@@ -359,7 +359,7 @@ export function useDailyRecordFormState({
     }
   }, [isSaving, onSave, formData, onClose]);
 
-  const isFormValid = formData.personId && formData.date && formData.reporter.name.trim();
+  const isFormValid = formData.userId && formData.date && formData.reporter.name.trim();
 
   return {
     formData,

--- a/src/features/daily/forms/useDailyUserOptions.ts
+++ b/src/features/daily/forms/useDailyUserOptions.ts
@@ -50,18 +50,18 @@ export const useDailyUserOptions = () => {
     return normalized;
   }, [users]);
 
-  const findByPersonId = useCallback(
-    (personId?: string | null) => {
-      if (!personId) {
+  const findByUserId = useCallback(
+    (userId?: string | null) => {
+      if (!userId) {
         return undefined;
       }
-      return options.find((option) => option.id === personId);
+      return options.find((option) => option.id === userId);
     },
     [options],
   );
 
   return {
     options,
-    findByPersonId,
+    findByUserId,
   };
 };

--- a/src/features/daily/lists/DailyRecordList.tsx
+++ b/src/features/daily/lists/DailyRecordList.tsx
@@ -154,11 +154,11 @@ export function DailyRecordList({
           const isHighlighted =
             !!highlightUserId &&
             !!highlightDate &&
-            record.personId === highlightUserId &&
+            record.userId === highlightUserId &&
             record.date === highlightDate;
 
           // Phase 2-1: 一時ハイライト（スクロール直後）
-          const isActiveHighlight = activeHighlightUserId === record.personId;
+          const isActiveHighlight = activeHighlightUserId === record.userId;
 
           // Check for problem behaviors
           const hasProblemBehavior =
@@ -176,7 +176,7 @@ export function DailyRecordList({
               key={record.id}
               variant="outlined"
               data-testid={`daily-record-card-${record.id}`}
-              data-person-id={record.personId}
+              data-person-id={record.userId}
               data-date-ymd={record.date}
               {...(isHighlighted && {
                 'data-highlighted': 'true',
@@ -222,10 +222,10 @@ export function DailyRecordList({
                   </Avatar>
                   <Box>
                     <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }} data-testid={`person-name-${record.id}`}>
-                      {record.personName}
+                      {record.userName}
                     </Typography>
                     <Typography variant="caption" color="text.secondary" data-testid={`person-id-${record.id}`}>
-                      ID: {record.personId}
+                      ID: {record.userId}
                     </Typography>
                   </Box>
                 </Box>
@@ -242,7 +242,7 @@ export function DailyRecordList({
                     size="small"
                     onClick={(e) => handleMenuOpen(e, record)}
                     data-testid={`menu-button-${record.id}`}
-                    aria-label={`${record.personName}さんのメニューを開く`}
+                    aria-label={`${record.userName}さんのメニューを開く`}
                     aria-haspopup="menu"
                   >
                     <MoreVertIcon />
@@ -415,7 +415,7 @@ export function DailyRecordList({
         onClose={handleMenuClose}
         data-testid="record-menu"
         MenuListProps={{
-          'aria-label': `${selectedRecord?.personName || ''}さんの操作メニュー`,
+          'aria-label': `${selectedRecord?.userName || ''}さんの操作メニュー`,
         }}
       >
         <MenuItem onClick={handleEdit} data-testid={`edit-record-menu-item-${selectedRecord?.id || ''}`}>
@@ -452,7 +452,7 @@ export function DailyRecordList({
         <DialogTitle id="delete-confirm-title">記録の削除</DialogTitle>
         <DialogContent>
           <DialogContentText>
-            {deleteConfirmRecord?.personName}さんの記録（{deleteConfirmRecord?.date}）を削除します。
+            {deleteConfirmRecord?.userName}さんの記録（{deleteConfirmRecord?.date}）を削除します。
             この操作は取り消せません。
           </DialogContentText>
         </DialogContent>

--- a/src/features/daily/lists/useDailyRecordViewModel.ts
+++ b/src/features/daily/lists/useDailyRecordViewModel.ts
@@ -8,8 +8,8 @@ import { toLocalDateISO } from '@/utils/getNow';
 
 type BaseRecord = {
   id: number;
-  personName: string;
-  personId: string;
+  userName: string;
+  userId: string;
   status: string;
   date: string;
   draft: { isDraft: boolean };
@@ -40,7 +40,7 @@ export type DailyRecordViewModel<TRecord extends BaseRecord> = {
   handleOpenForm: () => void;
   handleEditRecord: (record: TRecord) => void;
   handleCloseForm: () => void;
-  handleOpenAttendance: (record: { personId: string; date: string }) => void;
+  handleOpenAttendance: (record: { userId: string; date: string }) => void;
   handleSaveRecord: (record: Omit<TRecord, 'id'>) => Promise<void>;
   handleDeleteRecord: (recordId: number) => void;
   handleGenerateTodayRecords: () => void;
@@ -115,8 +115,8 @@ export function useDailyRecordViewModel<TRecord extends BaseRecord>(
     return records.filter((record) => {
       const matchesSearch =
         !searchQuery ||
-        record.personName.includes(searchQuery) ||
-        record.personId.includes(searchQuery);
+        record.userName.includes(searchQuery) ||
+        record.userId.includes(searchQuery);
 
       const matchesStatus = statusFilter === 'all' || record.status === statusFilter;
       const matchesDate = !dateFilter || record.date === dateFilter;
@@ -145,8 +145,8 @@ export function useDailyRecordViewModel<TRecord extends BaseRecord>(
   }, [setFormOpen, setEditingRecord]);
 
   const handleOpenAttendance = useCallback(
-    (record: { personId: string; date: string }) => {
-      navigate(`/daily/attendance?userId=${record.personId}&date=${record.date}`);
+    (record: { userId: string; date: string }) => {
+      navigate(`/daily/attendance?userId=${record.userId}&date=${record.date}`);
     },
     [navigate],
   );
@@ -171,7 +171,7 @@ export function useDailyRecordViewModel<TRecord extends BaseRecord>(
       // 成功通知
       const operation = editingRecord ? '更新' : '新規作成';
       toast.success(
-        `日次記録の${operation}が完了しました\n\n利用者: ${record.personName}\n日付: ${record.date}`,
+        `日次記録の${operation}が完了しました\n\n利用者: ${record.userName}\n日付: ${record.date}`,
         {
           duration: 4000,
           style: {
@@ -196,7 +196,7 @@ export function useDailyRecordViewModel<TRecord extends BaseRecord>(
       setRecords(records.filter((record) => record.id !== recordId));
 
       if (recordToDelete) {
-        toast.success(`${recordToDelete.personName}さんの記録を削除しました`, {
+        toast.success(`${recordToDelete.userName}さんの記録を削除しました`, {
           duration: 3000,
         });
       } else {
@@ -220,7 +220,7 @@ export function useDailyRecordViewModel<TRecord extends BaseRecord>(
     const today = toLocalDateISO();
     const existingPersonIds = records
       .filter((record) => record.date === today)
-      .map((record) => record.personId);
+      .map((record) => record.userId);
 
     const missingUsers = mockUsers.filter((_name, index) => {
       const userId = String(index + 1).padStart(3, '0');

--- a/src/features/dashboard/__tests__/activitySummary.spec.ts
+++ b/src/features/dashboard/__tests__/activitySummary.spec.ts
@@ -6,8 +6,8 @@ import { toLocalDateISO } from '@/utils/getNow';
 // Helper function to create mock PersonDaily records
 const createMockPersonDaily = (overrides: Partial<PersonDaily> = {}): PersonDaily => ({
   id: 1,
-  personId: '001',
-  personName: '田中太郎',
+  userId: '001',
+  userName: '田中太郎',
   date: toLocalDateISO(),
   status: '完了',
   reporter: { name: '職員A' },
@@ -32,10 +32,10 @@ describe('buildActivitySummary', () => {
   describe('基本的な集計機能', () => {
     it('完了/作成中/未作成を正しく集計する', () => {
       const records: PersonDaily[] = [
-        createMockPersonDaily({ id: 1, personId: '001', personName: '田中太郎', status: '完了' }),
-        createMockPersonDaily({ id: 2, personId: '002', personName: '佐藤花子', status: '作成中' }),
-        createMockPersonDaily({ id: 3, personId: '003', personName: '鈴木次郎', status: '未作成' }),
-        createMockPersonDaily({ id: 4, personId: '004', personName: '高橋美咲', status: '完了' }),
+        createMockPersonDaily({ id: 1, userId: '001', userName: '田中太郎', status: '完了' }),
+        createMockPersonDaily({ id: 2, userId: '002', userName: '佐藤花子', status: '作成中' }),
+        createMockPersonDaily({ id: 3, userId: '003', userName: '鈴木次郎', status: '未作成' }),
+        createMockPersonDaily({ id: 4, userId: '004', userName: '高橋美咲', status: '完了' }),
       ];
 
       const result = buildActivitySummary(records, 4);
@@ -107,10 +107,10 @@ describe('buildActivitySummary', () => {
 
     it('未作成が3-5件の場合はwarning alertを生成する', () => {
       const records: PersonDaily[] = [
-        createMockPersonDaily({ id: 1, personId: '001', personName: '田中太郎', status: '未作成' }),
-        createMockPersonDaily({ id: 2, personId: '002', personName: '佐藤花子', status: '未作成' }),
-        createMockPersonDaily({ id: 3, personId: '003', personName: '鈴木次郎', status: '未作成' }),
-        createMockPersonDaily({ id: 4, personId: '004', personName: '高橋美咲', status: '完了' }),
+        createMockPersonDaily({ id: 1, userId: '001', userName: '田中太郎', status: '未作成' }),
+        createMockPersonDaily({ id: 2, userId: '002', userName: '佐藤花子', status: '未作成' }),
+        createMockPersonDaily({ id: 3, userId: '003', userName: '鈴木次郎', status: '未作成' }),
+        createMockPersonDaily({ id: 4, userId: '004', userName: '高橋美咲', status: '完了' }),
       ];
 
       const result = buildActivitySummary(records, 4);
@@ -128,8 +128,8 @@ describe('buildActivitySummary', () => {
       const records: PersonDaily[] = Array.from({ length: 8 }, (_, i) =>
         createMockPersonDaily({
           id: i + 1,
-          personId: String(i + 1).padStart(3, '0'),
-          personName: `利用者${i + 1}`,
+          userId: String(i + 1).padStart(3, '0'),
+          userName: `利用者${i + 1}`,
           status: i < 6 ? '未作成' : '完了'
         })
       );
@@ -144,9 +144,9 @@ describe('buildActivitySummary', () => {
 
     it('作成中の記録がある場合はinfo alertを生成する', () => {
       const records: PersonDaily[] = [
-        createMockPersonDaily({ id: 1, personId: '001', personName: '田中太郎', status: '作成中' }),
-        createMockPersonDaily({ id: 2, personId: '002', personName: '佐藤花子', status: '作成中' }),
-        createMockPersonDaily({ id: 3, personId: '003', personName: '鈴木次郎', status: '完了' }),
+        createMockPersonDaily({ id: 1, userId: '001', userName: '田中太郎', status: '作成中' }),
+        createMockPersonDaily({ id: 2, userId: '002', userName: '佐藤花子', status: '作成中' }),
+        createMockPersonDaily({ id: 3, userId: '003', userName: '鈴木次郎', status: '完了' }),
       ];
 
       const result = buildActivitySummary(records, 3);
@@ -163,8 +163,8 @@ describe('buildActivitySummary', () => {
       const records: PersonDaily[] = Array.from({ length: 10 }, (_, i) =>
         createMockPersonDaily({
           id: i + 1,
-          personId: String(i + 1).padStart(3, '0'),
-          personName: `利用者${i + 1}`,
+          userId: String(i + 1).padStart(3, '0'),
+          userName: `利用者${i + 1}`,
           status: i < 8 ? '未作成' : '完了'
         })
       );

--- a/src/features/dashboard/__tests__/dashboardSummary.spec.ts
+++ b/src/features/dashboard/__tests__/dashboardSummary.spec.ts
@@ -19,8 +19,8 @@ const FIXED_DATE = '2025-01-01';
 function createMockPersonDaily(status: '未作成' | '作成中' | '完了' = '未作成', id = 1): PersonDaily {
   return {
     id,
-    personId: 'P001',
-    personName: 'Mock Person',
+    userId: 'P001',
+    userName: 'Mock Person',
     date: FIXED_DATE,
     status,
     reporter: { name: 'Reporter' },

--- a/src/features/dashboard/__tests__/useDashboardSummary.spec.ts
+++ b/src/features/dashboard/__tests__/useDashboardSummary.spec.ts
@@ -44,8 +44,8 @@ const createMinimalUser = (overrides?: Partial<IUserMaster>): IUserMaster => ({
 
 const createMinimalPersonDaily = (overrides?: Partial<PersonDaily>): PersonDaily => ({
   id: 1,
-  personId: 'U001',
-  personName: 'Test User',
+  userId: 'U001',
+  userName: 'Test User',
   date: '2026-02-23',
   status: '完了',
   reporter: { name: 'Staff A' },
@@ -92,8 +92,8 @@ const createMinimalAttendanceCounts = (
 const mockGenerateMockActivityRecords = (users: IUserMaster[], _today: string): PersonDaily[] => {
   return users.map((user, index) => createMinimalPersonDaily({
     id: index + 1,
-    personId: user.UserID,
-    personName: user.FullName,
+    userId: user.UserID,
+    userName: user.FullName,
   }));
 };
 

--- a/src/features/dashboard/activitySummary.ts
+++ b/src/features/dashboard/activitySummary.ts
@@ -28,7 +28,7 @@ export function buildActivitySummary(
   const topMissing = todayRecords
     .filter(r => r.status === '未作成')
     .slice(0, 5)
-    .map(r => `${r.personName}（${r.personId}）`);
+    .map(r => `${r.userName}（${r.userId}）`);
 
   const alerts: DashboardAlert[] = [];
 

--- a/src/features/dashboard/mocks/mockData.ts
+++ b/src/features/dashboard/mocks/mockData.ts
@@ -22,8 +22,8 @@ export const generateMockActivityRecords = (users: IUserMaster[], date: string):
 
     return {
       id: index + 1,
-      personId: user.UserID,
-      personName: user.FullName,
+      userId: user.UserID,
+      userName: user.FullName,
       date,
       status: Math.random() > 0.1 ? '完了' as const : '作成中' as const,
       reporter: { name: '職員A' },

--- a/src/features/dashboard/selectors/useActivitySummary.ts
+++ b/src/features/dashboard/selectors/useActivitySummary.ts
@@ -44,7 +44,7 @@ export function useActivitySummary(
     });
     try {
       const map = calculateUsageFromDailyRecords(activityRecords, users, currentMonth, {
-        userKey: (record) => String(record.personId ?? ''),
+        userKey: (record) => String(record.userId ?? ''),
         dateKey: (record) => record.date ?? '',
         countRule: (record) => record.status === '完了',
       });
@@ -119,7 +119,7 @@ export function useActivitySummary(
     const recordedUserIds = new Set(
       activityRecords
         .filter(r => r.status === '完了' || r.status === '作成中')
-        .map(r => normalizeUserId(String(r.personId)))
+        .map(r => normalizeUserId(String(r.userId)))
     );
 
     const rawPendingUserIds = users

--- a/src/features/handoff/HandoffQuickNoteCard.tsx
+++ b/src/features/handoff/HandoffQuickNoteCard.tsx
@@ -52,6 +52,15 @@ export const HandoffQuickNoteCard: React.FC = () => {
   const { createHandoff } = useHandoffTimeline();
   const { data: users } = useUsersDemo();
 
+  // UserRelation: O(1) ルックアップ
+  const userLookup = useMemo(() => {
+    const map = new Map<string, IUserMaster>();
+    for (const u of users) {
+      map.set(u.UserID.toString(), u);
+    }
+    return map;
+  }, [users]);
+
   const [target, setTarget] = useState<TargetOption>('ALL');
   const [category, setCategory] = useState<HandoffCategory>('体調');
   const [severity, setSeverity] = useState<HandoffSeverity>('通常');
@@ -157,7 +166,7 @@ export const HandoffQuickNoteCard: React.FC = () => {
                 if (value === 'ALL') {
                   setTarget('ALL');
                 } else {
-                  const user = users.find(u => u.UserID.toString() === value);
+                  const user = userLookup.get(value);
                   if (user) setTarget(user);
                 }
               }}

--- a/src/features/handoff/components/CompactNewHandoffInput.tsx
+++ b/src/features/handoff/components/CompactNewHandoffInput.tsx
@@ -26,7 +26,7 @@ import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import { alpha, useTheme } from '@mui/material/styles';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useUsersDemo } from '../../users/usersStoreDemo';
 import type { HandoffCategory, HandoffSeverity } from '../handoffTypes';
 import { useNewHandoffForm } from '../hooks/useNewHandoffForm';
@@ -63,6 +63,15 @@ export const CompactNewHandoffInput: React.FC<CompactNewHandoffInputProps> = ({
 }) => {
   const theme = useTheme();
   const { data: users } = useUsersDemo();
+
+  // O(1) ルックアップマップ
+  const userLookup = useMemo(() => {
+    const map = new Map<string, (typeof users)[number]>();
+    for (const u of users) {
+      map.set(u.UserID.toString(), u);
+    }
+    return map;
+  }, [users]);
 
   const form = useNewHandoffForm(onSuccess);
 
@@ -177,7 +186,7 @@ export const CompactNewHandoffInput: React.FC<CompactNewHandoffInputProps> = ({
                 if (value === 'ALL') {
                   form.setTarget('ALL');
                 } else {
-                  const user = users.find((u) => u.UserID.toString() === value);
+                  const user = userLookup.get(value);
                   if (user) form.setTarget(user);
                 }
               }}

--- a/src/features/handoff/hooks/__tests__/useImportantHandoffsForDaily.test.ts
+++ b/src/features/handoff/hooks/__tests__/useImportantHandoffsForDaily.test.ts
@@ -11,7 +11,7 @@ describe('useImportantHandoffsForDaily utilities', () => {
   const mockHandoffs: ImportantHandoffForDaily[] = [
     {
       id: 1,
-      personId: '001',
+      userId: '001',
       personDisplayName: '田中太郎',
       date: '2025-11-18',
       time: '09:30',
@@ -23,7 +23,7 @@ describe('useImportantHandoffsForDaily utilities', () => {
     },
     {
       id: 2,
-      personId: '001',
+      userId: '001',
       personDisplayName: '田中太郎',
       date: '2025-11-18',
       time: '14:15',

--- a/src/features/handoff/hooks/useImportantHandoffsForDaily.ts
+++ b/src/features/handoff/hooks/useImportantHandoffsForDaily.ts
@@ -8,7 +8,7 @@ import { toLocalDateISO } from '@/utils/getNow';
  */
 export interface ImportantHandoffForDaily {
   id: string | number;
-  personId: string;
+  userId: string;
   personDisplayName: string;
   date: string;      // 'YYYY-MM-DD'
   time: string;      // 'HH:mm' 時刻表示用
@@ -22,11 +22,11 @@ export interface ImportantHandoffForDaily {
 /**
  * 日次記録作成時に重要な申し送り情報を取得するフック
  *
- * @param personId 対象利用者のID
+ * @param userId 対象利用者のID
  * @param date 対象日付（YYYY-MM-DD）
  * @returns 重要度「重要」の申し送りのみ
  */
-export function useImportantHandoffsForDaily(personId: string, date: string) {
+export function useImportantHandoffsForDaily(userId: string, date: string) {
   const [importantHandoffs, setImportantHandoffs] = useState<ImportantHandoffForDaily[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -56,9 +56,11 @@ export function useImportantHandoffsForDaily(personId: string, date: string) {
       // 指定された利用者 + 重要度「重要」のみを抽出
       const filtered = allHandoffs
         .filter(handoff => {
-          // 利用者IDマッチング（userCode または personId で照合）
-          const userMatch = handoff.userCode === personId ||
-                           handoff.userDisplayName.includes(personId);
+          // 利用者IDマッチング: userCode（= UserID）で厳密照合
+          // NOTE: userId は呼び出し側で UserID に統一されている前提。
+          //       将来 UserRef ベースに移行する際は domain/user の
+          //       buildUserRefLookup を利用する。
+          const userMatch = handoff.userCode === userId;
 
           // 重要度フィルタ
           const severityMatch = handoff.severity === '重要';
@@ -71,7 +73,7 @@ export function useImportantHandoffsForDaily(personId: string, date: string) {
     } else {
       setImportantHandoffs([]);
     }
-  }, [personId, date, allHandoffs, handoffsLoading, handoffsError]);
+  }, [userId, date, allHandoffs, handoffsLoading, handoffsError]);
 
   return {
     items: importantHandoffs,
@@ -92,7 +94,7 @@ function convertToImportantHandoff(handoff: HandoffRecord): ImportantHandoffForD
 
   return {
     id: handoff.id,
-    personId: handoff.userCode,
+    userId: handoff.userCode,
     personDisplayName: handoff.userDisplayName,
     date,
     time,
@@ -164,13 +166,13 @@ function getStatusIcon(status: string): string {
  */
 export function shouldAutoGenerateSpecialNotes(
   isNewRecord: boolean,
-  personId: string,
+  userId: string,
   currentSpecialNotes: string,
   importantHandoffsCount: number
 ): boolean {
   return (
     isNewRecord &&                                    // 新規作成時のみ
-    Boolean(personId) &&                             // 利用者が選択済み
+    Boolean(userId) &&                             // 利用者が選択済み
     importantHandoffsCount > 0 &&                    // 重要な申し送りが存在
     (!currentSpecialNotes || currentSpecialNotes.trim() === '')  // 特記事項が空
   );

--- a/src/features/today/hooks/useTodayTasks.ts
+++ b/src/features/today/hooks/useTodayTasks.ts
@@ -21,6 +21,7 @@
 import { useMemo } from 'react';
 import { useHandoffTimeline } from '@/features/handoff/useHandoffTimeline';
 import { useTodaySummary } from '../domain/useTodaySummary';
+import { createUserNameResolver } from '@/domain/user';
 import {
   buildTodayTasks,
   dedupeTasks,
@@ -52,16 +53,11 @@ export function useTodayTasks(): TodayTasksResult {
   const todaySummary = useTodaySummary();
   const { todayHandoffs, loading: handoffLoading } = useHandoffTimeline('all', 'today');
 
-  // 2. Map users for name resolution
-  const userNameMap = useMemo(() => {
-    const map = new Map<string, string>();
-    for (const u of todaySummary.users) {
-      const uid = (u.UserID ?? '').trim() || `U${String(u.Id ?? 0).padStart(3, '0')}`;
-      const name = u.FullName ?? u.Title ?? uid;
-      map.set(uid, name);
-    }
-    return map;
-  }, [todaySummary.users]);
+  // 2. Build user name resolver via domain/user
+  const resolveUserName = useMemo(
+    () => createUserNameResolver(todaySummary.users),
+    [todaySummary.users],
+  );
 
   // 3. Build engine input from existing sources
   const engineInput: TodayEngineInput = useMemo(() => {
@@ -90,14 +86,14 @@ export function useTodayTasks(): TodayTasksResult {
       })),
       scheduleLanes: allLanes,
       handoffItems,
-      resolveUserName: (uid: string) => userNameMap.get(uid) ?? uid,
+      resolveUserName,
     };
   }, [
     todayHandoffs,
     todaySummary.dailyRecordStatus.pendingUserIds,
     todaySummary.briefingAlerts,
     todaySummary.scheduleLanesToday,
-    userNameMap,
+    resolveUserName,
   ]);
 
   // 4. Run pure engine pipeline

--- a/src/features/users/components/MonthlyUsageDashboardCard.tsx
+++ b/src/features/users/components/MonthlyUsageDashboardCard.tsx
@@ -50,7 +50,7 @@ const calculateMonthlyUsageCounts = (
       record.date.startsWith(monthPrefix)
     )
     .reduce<Record<string, number>>((acc, record) => {
-      acc[record.personId] = (acc[record.personId] || 0) + 1;
+      acc[record.userId] = (acc[record.userId] || 0) + 1;
       return acc;
     }, {});
 };

--- a/src/lib/__tests__/dailyRecordLogic.test.ts
+++ b/src/lib/__tests__/dailyRecordLogic.test.ts
@@ -17,8 +17,8 @@ import {
 // テスト用のモックデータ
 const createMockRecord = (overrides: Partial<PersonDaily> = {}): PersonDaily => ({
   id: 1,
-  personId: '001',
-  personName: '田中太郎',
+  userId: '001',
+  userName: '田中太郎',
   date: '2024-11-16',
   status: '完了',
   reporter: { name: '職員A' },
@@ -92,16 +92,16 @@ describe('dailyRecordLogic', () => {
         createMockRecord({ id: 2 })
       ];
       const newRecord = createRecordWithoutId({
-        personName: '佐藤花子',
-        personId: '002'
+        userName: '佐藤花子',
+        userId: '002'
       });
 
       const result = addDailyRecord(existingRecords, newRecord);
 
       expect(result).toHaveLength(3);
       expect(result[2].id).toBe(3);
-      expect(result[2].personName).toBe('佐藤花子');
-      expect(result[2].personId).toBe('002');
+      expect(result[2].userName).toBe('佐藤花子');
+      expect(result[2].userId).toBe('002');
     });
 
     it('元の配列は変更されない（immutable）', () => {
@@ -118,11 +118,11 @@ describe('dailyRecordLogic', () => {
   describe('updateDailyRecord', () => {
     it('指定されたIDのレコードを更新する', () => {
       const existingRecords = [
-        createMockRecord({ id: 1, personName: '田中太郎' }),
-        createMockRecord({ id: 2, personName: '佐藤花子' })
+        createMockRecord({ id: 1, userName: '田中太郎' }),
+        createMockRecord({ id: 2, userName: '佐藤花子' })
       ];
       const updatedRecord = createRecordWithoutId({
-        personName: '田中次郎',
+        userName: '田中次郎',
         status: '作成中'
       });
 
@@ -130,9 +130,9 @@ describe('dailyRecordLogic', () => {
 
       expect(result).toHaveLength(2);
       expect(result[0].id).toBe(1);
-      expect(result[0].personName).toBe('田中次郎');
+      expect(result[0].userName).toBe('田中次郎');
       expect(result[0].status).toBe('作成中');
-      expect(result[1].personName).toBe('佐藤花子'); // 他のレコードは変更されない
+      expect(result[1].userName).toBe('佐藤花子'); // 他のレコードは変更されない
     });
 
     it('存在しないIDを指定した場合、元の配列をそのまま返す', () => {
@@ -151,15 +151,15 @@ describe('dailyRecordLogic', () => {
   describe('deleteDailyRecord', () => {
     it('指定されたIDのレコードを削除する', () => {
       const existingRecords = [
-        createMockRecord({ id: 1, personName: '田中太郎' }),
-        createMockRecord({ id: 2, personName: '佐藤花子' }),
-        createMockRecord({ id: 3, personName: '鈴木次郎' })
+        createMockRecord({ id: 1, userName: '田中太郎' }),
+        createMockRecord({ id: 2, userName: '佐藤花子' }),
+        createMockRecord({ id: 3, userName: '鈴木次郎' })
       ];
 
       const result = deleteDailyRecord(existingRecords, 2);
 
       expect(result).toHaveLength(2);
-      expect(result.map(r => r.personName)).toEqual(['田中太郎', '鈴木次郎']);
+      expect(result.map(r => r.userName)).toEqual(['田中太郎', '鈴木次郎']);
     });
 
     it('存在しないIDを指定した場合、元の配列をそのまま返す', () => {
@@ -175,29 +175,29 @@ describe('dailyRecordLogic', () => {
     it('editingRecordIdが未定義の場合は新規追加', () => {
       const existingRecords = [createMockRecord({ id: 1 })];
       const newRecord = createRecordWithoutId({
-        personName: '佐藤花子'
+        userName: '佐藤花子'
       });
 
       const result = saveDailyRecord(existingRecords, newRecord);
 
       expect(result).toHaveLength(2);
       expect(result[1].id).toBe(2);
-      expect(result[1].personName).toBe('佐藤花子');
+      expect(result[1].userName).toBe('佐藤花子');
     });
 
     it('editingRecordIdが指定されている場合は更新', () => {
       const existingRecords = [
-        createMockRecord({ id: 1, personName: '田中太郎' })
+        createMockRecord({ id: 1, userName: '田中太郎' })
       ];
       const updatedRecord = createRecordWithoutId({
-        personName: '田中次郎'
+        userName: '田中次郎'
       });
 
       const result = saveDailyRecord(existingRecords, updatedRecord, 1);
 
       expect(result).toHaveLength(1);
       expect(result[0].id).toBe(1);
-      expect(result[0].personName).toBe('田中次郎');
+      expect(result[0].userName).toBe('田中次郎');
     });
   });
 
@@ -213,7 +213,7 @@ describe('dailyRecordLogic', () => {
 
     it('利用者名が空の場合、エラーを返す', () => {
       const invalidRecord = createRecordWithoutId({
-        personName: ''
+        userName: ''
       });
 
       const result = validateDailyRecord(invalidRecord);
@@ -224,7 +224,7 @@ describe('dailyRecordLogic', () => {
 
     it('利用者の選択が空の場合、エラーを返す', () => {
       const invalidRecord = createRecordWithoutId({
-        personId: ''
+        userId: ''
       });
 
       const result = validateDailyRecord(invalidRecord);
@@ -329,8 +329,8 @@ describe('dailyRecordLogic', () => {
 
     it('複数のエラーがある場合、全てのエラーを返す', () => {
       const invalidRecord = createRecordWithoutId({
-        personName: '',
-        personId: '',
+        userName: '',
+        userId: '',
         date: ''
       });
 
@@ -388,23 +388,23 @@ describe('dailyRecordLogic', () => {
 
   describe('searchRecordsByName', () => {
     const records = [
-      createMockRecord({ id: 1, personName: '田中太郎', personId: '001' }),
-      createMockRecord({ id: 2, personName: '佐藤花子', personId: '002' }),
-      createMockRecord({ id: 3, personName: '田中二郎', personId: '003' })
+      createMockRecord({ id: 1, userName: '田中太郎', userId: '001' }),
+      createMockRecord({ id: 2, userName: '佐藤花子', userId: '002' }),
+      createMockRecord({ id: 3, userName: '田中二郎', userId: '003' })
     ];
 
     it('利用者名での部分一致検索', () => {
       const result = searchRecordsByName(records, '田中');
 
       expect(result).toHaveLength(2);
-      expect(result.map(r => r.personName)).toEqual(['田中太郎', '田中二郎']);
+      expect(result.map(r => r.userName)).toEqual(['田中太郎', '田中二郎']);
     });
 
     it('利用者IDでの検索', () => {
       const result = searchRecordsByName(records, '002');
 
       expect(result).toHaveLength(1);
-      expect(result[0].personName).toBe('佐藤花子');
+      expect(result[0].userName).toBe('佐藤花子');
     });
 
     it('大文字小文字を無視して検索', () => {

--- a/src/pages/AnalysisDashboardPage.tsx
+++ b/src/pages/AnalysisDashboardPage.tsx
@@ -11,6 +11,7 @@ import { useProcedureStore } from '@/features/daily/stores/procedureStore';
 import { AttendanceSummaryCard } from '@/features/dashboard/components/AttendanceSummaryCard';
 import { IBDPageHeader } from '@/features/ibd/core/components/IBDPageHeader';
 import { useUsersDemo } from '@/features/users/usersStoreDemo';
+import { createUserNameResolver } from '@/domain/user';
 import { isDemoModeEnabled } from '@/lib/env';
 import { toLocalDateISO } from '@/utils/getNow';
 import AssessmentIcon from '@mui/icons-material/Assessment';
@@ -70,9 +71,13 @@ const AnalysisDashboardPage: React.FC = () => {
   );
 
   const { dailyStats } = useBehaviorAnalytics(analysisData);
+  const resolveUserName = useMemo(
+    () => createUserNameResolver(users),
+    [users],
+  );
   const selectedUserName = useMemo(
-    () => users.find((u) => u.UserID === targetUserId)?.FullName ?? '',
-    [targetUserId, users],
+    () => (targetUserId ? resolveUserName(targetUserId) : ''),
+    [targetUserId, resolveUserName],
   );
 
   // --- Execution stats ---

--- a/src/pages/AssessmentDashboardPage.tsx
+++ b/src/pages/AssessmentDashboardPage.tsx
@@ -6,6 +6,7 @@ import type { AssessmentItem, SensoryProfile, UserAssessment } from '@/features/
 import { useAssessmentStore } from '@/features/assessment/stores/assessmentStore';
 import { IBDPageHeader } from '@/features/ibd/core/components/IBDPageHeader';
 import { useUsersDemo } from '@/features/users/usersStoreDemo';
+import { createUserNameResolver } from '@/domain/user';
 import { isDemoModeEnabled } from '@/lib/env';
 import DownloadIcon from '@mui/icons-material/Download';
 import PersonIcon from '@mui/icons-material/Person';
@@ -95,9 +96,14 @@ const AssessmentDashboardPage: React.FC = () => {
     setFormData(data);
   }, [demoModeEnabled, getByUserId, seedDemoData, targetUserId]);
 
-  const selectedUserName = useMemo(() => {
-    return users.find((user) => user.UserID === targetUserId)?.FullName;
-  }, [targetUserId, users]);
+  const resolveUserName = useMemo(
+    () => createUserNameResolver(users),
+    [users],
+  );
+  const selectedUserName = useMemo(
+    () => (targetUserId ? resolveUserName(targetUserId) : undefined),
+    [targetUserId, resolveUserName],
+  );
 
   const handleSave = () => {
     if (!formData) return;

--- a/src/pages/DailyRecordPage.tsx
+++ b/src/pages/DailyRecordPage.tsx
@@ -137,7 +137,6 @@ export default function DailyRecordPage() {
     const adaptedSchedules = schedulesData.map((schedule) => ({
       id: schedule.id,
       userId: schedule.userId?.toString() || schedule.personId?.toString(),
-      personId: schedule.personId?.toString(),
       title: schedule.title || '',
       startLocal: schedule.startLocal || undefined,
       startUtc: schedule.startUtc || undefined,

--- a/src/pages/dailyRecordMockData.ts
+++ b/src/pages/dailyRecordMockData.ts
@@ -23,8 +23,8 @@ export const mockUsers = [
 export const mockRecords: PersonDaily[] = [
   {
     id: 1,
-    personId: '001',
-    personName: '田中太郎',
+    userId: '001',
+    userName: '田中太郎',
     date: toLocalDateISO(),
     status: '完了',
     reporter: { name: '職員A' },
@@ -56,8 +56,8 @@ export const mockRecords: PersonDaily[] = [
   },
   {
     id: 2,
-    personId: '002',
-    personName: '佐藤花子',
+    userId: '002',
+    userName: '佐藤花子',
     date: toLocalDateISO(),
     status: '作成中',
     reporter: { name: '職員B' },
@@ -89,8 +89,8 @@ export const mockRecords: PersonDaily[] = [
   },
   {
     id: 3,
-    personId: '003',
-    personName: '鈴木次郎',
+    userId: '003',
+    userName: '鈴木次郎',
     date: toLocalDateISO(),
     status: '未作成',
     reporter: { name: '' },
@@ -133,8 +133,8 @@ export const generateTodayRecords = (): PersonDaily[] => {
 
     return {
       id: index + 1,
-      personId: userId,
-      personName: name,
+      userId: userId,
+      userName: name,
       date: today,
       status,
       reporter: { name: status === '未作成' ? '' : '職員' + String.fromCharCode(65 + (index % 5)) },
@@ -176,8 +176,8 @@ export const createMissingRecord = (
   index: number,
 ): PersonDaily => ({
   id: Date.now() + index,
-  personId: userId,
-  personName: name,
+  userId: userId,
+  userName: name,
   date,
   status: '未作成',
   reporter: { name: '' },

--- a/src/utils/attendanceUtils.ts
+++ b/src/utils/attendanceUtils.ts
@@ -110,7 +110,7 @@ export function getAbsentUserIds(
       return isAbsentSchedule(schedule);
     })
     .map(schedule => {
-      const id = schedule.userId || schedule.personId;
+      const id = schedule.userId || schedule.userId;
       // number型対応: 文字列に統一
       return typeof id === 'number' ? String(id) : id;
     })

--- a/tests/unit/timeFlowUtils.spec.ts
+++ b/tests/unit/timeFlowUtils.spec.ts
@@ -69,8 +69,8 @@ describe('countRecordedSlots', () => {
     ({
       id: 1,
       supportPlanId: 'plan-1',
-      personId: 'u-1',
-      personName: 'Test',
+      userId: 'u-1',
+      userName: 'Test',
       date: '2026-03-14',
       timeSlot: '09:00 活動',
       activityKey: '09:00',


### PR DESCRIPTION
## Summary
- migrate daily/cross-module/dashboard/handoff/today flow to userId-based references
- update daily form/list/view-model and related test fixtures
- align dashboard and daily pages with snapshot-oriented data access

## Notes
- stacked on top of #1002