### PR TITLE
feat(timeline): 利用者タイムライン機能 Phase 1-4

### DIFF
--- a/src/domain/timeline/__tests__/buildTimeline.spec.ts
+++ b/src/domain/timeline/__tests__/buildTimeline.spec.ts
@@ -1,0 +1,246 @@
+/**
+ * buildTimeline — ユニットテスト
+ *
+ * 4ドメイン結合 → フィルタ → ソートの統合テスト。
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildTimeline } from '../buildTimeline';
+import type { TimelineSources, TimelineOptions } from '../buildTimeline';
+import type { PersonDaily } from '@/domain/daily/types';
+import type { HighRiskIncident } from '@/domain/support/highRiskIncident';
+import type { IndividualSupportPlan } from '@/domain/isp/schema';
+import type { HandoffRecord } from '@/features/handoff/handoffTypes';
+
+// ─── テストデータ ──────────────────────────────
+
+const makeDaily = (id: number, date: string): PersonDaily => ({
+  id,
+  userId: 'U001',
+  userName: '田中',
+  date,
+  status: '完了',
+  reporter: { name: '佐藤', id: 'R001' },
+  draft: { isDraft: false },
+  kind: 'A',
+  data: { amActivities: [], pmActivities: [] },
+});
+
+const makeIncident = (
+  id: string,
+  occurredAt: string,
+  severity: '低' | '中' | '高' | '重大インシデント' = '中',
+): HighRiskIncident => ({
+  id,
+  userId: 'U001',
+  occurredAt,
+  severity,
+  description: 'テスト',
+});
+
+const makeIsp = (
+  id: string,
+  createdAt: string,
+): IndividualSupportPlan =>
+  ({
+    id,
+    userId: 'U001',
+    title: 'テスト ISP',
+    planStartDate: '2026-04-01',
+    planEndDate: '2027-03-31',
+    userIntent: 'テスト',
+    familyIntent: '',
+    overallSupportPolicy: 'テスト',
+    qolIssues: '',
+    longTermGoals: ['目標'],
+    shortTermGoals: ['目標'],
+    supportSummary: '',
+    precautions: '',
+    consentAt: null,
+    deliveredAt: null,
+    monitoringSummary: '',
+    lastMonitoringAt: null,
+    nextReviewAt: null,
+    status: 'active',
+    isCurrent: true,
+    createdAt,
+    createdBy: 'admin',
+    updatedAt: createdAt,
+    updatedBy: 'admin',
+    version: 1,
+  }) as IndividualSupportPlan;
+
+const makeHandoff = (id: number, createdAt: string): HandoffRecord => ({
+  id,
+  title: '申し送り',
+  message: '',
+  userCode: 'UC001',
+  userDisplayName: '田中',
+  category: '体調',
+  severity: '通常',
+  status: '未対応',
+  timeBand: '午前',
+  createdAt,
+  createdByName: '佐藤',
+  isDraft: false,
+});
+
+// ─── テスト ─────────────────────────────────────
+
+describe('buildTimeline', () => {
+  // ── 基本結合 ──
+
+  it('空ソースなら空配列', () => {
+    expect(buildTimeline({})).toEqual([]);
+  });
+
+  it('全ドメインを結合してイベント数が正しい', () => {
+    const sources: TimelineSources = {
+      dailyRecords: [makeDaily(1, '2026-03-15')],
+      incidents: [makeIncident('INC-1', '2026-03-15T10:00:00Z')],
+      ispRecords: [makeIsp('ISP-1', '2026-03-15')],
+      handoffRecords: [makeHandoff(100, '2026-03-15T09:00:00Z')],
+    };
+    const result = buildTimeline(sources);
+    expect(result).toHaveLength(4);
+  });
+
+  // ── ソート ──
+
+  it('occurredAt 降順にソートされる', () => {
+    const sources: TimelineSources = {
+      dailyRecords: [makeDaily(1, '2026-03-10')],
+      incidents: [makeIncident('INC-1', '2026-03-15T10:00:00Z')],
+      handoffRecords: [makeHandoff(100, '2026-03-12T09:00:00Z')],
+    };
+    const result = buildTimeline(sources);
+    expect(result.map((e) => e.id)).toEqual([
+      'incident-INC-1',     // 2026-03-15
+      'handoff-100',        // 2026-03-12
+      'daily-1',            // 2026-03-10
+    ]);
+  });
+
+  // ── Handoff resolver ──
+
+  it('resolver が null を返した Handoff は除外される', () => {
+    const sources: TimelineSources = {
+      handoffRecords: [
+        makeHandoff(100, '2026-03-15T09:00:00Z'),
+        makeHandoff(101, '2026-03-15T10:00:00Z'),
+      ],
+    };
+    const options: TimelineOptions = {
+      resolveUserIdFromCode: (code) => (code === 'UC001' ? null : code),
+    };
+    // UC001 は null → 両方 UC001 なので全て除外
+    const result = buildTimeline(sources, options);
+    expect(result).toHaveLength(0);
+  });
+
+  it('resolver 省略時は identity として動作', () => {
+    const sources: TimelineSources = {
+      handoffRecords: [makeHandoff(100, '2026-03-15T09:00:00Z')],
+    };
+    const result = buildTimeline(sources);
+    expect(result).toHaveLength(1);
+    expect(result[0].userId).toBe('UC001'); // identity → userCode がそのまま
+  });
+
+  // ── ソースフィルタ ──
+
+  it('filter.sources で特定ドメインのみ取得', () => {
+    const sources: TimelineSources = {
+      dailyRecords: [makeDaily(1, '2026-03-15')],
+      incidents: [makeIncident('INC-1', '2026-03-15T10:00:00Z')],
+    };
+    const result = buildTimeline(sources, {
+      filter: { sources: ['daily'] },
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].source).toBe('daily');
+  });
+
+  // ── 期間フィルタ ──
+
+  it('filter.from で開始日以降のみ取得', () => {
+    const sources: TimelineSources = {
+      dailyRecords: [
+        makeDaily(1, '2026-03-01'),
+        makeDaily(2, '2026-03-15'),
+      ],
+    };
+    const result = buildTimeline(sources, {
+      filter: { from: '2026-03-10' },
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('daily-2');
+  });
+
+  it('filter.to で終了日以前のみ取得', () => {
+    const sources: TimelineSources = {
+      dailyRecords: [
+        makeDaily(1, '2026-03-01'),
+        makeDaily(2, '2026-03-15'),
+      ],
+    };
+    const result = buildTimeline(sources, {
+      filter: { to: '2026-03-10' },
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('daily-1');
+  });
+
+  // ── 重要度フィルタ ──
+
+  it('filter.severity で指定以上のみ取得', () => {
+    const sources: TimelineSources = {
+      dailyRecords: [makeDaily(1, '2026-03-15')], // info
+      incidents: [
+        makeIncident('INC-1', '2026-03-15T10:00:00Z', '中'), // warning
+        makeIncident('INC-2', '2026-03-15T11:00:00Z', '高'), // critical
+      ],
+    };
+    const result = buildTimeline(sources, {
+      filter: { severity: 'warning' },
+    });
+    expect(result).toHaveLength(2); // warning + critical
+    expect(result.every((e) => e.severity !== 'info')).toBe(true);
+  });
+
+  it('filter.severity=critical なら critical のみ', () => {
+    const sources: TimelineSources = {
+      incidents: [
+        makeIncident('INC-1', '2026-03-15T10:00:00Z', '中'), // warning
+        makeIncident('INC-2', '2026-03-15T11:00:00Z', '高'), // critical
+      ],
+    };
+    const result = buildTimeline(sources, {
+      filter: { severity: 'critical' },
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('incident-INC-2');
+  });
+
+  // ── 複合フィルタ ──
+
+  it('複数フィルタを同時適用', () => {
+    const sources: TimelineSources = {
+      dailyRecords: [makeDaily(1, '2026-03-15')],
+      incidents: [
+        makeIncident('INC-1', '2026-03-10T10:00:00Z', '低'), // info, 範囲外
+        makeIncident('INC-2', '2026-03-15T11:00:00Z', '高'), // critical, 範囲内
+      ],
+      handoffRecords: [makeHandoff(100, '2026-03-15T09:00:00Z')],
+    };
+    const result = buildTimeline(sources, {
+      filter: {
+        sources: ['incident'],
+        from: '2026-03-12',
+        severity: 'warning',
+      },
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('incident-INC-2');
+  });
+});

--- a/src/domain/timeline/__tests__/dailyAdapter.spec.ts
+++ b/src/domain/timeline/__tests__/dailyAdapter.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * dailyAdapter — ユニットテスト
+ */
+
+import { describe, it, expect } from 'vitest';
+import { dailyToTimelineEvent } from '../adapters/dailyAdapter';
+import type { PersonDaily, AxisDaily } from '@/domain/daily/types';
+
+const makePersonDaily = (overrides: Partial<PersonDaily> = {}): PersonDaily => ({
+  id: 1,
+  userId: 'U001',
+  userName: '田中太郎',
+  date: '2026-03-15',
+  status: '完了',
+  reporter: { name: '佐藤', id: 'R001' },
+  draft: { isDraft: false },
+  kind: 'A',
+  data: {
+    amActivities: ['作業'],
+    pmActivities: ['散歩'],
+    specialNotes: '体調良好',
+  },
+  ...overrides,
+});
+
+const makeAxisDaily = (overrides: Partial<AxisDaily> = {}): AxisDaily => ({
+  id: 2,
+  userId: 'U001',
+  userName: '田中太郎',
+  date: '2026-03-15',
+  status: '完了',
+  reporter: { name: '佐藤', id: 'R001' },
+  draft: { isDraft: false },
+  kind: 'B',
+  data: {
+    proactive: ['挨拶'],
+    skillSupports: ['手洗い'],
+    tags: [],
+    incidentRefIds: [],
+    notes: '安定していた',
+  },
+  ...overrides,
+});
+
+describe('dailyToTimelineEvent', () => {
+  it('A型レコードを変換: id, source, title が正しい', () => {
+    const result = dailyToTimelineEvent(makePersonDaily());
+    expect(result.id).toBe('daily-1');
+    expect(result.source).toBe('daily');
+    expect(result.userId).toBe('U001');
+    expect(result.title).toBe('日次記録 (個人)');
+    expect(result.severity).toBe('info');
+    expect(result.sourceRef).toEqual({ id: 1 });
+  });
+
+  it('B型レコードを変換: title に「軸別」が含まれる', () => {
+    const result = dailyToTimelineEvent(makeAxisDaily());
+    expect(result.id).toBe('daily-2');
+    expect(result.title).toBe('日次記録 (軸別)');
+  });
+
+  it('occurredAt は date に T00:00:00 を付加', () => {
+    const result = dailyToTimelineEvent(makePersonDaily({ date: '2026-01-01' }));
+    expect(result.occurredAt).toBe('2026-01-01T00:00:00');
+  });
+
+  it('A型: specialNotes が description に入る', () => {
+    const result = dailyToTimelineEvent(makePersonDaily());
+    expect(result.description).toBe('体調良好');
+  });
+
+  it('B型: notes が description に入る', () => {
+    const result = dailyToTimelineEvent(makeAxisDaily());
+    expect(result.description).toBe('安定していた');
+  });
+
+  it('description が空のときは undefined', () => {
+    const result = dailyToTimelineEvent(
+      makePersonDaily({
+        data: { amActivities: [], pmActivities: [], specialNotes: '' },
+      }),
+    );
+    expect(result.description).toBeUndefined();
+  });
+
+  it('meta に kind と status が含まれる', () => {
+    const result = dailyToTimelineEvent(makePersonDaily());
+    expect(result.meta).toEqual({ kind: 'A', status: '完了' });
+  });
+});

--- a/src/domain/timeline/__tests__/handoffAdapter.spec.ts
+++ b/src/domain/timeline/__tests__/handoffAdapter.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * handoffAdapter — ユニットテスト
+ *
+ * ResolveUserIdFromCode 注入パターンのテストを含む。
+ */
+
+import { describe, it, expect } from 'vitest';
+import { handoffToTimelineEvent } from '../adapters/handoffAdapter';
+import type { HandoffRecord, HandoffSeverity } from '@/features/handoff/handoffTypes';
+import type { ResolveUserIdFromCode } from '../types';
+
+const makeHandoff = (
+  overrides: Partial<HandoffRecord> = {},
+): HandoffRecord => ({
+  id: 100,
+  title: '水分摂取量の注意',
+  message: '午前中に水分をあまり取れていません',
+  userCode: 'UC001',
+  userDisplayName: '田中太郎',
+  category: '体調',
+  severity: '要注意',
+  status: '未対応',
+  timeBand: '午前',
+  createdAt: '2026-03-15T09:00:00Z',
+  createdByName: '佐藤花子',
+  isDraft: false,
+  ...overrides,
+});
+
+/** identity resolver（userCode = userId の場合） */
+const identityResolver: ResolveUserIdFromCode = (code) => code;
+
+/** ルックアップ resolver */
+const lookupResolver: ResolveUserIdFromCode = (code) => {
+  const map: Record<string, string> = { UC001: 'U001', UC002: 'U002' };
+  return map[code] ?? null;
+};
+
+/** 常に null を返す resolver */
+const nullResolver: ResolveUserIdFromCode = () => null;
+
+describe('handoffToTimelineEvent', () => {
+  it('identity resolver: userCode がそのまま userId になる', () => {
+    const result = handoffToTimelineEvent(makeHandoff(), identityResolver);
+    expect(result).not.toBeNull();
+    expect(result!.userId).toBe('UC001');
+  });
+
+  it('lookup resolver: userCode が userId に変換される', () => {
+    const result = handoffToTimelineEvent(makeHandoff(), lookupResolver);
+    expect(result).not.toBeNull();
+    expect(result!.userId).toBe('U001');
+  });
+
+  it('null resolver: 解決不能なら null を返す', () => {
+    const result = handoffToTimelineEvent(makeHandoff(), nullResolver);
+    expect(result).toBeNull();
+  });
+
+  it('基本変換: id, source, title, sourceRef が正しい', () => {
+    const result = handoffToTimelineEvent(makeHandoff(), identityResolver)!;
+    expect(result.id).toBe('handoff-100');
+    expect(result.source).toBe('handoff');
+    expect(result.title).toBe('申し送り: 水分摂取量の注意');
+    expect(result.sourceRef).toEqual({ id: 100 });
+  });
+
+  it('occurredAt に createdAt がそのまま使われる', () => {
+    const result = handoffToTimelineEvent(makeHandoff(), identityResolver)!;
+    expect(result.occurredAt).toBe('2026-03-15T09:00:00Z');
+  });
+
+  it.each<[HandoffSeverity, string]>([
+    ['通常', 'info'],
+    ['要注意', 'warning'],
+    ['重要', 'critical'],
+  ])('severity "%s" → "%s"', (input, expected) => {
+    const result = handoffToTimelineEvent(
+      makeHandoff({ severity: input }),
+      identityResolver,
+    )!;
+    expect(result.severity).toBe(expected);
+  });
+
+  it('description に message が入る', () => {
+    const result = handoffToTimelineEvent(makeHandoff(), identityResolver)!;
+    expect(result.description).toBe('午前中に水分をあまり取れていません');
+  });
+
+  it('message が空なら description は undefined', () => {
+    const result = handoffToTimelineEvent(
+      makeHandoff({ message: '' }),
+      identityResolver,
+    )!;
+    expect(result.description).toBeUndefined();
+  });
+
+  it('meta に category, severity, status が含まれる', () => {
+    const result = handoffToTimelineEvent(makeHandoff(), identityResolver)!;
+    expect(result.meta).toEqual({
+      category: '体調',
+      severity: '要注意',
+      status: '未対応',
+    });
+  });
+});

