### PR TITLE
feat(ui): add EmptyStateAction shared component (MVP-001)

### DIFF
--- a/src/components/ui/EmptyStateAction.tsx
+++ b/src/components/ui/EmptyStateAction.tsx
@@ -1,0 +1,165 @@
+/**
+ * EmptyStateAction — 行動指向のエンプティステート共通コンポーネント
+ *
+ * データがない状態でも「次に何をすべきか」を示し、
+ * ユーザーを迷子にしないUIを全画面に統一適用する。
+ *
+ * 3バリアント:
+ *  - success: 全完了（✅ 緑）
+ *  - info:    データなし（ℹ️ デフォルト）
+ *  - warning: 要対応（⚠️ 橙）
+ *
+ * 設計方針:
+ *  - ErrorState / LoadingState と同一のレイアウトパターン
+ *  - MUI の Box + Stack + Typography + Button で構成
+ *  - フェードインアニメーション + アイコンパルスで視覚的誘導
+ *
+ * @see docs/product/welfare-operations-os-requirements-v1.md §3 情報設計原則 #8
+ * @see docs/product/screen-catalog.md 付録: コンポーネント依存マトリクス
+ * @module components/ui/EmptyStateAction
+ */
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Fade from '@mui/material/Fade';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { keyframes } from '@mui/material/styles';
+import React from 'react';
+
+// ─── Pulse Animation ─────────────────────────────────────────
+const pulse = keyframes`
+  0%, 100% { transform: scale(1); opacity: 0.85; }
+  50%      { transform: scale(1.08); opacity: 1; }
+`;
+
+// ─── Types ───────────────────────────────────────────────────
+
+/** Visual variant controlling color scheme and default icon */
+export type EmptyStateVariant = 'success' | 'info' | 'warning';
+
+export type EmptyStateActionProps = {
+  /** Emoji or icon string displayed at the top */
+  icon?: string;
+  /** Main heading */
+  title: string;
+  /** Descriptive text explaining the state */
+  description?: string;
+  /** CTA button label — if provided, the action button is shown */
+  actionLabel?: string;
+  /** Callback when the CTA button is clicked */
+  onAction?: () => void;
+  /** Visual variant: success (green), info (default), warning (amber) */
+  variant?: EmptyStateVariant;
+  /** Minimum height for the container */
+  minHeight?: number | string;
+  /** Test ID for automated testing */
+  testId?: string;
+};
+
+// ─── Variant Config ──────────────────────────────────────────
+
+const VARIANT_CONFIG: Record<
+  EmptyStateVariant,
+  { defaultIcon: string; color: string; bgColor: string; buttonColor: 'success' | 'primary' | 'warning' }
+> = {
+  success: {
+    defaultIcon: '🎉',
+    color: 'success.main',
+    bgColor: 'rgba(46, 125, 50, 0.04)',
+    buttonColor: 'success',
+  },
+  info: {
+    defaultIcon: '📋',
+    color: 'text.secondary',
+    bgColor: 'rgba(25, 118, 210, 0.04)',
+    buttonColor: 'primary',
+  },
+  warning: {
+    defaultIcon: '⚠️',
+    color: 'warning.main',
+    bgColor: 'rgba(237, 108, 2, 0.04)',
+    buttonColor: 'warning',
+  },
+};
+
+// ─── Component ───────────────────────────────────────────────
+
+export const EmptyStateAction: React.FC<EmptyStateActionProps> = ({
+  icon,
+  title,
+  description,
+  actionLabel,
+  onAction,
+  variant = 'info',
+  minHeight = '10vh',
+  testId = 'empty-state-action',
+}) => {
+  const config = VARIANT_CONFIG[variant];
+  const displayIcon = icon ?? config.defaultIcon;
+
+  return (
+    <Fade in timeout={400}>
+      <Box
+        data-testid={testId}
+        sx={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          minHeight,
+          p: 4,
+          borderRadius: 2,
+          bgcolor: config.bgColor,
+        }}
+      >
+        <Stack spacing={2} alignItems="center" textAlign="center">
+          {/* Icon with subtle pulse animation */}
+          <Box
+            sx={{
+              fontSize: 40,
+              lineHeight: 1,
+              animation: `${pulse} 2.5s ease-in-out infinite`,
+            }}
+            role="img"
+            aria-label={title}
+          >
+            {displayIcon}
+          </Box>
+
+          {/* Title */}
+          <Typography
+            variant="h6"
+            sx={{
+              color: config.color,
+              fontWeight: 600,
+            }}
+          >
+            {title}
+          </Typography>
+
+          {/* Description */}
+          {description && (
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{ maxWidth: 400 }}
+            >
+              {description}
+            </Typography>
+          )}
+
+          {/* CTA Button */}
+          {actionLabel && onAction && (
+            <Button
+              variant="outlined"
+              color={config.buttonColor}
+              onClick={onAction}
+              sx={{ mt: 1 }}
+            >
+              {actionLabel}
+            </Button>
+          )}
+        </Stack>
+      </Box>
+    </Fade>
+  );
+};

