### PR TITLE
feat(support-plan-guide): P1-A~P2-B 制度HUD信号灯UI・MonitoringTab分割・5グループタブ・Markdown統合

### DIFF
--- a/src/app/links/__tests__/navigationLinks.test.ts
+++ b/src/app/links/__tests__/navigationLinks.test.ts
@@ -172,15 +172,15 @@ describe('buildIcebergPdcaUrl', () => {
 // ---------------------------------------------------------------------------
 
 describe('buildSupportPlanMonitoringUrl', () => {
-  it('userId と tab=monitoring を query param に含める', () => {
+  it('userId と tab=operations.monitoring を query param に含める', () => {
     expect(buildSupportPlanMonitoringUrl('I022')).toBe(
-      '/support-plan-guide?userId=I022&tab=monitoring',
+      '/support-plan-guide?userId=I022&tab=operations.monitoring',
     );
   });
 
-  it('tab は必ず monitoring 固定', () => {
+  it('tab は必ず operations.monitoring 固定', () => {
     const url = buildSupportPlanMonitoringUrl('U999');
-    expect(url).toContain('tab=monitoring');
+    expect(url).toContain('tab=operations.monitoring');
     expect(url).toContain('userId=U999');
   });
 });

--- a/src/app/links/navigationLinks.ts
+++ b/src/app/links/navigationLinks.ts
@@ -271,13 +271,20 @@ export function buildIcebergPdcaUrlWithHighlight(
 
 // ─── Support Plan Monitoring Navigation ───────────────────────────────
 
+import { resolveTabRoute, serializeTabRoute } from '@/features/support-plan-guide/domain/tabRoute';
+
 /**
- * /support-plan-guide?userId=xxx&tab=monitoring を生成する。
+ * /support-plan-guide?userId=xxx&tab=operations.monitoring を生成する。
  * Iceberg PDCA → Monitoring への導線で使用。
+ *
+ * 新形式 group.sub を使用。useDraftBootstrap の parseTabRoute が
+ * 旧形式（monitoring）・新形式（operations.monitoring）を両方受け入れるため
+ * 後方互換は維持される。
  */
 export function buildSupportPlanMonitoringUrl(userId: string): string {
   const search = new URLSearchParams();
   search.set('userId', userId);
-  search.set('tab', 'monitoring');
+  const route = resolveTabRoute('monitoring');
+  search.set('tab', route ? serializeTabRoute(route) : 'monitoring');
   return `/support-plan-guide?${search.toString()}`;
 }

--- a/src/features/support-plan-guide/components/RegulatorySection.tsx
+++ b/src/features/support-plan-guide/components/RegulatorySection.tsx
@@ -11,22 +11,44 @@ import Stack from '@mui/material/Stack';
 import PlayArrowRoundedIcon from '@mui/icons-material/PlayArrowRounded';
 import { RegulatorySummaryBand } from './RegulatorySummaryBand';
 import { PlanningSheetStatsGrid } from './PlanningSheetStatsGrid';
-import type { SupportPlanBundle } from '@/domain/isp/schema';
+import type { SupportPlanBundle, IspComplianceMetadata } from '@/domain/isp/schema';
+import type { DeadlineInfo, SectionKey } from '../types';
 import { buildDailySupportUrl } from '@/app/links/buildDailySupportUrl';
 
 type RegulatorySectionProps = {
   bundle: SupportPlanBundle;
   linkedUserId: string | null;
   onNavigate: (url: string) => void;
+  /** P2-B: 制度適合メタデータ */
+  compliance?: IspComplianceMetadata | null;
+  /** P2-B: 期限情報 */
+  deadlines?: {
+    creation: DeadlineInfo;
+    monitoring: DeadlineInfo;
+  };
+  /** P2-B: Iceberg 分析件数合計 */
+  icebergTotal?: number;
+  /** P2-B: HUD チップクリックでタブ遷移 */
+  onNavigateToTab?: (sub: SectionKey) => void;
 };
 
 const RegulatorySection: React.FC<RegulatorySectionProps> = ({
   bundle,
   linkedUserId,
   onNavigate,
+  compliance,
+  deadlines,
+  icebergTotal,
+  onNavigateToTab,
 }) => (
   <Stack spacing={1.5}>
-    <RegulatorySummaryBand bundle={bundle} />
+    <RegulatorySummaryBand
+      bundle={bundle}
+      compliance={compliance}
+      deadlines={deadlines}
+      icebergTotal={icebergTotal}
+      onNavigateToTab={onNavigateToTab}
+    />
     <PlanningSheetStatsGrid bundle={bundle} onNavigate={onNavigate} />
     {/* シートカードが無い場合のみ単一ボタンを表示 */}
     {linkedUserId && !(bundle.planningSheetItems?.length) && (

--- a/src/features/support-plan-guide/components/RegulatorySummaryBand.tsx
+++ b/src/features/support-plan-guide/components/RegulatorySummaryBand.tsx
@@ -1,122 +1,144 @@
 /**
- * RegulatorySummaryBand — SupportPlanGuidePage 上部の制度サマリー帯
+ * RegulatorySummaryBand — 制度適合 HUD 信号灯帯
  *
- * SupportPlanBundle のデータを使って、
- * ISP ステータス・シート数・Iceberg 分析件数・実施記録数・
- * 直近モニタリング・再分析推奨を表示する。
+ * P2-B: 制度状態を信号灯（🟢 OK / 🟡 注意 / 🔴 未対応）で可視化し、
+ * クリックで該当タブへ遷移できる。
  *
- * この帯が表示されることで、支援者はシートを開く前に
- * 「制度的にどういう状況か」をひと目で把握できる。
+ * 判定ロジックは domain/regulatoryHud.ts の純関数に完全分離。
+ * このコンポーネントは受け取った HudItem[] を表示するだけ。
  */
 import React, { useMemo } from 'react';
-import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
-import Divider from '@mui/material/Divider';
 import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
+import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
-import WarningAmberRoundedIcon from '@mui/icons-material/WarningAmberRounded';
+import Box from '@mui/material/Box';
 import AssessmentRoundedIcon from '@mui/icons-material/AssessmentRounded';
-import DescriptionRoundedIcon from '@mui/icons-material/DescriptionRounded';
-import EditNoteRoundedIcon from '@mui/icons-material/EditNoteRounded';
-import EventNoteRoundedIcon from '@mui/icons-material/EventNoteRounded';
-import PsychologyRoundedIcon from '@mui/icons-material/PsychologyRounded';
-import { ISP_STATUS_DISPLAY } from '@/domain/isp/schema';
-import type { IspStatus, SupportPlanBundle } from '@/domain/isp/schema';
+import CheckCircleRoundedIcon from '@mui/icons-material/CheckCircleRounded';
+import WarningAmberRoundedIcon from '@mui/icons-material/WarningAmberRounded';
+import ErrorRoundedIcon from '@mui/icons-material/ErrorRounded';
+import type { IspComplianceMetadata, SupportPlanBundle } from '@/domain/isp/schema';
+import type { DeadlineInfo, SectionKey } from '../types';
+import {
+  buildRegulatoryHudItems,
+  worstSignal,
+  signalCounts,
+  type RegulatoryHudInput,
+  type RegulatoryHudItem,
+  type RegulatorySignal,
+} from '../domain/regulatoryHud';
+
+// ────────────────────────────────────────────
+// 信号灯の色マッピング
+// ────────────────────────────────────────────
+
+const SIGNAL_CHIP_COLOR: Record<RegulatorySignal, 'success' | 'warning' | 'error'> = {
+  ok: 'success',
+  warning: 'warning',
+  danger: 'error',
+};
+
+const SIGNAL_ICON: Record<RegulatorySignal, React.ReactElement> = {
+  ok: <CheckCircleRoundedIcon />,
+  warning: <WarningAmberRoundedIcon />,
+  danger: <ErrorRoundedIcon />,
+};
+
+const SIGNAL_EMOJI: Record<RegulatorySignal, string> = {
+  ok: '🟢',
+  warning: '🟡',
+  danger: '🔴',
+};
+
+// ────────────────────────────────────────────
+// Props
+// ────────────────────────────────────────────
 
 type RegulatorySummaryBandProps = {
   bundle: SupportPlanBundle;
+  /** 制度適合メタデータ（コンプライアンスタブの入力データ） */
+  compliance?: IspComplianceMetadata | null;
+  /** 期限情報 */
+  deadlines?: {
+    creation: DeadlineInfo;
+    monitoring: DeadlineInfo;
+  };
+  /** Iceberg 分析件数の合計 */
+  icebergTotal?: number;
+  /** HUD チップクリック時に該当タブへ遷移するコールバック */
+  onNavigateToTab?: (sub: SectionKey) => void;
 };
 
-/**
- * 再分析推奨かどうかを判定する。
- *
- * ルール:
- * - latestMonitoring.planChangeRequired === true → 推奨
- * - latestMonitoring がない → 推奨
- * - latestMonitoring が 180 日以上前 → 推奨
- */
-function shouldRecommendReanalysis(
-  monitoring: SupportPlanBundle['latestMonitoring'],
-): boolean {
-  if (!monitoring) return true;
-  if (monitoring.planChangeRequired) return true;
+// ────────────────────────────────────────────
+// Component
+// ────────────────────────────────────────────
 
-  const monitoringDate = new Date(monitoring.date);
-  const daysSince = Math.floor(
-    (Date.now() - monitoringDate.getTime()) / (1000 * 60 * 60 * 24),
-  );
-  return daysSince >= 180;
-}
-
-/**
- * 実施記録の総数を集計する。
- */
-function totalRecordCount(countBySheet?: Record<string, number>): number {
-  if (!countBySheet) return 0;
-  return Object.values(countBySheet).reduce((a, b) => a + b, 0);
-}
-
-/**
- * ISP ステータスのラベルを返す。
- * ISP_STATUS_DISPLAY に存在しない場合はそのまま返す。
- */
-function ispStatusLabel(status: IspStatus): string {
-  return ISP_STATUS_DISPLAY[status] ?? status;
-}
-
-export const RegulatorySummaryBand: React.FC<RegulatorySummaryBandProps> = ({ bundle }) => {
+export const RegulatorySummaryBand: React.FC<RegulatorySummaryBandProps> = ({
+  bundle,
+  compliance = null,
+  deadlines,
+  icebergTotal: icebergTotalProp,
+  onNavigateToTab,
+}) => {
+  // fallback: bundle から Iceberg 件数を算出
   const icebergTotal = useMemo(() => {
+    if (icebergTotalProp != null) return icebergTotalProp;
     if (!bundle.icebergCountBySheet) return 0;
     return Object.values(bundle.icebergCountBySheet).reduce((a, b) => a + b, 0);
-  }, [bundle.icebergCountBySheet]);
+  }, [icebergTotalProp, bundle.icebergCountBySheet]);
 
-  const recordTotal = useMemo(
-    () => totalRecordCount(bundle.procedureRecordCountBySheet),
-    [bundle.procedureRecordCountBySheet],
+  // fallback: deadlines がない場合はデフォルト
+  const resolvedDeadlines = useMemo(
+    () =>
+      deadlines ?? {
+        creation: { label: '作成期限', color: 'default' as const },
+        monitoring: { label: 'モニタ期限', color: 'default' as const },
+      },
+    [deadlines],
   );
 
-  const needsReanalysis = useMemo(
-    () => shouldRecommendReanalysis(bundle.latestMonitoring),
-    [bundle.latestMonitoring],
+  // HUD 項目を生成
+  const hudInput: RegulatoryHudInput = useMemo(
+    () => ({
+      ispStatus: bundle.isp.status,
+      compliance,
+      deadlines: resolvedDeadlines,
+      latestMonitoring: bundle.latestMonitoring,
+      icebergTotal,
+    }),
+    [bundle.isp.status, compliance, resolvedDeadlines, bundle.latestMonitoring, icebergTotal],
   );
 
-  const nextReview = bundle.isp.nextReviewAt;
-  const daysUntilReview = useMemo(() => {
-    if (!nextReview) return null;
-    const due = new Date(nextReview);
-    const now = new Date();
-    return Math.floor((due.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
-  }, [nextReview]);
+  const hudItems = useMemo(() => buildRegulatoryHudItems(hudInput), [hudInput]);
+  const worst = useMemo(() => worstSignal(hudItems), [hudItems]);
+  const counts = useMemo(() => signalCounts(hudItems), [hudItems]);
 
-  const sheetCount = bundle.planningSheetCount ?? 0;
+  // ── バンドのボーダー色 ──
+  const borderColorMap: Record<RegulatorySignal, string> = {
+    ok: 'success.main',
+    warning: 'warning.main',
+    danger: 'error.main',
+  };
 
   return (
     <Paper
       variant="outlined"
       data-testid="regulatory-summary-band"
       sx={{
-        p: { xs: 1.5, md: 2 },
+        px: { xs: 1.5, md: 2 },
+        py: { xs: 1, md: 1.25 },
         background: (theme) =>
           theme.palette.mode === 'dark'
             ? 'linear-gradient(135deg, rgba(30,60,90,0.5) 0%, rgba(20,40,60,0.5) 100%)'
             : 'linear-gradient(135deg, rgba(232,245,255,0.8) 0%, rgba(240,248,255,0.9) 100%)',
-        borderColor: (theme) =>
-          needsReanalysis
-            ? theme.palette.warning.main
-            : theme.palette.divider,
+        borderColor: borderColorMap[worst],
+        borderWidth: worst === 'ok' ? 1 : 2,
+        transition: 'border-color 0.3s ease',
       }}
     >
-      <Stack spacing={1.5}>
+      <Stack spacing={0.75}>
         {/* ── ヘッダー行 ── */}
-        <Stack direction="row" alignItems="center" spacing={1}>
-          <AssessmentRoundedIcon fontSize="small" color="primary" />
-          <Typography variant="subtitle2" fontWeight={600}>
-            制度サマリー
-          </Typography>
-        </Stack>
-
-        {/* ── チップ行: メイン指標 ── */}
         <Stack
           direction="row"
           spacing={1}
@@ -124,128 +146,98 @@ export const RegulatorySummaryBand: React.FC<RegulatorySummaryBandProps> = ({ bu
           useFlexGap
           alignItems="center"
         >
-          {/* ISP ステータス */}
-          <Chip
-            size="small"
-            variant="outlined"
-            label={`ISP: ${ispStatusLabel(bundle.isp.status)}`}
-            color="primary"
-          />
+          <Stack direction="row" alignItems="center" spacing={0.5} sx={{ mr: 0.5 }}>
+            <AssessmentRoundedIcon sx={{ fontSize: 16 }} color="primary" />
+            <Typography variant="body2" fontWeight={600} sx={{ whiteSpace: 'nowrap' }}>
+              制度サマリー
+            </Typography>
+          </Stack>
 
-          {/* シート数 */}
-          <Chip
-            size="small"
-            variant="outlined"
-            icon={<DescriptionRoundedIcon />}
-            label={`シート: ${sheetCount}件`}
-          />
-
-          {/* Iceberg 分析件数 */}
-          <Chip
-            size="small"
-            variant="outlined"
-            icon={<PsychologyRoundedIcon />}
-            label={`Iceberg分析: ${icebergTotal}件`}
-          />
-
-          {/* 実施記録数 */}
-          <Chip
-            size="small"
-            variant="outlined"
-            icon={<EditNoteRoundedIcon />}
-            label={`実施記録: ${recordTotal}件`}
-            color={recordTotal === 0 ? 'warning' : 'default'}
-          />
-
-          {/* 次回見直し */}
-          {nextReview && (
-            <Chip
-              size="small"
-              variant="outlined"
-              icon={<EventNoteRoundedIcon />}
-              label={`次回見直し: ${nextReview}${daysUntilReview != null ? ` (${daysUntilReview}日後)` : ''}`}
-              color={daysUntilReview != null && daysUntilReview <= 30 ? 'warning' : 'default'}
-            />
-          )}
+          {/* サマリーバッジ */}
+          <Box
+            sx={{
+              px: 1,
+              py: 0.25,
+              borderRadius: 1,
+              bgcolor: `${borderColorMap[worst]}`,
+              color: 'white',
+              fontSize: '0.7rem',
+              fontWeight: 700,
+              lineHeight: 1.4,
+              minWidth: 'auto',
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 0.5,
+            }}
+          >
+            {counts.danger > 0 && `${SIGNAL_EMOJI.danger} ${counts.danger}`}
+            {counts.warning > 0 && ` ${SIGNAL_EMOJI.warning} ${counts.warning}`}
+            {counts.danger === 0 && counts.warning === 0 && `${SIGNAL_EMOJI.ok} すべて完了`}
+          </Box>
         </Stack>
 
-        {/* ── チップ行: ステータス指標 ── */}
-        <Divider sx={{ opacity: 0.5 }} />
+        {/* ── 信号灯チップ一覧 ── */}
         <Stack
           direction="row"
-          spacing={1}
+          spacing={0.75}
           flexWrap="wrap"
           useFlexGap
           alignItems="center"
         >
-          {/* 直近モニタリング */}
-          {bundle.latestMonitoring ? (
-            <Chip
-              size="small"
-              variant="outlined"
-              label={`直近モニタリング: ${bundle.latestMonitoring.date}`}
-              color={bundle.latestMonitoring.planChangeRequired ? 'warning' : 'success'}
-            />
-          ) : (
-            <Chip
-              size="small"
-              variant="filled"
-              label="モニタリング未実施"
-              color="warning"
-            />
-          )}
-
-          {/* 直近実施日 */}
-          {bundle.lastProcedureRecordDate && (
-            <Chip
-              size="small"
-              variant="outlined"
-              label={`最終実施: ${bundle.lastProcedureRecordDate}`}
-              color="default"
-            />
-          )}
-
-          {/* 再分析推奨 */}
-          {needsReanalysis && (
-            <Chip
-              size="small"
-              variant="filled"
-              icon={<WarningAmberRoundedIcon />}
-              label="再分析推奨"
-              color="warning"
-            />
-          )}
+          {hudItems.map((item) => (
+            <HudChip key={item.key} item={item} onNavigateToTab={onNavigateToTab} />
+          ))}
         </Stack>
-
-        {/* ── シートごとの内訳（3件以上ある場合） ── */}
-        {bundle.icebergCountBySheet && Object.keys(bundle.icebergCountBySheet).length > 0 && (
-          <>
-            <Divider sx={{ opacity: 0.5 }} />
-            <Box>
-              <Typography variant="caption" color="text.secondary" fontWeight={600} sx={{ mb: 0.5, display: 'block' }}>
-                シート別内訳
-              </Typography>
-              <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
-                {Object.entries(bundle.icebergCountBySheet).map(([sheetId, count]) => {
-                  const recordCount = bundle.procedureRecordCountBySheet?.[sheetId] ?? 0;
-                  return (
-                    <Chip
-                      key={sheetId}
-                      size="small"
-                      variant="outlined"
-                      label={`${sheetId.slice(0, 8)}… — 分析${count} / 記録${recordCount}`}
-                      sx={{ fontSize: '0.7rem' }}
-                    />
-                  );
-                })}
-              </Stack>
-            </Box>
-          </>
-        )}
       </Stack>
     </Paper>
   );
 };
 
+// ────────────────────────────────────────────
+// 個別チップ
+// ────────────────────────────────────────────
+
+const HudChip: React.FC<{
+  item: RegulatoryHudItem;
+  onNavigateToTab?: (sub: SectionKey) => void;
+}> = ({ item, onNavigateToTab }) => {
+  const chipColor = SIGNAL_CHIP_COLOR[item.signal];
+  const chipIcon = SIGNAL_ICON[item.signal];
+  const isClickable = !!item.navigateTo && !!onNavigateToTab;
+
+  const chip = (
+    <Chip
+      size="small"
+      variant={item.signal === 'ok' ? 'outlined' : 'filled'}
+      color={chipColor}
+      icon={chipIcon}
+      label={item.label}
+      data-testid={`hud-chip-${item.key}`}
+      onClick={isClickable ? () => onNavigateToTab!(item.navigateTo!) : undefined}
+      sx={{
+        cursor: isClickable ? 'pointer' : 'default',
+        fontWeight: item.signal === 'danger' ? 700 : 500,
+        transition: 'transform 0.15s ease, box-shadow 0.15s ease',
+        '&:hover': isClickable
+          ? {
+              transform: 'translateY(-1px)',
+              boxShadow: 1,
+            }
+          : undefined,
+      }}
+    />
+  );
+
+  if (item.detail) {
+    return (
+      <Tooltip title={item.detail} arrow placement="bottom">
+        {chip}
+      </Tooltip>
+    );
+  }
+
+  return chip;
+};
+
 /** テスト用 export */
-export { shouldRecommendReanalysis, totalRecordCount };
+export { buildRegulatoryHudItems, worstSignal };

--- a/src/features/support-plan-guide/components/SupportPlanTabHeader.tsx
+++ b/src/features/support-plan-guide/components/SupportPlanTabHeader.tsx
@@ -1,0 +1,137 @@
+/**
+ * SupportPlanTabHeader — 5グループ × サブタブの2段タブヘッダー
+ *
+ * P1-B: 10タブのフラット構造を group/sub の2段構造に再編。
+ *
+ * 設計:
+ *  - 上段: 5グループタブ（基本情報/計画策定/運用・実行/制度適合/出力）
+ *  - 下段: グループ内サブタブ（subs が2+ の場合のみ表示）
+ *  - 内部 state は増やさない: activeTab: SectionKey から group を導出
+ */
+import type { SectionKey } from '@/features/support-plan-guide/types';
+import {
+  TAB_GROUPS,
+  type TabGroupKey,
+} from '@/features/support-plan-guide/domain/tabRoute';
+import {
+  resolveTabRoute,
+  getGroupDefaultSub,
+  findGroupDef,
+} from '@/features/support-plan-guide/domain/tabRoute';
+import { SECTIONS } from '@/features/support-plan-guide/utils/helpers';
+import Tab from '@mui/material/Tab';
+import Tabs from '@mui/material/Tabs';
+import Box from '@mui/material/Box';
+import React from 'react';
+
+// ── サブタブラベル逆引き ──
+const SUB_LABELS: ReadonlyMap<SectionKey, string> = new Map(
+  SECTIONS.map((s) => [s.key, s.label]),
+);
+
+// ────────────────────────────────────────────
+// Props
+// ────────────────────────────────────────────
+
+export interface SupportPlanTabHeaderProps {
+  /** 現在アクティブな SectionKey */
+  activeTab: SectionKey;
+  /** タブ変更コールバック（SectionKey を直接渡す） */
+  onTabChange: (tab: SectionKey) => void;
+}
+
+// ────────────────────────────────────────────
+// Component
+// ────────────────────────────────────────────
+
+const SupportPlanTabHeader: React.FC<SupportPlanTabHeaderProps> = ({
+  activeTab,
+  onTabChange,
+}) => {
+  // ── activeTab → 現在のグループを導出 ──
+  const currentRoute = resolveTabRoute(activeTab);
+  const activeGroupKey: TabGroupKey = currentRoute?.group ?? 'basic';
+  const activeGroupDef = findGroupDef(activeGroupKey);
+
+  // ── グループタブクリック → グループのデフォルト sub に遷移 ──
+  const handleGroupChange = React.useCallback(
+    (_event: React.SyntheticEvent, newGroupKey: TabGroupKey) => {
+      const defaultSub = getGroupDefaultSub(newGroupKey);
+      if (defaultSub) {
+        onTabChange(defaultSub);
+      }
+    },
+    [onTabChange],
+  );
+
+  // ── サブタブクリック → そのまま sub を渡す ──
+  const handleSubChange = React.useCallback(
+    (_event: React.SyntheticEvent, newSub: SectionKey) => {
+      onTabChange(newSub);
+    },
+    [onTabChange],
+  );
+
+  return (
+    <Box>
+      {/* ── 上段: グループタブ ── */}
+      <Tabs
+        value={activeGroupKey}
+        onChange={handleGroupChange}
+        variant="fullWidth"
+        aria-label="支援計画セクショングループ"
+        sx={{
+          minHeight: 42,
+          '& .MuiTab-root': {
+            minHeight: 42,
+            fontWeight: 600,
+            fontSize: '0.85rem',
+          },
+        }}
+      >
+        {TAB_GROUPS.map((group) => (
+          <Tab
+            key={group.key}
+            value={group.key}
+            label={group.label}
+            id={`sp-group-tab-${group.key}`}
+            aria-controls={`sp-group-panel-${group.key}`}
+          />
+        ))}
+      </Tabs>
+
+      {/* ── 下段: サブタブ（2+ subs のグループのみ） ── */}
+      {activeGroupDef && activeGroupDef.subs.length > 1 && (
+        <Tabs
+          value={activeTab}
+          onChange={handleSubChange}
+          variant="scrollable"
+          scrollButtons="auto"
+          aria-label={`${activeGroupDef.label}セクション切り替え`}
+          sx={{
+            minHeight: 36,
+            borderTop: 1,
+            borderColor: 'divider',
+            '& .MuiTab-root': {
+              minHeight: 36,
+              fontSize: '0.8rem',
+              textTransform: 'none',
+            },
+          }}
+        >
+          {activeGroupDef.subs.map((sub) => (
+            <Tab
+              key={sub}
+              value={sub}
+              label={SUB_LABELS.get(sub) ?? sub}
+              id={`sp-sub-tab-${sub}`}
+              aria-controls={`support-plan-tabpanel-${sub}`}
+            />
+          ))}
+        </Tabs>
+      )}
+    </Box>
+  );
+};
+
+export default SupportPlanTabHeader;

--- a/src/features/support-plan-guide/components/tabs/MonitoringDashboardSection.tsx
+++ b/src/features/support-plan-guide/components/tabs/MonitoringDashboardSection.tsx
@@ -1,0 +1,72 @@
+/**
+ * MonitoringDashboardSection — 日次集計ダッシュボード + ISP判断記録
+ *
+ * MonitoringDailyDashboard への props 配線と保存中インジケーターを表示。
+ * 状態は useMonitoringTabState().dashboardState から受け取る。
+ */
+import CircularProgress from '@mui/material/CircularProgress';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import React from 'react';
+
+import MonitoringDailyDashboard from '@/features/monitoring/components/MonitoringDailyDashboard';
+import type { useMonitoringTabState } from '../../hooks/useMonitoringTabState';
+
+type DashboardState = ReturnType<typeof useMonitoringTabState>['dashboardState'];
+
+export type MonitoringDashboardSectionProps = {
+  isAdmin: boolean;
+} & DashboardState;
+
+const MonitoringDashboardSection: React.FC<MonitoringDashboardSectionProps> = ({
+  summary,
+  insightLines,
+  recordCount,
+  isAdmin,
+  goalNames,
+  decisionStatuses,
+  decisionNotes,
+  decisions,
+  isDecisionSaving,
+  isSavingDraft,
+  hasSavedDraft,
+  savedRecords,
+  onDecision,
+  onSaveDraft,
+  onApplyToEditor,
+  onReapplyBatch,
+  onAppendInsight,
+}) => (
+  <>
+    <MonitoringDailyDashboard
+      summary={summary}
+      insightLines={insightLines}
+      recordCount={recordCount}
+      isAdmin={isAdmin}
+      goalNames={goalNames}
+      decisionStatuses={decisionStatuses}
+      decisionNotes={decisionNotes}
+      onDecision={onDecision}
+      decisions={decisions}
+      onAppendInsight={onAppendInsight}
+      onSaveDraft={onSaveDraft}
+      isSavingDraft={isSavingDraft}
+      hasSavedDraft={hasSavedDraft}
+      onApplyToEditor={onApplyToEditor}
+      savedRecords={savedRecords}
+      onReapplyBatch={onReapplyBatch}
+    />
+
+    {/* ISP 判断保存中インジケーター */}
+    {isDecisionSaving && (
+      <Stack direction="row" spacing={1} alignItems="center" sx={{ pl: 1 }}>
+        <CircularProgress size={14} />
+        <Typography variant="caption" color="text.secondary">
+          判断を保存中…
+        </Typography>
+      </Stack>
+    )}
+  </>
+);
+
+export default React.memo(MonitoringDashboardSection);

--- a/src/features/support-plan-guide/components/tabs/MonitoringEvidencePanel.tsx
+++ b/src/features/support-plan-guide/components/tabs/MonitoringEvidencePanel.tsx
@@ -1,0 +1,197 @@
+/**
+ * MonitoringEvidencePanel — エビデンス引用セクション
+ *
+ * 日次記録エビデンス + Iceberg PDCA 分析結果引用 + 再分析リンク をまとめて表示。
+ * MonitoringTab.tsx 内のインラインコンポーネントを独立化。
+ */
+import AutoStoriesIcon from '@mui/icons-material/AutoStories';
+import BubbleChartIcon from '@mui/icons-material/BubbleChart';
+import ContentCopyRoundedIcon from '@mui/icons-material/ContentCopyRounded';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemText from '@mui/material/ListItemText';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { buildIcebergPdcaUrl } from '@/app/links/navigationLinks';
+import { buildIcebergEvidence } from '@/features/ibd/analysis/pdca/icebergEvidenceAdapter';
+import { useIcebergPdcaList } from '@/features/ibd/analysis/pdca/queries';
+import { buildMonitoringEvidence } from '@/features/ibd/plans/support-plan/monitoringEvidenceAdapter';
+import { todayYmd, minusDaysYmd } from '../../utils/helpers';
+
+// ── 日次記録エビデンス ─────────────────────────────────
+
+type DailyEvidenceProps = {
+  userId: string;
+  onAppend: (text: string) => void;
+  isAdmin: boolean;
+};
+
+const DailyEvidenceSection: React.FC<DailyEvidenceProps> = ({ userId, onAppend, isAdmin }) => {
+  const range = React.useMemo(() => {
+    const to = todayYmd();
+    return { from: minusDaysYmd(to, 60), to }; // 過去60日
+  }, []);
+
+  const evidence = React.useMemo(() => {
+    return buildMonitoringEvidence({ userId, range });
+  }, [userId, range]);
+
+  if (evidence.count === 0) return null;
+
+  return (
+    <Box sx={{ mt: 1, mb: 2 }}>
+      <Paper variant="outlined" sx={{ p: 2, bgcolor: 'action.hover', borderStyle: 'dashed' }}>
+        <Stack spacing={1.5}>
+          <Stack direction="row" justifyContent="space-between" alignItems="center">
+            <Stack direction="row" spacing={1} alignItems="center">
+              <AutoStoriesIcon fontSize="small" color="primary" />
+              <Typography variant="subtitle2" component="span" color="primary">
+                日次記録エビデンス（過去60日: {evidence.count}件）
+              </Typography>
+            </Stack>
+            <Button
+              size="small"
+              variant="contained"
+              color="primary"
+              startIcon={<ContentCopyRoundedIcon />}
+              onClick={() => onAppend(evidence.text)}
+              disabled={!isAdmin}
+            >
+              評価文へ引用
+            </Button>
+          </Stack>
+          <Typography variant="caption" color="text.secondary">
+            一覧入力テーブルから自動集計された実績です。モニタリング評価文の根拠として引用できます。
+          </Typography>
+          <Box sx={{ maxHeight: 200, overflowY: 'auto', bgcolor: 'background.paper', borderRadius: 1, p: 1, border: '1px solid', borderColor: 'divider' }}>
+            <List dense disablePadding>
+              {evidence.bullets.map((b: string, i: number) => (
+                <ListItem key={i} disableGutters sx={{ py: 0.25 }}>
+                  <ListItemText
+                    primary={b}
+                    primaryTypographyProps={{ variant: 'caption', sx: { display: 'block', lineHeight: 1.4 } }}
+                  />
+                </ListItem>
+              ))}
+            </List>
+          </Box>
+        </Stack>
+      </Paper>
+    </Box>
+  );
+};
+
+// ── Iceberg PDCA 分析結果引用 ──────────────────────────
+
+type IcebergEvidenceProps = {
+  userId: string;
+  onAppend: (text: string) => void;
+  isAdmin: boolean;
+};
+
+const IcebergEvidenceSection: React.FC<IcebergEvidenceProps> = ({ userId, onAppend, isAdmin }) => {
+  const { data: pdcaItems = [] } = useIcebergPdcaList({ userId });
+
+  const evidence = React.useMemo(
+    () => buildIcebergEvidence({ userId, items: pdcaItems }),
+    [userId, pdcaItems],
+  );
+
+  if (evidence.totalCount === 0) return null;
+
+  return (
+    <Box sx={{ mt: 1, mb: 2 }}>
+      <Paper variant="outlined" sx={{ p: 2, bgcolor: 'action.hover', borderStyle: 'dashed' }}>
+        <Stack spacing={1.5}>
+          <Stack direction="row" justifyContent="space-between" alignItems="center">
+            <Stack direction="row" spacing={1} alignItems="center">
+              <BubbleChartIcon fontSize="small" color="secondary" />
+              <Typography variant="subtitle2" component="span" color="secondary">
+                Iceberg PDCA 分析結果 ({evidence.actCount}件の改善 / 全{evidence.totalCount}件)
+              </Typography>
+            </Stack>
+            <Button
+              size="small"
+              variant="contained"
+              color="secondary"
+              startIcon={<ContentCopyRoundedIcon />}
+              onClick={() => onAppend(evidence.text)}
+              disabled={!isAdmin}
+              data-testid="iceberg-evidence-append"
+            >
+              評価文へ引用
+            </Button>
+          </Stack>
+          <Typography variant="caption" color="text.secondary">
+            ※ Iceberg PDCA で記録された行動分析・改善内容です。ACT フェーズの改善が優先表示されます。
+          </Typography>
+          <Box sx={{ maxHeight: 200, overflowY: 'auto', bgcolor: 'background.paper', borderRadius: 1, p: 1, border: '1px solid', borderColor: 'divider' }}>
+            <List dense disablePadding>
+              {evidence.bullets.map((b: string, i: number) => (
+                <ListItem key={i} disableGutters sx={{ py: 0.25 }}>
+                  <ListItemText
+                    primary={b}
+                    primaryTypographyProps={{ variant: 'caption', sx: { display: 'block', lineHeight: 1.4 } }}
+                  />
+                </ListItem>
+              ))}
+            </List>
+          </Box>
+        </Stack>
+      </Paper>
+    </Box>
+  );
+};
+
+// ── メインパネル ───────────────────────────────────────
+
+export type MonitoringEvidencePanelProps = {
+  userId: string;
+  isAdmin: boolean;
+  onAppendDailyEvidence: (text: string) => void;
+  onAppendIcebergEvidence: (text: string) => void;
+};
+
+const MonitoringEvidencePanel: React.FC<MonitoringEvidencePanelProps> = ({
+  userId,
+  isAdmin,
+  onAppendDailyEvidence,
+  onAppendIcebergEvidence,
+}) => {
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <DailyEvidenceSection
+        userId={userId}
+        isAdmin={isAdmin}
+        onAppend={onAppendDailyEvidence}
+      />
+      <IcebergEvidenceSection
+        userId={userId}
+        isAdmin={isAdmin}
+        onAppend={onAppendIcebergEvidence}
+      />
+      <Box sx={{ mt: 1 }}>
+        <Button
+          variant="outlined"
+          color="secondary"
+          size="small"
+          startIcon={<BubbleChartIcon />}
+          onClick={() => navigate(buildIcebergPdcaUrl(userId, { source: 'monitoring' }))}
+          data-testid="monitoring-reanalysis-link"
+        >
+          再分析する
+        </Button>
+      </Box>
+    </>
+  );
+};
+
+export default React.memo(MonitoringEvidencePanel);

--- a/src/features/support-plan-guide/components/tabs/MonitoringFieldSection.tsx
+++ b/src/features/support-plan-guide/components/tabs/MonitoringFieldSection.tsx
@@ -1,0 +1,29 @@
+/**
+ * MonitoringFieldSection — モニタリングフィールド入力セクション
+ *
+ * FieldCard を使い monitoringPlan / reviewTiming / lastMonitoringDate の
+ * 3 フィールドを描画する presentational コンポーネント。
+ */
+import Stack from '@mui/material/Stack';
+import React from 'react';
+
+import type { SectionConfig } from '../../types';
+import FieldCard from './FieldCard';
+import type { SectionTabProps } from './tabProps';
+
+export type MonitoringFieldSectionProps = {
+  section: SectionConfig;
+} & Pick<SectionTabProps, 'form' | 'isAdmin' | 'onFieldChange' | 'onAppendPhrase' | 'guardAdmin'>;
+
+const MonitoringFieldSection: React.FC<MonitoringFieldSectionProps> = ({
+  section,
+  ...fieldProps
+}) => (
+  <Stack spacing={2}>
+    {section.fields.map((field) => (
+      <FieldCard key={field.key} field={field} {...fieldProps} />
+    ))}
+  </Stack>
+);
+
+export default React.memo(MonitoringFieldSection);

--- a/src/features/support-plan-guide/components/tabs/MonitoringTab.tsx
+++ b/src/features/support-plan-guide/components/tabs/MonitoringTab.tsx
@@ -1,49 +1,33 @@
 /**
- * MonitoringTab — モニタリングタブ
+ * MonitoringTab — モニタリングタブ（オーケストレーター）
  *
  * SectionKey: 'monitoring'
  *
- * 他のセクションタブと異なり、MonitoringEvidenceSection を条件付きで描画する。
- * Phase 1: MonitoringDailyDashboard を前段に配置し、客観指標を可視化する。
- * Phase 4-C4: ISP 判断記録のフルスタック接続。
- *   - form.goals → goalNames / GoalLike
- *   - useIspRecommendationDecisions → decisionStatuses / onDecision
- *   - MonitoringDailyDashboard へ透過
+ * ## 設計原則
+ * - useMonitoringTabState() から state を受ける
+ * - 各 Section に props を渡す
+ * - 並べるだけ
+ *
+ * ## 責務マップ
+ * MonitoringTab (this file) = page orchestrator
+ *   ├ MonitoringDashboardSection  = 日次集計 + ISP判断
+ *   ├ MonitoringEvidencePanel     = 日次記録/Iceberg引用 + 再分析リンク
+ *   ├ MonitoringFieldSection      = FieldCard×3
+ *   └ useMonitoringTabState       = orchestration hook
  */
-import AutoStoriesIcon from '@mui/icons-material/AutoStories';
-import BubbleChartIcon from '@mui/icons-material/BubbleChart';
-import ContentCopyRoundedIcon from '@mui/icons-material/ContentCopyRounded';
 import Alert from '@mui/material/Alert';
-import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
-import CircularProgress from '@mui/material/CircularProgress';
-import List from '@mui/material/List';
-import ListItem from '@mui/material/ListItem';
-import ListItemText from '@mui/material/ListItemText';
-import Paper from '@mui/material/Paper';
 import Snackbar from '@mui/material/Snackbar';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
 
-import { useAuth } from '@/auth/useAuth';
-import { buildIcebergPdcaUrl } from '@/app/links/navigationLinks';
+import type { ToastState } from '../../types';
+import { findSection } from '../../utils/helpers';
+import { useMonitoringTabState } from '../../hooks/useMonitoringTabState';
 
-import { buildIcebergEvidence } from '@/features/ibd/analysis/pdca/icebergEvidenceAdapter';
-import { useIcebergPdcaList } from '@/features/ibd/analysis/pdca/queries';
-import { buildMonitoringEvidence } from '@/features/ibd/plans/support-plan/monitoringEvidenceAdapter';
-import MonitoringDailyDashboard from '@/features/monitoring/components/MonitoringDailyDashboard';
-import type { DraftBatch } from '@/features/monitoring/components/DraftHistoryPanel';
-import { useMonitoringDailyAnalytics } from '@/features/monitoring/hooks/useMonitoringDailyAnalytics';
-import { useIspRecommendationDecisions } from '@/features/monitoring/hooks/useIspRecommendationDecisions';
-import { useSupportPlanningSheet } from '@/features/monitoring/hooks/useSupportPlanningSheet';
-import type { GoalLike } from '@/features/monitoring/domain/goalProgressTypes';
-import type { SaveSupportPlanningSheetInput } from '@/features/monitoring/domain/supportPlanningSheetTypes';
-import type { SupportPlanStringFieldKey } from '../../types';
-import type { MonitoringEvidenceSectionProps, ToastState } from '../../types';
-import { findSection, minusDaysYmd, todayYmd } from '../../utils/helpers';
-import FieldCard from './FieldCard';
+import MonitoringDashboardSection from './MonitoringDashboardSection';
+import MonitoringEvidencePanel from './MonitoringEvidencePanel';
+import MonitoringFieldSection from './MonitoringFieldSection';
 import type { SectionTabProps } from './tabProps';
 
 export type MonitoringTabProps = SectionTabProps & {
@@ -53,339 +37,21 @@ export type MonitoringTabProps = SectionTabProps & {
   setToast: (toast: ToastState) => void;
 };
 
-// ─── ヘルパー ───────────────────────────────────────────
-
-const DEFAULT_LOOKBACK_DAYS = 60;
-
-/** form.goals → GoalLike[] を安定参照で返す */
-function useGoalLikes(goals: { id: string; domains?: string[]; overrideCategories?: string[] }[]): GoalLike[] {
-  return React.useMemo(
-    () => goals.map(g => ({ id: g.id, domains: g.domains, overrideCategories: g.overrideCategories })),
-    // JSON.stringify for stable comparison of deep goal array
-    [JSON.stringify(goals.map(g => g.id + (g.domains?.join(',') ?? '') + (g.overrideCategories?.join(',') ?? '')))],
-  );
-}
-
-/** form.goals → Record<goalId, label> */
-function useGoalNames(goals: { id: string; label: string }[]): Record<string, string> {
-  return React.useMemo(() => {
-    const map: Record<string, string> = {};
-    for (const g of goals) {
-      if (g.id && g.label) map[g.id] = g.label;
-    }
-    return map;
-    // JSON.stringify for stable comparison of deep goal array
-  }, [JSON.stringify(goals.map(g => `${g.id}:${g.label}`))]);
-}
-
-/** 集計期間（lookbackDays から算出） */
-function useMonitoringPeriod(lookbackDays = DEFAULT_LOOKBACK_DAYS) {
-  return React.useMemo(() => {
-    const to = new Date();
-    const from = new Date();
-    from.setDate(from.getDate() - lookbackDays);
-    return {
-      from: from.toISOString().slice(0, 10),
-      to: to.toISOString().slice(0, 10),
-    };
-  }, [lookbackDays]);
-}
-
-// ─── サブコンポーネント ──────────────────────────────────
-
-/** エビデンスセクション（内部コンポーネント） */
-const MonitoringEvidenceSection: React.FC<MonitoringEvidenceSectionProps> = ({ userId, onAppend, isAdmin }) => {
-  const range = React.useMemo(() => {
-    const to = todayYmd();
-    return { from: minusDaysYmd(to, 60), to }; // 過去60日
-  }, []);
-
-  const evidence = React.useMemo(() => {
-    return buildMonitoringEvidence({ userId, range });
-  }, [userId, range]);
-
-  if (evidence.count === 0) return null;
-
-  return (
-    <Box sx={{ mt: 1, mb: 2 }}>
-      <Paper variant="outlined" sx={{ p: 2, bgcolor: 'action.hover', borderStyle: 'dashed' }}>
-        <Stack spacing={1.5}>
-          <Stack direction="row" justifyContent="space-between" alignItems="center">
-            <Stack direction="row" spacing={1} alignItems="center">
-              <AutoStoriesIcon fontSize="small" color="primary" />
-              <Typography variant="subtitle2" component="span" color="primary">
-                日次記録エビデンス（過去60日: {evidence.count}件）
-              </Typography>
-            </Stack>
-            <Button
-              size="small"
-              variant="contained"
-              color="primary"
-              startIcon={<ContentCopyRoundedIcon />}
-              onClick={() => onAppend(evidence.text)}
-              disabled={!isAdmin}
-            >
-              評価文へ引用
-            </Button>
-          </Stack>
-          <Typography variant="caption" color="text.secondary">
-            一覧入力テーブルから自動集計された実績です。モニタリング評価文の根拠として引用できます。
-          </Typography>
-          <Box sx={{ maxHeight: 200, overflowY: 'auto', bgcolor: 'background.paper', borderRadius: 1, p: 1, border: '1px solid', borderColor: 'divider' }}>
-            <List dense disablePadding>
-              {evidence.bullets.map((b: string, i: number) => (
-                <ListItem key={i} disableGutters sx={{ py: 0.25 }}>
-                  <ListItemText
-                    primary={b}
-                    primaryTypographyProps={{ variant: 'caption', sx: { display: 'block', lineHeight: 1.4 } }}
-                  />
-                </ListItem>
-              ))}
-            </List>
-          </Box>
-        </Stack>
-      </Paper>
-    </Box>
-  );
-};
-
-/** Iceberg PDCA 分析結果の引用セクション */
-const IcebergEvidenceSection: React.FC<{
-  userId: string;
-  onAppend: (text: string) => void;
-  isAdmin: boolean;
-}> = ({ userId, onAppend, isAdmin }) => {
-  const { data: pdcaItems = [] } = useIcebergPdcaList({ userId });
-
-  const evidence = React.useMemo(
-    () => buildIcebergEvidence({ userId, items: pdcaItems }),
-    [userId, pdcaItems],
-  );
-
-  if (evidence.totalCount === 0) return null;
-
-  return (
-    <Box sx={{ mt: 1, mb: 2 }}>
-      <Paper variant="outlined" sx={{ p: 2, bgcolor: 'action.hover', borderStyle: 'dashed' }}>
-        <Stack spacing={1.5}>
-          <Stack direction="row" justifyContent="space-between" alignItems="center">
-            <Stack direction="row" spacing={1} alignItems="center">
-              <BubbleChartIcon fontSize="small" color="secondary" />
-              <Typography variant="subtitle2" component="span" color="secondary">
-                Iceberg PDCA 分析結果 ({evidence.actCount}件の改善 / 全{evidence.totalCount}件)
-              </Typography>
-            </Stack>
-            <Button
-              size="small"
-              variant="contained"
-              color="secondary"
-              startIcon={<ContentCopyRoundedIcon />}
-              onClick={() => onAppend(evidence.text)}
-              disabled={!isAdmin}
-              data-testid="iceberg-evidence-append"
-            >
-              評価文へ引用
-            </Button>
-          </Stack>
-          <Typography variant="caption" color="text.secondary">
-            ※ Iceberg PDCA で記録された行動分析・改善内容です。ACT フェーズの改善が優先表示されます。
-          </Typography>
-          <Box sx={{ maxHeight: 200, overflowY: 'auto', bgcolor: 'background.paper', borderRadius: 1, p: 1, border: '1px solid', borderColor: 'divider' }}>
-            <List dense disablePadding>
-              {evidence.bullets.map((b: string, i: number) => (
-                <ListItem key={i} disableGutters sx={{ py: 0.25 }}>
-                  <ListItemText
-                    primary={b}
-                    primaryTypographyProps={{ variant: 'caption', sx: { display: 'block', lineHeight: 1.4 } }}
-                  />
-                </ListItem>
-              ))}
-            </List>
-          </Box>
-        </Stack>
-      </Paper>
-    </Box>
-  );
-};
-
-// ─── メインコンポーネント ────────────────────────────────
-
 const MonitoringTab: React.FC<MonitoringTabProps> = ({ userId, setToast, ...sectionProps }) => {
-  const navigate = useNavigate();
   const section = findSection('monitoring');
-  const { account } = useAuth();
-
-  const userIdStr = userId ? String(userId) : '';
-
-  // ── Phase 3+4: goals から派生データを構築 ─────────────
-  const goalLikes = useGoalLikes(sectionProps.form.goals);
-  const goalNames = useGoalNames(sectionProps.form.goals);
-
-  // ── モニタリング集計（目標進捗 + ISP 提案含む） ─────────
-  const { summary, insightLines, recordCount } = useMonitoringDailyAnalytics(
-    userIdStr,
-    DEFAULT_LOOKBACK_DAYS,
-    goalLikes.length > 0 ? goalLikes : undefined,
-    Object.keys(goalNames).length > 0 ? goalNames : undefined,
-  );
-
-  // ── Phase 4-C4: ISP 判断記録 ──────────────────────────
-  const monitoringPeriod = useMonitoringPeriod(DEFAULT_LOOKBACK_DAYS);
 
   const {
-    decisionStatuses,
-    decisionNotes,
-    handleDecision,
-    isSaving,
-    error: decisionError,
-    decisions,
-  } = useIspRecommendationDecisions(
     userIdStr,
-    userIdStr ? monitoringPeriod : undefined,
-    summary?.ispRecommendations ?? null,
-    account?.username ?? 'unknown',
-  );
-
-  // ── Phase 5-C: ISP ドラフト保存 ─────────────────────────
-  const {
-    records: savedRecords,
-    saveDraft,
-    isSaving: isSavingDraft,
-    hasSaved: hasSavedDraft,
-    error: draftError,
-  } = useSupportPlanningSheet(userIdStr);
-
-  const handleSaveDraft = React.useCallback(async () => {
-    if (!decisions || decisions.length === 0) {
-      setSnackMsg('保存する判断レコードがありません');
-      setSnackSeverity('error');
-      setSnackOpen(true);
-      return;
-    }
-
-    const inputs: SaveSupportPlanningSheetInput[] = decisions.map(d => ({
-      userId: userIdStr,
-      goalId: d.goalId,
-      goalLabel: goalNames[d.goalId] ?? d.goalId,
-      decisionStatus: d.status,
-      decisionNote: d.note,
-      decisionBy: d.decidedBy,
-      decisionAt: d.decidedAt,
-      recommendationLevel: d.snapshot?.level ?? 'pending',
-      snapshot: d.snapshot ?? {
-        goalId: d.goalId,
-        level: 'pending',
-        reason: '',
-        suggestion: '',
-        capturedAt: d.decidedAt,
-      },
-    }));
-
-    let successCount = 0;
-    for (const input of inputs) {
-      const result = await saveDraft(input);
-      if (result) successCount++;
-    }
-
-    if (successCount === inputs.length) {
-      setSnackMsg(`${successCount}件のISP下書きを保存しました`);
-      setSnackSeverity('success');
-    } else if (draftError) {
-      setSnackMsg('ISP下書きの保存に失敗しました');
-      setSnackSeverity('error');
-    } else {
-      setSnackMsg(`${successCount}/${inputs.length}件を保存しました`);
-      setSnackSeverity('success');
-    }
-    setSnackOpen(true);
-  }, [decisions, userIdStr, goalNames, saveDraft, draftError]);
-
-  // ── saving / error フィードバック ──────────────────────
-  const [snackOpen, setSnackOpen] = React.useState(false);
-  const [snackMsg, setSnackMsg] = React.useState('');
-  const [snackSeverity, setSnackSeverity] = React.useState<'success' | 'error'>('success');
-
-  const handleDecisionWithFeedback = React.useCallback(
-    async (input: Parameters<typeof handleDecision>[0]) => {
-      await handleDecision(input);
-      if (!decisionError) {
-        setSnackMsg('判断を記録しました');
-        setSnackSeverity('success');
-      } else {
-        setSnackMsg('判断の保存に失敗しました');
-        setSnackSeverity('error');
-      }
-      setSnackOpen(true);
-    },
-    [handleDecision, decisionError],
-  );
-
-  /** monitoringPlan フィールドへの追記共通ヘルパー */
-  const appendToMonitoringPlan = React.useCallback(
-    (text: string, duplicateMsg: string, successMsg: string) => {
-      const currentVal = sectionProps.form.monitoringPlan || '';
-      const headerLine = text.split('\n')[0];
-      if (currentVal.includes(headerLine)) {
-        setToast({ open: true, message: duplicateMsg, severity: 'info' });
-        return;
-      }
-      sectionProps.onFieldChange('monitoringPlan', (currentVal ? currentVal + '\n\n' : '') + text);
-      setToast({ open: true, message: successMsg, severity: 'success' });
-    },
-    [sectionProps, setToast],
-  );
-
-  /** Phase 5-D: ドラフトセクションを ISP エディタのフィールドへ転記 */
-  const handleApplyToEditor = React.useCallback(
-    (fieldKey: SupportPlanStringFieldKey, text: string) => {
-      if (!sectionProps.isAdmin) return;
-      const currentVal = sectionProps.form[fieldKey] || '';
-      // 既に同じ内容がある場合は上書き確認代わりに置換する
-      const newVal = currentVal
-        ? `${currentVal}\n\n--- ドラフト反映 ---\n${text}`
-        : text;
-      sectionProps.onFieldChange(fieldKey, newVal);
-      setToast({
-        open: true,
-        message: `「${fieldKey}」フィールドへ反映しました`,
-        severity: 'success',
-      });
-    },
-    [sectionProps, setToast],
-  );
-
-  /** Phase 5-E: 過去バッチの判断内容を ISP エディタへ再反映 */
-  const handleReapplyBatch = React.useCallback(
-    (batch: DraftBatch) => {
-      if (!sectionProps.isAdmin) return;
-
-      // バッチ内の全レコードをまとめて conferenceNotes フィールドへ反映
-      const lines: string[] = [];
-      for (const r of batch.records) {
-        const statusLabel =
-          r.decisionStatus === 'accepted' ? '採用' :
-          r.decisionStatus === 'dismissed' ? '見送り' :
-          r.decisionStatus === 'deferred' ? '保留' : '未判断';
-        lines.push(`【${r.goalLabel}】 ${statusLabel}`);
-        if (r.decisionNote) lines.push(`  判断メモ: ${r.decisionNote}`);
-        if (r.snapshot.reason) lines.push(`  理由: ${r.snapshot.reason}`);
-      }
-      const text = lines.join('\n');
-
-      const currentVal = sectionProps.form.conferenceNotes || '';
-      const newVal = currentVal
-        ? `${currentVal}\n\n--- 過去ドラフト反映 ---\n${text}`
-        : text;
-      sectionProps.onFieldChange('conferenceNotes', newVal);
-
-      setToast({
-        open: true,
-        message: `${batch.records.length}件の判断レコードを「会議・同意の記録」へ反映しました`,
-        severity: 'success',
-      });
-    },
-    [sectionProps, setToast],
-  );
+    dashboardState,
+    evidenceState,
+    feedbackState,
+  } = useMonitoringTabState({
+    userId,
+    form: sectionProps.form,
+    isAdmin: sectionProps.isAdmin,
+    onFieldChange: sectionProps.onFieldChange,
+    setToast,
+  });
 
   if (!section) return null;
 
@@ -397,109 +63,47 @@ const MonitoringTab: React.FC<MonitoringTabProps> = ({ userId, setToast, ...sect
         </Typography>
       ) : null}
 
-      {/* Phase 1+4: 集計ダッシュボード + ISP 判断記録 */}
+      {/* 日次集計ダッシュボード + ISP 判断記録 */}
       {userIdStr && (
-        <MonitoringDailyDashboard
-          summary={summary}
-          insightLines={insightLines}
-          recordCount={recordCount}
+        <MonitoringDashboardSection
           isAdmin={sectionProps.isAdmin}
-          goalNames={goalNames}
-          decisionStatuses={decisionStatuses}
-          decisionNotes={decisionNotes}
-          onDecision={handleDecisionWithFeedback}
-          decisions={decisions}
-          onAppendInsight={(text) =>
-            appendToMonitoringPlan(
-              text,
-              'この期間の所見は既に引用されています。',
-              '所見ドラフトを引用しました。内容を調整してください。',
-            )
-          }
-          onSaveDraft={handleSaveDraft}
-          isSavingDraft={isSavingDraft}
-          hasSavedDraft={hasSavedDraft}
-          onApplyToEditor={handleApplyToEditor}
-          savedRecords={savedRecords}
-          onReapplyBatch={handleReapplyBatch}
+          {...dashboardState}
         />
       )}
 
-      {/* Phase 4-C4: 保存中インジケーター */}
-      {isSaving && (
-        <Stack direction="row" spacing={1} alignItems="center" sx={{ pl: 1 }}>
-          <CircularProgress size={14} />
-          <Typography variant="caption" color="text.secondary">
-            判断を保存中…
-          </Typography>
-        </Stack>
-      )}
-
-      {/* 既存: 日次記録エビデンス（生データ引用） */}
-      {userId && (
-        <MonitoringEvidenceSection
-          userId={String(userId)}
+      {/* 日次記録 + Iceberg PDCA エビデンス引用 + 再分析リンク */}
+      {userIdStr && (
+        <MonitoringEvidencePanel
+          userId={userIdStr}
           isAdmin={sectionProps.isAdmin}
-          onAppend={(text) =>
-            appendToMonitoringPlan(
-              text,
-              'この期間のエビデンスは既に引用されています。',
-              'エビデンスを引用しました。内容を調整してください。',
-            )
-          }
+          {...evidenceState}
         />
       )}
 
-      {/* 既存: Iceberg PDCA 引用 */}
-      {userId && (
-        <IcebergEvidenceSection
-          userId={String(userId)}
-          isAdmin={sectionProps.isAdmin}
-          onAppend={(text) =>
-            appendToMonitoringPlan(
-              text,
-              'Iceberg分析結果は既に引用されています。',
-              'Iceberg分析結果を引用しました。内容を調整してください。',
-            )
-          }
-        />
-      )}
+      {/* フィールド入力（monitoringPlan / reviewTiming / lastMonitoringDate） */}
+      <MonitoringFieldSection
+        section={section}
+        form={sectionProps.form}
+        isAdmin={sectionProps.isAdmin}
+        onFieldChange={sectionProps.onFieldChange}
+        onAppendPhrase={sectionProps.onAppendPhrase}
+        guardAdmin={sectionProps.guardAdmin}
+      />
 
-      {userId && (
-        <Box sx={{ mt: 1 }}>
-          <Button
-            variant="outlined"
-            color="secondary"
-            size="small"
-            startIcon={<BubbleChartIcon />}
-            onClick={() => navigate(buildIcebergPdcaUrl(String(userId), { source: 'monitoring' }))}
-            data-testid="monitoring-reanalysis-link"
-          >
-            再分析する
-          </Button>
-        </Box>
-      )}
-
-      <Stack spacing={2}>
-        {section.fields.map((field) => (
-          <FieldCard key={field.key} field={field} {...sectionProps} />
-        ))}
-      </Stack>
-
-      {/* Phase 4-C4: フィードバック Snackbar */}
+      {/* フィードバック Snackbar */}
       <Snackbar
-        open={snackOpen}
+        open={feedbackState.state.open}
         autoHideDuration={3000}
-        onClose={() => setSnackOpen(false)}
+        onClose={feedbackState.close}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
       >
         <Alert
-          severity={snackSeverity}
+          severity={feedbackState.state.severity}
           variant="filled"
-          onClose={() => setSnackOpen(false)}
+          onClose={feedbackState.close}
           sx={{ width: '100%' }}
         >
-          {snackMsg}
+          {feedbackState.state.message}
         </Alert>
       </Snackbar>
     </Stack>

--- a/src/features/support-plan-guide/domain/__tests__/regulatoryHud.spec.ts
+++ b/src/features/support-plan-guide/domain/__tests__/regulatoryHud.spec.ts
@@ -1,0 +1,353 @@
+/**
+ * regulatoryHud — 制度 HUD 信号灯 判定テスト
+ */
+import { describe, expect, it } from 'vitest';
+import type { IspComplianceMetadata } from '@/domain/isp/schema';
+import type { DeadlineInfo } from '../../types';
+import {
+  buildRegulatoryHudItems,
+  worstSignal,
+  signalCounts,
+  type RegulatoryHudInput,
+  type RegulatoryHudItem,
+} from '../regulatoryHud';
+
+// ── Helpers ──
+
+const makeDeadline = (overrides: Partial<DeadlineInfo> = {}): DeadlineInfo => ({
+  label: 'テスト期限',
+  color: 'default',
+  ...overrides,
+});
+
+const makeCompliance = (
+  overrides: Partial<IspComplianceMetadata> = {},
+): IspComplianceMetadata => ({
+  serviceType: 'other',
+  standardServiceHours: null,
+  consent: {
+    explainedAt: null,
+    explainedBy: '',
+    consentedAt: null,
+    consentedBy: '',
+    proxyName: '',
+    proxyRelation: '',
+    notes: '',
+  },
+  delivery: {
+    deliveredAt: null,
+    deliveredToUser: false,
+    deliveredToConsultationSupport: false,
+    deliveryMethod: '',
+    notes: '',
+  },
+  reviewControl: {
+    reviewCycleDays: 180,
+    lastReviewedAt: null,
+    nextReviewDueAt: null,
+    reviewReason: '',
+  },
+  approval: {
+    approvedBy: null,
+    approvedAt: null,
+    approvalStatus: 'draft',
+  },
+  ...overrides,
+});
+
+const makeInput = (overrides: Partial<RegulatoryHudInput> = {}): RegulatoryHudInput => ({
+  ispStatus: 'assessment',
+  compliance: null,
+  deadlines: {
+    creation: makeDeadline(),
+    monitoring: makeDeadline(),
+  },
+  latestMonitoring: null,
+  icebergTotal: 0,
+  ...overrides,
+});
+
+const findByKey = (items: RegulatoryHudItem[], key: string) =>
+  items.find((i) => i.key === key)!;
+
+// ── Tests ──
+
+describe('buildRegulatoryHudItems', () => {
+  it('6項目を返す', () => {
+    const items = buildRegulatoryHudItems(makeInput());
+    expect(items).toHaveLength(6);
+    expect(items.map((i) => i.key)).toEqual([
+      'isp-status',
+      'consent',
+      'delivery',
+      'creation-deadline',
+      'monitoring-deadline',
+      'iceberg-analysis',
+    ]);
+  });
+
+  // ── ISP ──
+
+  it('ISP active → ok', () => {
+    const items = buildRegulatoryHudItems(makeInput({ ispStatus: 'active' }));
+    expect(findByKey(items, 'isp-status').signal).toBe('ok');
+    expect(findByKey(items, 'isp-status').label).toContain('確定');
+  });
+
+  it('ISP assessment → danger', () => {
+    const items = buildRegulatoryHudItems(makeInput({ ispStatus: 'assessment' }));
+    expect(findByKey(items, 'isp-status').signal).toBe('danger');
+  });
+
+  // ── 同意 ──
+
+  it('同意取得済み → ok', () => {
+    const items = buildRegulatoryHudItems(
+      makeInput({
+        compliance: makeCompliance({
+          consent: {
+            explainedAt: '2025-04-01',
+            explainedBy: 'A',
+            consentedAt: '2025-04-02',
+            consentedBy: 'B',
+            proxyName: '',
+            proxyRelation: '',
+            notes: '',
+          },
+        }),
+      }),
+    );
+    expect(findByKey(items, 'consent').signal).toBe('ok');
+  });
+
+  it('説明済み同意なし → warning', () => {
+    const items = buildRegulatoryHudItems(
+      makeInput({
+        compliance: makeCompliance({
+          consent: {
+            explainedAt: '2025-04-01',
+            explainedBy: 'A',
+            consentedAt: null,
+            consentedBy: '',
+            proxyName: '',
+            proxyRelation: '',
+            notes: '',
+          },
+        }),
+      }),
+    );
+    expect(findByKey(items, 'consent').signal).toBe('warning');
+  });
+
+  it('compliance が null → 同意 danger', () => {
+    const items = buildRegulatoryHudItems(makeInput({ compliance: null }));
+    expect(findByKey(items, 'consent').signal).toBe('danger');
+  });
+
+  // ── 交付 ──
+
+  it('交付完了 → ok', () => {
+    const items = buildRegulatoryHudItems(
+      makeInput({
+        compliance: makeCompliance({
+          delivery: {
+            deliveredAt: '2025-04-05',
+            deliveredToUser: true,
+            deliveredToConsultationSupport: true,
+            deliveryMethod: '手渡し',
+            notes: '',
+          },
+        }),
+      }),
+    );
+    expect(findByKey(items, 'delivery').signal).toBe('ok');
+  });
+
+  it('交付一部のみ → warning', () => {
+    const items = buildRegulatoryHudItems(
+      makeInput({
+        compliance: makeCompliance({
+          delivery: {
+            deliveredAt: '2025-04-05',
+            deliveredToUser: true,
+            deliveredToConsultationSupport: false,
+            deliveryMethod: '',
+            notes: '',
+          },
+        }),
+      }),
+    );
+    expect(findByKey(items, 'delivery').signal).toBe('warning');
+  });
+
+  // ── 作成期限 ──
+
+  it('作成期限未設定 → warning', () => {
+    const items = buildRegulatoryHudItems(makeInput());
+    expect(findByKey(items, 'creation-deadline').signal).toBe('warning');
+  });
+
+  it('作成期限超過 → danger', () => {
+    const items = buildRegulatoryHudItems(
+      makeInput({
+        deadlines: {
+          creation: makeDeadline({ daysLeft: -3, date: new Date(), color: 'error' }),
+          monitoring: makeDeadline(),
+        },
+      }),
+    );
+    const item = findByKey(items, 'creation-deadline');
+    expect(item.signal).toBe('danger');
+    expect(item.label).toContain('3日超過');
+  });
+
+  it('作成期限残7日以内 → warning', () => {
+    const items = buildRegulatoryHudItems(
+      makeInput({
+        deadlines: {
+          creation: makeDeadline({ daysLeft: 5, date: new Date(), color: 'warning' }),
+          monitoring: makeDeadline(),
+        },
+      }),
+    );
+    expect(findByKey(items, 'creation-deadline').signal).toBe('warning');
+  });
+
+  it('作成期限十分 → ok', () => {
+    const items = buildRegulatoryHudItems(
+      makeInput({
+        deadlines: {
+          creation: makeDeadline({ daysLeft: 20, date: new Date(), color: 'success' }),
+          monitoring: makeDeadline(),
+        },
+      }),
+    );
+    expect(findByKey(items, 'creation-deadline').signal).toBe('ok');
+  });
+
+  // ── モニタリング期限 ──
+
+  it('モニタ期限超過 → danger', () => {
+    const items = buildRegulatoryHudItems(
+      makeInput({
+        deadlines: {
+          creation: makeDeadline(),
+          monitoring: makeDeadline({ daysLeft: -10, date: new Date(), color: 'error' }),
+        },
+      }),
+    );
+    expect(findByKey(items, 'monitoring-deadline').signal).toBe('danger');
+  });
+
+  it('モニタ期限14日以内 → warning', () => {
+    const items = buildRegulatoryHudItems(
+      makeInput({
+        deadlines: {
+          creation: makeDeadline(),
+          monitoring: makeDeadline({ daysLeft: 10, date: new Date(), color: 'warning' }),
+        },
+      }),
+    );
+    expect(findByKey(items, 'monitoring-deadline').signal).toBe('warning');
+  });
+
+  // ── Iceberg ──
+
+  it('モニタリング未実施 → danger', () => {
+    const items = buildRegulatoryHudItems(
+      makeInput({ latestMonitoring: null, icebergTotal: 0 }),
+    );
+    expect(findByKey(items, 'iceberg-analysis').signal).toBe('danger');
+  });
+
+  it('計画変更推奨 → warning', () => {
+    const items = buildRegulatoryHudItems(
+      makeInput({
+        latestMonitoring: { date: '2025-12-01', planChangeRequired: true },
+        icebergTotal: 3,
+      }),
+    );
+    expect(findByKey(items, 'iceberg-analysis').signal).toBe('warning');
+    expect(findByKey(items, 'iceberg-analysis').label).toContain('再分析');
+  });
+
+  it('Iceberg 分析あり + モニタリング正常 → ok', () => {
+    const recentDate = new Date();
+    recentDate.setDate(recentDate.getDate() - 30);
+    const items = buildRegulatoryHudItems(
+      makeInput({
+        latestMonitoring: {
+          date: recentDate.toISOString().slice(0, 10),
+          planChangeRequired: false,
+        },
+        icebergTotal: 5,
+      }),
+    );
+    expect(findByKey(items, 'iceberg-analysis').signal).toBe('ok');
+  });
+
+  // ── navigateTo ──
+
+  it('全項目に navigateTo が設定されている', () => {
+    const items = buildRegulatoryHudItems(makeInput());
+    for (const item of items) {
+      expect(item.navigateTo).toBeDefined();
+    }
+  });
+});
+
+// ── ヘルパー ──
+
+describe('worstSignal', () => {
+  it('danger が1つでもあれば danger', () => {
+    const items = buildRegulatoryHudItems(makeInput());
+    expect(worstSignal(items)).toBe('danger');
+  });
+
+  it('全て ok なら ok', () => {
+    const recentDate = new Date();
+    recentDate.setDate(recentDate.getDate() - 10);
+    const items = buildRegulatoryHudItems(
+      makeInput({
+        ispStatus: 'active',
+        compliance: makeCompliance({
+          consent: {
+            explainedAt: '2025-04-01',
+            explainedBy: 'A',
+            consentedAt: '2025-04-02',
+            consentedBy: 'B',
+            proxyName: '',
+            proxyRelation: '',
+            notes: '',
+          },
+          delivery: {
+            deliveredAt: '2025-04-05',
+            deliveredToUser: true,
+            deliveredToConsultationSupport: true,
+            deliveryMethod: '手渡し',
+            notes: '',
+          },
+        }),
+        deadlines: {
+          creation: makeDeadline({ daysLeft: 20, date: new Date(), color: 'success' }),
+          monitoring: makeDeadline({ daysLeft: 60, date: new Date(), color: 'success' }),
+        },
+        latestMonitoring: {
+          date: recentDate.toISOString().slice(0, 10),
+          planChangeRequired: false,
+        },
+        icebergTotal: 3,
+      }),
+    );
+    expect(worstSignal(items)).toBe('ok');
+  });
+});
+
+describe('signalCounts', () => {
+  it('信号ごとの件数を返す', () => {
+    const items = buildRegulatoryHudItems(makeInput({ ispStatus: 'active' }));
+    const counts = signalCounts(items);
+    expect(counts.ok).toBeGreaterThanOrEqual(1);
+    expect(counts.ok + counts.warning + counts.danger).toBe(6);
+  });
+});

--- a/src/features/support-plan-guide/domain/__tests__/tabRoute.spec.ts
+++ b/src/features/support-plan-guide/domain/__tests__/tabRoute.spec.ts
@@ -1,0 +1,265 @@
+/**
+ * tabRoute — ユニットテスト
+ *
+ * P1.5: group.sub ルーティングの正確性・互換性・エッジケースを検証。
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  findGroupDef,
+  getAllSubsFlat,
+  getGroupDefaultSub,
+  parseTabRoute,
+  resolveTabRoute,
+  resolveLegacyTabParam,
+  serializeTabRoute,
+  TAB_GROUPS,
+} from '../tabRoute';
+
+// ---------------------------------------------------------------------------
+// TAB_GROUPS — 構造検証
+// ---------------------------------------------------------------------------
+
+describe('TAB_GROUPS', () => {
+  it('5 グループが定義されている', () => {
+    expect(TAB_GROUPS).toHaveLength(5);
+  });
+
+  it('全 10 個の SectionKey がカバーされている', () => {
+    const allSubs = TAB_GROUPS.flatMap((g) => [...g.subs]);
+    expect(allSubs).toHaveLength(10);
+    expect(new Set(allSubs).size).toBe(10); // 重複なし
+  });
+
+  it('グループ key が一意', () => {
+    const keys = TAB_GROUPS.map((g) => g.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it.each([
+    ['basic', '基本情報', ['overview', 'assessment']],
+    ['plan', '計画策定', ['smart', 'supports', 'decision']],
+    ['operations', '運用・実行', ['monitoring', 'risk', 'excellence']],
+    ['system', '制度適合', ['compliance']],
+    ['output', '出力', ['preview']],
+  ] as const)('%s グループ: label=%s, subs=%j', (key, label, subs) => {
+    const group = TAB_GROUPS.find((g) => g.key === key);
+    expect(group).toBeDefined();
+    expect(group!.label).toBe(label);
+    expect([...group!.subs]).toEqual(subs);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveTabRoute — SectionKey → Route
+// ---------------------------------------------------------------------------
+
+describe('resolveTabRoute', () => {
+  it.each([
+    ['overview', 'basic'],
+    ['assessment', 'basic'],
+    ['smart', 'plan'],
+    ['supports', 'plan'],
+    ['decision', 'plan'],
+    ['monitoring', 'operations'],
+    ['risk', 'operations'],
+    ['excellence', 'operations'],
+    ['compliance', 'system'],
+    ['preview', 'output'],
+  ] as const)('%s → group=%s', (sub, expectedGroup) => {
+    const route = resolveTabRoute(sub);
+    expect(route).toEqual({ group: expectedGroup, sub });
+  });
+
+  it('存在しない key は undefined', () => {
+    // @ts-expect-error — intentional invalid key
+    expect(resolveTabRoute('nonexistent')).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// serializeTabRoute — Route → URL param 文字列
+// ---------------------------------------------------------------------------
+
+describe('serializeTabRoute', () => {
+  it('group.sub 形式で出力', () => {
+    expect(serializeTabRoute({ group: 'operations', sub: 'monitoring' })).toBe('operations.monitoring');
+  });
+
+  it('全タブのシリアライズが正しい', () => {
+    expect(serializeTabRoute({ group: 'basic', sub: 'overview' })).toBe('basic.overview');
+    expect(serializeTabRoute({ group: 'output', sub: 'preview' })).toBe('output.preview');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseTabRoute — URL param → Route (新形式 + レガシー互換)
+// ---------------------------------------------------------------------------
+
+describe('parseTabRoute', () => {
+  describe('新形式 (group.sub)', () => {
+    it.each([
+      ['basic.overview', 'basic', 'overview'],
+      ['basic.assessment', 'basic', 'assessment'],
+      ['plan.smart', 'plan', 'smart'],
+      ['plan.supports', 'plan', 'supports'],
+      ['plan.decision', 'plan', 'decision'],
+      ['operations.monitoring', 'operations', 'monitoring'],
+      ['operations.risk', 'operations', 'risk'],
+      ['operations.excellence', 'operations', 'excellence'],
+      ['system.compliance', 'system', 'compliance'],
+      ['output.preview', 'output', 'preview'],
+    ] as const)('%s → {group: %s, sub: %s}', (param, group, sub) => {
+      expect(parseTabRoute(param)).toEqual({ group, sub });
+    });
+  });
+
+  describe('レガシー互換 (sub のみ)', () => {
+    it.each([
+      ['monitoring', 'operations', 'monitoring'],
+      ['overview', 'basic', 'overview'],
+      ['compliance', 'system', 'compliance'],
+      ['preview', 'output', 'preview'],
+    ] as const)('%s → {group: %s, sub: %s}', (param, group, sub) => {
+      expect(parseTabRoute(param)).toEqual({ group, sub });
+    });
+  });
+
+  describe('不正入力', () => {
+    it('null → undefined', () => {
+      expect(parseTabRoute(null)).toBeUndefined();
+    });
+
+    it('空文字 → undefined', () => {
+      expect(parseTabRoute('')).toBeUndefined();
+    });
+
+    it('空白のみ → undefined', () => {
+      expect(parseTabRoute('   ')).toBeUndefined();
+    });
+
+    it('存在しない sub → undefined', () => {
+      expect(parseTabRoute('nonexistent')).toBeUndefined();
+    });
+
+    it('存在しない group.sub → undefined', () => {
+      expect(parseTabRoute('invalid.monitoring')).toBeUndefined();
+    });
+
+    it('group と sub の不整合 → undefined', () => {
+      // monitoring は operations グループなので basic.monitoring は不正
+      expect(parseTabRoute('basic.monitoring')).toBeUndefined();
+    });
+
+    it('ドットのみ → undefined', () => {
+      expect(parseTabRoute('.')).toBeUndefined();
+    });
+
+    it('ドットから始まる → undefined', () => {
+      expect(parseTabRoute('.monitoring')).toBeUndefined();
+    });
+  });
+
+  describe('ラウンドトリップ', () => {
+    it('serialize → parse が一致する', () => {
+      const original = { group: 'operations' as const, sub: 'monitoring' as const };
+      const serialized = serializeTabRoute(original);
+      const parsed = parseTabRoute(serialized);
+      expect(parsed).toEqual(original);
+    });
+
+    it('全タブのラウンドトリップ', () => {
+      for (const group of TAB_GROUPS) {
+        for (const sub of group.subs) {
+          const route = resolveTabRoute(sub);
+          expect(route).toBeDefined();
+          const serialized = serializeTabRoute(route!);
+          const parsed = parseTabRoute(serialized);
+          expect(parsed).toEqual(route);
+        }
+      }
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveLegacyTabParam — 旧形式アダプター
+// ---------------------------------------------------------------------------
+
+describe('resolveLegacyTabParam', () => {
+  it('有効な旧パラメータ → Route', () => {
+    expect(resolveLegacyTabParam('monitoring')).toEqual({
+      group: 'operations',
+      sub: 'monitoring',
+    });
+  });
+
+  it('空文字 → undefined', () => {
+    expect(resolveLegacyTabParam('')).toBeUndefined();
+  });
+
+  it('無効な値 → undefined', () => {
+    expect(resolveLegacyTabParam('nonexistent')).toBeUndefined();
+  });
+
+  it('前後の空白は trim される', () => {
+    expect(resolveLegacyTabParam('  monitoring  ')).toEqual({
+      group: 'operations',
+      sub: 'monitoring',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ヘルパー関数
+// ---------------------------------------------------------------------------
+
+describe('findGroupDef', () => {
+  it('存在するグループを返す', () => {
+    const group = findGroupDef('plan');
+    expect(group).toBeDefined();
+    expect(group!.label).toBe('計画策定');
+  });
+
+  it('存在しないグループは undefined', () => {
+    // @ts-expect-error — intentional invalid key
+    expect(findGroupDef('nonexistent')).toBeUndefined();
+  });
+});
+
+describe('getGroupDefaultSub', () => {
+  it.each([
+    ['basic', 'overview'],
+    ['plan', 'smart'],
+    ['operations', 'monitoring'],
+    ['system', 'compliance'],
+    ['output', 'preview'],
+  ] as const)('%s → %s', (group, expected) => {
+    expect(getGroupDefaultSub(group)).toBe(expected);
+  });
+});
+
+describe('getAllSubsFlat', () => {
+  it('全 10 個をフラット順で返す', () => {
+    const subs = getAllSubsFlat();
+    expect(subs).toHaveLength(10);
+    expect(subs[0]).toBe('overview');
+    expect(subs[9]).toBe('preview');
+  });
+
+  it('グループ定義順にフラット展開される（TAB_GROUPS 順）', () => {
+    const expectedOrder = [
+      // basic
+      'overview', 'assessment',
+      // plan
+      'smart', 'supports', 'decision',
+      // operations
+      'monitoring', 'risk', 'excellence',
+      // system
+      'compliance',
+      // output
+      'preview',
+    ];
+    expect(getAllSubsFlat()).toEqual(expectedOrder);
+  });
+});

--- a/src/features/support-plan-guide/domain/regulatoryHud.ts
+++ b/src/features/support-plan-guide/domain/regulatoryHud.ts
@@ -1,0 +1,380 @@
+/**
+ * regulatoryHud — 制度適合 HUD 信号灯の判定ロジック
+ *
+ * P2-B: RegulatorySummaryBand のチップを
+ * 「見れば次の対応が分かる」信号灯 UI に進化させる。
+ *
+ * 設計原則:
+ *  - 純粋関数のみ（React 非依存）
+ *  - 判定ロジックと表示を完全分離
+ *  - 各項目は group.sub ルートを持ち、クリックで該当タブへ遷移可能
+ */
+
+import type { IspComplianceMetadata, IspStatus } from '@/domain/isp/schema';
+import type { DeadlineInfo } from '../types';
+import type { SectionKey } from '../types';
+
+// ────────────────────────────────────────────
+// 信号灯型定義
+// ────────────────────────────────────────────
+
+/** 信号の三段階: ok / warning / danger */
+export type RegulatorySignal = 'ok' | 'warning' | 'danger';
+
+/** 信号灯 HUD の1項目 */
+export type RegulatoryHudItem = {
+  /** 一意識別子 */
+  key: string;
+  /** 表示ラベル（短い自然言語） */
+  label: string;
+  /** 信号色 */
+  signal: RegulatorySignal;
+  /** 補足テキスト（ツールチップ / 副テキスト用） */
+  detail?: string;
+  /** クリック時の遷移先 SectionKey */
+  navigateTo?: SectionKey;
+};
+
+// ────────────────────────────────────────────
+// 入力型
+// ────────────────────────────────────────────
+
+export type RegulatoryHudInput = {
+  /** ISP ステータス */
+  ispStatus: IspStatus;
+  /** コンプライアンスメタデータ（null = 制度適合タブ未設定） */
+  compliance: IspComplianceMetadata | null;
+  /** 期限情報 */
+  deadlines: {
+    creation: DeadlineInfo;
+    monitoring: DeadlineInfo;
+  };
+  /** 最新モニタリング情報 */
+  latestMonitoring: { date: string; planChangeRequired: boolean } | null | undefined;
+  /** Iceberg 分析件数合計 */
+  icebergTotal: number;
+};
+
+// ────────────────────────────────────────────
+// 個別判定関数
+// ────────────────────────────────────────────
+
+/** ISP 確定状況を判定する */
+function judgeIspStatus(status: IspStatus): RegulatoryHudItem {
+  if (status === 'active') {
+    return {
+      key: 'isp-status',
+      label: 'ISP確定済み',
+      signal: 'ok',
+      navigateTo: 'overview',
+    };
+  }
+  return {
+    key: 'isp-status',
+    label: 'ISP未確定',
+    signal: 'danger',
+    detail: 'ISPが確定されていません。計画を完成させてください。',
+    navigateTo: 'overview',
+  };
+}
+
+/** 同意取得状況を判定する */
+function judgeConsent(compliance: IspComplianceMetadata | null): RegulatoryHudItem {
+  if (!compliance) {
+    return {
+      key: 'consent',
+      label: '同意未取得',
+      signal: 'danger',
+      detail: '同意記録が設定されていません。',
+      navigateTo: 'compliance',
+    };
+  }
+
+  const { consent } = compliance;
+  if (consent.consentedAt && consent.consentedBy) {
+    return {
+      key: 'consent',
+      label: '同意取得済み',
+      signal: 'ok',
+      navigateTo: 'compliance',
+    };
+  }
+
+  if (consent.explainedAt) {
+    return {
+      key: 'consent',
+      label: '説明済み・同意待ち',
+      signal: 'warning',
+      detail: '説明は実施済みですが、同意がまだ取得されていません。',
+      navigateTo: 'compliance',
+    };
+  }
+
+  return {
+    key: 'consent',
+    label: '同意未取得',
+    signal: 'danger',
+    detail: '同意記録が未入力です。',
+    navigateTo: 'compliance',
+  };
+}
+
+/** 交付状況を判定する */
+function judgeDelivery(compliance: IspComplianceMetadata | null): RegulatoryHudItem {
+  if (!compliance) {
+    return {
+      key: 'delivery',
+      label: '交付未完了',
+      signal: 'danger',
+      detail: '交付記録が設定されていません。',
+      navigateTo: 'compliance',
+    };
+  }
+
+  const { delivery } = compliance;
+  if (delivery.deliveredToUser && delivery.deliveredToConsultationSupport) {
+    return {
+      key: 'delivery',
+      label: '交付完了',
+      signal: 'ok',
+      navigateTo: 'compliance',
+    };
+  }
+
+  if (delivery.deliveredToUser || delivery.deliveredToConsultationSupport) {
+    return {
+      key: 'delivery',
+      label: '交付一部完了',
+      signal: 'warning',
+      detail: delivery.deliveredToUser
+        ? '相談支援専門員への交付がまだです。'
+        : '本人への交付がまだです。',
+      navigateTo: 'compliance',
+    };
+  }
+
+  return {
+    key: 'delivery',
+    label: '交付未完了',
+    signal: 'danger',
+    detail: '計画の交付がまだ行われていません。',
+    navigateTo: 'compliance',
+  };
+}
+
+/** 作成期限を判定する */
+function judgeCreationDeadline(deadline: DeadlineInfo): RegulatoryHudItem {
+  if (deadline.daysLeft == null || deadline.date == null) {
+    return {
+      key: 'creation-deadline',
+      label: '作成期限未設定',
+      signal: 'warning',
+      detail: '計画期間を入力すると作成期限が計算されます。',
+      navigateTo: 'overview',
+    };
+  }
+
+  if (deadline.daysLeft < 0) {
+    return {
+      key: 'creation-deadline',
+      label: `作成期限 ${Math.abs(deadline.daysLeft)}日超過`,
+      signal: 'danger',
+      detail: `作成期限を${Math.abs(deadline.daysLeft)}日超過しています。`,
+      navigateTo: 'overview',
+    };
+  }
+
+  if (deadline.daysLeft === 0) {
+    return {
+      key: 'creation-deadline',
+      label: '作成期限 本日',
+      signal: 'danger',
+      detail: '作成期限が本日です。',
+      navigateTo: 'overview',
+    };
+  }
+
+  if (deadline.daysLeft <= 7) {
+    return {
+      key: 'creation-deadline',
+      label: `作成期限 残${deadline.daysLeft}日`,
+      signal: 'warning',
+      detail: `作成期限まで残り${deadline.daysLeft}日です。`,
+      navigateTo: 'overview',
+    };
+  }
+
+  return {
+    key: 'creation-deadline',
+    label: `作成期限 残${deadline.daysLeft}日`,
+    signal: 'ok',
+    navigateTo: 'overview',
+  };
+}
+
+/** モニタリング期限を判定する */
+function judgeMonitoringDeadline(deadline: DeadlineInfo): RegulatoryHudItem {
+  if (deadline.daysLeft == null || deadline.date == null) {
+    return {
+      key: 'monitoring-deadline',
+      label: 'モニタ期限未設定',
+      signal: 'warning',
+      detail: 'モニタリング計画を入力すると期限が計算されます。',
+      navigateTo: 'monitoring',
+    };
+  }
+
+  if (deadline.daysLeft < 0) {
+    return {
+      key: 'monitoring-deadline',
+      label: `モニタ期限 ${Math.abs(deadline.daysLeft)}日超過`,
+      signal: 'danger',
+      detail: `モニタリング期限を${Math.abs(deadline.daysLeft)}日超過しています。`,
+      navigateTo: 'monitoring',
+    };
+  }
+
+  if (deadline.daysLeft === 0) {
+    return {
+      key: 'monitoring-deadline',
+      label: 'モニタ期限 本日',
+      signal: 'danger',
+      detail: 'モニタリング期限が本日です。',
+      navigateTo: 'monitoring',
+    };
+  }
+
+  if (deadline.daysLeft <= 14) {
+    return {
+      key: 'monitoring-deadline',
+      label: `モニタ期限 残${deadline.daysLeft}日`,
+      signal: 'warning',
+      detail: `モニタリング期限まで残り${deadline.daysLeft}日です。`,
+      navigateTo: 'monitoring',
+    };
+  }
+
+  return {
+    key: 'monitoring-deadline',
+    label: `モニタ期限 残${deadline.daysLeft}日`,
+    signal: 'ok',
+    navigateTo: 'monitoring',
+  };
+}
+
+/**
+ * Iceberg 分析 / 再分析推奨を判定する。
+ *
+ * ルール:
+ * - latestMonitoring.planChangeRequired === true → 再分析推奨（warning）
+ * - latestMonitoring がない → 未実施（danger）
+ * - latestMonitoring が 180 日以上前 → 再分析推奨（warning）
+ * - それ以外で icebergTotal > 0 → OK
+ * - icebergTotal === 0 → warning（分析がまだ）
+ */
+function judgeIcebergAnalysis(
+  latestMonitoring: { date: string; planChangeRequired: boolean } | null | undefined,
+  icebergTotal: number,
+): RegulatoryHudItem {
+  if (!latestMonitoring) {
+    return {
+      key: 'iceberg-analysis',
+      label: 'モニタリング未実施',
+      signal: 'danger',
+      detail: 'モニタリングが一度も実施されていません。',
+      navigateTo: 'monitoring',
+    };
+  }
+
+  if (latestMonitoring.planChangeRequired) {
+    return {
+      key: 'iceberg-analysis',
+      label: '再分析推奨',
+      signal: 'warning',
+      detail: 'モニタリングにより計画変更が推奨されています。',
+      navigateTo: 'monitoring',
+    };
+  }
+
+  const daysSince = Math.floor(
+    (Date.now() - new Date(latestMonitoring.date).getTime()) / (1000 * 60 * 60 * 24),
+  );
+
+  if (daysSince >= 180) {
+    return {
+      key: 'iceberg-analysis',
+      label: '再分析推奨',
+      signal: 'warning',
+      detail: `前回モニタリングから${daysSince}日経過（180日以上）。`,
+      navigateTo: 'monitoring',
+    };
+  }
+
+  if (icebergTotal > 0) {
+    return {
+      key: 'iceberg-analysis',
+      label: `Iceberg分析 ${icebergTotal}件`,
+      signal: 'ok',
+      navigateTo: 'monitoring',
+    };
+  }
+
+  return {
+    key: 'iceberg-analysis',
+    label: 'Iceberg分析なし',
+    signal: 'warning',
+    detail: 'Iceberg分析がまだ実施されていません。',
+    navigateTo: 'monitoring',
+  };
+}
+
+// ────────────────────────────────────────────
+// メインビルダー
+// ────────────────────────────────────────────
+
+/**
+ * 制度 HUD 信号灯項目を生成する。
+ *
+ * 6項目を固定順で返す:
+ * 1. ISP確定状況
+ * 2. 同意取得状況
+ * 3. 交付状況
+ * 4. 作成期限
+ * 5. モニタリング期限
+ * 6. Iceberg分析 / 再分析推奨
+ */
+export function buildRegulatoryHudItems(input: RegulatoryHudInput): RegulatoryHudItem[] {
+  return [
+    judgeIspStatus(input.ispStatus),
+    judgeConsent(input.compliance),
+    judgeDelivery(input.compliance),
+    judgeCreationDeadline(input.deadlines.creation),
+    judgeMonitoringDeadline(input.deadlines.monitoring),
+    judgeIcebergAnalysis(input.latestMonitoring, input.icebergTotal),
+  ];
+}
+
+// ────────────────────────────────────────────
+// ヘルパー: 全体ステータスの導出
+// ────────────────────────────────────────────
+
+/**
+ * HUD 項目群から、最も深刻な信号を返す。
+ * UI 側でバンドのボーダー色等に使う。
+ */
+export function worstSignal(items: RegulatoryHudItem[]): RegulatorySignal {
+  if (items.some((i) => i.signal === 'danger')) return 'danger';
+  if (items.some((i) => i.signal === 'warning')) return 'warning';
+  return 'ok';
+}
+
+/**
+ * 信号ごとの件数を返す。
+ */
+export function signalCounts(items: RegulatoryHudItem[]): Record<RegulatorySignal, number> {
+  return {
+    ok: items.filter((i) => i.signal === 'ok').length,
+    warning: items.filter((i) => i.signal === 'warning').length,
+    danger: items.filter((i) => i.signal === 'danger').length,
+  };
+}

--- a/src/features/support-plan-guide/domain/tabRoute.ts
+++ b/src/features/support-plan-guide/domain/tabRoute.ts
@@ -1,0 +1,155 @@
+/**
+ * tabRoute — Support Plan Guide のタブルーティング SSOT
+ *
+ * P1.5: group.sub 形式でタブ遷移を正規化し、
+ * URL / 内部 state / UI 表示の一元的な真実源を提供する。
+ *
+ * 設計原則:
+ *  - 純粋関数のみ（React 非依存）
+ *  - SectionKey との後方互換を維持
+ *  - 旧 ?tab=monitoring → 新 operations.monitoring の段階移行
+ */
+
+import type { SectionKey } from '../types';
+
+// ────────────────────────────────────────────
+// Group / Route 型定義
+// ────────────────────────────────────────────
+
+export type TabGroupKey = 'basic' | 'plan' | 'operations' | 'system' | 'output';
+
+export type SupportPlanTabRoute = {
+  group: TabGroupKey;
+  sub: SectionKey;
+};
+
+// ────────────────────────────────────────────
+// Group → Sub マッピング（SSOT）
+// ────────────────────────────────────────────
+
+export type TabGroupDef = {
+  readonly key: TabGroupKey;
+  readonly label: string;
+  readonly subs: readonly SectionKey[];
+};
+
+export const TAB_GROUPS: readonly TabGroupDef[] = [
+  { key: 'basic',      label: '基本情報',   subs: ['overview', 'assessment'] },
+  { key: 'plan',       label: '計画策定',   subs: ['smart', 'supports', 'decision'] },
+  { key: 'operations', label: '運用・実行', subs: ['monitoring', 'risk', 'excellence'] },
+  { key: 'system',     label: '制度適合',   subs: ['compliance'] },
+  { key: 'output',     label: '出力',       subs: ['preview'] },
+] as const;
+
+// ── 逆引きインデックス: SectionKey → TabGroupKey ──
+const SUB_TO_GROUP: ReadonlyMap<SectionKey, TabGroupKey> = (() => {
+  const map = new Map<SectionKey, TabGroupKey>();
+  for (const group of TAB_GROUPS) {
+    for (const sub of group.subs) {
+      map.set(sub, group.key);
+    }
+  }
+  return map;
+})();
+
+// ── 全 SectionKey セット（バリデーション用） ──
+const ALL_SUBS: ReadonlySet<SectionKey> = new Set(SUB_TO_GROUP.keys());
+
+// ── 全 TabGroupKey セット ──
+const ALL_GROUPS: ReadonlySet<TabGroupKey> = new Set(TAB_GROUPS.map((g) => g.key));
+
+// ────────────────────────────────────────────
+// ユーティリティ関数
+// ────────────────────────────────────────────
+
+/**
+ * SectionKey → SupportPlanTabRoute に変換する。
+ * マッピングに存在しない key の場合は undefined を返す。
+ */
+export function resolveTabRoute(sub: SectionKey): SupportPlanTabRoute | undefined {
+  const group = SUB_TO_GROUP.get(sub);
+  if (!group) return undefined;
+  return { group, sub };
+}
+
+/**
+ * SupportPlanTabRoute → URL param 文字列 (`operations.monitoring`) を生成する。
+ */
+export function serializeTabRoute(route: SupportPlanTabRoute): string {
+  return `${route.group}.${route.sub}`;
+}
+
+/**
+ * URL param 文字列 → SupportPlanTabRoute をパースする。
+ *
+ * 有効な形式:
+ *   - `operations.monitoring` (新形式 group.sub)
+ *   - `monitoring` (旧形式 SectionKey のみ — レガシー互換)
+ *
+ * 無効な場合は undefined を返す。
+ */
+export function parseTabRoute(param: string | null): SupportPlanTabRoute | undefined {
+  if (!param) return undefined;
+
+  const trimmed = param.trim();
+  if (!trimmed) return undefined;
+
+  // 新形式: group.sub
+  const dotIndex = trimmed.indexOf('.');
+  if (dotIndex > 0) {
+    const groupPart = trimmed.slice(0, dotIndex);
+    const subPart = trimmed.slice(dotIndex + 1);
+
+    if (ALL_GROUPS.has(groupPart as TabGroupKey) && ALL_SUBS.has(subPart as SectionKey)) {
+      const expectedGroup = SUB_TO_GROUP.get(subPart as SectionKey);
+      // group と sub の整合性を検証
+      if (expectedGroup === groupPart) {
+        return { group: groupPart as TabGroupKey, sub: subPart as SectionKey };
+      }
+    }
+    return undefined;
+  }
+
+  // レガシー形式: sub のみ → resolveLegacyTabParam にフォールバック
+  return resolveLegacyTabParam(trimmed);
+}
+
+/**
+ * 旧形式の tab パラメータ (例: `monitoring`) を新形式 Route に変換する。
+ * 旧 `?tab=monitoring` の URL をそのまま吸収するためのアダプター。
+ *
+ * 無効な値の場合は undefined を返す（呼び出し元で 'overview' へフォールバック）。
+ */
+export function resolveLegacyTabParam(param: string): SupportPlanTabRoute | undefined {
+  if (!param) return undefined;
+  const trimmed = param.trim();
+  if (!ALL_SUBS.has(trimmed as SectionKey)) return undefined;
+  return resolveTabRoute(trimmed as SectionKey);
+}
+
+// ────────────────────────────────────────────
+// ヘルパー: グループ情報の取得
+// ────────────────────────────────────────────
+
+/**
+ * TabGroupKey からグループ定義を取得する。
+ */
+export function findGroupDef(groupKey: TabGroupKey): TabGroupDef | undefined {
+  return TAB_GROUPS.find((g) => g.key === groupKey);
+}
+
+/**
+ * SectionKey が属するグループの最初の sub を取得する。
+ * グループ内ナビゲーションのデフォルト遷移先として使用。
+ */
+export function getGroupDefaultSub(groupKey: TabGroupKey): SectionKey | undefined {
+  const group = findGroupDef(groupKey);
+  return group?.subs[0];
+}
+
+/**
+ * 全 SectionKey をフラット順で返す（TAB_ORDER 互換）。
+ */
+export function getAllSubsFlat(): SectionKey[] {
+  return TAB_GROUPS.flatMap((g) => [...g.subs]);
+}

--- a/src/features/support-plan-guide/hooks/useDraftBootstrap.ts
+++ b/src/features/support-plan-guide/hooks/useDraftBootstrap.ts
@@ -9,18 +9,15 @@
 import { estimatePayloadSize, HYDRATION_FEATURES, startFeatureSpan } from '@/hydration/features';
 import React from 'react';
 import type { SupportPlanDraftRepository } from '../domain/SupportPlanDraftRepository';
+import { parseTabRoute } from '../domain/tabRoute';
 import type { SectionKey, SupportPlanDraft, ToastState, UserOption } from '../types';
 import { MAX_DRAFTS } from '../types';
 import { createDraft, createDraftForUser, sanitizeForm } from '../utils/helpers';
 import { loadFromLocalStorage, persistToLocalStorage } from './draftPersistence';
 
-/** tab query param が有効な SectionKey かを検証 */
-const VALID_TABS: ReadonlySet<SectionKey> = new Set<SectionKey>([
-  'overview', 'assessment', 'smart', 'supports',
-  'decision', 'monitoring', 'risk', 'excellence', 'preview',
-]);
+/** tab query param を SectionKey に解決する（新形式 group.sub + 旧形式 sub を両方サポート） */
 const parseTabParam = (value: string | null): SectionKey | undefined =>
-  value && VALID_TABS.has(value as SectionKey) ? (value as SectionKey) : undefined;
+  parseTabRoute(value)?.sub;
 
 export interface DraftBootstrapParams {
   repository: SupportPlanDraftRepository;

--- a/src/features/support-plan-guide/hooks/useMonitoringTabState.ts
+++ b/src/features/support-plan-guide/hooks/useMonitoringTabState.ts
@@ -1,0 +1,317 @@
+/**
+ * useMonitoringTabState — MonitoringTab オーケストレーション hook
+ *
+ * MonitoringTab.tsx から全ての hook 呼び出しとコールバック定義を集約。
+ * MonitoringTab は本 hook から返される state/actions を各 Section に配るだけ。
+ *
+ * ## 責務マップ
+ * - fieldState   → FieldCard の追記ヘルパー
+ * - dashboardState → MonitoringDailyDashboard + ISP 判断 + ドラフト保存
+ * - evidenceState  → 日次記録・Iceberg PDCA エビデンス引用
+ * - feedbackState  → Snackbar 状態管理
+ */
+import React from 'react';
+
+import { useAuth } from '@/auth/useAuth';
+import { useMonitoringDailyAnalytics } from '@/features/monitoring/hooks/useMonitoringDailyAnalytics';
+import { useIspRecommendationDecisions } from '@/features/monitoring/hooks/useIspRecommendationDecisions';
+import { useSupportPlanningSheet } from '@/features/monitoring/hooks/useSupportPlanningSheet';
+import type { GoalLike } from '@/features/monitoring/domain/goalProgressTypes';
+import type { SaveSupportPlanningSheetInput } from '@/features/monitoring/domain/supportPlanningSheetTypes';
+import type { DraftBatch } from '@/features/monitoring/components/DraftHistoryPanel';
+import type { SupportPlanStringFieldKey, ToastState } from '../types';
+import type { SectionTabProps } from '../components/tabs/tabProps';
+
+// ── 定数 ────────────────────────────────────────────────
+const DEFAULT_LOOKBACK_DAYS = 60;
+
+// ── 内部ヘルパー hook ──────────────────────────────────
+
+/** form.goals → GoalLike[] を安定参照で返す */
+function useGoalLikes(goals: { id: string; domains?: string[]; overrideCategories?: string[] }[]): GoalLike[] {
+  return React.useMemo(
+    () => goals.map(g => ({ id: g.id, domains: g.domains, overrideCategories: g.overrideCategories })),
+    // JSON.stringify for stable comparison of deep goal array
+    [JSON.stringify(goals.map(g => g.id + (g.domains?.join(',') ?? '') + (g.overrideCategories?.join(',') ?? '')))],
+  );
+}
+
+/** form.goals → Record<goalId, label> */
+function useGoalNames(goals: { id: string; label: string }[]): Record<string, string> {
+  return React.useMemo(() => {
+    const map: Record<string, string> = {};
+    for (const g of goals) {
+      if (g.id && g.label) map[g.id] = g.label;
+    }
+    return map;
+    // JSON.stringify for stable comparison of deep goal array
+  }, [JSON.stringify(goals.map(g => `${g.id}:${g.label}`))]);
+}
+
+/** 集計期間（lookbackDays から算出） */
+function useMonitoringPeriod(lookbackDays = DEFAULT_LOOKBACK_DAYS) {
+  return React.useMemo(() => {
+    const to = new Date();
+    const from = new Date();
+    from.setDate(from.getDate() - lookbackDays);
+    return {
+      from: from.toISOString().slice(0, 10),
+      to: to.toISOString().slice(0, 10),
+    };
+  }, [lookbackDays]);
+}
+
+// ── Snackbar 状態 ──────────────────────────────────────
+
+export type SnackbarState = {
+  open: boolean;
+  message: string;
+  severity: 'success' | 'error';
+};
+
+function useSnackbar() {
+  const [state, setState] = React.useState<SnackbarState>({
+    open: false,
+    message: '',
+    severity: 'success',
+  });
+
+  const show = React.useCallback((message: string, severity: 'success' | 'error') => {
+    setState({ open: true, message, severity });
+  }, []);
+
+  const close = React.useCallback(() => {
+    setState(prev => ({ ...prev, open: false }));
+  }, []);
+
+  return { state, show, close };
+}
+
+// ── メイン hook ────────────────────────────────────────
+
+export type UseMonitoringTabStateInput = {
+  userId: string | number | null | undefined;
+  form: SectionTabProps['form'];
+  isAdmin: SectionTabProps['isAdmin'];
+  onFieldChange: SectionTabProps['onFieldChange'];
+  setToast: (toast: ToastState) => void;
+};
+
+export function useMonitoringTabState({
+  userId,
+  form,
+  isAdmin,
+  onFieldChange,
+  setToast,
+}: UseMonitoringTabStateInput) {
+  const { account } = useAuth();
+  const userIdStr = userId ? String(userId) : '';
+
+  // ── goals 派生データ ─────────────────────────────────
+  const goalLikes = useGoalLikes(form.goals);
+  const goalNames = useGoalNames(form.goals);
+
+  // ── モニタリング集計 ─────────────────────────────────
+  const { summary, insightLines, recordCount } = useMonitoringDailyAnalytics(
+    userIdStr,
+    DEFAULT_LOOKBACK_DAYS,
+    goalLikes.length > 0 ? goalLikes : undefined,
+    Object.keys(goalNames).length > 0 ? goalNames : undefined,
+  );
+
+  // ── ISP 判断記録 ─────────────────────────────────────
+  const monitoringPeriod = useMonitoringPeriod(DEFAULT_LOOKBACK_DAYS);
+
+  const {
+    decisionStatuses,
+    decisionNotes,
+    handleDecision,
+    isSaving: isDecisionSaving,
+    error: decisionError,
+    decisions,
+  } = useIspRecommendationDecisions(
+    userIdStr,
+    userIdStr ? monitoringPeriod : undefined,
+    summary?.ispRecommendations ?? null,
+    account?.username ?? 'unknown',
+  );
+
+  // ── ISP ドラフト保存 ─────────────────────────────────
+  const {
+    records: savedRecords,
+    saveDraft,
+    isSaving: isSavingDraft,
+    hasSaved: hasSavedDraft,
+    error: draftError,
+  } = useSupportPlanningSheet(userIdStr);
+
+  // ── Snackbar ─────────────────────────────────────────
+  const snackbar = useSnackbar();
+
+  // ── コールバック: ドラフト保存 ───────────────────────
+  const handleSaveDraft = React.useCallback(async () => {
+    if (!decisions || decisions.length === 0) {
+      snackbar.show('保存する判断レコードがありません', 'error');
+      return;
+    }
+
+    const inputs: SaveSupportPlanningSheetInput[] = decisions.map(d => ({
+      userId: userIdStr,
+      goalId: d.goalId,
+      goalLabel: goalNames[d.goalId] ?? d.goalId,
+      decisionStatus: d.status,
+      decisionNote: d.note,
+      decisionBy: d.decidedBy,
+      decisionAt: d.decidedAt,
+      recommendationLevel: d.snapshot?.level ?? 'pending',
+      snapshot: d.snapshot ?? {
+        goalId: d.goalId,
+        level: 'pending',
+        reason: '',
+        suggestion: '',
+        capturedAt: d.decidedAt,
+      },
+    }));
+
+    let successCount = 0;
+    for (const input of inputs) {
+      const result = await saveDraft(input);
+      if (result) successCount++;
+    }
+
+    if (successCount === inputs.length) {
+      snackbar.show(`${successCount}件のISP下書きを保存しました`, 'success');
+    } else if (draftError) {
+      snackbar.show('ISP下書きの保存に失敗しました', 'error');
+    } else {
+      snackbar.show(`${successCount}/${inputs.length}件を保存しました`, 'success');
+    }
+  }, [decisions, userIdStr, goalNames, saveDraft, draftError, snackbar]);
+
+  // ── コールバック: 判断 with フィードバック ───────────
+  const handleDecisionWithFeedback = React.useCallback(
+    async (input: Parameters<typeof handleDecision>[0]) => {
+      await handleDecision(input);
+      if (!decisionError) {
+        snackbar.show('判断を記録しました', 'success');
+      } else {
+        snackbar.show('判断の保存に失敗しました', 'error');
+      }
+    },
+    [handleDecision, decisionError, snackbar],
+  );
+
+  // ── コールバック: monitoringPlan への追記 ────────────
+  const appendToMonitoringPlan = React.useCallback(
+    (text: string, duplicateMsg: string, successMsg: string) => {
+      const currentVal = form.monitoringPlan || '';
+      const headerLine = text.split('\n')[0];
+      if (currentVal.includes(headerLine)) {
+        setToast({ open: true, message: duplicateMsg, severity: 'info' });
+        return;
+      }
+      onFieldChange('monitoringPlan', (currentVal ? currentVal + '\n\n' : '') + text);
+      setToast({ open: true, message: successMsg, severity: 'success' });
+    },
+    [form.monitoringPlan, onFieldChange, setToast],
+  );
+
+  // ── コールバック: ドラフト → エディタ転記 ───────────
+  const handleApplyToEditor = React.useCallback(
+    (fieldKey: SupportPlanStringFieldKey, text: string) => {
+      if (!isAdmin) return;
+      const currentVal = form[fieldKey] || '';
+      const newVal = currentVal
+        ? `${currentVal}\n\n--- ドラフト反映 ---\n${text}`
+        : text;
+      onFieldChange(fieldKey, newVal);
+      setToast({
+        open: true,
+        message: `「${fieldKey}」フィールドへ反映しました`,
+        severity: 'success',
+      });
+    },
+    [form, isAdmin, onFieldChange, setToast],
+  );
+
+  // ── コールバック: 過去バッチ再反映 ──────────────────
+  const handleReapplyBatch = React.useCallback(
+    (batch: DraftBatch) => {
+      if (!isAdmin) return;
+
+      const lines: string[] = [];
+      for (const r of batch.records) {
+        const statusLabel =
+          r.decisionStatus === 'accepted' ? '採用' :
+          r.decisionStatus === 'dismissed' ? '見送り' :
+          r.decisionStatus === 'deferred' ? '保留' : '未判断';
+        lines.push(`【${r.goalLabel}】 ${statusLabel}`);
+        if (r.decisionNote) lines.push(`  判断メモ: ${r.decisionNote}`);
+        if (r.snapshot.reason) lines.push(`  理由: ${r.snapshot.reason}`);
+      }
+      const text = lines.join('\n');
+
+      const currentVal = form.conferenceNotes || '';
+      const newVal = currentVal
+        ? `${currentVal}\n\n--- 過去ドラフト反映 ---\n${text}`
+        : text;
+      onFieldChange('conferenceNotes', newVal);
+
+      setToast({
+        open: true,
+        message: `${batch.records.length}件の判断レコードを「会議・同意の記録」へ反映しました`,
+        severity: 'success',
+      });
+    },
+    [form.conferenceNotes, isAdmin, onFieldChange, setToast],
+  );
+
+  // ── 戻り値: 3 セクション + feedback に分割 ──────────
+  return {
+    userIdStr,
+
+    /** MonitoringDashboardSection 用 */
+    dashboardState: {
+      summary,
+      insightLines,
+      recordCount,
+      goalNames,
+      decisionStatuses,
+      decisionNotes,
+      decisions,
+      isDecisionSaving,
+      isSavingDraft,
+      hasSavedDraft,
+      savedRecords,
+      onDecision: handleDecisionWithFeedback,
+      onSaveDraft: handleSaveDraft,
+      onApplyToEditor: handleApplyToEditor,
+      onReapplyBatch: handleReapplyBatch,
+      onAppendInsight: (text: string) =>
+        appendToMonitoringPlan(
+          text,
+          'この期間の所見は既に引用されています。',
+          '所見ドラフトを引用しました。内容を調整してください。',
+        ),
+    },
+
+    /** MonitoringEvidenceSection 用 */
+    evidenceState: {
+      onAppendDailyEvidence: (text: string) =>
+        appendToMonitoringPlan(
+          text,
+          'この期間のエビデンスは既に引用されています。',
+          'エビデンスを引用しました。内容を調整してください。',
+        ),
+      onAppendIcebergEvidence: (text: string) =>
+        appendToMonitoringPlan(
+          text,
+          'Iceberg分析結果は既に引用されています。',
+          'Iceberg分析結果を引用しました。内容を調整してください。',
+        ),
+    },
+
+    /** Snackbar 制御 */
+    feedbackState: snackbar,
+  };
+}

--- a/src/features/support-plan-guide/hooks/useSupportPlanForm.ts
+++ b/src/features/support-plan-guide/hooks/useSupportPlanForm.ts
@@ -41,7 +41,7 @@ import {
     createEmptyForm,
     sanitizeValue,
 } from '../utils/helpers';
-import { buildMarkdown } from '../utils/markdownExport';
+import { buildSupportPlanMarkdown } from '../utils/markdownExport';
 
 // Sub-hooks
 import { useDraftAutoSave } from './useDraftAutoSave';
@@ -184,7 +184,7 @@ export function useSupportPlanForm({
   );
   const activeDraft = activeDraftId ? drafts[activeDraftId] : undefined;
   const form = activeDraft?.data ?? createEmptyForm();
-  const markdown = React.useMemo(() => buildMarkdown(form), [form]);
+  // markdown は complianceForm 初期化後に計算（P2-A: compliance/deadline 統合）
   const deadlines = React.useMemo(() => computeDeadlineInfo(form), [form]);
 
   const auditAlertCount = React.useMemo(() => {
@@ -277,6 +277,24 @@ export function useSupportPlanForm({
     setSelectedMasterUserId,
   });
 
+  // ── Compliance form (A-2) ── ※ markdown 計算に必要なため Export/Import より先に初期化
+  const complianceForm = useComplianceForm({
+    activeDraft,
+    activeDraftId,
+    isAdmin,
+    setDrafts,
+  });
+
+  // ── Markdown (P2-A: form + compliance + deadlines 統合) ──
+  const markdown = React.useMemo(
+    () => buildSupportPlanMarkdown({
+      form,
+      compliance: complianceForm.compliance,
+      deadlines,
+    }),
+    [form, complianceForm.compliance, deadlines],
+  );
+
   const { handleCopyMarkdown, handleExportJson, handleDownloadMarkdown, handleImportJson } = useDraftExportImport({
     activeDraftId,
     drafts,
@@ -291,14 +309,6 @@ export function useSupportPlanForm({
   });
 
   const { handleGoalChange, handleToggleDomain, handleAddGoal, handleDeleteGoal } = useGoalActions({
-    activeDraftId,
-    isAdmin,
-    setDrafts,
-  });
-
-  // ── Compliance form (A-2) ──
-  const complianceForm = useComplianceForm({
-    activeDraft,
     activeDraftId,
     isAdmin,
     setDrafts,

--- a/src/features/support-plan-guide/utils/__tests__/markdownExportCompliance.spec.ts
+++ b/src/features/support-plan-guide/utils/__tests__/markdownExportCompliance.spec.ts
@@ -1,0 +1,259 @@
+/**
+ * markdownExport — P2-A: buildSupportPlanMarkdown テスト
+ *
+ * ExportModel（form + compliance + deadlines）から
+ * 正しく Markdown セクションが生成されることを検証する。
+ */
+import { describe, expect, it } from 'vitest';
+import type { IspComplianceMetadata } from '@/domain/isp/schema';
+import type { DeadlineInfo, SupportPlanForm } from '../../types';
+import { defaultFormState } from '../../types';
+import { buildSupportPlanMarkdown, type SupportPlanExportModel } from '../markdownExport';
+
+// ── Helpers ──
+
+const makeForm = (overrides: Partial<SupportPlanForm>): SupportPlanForm => ({
+  ...defaultFormState,
+  ...overrides,
+});
+
+const makeDeadline = (overrides: Partial<DeadlineInfo> = {}): DeadlineInfo => ({
+  label: 'テスト期限',
+  color: 'default',
+  ...overrides,
+});
+
+const makeCompliance = (overrides: Partial<IspComplianceMetadata> = {}): IspComplianceMetadata => ({
+  serviceType: 'other',
+  standardServiceHours: null,
+  consent: {
+    explainedAt: null,
+    explainedBy: '',
+    consentedAt: null,
+    consentedBy: '',
+    proxyName: '',
+    proxyRelation: '',
+    notes: '',
+  },
+  delivery: {
+    deliveredAt: null,
+    deliveredToUser: false,
+    deliveredToConsultationSupport: false,
+    deliveryMethod: '',
+    notes: '',
+  },
+  reviewControl: {
+    reviewCycleDays: 180,
+    lastReviewedAt: null,
+    nextReviewDueAt: null,
+    reviewReason: '',
+  },
+  approval: {
+    approvedBy: null,
+    approvedAt: null,
+    approvalStatus: 'draft',
+  },
+  ...overrides,
+});
+
+const makeModel = (overrides: Partial<SupportPlanExportModel> = {}): SupportPlanExportModel => ({
+  form: makeForm({}),
+  compliance: null,
+  deadlines: {
+    creation: makeDeadline({ label: '作成期限(開始+30日)' }),
+    monitoring: makeDeadline({ label: '次回モニタ期限(6か月)' }),
+  },
+  ...overrides,
+});
+
+// ── Tests ──
+
+describe('buildSupportPlanMarkdown — P2-A 統合出力', () => {
+  it('compliance が null でも既存の form セクションは正常に出力される', () => {
+    const model = makeModel({
+      form: makeForm({ serviceUserName: '田中太郎', supportLevel: '支援区分3' }),
+      compliance: null,
+    });
+    const md = buildSupportPlanMarkdown(model);
+    expect(md).toContain('利用者名: 田中太郎');
+    expect(md).toContain('支援区分 / 医療等: 支援区分3');
+    // compliance section should not appear when null
+    expect(md).not.toContain('制度適合');
+  });
+
+  it('同意記録が Markdown に含まれる', () => {
+    const model = makeModel({
+      compliance: makeCompliance({
+        consent: {
+          explainedAt: '2025-04-01T10:00:00Z',
+          explainedBy: '山田花子',
+          consentedAt: '2025-04-02T14:00:00Z',
+          consentedBy: '田中太郎',
+          proxyName: '',
+          proxyRelation: '',
+          notes: '',
+        },
+      }),
+    });
+    const md = buildSupportPlanMarkdown(model);
+    expect(md).toContain('## 制度適合（コンプライアンス）');
+    expect(md).toContain('### 同意記録');
+    expect(md).toContain('説明実施者: 山田花子');
+    expect(md).toContain('同意者: 田中太郎');
+  });
+
+  it('代理人情報が含まれる（続柄付き）', () => {
+    const model = makeModel({
+      compliance: makeCompliance({
+        consent: {
+          explainedAt: '2025-04-01',
+          explainedBy: '支援者A',
+          consentedAt: '2025-04-02',
+          consentedBy: '家族B',
+          proxyName: '代理人C',
+          proxyRelation: '母',
+          notes: '',
+        },
+      }),
+    });
+    const md = buildSupportPlanMarkdown(model);
+    expect(md).toContain('代理人: 代理人C（母）');
+  });
+
+  it('交付記録が正しく出力される', () => {
+    const model = makeModel({
+      compliance: makeCompliance({
+        delivery: {
+          deliveredAt: '2025-04-05T09:00:00Z',
+          deliveredToUser: true,
+          deliveredToConsultationSupport: false,
+          deliveryMethod: '手渡し',
+          notes: '',
+        },
+      }),
+    });
+    const md = buildSupportPlanMarkdown(model);
+    expect(md).toContain('### 交付記録');
+    expect(md).toContain('本人への交付: ✓ 済');
+    expect(md).toContain('相談支援専門員への交付: ✗ 未');
+    expect(md).toContain('交付方法: 手渡し');
+  });
+
+  it('承認済みの場合、承認記録が出力される', () => {
+    const model = makeModel({
+      compliance: makeCompliance({
+        approval: {
+          approvedBy: 'admin@example.com',
+          approvedAt: '2025-04-10T12:00:00Z',
+          approvalStatus: 'approved',
+        },
+      }),
+    });
+    const md = buildSupportPlanMarkdown(model);
+    expect(md).toContain('### 承認記録');
+    expect(md).toContain('ステータス: ✓ 承認済み');
+    expect(md).toContain('承認者: admin@example.com');
+  });
+
+  it('下書き状態の場合、承認ステータスが「下書き」と表示される', () => {
+    const model = makeModel({
+      compliance: makeCompliance({
+        approval: {
+          approvedBy: null,
+          approvedAt: null,
+          approvalStatus: 'draft',
+        },
+      }),
+    });
+    const md = buildSupportPlanMarkdown(model);
+    expect(md).toContain('ステータス: 下書き');
+    expect(md).not.toContain('承認者:');
+  });
+
+  it('期限情報セクションが出力される（残日数あり）', () => {
+    const futureDate = new Date();
+    futureDate.setDate(futureDate.getDate() + 15);
+    const model = makeModel({
+      deadlines: {
+        creation: makeDeadline({
+          label: '作成期限(開始+30日)',
+          date: futureDate,
+          daysLeft: 15,
+          color: 'success',
+        }),
+        monitoring: makeDeadline({
+          label: '次回モニタ期限(6か月)',
+          date: undefined,
+          daysLeft: undefined,
+          color: 'default',
+        }),
+      },
+    });
+    const md = buildSupportPlanMarkdown(model);
+    expect(md).toContain('## 期限管理');
+    expect(md).toContain('作成期限(開始+30日)');
+    expect(md).toContain('残り 15日');
+    expect(md).toContain('次回モニタ期限(6か月)');
+    expect(md).toContain('未設定');
+  });
+
+  it('期限超過の場合、超過日数が表示される', () => {
+    const pastDate = new Date();
+    pastDate.setDate(pastDate.getDate() - 5);
+    const model = makeModel({
+      deadlines: {
+        creation: makeDeadline({
+          label: '作成期限(開始+30日)',
+          date: pastDate,
+          daysLeft: -5,
+          color: 'error',
+        }),
+        monitoring: makeDeadline({
+          label: '次回モニタ期限(6か月)',
+          date: new Date(),
+          daysLeft: 0,
+          color: 'warning',
+        }),
+      },
+    });
+    const md = buildSupportPlanMarkdown(model);
+    expect(md).toContain('⚠ 5日超過');
+    expect(md).toContain('⚠ 本日期限');
+  });
+
+  it('goals も compliance も含む統合出力が正しく生成される', () => {
+    const model = makeModel({
+      form: makeForm({
+        serviceUserName: '鈴木一郎',
+        goals: [
+          { id: '1', type: 'long', label: '長期A', text: '自立生活を目指す', domains: [] },
+        ],
+      }),
+      compliance: makeCompliance({
+        consent: {
+          explainedAt: '2025-04-01',
+          explainedBy: '相談員A',
+          consentedAt: '2025-04-02',
+          consentedBy: '鈴木一郎',
+          proxyName: '',
+          proxyRelation: '',
+          notes: '',
+        },
+        approval: {
+          approvedBy: 'sabikan@example.com',
+          approvedAt: '2025-04-05',
+          approvalStatus: 'approved',
+        },
+      }),
+    });
+    const md = buildSupportPlanMarkdown(model);
+    // form sections
+    expect(md).toContain('利用者名: 鈴木一郎');
+    expect(md).toContain('**長期A**: 自立生活を目指す');
+    // compliance sections
+    expect(md).toContain('説明実施者: 相談員A');
+    expect(md).toContain('✓ 承認済み');
+    // deadline sections
+    expect(md).toContain('## 期限管理');
+  });
+});

--- a/src/features/support-plan-guide/utils/helpers.ts
+++ b/src/features/support-plan-guide/utils/helpers.ts
@@ -360,3 +360,8 @@ export const TAB_SECTIONS = TAB_ORDER.map((key) => ({
   key,
   label: findSection(key)?.label ?? key,
 }));
+
+// ── group.sub ルーティング (P1.5 SSOT) ──
+// P1-B で UI 層が TAB_GROUPS を直接参照するための re-export
+export { TAB_GROUPS, getAllSubsFlat } from '../domain/tabRoute';
+export type { TabGroupKey, TabGroupDef, SupportPlanTabRoute } from '../domain/tabRoute';

--- a/src/features/support-plan-guide/utils/markdownExport.ts
+++ b/src/features/support-plan-guide/utils/markdownExport.ts
@@ -4,11 +4,32 @@
  * buildMarkdown() を SupportPlanGuidePage.tsx から抽出。
  *
  * Phase 5: form.goals (GoalItem[]) のみを出力ソースとする。
+ * Phase P2-A: buildSupportPlanMarkdown() で compliance / deadline を統合。
  */
 import type { GoalItem } from '@/features/shared/goal/goalTypes';
-import type { SupportPlanForm } from '../types';
+import type { IspComplianceMetadata } from '@/domain/isp/schema';
+import type { DeadlineInfo, SupportPlanForm } from '../types';
 
-// ── Goal → Markdown 変換ヘルパー ──
+// ────────────────────────────────────────────
+// Export Model
+// ────────────────────────────────────────────
+
+/** Markdown / PDF 出力用の統合モデル */
+export type SupportPlanExportModel = {
+  /** フォームデータ */
+  form: SupportPlanForm;
+  /** コンプライアンスメタデータ（null = 未設定） */
+  compliance: IspComplianceMetadata | null;
+  /** 期限情報 */
+  deadlines: {
+    creation: DeadlineInfo;
+    monitoring: DeadlineInfo;
+  };
+};
+
+// ────────────────────────────────────────────
+// Goal → Markdown 変換ヘルパー
+// ────────────────────────────────────────────
 
 /** GoalItem[] を type でフィルタし、箇条書き Markdown 行を生成する */
 function goalsToLines(goals: GoalItem[] | undefined, type: GoalItem['type']): string[] {
@@ -21,8 +42,14 @@ function goalsToLines(goals: GoalItem[] | undefined, type: GoalItem['type']): st
   });
 }
 
-export const buildMarkdown = (form: SupportPlanForm) => {
-  // ── 目標セクション: goals のみ ──
+// ────────────────────────────────────────────
+// Form → Sections (共通ロジック)
+// ────────────────────────────────────────────
+
+type MdSection = { title: string; lines: string[] };
+
+/** フォームデータからセクション一覧を構築する（form 部分のみ） */
+function buildFormSections(form: SupportPlanForm): MdSection[] {
   const longGoalLines = goalsToLines(form.goals, 'long');
   const shortGoalLines = goalsToLines(form.goals, 'short');
   const supportGoalLines = goalsToLines(form.goals, 'support');
@@ -32,7 +59,7 @@ export const buildMarkdown = (form: SupportPlanForm) => {
     ...(shortGoalLines.length > 0 ? ['### 短期目標', ...shortGoalLines] : []),
   ];
 
-  const sections: Array<{ title: string; lines: string[] }> = [
+  return [
     {
       title: '基本情報',
       lines: [
@@ -83,16 +110,134 @@ export const buildMarkdown = (form: SupportPlanForm) => {
       lines: [form.improvementIdeas && form.improvementIdeas].filter(Boolean) as string[],
     },
   ];
+}
 
-  const sectionsBody = sections
+/** セクション配列を Markdown 文字列にレンダリングする */
+function renderSections(sections: MdSection[]): string {
+  return sections
     .map((section) => {
-      if (section.lines.length === 0) {
-        return '';
-      }
+      if (section.lines.length === 0) return '';
       return `## ${section.title}\n${section.lines.join('\n')}`;
     })
     .filter(Boolean)
     .join('\n\n');
+}
 
-  return sectionsBody ? `# 個別支援計画書ドラフト\n\n${sectionsBody}\n` : '# 個別支援計画書ドラフト\n';
+// ────────────────────────────────────────────
+// Compliance → Markdown セクション
+// ────────────────────────────────────────────
+
+/** ISO 8601 日付文字列を日本語日付に変換 */
+function formatIsoDate(iso: string | null | undefined): string {
+  if (!iso) return '未入力';
+  try {
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) return '未入力';
+    return d.toLocaleDateString('ja-JP', { year: 'numeric', month: '2-digit', day: '2-digit' });
+  } catch {
+    return '未入力';
+  }
+}
+
+/** コンプライアンスデータから Markdown セクションを構築 */
+function buildComplianceSection(compliance: IspComplianceMetadata | null): MdSection {
+  if (!compliance) {
+    return { title: '制度適合（コンプライアンス）', lines: [] };
+  }
+
+  const { consent, delivery, approval } = compliance;
+  const lines: string[] = [];
+
+  // 同意記録
+  lines.push('### 同意記録');
+  lines.push(`- 説明実施日: ${formatIsoDate(consent.explainedAt)}`);
+  if (consent.explainedBy) lines.push(`- 説明実施者: ${consent.explainedBy}`);
+  lines.push(`- 同意取得日: ${formatIsoDate(consent.consentedAt)}`);
+  if (consent.consentedBy) lines.push(`- 同意者: ${consent.consentedBy}`);
+  if (consent.proxyName) {
+    lines.push(`- 代理人: ${consent.proxyName}${consent.proxyRelation ? `（${consent.proxyRelation}）` : ''}`);
+  }
+  if (consent.notes) lines.push(`- 備考: ${consent.notes}`);
+
+  // 交付記録
+  lines.push('### 交付記録');
+  lines.push(`- 交付日: ${formatIsoDate(delivery.deliveredAt)}`);
+  lines.push(`- 本人への交付: ${delivery.deliveredToUser ? '✓ 済' : '✗ 未'}`);
+  lines.push(`- 相談支援専門員への交付: ${delivery.deliveredToConsultationSupport ? '✓ 済' : '✗ 未'}`);
+  if (delivery.deliveryMethod) lines.push(`- 交付方法: ${delivery.deliveryMethod}`);
+  if (delivery.notes) lines.push(`- 備考: ${delivery.notes}`);
+
+  // 承認記録
+  lines.push('### 承認記録');
+  lines.push(`- ステータス: ${approval.approvalStatus === 'approved' ? '✓ 承認済み' : '下書き'}`);
+  if (approval.approvedBy) lines.push(`- 承認者: ${approval.approvedBy}`);
+  if (approval.approvedAt) lines.push(`- 承認日時: ${formatIsoDate(approval.approvedAt)}`);
+
+  return { title: '制度適合（コンプライアンス）', lines };
+}
+
+// ────────────────────────────────────────────
+// Deadline → Markdown セクション
+// ────────────────────────────────────────────
+
+/** DeadlineInfo の色をステータス文字列に変換 */
+function deadlineStatus(info: DeadlineInfo): string {
+  if (info.daysLeft === undefined || !info.date) return '未設定';
+  if (info.daysLeft < 0) return `⚠ ${Math.abs(info.daysLeft)}日超過`;
+  if (info.daysLeft === 0) return '⚠ 本日期限';
+  return `残り ${info.daysLeft}日`;
+}
+
+/** 期限情報から Markdown セクションを構築 */
+function buildDeadlineSection(deadlines: SupportPlanExportModel['deadlines']): MdSection {
+  const { creation, monitoring } = deadlines;
+  const lines: string[] = [];
+
+  // 作成期限
+  const creationDate = creation.date
+    ? creation.date.toLocaleDateString('ja-JP', { year: 'numeric', month: '2-digit', day: '2-digit' })
+    : '未設定';
+  lines.push(`- ${creation.label}: ${creationDate}（${deadlineStatus(creation)}）`);
+
+  // モニタ期限
+  const monitoringDate = monitoring.date
+    ? monitoring.date.toLocaleDateString('ja-JP', { year: 'numeric', month: '2-digit', day: '2-digit' })
+    : '未設定';
+  lines.push(`- ${monitoring.label}: ${monitoringDate}（${deadlineStatus(monitoring)}）`);
+
+  return { title: '期限管理', lines };
+}
+
+// ────────────────────────────────────────────
+// Public API
+// ────────────────────────────────────────────
+
+/**
+ * @deprecated P2-A: buildSupportPlanMarkdown() を使用してください。
+ * 後方互換のため残しています。
+ */
+export const buildMarkdown = (form: SupportPlanForm): string => {
+  const sections = buildFormSections(form);
+  const body = renderSections(sections);
+  return body ? `# 個別支援計画書ドラフト\n\n${body}\n` : '# 個別支援計画書ドラフト\n';
+};
+
+/**
+ * P2-A: ExportModel から Markdown を生成する。
+ *
+ * form + compliance + deadlines を統合して出力。
+ */
+export const buildSupportPlanMarkdown = (model: SupportPlanExportModel): string => {
+  const formSections = buildFormSections(model.form);
+  const complianceSection = buildComplianceSection(model.compliance);
+  const deadlineSection = buildDeadlineSection(model.deadlines);
+
+  const allSections = [
+    ...formSections,
+    complianceSection,
+    deadlineSection,
+  ];
+
+  const body = renderSections(allSections);
+  return body ? `# 個別支援計画書ドラフト\n\n${body}\n` : '# 個別支援計画書ドラフト\n';
 };

--- a/src/pages/SupportPlanGuidePage.tsx
+++ b/src/pages/SupportPlanGuidePage.tsx
@@ -27,8 +27,9 @@ import {
 } from '@/features/support-plan-guide/types';
 import {
     computeRequiredCompletion,
-    TAB_SECTIONS,
 } from '@/features/support-plan-guide/utils/helpers';
+import { getAllSubsFlat } from '@/features/support-plan-guide/domain/tabRoute';
+import SupportPlanTabHeader from '@/features/support-plan-guide/components/SupportPlanTabHeader';
 import { useUsersStore } from '@/features/users/store';
 import { HYDRATION_FEATURES, startFeatureSpan } from '@/hydration/features';
 import { PREFETCH_KEYS, prefetchByKey, warmRoute } from '@/prefetch/routes';
@@ -44,8 +45,6 @@ import Chip from '@mui/material/Chip';
 import CircularProgress from '@mui/material/CircularProgress';
 import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
-import Tab from '@mui/material/Tab';
-import Tabs from '@mui/material/Tabs';
 import Tooltip from '@mui/material/Tooltip';
 
 import React, { Suspense } from 'react';
@@ -129,6 +128,7 @@ export default function SupportPlanGuidePage() {
     activeDraft,
     form,
     markdown,
+    deadlines,
     auditAlertCount,
     filledCount,
     completionPercent,
@@ -340,8 +340,8 @@ export default function SupportPlanGuidePage() {
   const { currentSheet: _currentSheet, allCurrentSheets: _allCurrentSheets, isLoading: _isLoadingSheets } = useCurrentPlanningSheet(regulatoryUserId, planningSheetRepo);
 
   return (
-    <Box sx={{ p: { xs: 2, md: 3 }, pb: 4 }}>
-      <Stack spacing={3}>
+    <Box sx={{ p: { xs: 1.5, md: 2 }, pb: 4 }}>
+      <Stack spacing={2}>
         {!isAdmin && (
           <Alert severity="info" sx={{ mb: 1 }}>
             このページは閲覧のみです。編集・保存は管理者（サビ管）権限が必要です。
@@ -355,16 +355,20 @@ export default function SupportPlanGuidePage() {
               bundle={regulatoryBundle}
               linkedUserId={linkedUserId}
               onNavigate={(url) => navigate(url)}
+              compliance={complianceForm.compliance}
+              deadlines={deadlines}
+              icebergTotal={icebergEvidence?.sessionCount ? Object.values(icebergEvidence.sessionCount).reduce((a, b) => a + b, 0) : undefined}
+              onNavigateToTab={setActiveTab}
             />
           </Suspense>
         )}
 
         <Paper
           variant="outlined"
-          sx={{ p: { xs: 2, md: 3 } }}
+          sx={{ px: { xs: 1.5, md: 2 }, py: { xs: 1, md: 1.25 } }}
           {...tid(TESTIDS['support-plan-hud'])}
         >
-          <Stack spacing={1.5}>
+          <Stack spacing={0.75}>
             <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
               {draftList.length > 0 ? (
                 draftList.map(getDraftProgressChip)
@@ -429,27 +433,14 @@ export default function SupportPlanGuidePage() {
           </Stack>
         </Paper>
 
-        <Paper variant="outlined" sx={{ p: { xs: 1, md: 2 } }}>
-          <Tabs
-            value={activeTab}
-            onChange={(_event, nextValue) => setActiveTab(nextValue as SectionKey)}
-            variant="scrollable"
-            scrollButtons="auto"
-            aria-label="支援計画セクション切り替え"
-          >
-            {TAB_SECTIONS.map((tab) => (
-              <Tab
-                key={tab.key}
-                value={tab.key}
-                label={tab.label}
-                id={`support-plan-tab-${tab.key}`}
-                aria-controls={`support-plan-tabpanel-${tab.key}`}
-              />
-            ))}
-          </Tabs>
-          {TAB_SECTIONS.map((tab) => (
-            <TabPanel key={tab.key} current={activeTab} value={tab.key}>
-              {renderTabContent(tab.key)}
+        <Paper variant="outlined" sx={{ px: { xs: 1, md: 1.5 }, py: { xs: 0.5, md: 1 } }}>
+          <SupportPlanTabHeader
+            activeTab={activeTab}
+            onTabChange={setActiveTab}
+          />
+          {getAllSubsFlat().map((sub) => (
+            <TabPanel key={sub} current={activeTab} value={sub}>
+              {renderTabContent(sub)}
             </TabPanel>
           ))}
         </Paper>


### PR DESCRIPTION
## 概要

支援計画ガイドの運用品質向上: P1-A～P2-B の5段階改善を一括実装。

## 変更内容

### P1-A: MonitoringTab 分割 (510→104行)
- `useMonitoringTabState.ts` に状態・callback を集約
- `MonitoringFieldSection` / `DashboardSection` / `EvidencePanel` に UI 分離
- `MonitoringTab.tsx` は thin orchestrator に

### P1.5: group.sub URL 正規化
- `tabRoute.ts` に parse/serialize/legacy 吸収を純関数で分離
- `overview.basic` / `plan.smart` 等の正規形ルーティング

### P1-B: 5グループ×サブタブ UI
- `SupportPlanTabHeader.tsx` を独立コンポーネント化
- 基本情報/計画策定/運用・実行/制度適合/出力 の5グループ構造

### P2-A: Markdown 生成パイプライン統合
- `SupportPlanExportModel` + `buildSupportPlanMarkdown()`
- 同意・交付・承認・期限管理セクションを統合出力
- `markdownExportCompliance.spec.ts` (9テスト)

### P2-B: 制度 HUD 信号灯 UI
- `domain/regulatoryHud.ts`: 6項目の信号判定純関数
  - ISP状態/同意/交付/作成期限/モニタ期限/Iceberg分析
- `RegulatorySummaryBand.tsx`: 色分けChip + クリック遷移
- `regulatoryHud.spec.ts` (21テスト)
- `SupportPlanGuidePage.tsx`: compliance/deadlines/onNavigateToTab 接続

## テスト
- 全 195 テスト pass・回帰なし
- lint / typecheck / pre-push フック通過

## 影響範囲
- `src/features/support-plan-guide/` 内のみ
- `src/pages/SupportPlanGuidePage.tsx`
- `src/app/links/navigationLinks.ts` (軽微リンク更新)