--- a/src/domain/timeline/__tests__/incidentAdapter.spec.ts
+++ b/src/domain/timeline/__tests__/incidentAdapter.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * incidentAdapter — ユニットテスト
+ */
+
+import { describe, it, expect } from 'vitest';
+import { incidentToTimelineEvent } from '../adapters/incidentAdapter';
+import type { HighRiskIncident, RiskSeverity } from '@/domain/support/highRiskIncident';
+
+const makeIncident = (
+  overrides: Partial<HighRiskIncident> = {},
+): HighRiskIncident => ({
+  id: 'INC-001',
+  userId: 'U001',
+  occurredAt: '2026-03-15T10:30:00Z',
+  severity: '中',
+  description: '他傷行動あり',
+  ...overrides,
+});
+
+describe('incidentToTimelineEvent', () => {
+  it('基本変換: id, source, userId が正しい', () => {
+    const result = incidentToTimelineEvent(makeIncident());
+    expect(result.id).toBe('incident-INC-001');
+    expect(result.source).toBe('incident');
+    expect(result.userId).toBe('U001');
+    expect(result.sourceRef).toEqual({ id: 'INC-001' });
+  });
+
+  it('occurredAt がそのまま渡される', () => {
+    const result = incidentToTimelineEvent(makeIncident());
+    expect(result.occurredAt).toBe('2026-03-15T10:30:00Z');
+  });
+
+  it('title に severity が含まれる', () => {
+    const result = incidentToTimelineEvent(makeIncident({ severity: '高' }));
+    expect(result.title).toBe('インシデント (高)');
+  });
+
+  it.each<[RiskSeverity, string]>([
+    ['低', 'info'],
+    ['中', 'warning'],
+    ['高', 'critical'],
+    ['重大インシデント', 'critical'],
+  ])('severity "%s" → "%s"', (input, expected) => {
+    const result = incidentToTimelineEvent(makeIncident({ severity: input }));
+    expect(result.severity).toBe(expected);
+  });
+
+  it('description が変換される', () => {
+    const result = incidentToTimelineEvent(
+      makeIncident({ description: 'テスト詳細' }),
+    );
+    expect(result.description).toBe('テスト詳細');
+  });
+
+  it('meta に severity が含まれる', () => {
+    const result = incidentToTimelineEvent(makeIncident({ severity: '高' }));
+    expect(result.meta).toEqual({ severity: '高' });
+  });
+});

--- a/src/domain/timeline/__tests__/ispAdapter.spec.ts
+++ b/src/domain/timeline/__tests__/ispAdapter.spec.ts
@@ -1,0 +1,79 @@
+/**
+ * ispAdapter — ユニットテスト
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ispToTimelineEvent } from '../adapters/ispAdapter';
+import type { IndividualSupportPlan } from '@/domain/isp/schema';
+
+const makeIsp = (
+  overrides: Partial<IndividualSupportPlan> = {},
+): IndividualSupportPlan =>
+  ({
+    id: 'ISP-001',
+    userId: 'U001',
+    title: '2026年度 個別支援計画',
+    planStartDate: '2026-04-01',
+    planEndDate: '2027-03-31',
+    userIntent: '自立した生活',
+    familyIntent: '',
+    overallSupportPolicy: '丁寧な支援',
+    qolIssues: '',
+    longTermGoals: ['就労定着'],
+    shortTermGoals: ['出席率90%'],
+    supportSummary: '',
+    precautions: '',
+    consentAt: null,
+    deliveredAt: null,
+    monitoringSummary: '',
+    lastMonitoringAt: null,
+    nextReviewAt: null,
+    status: 'active',
+    isCurrent: true,
+    createdAt: '2026-03-15',
+    createdBy: 'admin',
+    updatedAt: '2026-03-15',
+    updatedBy: 'admin',
+    version: 1,
+    ...overrides,
+  }) as IndividualSupportPlan;
+
+describe('ispToTimelineEvent', () => {
+  it('基本変換: id, source, userId が正しい', () => {
+    const result = ispToTimelineEvent(makeIsp());
+    expect(result.id).toBe('isp-ISP-001');
+    expect(result.source).toBe('isp');
+    expect(result.userId).toBe('U001');
+    expect(result.sourceRef).toEqual({ id: 'ISP-001' });
+  });
+
+  it('occurredAt に createdAt が使われる', () => {
+    const result = ispToTimelineEvent(makeIsp({ createdAt: '2026-04-01' }));
+    expect(result.occurredAt).toBe('2026-04-01');
+  });
+
+  it('severity は常に info', () => {
+    const result = ispToTimelineEvent(makeIsp());
+    expect(result.severity).toBe('info');
+  });
+
+  it('title にステータスの日本語ラベルが含まれる', () => {
+    const result = ispToTimelineEvent(makeIsp({ status: 'active' }));
+    expect(result.title).toBe('個別支援計画 (実施中)');
+  });
+
+  it('title: assessment → アセスメント', () => {
+    const result = ispToTimelineEvent(makeIsp({ status: 'assessment' }));
+    expect(result.title).toBe('個別支援計画 (アセスメント)');
+  });
+
+  it('title: monitoring → モニタリング', () => {
+    const result = ispToTimelineEvent(makeIsp({ status: 'monitoring' }));
+    expect(result.title).toBe('個別支援計画 (モニタリング)');
+  });
+
+  it('meta に status と version が含まれる', () => {
+    const result = ispToTimelineEvent(makeIsp({ status: 'active', version: 3 }));
+    expect(result.meta).toEqual({ status: 'active', version: 3 });
+  });
+});

--- a/src/domain/timeline/adapters/dailyAdapter.ts
+++ b/src/domain/timeline/adapters/dailyAdapter.ts
@@ -1,0 +1,41 @@
+/**
+ * dailyAdapter — AnyDaily → TimelineEvent 変換
+ *
+ * Daily ドメインの A型（個人）/ B型（軸別）レコードを
+ * 統一タイムラインイベントに変換する純粋関数。
+ *
+ * 変換ルール:
+ *   - occurredAt: `daily.date` (YYYY-MM-DD) → ISO 形式 (T00:00:00 付加)
+ *   - severity: 常に 'info'（日次記録に重要度概念なし）
+ *   - description: A型は specialNotes、B型は notes
+ */
+
+import type { AnyDaily } from '@/domain/daily/types';
+import type { TimelineEvent } from '../types';
+
+/**
+ * AnyDaily を TimelineEvent に変換する。
+ *
+ * @param daily - Daily レコード（A型 or B型）
+ * @returns 統一タイムラインイベント
+ */
+export function dailyToTimelineEvent(daily: AnyDaily): TimelineEvent {
+  const kindLabel = daily.kind === 'A' ? '個人' : '軸別';
+  const description =
+    daily.kind === 'A' ? daily.data.specialNotes : daily.data.notes;
+
+  return {
+    id: `daily-${daily.id}`,
+    source: 'daily',
+    userId: daily.userId,
+    occurredAt: `${daily.date}T00:00:00`,
+    title: `日次記録 (${kindLabel})`,
+    description: description || undefined,
+    severity: 'info',
+    sourceRef: { id: daily.id },
+    meta: {
+      kind: daily.kind,
+      status: daily.status,
+    },
+  };
+}

--- a/src/domain/timeline/adapters/handoffAdapter.ts
+++ b/src/domain/timeline/adapters/handoffAdapter.ts
@@ -1,0 +1,58 @@
+/**
+ * handoffAdapter — HandoffRecord → TimelineEvent 変換
+ *
+ * 申し送りドメインのレコードを統一タイムラインイベントに変換する純粋関数。
+ *
+ * 設計方針:
+ *   - `userCode` → `userId` の変換は外部から resolver を注入する
+ *   - 同一値の環境では identity ((code) => code) を渡す
+ *   - resolver が null を返した場合、そのイベントは除外（null を返す）
+ *
+ * 変換ルール:
+ *   - occurredAt: `handoff.createdAt`（ISO 8601）
+ *   - severity: '通常' → info, '要注意' → warning, '重要' → critical
+ */
+
+import type { HandoffRecord, HandoffSeverity } from '@/features/handoff/handoffTypes';
+import type { TimelineEvent, TimelineSeverity, ResolveUserIdFromCode } from '../types';
+
+/** Handoff severity → 統一 severity マッピング */
+const SEVERITY_MAP: Record<HandoffSeverity, TimelineSeverity> = {
+  '通常': 'info',
+  '要注意': 'warning',
+  '重要': 'critical',
+};
+
+/**
+ * HandoffRecord を TimelineEvent に変換する。
+ *
+ * userCode → userId の解決に失敗した場合は null を返す。
+ * 呼び出し元で `.filter()` してタイムラインから除外すること。
+ *
+ * @param handoff - 申し送りレコード
+ * @param resolveUserId - userCode → userId 変換関数
+ * @returns 統一タイムラインイベント、または null（解決失敗時）
+ */
+export function handoffToTimelineEvent(
+  handoff: HandoffRecord,
+  resolveUserId: ResolveUserIdFromCode,
+): TimelineEvent | null {
+  const userId = resolveUserId(handoff.userCode);
+  if (!userId) return null;
+
+  return {
+    id: `handoff-${handoff.id}`,
+    source: 'handoff',
+    userId,
+    occurredAt: handoff.createdAt,
+    title: `申し送り: ${handoff.title}`,
+    description: handoff.message || undefined,
+    severity: SEVERITY_MAP[handoff.severity] ?? 'info',
+    sourceRef: { id: handoff.id },
+    meta: {
+      category: handoff.category,
+      severity: handoff.severity,
+      status: handoff.status,
+    },
+  };
+}

--- a/src/domain/timeline/adapters/incidentAdapter.ts
+++ b/src/domain/timeline/adapters/incidentAdapter.ts
@@ -1,0 +1,41 @@
+/**
+ * incidentAdapter — HighRiskIncident → TimelineEvent 変換
+ *
+ * インシデントドメインの重大事例レコードを
+ * 統一タイムラインイベントに変換する純粋関数。
+ *
+ * 変換ルール:
+ *   - occurredAt: そのまま（ISO 8601）
+ *   - severity: '低' → info, '中' → warning, '高'/'重大インシデント' → critical
+ */
+
+import type { HighRiskIncident, RiskSeverity } from '@/domain/support/highRiskIncident';
+import type { TimelineEvent, TimelineSeverity } from '../types';
+
+/** Incident severity → 統一 severity マッピング */
+const SEVERITY_MAP: Record<RiskSeverity, TimelineSeverity> = {
+  '低': 'info',
+  '中': 'warning',
+  '高': 'critical',
+  '重大インシデント': 'critical',
+};
+
+/**
+ * HighRiskIncident を TimelineEvent に変換する。
+ *
+ * @param incident - インシデントレコード
+ * @returns 統一タイムラインイベント
+ */
+export function incidentToTimelineEvent(incident: HighRiskIncident): TimelineEvent {
+  return {
+    id: `incident-${incident.id}`,
+    source: 'incident',
+    userId: incident.userId,
+    occurredAt: incident.occurredAt,
+    title: `インシデント (${incident.severity})`,
+    description: incident.description,
+    severity: SEVERITY_MAP[incident.severity] ?? 'warning',
+    sourceRef: { id: incident.id },
+    meta: { severity: incident.severity },
+  };
+}

--- a/src/domain/timeline/adapters/index.ts
+++ b/src/domain/timeline/adapters/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Timeline Adapters — 統合 export
+ */
+export { dailyToTimelineEvent } from './dailyAdapter';
+export { incidentToTimelineEvent } from './incidentAdapter';
+export { ispToTimelineEvent } from './ispAdapter';
+export { handoffToTimelineEvent } from './handoffAdapter';

