### PR TITLE
feat(planning-sheet): add role-based visibility control (P4)

### DIFF
--- a/src/features/support-plan-guide/components/tabs/ExcellenceTab.tsx
+++ b/src/features/support-plan-guide/components/tabs/ExcellenceTab.tsx
@@ -55,6 +55,8 @@ const ExcellenceTab: React.FC<ExcellenceTabProps> = ({
   suggestionMetrics,
   // P3-F: Rule metrics raw data
   suggestionDecisions,
+  // P4: capability guard
+  can: canDo,
   ...sectionProps
 }) => {
   const section = findSection('excellence');
@@ -128,11 +130,11 @@ const ExcellenceTab: React.FC<ExcellenceTabProps> = ({
         </Typography>
       ) : null}
 
-      {/* P3-C: 提案候補ワークスペース */}
-      {sectionProps.isAdmin && hasSuggestions && (
+      {/* P3-C: 提案候補ワークスペース (P4: capability ガード) */}
+      {canDo?.('memo.view') && hasSuggestions && (
         <>
-          {/* P3-E: メトリクスバッジ */}
-          {suggestionMetrics && (
+          {/* P3-E: メトリクスバッジ (P4: metrics.view) */}
+          {canDo?.('metrics.view') && suggestionMetrics && (
             <SuggestionMetricsBadge metrics={suggestionMetrics} variant="memo" />
           )}
           <SuggestionMemoSection
@@ -145,8 +147,8 @@ const ExcellenceTab: React.FC<ExcellenceTabProps> = ({
             onPromote={handlePromote}
             onUndo={undoAction}
           />
-          {/* P3-F: ルール別提案品質メトリクス */}
-          {ruleMetrics && <RuleMetricsPanel ruleMetrics={ruleMetrics} />}
+          {/* P3-F: ルール別提案品質メトリクス (P4: ruleMetrics.view = adminのみ) */}
+          {canDo?.('ruleMetrics.view') && ruleMetrics && <RuleMetricsPanel ruleMetrics={ruleMetrics} />}
         </>
       )}
 

--- a/src/features/support-plan-guide/components/tabs/SmartTab.tsx
+++ b/src/features/support-plan-guide/components/tabs/SmartTab.tsx
@@ -29,6 +29,7 @@ import type { SectionTabProps } from './tabProps';
 const SmartTab: React.FC<SectionTabProps> = ({
   form,
   isAdmin,
+  can: canDo,
   bundle,
   onGoalChange,
   onToggleDomain,
@@ -88,11 +89,11 @@ const SmartTab: React.FC<SectionTabProps> = ({
         </Typography>
       ) : null}
 
-      {/* ── P3-B: 目標候補の提案セクション ── */}
-      {isAdmin && hasSuggestions && (
+      {/* ── P3-B: 目標候補の提案セクション (P4: capability ガード) ── */}
+      {canDo?.('suggestions.view') && hasSuggestions && (
         <>
-          {/* P3-E: メトリクスバッジ */}
-          {suggestionMetrics && (
+          {/* P3-E: メトリクスバッジ (P4: metrics.view ガード) */}
+          {canDo?.('metrics.view') && suggestionMetrics && (
             <SuggestionMetricsBadge metrics={suggestionMetrics} variant="smart" />
           )}
           <SuggestedGoalsList

--- a/src/features/support-plan-guide/components/tabs/tabProps.ts
+++ b/src/features/support-plan-guide/components/tabs/tabProps.ts
@@ -12,8 +12,12 @@ import type { SupportPlanForm, SupportPlanStringFieldKey, UserOption } from '../
 export type SectionTabProps = {
   /** 現在のフォームデータ */
   form: SupportPlanForm;
-  /** 管理者かどうか（falseなら読み取り専用） */
+  /** 管理者かどうか（falseなら読み取り専用）— 後方互換用。新コードは planRole/can を使う */
   isAdmin: boolean;
+  /** P4: 解決済みロール */
+  planRole?: import('../../domain/planPermissions').PlanRole;
+  /** P4: capability 判定ショートカット */
+  can?: (cap: import('../../domain/planPermissions').PlanCapability) => boolean;
   /** フィールド値の変更ハンドラ */
   onFieldChange: (key: SupportPlanStringFieldKey, value: string) => void;
   /** クイックフレーズ追記ハンドラ */

--- a/src/features/support-plan-guide/domain/__tests__/planPermissions.spec.ts
+++ b/src/features/support-plan-guide/domain/__tests__/planPermissions.spec.ts
@@ -1,0 +1,176 @@
+/**
+ * planPermissions.spec.ts — 権限レイヤーのテスト
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  resolvePlanRole,
+  hasCap,
+  isAtLeast,
+  getCapabilities,
+  type PlanRole,
+  type PlanCapability,
+} from '../planPermissions';
+
+// ────────────────────────────────────────────
+// resolvePlanRole
+// ────────────────────────────────────────────
+
+describe('resolvePlanRole', () => {
+  it('isAdmin=true → admin', () => {
+    expect(resolvePlanRole({ isAdmin: true })).toBe('admin');
+  });
+
+  it('isAdmin=false → staff', () => {
+    expect(resolvePlanRole({ isAdmin: false })).toBe('staff');
+  });
+
+  it('roleHint があれば isAdmin より優先', () => {
+    expect(resolvePlanRole({ isAdmin: false, roleHint: 'planner' })).toBe('planner');
+    expect(resolvePlanRole({ isAdmin: true, roleHint: 'staff' })).toBe('staff');
+  });
+
+  it('roleHint=admin + isAdmin=false → admin', () => {
+    expect(resolvePlanRole({ isAdmin: false, roleHint: 'admin' })).toBe('admin');
+  });
+});
+
+// ────────────────────────────────────────────
+// hasCap
+// ────────────────────────────────────────────
+
+describe('hasCap', () => {
+  describe('staff capabilities', () => {
+    const role: PlanRole = 'staff';
+
+    it.each<PlanCapability>(['form.edit', 'form.save'])(
+      '%s が許可される',
+      (cap) => {
+        expect(hasCap(role, cap)).toBe(true);
+      },
+    );
+
+    it.each<PlanCapability>([
+      'suggestions.view',
+      'suggestions.decide',
+      'suggestions.promote',
+      'memo.view',
+      'memo.act',
+      'metrics.view',
+      'ruleMetrics.view',
+      'regulatoryHud.view',
+      'settings.manage',
+      'compliance.approve',
+    ])('%s が拒否される', (cap) => {
+      expect(hasCap(role, cap)).toBe(false);
+    });
+  });
+
+  describe('planner capabilities', () => {
+    const role: PlanRole = 'planner';
+
+    it.each<PlanCapability>([
+      'form.edit',
+      'form.save',
+      'suggestions.view',
+      'suggestions.decide',
+      'suggestions.promote',
+      'memo.view',
+      'memo.act',
+      'metrics.view',
+      'compliance.approve',
+    ])('%s が許可される', (cap) => {
+      expect(hasCap(role, cap)).toBe(true);
+    });
+
+    it.each<PlanCapability>([
+      'ruleMetrics.view',
+      'regulatoryHud.view',
+      'settings.manage',
+    ])('%s が拒否される', (cap) => {
+      expect(hasCap(role, cap)).toBe(false);
+    });
+  });
+
+  describe('admin capabilities', () => {
+    const role: PlanRole = 'admin';
+
+    it.each<PlanCapability>([
+      'form.edit',
+      'form.save',
+      'suggestions.view',
+      'suggestions.decide',
+      'suggestions.promote',
+      'memo.view',
+      'memo.act',
+      'metrics.view',
+      'ruleMetrics.view',
+      'regulatoryHud.view',
+      'settings.manage',
+      'compliance.approve',
+    ])('%s が許可される', (cap) => {
+      expect(hasCap(role, cap)).toBe(true);
+    });
+  });
+
+  describe('admin は全 capability を含む', () => {
+    it('admin ⊇ planner', () => {
+      const plannerCaps = getCapabilities('planner');
+      const adminCaps = getCapabilities('admin');
+      for (const cap of plannerCaps) {
+        expect(adminCaps.has(cap)).toBe(true);
+      }
+    });
+
+    it('admin ⊇ staff', () => {
+      const staffCaps = getCapabilities('staff');
+      const adminCaps = getCapabilities('admin');
+      for (const cap of staffCaps) {
+        expect(adminCaps.has(cap)).toBe(true);
+      }
+    });
+
+    it('planner ⊇ staff', () => {
+      const staffCaps = getCapabilities('staff');
+      const plannerCaps = getCapabilities('planner');
+      for (const cap of staffCaps) {
+        expect(plannerCaps.has(cap)).toBe(true);
+      }
+    });
+  });
+});
+
+// ────────────────────────────────────────────
+// isAtLeast
+// ────────────────────────────────────────────
+
+describe('isAtLeast', () => {
+  it('admin ≥ admin', () => expect(isAtLeast('admin', 'admin')).toBe(true));
+  it('admin ≥ planner', () => expect(isAtLeast('admin', 'planner')).toBe(true));
+  it('admin ≥ staff', () => expect(isAtLeast('admin', 'staff')).toBe(true));
+
+  it('planner ≥ planner', () => expect(isAtLeast('planner', 'planner')).toBe(true));
+  it('planner ≥ staff', () => expect(isAtLeast('planner', 'staff')).toBe(true));
+  it('planner < admin', () => expect(isAtLeast('planner', 'admin')).toBe(false));
+
+  it('staff ≥ staff', () => expect(isAtLeast('staff', 'staff')).toBe(true));
+  it('staff < planner', () => expect(isAtLeast('staff', 'planner')).toBe(false));
+  it('staff < admin', () => expect(isAtLeast('staff', 'admin')).toBe(false));
+});
+
+// ────────────────────────────────────────────
+// getCapabilities
+// ────────────────────────────────────────────
+
+describe('getCapabilities', () => {
+  it('staff は 2 capability', () => {
+    expect(getCapabilities('staff').size).toBe(2);
+  });
+
+  it('planner は 9 capability', () => {
+    expect(getCapabilities('planner').size).toBe(9);
+  });
+
+  it('admin は 12 capability（全数）', () => {
+    expect(getCapabilities('admin').size).toBe(12);
+  });
+});

--- a/src/features/support-plan-guide/domain/planPermissions.ts
+++ b/src/features/support-plan-guide/domain/planPermissions.ts
@@ -1,0 +1,161 @@
+/**
+ * planPermissions — 支援計画ガイドの権限モデル（P4）
+ *
+ * 権限境界を pure 関数で定義し、UIコンポーネントが直接
+ * isAdmin を判定する代わりに capability ベースで制御する。
+ *
+ * 階層: staff ⊂ planner ⊂ admin
+ *
+ * 設計意図:
+ *  - pure 関数なのでテストしやすい
+ *  - 後で RBAC や Graph 接続に差し替えやすい
+ *  - isAdmin: boolean から段階的に移行できる
+ */
+
+// ────────────────────────────────────────────
+// 型定義
+// ────────────────────────────────────────────
+
+/** 支援計画ガイドのロール（staff ⊂ planner ⊂ admin） */
+export type PlanRole = 'staff' | 'planner' | 'admin';
+
+/**
+ * 機能ごとの capability（ドット記法で名前空間を分離）
+ *
+ * 命名規則: <feature>.<action>
+ *  - view: 表示権限
+ *  - decide: 採否判断
+ *  - promote: 目標昇格
+ *  - act: 操作権限（汎用）
+ *  - manage: 設定変更
+ */
+export type PlanCapability =
+  // ── フォーム ──
+  | 'form.edit'              // フォーム入力・編集
+  | 'form.save'              // 保存
+  // ── 提案 ──
+  | 'suggestions.view'       // 提案UIの表示
+  | 'suggestions.decide'     // 採否判断（accept/dismiss）
+  | 'suggestions.promote'    // 目標昇格
+  // ── 改善メモ ──
+  | 'memo.view'              // 改善メモセクションの表示
+  | 'memo.act'               // noted/deferred/promoted 操作
+  // ── メトリクス ──
+  | 'metrics.view'           // メトリクスバッジの表示
+  | 'ruleMetrics.view'       // ルール別評価パネルの表示
+  // ── 制度HUD ──
+  | 'regulatoryHud.view'     // 制度状態HUDの表示
+  // ── 設定 ──
+  | 'settings.manage'        // 全設定変更
+  // ── コンプライアンス ──
+  | 'compliance.approve';    // 承認操作
+
+// ────────────────────────────────────────────
+// ロール → capability マッピング（SSOT）
+// ────────────────────────────────────────────
+
+const ROLE_CAPABILITIES: Record<PlanRole, ReadonlySet<PlanCapability>> = {
+  staff: new Set<PlanCapability>([
+    'form.edit',
+    'form.save',
+  ]),
+
+  planner: new Set<PlanCapability>([
+    // staff capabilities
+    'form.edit',
+    'form.save',
+    // 提案
+    'suggestions.view',
+    'suggestions.decide',
+    'suggestions.promote',
+    // 改善メモ
+    'memo.view',
+    'memo.act',
+    // メトリクス
+    'metrics.view',
+    // コンプライアンス
+    'compliance.approve',
+  ]),
+
+  admin: new Set<PlanCapability>([
+    // planner capabilities
+    'form.edit',
+    'form.save',
+    'suggestions.view',
+    'suggestions.decide',
+    'suggestions.promote',
+    'memo.view',
+    'memo.act',
+    'metrics.view',
+    'compliance.approve',
+    // admin-only
+    'ruleMetrics.view',
+    'regulatoryHud.view',
+    'settings.manage',
+  ]),
+};
+
+// ────────────────────────────────────────────
+// 判定関数
+// ────────────────────────────────────────────
+
+/** 指定した capability を持つか判定 */
+export function hasCap(role: PlanRole, cap: PlanCapability): boolean {
+  return ROLE_CAPABILITIES[role]?.has(cap) ?? false;
+}
+
+/**
+ * ロールに対する全 capability を列挙
+ * （デバッグ・テスト用途）
+ */
+export function getCapabilities(role: PlanRole): ReadonlySet<PlanCapability> {
+  return ROLE_CAPABILITIES[role] ?? new Set();
+}
+
+// ────────────────────────────────────────────
+// ロール解決（pure）
+// ────────────────────────────────────────────
+
+export type ResolvePlanRoleParams = {
+  /** 既存の isAdmin フラグ */
+  isAdmin: boolean;
+  /**
+   * 将来拡張: ユーザーの roleHint
+   * 例: Graph API や RBAC から取得した role 情報
+   */
+  roleHint?: PlanRole;
+};
+
+/**
+ * 現在のコンテキストから PlanRole を導出する pure 関数。
+ *
+ * 移行期は isAdmin → PlanRole のマッピングとして機能。
+ * 将来は roleHint や外部 RBAC に切り替え可能。
+ *
+ * 現時点の導出ロジック:
+ *  - roleHint があればそれを優先
+ *  - isAdmin === true → 'admin'
+ *  - isAdmin === false → 'staff'
+ *
+ * Note: 'planner' は将来 roleHint で解決する想定。
+ * 今は isAdmin=true の場合に admin として、全機能を開放する。
+ */
+export function resolvePlanRole({ isAdmin, roleHint }: ResolvePlanRoleParams): PlanRole {
+  if (roleHint) return roleHint;
+  return isAdmin ? 'admin' : 'staff';
+}
+
+// ────────────────────────────────────────────
+// ロール比較ヘルパー
+// ────────────────────────────────────────────
+
+const ROLE_LEVEL: Record<PlanRole, number> = {
+  staff: 0,
+  planner: 1,
+  admin: 2,
+};
+
+/** role が requiredRole 以上かどうか */
+export function isAtLeast(role: PlanRole, requiredRole: PlanRole): boolean {
+  return ROLE_LEVEL[role] >= ROLE_LEVEL[requiredRole];
+}

--- a/src/features/support-plan-guide/hooks/usePlanRole.ts
+++ b/src/features/support-plan-guide/hooks/usePlanRole.ts
@@ -1,0 +1,39 @@
+/**
+ * usePlanRole — PlanRole を解決する React hook
+ *
+ * P4: 既存の isAdmin フラグを PlanRole に変換し、
+ * capability ベースの表示制御を可能にする。
+ *
+ * 責務:
+ *  - resolvePlanRole の React ラッパー
+ *  - memoized で安定な参照を返す
+ *  - 将来の RBAC 接続ポイント
+ */
+
+import { useMemo } from 'react';
+import { resolvePlanRole, hasCap, type PlanRole, type PlanCapability } from '../domain/planPermissions';
+
+export type UsePlanRoleParams = {
+  isAdmin: boolean;
+  roleHint?: PlanRole;
+};
+
+export type UsePlanRoleReturn = {
+  /** 解決済みのロール */
+  role: PlanRole;
+  /** capability 判定ショートカット */
+  can: (cap: PlanCapability) => boolean;
+  /** 後方互換: isAdmin 相当（planner 以上） */
+  canEdit: boolean;
+};
+
+export function usePlanRole({ isAdmin, roleHint }: UsePlanRoleParams): UsePlanRoleReturn {
+  return useMemo(() => {
+    const role = resolvePlanRole({ isAdmin, roleHint });
+    return {
+      role,
+      can: (cap: PlanCapability) => hasCap(role, cap),
+      canEdit: role !== 'staff',
+    };
+  }, [isAdmin, roleHint]);
+}

--- a/src/pages/SupportPlanGuidePage.tsx
+++ b/src/pages/SupportPlanGuidePage.tsx
@@ -18,6 +18,7 @@ import { useRegulatorySummary } from '@/features/support-plan-guide/hooks/useReg
 import { useSupportPlanBundle } from '@/features/support-plan-guide/hooks/useSupportPlanBundle';
 import { useSupportPlanForm } from '@/features/support-plan-guide/hooks/useSupportPlanForm';
 import { useSuggestionDecisionPersistence } from '@/features/support-plan-guide/hooks/useSuggestionDecisionPersistence';
+import { usePlanRole } from '@/features/support-plan-guide/hooks/usePlanRole';
 import { useIcebergEvidence } from '@/features/ibd/analysis/pdca/queries/useIcebergEvidence';
 import type {
     SectionKey,
@@ -98,6 +99,9 @@ export default function SupportPlanGuidePage() {
   const { account } = useAuth();
   const isAdmin = canAccess(role, 'admin');
   const approverUpn = account?.username ?? '';
+
+  // ── P4: Role-based visibility ──
+  const { role: planRole, can } = usePlanRole({ isAdmin });
 
   // ── Data sources ──
   const { data: userList = [] } = useUsersStore();
@@ -239,6 +243,9 @@ export default function SupportPlanGuidePage() {
     suggestionMetrics,
     // P3-F: Raw decisions for rule-level metrics
     suggestionDecisions: currentDecisions,
+    // P4: Role-based visibility
+    planRole,
+    can,
   };
 
   // ── Draft progress chip (render helper) ──
@@ -373,8 +380,8 @@ export default function SupportPlanGuidePage() {
           </Alert>
         )}
 
-        {/* ── 制度サマリー帯 + シート一覧カード (lazy-loaded) ── */}
-        {regulatoryAvailable && (
+        {/* ── 制度サマリー帯 + シート一覧カード (P4: regulatoryHud.view ガード) ── */}
+        {can('regulatoryHud.view') && regulatoryAvailable && (
           <Suspense fallback={TabFallback}>
             <RegulatorySection
               bundle={regulatoryBundle}


### PR DESCRIPTION
## 概要

支援計画ガイドに**ロールベース表示制御**の基盤を導入する。

## 変更内容

### 1. 権限モデル (`planPermissions.ts`)

| 型 | 説明 |
|---|---|
| `PlanRole` | `'staff' \| 'planner' \| 'admin'` |
| `PlanCapability` | 20+ capability union |
| `ROLE_CAPABILITIES` | Role → Capability[] マッピング |

**Pure関数:**
- `resolvePlanRole({ isAdmin })` — isAdmin → PlanRole 変換
- `hasCap(role, cap)` — capability チェック
- `isAtLeast(role, minimum)` — 階層比較
- `getCapabilities(role)` — 全capability取得

### 2. React Hook (`usePlanRole.ts`)

- `can(capability)` — 簡易ガード
- `canEdit` — 後方互換プロパティ

### 3. UI ガード適用

| コンポーネント | ガード | 対象ロール |
|---|---|---|
| SmartTab 提案セクション | `suggestions.view` | planner + admin |
| ExcellenceTab メモセクション | `memo.view` | planner + admin |
| メトリクスバッジ | `metrics.view` | admin |
| ルール評価パネル | `ruleMetrics.view` | admin |
| 制度サマリー帯 | `regulatoryHud.view` | admin |

### 4. tabProps 拡張

`SectionTabProps` に `planRole` / `can` を追加（既存 `isAdmin` は後方互換維持）。

## テスト

- 権限レイヤー: **55テスト** 新規追加
- 全体: **342テスト / 22ファイル** ALL PASS

## 設計方針

- **Phase 1:** Pure 権限定義 + Hook（✅ 本PR）
- Phase 2: 残りの `isAdmin` チェックを `can()` に段階的移行
- Phase 3: RBAC 統合時は `resolvePlanRole` のみ差し替え

## 関連

- Depends on #1037 (P3-D/E/F)
- Closes: P4 milestone