### PR TITLE
feat(support-plan-guide): P3-A buildSuggestedGoals() 目標候補自動生成 MVP

### DIFF
--- a/src/features/support-plan-guide/domain/__tests__/suggestedGoals.spec.ts
+++ b/src/features/support-plan-guide/domain/__tests__/suggestedGoals.spec.ts
@@ -1,0 +1,384 @@
+/**
+ * suggestedGoals — 目標候補生成テスト
+ *
+ * P3-A: buildSuggestedGoals の全ルールを検証する。
+ */
+import { describe, expect, it, beforeEach } from 'vitest';
+import type { GoalItem } from '@/features/shared/goal/goalTypes';
+import {
+  buildSuggestedGoals,
+  inferDomains,
+  suggestionToGoalItem,
+  _resetCounter,
+  type SuggestedGoalsInput,
+  type AssessmentSummaryInput,
+  type IcebergSummaryInput,
+  type MonitoringSummaryInput,
+  type GoalSuggestion,
+} from '../suggestedGoals';
+
+// ── Helpers ──
+
+const makeAssessment = (
+  overrides: Partial<AssessmentSummaryInput> = {},
+): AssessmentSummaryInput => ({
+  targetBehaviors: [],
+  hypotheses: [],
+  riskLevel: 'low',
+  healthFactors: [],
+  ...overrides,
+});
+
+const makeIceberg = (
+  overrides: Partial<IcebergSummaryInput> = {},
+): IcebergSummaryInput => ({
+  observationFacts: '',
+  supportIssues: '',
+  supportPolicy: '',
+  concreteApproaches: '',
+  targetScene: '',
+  targetDomain: '',
+  ...overrides,
+});
+
+const makeMonitoring = (
+  overrides: Partial<MonitoringSummaryInput> = {},
+): MonitoringSummaryInput => ({
+  monitoringPlan: '',
+  reviewTiming: '',
+  planChangeRequired: false,
+  improvementIdeas: '',
+  ...overrides,
+});
+
+const makeInput = (
+  overrides: Partial<SuggestedGoalsInput> = {},
+): SuggestedGoalsInput => ({
+  assessments: [],
+  icebergSummaries: [],
+  monitoring: null,
+  existingGoals: [],
+  assessmentSummaryText: '',
+  strengths: '',
+  ...overrides,
+});
+
+const makeGoal = (overrides: Partial<GoalItem> = {}): GoalItem => ({
+  id: 'g-1',
+  type: 'short',
+  label: '',
+  text: '',
+  domains: [],
+  ...overrides,
+});
+
+// ── Tests ──
+
+describe('buildSuggestedGoals', () => {
+  beforeEach(() => {
+    _resetCounter();
+  });
+
+  // ── 空入力 ──
+
+  it('入力が空の場合は空配列を返す', () => {
+    const result = buildSuggestedGoals(makeInput());
+    expect(result).toEqual([]);
+  });
+
+  // ── アセスメント ──
+
+  describe('アセスメント由来', () => {
+    it('高リスク → リスク軽減目標を提案（priority: high）', () => {
+      const result = buildSuggestedGoals(
+        makeInput({
+          assessments: [makeAssessment({ riskLevel: 'high' })],
+        }),
+      );
+      const risk = result.find((s) => s.title.includes('リスク軽減'));
+      expect(risk).toBeDefined();
+      expect(risk!.priority).toBe('high');
+      expect(risk!.goalType).toBe('long');
+      expect(risk!.domains).toContain('health');
+      expect(risk!.provenance).toEqual(['アセスメント: リスクレベル＝高']);
+    });
+
+    it('低リスク → リスク軽減目標を提案しない', () => {
+      const result = buildSuggestedGoals(
+        makeInput({
+          assessments: [makeAssessment({ riskLevel: 'low' })],
+        }),
+      );
+      expect(result.find((s) => s.title.includes('リスク軽減'))).toBeUndefined();
+    });
+
+    it('対象行動 → 行動目標を提案', () => {
+      const result = buildSuggestedGoals(
+        makeInput({
+          assessments: [makeAssessment({ targetBehaviors: ['自傷行為', '物を投げる'] })],
+        }),
+      );
+      expect(result).toHaveLength(2);
+      expect(result[0].title).toContain('自傷行為');
+      expect(result[0].goalType).toBe('short');
+      expect(result[1].title).toContain('物を投げる');
+    });
+
+    it('仮説（中以上の信頼度） → 代替手段の目標を提案', () => {
+      const result = buildSuggestedGoals(
+        makeInput({
+          assessments: [
+            makeAssessment({
+              hypotheses: [
+                { function: '注目獲得', evidence: '発生直後に職員が即応', confidence: 'high' },
+                { function: '回避', evidence: '不明', confidence: 'low' },
+              ],
+            }),
+          ],
+        }),
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].title).toContain('注目獲得');
+      expect(result[0].goalType).toBe('support');
+    });
+
+    it('信頼度 low の仮説は除外される', () => {
+      const result = buildSuggestedGoals(
+        makeInput({
+          assessments: [
+            makeAssessment({
+              hypotheses: [
+                { function: '回避', evidence: '不明', confidence: 'low' },
+              ],
+            }),
+          ],
+        }),
+      );
+      expect(result).toHaveLength(0);
+    });
+
+    it('健康要因 → 健康管理目標を提案', () => {
+      const result = buildSuggestedGoals(
+        makeInput({
+          assessments: [makeAssessment({ healthFactors: ['てんかん', '服薬管理'] })],
+        }),
+      );
+      const health = result.find((s) => s.title.includes('健康管理'));
+      expect(health).toBeDefined();
+      expect(health!.domains).toContain('health');
+      expect(health!.suggestedSupports).toHaveLength(2);
+    });
+  });
+
+  // ── Iceberg ──
+
+  describe('Iceberg分析由来', () => {
+    it('supportIssues → 短期目標を提案', () => {
+      const result = buildSuggestedGoals(
+        makeInput({
+          icebergSummaries: [
+            makeIceberg({
+              supportIssues: '感覚刺激による不安定。見通しが持てないと混乱する',
+              targetScene: '朝の会',
+              targetDomain: '認知',
+            }),
+          ],
+        }),
+      );
+      expect(result.length).toBeGreaterThanOrEqual(1);
+      expect(result[0].goalType).toBe('short');
+      expect(result[0].provenance).toContain('Iceberg分析: 支援課題');
+    });
+
+    it('supportPolicy → 長期目標を提案', () => {
+      const result = buildSuggestedGoals(
+        makeInput({
+          icebergSummaries: [
+            makeIceberg({
+              supportPolicy: '段階的に社会参加の機会を拡大する',
+            }),
+          ],
+        }),
+      );
+      const policy = result.find((s) => s.provenance.includes('Iceberg分析: 対応方針'));
+      expect(policy).toBeDefined();
+      expect(policy!.goalType).toBe('long');
+    });
+
+    it('supportIssues が最大3件に制限される', () => {
+      const result = buildSuggestedGoals(
+        makeInput({
+          icebergSummaries: [
+            makeIceberg({
+              supportIssues: '課題1。課題2。課題3。課題4。課題5',
+            }),
+          ],
+        }),
+      );
+      const issueItems = result.filter((s) =>
+        s.provenance.includes('Iceberg分析: 支援課題'),
+      );
+      expect(issueItems.length).toBeLessThanOrEqual(3);
+    });
+  });
+
+  // ── モニタリング ──
+
+  describe('モニタリング由来', () => {
+    it('planChangeRequired → 計画見直し目標を提案（priority: high）', () => {
+      const result = buildSuggestedGoals(
+        makeInput({
+          monitoring: makeMonitoring({ planChangeRequired: true }),
+        }),
+      );
+      const change = result.find((s) => s.title.includes('計画見直し'));
+      expect(change).toBeDefined();
+      expect(change!.priority).toBe('high');
+    });
+
+    it('改善メモ → 支援内容の候補を提案', () => {
+      const result = buildSuggestedGoals(
+        makeInput({
+          monitoring: makeMonitoring({
+            improvementIdeas: '視覚支援を強化する。タイマーを導入する',
+          }),
+        }),
+      );
+      expect(result.length).toBeGreaterThanOrEqual(1);
+      expect(result[0].priority).toBe('low');
+      expect(result[0].provenance).toContain('改善メモ');
+    });
+
+    it('monitoring が null → モニタリング由来の提案なし', () => {
+      const result = buildSuggestedGoals(makeInput({ monitoring: null }));
+      expect(result).toEqual([]);
+    });
+  });
+
+  // ── フォームテキスト ──
+
+  describe('フォームテキスト由来', () => {
+    it('ストレングス → 活動拡大の目標を提案', () => {
+      const result = buildSuggestedGoals(
+        makeInput({ strengths: '音楽が好き。手先が器用' }),
+      );
+      expect(result.length).toBeGreaterThanOrEqual(1);
+      expect(result[0].title).toContain('ストレングス');
+      expect(result[0].provenance).toContain('フォーム: ストレングス');
+    });
+  });
+
+  // ── 重複排除 ──
+
+  describe('重複排除', () => {
+    it('既存 goals のラベルと重複する候補は除外される', () => {
+      const result = buildSuggestedGoals(
+        makeInput({
+          assessments: [makeAssessment({ targetBehaviors: ['自傷行為'] })],
+          existingGoals: [
+            makeGoal({ label: '自傷行為の頻度・強度の低減', text: '' }),
+          ],
+        }),
+      );
+      expect(result.find((s) => s.title.includes('自傷行為'))).toBeUndefined();
+    });
+  });
+
+  // ── 優先度ソート ──
+
+  describe('優先度ソート', () => {
+    it('high → medium → low の順にソートされる', () => {
+      const result = buildSuggestedGoals(
+        makeInput({
+          assessments: [
+            makeAssessment({
+              riskLevel: 'high',
+              targetBehaviors: ['パニック'],
+              healthFactors: ['てんかん'],
+            }),
+          ],
+          monitoring: makeMonitoring({
+            improvementIdeas: '散歩の機会を増やす',
+          }),
+        }),
+      );
+      expect(result.length).toBeGreaterThanOrEqual(3);
+
+      const priorities = result.map((s) => s.priority);
+      const highIdx = priorities.indexOf('high');
+      const medIdx = priorities.indexOf('medium');
+      const lowIdx = priorities.indexOf('low');
+
+      if (highIdx >= 0 && medIdx >= 0) expect(highIdx).toBeLessThan(medIdx);
+      if (medIdx >= 0 && lowIdx >= 0) expect(medIdx).toBeLessThan(lowIdx);
+    });
+  });
+
+  // ── 最大件数制限 ──
+
+  describe('最大件数制限', () => {
+    it('最大15件に制限される', () => {
+      const result = buildSuggestedGoals(
+        makeInput({
+          assessments: [
+            makeAssessment({
+              targetBehaviors: Array.from({ length: 20 }, (_, i) => `行動${i + 1}`),
+            }),
+          ],
+        }),
+      );
+      expect(result.length).toBeLessThanOrEqual(15);
+    });
+  });
+});
+
+// ── inferDomains ──
+
+describe('inferDomains', () => {
+  it('健康関連キーワード → health', () => {
+    expect(inferDomains('服薬管理を徹底する')).toContain('health');
+  });
+
+  it('コミュニケーション関連 → language', () => {
+    expect(inferDomains('コミュニケーション手段を増やす')).toContain('language');
+  });
+
+  it('社会関連 → social', () => {
+    expect(inferDomains('集団活動への参加を促す')).toContain('social');
+  });
+
+  it('複数ドメインにマッチする場合は全て返す', () => {
+    const domains = inferDomains('健康管理と社会参加を支援する');
+    expect(domains).toContain('health');
+    expect(domains).toContain('social');
+  });
+
+  it('マッチなし → cognitive がデフォルト', () => {
+    expect(inferDomains('特に該当なし')).toEqual(['cognitive']);
+  });
+});
+
+// ── suggestionToGoalItem ──
+
+describe('suggestionToGoalItem', () => {
+  it('GoalSuggestion → GoalItem に変換する', () => {
+    const suggestion: GoalSuggestion = {
+      id: 'test-1',
+      title: 'テスト目標',
+      rationale: 'テストの根拠',
+      suggestedSupports: ['支援A'],
+      priority: 'high',
+      provenance: ['テスト出典'],
+      goalType: 'short',
+      domains: ['health', 'cognitive'],
+    };
+    const goal = suggestionToGoalItem(suggestion);
+    expect(goal).toEqual({
+      id: 'test-1',
+      type: 'short',
+      label: 'テスト目標',
+      text: 'テストの根拠',
+      domains: ['health', 'cognitive'],
+    });
+  });
+});