--- a/src/domain/timeline/adapters/ispAdapter.ts
+++ b/src/domain/timeline/adapters/ispAdapter.ts
@@ -1,0 +1,40 @@
+/**
+ * ispAdapter — IndividualSupportPlan → TimelineEvent 変換
+ *
+ * ISP ドメインの個別支援計画レコードを
+ * 統一タイムラインイベントに変換する純粋関数。
+ *
+ * 変換ルール:
+ *   - occurredAt: `isp.createdAt`（ISO 8601）
+ *   - severity: 常に 'info'（ISP にリスクレベル概念なし）
+ *   - title: ISP ステータスの日本語ラベルを含む
+ *   - userId: schema 型は string だがフォールバックとして String() を適用
+ */
+
+import type { IndividualSupportPlan, IspStatus } from '@/domain/isp/schema';
+import { ISP_STATUS_DISPLAY } from '@/domain/isp/schema';
+import type { TimelineEvent } from '../types';
+
+/**
+ * IndividualSupportPlan を TimelineEvent に変換する。
+ *
+ * @param isp - ISP レコード
+ * @returns 統一タイムラインイベント
+ */
+export function ispToTimelineEvent(isp: IndividualSupportPlan): TimelineEvent {
+  const statusLabel = ISP_STATUS_DISPLAY[isp.status as IspStatus] ?? isp.status;
+
+  return {
+    id: `isp-${isp.id}`,
+    source: 'isp',
+    userId: String(isp.userId),
+    occurredAt: isp.createdAt,
+    title: `個別支援計画 (${statusLabel})`,
+    severity: 'info',
+    sourceRef: { id: isp.id },
+    meta: {
+      status: isp.status,
+      version: isp.version,
+    },
+  };
+}

--- a/src/domain/timeline/buildTimeline.ts
+++ b/src/domain/timeline/buildTimeline.ts
@@ -1,0 +1,149 @@
+/**
+ * buildTimeline — 4ドメインを統合する純粋関数
+ *
+ * Daily / Incident / ISP / Handoff のレコードを受け取り、
+ * 各 adapter で TimelineEvent に変換 → merge → filter → sort する。
+ *
+ * 設計方針:
+ *   - 純粋関数（副作用なし、テスト容易）
+ *   - Handoff の userCode → userId 変換は ResolveUserIdFromCode で注入
+ *   - フィルタは client-side で完結（Phase 1）
+ *   - ソートは occurredAt 降順（直近のイベントを上位に）
+ */
+
+import type { AnyDaily } from '@/domain/daily/types';
+import type { HighRiskIncident } from '@/domain/support/highRiskIncident';
+import type { IndividualSupportPlan } from '@/domain/isp/schema';
+import type { HandoffRecord } from '@/features/handoff/handoffTypes';
+import type {
+  TimelineEvent,
+  TimelineFilter,
+  TimelineSeverity,
+  ResolveUserIdFromCode,
+} from './types';
+import {
+  dailyToTimelineEvent,
+  incidentToTimelineEvent,
+  ispToTimelineEvent,
+  handoffToTimelineEvent,
+} from './adapters';
+
+// ─────────────────────────────────────────────
+// 入力型
+// ─────────────────────────────────────────────
+
+/** 4ドメインのソースデータ */
+export type TimelineSources = {
+  dailyRecords?: AnyDaily[];
+  incidents?: HighRiskIncident[];
+  ispRecords?: IndividualSupportPlan[];
+  handoffRecords?: HandoffRecord[];
+};
+
+/** buildTimeline のオプション */
+export type TimelineOptions = {
+  /** フィルタ条件 */
+  filter?: TimelineFilter;
+  /**
+   * Handoff の userCode → userId 変換関数。
+   * 省略時は identity (code => code) として扱う。
+   */
+  resolveUserIdFromCode?: ResolveUserIdFromCode;
+};
+
+// ─────────────────────────────────────────────
+// severity 比較用の重み
+// ─────────────────────────────────────────────
+
+const SEVERITY_WEIGHT: Record<TimelineSeverity, number> = {
+  info: 0,
+  warning: 1,
+  critical: 2,
+};
+
+// ─────────────────────────────────────────────
+// フィルタ適用
+// ─────────────────────────────────────────────
+
+function applyFilter(
+  events: TimelineEvent[],
+  filter: TimelineFilter,
+): TimelineEvent[] {
+  let result = events;
+
+  // source filter
+  if (filter.sources && filter.sources.length > 0) {
+    const allowed = new Set(filter.sources);
+    result = result.filter((e) => allowed.has(e.source));
+  }
+
+  // date range filter
+  if (filter.from) {
+    const from = filter.from;
+    result = result.filter((e) => e.occurredAt >= from);
+  }
+  if (filter.to) {
+    const to = filter.to;
+    result = result.filter((e) => e.occurredAt <= to);
+  }
+
+  // severity filter (指定以上のみ)
+  if (filter.severity) {
+    const minWeight = SEVERITY_WEIGHT[filter.severity];
+    result = result.filter(
+      (e) => SEVERITY_WEIGHT[e.severity] >= minWeight,
+    );
+  }
+
+  return result;
+}
+
+// ─────────────────────────────────────────────
+// buildTimeline
+// ─────────────────────────────────────────────
+
+/**
+ * 4ドメインのソースデータを統合してタイムラインを構築する。
+ *
+ * @param sources - 各ドメインのレコード配列（省略可能）
+ * @param options - フィルタ条件 + Handoff userCode 変換関数
+ * @returns occurredAt 降順にソートされた TimelineEvent 配列
+ *
+ * @example
+ * ```ts
+ * const events = buildTimeline(
+ *   { dailyRecords, incidents, handoffRecords },
+ *   {
+ *     filter: { sources: ['daily', 'incident'] },
+ *     resolveUserIdFromCode: (code) => userMasterMap.get(code)?.userId ?? null,
+ *   },
+ * );
+ * ```
+ */
+export function buildTimeline(
+  sources: TimelineSources,
+  options?: TimelineOptions,
+): TimelineEvent[] {
+  const resolveUserId: ResolveUserIdFromCode =
+    options?.resolveUserIdFromCode ?? ((code) => code);
+
+  // 1. 各 adapter で変換
+  const events: TimelineEvent[] = [
+    ...(sources.dailyRecords ?? []).map(dailyToTimelineEvent),
+    ...(sources.incidents ?? []).map(incidentToTimelineEvent),
+    ...(sources.ispRecords ?? []).map(ispToTimelineEvent),
+    ...(sources.handoffRecords ?? [])
+      .map((h) => handoffToTimelineEvent(h, resolveUserId))
+      .filter((e): e is TimelineEvent => e !== null),
+  ];
+
+  // 2. フィルタ適用
+  const filtered = options?.filter
+    ? applyFilter(events, options.filter)
+    : events;
+
+  // 3. occurredAt 降順ソート（直近が先頭）
+  return filtered.sort((a, b) =>
+    b.occurredAt.localeCompare(a.occurredAt),
+  );
+}

--- a/src/domain/timeline/index.ts
+++ b/src/domain/timeline/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Timeline Domain — 公開 API
+ */
+
+// 型
+export type {
+  TimelineEvent,
+  TimelineEventSource,
+  TimelineSeverity,
+  TimelineFilter,
+  ResolveUserIdFromCode,
+} from './types';
+
+// 定数
+export { TIMELINE_SOURCES, TIMELINE_SOURCE_LABELS } from './types';
+
+// コア関数
+export { buildTimeline } from './buildTimeline';
+export type { TimelineSources, TimelineOptions } from './buildTimeline';
+
+// adapters (個別利用が必要な場合)
+export {
+  dailyToTimelineEvent,
+  incidentToTimelineEvent,
+  ispToTimelineEvent,
+  handoffToTimelineEvent,
+} from './adapters';

--- a/src/domain/timeline/types.ts
+++ b/src/domain/timeline/types.ts
@@ -1,0 +1,110 @@
+/**
+ * Timeline Domain — 共通型定義
+ *
+ * 4ドメイン（Daily / Incident / ISP / Handoff）を userId 軸で
+ * 時系列に統合するための共通表示モデル。
+ *
+ * 設計方針:
+ *   - TimelineEvent: 全ドメインの差異を吸収した統一イベント型
+ *   - TimelineFilter: ソース種別・期間・重要度によるフィルタ
+ *   - Pure types only — ランタイムロジックを含まない
+ *
+ * @see docs/architecture/user_timeline_architecture.md
+ */
+
+// ─────────────────────────────────────────────
+// イベントソース種別
+// ─────────────────────────────────────────────
+
+/** タイムラインイベントの発生元ドメイン */
+export type TimelineEventSource = 'daily' | 'incident' | 'isp' | 'handoff';
+
+/** 全ソース種別（フィルタ UI 等で使用） */
+export const TIMELINE_SOURCES: readonly TimelineEventSource[] = [
+  'daily',
+  'incident',
+  'isp',
+  'handoff',
+] as const;
+
+/** ソース種別の日本語ラベル */
+export const TIMELINE_SOURCE_LABELS: Record<TimelineEventSource, string> = {
+  daily: '日次記録',
+  incident: 'インシデント',
+  isp: '個別支援計画',
+  handoff: '申し送り',
+} as const;
+
+// ─────────────────────────────────────────────
+// 重要度
+// ─────────────────────────────────────────────
+
+/** 重要度の統一3段階表現 */
+export type TimelineSeverity = 'info' | 'warning' | 'critical';
+
+// ─────────────────────────────────────────────
+// TimelineEvent — 統一イベント
+// ─────────────────────────────────────────────
+
+/**
+ * 4ドメインの差異を吸収した統一タイムラインイベント。
+ *
+ * 各 adapter が元ドメインモデルからこの型に変換する。
+ * - id: "daily-123", "incident-abc" のような一意キー
+ * - occurredAt: ソートキー（ISO 8601）
+ * - severity: 3段階に正規化
+ */
+export type TimelineEvent = {
+  /** イベント一意キー（"daily-123", "incident-abc" 等） */
+  readonly id: string;
+  /** ソースドメイン */
+  readonly source: TimelineEventSource;
+  /** 対象利用者 ID */
+  readonly userId: string;
+  /** イベント発生日時（ISO 8601） — ソートキー */
+  readonly occurredAt: string;
+  /** 表示タイトル（1行） */
+  readonly title: string;
+  /** 補足テキスト（省略可能） */
+  readonly description?: string;
+  /** 統一された重要度 */
+  readonly severity: TimelineSeverity;
+  /** ソースレコードへの参照情報 */
+  readonly sourceRef: {
+    /** ソースレコードの ID */
+    readonly id: string | number;
+    /** 画面遷移用パス（省略可能） */
+    readonly path?: string;
+  };
+  /** ドメイン固有のメタデータ（チップ表示等） */
+  readonly meta?: Record<string, string | number | boolean>;
+};
+
+// ─────────────────────────────────────────────
+// TimelineFilter — 絞り込み
+// ─────────────────────────────────────────────
+
+/** タイムライン絞り込み条件 */
+export type TimelineFilter = {
+  /** 表示するソース種別（省略時: 全ソース） */
+  sources?: TimelineEventSource[];
+  /** 期間（開始、ISO 8601） */
+  from?: string;
+  /** 期間（終了、ISO 8601） */
+  to?: string;
+  /** 重要度フィルタ（指定以上のみ表示） */
+  severity?: TimelineSeverity;
+};
+
+// ─────────────────────────────────────────────
+// ResolveUserIdFromCode — Handoff 用
+// ─────────────────────────────────────────────
+
+/**
+ * Handoff の userCode → userId 変換関数。
+ *
+ * 同一値の環境では identity ((code) => code) を渡す。
+ * 値が異なる環境では UserMaster ルックアップを渡す。
+ * null を返した場合、そのイベントはタイムラインから除外される。
+ */
+export type ResolveUserIdFromCode = (userCode: string) => string | null;

