### PR TITLE
docs: SharePoint audit response - provisioning log and runbook update (#973 #974 #975)

### DIFF
--- a/docs/operations/CHANGELOG_OPERATIONS.md
+++ b/docs/operations/CHANGELOG_OPERATIONS.md
@@ -1,0 +1,56 @@
+# Operations Change Log
+
+> **目的**: 本番環境への変更をすべて記録し、障害時の原因特定を即座に行えるようにする  
+> **ルール**: Production 環境に変更を入れたら必ず 1 エントリ追記する  
+> **対象**: SharePoint 設定変更 / List 作成・削除 / Index 追加 / Power Automate 変更 / Automation 変更  
+> **対象外**: UI 変更 / TypeScript 修正 / テスト追加（これらは PR で追跡）
+
+---
+
+## 記入フォーマット
+
+```
+## YYYY-MM-DD
+
+### [変更カテゴリ]
+
+- 変更内容1
+- 変更内容2
+
+Operator: [実施者]
+Environment: [実施環境]
+Issue: [関連Issue番号]
+```
+
+---
+
+## 2026-03-17
+
+### SharePoint Provisioning (#973 / #974 / #975)
+
+#### リスト作成 (#973)
+- `Holiday_Master` list created (6 columns: Title/Date/Label/Type/FiscalYear/IsActive + Date index)
+- `PdfOutput_Log` list created (10 columns + 3 indexes: OutputType/UserCode/OutputDate)
+
+#### インデックス追加 (#974)
+- `DailyActivityRecords`: UserCode, RecordDate (2 indexes added)
+- `SupportRecord_Daily`: UserId, 記録日 (2 indexes added) ※不要な AM活動/Completed も追加（影響なし）
+- `Schedules`: EventDate, MonthKey, ServiceType (3 indexes added)
+- **未作成リスト（対象外）**: AttendanceDaily, ServiceProvisionRecords, Transport_Log, SupportProcedureRecord_Daily
+  - → SharePoint 上に未プロビジョニングのため、インデックス追加は将来対応
+  - → Runbook Section 3.1 に必須設定として記録済み
+
+#### 一意制約 (#975)
+- `Users_Master.UserID` duplicate check: passed → unique constraint enabled
+
+#### Holiday_Master 仕上げ
+- Title 列 → 「祝日名」に変更: 完了
+- 祝日データ 18件投入: 完了
+
+Operator: sougo  
+Environment: SharePoint Web UI (manual) + Browser subagent — Tenant: isogokatudouhome / Site: /sites/welfare  
+Issue: #973 #974 #975 #976(closed, no target)
+
+---
+
+<!-- 次のエントリはここに追記 -->

--- a/docs/runbooks/sharepoint-provisioning.md
+++ b/docs/runbooks/sharepoint-provisioning.md
@@ -163,17 +163,17 @@ if (-not (Get-PnPList -Identity "PdfOutput_Log" -ErrorAction SilentlyContinue)) 
 
 ## 3. 既存リストへのインデックス追加
 
-```powershell
-Write-Host "`n=== インデックス追加 ===" -ForegroundColor Cyan
+> **2026-03-17 確認結果**: 以下のリストが SharePoint 上に存在し、インデックスを追加可能。
+> 未作成リスト（AttendanceDaily 等）は Section 3.1 を参照。
 
+```powershell
+Write-Host "`n=== インデックス追加（既存リスト） ===" -ForegroundColor Cyan
+
+# ── 既存リスト（2026-03-17 時点で SharePoint 上に存在確認済み） ──
 $indexTargets = @(
     @{ List = "DailyActivityRecords"; Fields = @("UserCode", "RecordDate") },
     @{ List = "SupportRecord_Daily"; Fields = @("cr013_personId", "cr013_date") },
-    @{ List = "AttendanceDaily"; Fields = @("UserCode", "RecordDate", "Key") },
-    @{ List = "ServiceProvisionRecords"; Fields = @("EntryKey", "UserCode", "RecordDate") },
-    @{ List = "Transport_Log"; Fields = @("UserCode", "RecordDate", "Title") },
-    @{ List = "SupportProcedureRecord_Daily"; Fields = @("UserCode", "RecordDate") },
-    @{ List = "Schedules"; Fields = @("Date", "MonthKey", "ServiceType") }
+    @{ List = "Schedules"; Fields = @("EventDate", "MonthKey", "ServiceType") }
 )
 
 $totalAdded = 0
@@ -203,6 +203,51 @@ foreach ($target in $indexTargets) {
 }
 
 Write-Host "`n  📊 Summary: Added=$totalAdded Skipped=$totalSkipped Failed=$totalFailed" -ForegroundColor Cyan
+```
+
+---
+
+### 3.1 未作成リスト — プロビジョニング時の必須設定
+
+> **状態**: 2026-03-17 時点で SharePoint 上に未作成。  
+> コードベース（`src/sharepoint/fields/*.ts`）に列定義は存在する。  
+> **リスト作成時に下記インデックスを必ず設定すること。**
+
+| リスト名 | 必須インデックス列 | 用途 | 定義ファイル |
+|---------|------------------|------|------------|
+| `AttendanceDaily` | `UserCode`, `RecordDate`, `Key` | 利用者出欠日次 | `attendanceFields.ts` |
+| `ServiceProvisionRecords` | `EntryKey`, `UserCode`, `RecordDate` | サービス提供記録 | `serviceProvisionFields.ts` |
+| `Transport_Log` | `UserCode`, `RecordDate`, `Title` | 送迎記録 | `transportFields.ts` |
+| `SupportProcedureRecord_Daily` | `UserCode`, `RecordDate` | 支援手順書兼記録 | `ispThreeLayerFields.ts` |
+
+#### Unique 制約候補（将来検討）
+
+| リスト | 列 | キー形式 |
+|--------|-----|----------|
+| `AttendanceDaily` | `Key` | `{UserCode}_{yyyy-MM-dd}` |
+| `ServiceProvisionRecords` | `EntryKey` | 複合キー |
+| `Transport_Log` | `Title` | `{UserCode}_{Date}_{Direction}` |
+
+```powershell
+# ── 未作成リスト用（リスト作成後に実行） ──
+$futureIndexTargets = @(
+    @{ List = "AttendanceDaily"; Fields = @("UserCode", "RecordDate", "Key") },
+    @{ List = "ServiceProvisionRecords"; Fields = @("EntryKey", "UserCode", "RecordDate") },
+    @{ List = "Transport_Log"; Fields = @("UserCode", "RecordDate", "Title") },
+    @{ List = "SupportProcedureRecord_Daily"; Fields = @("UserCode", "RecordDate") }
+)
+
+foreach ($target in $futureIndexTargets) {
+    Write-Host "`n  --- $($target.List) ---" -ForegroundColor White
+    foreach ($fieldName in $target.Fields) {
+        try {
+            Set-PnPField -List $target.List -Identity $fieldName -Values @{Indexed=$true}
+            Write-Host "    ✅ Indexed: $fieldName" -ForegroundColor Green
+        } catch {
+            Write-Host "    ⚠️ Failed: $fieldName — $_" -ForegroundColor Yellow
+        }
+    }
+}
 ```
 
 ---


### PR DESCRIPTION
## Summary
SharePoint audit response documentation update.

### Changes
- Created docs/operations/CHANGELOG_OPERATIONS.md with execution results
- - Updated docs/runbooks/sharepoint-provisioning.md:
-   - Section 3: Split into existing vs unprovisioned lists
-   - Section 3.1: Added mandatory index specs for future provisioning
### SharePoint Changes Documented
- Holiday_Master: created (6 columns + Date index + 18 holidays)
- - PdfOutput_Log: created (10 columns + 3 indexes)
- - Indexes: DailyActivityRecords(2), SupportRecord_Daily(2), Schedules(3)
- - Users_Master.UserID: unique constraint enabled
- - 4 unprovisioned lists documented for future setup
Closes #973 Closes #974 Closes #975 Closes #976