--- a/src/features/support-plan-guide/domain/__tests__/suggestedGoalsAdapter.spec.ts
+++ b/src/features/support-plan-guide/domain/__tests__/suggestedGoalsAdapter.spec.ts
@@ -1,0 +1,203 @@
+/**
+ * suggestedGoalsAdapter — アダプターテスト
+ */
+import { describe, expect, it } from 'vitest';
+import type { SupportPlanBundle, SupportPlanningSheet } from '@/domain/isp/schema';
+import type { SupportPlanForm } from '../../types';
+import {
+  toAssessmentSummary,
+  toIcebergSummary,
+  toMonitoringSummary,
+  toSuggestedGoalsInput,
+} from '../suggestedGoalsAdapter';
+
+// ── Helpers ──
+
+const makeMinimalSheet = (overrides: Partial<SupportPlanningSheet> = {}): SupportPlanningSheet =>
+  ({
+    id: 'sheet-1',
+    userId: 'u-1',
+    ispId: 'isp-1',
+    title: 'テストシート',
+    targetScene: '朝の会',
+    targetDomain: '認知',
+    observationFacts: '大声を出す場面が週3回以上',
+    collectedInformation: '',
+    interpretationHypothesis: '注目獲得と推測',
+    supportIssues: '適切な要求表現が未獲得',
+    supportPolicy: '段階的にコミュニケーション手段を指導する',
+    environmentalAdjustments: '',
+    concreteApproaches: '絵カードによる要求表現練習',
+    appliedFrom: null,
+    nextReviewAt: null,
+    supportStartDate: null,
+    monitoringCycleDays: 90,
+    authoredByStaffId: '',
+    authoredByQualification: 'unknown',
+    authoredAt: null,
+    applicableServiceType: 'other',
+    applicableAddOnTypes: ['none'],
+    deliveredToUserAt: null,
+    reviewedAt: null,
+    hasMedicalCoordination: false,
+    hasEducationCoordination: false,
+    status: 'draft',
+    isCurrent: true,
+    intake: {
+      referralSource: '',
+      referralDate: null,
+      presentingProblem: '',
+      targetBehaviorsDraft: [],
+      behaviorItemsTotal: null,
+      incidentSummaryLast30d: '',
+      communicationModes: [],
+      sensoryTriggers: [],
+      medicalFlags: [],
+      consentScope: [],
+      consentDate: null,
+    },
+    assessment: {
+      targetBehaviors: [
+        { name: '大声', operationalDefinition: '70dB以上の発声', frequency: '週3回', intensity: '中', duration: '1-5分' },
+      ],
+      abcEvents: [],
+      hypotheses: [
+        { function: '注目獲得', evidence: '職員即応パターン', confidence: 'high' as const },
+      ],
+      riskLevel: 'medium' as const,
+      healthFactors: ['てんかん'],
+      teamConsensusNote: '',
+    },
+    planning: {
+      supportPriorities: [],
+      antecedentStrategies: [],
+      teachingStrategies: [],
+      consequenceStrategies: [],
+      procedureSteps: [],
+      crisisThresholds: null,
+      restraintPolicy: 'prohibited_except_emergency' as const,
+      reviewCycleDays: 180,
+    },
+    regulatoryBasisSnapshot: undefined as never,
+    createdAt: '',
+    updatedAt: '',
+    createdBy: '',
+    updatedBy: '',
+    ...overrides,
+  }) as SupportPlanningSheet;
+
+const makeMinimalForm = (overrides: Partial<SupportPlanForm> = {}): SupportPlanForm => ({
+  serviceUserName: 'テスト太郎',
+  supportLevel: '区分3',
+  planPeriod: '2025/04/01 - 2025/09/30',
+  assessmentSummary: '大声を出す行動に注目獲得の機能が推測される',
+  strengths: '音楽が好き',
+  decisionSupport: '',
+  conferenceNotes: '',
+  monitoringPlan: '月1回のモニタリング',
+  reviewTiming: '6ヶ月後',
+  riskManagement: '',
+  complianceControls: '',
+  improvementIdeas: 'タイマーの導入を検討',
+  lastMonitoringDate: '',
+  goals: [],
+  ...overrides,
+});
+
+// ── Tests ──
+
+describe('toAssessmentSummary', () => {
+  it('sheet.assessment を AssessmentSummaryInput に変換する', () => {
+    const result = toAssessmentSummary(makeMinimalSheet());
+    expect(result.targetBehaviors).toEqual(['大声']);
+    expect(result.hypotheses).toHaveLength(1);
+    expect(result.hypotheses[0].function).toBe('注目獲得');
+    expect(result.riskLevel).toBe('medium');
+    expect(result.healthFactors).toEqual(['てんかん']);
+  });
+
+  it('空の assessment でもエラーにならない', () => {
+    const sheet = makeMinimalSheet({
+      assessment: {
+        targetBehaviors: [],
+        abcEvents: [],
+        hypotheses: [],
+        riskLevel: 'low',
+        healthFactors: [],
+        teamConsensusNote: '',
+      },
+    });
+    const result = toAssessmentSummary(sheet);
+    expect(result.targetBehaviors).toEqual([]);
+    expect(result.hypotheses).toEqual([]);
+  });
+});
+
+describe('toIcebergSummary', () => {
+  it('sheet の Iceberg 情報を IcebergSummaryInput に変換する', () => {
+    const result = toIcebergSummary(makeMinimalSheet());
+    expect(result.observationFacts).toBe('大声を出す場面が週3回以上');
+    expect(result.supportIssues).toBe('適切な要求表現が未獲得');
+    expect(result.targetScene).toBe('朝の会');
+  });
+});
+
+describe('toMonitoringSummary', () => {
+  it('フォーム + latestMonitoring → MonitoringSummaryInput', () => {
+    const result = toMonitoringSummary(
+      makeMinimalForm(),
+      { date: '2025-06-01', planChangeRequired: true },
+    );
+    expect(result).not.toBeNull();
+    expect(result!.planChangeRequired).toBe(true);
+    expect(result!.monitoringPlan).toBe('月1回のモニタリング');
+    expect(result!.improvementIdeas).toBe('タイマーの導入を検討');
+  });
+
+  it('モニタリング未実施 + フォーム空 → null', () => {
+    const result = toMonitoringSummary(
+      makeMinimalForm({ monitoringPlan: '', improvementIdeas: '' }),
+      null,
+    );
+    expect(result).toBeNull();
+  });
+
+  it('latestMonitoring が null でもフォームに記載あれば返す', () => {
+    const result = toMonitoringSummary(
+      makeMinimalForm({ monitoringPlan: '観察する' }),
+      null,
+    );
+    expect(result).not.toBeNull();
+  });
+});
+
+describe('toSuggestedGoalsInput', () => {
+  it('bundle + form を統合して入力を生成する', () => {
+    const bundle: SupportPlanBundle = {
+      isp: {} as SupportPlanBundle['isp'],
+      planningSheets: [makeMinimalSheet()],
+      recentProcedureRecords: [],
+      latestMonitoring: { date: '2025-06-01', planChangeRequired: false },
+    };
+    const form = makeMinimalForm();
+    const result = toSuggestedGoalsInput(bundle, form);
+
+    expect(result.assessments).toHaveLength(1);
+    expect(result.icebergSummaries).toHaveLength(1);
+    expect(result.monitoring).not.toBeNull();
+    expect(result.existingGoals).toEqual([]);
+    expect(result.assessmentSummaryText).toContain('注目獲得');
+    expect(result.strengths).toBe('音楽が好き');
+  });
+
+  it('planningSheets が空でも動作する', () => {
+    const bundle: SupportPlanBundle = {
+      isp: {} as SupportPlanBundle['isp'],
+      planningSheets: [],
+      recentProcedureRecords: [],
+    };
+    const result = toSuggestedGoalsInput(bundle, makeMinimalForm());
+    expect(result.assessments).toEqual([]);
+    expect(result.icebergSummaries).toEqual([]);
+  });
+});