--- a/src/features/timeline/__tests__/createTimelineDataFetcher.spec.ts
+++ b/src/features/timeline/__tests__/createTimelineDataFetcher.spec.ts
@@ -1,0 +1,359 @@
+/**
+ * createTimelineDataFetcher — フェッチャーユニットテスト
+ *
+ * Repository モックを使って、各ソースの取得・変換・エラー耐性を検証する。
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { createTimelineDataFetcher } from '../createTimelineDataFetcher';
+import type { DailyRecordRepository, DailyRecordItem } from '@/features/daily/domain/DailyRecordRepository';
+import type { IncidentRepository, IncidentRecord } from '@/domain/support/incidentRepository';
+import type { IspRepository } from '@/domain/isp/port';
+import type { IspListItem } from '@/domain/isp/schema';
+import type { HandoffRepository } from '@/features/handoff/domain/HandoffRepository';
+import type { HandoffRecord } from '@/features/handoff/handoffTypes';
+
+// ─────────────────────────────────────────────
+// テストヘルパー
+// ─────────────────────────────────────────────
+
+function makeDailyItem(overrides: Partial<DailyRecordItem> = {}): DailyRecordItem {
+  return {
+    date: '2026-03-15',
+    reporter: { name: 'テスト太郎', role: '支援員' },
+    userRows: [
+      {
+        userId: 'user-1',
+        userName: '利用者A',
+        amActivity: '午前活動',
+        pmActivity: '午後活動',
+        lunchAmount: '完食',
+        problemBehavior: {
+          selfHarm: false,
+          otherInjury: false,
+          loudVoice: false,
+          pica: false,
+          other: false,
+        },
+        specialNotes: 'テストメモ',
+        behaviorTags: [],
+      },
+      {
+        userId: 'user-2',
+        userName: '利用者B',
+        amActivity: '別の活動',
+        pmActivity: '',
+        lunchAmount: '',
+        problemBehavior: {
+          selfHarm: false,
+          otherInjury: false,
+          loudVoice: false,
+          pica: false,
+          other: false,
+        },
+        specialNotes: '',
+        behaviorTags: [],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function makeIncidentRecord(userId: string): IncidentRecord {
+  return {
+    id: 'inc-1',
+    userId,
+    title: 'テスト事故',
+    description: '事故の詳細',
+    occurredAt: '2026-03-15T10:00:00',
+    severity: '中',
+    reportedAt: '2026-03-15T10:30:00',
+    reportedBy: '報告者',
+    incidentType: 'behavior',
+    immediateResponse: '即時対応',
+    relatedStaff: ['スタッフA'],
+    outcome: '結果',
+    followUpRequired: false,
+    createdAt: '2026-03-15T10:30:00',
+    modifiedAt: '2026-03-15T10:30:00',
+  };
+}
+
+function makeIspListItem(userId: string): IspListItem {
+  return {
+    id: 'isp-1',
+    userId,
+    title: 'ISP テスト',
+    planStartDate: '2026-01-01',
+    planEndDate: '2026-12-31',
+    status: 'approved',
+    isCurrent: true,
+    version: 1,
+    createdAt: '2026-01-01T00:00:00',
+    modifiedAt: '2026-01-01T00:00:00',
+  };
+}
+
+function makeHandoffRecord(): HandoffRecord {
+  return {
+    id: 1,
+    userCode: 'UC001',
+    userName: '利用者A',
+    category: '健康管理',
+    severity: '通常',
+    message: 'テスト申し送り',
+    status: '未対応',
+    createdAt: '2026-03-15T08:00:00',
+    createdBy: '作成者',
+  };
+}
+
+// ─────────────────────────────────────────────
+// テスト
+// ─────────────────────────────────────────────
+
+describe('createTimelineDataFetcher', () => {
+  it('Repository 未指定なら全ソース空配列を返す', async () => {
+    const fetcher = createTimelineDataFetcher({});
+    const result = await fetcher('user-1');
+
+    expect(result.dailyRecords).toEqual([]);
+    expect(result.incidents).toEqual([]);
+    expect(result.ispRecords).toEqual([]);
+    expect(result.handoffRecords).toEqual([]);
+    expect(result.rawHandoffCount).toBe(0);
+  });
+
+  describe('Daily', () => {
+    it('指定 userId の行だけ抽出する', async () => {
+      const dailyRepo: DailyRecordRepository = {
+        list: vi.fn().mockResolvedValue([makeDailyItem({ id: '100' })]),
+        load: vi.fn(),
+        save: vi.fn(),
+        approve: vi.fn(),
+      };
+
+      const fetcher = createTimelineDataFetcher({ dailyRepo });
+      const result = await fetcher('user-1');
+
+      // user-1 の行だけ抽出される（user-2 は除外）
+      expect(result.dailyRecords).toHaveLength(1);
+      expect(result.dailyRecords[0].userId).toBe('user-1');
+      expect(result.dailyRecords[0].kind).toBe('A');
+      expect(result.dailyRecords[0].date).toBe('2026-03-15');
+    });
+
+    it('DailyRecordUserRow → PersonDaily の変換が正しい', async () => {
+      const dailyRepo: DailyRecordRepository = {
+        list: vi.fn().mockResolvedValue([makeDailyItem({ id: '200' })]),
+        load: vi.fn(),
+        save: vi.fn(),
+        approve: vi.fn(),
+      };
+
+      const fetcher = createTimelineDataFetcher({ dailyRepo });
+      const result = await fetcher('user-1');
+      const daily = result.dailyRecords[0];
+
+      expect(daily.kind).toBe('A');
+      if (daily.kind === 'A') {
+        expect(daily.data.amActivities).toEqual(['午前活動']);
+        expect(daily.data.pmActivities).toEqual(['午後活動']);
+        expect(daily.data.specialNotes).toBe('テストメモ');
+      }
+    });
+
+    it('Daily 取得エラー時は空配列を返しログ出力する', async () => {
+      const dailyRepo: DailyRecordRepository = {
+        list: vi.fn().mockRejectedValue(new Error('API Error')),
+        load: vi.fn(),
+        save: vi.fn(),
+        approve: vi.fn(),
+      };
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const fetcher = createTimelineDataFetcher({ dailyRepo });
+      const result = await fetcher('user-1');
+
+      expect(result.dailyRecords).toEqual([]);
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[Timeline] Daily fetch failed:',
+        expect.any(Error),
+      );
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe('Incident', () => {
+    it('userId で取得されたインシデントを返す', async () => {
+      const incidentRepo: IncidentRepository = {
+        getByUserId: vi.fn().mockResolvedValue([makeIncidentRecord('user-1')]),
+        getAll: vi.fn(),
+        getById: vi.fn(),
+        save: vi.fn(),
+        delete: vi.fn(),
+      };
+
+      const fetcher = createTimelineDataFetcher({ incidentRepo });
+      const result = await fetcher('user-1');
+
+      expect(result.incidents).toHaveLength(1);
+      expect(result.incidents[0].userId).toBe('user-1');
+    });
+
+    it('Incident 取得エラー時は空配列を返す', async () => {
+      const incidentRepo: IncidentRepository = {
+        getByUserId: vi.fn().mockRejectedValue(new Error('DB Error')),
+        getAll: vi.fn(),
+        getById: vi.fn(),
+        save: vi.fn(),
+        delete: vi.fn(),
+      };
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const fetcher = createTimelineDataFetcher({ incidentRepo });
+      const result = await fetcher('user-1');
+
+      expect(result.incidents).toEqual([]);
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe('ISP', () => {
+    it('userId で取得された ISP を返す', async () => {
+      const ispRepo = {
+        listByUser: vi.fn().mockResolvedValue([makeIspListItem('user-1')]),
+        getById: vi.fn(),
+        getCurrentByUser: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+      } as unknown as IspRepository;
+
+      const fetcher = createTimelineDataFetcher({ ispRepo });
+      const result = await fetcher('user-1');
+
+      expect(result.ispRecords).toHaveLength(1);
+    });
+
+    it('ISP 取得エラー時は空配列を返す', async () => {
+      const ispRepo = {
+        listByUser: vi.fn().mockRejectedValue(new Error('SP Error')),
+        getById: vi.fn(),
+        getCurrentByUser: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+      } as unknown as IspRepository;
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const fetcher = createTimelineDataFetcher({ ispRepo });
+      const result = await fetcher('user-1');
+
+      expect(result.ispRecords).toEqual([]);
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe('Handoff', () => {
+    it('全 Handoff レコードと rawHandoffCount を返す', async () => {
+      const handoffRepo: HandoffRepository = {
+        getRecords: vi.fn().mockResolvedValue([makeHandoffRecord(), makeHandoffRecord()]),
+        createRecord: vi.fn(),
+        updateStatus: vi.fn(),
+      };
+
+      const fetcher = createTimelineDataFetcher({ handoffRepo });
+      const result = await fetcher('user-1');
+
+      expect(result.handoffRecords).toHaveLength(2);
+      expect(result.rawHandoffCount).toBe(2);
+    });
+
+    it('Handoff 取得エラー時は空配列と rawHandoffCount=0 を返す', async () => {
+      const handoffRepo: HandoffRepository = {
+        getRecords: vi.fn().mockRejectedValue(new Error('Network Error')),
+        createRecord: vi.fn(),
+        updateStatus: vi.fn(),
+      };
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const fetcher = createTimelineDataFetcher({ handoffRepo });
+      const result = await fetcher('user-1');
+
+      expect(result.handoffRecords).toEqual([]);
+      expect(result.rawHandoffCount).toBe(0);
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe('複合', () => {
+    it('全ソース接続時に各データが正しく返る', async () => {
+      const dailyRepo: DailyRecordRepository = {
+        list: vi.fn().mockResolvedValue([makeDailyItem({ id: '300' })]),
+        load: vi.fn(),
+        save: vi.fn(),
+        approve: vi.fn(),
+      };
+
+      const incidentRepo: IncidentRepository = {
+        getByUserId: vi.fn().mockResolvedValue([makeIncidentRecord('user-1')]),
+        getAll: vi.fn(),
+        getById: vi.fn(),
+        save: vi.fn(),
+        delete: vi.fn(),
+      };
+
+      const ispRepo = {
+        listByUser: vi.fn().mockResolvedValue([makeIspListItem('user-1')]),
+        getById: vi.fn(),
+        getCurrentByUser: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+      } as unknown as IspRepository;
+
+      const handoffRepo: HandoffRepository = {
+        getRecords: vi.fn().mockResolvedValue([makeHandoffRecord()]),
+        createRecord: vi.fn(),
+        updateStatus: vi.fn(),
+      };
+
+      const fetcher = createTimelineDataFetcher({
+        dailyRepo,
+        incidentRepo,
+        ispRepo,
+        handoffRepo,
+      });
+      const result = await fetcher('user-1');
+
+      expect(result.dailyRecords.length).toBeGreaterThan(0);
+      expect(result.incidents.length).toBeGreaterThan(0);
+      expect(result.ispRecords.length).toBeGreaterThan(0);
+      expect(result.handoffRecords.length).toBeGreaterThan(0);
+    });
+
+    it('一部ソースがエラーでも他ソースは正常に返る', async () => {
+      const dailyRepo: DailyRecordRepository = {
+        list: vi.fn().mockRejectedValue(new Error('Daily Error')),
+        load: vi.fn(),
+        save: vi.fn(),
+        approve: vi.fn(),
+      };
+
+      const incidentRepo: IncidentRepository = {
+        getByUserId: vi.fn().mockResolvedValue([makeIncidentRecord('user-1')]),
+        getAll: vi.fn(),
+        getById: vi.fn(),
+        save: vi.fn(),
+        delete: vi.fn(),
+      };
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const fetcher = createTimelineDataFetcher({ dailyRepo, incidentRepo });
+      const result = await fetcher('user-1');
+
+      // Daily はエラーで空、Incident は正常
+      expect(result.dailyRecords).toEqual([]);
+      expect(result.incidents).toHaveLength(1);
+      warnSpy.mockRestore();
+    });
+  });
+});

--- a/src/features/timeline/__tests__/useUserTimeline.spec.ts
+++ b/src/features/timeline/__tests__/useUserTimeline.spec.ts
@@ -1,0 +1,410 @@
+/**
+ * useUserTimeline.spec — Phase 2 hook テスト
+ *
+ * テスト方針:
+ *   - fetcher は mock 関数で注入（データ取得のテストではなく接続のテスト）
+ *   - buildTimeline の計算ロジック自体は Phase 1 でテスト済み
+ *   - hook 層のテスト対象: fetcher 呼び出し → buildTimeline 接続 → 状態管理
+ *
+ * カバレッジ:
+ *   1. 正常系 — 4ソース統合
+ *   2. Handoff userCode 解決失敗 → unresolvedHandoff カウント
+ *   3. loading / error 状態遷移
+ *   4. filter 反映
+ *   5. sourceCounts 正確性
+ *   6. refresh による再取得
+ *   7. buildResolveUserIdFromCode 単体テスト
+ *   8. 空データ / userId 変更
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+
+import {
+  useUserTimeline,
+  buildResolveUserIdFromCode,
+} from '../useUserTimeline';
+import type {
+  TimelineDataFetcher,
+  UseUserTimelineOptions,
+} from '../useUserTimeline';
+import type { TimelineSources } from '@/domain/timeline';
+import type { AnyDaily } from '@/domain/daily/types';
+import type { HighRiskIncident } from '@/domain/support/highRiskIncident';
+import type { IndividualSupportPlan } from '@/domain/isp/schema';
+import type { HandoffRecord } from '@/features/handoff/handoffTypes';
+import type { IUserMaster } from '@/features/users/types';
+
+// ─────────────────────────────────────────────
+// Test data factories
+// ─────────────────────────────────────────────
+
+function makeDaily(userId: string, date: string): AnyDaily {
+  return {
+    id: 1,
+    userId,
+    userName: '田中太郎',
+    date,
+    status: '完了',
+    reporter: { name: 'スタッフA' },
+    draft: { isDraft: false },
+    kind: 'A' as const,
+    data: {
+      amActivities: ['活動1'],
+      pmActivities: [],
+      specialNotes: '特記事項あり',
+    },
+  } as AnyDaily;
+}
+
+function makeIncident(userId: string): HighRiskIncident {
+  return {
+    id: 'inc-1',
+    userId,
+    occurredAt: '2026-03-10T14:00:00',
+    severity: '高' as const,
+    description: 'テスト事象',
+  } as HighRiskIncident;
+}
+
+function makeIsp(userId: string): IndividualSupportPlan {
+  return {
+    id: 'isp-1',
+    userId,
+    createdAt: '2026-03-01T10:00:00',
+    createdBy: 'admin',
+    updatedAt: '2026-03-01T10:00:00',
+    updatedBy: 'admin',
+    version: 1,
+    status: 'active',
+    title: 'テスト計画',
+    planStartDate: '2026-03-01',
+    planEndDate: '2026-09-01',
+    userIntent: '自立',
+    familyIntent: '',
+    overallSupportPolicy: '支援方針',
+    longTermGoals: [],
+    shortTermGoals: [],
+    isCurrent: true,
+  } as unknown as IndividualSupportPlan;
+}
+
+function makeHandoff(userCode: string): HandoffRecord {
+  return {
+    id: 1,
+    userCode,
+    userDisplayName: '田中太郎',
+    title: '申し送り件名',
+    message: '申し送り内容',
+    severity: '通常' as const,
+    createdAt: '2026-03-10T09:00:00',
+    status: '未対応' as const,
+    category: '全般' as const,
+    timeBand: '日中' as const,
+    createdByName: 'スタッフB',
+    isDraft: false,
+  } as unknown as HandoffRecord;
+}
+
+const mockUsers: IUserMaster[] = [
+  { Id: 101, Title: '田中太郎', UserID: '101', FullName: '田中太郎' } as IUserMaster,
+  { Id: 102, Title: '佐藤花子', UserID: '102', FullName: '佐藤花子' } as IUserMaster,
+];
+
+// ─────────────────────────────────────────────
+// buildResolveUserIdFromCode の単体テスト
+// ─────────────────────────────────────────────
+
+describe('buildResolveUserIdFromCode', () => {
+  it('UserMaster から userCode → userId の resolver を構築する', () => {
+    const resolve = buildResolveUserIdFromCode(mockUsers);
+
+    expect(resolve('101')).toBe('101');
+    expect(resolve('102')).toBe('102');
+    expect(resolve('999')).toBeNull();
+  });
+
+  it('空の users では常に null を返す', () => {
+    const resolve = buildResolveUserIdFromCode([]);
+
+    expect(resolve('101')).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────
+// useUserTimeline のテスト
+// ─────────────────────────────────────────────
+
+describe('useUserTimeline', () => {
+  let fetcher: ReturnType<typeof vi.fn<TimelineDataFetcher>>;
+
+  /** デフォルトの fetcher を作成（4ソースすべてデータあり） */
+  function createFetcher(
+    overrides?: Partial<TimelineSources & { rawHandoffCount: number }>,
+  ) {
+    const defaults: TimelineSources & { rawHandoffCount: number } = {
+      dailyRecords: [makeDaily('101', '2026-03-10')],
+      incidents: [makeIncident('101')],
+      ispRecords: [makeIsp('101')],
+      handoffRecords: [makeHandoff('101')],
+      rawHandoffCount: 1,
+      ...overrides,
+    };
+    return vi.fn<TimelineDataFetcher>().mockResolvedValue(defaults);
+  }
+
+  beforeEach(() => {
+    fetcher = createFetcher();
+  });
+
+  // ─── 1. 正常系 ───
+
+  it('4ソースのデータを統合してタイムラインを返す', async () => {
+    const { result } = renderHook(() =>
+      useUserTimeline('101', fetcher, mockUsers),
+    );
+
+    // 初期状態: loading
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Daily(1) + Incident(1) + ISP(1) + Handoff(1) = 4
+    expect(result.current.events).toHaveLength(4);
+    expect(result.current.error).toBeNull();
+
+    // fetcher が正しい userId で呼ばれている
+    expect(fetcher).toHaveBeenCalledWith('101');
+  });
+
+  // ─── 2. イベントが occurredAt 降順になっている ───
+
+  it('イベントは occurredAt 降順にソートされている', async () => {
+    const { result } = renderHook(() =>
+      useUserTimeline('101', fetcher, mockUsers),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const dates = result.current.events.map((e) => e.occurredAt);
+    for (let i = 1; i < dates.length; i++) {
+      expect(dates[i - 1] >= dates[i]).toBe(true);
+    }
+  });
+
+  // ─── 3. Handoff unresolved ───
+
+  it('Handoff の userCode が解決できない場合は除外し unresolvedHandoff をカウントする', async () => {
+    fetcher = createFetcher({
+      handoffRecords: [
+        makeHandoff('101'), // 解決可能
+        makeHandoff('999'), // 解決不可
+      ],
+      rawHandoffCount: 2,
+    });
+
+    const { result } = renderHook(() =>
+      useUserTimeline('101', fetcher, mockUsers),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.sourceCounts.handoff).toBe(1);
+    expect(result.current.sourceCounts.unresolvedHandoff).toBe(1);
+  });
+
+  // ─── 4. loading 状態 ───
+
+  it('取得中は isLoading が true になる', async () => {
+    fetcher = vi.fn<TimelineDataFetcher>().mockImplementation(
+      () =>
+        new Promise((resolve) =>
+          setTimeout(
+            () =>
+              resolve({
+                dailyRecords: [],
+                incidents: [],
+                ispRecords: [],
+                handoffRecords: [],
+                rawHandoffCount: 0,
+              }),
+            100,
+          ),
+        ),
+    );
+
+    const { result } = renderHook(() =>
+      useUserTimeline('101', fetcher, mockUsers),
+    );
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  // ─── 5. エラー状態 ───
+
+  it('fetcher がエラーを投げた場合は error に設定される', async () => {
+    fetcher = vi.fn<TimelineDataFetcher>().mockRejectedValue(
+      new Error('fetch failed'),
+    );
+
+    const { result } = renderHook(() =>
+      useUserTimeline('101', fetcher, mockUsers),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe('fetch failed');
+    expect(result.current.events).toEqual([]);
+  });
+
+  // ─── 6. filter 反映 ───
+
+  it('filter.sources で特定ソースのみ表示する', async () => {
+    const options: UseUserTimelineOptions = {
+      filter: { sources: ['daily'] },
+    };
+
+    const { result } = renderHook(() =>
+      useUserTimeline('101', fetcher, mockUsers, options),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // フィルタ後は daily のみ
+    expect(result.current.events).toHaveLength(1);
+    expect(result.current.events[0].source).toBe('daily');
+
+    // sourceCounts はフィルタ前の件数を反映
+    expect(result.current.sourceCounts.total).toBe(4);
+  });
+
+  // ─── 7. sourceCounts の正確性 ───
+
+  it('sourceCounts がソースごとの件数を正確に返す', async () => {
+    fetcher = createFetcher({
+      handoffRecords: [makeHandoff('101'), makeHandoff('101')],
+      rawHandoffCount: 2,
+    });
+
+    const { result } = renderHook(() =>
+      useUserTimeline('101', fetcher, mockUsers),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const counts = result.current.sourceCounts;
+    expect(counts.daily).toBe(1);
+    expect(counts.incident).toBe(1);
+    expect(counts.isp).toBe(1);
+    expect(counts.handoff).toBe(2);
+    expect(counts.total).toBe(5);
+    expect(counts.unresolvedHandoff).toBe(0);
+  });
+
+  // ─── 8. refresh ───
+
+  it('refresh() で再取得される', async () => {
+    const { result } = renderHook(() =>
+      useUserTimeline('101', fetcher, mockUsers),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.refresh();
+    });
+
+    await waitFor(() => {
+      expect(fetcher).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ─── 9. 空のソースデータ ───
+
+  it('全ソースが空でもエラーにならない', async () => {
+    fetcher = createFetcher({
+      dailyRecords: [],
+      incidents: [],
+      ispRecords: [],
+      handoffRecords: [],
+      rawHandoffCount: 0,
+    });
+
+    const { result } = renderHook(() =>
+      useUserTimeline('101', fetcher, mockUsers),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.events).toEqual([]);
+    expect(result.current.sourceCounts.total).toBe(0);
+    expect(result.current.error).toBeNull();
+  });
+
+  // ─── 10. userId 変更 ───
+
+  it('userId が変わると再取得される', async () => {
+    const { result, rerender } = renderHook(
+      ({ userId }: { userId: string }) =>
+        useUserTimeline(userId, fetcher, mockUsers),
+      { initialProps: { userId: '101' } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(fetcher).toHaveBeenCalledWith('101');
+
+    // userId を変更
+    rerender({ userId: '102' });
+
+    await waitFor(() => {
+      expect(fetcher).toHaveBeenCalledWith('102');
+    });
+  });
+
+  // ─── 11. severity filter ───
+
+  it('severity filter で指定以上のイベントのみ返す', async () => {
+    const options: UseUserTimelineOptions = {
+      filter: { severity: 'critical' },
+    };
+
+    const { result } = renderHook(() =>
+      useUserTimeline('101', fetcher, mockUsers, options),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Incident (severity: '高' → critical) のみ
+    for (const event of result.current.events) {
+      expect(event.severity).toBe('critical');
+    }
+  });
+});

--- a/src/features/timeline/components/TimelineEventCard.tsx
+++ b/src/features/timeline/components/TimelineEventCard.tsx
@@ -1,0 +1,181 @@
+/**
+ * TimelineEventCard — タイムラインイベント1件の表示カード
+ *
+ * 責務:
+ *   - source 種別チップ（色分け）
+ *   - occurredAt の日時表示
+ *   - title / description の表示
+ *   - severity に応じた視覚マーカー
+ *
+ * 設計:
+ *   - カードはクリック不可（Phase 3 MVP）
+ *   - source チップは最小限の色分けで視認性を確保
+ *   - description は長い場合に省略表示（2行まで）
+ */
+
+import React from 'react';
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import Typography from '@mui/material/Typography';
+import {
+  type TimelineEvent,
+  type TimelineEventSource,
+  type TimelineSeverity,
+  TIMELINE_SOURCE_LABELS,
+} from '@/domain/timeline';
+import { motionTokens } from '@/app/theme';
+
+// ─────────────────────────────────────────────
+// Source チップカラー
+// ─────────────────────────────────────────────
+
+const SOURCE_CHIP_COLORS: Record<
+  TimelineEventSource,
+  { bg: string; text: string }
+> = {
+  daily: { bg: '#E8F0E4', text: '#3D6B3C' },
+  incident: { bg: '#FDE8E8', text: '#C94A4A' },
+  isp: { bg: '#E8EEF9', text: '#3B5998' },
+  handoff: { bg: '#FFF3E0', text: '#B45309' },
+};
+
+// ─────────────────────────────────────────────
+// Severity インジケーター
+// ─────────────────────────────────────────────
+
+const SEVERITY_COLORS: Record<TimelineSeverity, string> = {
+  info: '#5B8C5A',
+  warning: '#D4A843',
+  critical: '#C94A4A',
+};
+
+// ─────────────────────────────────────────────
+// 日時表示
+// ─────────────────────────────────────────────
+
+function formatOccurredAt(iso: string): string {
+  try {
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) return iso;
+    const month = d.getMonth() + 1;
+    const day = d.getDate();
+    const hours = String(d.getHours()).padStart(2, '0');
+    const minutes = String(d.getMinutes()).padStart(2, '0');
+    // T00:00:00 の場合は時刻を省略（Daily など日付のみのソース）
+    if (hours === '00' && minutes === '00') {
+      return `${month}/${day}`;
+    }
+    return `${month}/${day} ${hours}:${minutes}`;
+  } catch {
+    return iso;
+  }
+}
+
+// ─────────────────────────────────────────────
+// Component
+// ─────────────────────────────────────────────
+
+export interface TimelineEventCardProps {
+  event: TimelineEvent;
+}
+
+export const TimelineEventCard: React.FC<TimelineEventCardProps> = ({
+  event,
+}) => {
+  const chipColor = SOURCE_CHIP_COLORS[event.source];
+  const severityColor = SEVERITY_COLORS[event.severity];
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        gap: 1.5,
+        px: 2,
+        py: 1.5,
+        bgcolor: 'background.paper',
+        borderRadius: 1,
+        border: '1px solid',
+        borderColor: 'divider',
+        transition: motionTokens.transition.hoverAll,
+        '&:hover': {
+          borderColor: severityColor,
+          boxShadow: `0 0 0 1px ${severityColor}20`,
+        },
+      }}
+    >
+      {/* Severity indicator bar */}
+      <Box
+        sx={{
+          width: 4,
+          minHeight: '100%',
+          bgcolor: severityColor,
+          borderRadius: 1,
+          flexShrink: 0,
+        }}
+      />
+
+      {/* Content */}
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        {/* Header row: source chip + date */}
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: 1,
+            mb: 0.5,
+          }}
+        >
+          <Chip
+            label={TIMELINE_SOURCE_LABELS[event.source]}
+            size="small"
+            sx={{
+              bgcolor: chipColor.bg,
+              color: chipColor.text,
+              fontWeight: 600,
+              fontSize: '0.7rem',
+              height: 22,
+              '& .MuiChip-label': { px: 1 },
+            }}
+          />
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{ flexShrink: 0 }}
+          >
+            {formatOccurredAt(event.occurredAt)}
+          </Typography>
+        </Box>
+
+        {/* Title */}
+        <Typography
+          variant="body2"
+          sx={{
+            fontWeight: 600,
+            lineHeight: 1.4,
+            mb: event.description ? 0.5 : 0,
+          }}
+        >
+          {event.title}
+        </Typography>
+
+        {/* Description (optional, max 2 lines) */}
+        {event.description && (
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{
+              display: '-webkit-box',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical',
+              overflow: 'hidden',
+              lineHeight: 1.5,
+            }}
+          >
+            {event.description}
+          </Typography>
+        )}
+      </Box>
+    </Box>
+  );
+};

--- a/src/features/timeline/components/TimelineEventList.tsx
+++ b/src/features/timeline/components/TimelineEventList.tsx
@@ -1,0 +1,108 @@
+/**
+ * TimelineEventList — タイムラインイベント一覧
+ *
+ * 責務:
+ *   - event 配列をレンダリング
+ *   - 日付降順の一覧表示（日付グループ区切り付き）
+ *   - empty state は呼び出し元で処理する前提
+ */
+
+import React from 'react';
+import Box from '@mui/material/Box';
+import Divider from '@mui/material/Divider';
+import Typography from '@mui/material/Typography';
+import type { TimelineEvent } from '@/domain/timeline';
+import { TimelineEventCard } from './TimelineEventCard';
+
+// ─────────────────────────────────────────────
+// 日付グループヘルパー
+// ─────────────────────────────────────────────
+
+function toDateKey(iso: string): string {
+  try {
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) return '不明';
+    return `${d.getFullYear()}/${d.getMonth() + 1}/${d.getDate()}`;
+  } catch {
+    return '不明';
+  }
+}
+
+function formatDateLabel(dateKey: string): string {
+  const today = new Date();
+  const todayKey = `${today.getFullYear()}/${today.getMonth() + 1}/${today.getDate()}`;
+
+  const yesterday = new Date(today);
+  yesterday.setDate(yesterday.getDate() - 1);
+  const yesterdayKey = `${yesterday.getFullYear()}/${yesterday.getMonth() + 1}/${yesterday.getDate()}`;
+
+  if (dateKey === todayKey) return '今日';
+  if (dateKey === yesterdayKey) return '昨日';
+  return dateKey;
+}
+
+/** 日付グループに分割（入力は降順ソート済み前提） */
+function groupByDate(
+  events: readonly TimelineEvent[],
+): { dateLabel: string; events: TimelineEvent[] }[] {
+  const groups: { dateLabel: string; events: TimelineEvent[] }[] = [];
+  let currentKey = '';
+
+  for (const event of events) {
+    const key = toDateKey(event.occurredAt);
+    if (key !== currentKey) {
+      currentKey = key;
+      groups.push({ dateLabel: formatDateLabel(key), events: [] });
+    }
+    groups[groups.length - 1].events.push(event);
+  }
+
+  return groups;
+}
+
+// ─────────────────────────────────────────────
+// Component
+// ─────────────────────────────────────────────
+
+export interface TimelineEventListProps {
+  events: readonly TimelineEvent[];
+}
+
+export const TimelineEventList: React.FC<TimelineEventListProps> = ({
+  events,
+}) => {
+  if (events.length === 0) return null;
+
+  const groups = groupByDate(events);
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      {groups.map((group, gi) => (
+        <Box key={group.dateLabel}>
+          {/* 日付セパレーター */}
+          {gi > 0 && <Divider sx={{ mb: 2 }} />}
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{
+              fontWeight: 700,
+              textTransform: 'uppercase',
+              letterSpacing: '0.05em',
+              mb: 1,
+              display: 'block',
+            }}
+          >
+            {group.dateLabel}
+          </Typography>
+
+          {/* イベントカード群 */}
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+            {group.events.map((event) => (
+              <TimelineEventCard key={event.id} event={event} />
+            ))}
+          </Box>
+        </Box>
+      ))}
+    </Box>
+  );
+};