--- a/tests/unit/EmptyStateAction.spec.tsx
+++ b/tests/unit/EmptyStateAction.spec.tsx
@@ -1,0 +1,110 @@
+/**
+ * EmptyStateAction — Unit Tests
+ *
+ * @see src/components/ui/EmptyStateAction.tsx
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { EmptyStateAction } from '../../src/components/ui/EmptyStateAction';
+
+describe('EmptyStateAction', () => {
+  // ─── Rendering ─────────────────────────────────────────────
+
+  it('renders title and description', () => {
+    render(
+      <EmptyStateAction
+        title="データがありません"
+        description="新しいデータを追加してください"
+      />,
+    );
+    expect(screen.getByText('データがありません')).toBeInTheDocument();
+    expect(screen.getByText('新しいデータを追加してください')).toBeInTheDocument();
+  });
+
+  it('renders with default info variant when no variant specified', () => {
+    render(<EmptyStateAction title="テスト" />);
+    const container = screen.getByTestId('empty-state-action');
+    expect(container).toBeInTheDocument();
+    // Default icon for info variant is 📋
+    expect(screen.getByRole('img', { name: 'テスト' })).toHaveTextContent('📋');
+  });
+
+  // ─── Variants ──────────────────────────────────────────────
+
+  it('renders success variant with default icon', () => {
+    render(<EmptyStateAction title="完了" variant="success" />);
+    expect(screen.getByRole('img', { name: '完了' })).toHaveTextContent('🎉');
+  });
+
+  it('renders warning variant with default icon', () => {
+    render(<EmptyStateAction title="注意" variant="warning" />);
+    expect(screen.getByRole('img', { name: '注意' })).toHaveTextContent('⚠️');
+  });
+
+  it('uses custom icon when provided', () => {
+    render(<EmptyStateAction title="カスタム" icon="🚀" />);
+    expect(screen.getByRole('img', { name: 'カスタム' })).toHaveTextContent('🚀');
+  });
+
+  // ─── Action Button ────────────────────────────────────────
+
+  it('renders action button when actionLabel and onAction are provided', () => {
+    const handleAction = vi.fn();
+    render(
+      <EmptyStateAction
+        title="空の状態"
+        actionLabel="追加する"
+        onAction={handleAction}
+      />,
+    );
+    const button = screen.getByRole('button', { name: '追加する' });
+    expect(button).toBeInTheDocument();
+  });
+
+  it('calls onAction when button is clicked', () => {
+    const handleAction = vi.fn();
+    render(
+      <EmptyStateAction
+        title="空の状態"
+        actionLabel="記録を開始"
+        onAction={handleAction}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: '記録を開始' }));
+    expect(handleAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render action button when actionLabel is missing', () => {
+    const handleAction = vi.fn();
+    render(
+      <EmptyStateAction
+        title="空の状態"
+        onAction={handleAction}
+      />,
+    );
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('does not render action button when onAction is missing', () => {
+    render(
+      <EmptyStateAction
+        title="空の状態"
+        actionLabel="ボタン"
+      />,
+    );
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  // ─── Optional Props ───────────────────────────────────────
+
+  it('renders without description', () => {
+    render(<EmptyStateAction title="タイトルのみ" />);
+    expect(screen.getByText('タイトルのみ')).toBeInTheDocument();
+  });
+
+  it('respects custom testId', () => {
+    render(<EmptyStateAction title="テスト" testId="custom-empty" />);
+    expect(screen.getByTestId('custom-empty')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要

全画面で統一的に使用する「行動指向のエンプティステート」共通コンポーネントを新規作成。

**MVP-001 / Sprint 1 最初の Issue**

## 目的

データがない状態でも「次に何をすべきか」を示し、ユーザーを迷子にしないUIを全画面に統一適用する。要件定義書 §3 情報設計原則 #8「行動指向のエンプティステート」への対応。

## 追加ファイル

| ファイル | 内容 |
|---------|------|
| `src/components/ui/EmptyStateAction.tsx` | 本体コンポーネント |
| `tests/unit/EmptyStateAction.spec.tsx` | ユニットテスト（11件） |

## 設計方針

- 既存の `ErrorState` / `LoadingState` と同一のレイアウトパターン（Box + Stack + Typography + Button）
- 3バリアント: `success`（緑 🎉）、`info`（デフォルト 📋）、`warning`（橙 ⚠️）
- フェードインアニメーション + アイコン軽微パルスで視覚的誘導
- CTA ボタン（`actionLabel` + `onAction`）で次の行動を促す
- `testId` prop でE2Eテスト対応

## 検証結果

- ✅ ユニットテスト: 11/11 pass
- ✅ lint: 0 warnings
- ✅ typecheck: pass
- ✅ 既存テスト: 6588 pass（nav-router-consistency の既存失敗1件のみ — 本PRとは無関係）

## 今後の利用先（Sprint 1）

| 利用先 | Issue |
|--------|-------|
| ActionQueueCard — 全件完了時 | #1024 |
| UserDetailPage — データなし時 | #1025 |
| ExceptionTable — 例外ゼロ時 | #1028 |
| ExceptionCenterPage | #1029 |

## 関連

- Closes #1020
- Ref: `docs/product/screen-catalog.md`, `docs/product/sprint-1-plan.md`