--- a/src/features/support-plan-guide/domain/suggestedGoals.ts
+++ b/src/features/support-plan-guide/domain/suggestedGoals.ts
@@ -1,0 +1,486 @@
+/**
+ * suggestedGoals — 目標候補の自動生成（ルールベース MVP）
+ *
+ * P3-A: 既存データ（アセスメント / Iceberg分析 / モニタリング / 既存goals）
+ * から、支援計画の目標候補を **説明可能な形** で返す。
+ *
+ * 設計原則:
+ *  - 純粋関数のみ（React 非依存）
+ *  - AI / LLM 非依存（ルールベース + キーワードマッチ）
+ *  - provenance（根拠の出典）を必ず付与
+ *  - 既存 goals との重複を自動除外
+ */
+
+import type { GoalItem } from '@/features/shared/goal/goalTypes';
+
+// ────────────────────────────────────────────
+// 出力型
+// ────────────────────────────────────────────
+
+export type GoalPriority = 'high' | 'medium' | 'low';
+
+/** 目標候補1件 */
+export type GoalSuggestion = {
+  /** 一意識別子 */
+  id: string;
+  /** 提案タイトル（短い自然言語） */
+  title: string;
+  /** 提案根拠の説明 */
+  rationale: string;
+  /** 推奨する支援内容の候補 */
+  suggestedSupports: string[];
+  /** 優先度 */
+  priority: GoalPriority;
+  /** 根拠の出典（どのデータソースから導出したか） */
+  provenance: string[];
+  /** 推奨する目標タイプ */
+  goalType: GoalItem['type'];
+  /** 推奨ドメイン */
+  domains: string[];
+};
+
+// ────────────────────────────────────────────
+// 入力型
+// ────────────────────────────────────────────
+
+/** アセスメント要約（planning sheet の assessment セクション相当） */
+export type AssessmentSummaryInput = {
+  /** 対象行動名リスト */
+  targetBehaviors: string[];
+  /** 行動の機能仮説 */
+  hypotheses: Array<{ function: string; evidence: string; confidence: 'low' | 'medium' | 'high' }>;
+  /** リスクレベル */
+  riskLevel: 'low' | 'medium' | 'high';
+  /** 健康上の要因 */
+  healthFactors: string[];
+};
+
+/** Iceberg 分析要約 */
+export type IcebergSummaryInput = {
+  /** 行動観察の事実（observationFacts の要約テキスト） */
+  observationFacts: string;
+  /** 支援課題（supportIssues の要約テキスト） */
+  supportIssues: string;
+  /** 対応方針（supportPolicy の要約テキスト） */
+  supportPolicy: string;
+  /** 関わり方の具体策 */
+  concreteApproaches: string;
+  /** 対象場面 */
+  targetScene: string;
+  /** 対象領域 */
+  targetDomain: string;
+};
+
+/** モニタリング要約 */
+export type MonitoringSummaryInput = {
+  /** モニタリング計画テキスト */
+  monitoringPlan: string;
+  /** 見直しタイミング */
+  reviewTiming: string;
+  /** 計画変更推奨 */
+  planChangeRequired: boolean;
+  /** 改善メモ */
+  improvementIdeas: string;
+};
+
+/** buildSuggestedGoals への入力 */
+export type SuggestedGoalsInput = {
+  /** アセスメント情報（複数シートから結合可） */
+  assessments: AssessmentSummaryInput[];
+  /** Iceberg 分析情報（複数シートから結合可） */
+  icebergSummaries: IcebergSummaryInput[];
+  /** モニタリング情報 */
+  monitoring: MonitoringSummaryInput | null;
+  /** 既存の goals（重複排除用） */
+  existingGoals: GoalItem[];
+  /** アセスメント概要テキスト（フォームの assessmentSummary） */
+  assessmentSummaryText: string;
+  /** ストレングス */
+  strengths: string;
+};
+
+// ────────────────────────────────────────────
+// キーワード → ドメイン マッピング
+// ────────────────────────────────────────────
+
+type DomainKeywordRule = {
+  domain: string;
+  keywords: string[];
+};
+
+const DOMAIN_KEYWORD_RULES: DomainKeywordRule[] = [
+  {
+    domain: 'health',
+    keywords: ['健康', '体調', '服薬', '睡眠', '食事', '栄養', '医療', '通院', '体重', '発作', 'てんかん', '生活習慣'],
+  },
+  {
+    domain: 'motor',
+    keywords: ['運動', '感覚', '歩行', '姿勢', '動作', '筋力', '転倒', 'バランス', '移動', '手先', '巧緻性', '感覚過敏'],
+  },
+  {
+    domain: 'cognitive',
+    keywords: ['認知', '行動', '注意', '記憶', '理解', '判断', '学習', '問題行動', '自傷', '他害', 'こだわり', 'パニック', '切替', '見通し'],
+  },
+  {
+    domain: 'language',
+    keywords: ['言語', 'コミュニケーション', '発話', '表現', '会話', '意思', '伝達', '要求', '応答', '理解力', 'やりとり'],
+  },
+  {
+    domain: 'social',
+    keywords: ['社会', '人間関係', '参加', '活動', '集団', '余暇', '就労', '地域', '社交', '対人', 'ルール', '順番', '協調'],
+  },
+];
+
+// ────────────────────────────────────────────
+// 内部ユーティリティ
+// ────────────────────────────────────────────
+
+let _counter = 0;
+
+/** 候補用の一意 ID を生成する */
+export function generateSuggestionId(): string {
+  _counter += 1;
+  return `suggestion-${Date.now()}-${_counter}`;
+}
+
+/** @internal テスト用にカウンターをリセット */
+export function _resetCounter(): void {
+  _counter = 0;
+}
+
+/** テキストからドメインを推論する */
+export function inferDomains(text: string): string[] {
+  const matched: string[] = [];
+  const lowerText = text.toLowerCase();
+  for (const rule of DOMAIN_KEYWORD_RULES) {
+    if (rule.keywords.some((kw) => lowerText.includes(kw))) {
+      matched.push(rule.domain);
+    }
+  }
+  return matched.length > 0 ? matched : ['cognitive']; // デフォルト: 認知・行動
+}
+
+/** 既存 goals にテキストが類似するか判定（簡易部分一致） */
+function isDuplicate(title: string, existingGoals: GoalItem[]): boolean {
+  const normalized = title.replace(/\s+/g, '').toLowerCase();
+  return existingGoals.some((g) => {
+    const existingNorm = (g.label + g.text).replace(/\s+/g, '').toLowerCase();
+    // 8文字以上の共通部分があれば重複とみなす
+    return (
+      normalized.length >= 8 &&
+      (existingNorm.includes(normalized.slice(0, 8)) ||
+        normalized.includes(existingNorm.slice(0, 8)))
+    );
+  });
+}
+
+/** テキストを行に分割して空行を除去する */
+function splitLines(text: string): string[] {
+  return text
+    .split(/[。\n]/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+// ────────────────────────────────────────────
+// 候補生成ルール
+// ────────────────────────────────────────────
+
+/** アセスメントから長期目標候補を生成する */
+function suggestFromAssessments(
+  assessments: AssessmentSummaryInput[],
+  existingGoals: GoalItem[],
+): GoalSuggestion[] {
+  const suggestions: GoalSuggestion[] = [];
+
+  for (const assessment of assessments) {
+    // 高リスクの場合 → リスク軽減の長期目標を提案
+    if (assessment.riskLevel === 'high') {
+      const title = 'リスク軽減に向けた安全な環境の確保';
+      if (!isDuplicate(title, existingGoals)) {
+        suggestions.push({
+          id: generateSuggestionId(),
+          title,
+          rationale: 'アセスメントにおいてリスクレベルが「高」と評価されています。安全確保を最優先目標とすることを推奨します。',
+          suggestedSupports: [
+            '危機時のエスカレーション手順の整備',
+            '環境調整による刺激の低減',
+            '定期的なリスクモニタリングの実施',
+          ],
+          priority: 'high',
+          provenance: ['アセスメント: リスクレベル＝高'],
+          goalType: 'long',
+          domains: ['health'],
+        });
+      }
+    }
+
+    // 対象行動から短期目標を提案
+    for (const behavior of assessment.targetBehaviors) {
+      if (!behavior) continue;
+      const title = `${behavior}の頻度・強度の低減`;
+      if (!isDuplicate(title, existingGoals)) {
+        suggestions.push({
+          id: generateSuggestionId(),
+          title,
+          rationale: `対象行動「${behavior}」が特定されています。具体的で測定可能な行動目標の設定を推奨します。`,
+          suggestedSupports: [
+            `${behavior}発生時の対応手順の統一`,
+            '代替行動の指導',
+            '前兆行動への早期介入',
+          ],
+          priority: 'high',
+          provenance: [`アセスメント: 対象行動「${behavior}」`],
+          goalType: 'short',
+          domains: inferDomains(behavior),
+        });
+      }
+    }
+
+    // 仮説から支援内容の候補を提案
+    for (const hyp of assessment.hypotheses) {
+      if (!hyp.function || hyp.confidence === 'low') continue;
+      const title = `行動の機能（${hyp.function}）に基づく代替手段の獲得`;
+      if (!isDuplicate(title, existingGoals)) {
+        suggestions.push({
+          id: generateSuggestionId(),
+          title,
+          rationale: `行動の機能が「${hyp.function}」と仮説されています（信頼度: ${hyp.confidence}）。この機能を満たす代替行動の獲得を目標とすることを推奨します。`,
+          suggestedSupports: [
+            `${hyp.function}の要求を適切に表現する方法の指導`,
+            '機能的等価行動（FCT）の訓練',
+          ],
+          priority: hyp.confidence === 'high' ? 'high' : 'medium',
+          provenance: [`アセスメント: 機能仮説「${hyp.function}」（${hyp.confidence}）`],
+          goalType: 'support',
+          domains: inferDomains(hyp.function + ' ' + hyp.evidence),
+        });
+      }
+    }
+
+    // 健康要因があれば健康目標を提案
+    if (assessment.healthFactors.length > 0) {
+      const factorsStr = assessment.healthFactors.join('・');
+      const title = '健康管理体制の整備';
+      if (!isDuplicate(title, existingGoals)) {
+        suggestions.push({
+          id: generateSuggestionId(),
+          title,
+          rationale: `健康上の要因（${factorsStr}）が確認されています。行動支援と並行した健康管理を推奨します。`,
+          suggestedSupports: assessment.healthFactors.map((f) => `${f}に関する定期確認と記録`),
+          priority: 'medium',
+          provenance: [`アセスメント: 健康要因（${factorsStr}）`],
+          goalType: 'long',
+          domains: ['health'],
+        });
+      }
+    }
+  }
+
+  return suggestions;
+}
+
+/** Iceberg 分析から目標候補を生成する */
+function suggestFromIceberg(
+  summaries: IcebergSummaryInput[],
+  existingGoals: GoalItem[],
+): GoalSuggestion[] {
+  const suggestions: GoalSuggestion[] = [];
+
+  for (const summary of summaries) {
+    // supportIssues から課題ベースの目標を提案
+    const issues = splitLines(summary.supportIssues);
+    for (const issue of issues.slice(0, 3)) {
+      // 最大3件
+      const title = issue.length > 40 ? issue.slice(0, 40) + '…' : issue;
+      if (!isDuplicate(title, existingGoals)) {
+        const domains = inferDomains(
+          `${summary.targetDomain} ${summary.targetScene} ${issue}`,
+        );
+        suggestions.push({
+          id: generateSuggestionId(),
+          title,
+          rationale: `Iceberg分析で支援課題として「${issue}」が特定されています。`,
+          suggestedSupports: summary.concreteApproaches
+            ? splitLines(summary.concreteApproaches).slice(0, 3)
+            : [],
+          priority: 'medium',
+          provenance: [
+            `Iceberg分析: 支援課題`,
+            ...(summary.targetScene ? [`場面: ${summary.targetScene}`] : []),
+          ],
+          goalType: 'short',
+          domains,
+        });
+      }
+    }
+
+    // supportPolicy から長期方針を提案
+    if (summary.supportPolicy) {
+      const policyLines = splitLines(summary.supportPolicy);
+      for (const policy of policyLines.slice(0, 2)) {
+        const title = policy.length > 40 ? policy.slice(0, 40) + '…' : policy;
+        if (!isDuplicate(title, existingGoals)) {
+          suggestions.push({
+            id: generateSuggestionId(),
+            title,
+            rationale: `Iceberg分析の対応方針に基づく目標候補です。`,
+            suggestedSupports: [],
+            priority: 'medium',
+            provenance: ['Iceberg分析: 対応方針'],
+            goalType: 'long',
+            domains: inferDomains(`${summary.targetDomain} ${policy}`),
+          });
+        }
+      }
+    }
+  }
+
+  return suggestions;
+}
+
+/** モニタリング情報から改善目標を提案する */
+function suggestFromMonitoring(
+  monitoring: MonitoringSummaryInput | null,
+  existingGoals: GoalItem[],
+): GoalSuggestion[] {
+  if (!monitoring) return [];
+  const suggestions: GoalSuggestion[] = [];
+
+  // 計画変更推奨の場合
+  if (monitoring.planChangeRequired) {
+    const title = 'モニタリング結果に基づく計画見直し';
+    if (!isDuplicate(title, existingGoals)) {
+      suggestions.push({
+        id: generateSuggestionId(),
+        title,
+        rationale: 'モニタリングにより計画変更が推奨されています。現状に合わせた目標の再設定を推奨します。',
+        suggestedSupports: [
+          '現行目標の達成度評価',
+          '新たなニーズの再アセスメント',
+          '目標と支援内容の再設計',
+        ],
+        priority: 'high',
+        provenance: ['モニタリング: 計画変更推奨'],
+        goalType: 'long',
+        domains: ['cognitive'],
+      });
+    }
+  }
+
+  // 改善メモから提案
+  if (monitoring.improvementIdeas) {
+    const ideas = splitLines(monitoring.improvementIdeas);
+    for (const idea of ideas.slice(0, 3)) {
+      const title = idea.length > 40 ? idea.slice(0, 40) + '…' : idea;
+      if (!isDuplicate(title, existingGoals)) {
+        suggestions.push({
+          id: generateSuggestionId(),
+          title,
+          rationale: '改善メモに記載された案を目標候補として提案します。',
+          suggestedSupports: [],
+          priority: 'low',
+          provenance: ['改善メモ'],
+          goalType: 'support',
+          domains: inferDomains(idea),
+        });
+      }
+    }
+  }
+
+  return suggestions;
+}
+
+/** アセスメント概要テキストとストレングスから補足提案 */
+function suggestFromFormText(
+  assessmentSummaryText: string,
+  strengths: string,
+  existingGoals: GoalItem[],
+): GoalSuggestion[] {
+  const suggestions: GoalSuggestion[] = [];
+
+  // ストレングスがあればそれを活かす目標を提案
+  if (strengths) {
+    const strengthLines = splitLines(strengths);
+    for (const s of strengthLines.slice(0, 2)) {
+      const title = `ストレングス「${s.slice(0, 20)}」を活かした活動拡大`;
+      if (!isDuplicate(title, existingGoals)) {
+        suggestions.push({
+          id: generateSuggestionId(),
+          title,
+          rationale: `ご本人のストレングスとして「${s}」が記録されています。これを活かした支援を推奨します。`,
+          suggestedSupports: [
+            `${s}を活用した新しい活動機会の提供`,
+            `${s}に基づく成功体験の蓄積`,
+          ],
+          priority: 'low',
+          provenance: ['フォーム: ストレングス'],
+          goalType: 'long',
+          domains: inferDomains(s),
+        });
+      }
+    }
+  }
+
+  return suggestions;
+}
+
+// ────────────────────────────────────────────
+// 優先度ソート
+// ────────────────────────────────────────────
+
+const PRIORITY_ORDER: Record<GoalPriority, number> = {
+  high: 0,
+  medium: 1,
+  low: 2,
+};
+
+function sortByPriority(suggestions: GoalSuggestion[]): GoalSuggestion[] {
+  return [...suggestions].sort((a, b) => PRIORITY_ORDER[a.priority] - PRIORITY_ORDER[b.priority]);
+}
+
+// ────────────────────────────────────────────
+// メインビルダー
+// ────────────────────────────────────────────
+
+/**
+ * 既存データから目標候補を生成する。
+ *
+ * ルール:
+ * 1. アセスメント（リスク / 対象行動 / 仮説 / 健康要因）
+ * 2. Iceberg 分析（支援課題 / 対応方針）
+ * 3. モニタリング（計画変更推奨 / 改善メモ）
+ * 4. フォームテキスト（ストレングス）
+ *
+ * - 既存 goals との重複は自動除外
+ * - 優先度順にソートして返す
+ * - 最大 15 件に制限
+ */
+export function buildSuggestedGoals(input: SuggestedGoalsInput): GoalSuggestion[] {
+  const all: GoalSuggestion[] = [
+    ...suggestFromAssessments(input.assessments, input.existingGoals),
+    ...suggestFromIceberg(input.icebergSummaries, input.existingGoals),
+    ...suggestFromMonitoring(input.monitoring, input.existingGoals),
+    ...suggestFromFormText(
+      input.assessmentSummaryText,
+      input.strengths,
+      input.existingGoals,
+    ),
+  ];
+
+  return sortByPriority(all).slice(0, 15);
+}
+
+/**
+ * GoalSuggestion → GoalItem 変換ヘルパー。
+ * ユーザーが候補を「採用」したときに使う。
+ */
+export function suggestionToGoalItem(suggestion: GoalSuggestion): GoalItem {
+  return {
+    id: suggestion.id,
+    type: suggestion.goalType,
+    label: suggestion.title,
+    text: suggestion.rationale,
+    domains: suggestion.domains,
+  };
+}

--- a/src/features/support-plan-guide/domain/suggestedGoalsAdapter.ts
+++ b/src/features/support-plan-guide/domain/suggestedGoalsAdapter.ts
@@ -1,0 +1,97 @@
+/**
+ * suggestedGoalsAdapter — SupportPlanBundle → SuggestedGoalsInput 変換
+ *
+ * P3-A Phase 2: 既存のドメインモデルを buildSuggestedGoals の入力形式に寄せる。
+ *
+ * 設計原則:
+ *  - 純粋関数のみ（React 非依存）
+ *  - SupportPlanBundle + SupportPlanForm からデータを集約
+ */
+
+import type { SupportPlanBundle, SupportPlanningSheet } from '@/domain/isp/schema';
+import type { SupportPlanForm } from '../types';
+import type {
+  SuggestedGoalsInput,
+  AssessmentSummaryInput,
+  IcebergSummaryInput,
+  MonitoringSummaryInput,
+} from './suggestedGoals';
+
+// ────────────────────────────────────────────
+// 個別変換関数
+// ────────────────────────────────────────────
+
+/** SupportPlanningSheet.assessment → AssessmentSummaryInput */
+export function toAssessmentSummary(
+  sheet: SupportPlanningSheet,
+): AssessmentSummaryInput {
+  const { assessment } = sheet;
+  return {
+    targetBehaviors: assessment.targetBehaviors.map((b) => b.name).filter(Boolean),
+    hypotheses: assessment.hypotheses.map((h) => ({
+      function: h.function,
+      evidence: h.evidence,
+      confidence: h.confidence,
+    })),
+    riskLevel: assessment.riskLevel,
+    healthFactors: assessment.healthFactors,
+  };
+}
+
+/** SupportPlanningSheet → IcebergSummaryInput */
+export function toIcebergSummary(
+  sheet: SupportPlanningSheet,
+): IcebergSummaryInput {
+  return {
+    observationFacts: sheet.observationFacts ?? '',
+    supportIssues: sheet.supportIssues ?? '',
+    supportPolicy: sheet.supportPolicy ?? '',
+    concreteApproaches: sheet.concreteApproaches ?? '',
+    targetScene: sheet.targetScene ?? '',
+    targetDomain: sheet.targetDomain ?? '',
+  };
+}
+
+/** SupportPlanForm → MonitoringSummaryInput */
+export function toMonitoringSummary(
+  form: SupportPlanForm,
+  latestMonitoring: SupportPlanBundle['latestMonitoring'],
+): MonitoringSummaryInput | null {
+  // モニタリング情報がなく、フォームにも記載がなければ null
+  if (!latestMonitoring && !form.monitoringPlan && !form.improvementIdeas) {
+    return null;
+  }
+  return {
+    monitoringPlan: form.monitoringPlan,
+    reviewTiming: form.reviewTiming,
+    planChangeRequired: latestMonitoring?.planChangeRequired ?? false,
+    improvementIdeas: form.improvementIdeas,
+  };
+}
+
+// ────────────────────────────────────────────
+// メインアダプター
+// ────────────────────────────────────────────
+
+/**
+ * SupportPlanBundle + SupportPlanForm を SuggestedGoalsInput に変換する。
+ *
+ * UI 側では以下のように呼び出す:
+ * ```ts
+ * const input = toSuggestedGoalsInput(bundle, form);
+ * const suggestions = buildSuggestedGoals(input);
+ * ```
+ */
+export function toSuggestedGoalsInput(
+  bundle: SupportPlanBundle,
+  form: SupportPlanForm,
+): SuggestedGoalsInput {
+  return {
+    assessments: bundle.planningSheets.map(toAssessmentSummary),
+    icebergSummaries: bundle.planningSheets.map(toIcebergSummary),
+    monitoring: toMonitoringSummary(form, bundle.latestMonitoring),
+    existingGoals: form.goals,
+    assessmentSummaryText: form.assessmentSummary,
+    strengths: form.strengths,
+  };
+}


### PR DESCRIPTION
## 概要

支援計画ガイドに **目標候補の自動生成（ルールベース）** を追加する domain layer の MVP。

## 新規ファイル

### `domain/suggestedGoals.ts`
- `GoalSuggestion` 型定義（id / title / rationale / suggestedSupports / priority / provenance / goalType / domains）
- `buildSuggestedGoals()`: アセスメント / Iceberg / モニタリング / フォームテキストから目標候補を生成
- `inferDomains()`: テキストからドメイン（health / motor / cognitive / language / social）を推論
- `suggestionToGoalItem()`: 候補採用時の GoalItem 変換ヘルパー

### `domain/suggestedGoalsAdapter.ts`
- `toSuggestedGoalsInput()`: SupportPlanBundle + SupportPlanForm → SuggestedGoalsInput 変換
- 個別変換: toAssessmentSummary / toIcebergSummary / toMonitoringSummary

## 設計方針
- **ルールベース（AI/LLM 非依存）**: キーワードマッチ + 構造ルール
- **説明可能性**: 全候補に provenance（出典）を付与
- **重複排除**: 既存 goals のラベルとの8文字以上部分一致で自動除外
- **純粋関数**: React / 副作用 非依存
- **最大15件 / 優先度順ソート（high → medium → low）**

## テスト
- `suggestedGoals.spec.ts`: **23 テスト**（全ルール / 重複排除 / ソート / 件数制限）
- `suggestedGoalsAdapter.spec.ts`: **8 テスト**（型変換 / null安全 / 統合）
- 既存テスト 226 pass（リグレッションなし）

## 次のステップ
- UI 統合（SuggestedGoalsList コンポーネント）
- 候補採用の accept/dismiss フロー
- 改善メモへの提案表示