--- a/src/features/timeline/components/TimelineFilterBar.tsx
+++ b/src/features/timeline/components/TimelineFilterBar.tsx
@@ -1,0 +1,216 @@
+/**
+ * TimelineFilterBar — タイムライン絞り込みバー
+ *
+ * 責務:
+ *   - source filter（トグルチップ）
+ *   - severity filter
+ *   - ソースごとの件数表示
+ *   - unresolvedHandoff 件数があれば警告表示
+ *
+ * 設計:
+ *   - 外から filter と onFilterChange を受け取る（制御コンポーネント）
+ *   - チップクリックで source ON/OFF
+ *   - severity はドロップダウン
+ */
+
+import React from 'react';
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import Select, { type SelectChangeEvent } from '@mui/material/Select';
+import Typography from '@mui/material/Typography';
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import {
+  type TimelineEventSource,
+  type TimelineFilter,
+  type TimelineSeverity,
+  TIMELINE_SOURCES,
+  TIMELINE_SOURCE_LABELS,
+} from '@/domain/timeline';
+import { motionTokens } from '@/app/theme';
+
+// ─────────────────────────────────────────────
+// Source チップカラー（カードと統一）
+// ─────────────────────────────────────────────
+
+const SOURCE_CHIP_COLORS: Record<
+  TimelineEventSource,
+  { bg: string; text: string; selectedBg: string }
+> = {
+  daily: { bg: '#E8F0E4', text: '#3D6B3C', selectedBg: '#3D6B3C' },
+  incident: { bg: '#FDE8E8', text: '#C94A4A', selectedBg: '#C94A4A' },
+  isp: { bg: '#E8EEF9', text: '#3B5998', selectedBg: '#3B5998' },
+  handoff: { bg: '#FFF3E0', text: '#B45309', selectedBg: '#B45309' },
+};
+
+const SEVERITY_OPTIONS: { value: '' | TimelineSeverity; label: string }[] = [
+  { value: '', label: 'すべて' },
+  { value: 'info', label: '情報以上' },
+  { value: 'warning', label: '警告以上' },
+  { value: 'critical', label: '重大のみ' },
+];
+
+// ─────────────────────────────────────────────
+// Props
+// ─────────────────────────────────────────────
+
+export interface TimelineFilterBarProps {
+  /** 現在のフィルタ */
+  filter: TimelineFilter;
+  /** フィルタ更新 */
+  onFilterChange: (filter: TimelineFilter) => void;
+  /** ソースごとの件数 */
+  sourceCounts: Record<TimelineEventSource, number>;
+  /** 未解決 handoff 件数 */
+  unresolvedHandoff?: number;
+  /** 総表示件数 */
+  totalCount: number;
+}
+
+// ─────────────────────────────────────────────
+// Component
+// ─────────────────────────────────────────────
+
+export const TimelineFilterBar: React.FC<TimelineFilterBarProps> = ({
+  filter,
+  onFilterChange,
+  sourceCounts,
+  unresolvedHandoff = 0,
+  totalCount,
+}) => {
+  const activeSources = filter.sources ?? [];
+  const isAllSources = activeSources.length === 0;
+
+  const handleSourceToggle = (source: TimelineEventSource) => {
+    let next: TimelineEventSource[];
+
+    if (isAllSources) {
+      // 「全選択」状態からクリック → そのソースだけを選択
+      next = [source];
+    } else if (activeSources.includes(source)) {
+      // 選択解除
+      next = activeSources.filter((s) => s !== source);
+      // 全部外れたら「全選択」に戻す
+      if (next.length === 0) next = [];
+    } else {
+      // 追加
+      next = [...activeSources, source];
+      // 全種類選択されたら「全選択」に戻す
+      if (next.length === TIMELINE_SOURCES.length) next = [];
+    }
+
+    onFilterChange({ ...filter, sources: next.length > 0 ? next : undefined });
+  };
+
+  const handleSeverityChange = (e: SelectChangeEvent<string>) => {
+    const value = e.target.value as '' | TimelineSeverity;
+    onFilterChange({
+      ...filter,
+      severity: value || undefined,
+    });
+  };
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+      {/* Source filter chips */}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          flexWrap: 'wrap',
+          gap: 1,
+        }}
+      >
+        {TIMELINE_SOURCES.map((source) => {
+          const colors = SOURCE_CHIP_COLORS[source];
+          const isActive = isAllSources || activeSources.includes(source);
+          const count = sourceCounts[source] ?? 0;
+
+          return (
+            <Chip
+              key={source}
+              label={`${TIMELINE_SOURCE_LABELS[source]} (${count})`}
+              size="small"
+              onClick={() => handleSourceToggle(source)}
+              sx={{
+                fontWeight: 600,
+                fontSize: '0.75rem',
+                bgcolor: isActive ? colors.selectedBg : colors.bg,
+                color: isActive ? '#fff' : colors.text,
+                border: '1px solid',
+                borderColor: isActive ? colors.selectedBg : 'transparent',
+                opacity: isActive ? 1 : 0.6,
+                transition: motionTokens.transition.microAll,
+                '&:hover': {
+                  opacity: 1,
+                  bgcolor: isActive ? colors.selectedBg : colors.bg,
+                },
+              }}
+            />
+          );
+        })}
+
+        {/* Severity filter */}
+        <FormControl size="small" sx={{ minWidth: 120, ml: 'auto' }}>
+          <InputLabel id="timeline-severity-label" sx={{ fontSize: '0.8rem' }}>
+            重要度
+          </InputLabel>
+          <Select
+            labelId="timeline-severity-label"
+            value={filter.severity ?? ''}
+            label="重要度"
+            onChange={handleSeverityChange}
+            sx={{ fontSize: '0.8rem', height: 32 }}
+          >
+            {SEVERITY_OPTIONS.map((opt) => (
+              <MenuItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </Box>
+
+      {/* Summary line + unresolved warning */}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 1,
+        }}
+      >
+        <Typography variant="caption" color="text.secondary">
+          表示: {totalCount}件
+        </Typography>
+
+        {unresolvedHandoff > 0 && (
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 0.5,
+              px: 1,
+              py: 0.25,
+              bgcolor: 'warning.lighter',
+              borderRadius: 1,
+            }}
+          >
+            <WarningAmberIcon
+              sx={{ fontSize: 14, color: 'warning.main' }}
+            />
+            <Typography
+              variant="caption"
+              color="warning.dark"
+              sx={{ fontWeight: 600, fontSize: '0.7rem' }}
+            >
+              未解決 handoff: {unresolvedHandoff}件
+            </Typography>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+};

--- a/src/features/timeline/components/UserTimelinePanel.tsx
+++ b/src/features/timeline/components/UserTimelinePanel.tsx
@@ -1,0 +1,252 @@
+/**
+ * UserTimelinePanel — 利用者タイムライン パネルコンポーネント
+ *
+ * 責務:
+ *   - userId を受け取る
+ *   - useUserTimeline(...) を呼ぶ
+ *   - loading / error / empty を分岐表示
+ *   - filter state を内部で管理
+ *   - TimelineFilterBar + TimelineEventList を組み立てる
+ *
+ * 設計:
+ *   - データ取得は外から注入された fetcher に委譲
+ *   - 表示のみの責務（thin view layer）
+ *   - Phase 3 MVP: read-only の時系列一覧
+ */
+
+import React, { useState } from 'react';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import Skeleton from '@mui/material/Skeleton';
+import Typography from '@mui/material/Typography';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import TimelineIcon from '@mui/icons-material/Timeline';
+import type { TimelineFilter } from '@/domain/timeline';
+import type { IUserMaster } from '@/features/users/types';
+import {
+  useUserTimeline,
+  type TimelineDataFetcher,
+} from '@/features/timeline/useUserTimeline';
+import { TimelineFilterBar } from './TimelineFilterBar';
+import { TimelineEventList } from './TimelineEventList';
+import { motionTokens } from '@/app/theme';
+
+// ─────────────────────────────────────────────
+// Props
+// ─────────────────────────────────────────────
+
+export interface UserTimelinePanelProps {
+  /** 対象利用者 ID */
+  userId: string;
+  /** 対象利用者名（ヘッダー表示用、省略可） */
+  userName?: string;
+  /** データ取得関数 */
+  fetcher: TimelineDataFetcher;
+  /** UserMaster 一覧（Handoff resolver 構築用） */
+  users: IUserMaster[];
+}
+
+// ─────────────────────────────────────────────
+// Loading Skeleton
+// ─────────────────────────────────────────────
+
+const TimelineSkeleton: React.FC = () => (
+  <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+    {/* Filter bar skeleton */}
+    <Box sx={{ display: 'flex', gap: 1 }}>
+      {[1, 2, 3, 4].map((i) => (
+        <Skeleton
+          key={i}
+          variant="rounded"
+          width={90}
+          height={28}
+          sx={{ borderRadius: 4 }}
+        />
+      ))}
+      <Box sx={{ ml: 'auto' }}>
+        <Skeleton variant="rounded" width={120} height={32} />
+      </Box>
+    </Box>
+    <Skeleton variant="text" width={80} height={18} />
+
+    {/* Event cards skeleton */}
+    <Skeleton variant="text" width={60} height={16} />
+    {[1, 2, 3, 4, 5].map((i) => (
+      <Skeleton
+        key={i}
+        variant="rounded"
+        height={72}
+        sx={{ borderRadius: 1 }}
+      />
+    ))}
+  </Box>
+);
+
+// ─────────────────────────────────────────────
+// Empty State
+// ─────────────────────────────────────────────
+
+const TimelineEmptyState: React.FC<{ userName?: string }> = ({ userName }) => (
+  <Box
+    sx={{
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      py: 6,
+      px: 3,
+      textAlign: 'center',
+    }}
+  >
+    <TimelineIcon
+      sx={{ fontSize: 48, color: 'text.secondary', opacity: 0.4, mb: 2 }}
+    />
+    <Typography variant="subtitle1" fontWeight={700} sx={{ mb: 0.5 }}>
+      タイムラインイベントがありません
+    </Typography>
+    <Typography variant="body2" color="text.secondary">
+      {userName
+        ? `${userName}さんの日次記録・インシデント・個別支援計画・申し送りが表示されます。`
+        : 'この利用者の記録がまだありません。'}
+    </Typography>
+  </Box>
+);
+
+// ─────────────────────────────────────────────
+// Component
+// ─────────────────────────────────────────────
+
+export const UserTimelinePanel: React.FC<UserTimelinePanelProps> = ({
+  userId,
+  userName,
+  fetcher,
+  users,
+}) => {
+  // ── Filter state（このパネル内で管理） ──
+  const [filter, setFilter] = useState<TimelineFilter>({});
+
+  // ── hook 呼び出し ──
+  const { events, isLoading, error, refresh, sourceCounts } = useUserTimeline(
+    userId,
+    fetcher,
+    users,
+    { filter },
+  );
+
+  // ── Error ──
+  if (error) {
+    return (
+      <Box>
+        <Alert
+          severity="error"
+          sx={{ mb: 2 }}
+          action={
+            <Button
+              size="small"
+              onClick={refresh}
+              startIcon={<RefreshIcon />}
+            >
+              再試行
+            </Button>
+          }
+        >
+          タイムラインの取得に失敗しました: {error.message}
+        </Alert>
+      </Box>
+    );
+  }
+
+  // ── Loading ──
+  if (isLoading) {
+    return <TimelineSkeleton />;
+  }
+
+  // ── Content ──
+  const hasAnyData = sourceCounts.total > 0;
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 2,
+      }}
+    >
+      {/* ヘッダー */}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        <Typography
+          variant="h6"
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            fontWeight: 700,
+          }}
+        >
+          <TimelineIcon color="primary" />
+          {userName ? `${userName}さんのタイムライン` : 'タイムライン'}
+        </Typography>
+        <Button
+          size="small"
+          variant="outlined"
+          startIcon={
+            isLoading ? (
+              <CircularProgress size={14} />
+            ) : (
+              <RefreshIcon />
+            )
+          }
+          onClick={refresh}
+          disabled={isLoading}
+          sx={{
+            textTransform: 'none',
+            fontSize: '0.8rem',
+            transition: motionTokens.transition.microAll,
+          }}
+        >
+          更新
+        </Button>
+      </Box>
+
+      {/* フィルタバー（データがある場合のみ） */}
+      {hasAnyData && (
+        <TimelineFilterBar
+          filter={filter}
+          onFilterChange={setFilter}
+          sourceCounts={sourceCounts}
+          unresolvedHandoff={sourceCounts.unresolvedHandoff}
+          totalCount={events.length}
+        />
+      )}
+
+      {/* イベント一覧 or Empty */}
+      {events.length > 0 ? (
+        <TimelineEventList events={events} />
+      ) : hasAnyData ? (
+        // フィルタ結果が空
+        <Box sx={{ py: 4, textAlign: 'center' }}>
+          <Typography variant="body2" color="text.secondary">
+            現在のフィルタ条件に一致するイベントがありません。
+          </Typography>
+          <Button
+            size="small"
+            sx={{ mt: 1, textTransform: 'none' }}
+            onClick={() => setFilter({})}
+          >
+            フィルタをリセット
+          </Button>
+        </Box>
+      ) : (
+        <TimelineEmptyState userName={userName} />
+      )}
+    </Box>
+  );
+};

--- a/src/features/timeline/components/index.ts
+++ b/src/features/timeline/components/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Timeline UI Components — barrel export
+ *
+ * Phase 3 MVP のタイムライン表示コンポーネント群。
+ *
+ * 構成:
+ *   UserTimelinePanel — 統合パネル（主エントリポイント）
+ *   TimelineFilterBar — フィルタ操作UI
+ *   TimelineEventList — イベント一覧（日付グループ付き）
+ *   TimelineEventCard — 個別イベントカード
+ */
+
+export { UserTimelinePanel } from './UserTimelinePanel';
+export type { UserTimelinePanelProps } from './UserTimelinePanel';
+
+export { TimelineFilterBar } from './TimelineFilterBar';
+export type { TimelineFilterBarProps } from './TimelineFilterBar';
+
+export { TimelineEventList } from './TimelineEventList';
+export type { TimelineEventListProps } from './TimelineEventList';
+
+export { TimelineEventCard } from './TimelineEventCard';
+export type { TimelineEventCardProps } from './TimelineEventCard';

--- a/src/features/timeline/createTimelineDataFetcher.ts
+++ b/src/features/timeline/createTimelineDataFetcher.ts
@@ -1,0 +1,224 @@
+/**
+ * createTimelineDataFetcher — タイムライン用データ取得関数ファクトリ
+ *
+ * 各ドメインの Repository を受け取り、userId に紐づくデータを取得して
+ * TimelineSources 形式に変換する fetcher を生成する。
+ *
+ * 設計方針:
+ *   - fetcher は plain function（hook 禁止）→ Repository は外部注入
+ *   - Repository の生データ差異は fetcher 内で吸収
+ *   - 直近30日をデフォルト範囲とする（Phase 5 で可変化予定）
+ *
+ * Phase 4 接続状況:
+ *   - Step 1: Daily ✅
+ *   - Step 2: Incident ✅
+ *   - Step 3: ISP ✅
+ *   - Step 4: Handoff ✅
+ *
+ * @see features/timeline/useUserTimeline.ts — 消費側 hook
+ * @see domain/timeline/buildTimeline.ts — データ変換
+ */
+
+import type { AnyDaily, PersonDaily } from '@/domain/daily/types';
+import type { DailyRecordRepository, DailyRecordItem } from '@/features/daily/domain/DailyRecordRepository';
+import type { DailyRecordUserRow } from '@/features/daily/schema';
+import type { HighRiskIncident } from '@/domain/support/highRiskIncident';
+import type { IncidentRepository } from '@/domain/support/incidentRepository';
+import type { IspRepository } from '@/domain/isp/port';
+import type { IndividualSupportPlan } from '@/domain/isp/schema';
+import type { HandoffRepository } from '@/features/handoff/domain/HandoffRepository';
+import type { HandoffRecord } from '@/features/handoff/handoffTypes';
+import type { TimelineDataFetcher } from './useUserTimeline';
+
+// ─────────────────────────────────────────────
+// Repository 依存性定義
+// ─────────────────────────────────────────────
+
+/**
+ * fetcher が必要とする Repository の集合。
+ *
+ * 各プロパティは省略可能 — 未接続のソースは空配列を返す。
+ * これにより段階的な接続が安全に行える。
+ */
+export type TimelineRepositories = {
+  dailyRepo?: DailyRecordRepository;
+  incidentRepo?: IncidentRepository;
+  ispRepo?: IspRepository;
+  handoffRepo?: HandoffRepository;
+};
+
+// ─────────────────────────────────────────────
+// 日付ユーティリティ
+// ─────────────────────────────────────────────
+
+/** 直近 N 日間の日付範囲を YYYY-MM-DD で返す */
+function getDateRange(days: number): { startDate: string; endDate: string } {
+  const now = new Date();
+  const end = formatYmd(now);
+
+  const start = new Date(now);
+  start.setDate(start.getDate() - days);
+  const startDate = formatYmd(start);
+
+  return { startDate, endDate: end };
+}
+
+function formatYmd(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+// ─────────────────────────────────────────────
+// DailyRecordItem → AnyDaily 変換
+// ─────────────────────────────────────────────
+
+/**
+ * DailyRecordItem (repository) → AnyDaily[] (adapter 互換) 変換。
+ *
+ * DailyRecordItem は1日分のバルクレコード（userRows を含む）。
+ * タイムラインは user 単位なので、指定 userId の行だけ抽出し
+ * PersonDaily (kind: 'A') に変換する。
+ *
+ * 型マッピング:
+ *   DailyRecordUserRow.amActivity (string) → DailyAData.specialNotes (string)
+ *   ※ amActivities (string[]) は UserRow から直接取れないため、
+ *      amActivity を specialNotes にまとめて adapter に渡す。
+ *      dailyAdapter は specialNotes を description として使う。
+ */
+function dailyItemToAnyDailies(
+  item: DailyRecordItem,
+  userId: string,
+): AnyDaily[] {
+  const userRows: DailyRecordUserRow[] =
+    (item as Record<string, unknown>).userRows as DailyRecordUserRow[] ?? [];
+  const date = item.date ?? '';
+  const reporter = (item as Record<string, unknown>).reporter as
+    | { name: string; role?: string }
+    | undefined;
+
+  return userRows
+    .filter((row) => String(row.userId) === userId)
+    .map((row, idx): PersonDaily => ({
+      id: Number(item.id ?? 0) * 1000 + idx,
+      userId: String(row.userId),
+      userName: row.userName,
+      date,
+      status: '完了',
+      reporter: { name: reporter?.name ?? '' },
+      draft: { isDraft: false },
+      kind: 'A',
+      data: {
+        // DailyRecordUserRow → DailyAData の変換
+        // amActivities / pmActivities は string[] だが、UserRow には
+        // amActivity / pmActivity (単一文字列) しかないため配列化する
+        amActivities: row.amActivity ? [row.amActivity] : [],
+        pmActivities: row.pmActivity ? [row.pmActivity] : [],
+        specialNotes: row.specialNotes || undefined,
+        problemBehavior: row.problemBehavior
+          ? {
+              selfHarm: row.problemBehavior.selfHarm,
+              otherInjury: row.problemBehavior.otherInjury,
+              loudVoice: row.problemBehavior.loudVoice,
+              pica: row.problemBehavior.pica,
+              other: row.problemBehavior.other,
+            }
+          : undefined,
+        seizureRecord: { occurred: false },
+      },
+    }));
+}
+
+// ─────────────────────────────────────────────
+// createTimelineDataFetcher
+// ─────────────────────────────────────────────
+
+/**
+ * タイムラインのデータ取得関数を生成する。
+ *
+ * @param repos - 各ドメインの Repository（省略可能）
+ * @param rangeDays - 取得日数（デフォルト: 30日）
+ * @returns async fetcher function
+ *
+ * @example
+ * ```ts
+ * const dailyRepo = useDailyRecordRepository();
+ * const fetcher = createTimelineDataFetcher({ dailyRepo });
+ * const { events } = useUserTimeline(userId, fetcher, users);
+ * ```
+ */
+export function createTimelineDataFetcher(
+  repos: TimelineRepositories = {},
+  rangeDays = 30,
+): TimelineDataFetcher {
+  return async (userId: string) => {
+    const { startDate, endDate } = getDateRange(rangeDays);
+
+    // ─── Daily ───
+    let dailyRecords: AnyDaily[] = [];
+    if (repos.dailyRepo) {
+      try {
+        const items = await repos.dailyRepo.list({
+          range: { startDate, endDate },
+        });
+        dailyRecords = items.flatMap((item) =>
+          dailyItemToAnyDailies(item, userId),
+        );
+      } catch (err) {
+        console.warn('[Timeline] Daily fetch failed:', err);
+      }
+    }
+
+    // ─── Incident ───
+    // IncidentRecord は HighRiskIncident のスーパーセット。
+    // adapter は HighRiskIncident を期待するので、そのまま渡せる。
+    let incidents: HighRiskIncident[] = [];
+    if (repos.incidentRepo) {
+      try {
+        const records = await repos.incidentRepo.getByUserId(userId);
+        incidents = records;
+      } catch (err) {
+        console.warn('[Timeline] Incident fetch failed:', err);
+      }
+    }
+
+    // ─── ISP ───
+    // IspRepository.listByUser() は IspListItem[] を返す。
+    // IspListItem は IndividualSupportPlan のサブセット（summary 形式）。
+    // ISP adapter が必要とするフィールド (id, userId, planStartDate, status, title) を持つ。
+    let ispRecords: IndividualSupportPlan[] = [];
+    if (repos.ispRepo) {
+      try {
+        const list = await repos.ispRepo.listByUser(userId);
+        ispRecords = list as unknown as IndividualSupportPlan[];
+      } catch (err) {
+        console.warn('[Timeline] ISP fetch failed:', err);
+      }
+    }
+
+    // ─── Handoff ───
+    // getRecords('week', 'all') で直近1週間のデータを取得。
+    // userId でのフィルタは buildTimeline 内の handoffAdapter が
+    // resolveUserIdFromCode を使って行う。
+    let handoffRecords: HandoffRecord[] = [];
+    let rawHandoffCount = 0;
+    if (repos.handoffRepo) {
+      try {
+        const records = await repos.handoffRepo.getRecords('week', 'all');
+        rawHandoffCount = records.length;
+        handoffRecords = records;
+      } catch (err) {
+        console.warn('[Timeline] Handoff fetch failed:', err);
+      }
+    }
+
+    return {
+      dailyRecords,
+      incidents,
+      ispRecords,
+      handoffRecords,
+      rawHandoffCount,
+    };
+  };
+}

--- a/src/features/timeline/useUserTimeline.ts
+++ b/src/features/timeline/useUserTimeline.ts
@@ -1,0 +1,260 @@
+/**
+ * useUserTimeline — 利用者タイムライン hook（Phase 2）
+ *
+ * 4ドメイン（Daily / Incident / ISP / Handoff）のデータを userId 軸で集約し、
+ * buildTimeline に渡す薄い orchestration 層。
+ *
+ * 設計方針:
+ *   - hook 自身はロジックを持たない（計算は buildTimeline に委譲）
+ *   - 各ソースの取得 → adapter → buildTimeline → 出力
+ *   - Handoff の ResolveUserIdFromCode は hook 内で構築
+ *   - sourceCounts でフィルタ UI / デバッグ用の件数を提供
+ *
+ * データ取得の責務:
+ *   この hook は「データの取得」と「buildTimeline への接続」のみを担う。
+ *   各リポジトリの型差異（DailyRecordItem vs AnyDaily 等）の吸収は
+ *   hook に渡す前に呼び出し側で行う。
+ *   hook 自体は TimelineSources の型をそのまま受け取る。
+ *
+ * @see domain/timeline/buildTimeline.ts — コア計算ロジック
+ * @see domain/timeline/types.ts — 共通型定義
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import type {
+  TimelineEvent,
+  TimelineFilter,
+  TimelineEventSource,
+  ResolveUserIdFromCode,
+} from '@/domain/timeline';
+import { buildTimeline, TIMELINE_SOURCES } from '@/domain/timeline';
+import type { TimelineSources } from '@/domain/timeline';
+
+import type { IUserMaster } from '@/features/users/types';
+
+// ─────────────────────────────────────────────
+// 型定義
+// ─────────────────────────────────────────────
+
+/** ソースごとの件数（フィルタ前） */
+export type TimelineSourceCounts = Record<TimelineEventSource, number> & {
+  total: number;
+  /** Handoff の userCode 解決に失敗した件数 */
+  unresolvedHandoff: number;
+};
+
+/**
+ * タイムラインのデータソースを取得する関数。
+ *
+ * hook から呼ばれ、4ドメインのデータを取得して返す。
+ * userId でのフィルタリングは fetcher 内で行う。
+ *
+ * @param userId - 対象利用者 ID
+ * @returns 各ドメインのレコード配列 + 元の handoff 件数
+ */
+export type TimelineDataFetcher = (
+  userId: string,
+) => Promise<TimelineSources & { rawHandoffCount: number }>;
+
+/** useUserTimeline のオプション */
+export type UseUserTimelineOptions = {
+  /** 絞り込みフィルタ */
+  filter?: TimelineFilter;
+};
+
+/** useUserTimeline の戻り値 */
+export type UseUserTimelineReturn = {
+  /** フィルタ適用済みのタイムラインイベント（occurredAt 降順） */
+  events: TimelineEvent[];
+  /** 読み込み中フラグ */
+  isLoading: boolean;
+  /** エラー（あれば） */
+  error: Error | null;
+  /** データ再取得 */
+  refresh: () => void;
+  /** ソースごとの件数（フィルタ前） */
+  sourceCounts: TimelineSourceCounts;
+};
+
+// ─────────────────────────────────────────────
+// 空の sourceCounts
+// ─────────────────────────────────────────────
+
+const EMPTY_COUNTS: TimelineSourceCounts = {
+  total: 0,
+  daily: 0,
+  incident: 0,
+  isp: 0,
+  handoff: 0,
+  unresolvedHandoff: 0,
+};
+
+// ─────────────────────────────────────────────
+// UserCode → UserId resolver 構築
+// ─────────────────────────────────────────────
+
+/**
+ * UserMaster 一覧から userCode → userId の resolver を構築する。
+ *
+ * IUserMaster.Id (number) を string 化した値を userCode と照合する。
+ * UserID フィールドがあればそれを userId として使い、なければ Id を流用する。
+ * マッチしない場合は null を返し、そのイベントはタイムラインから除外される。
+ */
+export function buildResolveUserIdFromCode(
+  users: IUserMaster[],
+): ResolveUserIdFromCode {
+  // O(1) ルックアップ用 Map: userCode (= Id.toString()) → userId (= UserID)
+  const map = new Map<string, string>();
+  for (const user of users) {
+    const code = String(user.Id);
+    // UserID フィールドがある場合はそれを使い、なければ code をそのまま使う
+    const resolvedId = user.UserID ?? code;
+    map.set(code, resolvedId);
+  }
+  return (userCode: string) => map.get(userCode) ?? null;
+}
+
+// ─────────────────────────────────────────────
+// sourceCounts 計算
+// ─────────────────────────────────────────────
+
+function computeSourceCounts(
+  allEvents: TimelineEvent[],
+  rawHandoffCount: number,
+): TimelineSourceCounts {
+  const counts: TimelineSourceCounts = { ...EMPTY_COUNTS };
+
+  for (const source of TIMELINE_SOURCES) {
+    counts[source] = allEvents.filter((e) => e.source === source).length;
+  }
+
+  counts.total = allEvents.length;
+  // 解決失敗 = 元の Handoff 件数 - タイムラインに含まれた Handoff 件数
+  counts.unresolvedHandoff = rawHandoffCount - counts.handoff;
+
+  return counts;
+}
+
+// ─────────────────────────────────────────────
+// useUserTimeline
+// ─────────────────────────────────────────────
+
+/**
+ * 利用者タイムラインを取得する React Hook。
+ *
+ * 4ドメインのデータを userId で絞り込み、buildTimeline で統合する。
+ * hook 自体はデータ取得と接続のみを担い、計算ロジックは持たない。
+ *
+ * @param userId - 対象利用者の ID
+ * @param fetcher - データ取得関数（4ドメインのレコードを返す）
+ * @param users - UserMaster 一覧（Handoff resolver 構築用）
+ * @param options - フィルタ条件
+ *
+ * @example
+ * ```tsx
+ * const fetcher: TimelineDataFetcher = async (userId) => ({
+ *   dailyRecords: await dailyRepo.listByUser(userId),
+ *   incidents: await incidentRepo.getByUserId(userId),
+ *   ispRecords: await ispRepo.listByUser(userId),
+ *   handoffRecords: await handoffRepo.getRecords('week', 'all'),
+ *   rawHandoffCount: allHandoff.length,
+ * });
+ *
+ * const { events, isLoading, sourceCounts } = useUserTimeline(
+ *   selectedUserId,
+ *   fetcher,
+ *   users,
+ *   { filter: { sources: ['daily', 'incident'] } },
+ * );
+ * ```
+ */
+export function useUserTimeline(
+  userId: string,
+  fetcher: TimelineDataFetcher,
+  users: IUserMaster[],
+  options?: UseUserTimelineOptions,
+): UseUserTimelineReturn {
+  const [events, setEvents] = useState<TimelineEvent[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const [sourceCounts, setSourceCounts] = useState<TimelineSourceCounts>(EMPTY_COUNTS);
+
+  // refreshTrigger で手動リロードを実現
+  const [refreshTrigger, setRefreshTrigger] = useState(0);
+  const refresh = useCallback(() => setRefreshTrigger((n) => n + 1), []);
+
+  // Handoff resolver を users から構築（users が変わったときだけ再構築）
+  const resolveUserIdFromCode = useMemo(
+    () => buildResolveUserIdFromCode(users),
+    [users],
+  );
+
+  // options を安定化（インラインオブジェクトの identity churn を防ぐ）
+  const optionsKey = JSON.stringify(options ?? null);
+  const stableOptions = useRef(options);
+  stableOptions.current = options;
+
+  // fetcher を ref に退避（参照安定化）
+  const fetcherRef = useRef(fetcher);
+  fetcherRef.current = fetcher;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchTimeline = async () => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const currentOptions = stableOptions.current;
+
+        // ─── データ取得（fetcher に委譲） ───
+        const { rawHandoffCount, ...sources } =
+          await fetcherRef.current(userId);
+
+        if (cancelled) return;
+
+        // ─── buildTimeline に委譲 ───
+
+        // フィルタ前のイベントで sourceCounts を計算
+        const allEvents = buildTimeline(sources, {
+          resolveUserIdFromCode,
+        });
+
+        const counts = computeSourceCounts(allEvents, rawHandoffCount);
+
+        // フィルタ適用済みイベント
+        const filteredEvents = currentOptions?.filter
+          ? buildTimeline(sources, {
+              filter: currentOptions.filter,
+              resolveUserIdFromCode,
+            })
+          : allEvents;
+
+        if (cancelled) return;
+
+        setEvents(filteredEvents);
+        setSourceCounts(counts);
+      } catch (err) {
+        if (!cancelled) {
+          setError(
+            err instanceof Error ? err : new Error(String(err)),
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void fetchTimeline();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [userId, refreshTrigger, resolveUserIdFromCode, optionsKey]);
+
+  return { events, isLoading, error, refresh, sourceCounts };
+}

--- a/src/features/users/UserDetailSections/SectionDetailContent.tsx
+++ b/src/features/users/UserDetailSections/SectionDetailContent.tsx
@@ -19,6 +19,10 @@ const ISPSummarySectionLazy = React.lazy(() =>
   import('./ISPSummarySection').then((m) => ({ default: m.ISPSummarySection })),
 );
 
+const TimelineSectionWrapperLazy = React.lazy(() =>
+  import('./TimelineSectionWrapper').then((m) => ({ default: m.TimelineSectionWrapper })),
+);
+
 type SectionDetailContentProps = {
   section: MenuSection;
   user: IUserMaster;
@@ -90,6 +94,15 @@ export const SectionDetailContent: React.FC<SectionDetailContentProps> = ({
     return (
       <Suspense fallback={<LoadingState message="個別支援計画書を準備中…" inline />}>
         <ISPSummarySectionLazy userId={user.UserID} />
+      </Suspense>
+    );
+  }
+
+  // ── Timeline — lazy-loaded timeline panel ──
+  if (section.key === 'timeline') {
+    return (
+      <Suspense fallback={<LoadingState message="タイムラインを準備中…" inline />}>
+        <TimelineSectionWrapperLazy user={user} />
       </Suspense>
     );
   }

--- a/src/features/users/UserDetailSections/TimelineSectionWrapper.tsx
+++ b/src/features/users/UserDetailSections/TimelineSectionWrapper.tsx
@@ -1,0 +1,71 @@
+/**
+ * TimelineSectionWrapper — User Detail Sections 内のタイムラインタブ用ラッパー
+ *
+ * 責務:
+ *   - IUserMaster の userId を抽出して UserTimelinePanel に渡す
+ *   - useUsersStore から users 一覧を取得して Handoff resolver 構築用に渡す
+ *   - 各ドメインの Repository を hook 経由で取得し、fetcher に注入する
+ *
+ * このコンポーネントは SectionDetailContent から lazy-load される。
+ * 表示ロジックは UserTimelinePanel に完全委譲。
+ *
+ * 段階接続:
+ *   - Daily: useDailyRecordRepository() ✅
+ *   - Incident: localIncidentRepository (直接 import) ✅
+ *   - ISP: useIspRepositories().ispRepo ✅
+ *   - Handoff: useHandoffData().repo ✅
+ *
+ * @see features/timeline/components/UserTimelinePanel.tsx — 表示パネル
+ * @see features/timeline/useUserTimeline.ts — orchestration hook
+ */
+
+import React, { useMemo } from 'react';
+import { UserTimelinePanel } from '@/features/timeline/components/UserTimelinePanel';
+import { createTimelineDataFetcher } from '@/features/timeline/createTimelineDataFetcher';
+import { useUsersStore } from '@/features/users/store';
+import { useDailyRecordRepository } from '@/features/daily/repositoryFactory';
+import { localIncidentRepository } from '@/infra/localStorage/localIncidentRepository';
+import { useIspRepositories } from '@/features/support-plan-guide/hooks/useIspRepositories';
+import { useHandoffData } from '@/features/handoff/hooks/useHandoffData';
+import type { IUserMaster } from '../types';
+
+export interface TimelineSectionWrapperProps {
+  /** 対象利用者 */
+  user: IUserMaster;
+}
+
+export const TimelineSectionWrapper: React.FC<TimelineSectionWrapperProps> = ({
+  user,
+}) => {
+  // userId を IUserMaster から抽出
+  const userId = user.UserID ?? String(user.Id);
+
+  // UserMaster 一覧（Handoff resolver 構築用）
+  const { data: users = [] } = useUsersStore();
+
+  // ─── Repository 取得（Hook ルール遵守: すべて無条件で呼ぶ） ───
+  const dailyRepo = useDailyRecordRepository();
+  const { ispRepo } = useIspRepositories();
+  const { repo: handoffRepo } = useHandoffData();
+
+  // fetcher を安定化（依存する repo が変わったときだけ再構築）
+  const fetcher = useMemo(
+    () =>
+      createTimelineDataFetcher({
+        dailyRepo,
+        incidentRepo: localIncidentRepository,
+        ispRepo,
+        handoffRepo,
+      }),
+    [dailyRepo, ispRepo, handoffRepo],
+  );
+
+  return (
+    <UserTimelinePanel
+      userId={userId}
+      userName={user.FullName}
+      fetcher={fetcher}
+      users={users}
+    />
+  );
+};

--- a/src/features/users/UserDetailSections/menuSections.ts
+++ b/src/features/users/UserDetailSections/menuSections.ts
@@ -5,6 +5,7 @@ import FactCheckRoundedIcon from '@mui/icons-material/FactCheckRounded';
 import PersonAddRoundedIcon from '@mui/icons-material/PersonAddRounded';
 import PsychologyIcon from '@mui/icons-material/Psychology';
 import SupportIcon from '@mui/icons-material/Support';
+import TimelineRoundedIcon from '@mui/icons-material/TimelineRounded';
 import type { MenuSection, MenuSectionKey } from './types';
 
 const menuSections: MenuSection[] = [
@@ -49,6 +50,20 @@ const menuSections: MenuSection[] = [
       '短期・中期目標の設定と進捗レビュー',
       '支援内容の見直しや家族との合意記録',
       '評価コメントと次期課題の整理',
+    ],
+  },
+  {
+    key: 'timeline',
+    anchor: 'timeline',
+    title: 'タイムライン',
+    description: '日次記録・インシデント・個別支援計画・申し送りを時系列で俯瞰します。',
+    icon: TimelineRoundedIcon,
+    avatarColor: '#5C6BC0',
+    status: 'available',
+    highlights: [
+      '4ドメインのイベントを時系列で統合表示',
+      'ソース別フィルタと重要度での絞り込み',
+      '日付グループによる直感的な履歴確認',
     ],
   },
   {
@@ -112,6 +127,7 @@ const menuSections: MenuSection[] = [
 const TAB_SECTION_KEYS: MenuSectionKey[] = [
   'basic',
   'support-plan',
+  'timeline',
   'service-records',
   'support-procedure',
   'assessment',

--- a/src/features/users/UserDetailSections/types.ts
+++ b/src/features/users/UserDetailSections/types.ts
@@ -4,6 +4,7 @@ type MenuSectionKey =
   | 'create-user'
   | 'basic'
   | 'support-plan'
+  | 'timeline'
   | 'service-records'
   | 'support-procedure'
   | 'assessment'


### PR DESCRIPTION
## 概要

利用者詳細画面に **タイムライン** タブを追加し、日次記録・インシデント・ISP・申し送りを時系列で俯瞰できるようにしました。

## Phase 完了状況

| Phase | 内容 | 状態 |
|-------|------|------|
| Phase 1 | Domain 層（adapter + buildTimeline） | ✅ |
| Phase 2 | Hook 層（useUserTimeline） | ✅ |
| Phase 3 | UI 統合（TimelineSectionWrapper + タブ追加） | ✅ |
| Phase 4 | Fetcher 実装（4ドメイン Repository 接続） | ✅ |

## アーキテクチャ

3層に分離した設計です:

- **domain/timeline** — 純粋関数（adapter 変換 + buildTimeline 集約/フィルタ/ソート）
- **features/timeline** — データ取得（createTimelineDataFetcher）、React hook、UIコンポーネント
- **UserDetailSections/TimelineSectionWrapper** — UserDetail コンテキストとタイムラインのブリッジ

## 主な設計判断

### 1. Repository DI パターン
`createTimelineDataFetcher` は plain function なので hook を直接呼べません。
`TimelineSectionWrapper` が hook 経由で Repository を取得し、fetcher に注入する構造です。

### 2. ソース別エラー耐性
各ソースの取得は独立した try/catch で囲まれており、1ソースのエラーが他ソースに波及しません。

### 3. 型変換の吸収
`DailyRecordUserRow` → `PersonDaily` の差異を fetcher 内で吸収。
Handoff の `userCode` → `userId` 解決は `buildResolveUserIdFromCode` で明示的に行います。

### 4. Lazy Loading
タイムラインタブは `React.lazy()` で遅延読み込み。バンドルサイズへの影響を最小化。

## 変更ファイル

### 新規 (22 files)
- `src/domain/timeline/` — 型定義、adapter (daily/incident/isp/handoff)、buildTimeline
- `src/features/timeline/` — createTimelineDataFetcher、useUserTimeline、UI コンポーネント群
- `src/features/users/UserDetailSections/TimelineSectionWrapper.tsx`

### 変更 (3 files)
- `types.ts` — `MenuSectionKey` に `timeline` 追加
- `menuSections.ts` — タイムラインセクション定義追加
- `SectionDetailContent.tsx` — lazy-load 登録

## テスト

**70 テスト / 7 ファイル — 全パス ✅**

| テストファイル | テスト数 |
|-------------|--------|
| dailyAdapter.spec.ts | 5 |
| incidentAdapter.spec.ts | 7 |
| ispAdapter.spec.ts | 7 |
| handoffAdapter.spec.ts | 11 |
| buildTimeline.spec.ts | 11 |
| useUserTimeline.spec.ts | 13 |
| createTimelineDataFetcher.spec.ts | 12 |

## Next Steps

- Phase 5: TimelineEventCard からソース詳細画面へのナビゲーション
- Phase 6: タブヘッダーへの sourceCounts イベント件数表示