### PR TITLE
🚀 Feature: Today Action Engine Telemetry & HUD Integration (Phase 4-A / 4-B)

### DIFF
--- a/docs/architecture/today-action-engine.md
+++ b/docs/architecture/today-action-engine.md
@@ -1,0 +1,122 @@
+# Today Action Queue Engine Architecture
+
+福祉OSにおける「Today（本日業務の実行レイヤー）」の中核となる、Action Queue Engineのアーキテクチャ図です。
+この設計の最大の特徴は、一般的な「UI側でソートや重要度判定を行う」アプローチを捨て、**「Domain Engineで完全な順序と状態を決定し、UI側は描画と橋渡しに徹する（アンプとして機能する）」**小さなOS設計となっている点です。
+
+## Architecture Diagram
+
+```mermaid
+graph TD
+    %% Styling
+    classDef domain fill:#f9f0ff,stroke:#d0b3e6,stroke-width:2px;
+    classDef hook fill:#e6f3ff,stroke:#99c2ff,stroke-width:2px;
+    classDef page fill:#fff0eb,stroke:#ffb399,stroke-width:2px;
+    classDef widget fill:#f0f9f0,stroke:#99e699,stroke-width:2px;
+    classDef env fill:#f0f0f0,stroke:#cccccc,stroke-width:2px;
+    
+    %% Inputs
+    subgraph DataSources [1. Data Sources]
+        DB_Schedule[Schedules]
+        DB_Handoff[Handoff / Logs]
+        DB_Vital[Vital Alerts]
+        DB_Incident[Incidents]
+    end
+
+    %% Domain Engine (Functional Pipeline)
+    subgraph DomainEngine [2. Domain Engine (Pure Functional Pipeline)]
+        direction TB
+        Raw[Raw Action Sources]
+        Score[Priority Scoring]
+        Urgency[Urgency Calculator]
+        Overdue[Overdue Evaluator]
+        Sort[Queue Sorter]
+        Map[ActionCard Mapper]
+        
+        Raw --> Score --> Urgency --> Overdue --> Sort --> Map
+    end
+    class DomainEngine domain
+
+    %% App Layer (Hook)
+    subgraph AppLayer [3. Application Layer (Hooks)]
+        Hook[useTodayActionQueue\n- Fetches data & invokes Engine -]
+    end
+    class AppLayer hook
+
+    %% Execution Layer (Page)
+    subgraph ExecutionLayer [4. Execution Layer (Page)]
+        Page[TodayOpsPage\n- Orchestrator -]
+        Bridge[ActionType Bridge\n- Interprets intent -]
+        
+        Page --> Bridge
+    end
+    class ExecutionLayer page
+
+    %% Presentation Layer (Widget)
+    subgraph PresentationLayer [5. Presentation Layer (UI Component)]
+        Widget[ActionQueueTimelineWidget\n- Amplifier -]
+        Cards[ActionCard Components\n- Strict visual contract -]
+        
+        Widget --> Cards
+    end
+    class PresentationLayer widget
+
+    %% Environment Operations
+    subgraph Environment [6. Target Environment]
+        ExecDrawer[QuickRecord Drawer]
+        ExecNav[React Router \n(Navigation)]
+        ExecAck[Acknowledge API \n(No-op / Logging)]
+    end
+    class Environment env
+
+    %% Data Flow
+    DataSources -.-> AppLayer
+    AppLayer -->|1. Feed Raw Data| DomainEngine
+    DomainEngine -->|2. IActionCard[] \nStrictly Ordered| AppLayer
+    
+    AppLayer -->|3. Pass Queue| Page
+    Page -->|4. Pass Queue & Handlers| Widget
+    
+    Cards -->|5. onClick| Bridge
+    Bridge -->|Action: OPEN_DRAWER| ExecDrawer
+    Bridge -->|Action: NAVIGATE| ExecNav
+    Bridge -->|Action: ACKNOWLEDGE| ExecAck
+
+```
+
+## Key Characteristics
+
+1. **Domain Engine (Decision Authority)**: 
+   Engineが「優先度（Priority）」「緊急度（Urgency）」「期限切れ（Overdue）」「順序（Sort）」のすべての決定権を持ちます。施設ごとのルール変更やアルゴリズムの調整はすべてこの層に閉じます。
+2. **ActionType Bridge (Structural Contract)**:
+   UIコンポーネントは具体的な業務ロジックを知りません。持っている情報は `OPEN_DRAWER`, `NAVIGATE`, `ACKNOWLEDGE` などの抽象化された `actionType` のみであり、Pageがそれを解釈してOS（ブラウザやルーター）の実際の挙動へ橋渡しします。
+3. **UI as an Amplifier (描画と橋渡し)**:
+   Widgetやカードは「受け取った配列を勝手に並び替えない」「重要フラグがあれば強調表示するだけ」という『アンプ（増幅器）』として振る舞います。これにより、Engineの進化によってUIが壊れることを防ぎます。
+
+## Telemetry Flow (Phase 4)
+
+Today Action Engine は単なる判断エンジンにとどまらず、**観測可能な運用OSコンポーネント**として機能します。
+意思決定系（Engine）と観測系（Telemetry）が交差せず並走するアーキテクチャを採用しています。
+
+```text
+useTodayActionQueue
+  builds queue (Pure Engine)
+  → summarizes latest queue (summarizeTodayQueue)
+  → pushes sample into ring buffer (diagnostic store)
+  → HydrationHud reads latest sample via TodayQueueHudPanel
+```
+
+### Telemetry Design Guidelines
+
+1. **HUD Display Conditions**
+   - HUD (Today Queue Telemetry) は、開発時または Diagnostics が有効（`isHudExplicitlyEnabled` 等）な環境でのみ表示される dev-only パネルです。
+   - Production の user-facing UI には情報が漏れないように分離されています。
+2. **Duplicate Push Guard (署名仕様)**
+   - Telemetry 更新のスパムを防ぐため、`id / priority / isOverdue` を連結したシグネチャを使用しています。
+   - 文言の変化やペイロードの差分では送信せず、「キューの並び順」と「重要な状態変化（優先度、期限切れ）」があった時のみ差異として監視バッファに送られます。
+3. **Thin Presentation Layer**
+   - `TodayQueueHudPanel` は store の latest sample を読むだけで、UI側での再集計は一切行いません（極薄プレゼンテーション層）。
+
+## Next Steps
+
+* **Phase 4-C**: Priority Rule Table (ハードコードされている優先順位を外部ルールテーブル化。施設差分や運用差分に強くする)
+* **Ops Dashboard Integration**: 取れた Telemetry を HUD だけでなく、将来的に本番運用のダッシュボード側に渡し、業務分析OSへの入力源とする

--- a/docs/today-action-telemetry-spec.md
+++ b/docs/today-action-telemetry-spec.md
@@ -1,0 +1,127 @@
+# Today Action Engine Telemetry & HUD 実装指示書 (Phase 4)
+
+## 背景と目的
+Today Action Engine（Phase 1〜3）により、業務アクションの優先度判定とUIの完全な分離が達成されました。
+Phase 4では、この分離されたアーキテクチャの強みを活かし、**「Engineがどのような判断を下したか」を副作用なく観測・可視化**します。
+
+* **Phase 4-A (Telemetry)**: Action Queueの健康状態（ヘルス）を要約して記録する
+* **Phase 4-B (HUD)**: 開発・検証時に、現在のメトリクスを即座に確認する
+
+これにより、「特定の優先度が偏っていないか」「キューが爆発していないか」といった運用上の異常をリアルタイムに検知できる「運用OS」への進化を目指します。
+
+---
+
+## 遵守すべき設計の3原則
+
+1. **Engine は純粋関数のまま維持する**
+   * `buildTodayActionQueue()` の内部でTelemetryを送信してはいけません。
+   * 通信や観測は、必ずフック層 (`useTodayActionQueue`) で行います。
+2. **Telemetry は「結果の要約」だけを送る**
+   * カードの全文やPayloadを流さず、要素数や状態（P0の数など）の集計値のみを記録します。
+3. **HUD は「診断専用（Dev Only）」に徹する**
+   * 運用者向けの業務UIには混ぜず、既存の開発用HUD等の隅に独立して配置します。
+
+---
+
+## ステップ別 実装手順（推奨 4 PR構成）
+
+実装は小さく安全に切り出します。以下の順序でPRを作成してください。
+
+### PR 1: Telemetry 型定義と純粋集約関数 (UI非依存)
+Engineが出力した `ActionCard[]` を要約するPure Functionを作成します。
+
+**作成ファイル:**
+* `src/features/today/telemetry/todayQueueTelemetry.types.ts`
+* `src/features/today/telemetry/summarizeTodayQueue.ts`
+* `src/features/today/telemetry/summarizeTodayQueue.spec.ts`
+
+**実装仕様:**
+```typescript
+// todayQueueTelemetry.types.ts
+export interface TodayQueueTelemetrySample {
+  timestamp: number;
+  queueSize: number;
+  p0Count: number;
+  p1Count: number;
+  p2Count: number;
+  p3Count: number;
+  overdueCount: number;
+  requiresAttentionCount: number;
+}
+
+// summarizeTodayQueue.ts
+import type { ActionCard } from '../domain/models/queue.types';
+import type { TodayQueueTelemetrySample } from './todayQueueTelemetry.types';
+
+export function summarizeTodayQueue(
+  items: ActionCard[],
+  timestamp: number
+): TodayQueueTelemetrySample {
+  return {
+    timestamp,
+    queueSize: items.length,
+    p0Count: items.filter((x) => x.priority === 'P0').length,
+    p1Count: items.filter((x) => x.priority === 'P1').length,
+    p2Count: items.filter((x) => x.priority === 'P2').length,
+    p3Count: items.filter((x) => x.priority === 'P3').length,
+    overdueCount: items.filter((x) => x.isOverdue).length,
+    requiresAttentionCount: items.filter((x) => x.requiresAttention).length,
+  };
+}
+```
+
+---
+
+### PR 2: Telemetry Store の新設
+履歴を一定数（直近50件程度）保持するための、軽量なStoreを作成します。
+
+**作成ファイル:**
+* `src/features/today/telemetry/todayQueueTelemetryStore.ts`
+* (Storeのテスト)
+
+**実装仕様:**
+* `samples` 配列の保持（上限を設ける）
+* `pushSample(sample)` メソッド
+* `clearSamples()` メソッド
+* `getLatestSample()` (getter)
+
+---
+
+### PR 3: Hook への Telemetry 接続
+Queueが再計算されたタイミングで、Summaryを作成してStoreにPushします。HUDはまだ作りません。
+
+**更新ファイル:**
+* `src/features/today/hooks/useTodayActionQueue.ts`
+
+**実装仕様:**
+* `useEffect`等を用いて、`actionQueue` の内容が確定したタイミングで1度だけ `summarizeTodayQueue` を実行。
+* 結果を `todayQueueTelemetryStore` へ送る。
+
+---
+
+### PR 4: Diagnostics HUD の作成と注入
+開発時にAction Queueの健康状態を確認するためのパネルを作成します。
+
+**作成ファイル:**
+* `src/features/today/widgets/TodayQueueHudPanel.tsx`
+
+**実装仕様:**
+* Storeから `latestSample` を購読し表示する。
+* 表示はテキストベースで十分（グラフ化は不要）。
+* 異常値のハイライトを入れる：
+  * `p0Count > 0` → ⚠️ Warning (Red系)
+  * `overdueCount > 0` → ⚠️ Caution (Orange系)
+  * `queueSize` が一定以上 → High Load
+* 既存の開発用HUD領域や、Devビルド時のみ表示されるエリアにこのコンポーネントを配置する。
+
+---
+
+## やらないこと（非推奨事項）
+
+Phase 4-A/B の完了条件をシャープに保つため、**以下は現時点では実装しません**：
+* Payloadなど詳細データの記録（トークン・通信量の無駄）
+* Action個別のクリック・開封ログ（別機構で追及すべき）
+* 最初からリッチな時系列グラフを描くこと（まずは最新1件の表示で十分）
+* 本番データベースへの永続化（まずはクライアント上での観測から始める）
+
+以上の制約を守り、「**Today Action Engine の純粋性は維持したまま、Hook層で出力結果を観測・集約し、HUDにLatest Healthとして表示する**」ことを目指します。

--- a/pr_desc.md
+++ b/pr_desc.md
@@ -1,0 +1,34 @@
+# 🚀 Feature: Today Action Engine Telemetry & HUD Integration (Phase 4-A / 4-B)
+
+**Today Action Engine を、単なる判断エンジンから「観測可能な運用OSコンポーネント」へ昇格させました。**
+
+## 💡 概要
+
+Today の業務実行レイヤー（Action Queue）に対し、既存の純粋な優先度判断アルゴリズム（Engine）を全く汚染することなく、リアルタイムな業務負荷やタスク構成を観測できる Telemetry の流路を実装しました。これにより「意志決定系」と「観測系」が見事に並走・分離するアーキテクチャが完成しています。
+
+## ✨ 実装のハイライト
+
+1. **Telemetry Store の新設**
+   - 揮発性の Ring Buffer（Zustand ベース）を用いてキューの状態を一定数キャッシュする `TodayQueueTelemetryStore` を実装。
+   - `queueSize`, `p0Count`, `overdueCount` などの「業務の健康状態」を示す重要件数を `summarizeTodayQueue` 関数で集計します。
+2. **Hook への観測点と重複送信ガード（Smart Push）の追加**
+   - `useTodayActionQueue` でキューが算定された直後の最も信頼できるタイミングを観測点に設定。
+   - **重複送信ガード機能**: 
+     「UIの文言変化など意図しない再レンダリング」で Telemetry がスパムされないよう、各アイテムの `id + priority + isOverdue` 特徴量でシグネチャを生成。並び順と重要なタスク状態変化があった場合のみバッファへ記録します。
+3. **Queue Diagnostics HUD パネル**
+   - `HydrationHud` の診断セクション内に `<TodayQueueHudPanel />` を新規追加しました（dev-only でのみ表示）。
+   - 「Store の Latest Sample をただ表示するだけ」の **極薄プレゼンテーション** に徹底し、HUD内での再集計は行いません。
+   - これにより、Fetch Health / Circuit Breaker / Prefetch と合わせた包括的な監視をシームレスに行える環境が整いました。
+
+## 🔧 Architecture / OS Principles
+
+- **Engine の純粋防衛:** ロギング・バッファリングの責務を Hook に移譲したため、Engine 側での副作用はゼロです。
+- **分離された情報公開:** HUD の表示は Diagnostics 環境に制約し、一般ユーザの画面（Production UI）には決して影響が出ない堅牢な仕様としています。
+
+## 🎯 Next Steps (Options)
+
+この基盤をベースに、今後は以下の展開が考えられます。
+* **Phase 4-C: Priority Rule Table**
+  現在のハードコードされた優先順位（Vital=P0, Incident=P1 等）を分離可能な外部ルールテーブル化し、施設/運用別のカスタマイズに備える。
+* **Ops Dashboard Integration**
+  今回整備された HUD 向けの Telemetry バッファを、本格的な本番運用向け運用OSダッシュボード（またはビッグデータ基盤）の入力源となるよう拡張する。

--- a/src/debug/HydrationHud.tsx
+++ b/src/debug/HydrationHud.tsx
@@ -25,6 +25,7 @@ import {
   toTelemetrySpan,
   type HydrationTelemetrySpan,
 } from '@/telemetry/hydrationBeacon';
+import { TodayQueueHudPanel } from '@/features/today/telemetry/TodayQueueHudPanel';
 import { useCallback, useEffect, useMemo, useState, type CSSProperties } from 'react';
 
 const STORAGE_KEY = 'prefetch:hud:visible';
@@ -465,6 +466,8 @@ export const HydrationHud: React.FC = () => {
                 </span>
               </div>
             </div>
+            {/* ── Today Queue Telemetry ───────────────────── */}
+            <TodayQueueHudPanel />
             <div style={sectionLabelStyle}>
             <span style={{ textTransform: 'uppercase', letterSpacing: 0.8 }}>Prefetch</span>
             <span style={totalStyle}>{prefetchEntries.length}</span>

--- a/src/features/today/hooks/__tests__/useTodayActionQueue.spec.ts
+++ b/src/features/today/hooks/__tests__/useTodayActionQueue.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useTodayActionQueue } from '../useTodayActionQueue';
+import { useTodayQueueTelemetryStore } from '../../telemetry/todayQueueTelemetryStore';
 
 describe('useTodayActionQueue', () => {
   beforeEach(() => {
@@ -41,5 +42,48 @@ describe('useTodayActionQueue', () => {
     // 再計算が走っているためオブジェクト参照が異なるはず
     // ※今回はUrgencyScoreや値が変わらなくても常に新しい配列が生成される設計
     expect(newQueue).not.toBe(initialQueue);
+  });
+
+  describe('Telemetry Tracking', () => {
+    beforeEach(() => {
+      useTodayQueueTelemetryStore.setState({ samples: [] });
+    });
+
+    it('queue 確定時に sample を1件 push する', () => {
+      renderHook(() => useTodayActionQueue());
+
+      const samples = useTodayQueueTelemetryStore.getState().samples;
+      // 最初のデータのフェッチ後に1回記録されるはず
+      expect(samples).toHaveLength(1);
+      
+      const latest = samples[0];
+      expect(latest.queueSize).toBeGreaterThan(0);
+      expect(latest.timestamp).toBeGreaterThan(0);
+    });
+
+    it('同一 queue 再レンダーで重複 push しない', () => {
+      const { rerender } = renderHook(() => useTodayActionQueue());
+
+      const stateBeforeRerender = useTodayQueueTelemetryStore.getState();
+      expect(stateBeforeRerender.samples).toHaveLength(1);
+
+      // 無関係な再レンダーを強制
+      rerender();
+
+      // 同じ要素で再レンダーされた場合でもシグネチャが変わらないため増えない
+      const stateAfterRerender = useTodayQueueTelemetryStore.getState();
+      expect(stateAfterRerender.samples).toHaveLength(1);
+    });
+
+    it('loading 中は push しない', () => {
+      renderHook(() => useTodayActionQueue());
+
+      // 今回、モックは同期的にすぐ完了してしまう。
+      // ただし Hook の初期ステートとして isLoading = true が挟まる。
+      // もし isLoading = true の状態で評価されていれば、samples に空要素等が混ざる可能性がある。
+      // しかしガードが入っているため、正常な 1回だけの記録となっていることを確認する
+      const samples = useTodayQueueTelemetryStore.getState().samples;
+      expect(samples).toHaveLength(1);
+    });
   });
 });

--- a/src/features/today/hooks/useTodayActionQueue.ts
+++ b/src/features/today/hooks/useTodayActionQueue.ts
@@ -1,7 +1,9 @@
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import type { ActionCard, RawActionSource } from '../domain/models/queue.types';
 import { buildTodayActionQueue } from '../domain/engine/buildTodayActionQueue';
 import { fetchMockActionSources } from '../domain/repositories/mockActionSources';
+import { summarizeTodayQueue } from '../telemetry/summarizeTodayQueue';
+import { useTodayQueueTelemetryStore } from '../telemetry/todayQueueTelemetryStore';
 
 interface UseTodayActionQueueOptions {
   pollingIntervalMs?: number;
@@ -61,6 +63,30 @@ export function useTodayActionQueue(
     if (sources.length === 0) return [];
     return buildTodayActionQueue(sources, now, currentStaffId);
   }, [sources, now, currentStaffId]);
+
+  // 5. Telemetry 観測と送信
+  const pushSample = useTodayQueueTelemetryStore((s) => s.pushSample);
+  const lastSignatureRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (isLoading) return;
+
+    // データがフェッチされていない初期状態はスキップ
+    if (sources.length === 0 && actionQueue.length === 0) return;
+
+    // queueの意図的変更を判定する署名を生成
+    const signature = JSON.stringify({
+      ids: actionQueue.map((x) => x.id),
+      priorities: actionQueue.map((x) => x.priority),
+      overdue: actionQueue.map((x) => x.isOverdue),
+    });
+
+    if (lastSignatureRef.current === signature) return;
+    lastSignatureRef.current = signature;
+
+    const sample = summarizeTodayQueue(actionQueue, Date.now());
+    pushSample(sample);
+  }, [actionQueue, isLoading, pushSample, sources.length]);
 
   return {
     actionQueue,

--- a/src/features/today/layouts/TodayBentoLayout.tsx
+++ b/src/features/today/layouts/TodayBentoLayout.tsx
@@ -52,6 +52,7 @@ import { TodayTasksCard, type TodayTasksCardProps } from '../widgets/TodayTasksC
 import { TodayServiceStructureCard } from '../widgets/TodayServiceStructureCard';
 import { UserCompactList, type UserRow } from '../widgets/UserCompactList';
 import { ActionQueueCard, type ActionQueueCardProps } from '../widgets/ActionQueueCard';
+import { ActionQueueTimelineWidget, type ActionQueueTimelineWidgetProps } from '../widgets/ActionQueueTimelineWidget';
 import { TodayPhaseIndicator } from '../widgets/TodayPhaseIndicator';
 
 // ─── Types ───────────────────────────────────────────────────
@@ -84,6 +85,8 @@ export type TodayBentoProps = {
   todayTasks?: TodayTasksCardProps;
   /** 未処理キュー表示 (optional: widget hidden when undefined) */
   actionQueue?: ActionQueueCardProps;
+  /** Timeline Engine queue (optional) */
+  actionQueueTimeline?: ActionQueueTimelineWidgetProps;
   /** 支援計画管理カード (optional: hidden when undefined) */
   workflowCard?: PlanningWorkflowCardProps;
   transport: { pending: TransportUser[]; inProgress: TransportUser[]; onArrived: (id: string) => void };
@@ -130,6 +133,7 @@ export const TodayBentoLayout: React.FC<TodayBentoProps> = ({
   onPhaseNavigate,
   todayTasks,
   actionQueue,
+  actionQueueTimeline,
   workflowCard,
   transportCard,
   users,
@@ -175,6 +179,18 @@ export const TodayBentoLayout: React.FC<TodayBentoProps> = ({
             testId="bento-action-queue"
           >
             <ActionQueueCard {...actionQueue} />
+          </BentoCard>
+        )}
+
+        {/* ── Row 0.4: ActionQueueTimeline (Engine-driven Action Queue) ── */}
+        {actionQueueTimeline && (
+          <BentoCard
+            colSpan={{ xs: 1, sm: 2, md: 4 }}
+            variant="default"
+            testId="bento-action-queue-timeline"
+          >
+            <SectionLabel emoji="⚡️" text="アクションキュー" />
+            <ActionQueueTimelineWidget {...actionQueueTimeline} />
           </BentoCard>
         )}
 

--- a/src/features/today/telemetry/TodayQueueHudPanel.tsx
+++ b/src/features/today/telemetry/TodayQueueHudPanel.tsx
@@ -1,0 +1,107 @@
+import type { CSSProperties } from 'react';
+import { useTodayQueueTelemetryStore, selectLatestTodayQueueSample } from './todayQueueTelemetryStore';
+
+const sectionLabelStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  fontSize: 13,
+  marginBottom: 8,
+  marginTop: 12,
+};
+
+const rowStyle: CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: '1fr',
+  gap: 4,
+  fontSize: 12,
+  lineHeight: 1.4,
+  padding: '6px 8px 6px 10px',
+  borderRadius: 8,
+  border: '1px solid rgba(148, 163, 184, 0.2)',
+  backgroundColor: 'rgba(30, 41, 59, 0.7)',
+};
+
+const emptyStateStyle: CSSProperties = {
+  fontSize: 12,
+  opacity: 0.7,
+  padding: '6px 8px 6px 10px',
+  textAlign: 'center',
+};
+
+const STATUS_COLORS = {
+  muted: 'rgba(148, 163, 184, 0.4)',
+  neutral: 'rgba(148, 163, 184, 0.8)',
+  caution: '#fbbf24', // yellow
+  warning: '#f87171', // red
+};
+
+export function TodayQueueHudPanel() {
+  const latest = useTodayQueueTelemetryStore(selectLatestTodayQueueSample);
+
+  if (!latest) {
+    return (
+      <>
+        <div style={sectionLabelStyle}>
+          <span style={{ textTransform: 'uppercase', letterSpacing: 0.8 }}>Today Queue</span>
+        </div>
+        <div data-testid="hud-today-queue-empty" style={emptyStateStyle}>
+          No queue telemetry yet
+        </div>
+      </>
+    );
+  }
+
+  // Determine status color
+  let statusColor = STATUS_COLORS.neutral;
+  if (latest.p0Count > 0) {
+    statusColor = STATUS_COLORS.warning;
+  } else if (latest.overdueCount > 0) {
+    statusColor = STATUS_COLORS.caution;
+  } else if (latest.queueSize === 0) {
+    statusColor = STATUS_COLORS.muted;
+  }
+
+  return (
+    <>
+      <div style={sectionLabelStyle}>
+        <span style={{ textTransform: 'uppercase', letterSpacing: 0.8 }}>Today Queue</span>
+        <span style={{ fontWeight: 600, letterSpacing: 0.2 }}>{latest.queueSize}</span>
+      </div>
+      <div
+        data-testid="hud-today-queue-data"
+        style={{
+          ...rowStyle,
+          borderLeft: `3px solid ${statusColor}`,
+          boxShadow: latest.p0Count > 0 ? '0 0 0 1px rgba(248, 113, 113, 0.35)' : 'none',
+        }}
+      >
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: '4px 8px', fontSize: 11 }}>
+          <StatCell label="Total" value={String(latest.queueSize)} />
+          <StatCell label="P0" value={String(latest.p0Count)} warn={latest.p0Count > 0} />
+          <StatCell label="P1" value={String(latest.p1Count)} />
+          <StatCell label="P2" value={String(latest.p2Count)} />
+          <StatCell label="P3" value={String(latest.p3Count)} />
+          <StatCell label="Overdue" value={String(latest.overdueCount)} caution={latest.overdueCount > 0} />
+          <StatCell label="Attn" value={String(latest.requiresAttentionCount)} caution={latest.requiresAttentionCount > 0} />
+        </div>
+        <div style={{ fontSize: 10, opacity: 0.5, textAlign: 'right', marginTop: 2 }}>
+          {new Date(latest.timestamp).toLocaleTimeString()}
+        </div>
+      </div>
+    </>
+  );
+}
+
+function StatCell({ label, value, warn, caution }: { label: string; value: string; warn?: boolean; caution?: boolean }) {
+  let color = '#e2e8f0';
+  if (warn) color = STATUS_COLORS.warning;
+  else if (caution) color = STATUS_COLORS.caution;
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column' }}>
+      <span style={{ opacity: 0.5, fontSize: 10, textTransform: 'uppercase' }}>{label}</span>
+      <span style={{ fontWeight: 600, color }}>{value}</span>
+    </div>
+  );
+}

--- a/src/features/today/telemetry/__tests__/TodayQueueHudPanel.spec.tsx
+++ b/src/features/today/telemetry/__tests__/TodayQueueHudPanel.spec.tsx
@@ -1,0 +1,88 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { useTodayQueueTelemetryStore } from '../todayQueueTelemetryStore';
+import { TodayQueueHudPanel } from '../TodayQueueHudPanel';
+
+describe('TodayQueueHudPanel', () => {
+  beforeEach(() => {
+    // Reset global zustand state
+    useTodayQueueTelemetryStore.setState({ samples: [] });
+  });
+
+  const baseSample = {
+    timestamp: 1000,
+    queueSize: 10,
+    p0Count: 0,
+    p1Count: 0,
+    p2Count: 0,
+    p3Count: 0,
+    overdueCount: 0,
+    requiresAttentionCount: 0,
+  };
+
+  it('sample がないとき "No queue telemetry yet" が表示される', () => {
+    render(<TodayQueueHudPanel />);
+    expect(screen.getByText('No queue telemetry yet')).not.toBeNull();
+    expect(screen.queryByTestId('hud-today-queue-data')).toBeNull();
+  });
+
+  it('sample があるとき items / P0 / overdue などが表示される', () => {
+    useTodayQueueTelemetryStore.setState({
+      samples: [
+        {
+          ...baseSample,
+          queueSize: 5,
+        },
+      ],
+    });
+
+    render(<TodayQueueHudPanel />);
+    
+    // データコンテナが表示されていること
+    const panel = screen.getByTestId('hud-today-queue-data');
+    expect(panel).not.toBeNull();
+    
+    // items / P0 / overdue などのラベルが表示されていること
+    expect(screen.getByText(/total/i)).not.toBeNull();
+    expect(screen.getByText('P0')).not.toBeNull();
+    expect(screen.getByText(/overdue/i)).not.toBeNull();
+  });
+
+  it('P0 があるとき warning 的な強調が出る', () => {
+    useTodayQueueTelemetryStore.setState({
+      samples: [{ ...baseSample, p0Count: 1 }],
+    });
+
+    render(<TodayQueueHudPanel />);
+    const panel = screen.getByTestId('hud-today-queue-data');
+    
+    // Warning色になっていること (#f87171) と shadow がついていること
+    expect(panel.style.borderLeft).toContain('rgb(248, 113, 113)'); // browser converts hex to rgb
+    expect(panel.style.boxShadow).not.toBe('none');
+  });
+
+  it('overdue があるとき overdue 強調(caution)が出る', () => {
+    useTodayQueueTelemetryStore.setState({
+      samples: [{ ...baseSample, overdueCount: 1 }],
+    });
+
+    render(<TodayQueueHudPanel />);
+    const panel = screen.getByTestId('hud-today-queue-data');
+    
+    // Caution色になっていること (#fbbf24) と shadow はついていないこと
+    expect(panel.style.borderLeft).toContain('rgb(251, 191, 36)');
+    expect(panel.style.boxShadow).toBe('none');
+  });
+
+  it('queueSize === 0 のとき muted / calm になる', () => {
+    useTodayQueueTelemetryStore.setState({
+      samples: [{ ...baseSample, queueSize: 0 }],
+    });
+
+    render(<TodayQueueHudPanel />);
+    const panel = screen.getByTestId('hud-today-queue-data');
+    
+    // Muted色になっていること
+    expect(panel.style.borderLeft).toContain('rgba(148, 163, 184, 0.4)');
+  });
+});

--- a/src/features/today/telemetry/summarizeTodayQueue.spec.ts
+++ b/src/features/today/telemetry/summarizeTodayQueue.spec.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import type { ActionCard } from '../domain/models/queue.types';
+import { summarizeTodayQueue } from './summarizeTodayQueue';
+
+describe('summarizeTodayQueue', () => {
+  const baseCard: Omit<ActionCard, 'id' | 'title' | 'priority' | 'isOverdue' | 'requiresAttention'> = {
+    contextMessage: '',
+    actionType: 'ACKNOWLEDGE',
+    payload: null,
+  };
+
+  it('summarizes an empty array correctly', () => {
+    const timestamp = 1234567890;
+    const result = summarizeTodayQueue([], timestamp);
+
+    expect(result).toEqual({
+      timestamp,
+      queueSize: 0,
+      p0Count: 0,
+      p1Count: 0,
+      p2Count: 0,
+      p3Count: 0,
+      overdueCount: 0,
+      requiresAttentionCount: 0,
+    });
+  });
+
+  it('correctly counts priorities', () => {
+    const items: ActionCard[] = [
+      { ...baseCard, id: '1', title: 'A', priority: 'P0', isOverdue: false, requiresAttention: false },
+      { ...baseCard, id: '2', title: 'B', priority: 'P0', isOverdue: false, requiresAttention: false },
+      { ...baseCard, id: '3', title: 'C', priority: 'P1', isOverdue: false, requiresAttention: false },
+      { ...baseCard, id: '4', title: 'D', priority: 'P2', isOverdue: false, requiresAttention: false },
+      { ...baseCard, id: '5', title: 'E', priority: 'P3', isOverdue: false, requiresAttention: false },
+    ];
+    const timestamp = 1000;
+    const result = summarizeTodayQueue(items, timestamp);
+
+    expect(result.queueSize).toBe(5);
+    expect(result.p0Count).toBe(2);
+    expect(result.p1Count).toBe(1);
+    expect(result.p2Count).toBe(1);
+    expect(result.p3Count).toBe(1);
+  });
+
+  it('correctly counts overdue and requiresAttention independently of priority', () => {
+    const items: ActionCard[] = [
+      { ...baseCard, id: '1', title: 'A', priority: 'P2', isOverdue: true, requiresAttention: false },
+      { ...baseCard, id: '2', title: 'B', priority: 'P3', isOverdue: false, requiresAttention: true },
+      // Both overdue and requiresAttention
+      { ...baseCard, id: '3', title: 'C', priority: 'P1', isOverdue: true, requiresAttention: true },
+    ];
+    const timestamp = 2000;
+    const result = summarizeTodayQueue(items, timestamp);
+
+    expect(result.overdueCount).toBe(2);
+    expect(result.requiresAttentionCount).toBe(2);
+    // Sanity check priorities
+    expect(result.p1Count).toBe(1);
+    expect(result.p2Count).toBe(1);
+    expect(result.p3Count).toBe(1);
+  });
+
+  it('does not mutate the input array', () => {
+    const items: ActionCard[] = [
+      { ...baseCard, id: '1', title: 'A', priority: 'P0', isOverdue: true, requiresAttention: true },
+    ];
+    // Freeze the array and its objects to ensure no mutations happen internally
+    Object.freeze(items[0]);
+    Object.freeze(items);
+
+    const timestamp = 3000;
+    
+    // If it mutates, this will throw an error in strict mode
+    expect(() => summarizeTodayQueue(items as ActionCard[], timestamp)).not.toThrow();
+  });
+
+  it('preserves the provided timestamp exactly', () => {
+    const items: ActionCard[] = [{ ...baseCard, id: '1', title: 'A', priority: 'P0', isOverdue: false, requiresAttention: false }];
+    const timestamp = 999999999;
+    const result = summarizeTodayQueue(items, timestamp);
+    
+    expect(result.timestamp).toBe(999999999);
+  });
+});

--- a/src/features/today/telemetry/summarizeTodayQueue.ts
+++ b/src/features/today/telemetry/summarizeTodayQueue.ts
@@ -1,0 +1,18 @@
+import type { ActionCard } from '../domain/models/queue.types';
+import type { TodayQueueTelemetrySample } from './todayQueueTelemetry.types';
+
+export function summarizeTodayQueue(
+  items: ActionCard[],
+  timestamp: number
+): TodayQueueTelemetrySample {
+  return {
+    timestamp,
+    queueSize: items.length,
+    p0Count: items.filter((x) => x.priority === 'P0').length,
+    p1Count: items.filter((x) => x.priority === 'P1').length,
+    p2Count: items.filter((x) => x.priority === 'P2').length,
+    p3Count: items.filter((x) => x.priority === 'P3').length,
+    overdueCount: items.filter((x) => x.isOverdue).length,
+    requiresAttentionCount: items.filter((x) => x.requiresAttention).length,
+  };
+}

--- a/src/features/today/telemetry/todayQueueTelemetry.types.ts
+++ b/src/features/today/telemetry/todayQueueTelemetry.types.ts
@@ -1,0 +1,10 @@
+export interface TodayQueueTelemetrySample {
+  timestamp: number;
+  queueSize: number;
+  p0Count: number;
+  p1Count: number;
+  p2Count: number;
+  p3Count: number;
+  overdueCount: number;
+  requiresAttentionCount: number;
+}

--- a/src/features/today/telemetry/todayQueueTelemetryStore.spec.ts
+++ b/src/features/today/telemetry/todayQueueTelemetryStore.spec.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { TodayQueueTelemetrySample } from './todayQueueTelemetry.types';
+import {
+  MAX_TELEMETRY_SAMPLES,
+  selectLatestTodayQueueSample,
+  useTodayQueueTelemetryStore,
+} from './todayQueueTelemetryStore';
+
+describe('todayQueueTelemetryStore', () => {
+  const dummySample: TodayQueueTelemetrySample = {
+    timestamp: 1000,
+    queueSize: 1,
+    p0Count: 0,
+    p1Count: 0,
+    p2Count: 0,
+    p3Count: 0,
+    overdueCount: 0,
+    requiresAttentionCount: 0,
+  };
+
+  beforeEach(() => {
+    // Reset state before each test to ensure tests are isolated
+    useTodayQueueTelemetryStore.setState({ samples: [] });
+  });
+
+  it('starts with empty samples', () => {
+    const state = useTodayQueueTelemetryStore.getState();
+    expect(state.samples).toEqual([]);
+    expect(selectLatestTodayQueueSample(state)).toBeUndefined();
+  });
+
+  it('can push a sample', () => {
+    const store = useTodayQueueTelemetryStore.getState();
+    store.pushSample(dummySample);
+
+    const newState = useTodayQueueTelemetryStore.getState();
+    expect(newState.samples).toHaveLength(1);
+    expect(newState.samples[0]).toEqual(dummySample);
+  });
+
+  it('can clear samples', () => {
+    const store = useTodayQueueTelemetryStore.getState();
+    store.pushSample(dummySample);
+
+    // Act
+    useTodayQueueTelemetryStore.getState().clearSamples();
+
+    // Assert
+    const clearedState = useTodayQueueTelemetryStore.getState();
+    expect(clearedState.samples).toEqual([]);
+    expect(selectLatestTodayQueueSample(clearedState)).toBeUndefined();
+  });
+
+  it('retrieves the last pushed sample using selectLatestTodayQueueSample', () => {
+    const store = useTodayQueueTelemetryStore.getState();
+    const sample1 = { ...dummySample, timestamp: 1000 };
+    const sample2 = { ...dummySample, timestamp: 2000 };
+
+    store.pushSample(sample1);
+    store.pushSample(sample2);
+
+    const latest = selectLatestTodayQueueSample(
+      useTodayQueueTelemetryStore.getState()
+    );
+    expect(latest).toEqual(sample2);
+  });
+
+  it(`truncates to exactly MAX_TELEMETRY_SAMPLES (${MAX_TELEMETRY_SAMPLES}) and drops the oldest`, () => {
+    const store = useTodayQueueTelemetryStore.getState();
+
+    // Push MAX_TELEMETRY_SAMPLES + 5 items
+    const overage = 5;
+    for (let i = 0; i < MAX_TELEMETRY_SAMPLES + overage; i++) {
+      store.pushSample({ ...dummySample, timestamp: i });
+    }
+
+    const newState = useTodayQueueTelemetryStore.getState();
+    
+    // Total should not exceed max
+    expect(newState.samples).toHaveLength(MAX_TELEMETRY_SAMPLES);
+
+    // Oldest 5 items should have been dropped.
+    // Index 0 shouldn't be timestamp 0, it should be overage
+    expect(newState.samples[0].timestamp).toBe(overage);
+
+    // The newest should be our last push operation
+    const latest = selectLatestTodayQueueSample(newState);
+    expect(latest?.timestamp).toBe(MAX_TELEMETRY_SAMPLES + overage - 1);
+  });
+});

--- a/src/features/today/telemetry/todayQueueTelemetryStore.ts
+++ b/src/features/today/telemetry/todayQueueTelemetryStore.ts
@@ -1,0 +1,34 @@
+import { create } from 'zustand';
+import type { TodayQueueTelemetrySample } from './todayQueueTelemetry.types';
+
+export const MAX_TELEMETRY_SAMPLES = 100;
+
+export interface TodayQueueTelemetryState {
+  samples: TodayQueueTelemetrySample[];
+  pushSample: (sample: TodayQueueTelemetrySample) => void;
+  clearSamples: () => void;
+}
+
+export const useTodayQueueTelemetryStore = create<TodayQueueTelemetryState>((set) => ({
+  samples: [],
+
+  pushSample: (sample) =>
+    set((state) => {
+      const next = [...state.samples, sample];
+      return {
+        samples:
+          next.length > MAX_TELEMETRY_SAMPLES
+            ? next.slice(next.length - MAX_TELEMETRY_SAMPLES)
+            : next,
+      };
+    }),
+
+  clearSamples: () => set({ samples: [] }),
+}));
+
+// Selectors
+export function selectLatestTodayQueueSample(
+  state: TodayQueueTelemetryState
+): TodayQueueTelemetrySample | undefined {
+  return state.samples[state.samples.length - 1];
+}

--- a/src/features/today/widgets/ActionCard.spec.tsx
+++ b/src/features/today/widgets/ActionCard.spec.tsx
@@ -1,0 +1,66 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { ActionCard } from './ActionCard';
+import type { ActionCard as IActionCard } from '../domain/models/queue.types';
+import { ThemeProvider, createTheme } from '@mui/material';
+
+const theme = createTheme();
+
+const renderWithTheme = (ui: React.ReactElement) => {
+  return render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>);
+};
+
+describe('ActionCard', () => {
+  const baseAction: IActionCard = {
+    id: 'act-1',
+    title: 'Test Action',
+    priority: 'P1',
+    contextMessage: 'This is a test context message',
+    actionType: 'NAVIGATE',
+    requiresAttention: false,
+    isOverdue: false,
+    payload: { path: '/test' }
+  };
+
+  it('renders correctly with given priority', () => {
+    renderWithTheme(<ActionCard action={baseAction} />);
+    expect(screen.getByText('Test Action')).toBeInTheDocument();
+    expect(screen.getByText('This is a test context message')).toBeInTheDocument();
+    expect(screen.getByText('高優先 (P1)')).toBeInTheDocument();
+  });
+
+  it('displays attention elements for P0 urgency', () => {
+    const p0Action = { ...baseAction, priority: 'P0' as const };
+    renderWithTheme(<ActionCard action={p0Action} />);
+    expect(screen.getByText('最優先 (P0)')).toBeInTheDocument();
+    
+    // MUI components with background colors
+    const cardElement = screen.getByTestId('action-card-act-1');
+    expect(cardElement).toBeInTheDocument();
+  });
+
+  it('displays overdue chip when isOverdue is true', () => {
+    const overdueAction = { ...baseAction, isOverdue: true };
+    renderWithTheme(<ActionCard action={overdueAction} />);
+    expect(screen.getByText('超過')).toBeInTheDocument();
+  });
+
+  it('calls onClick when clicking the card itself', () => {
+    const handleClick = vi.fn();
+    renderWithTheme(<ActionCard action={baseAction} onClick={handleClick} />);
+    const card = screen.getByTestId('action-card-act-1');
+    fireEvent.click(card);
+    expect(handleClick).toHaveBeenCalledWith(baseAction);
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClick when clicking the action icon button', () => {
+    const handleClick = vi.fn();
+    renderWithTheme(<ActionCard action={baseAction} onClick={handleClick} />);
+    const button = screen.getByRole('button');
+    fireEvent.click(button);
+    expect(handleClick).toHaveBeenCalledWith(baseAction);
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/today/widgets/ActionCard.tsx
+++ b/src/features/today/widgets/ActionCard.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { Box, Typography, Chip, IconButton, useTheme, alpha } from '@mui/material';
+import AssignmentLateIcon from '@mui/icons-material/AssignmentLate';
+import LaunchIcon from '@mui/icons-material/Launch';
+import CheckBoxOutlinedIcon from '@mui/icons-material/CheckBoxOutlined';
+
+import type { ActionCard as IActionCard, ActionPriority, ActionType } from '../domain/models/queue.types';
+
+export interface ActionCardProps {
+  action: IActionCard;
+  onClick?: (action: IActionCard) => void;
+}
+
+const PRIORITY_STYLES: Record<ActionPriority, { color: string; label: string }> = {
+  P0: { color: '#d32f2f', label: '最優先 (P0)' },   // error
+  P1: { color: '#ed6c02', label: '高優先 (P1)' },   // warning
+  P2: { color: '#0288d1', label: '低優先 (P2)' },   // info
+  P3: { color: '#9e9e9e', label: '定常 (P3)' }      // grey
+};
+
+const ACTION_ICONS: Record<ActionType, React.ReactNode> = {
+  OPEN_DRAWER: <LaunchIcon fontSize="small" />,
+  NAVIGATE: <LaunchIcon fontSize="small" />,
+  ACKNOWLEDGE: <AssignmentLateIcon fontSize="small" />,
+};
+
+export const ActionCard: React.FC<ActionCardProps> = ({ action, onClick }) => {
+  const theme = useTheme();
+  const priorityStyle = PRIORITY_STYLES[action.priority];
+  const isCritical = action.priority === 'P0';
+
+  return (
+    <Box
+      onClick={() => onClick?.(action)}
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        p: 2,
+        mb: 1.5,
+        borderRadius: 2,
+        border: `1px solid ${alpha(priorityStyle.color, 0.4)}`,
+        bgcolor: isCritical ? alpha(priorityStyle.color, 0.05) : 'background.paper',
+        cursor: onClick ? 'pointer' : 'default',
+        transition: 'all 0.2s',
+        '&:hover': {
+          bgcolor: alpha(priorityStyle.color, 0.1),
+          borderColor: priorityStyle.color,
+          transform: 'translateY(-2px)'
+        }
+      }}
+      data-testid={`action-card-${action.id}`}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flex: 1 }}>
+        {/* Source Icon Segment */}
+        <Box sx={{ color: priorityStyle.color, display: 'flex', alignItems: 'center' }}>
+          {ACTION_ICONS[action.actionType]}
+        </Box>
+
+        {/* Content Segment */}
+        <Box sx={{ flex: 1 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
+            <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+              {action.title}
+            </Typography>
+            <Chip 
+              label={priorityStyle.label} 
+              size="small" 
+              sx={{ 
+                height: 20, 
+                fontSize: '0.65rem', 
+                bgcolor: priorityStyle.color, 
+                color: '#fff',
+                fontWeight: 'bold',
+                ...(isCritical && { animation: 'pulse 1.5s infinite' })
+              }} 
+            />
+            {action.isOverdue && (
+              <Chip
+                label="超過"
+                size="small"
+                sx={{
+                  height: 20,
+                  fontSize: '0.65rem',
+                  bgcolor: theme.palette.error.main,
+                  color: '#fff',
+                  fontWeight: 'bold'
+                }}
+              />
+            )}
+          </Box>
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+            {action.contextMessage}
+          </Typography>
+        </Box>
+      </Box>
+
+      {/* Action CTA Segment */}
+      <IconButton 
+        size="small" 
+        sx={{ 
+          color: priorityStyle.color,
+          bgcolor: alpha(priorityStyle.color, 0.1),
+          '&:hover': { bgcolor: alpha(priorityStyle.color, 0.2) }
+        }}
+        onClick={(e) => {
+          e.stopPropagation();
+          onClick?.(action);
+        }}
+      >
+        <CheckBoxOutlinedIcon />
+      </IconButton>
+    </Box>
+  );
+};

--- a/src/features/today/widgets/ActionQueueTimelineWidget.spec.tsx
+++ b/src/features/today/widgets/ActionQueueTimelineWidget.spec.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { ActionQueueTimelineWidget } from './ActionQueueTimelineWidget';
+import type { ActionCard as IActionCard } from '../domain/models/queue.types';
+
+describe('ActionQueueTimelineWidget', () => {
+  const dummyActions: IActionCard[] = [
+    {
+      id: 'act-1',
+      title: 'Action 1',
+      priority: 'P1',
+      contextMessage: 'Message 1',
+      actionType: 'NAVIGATE',
+      requiresAttention: false,
+      isOverdue: false,
+      payload: null,
+    },
+    {
+      id: 'act-2',
+      title: 'Action 2',
+      priority: 'P2',
+      contextMessage: 'Message 2',
+      actionType: 'OPEN_DRAWER',
+      requiresAttention: false,
+      isOverdue: false,
+      payload: null,
+    },
+  ];
+
+  it('displays loading skeletons when isLoading is true', () => {
+    const { container } = render(<ActionQueueTimelineWidget actionQueue={[]} isLoading={true} />);
+    // Check if skeletons are rendered (mui skeleton uses MuiSkeleton-root class)
+    const skeletons = container.querySelectorAll('.MuiSkeleton-root');
+    expect(skeletons.length).toBe(3);
+  });
+
+  it('displays empty state when actionQueue is empty and not loading', () => {
+    render(<ActionQueueTimelineWidget actionQueue={[]} isLoading={false} />);
+    expect(screen.getByText('現在の待機アクションはありません')).toBeInTheDocument();
+    expect(screen.getByText('すべての業務が完了しているか、直近のタスクがありません')).toBeInTheDocument();
+  });
+
+  it('displays the list of ActionCards when actionQueue has items', () => {
+    const handleActionClick = vi.fn();
+    render(
+      <ActionQueueTimelineWidget
+        actionQueue={dummyActions}
+        isLoading={false}
+        onActionClick={handleActionClick}
+      />
+    );
+    
+    // Test that the cards are rendered
+    expect(screen.getByText('Action 1')).toBeInTheDocument();
+    expect(screen.getByText('Action 2')).toBeInTheDocument();
+    
+    // The empty state should not be present
+    expect(screen.queryByText('現在の待機アクションはありません')).not.toBeInTheDocument();
+  });
+
+  it('renders ActionCards in the exact order provided by the engine without re-sorting', () => {
+    const handleActionClick = vi.fn();
+    const unorderedActions: IActionCard[] = [
+      { id: 'a1', title: 'Action P2', priority: 'P2', contextMessage: '', actionType: 'NAVIGATE', requiresAttention: false, isOverdue: false, payload: null },
+      { id: 'a2', title: 'Action P0', priority: 'P0', contextMessage: '', actionType: 'NAVIGATE', requiresAttention: true, isOverdue: false, payload: null },
+      { id: 'a3', title: 'Action P3', priority: 'P3', contextMessage: '', actionType: 'NAVIGATE', requiresAttention: false, isOverdue: false, payload: null },
+    ];
+    
+    render(
+      <ActionQueueTimelineWidget
+        actionQueue={unorderedActions}
+        isLoading={false}
+        onActionClick={handleActionClick}
+      />
+    );
+    
+    // Find all titles
+    const titles = screen.getAllByText(/Action P/);
+    expect(titles.length).toBe(3);
+    // Elements should appear in DOM in same order as they are in the array
+    expect(titles[0]).toHaveTextContent('Action P2');
+    expect(titles[1]).toHaveTextContent('Action P0');
+    expect(titles[2]).toHaveTextContent('Action P3');
+  });
+});

--- a/src/features/today/widgets/ActionQueueTimelineWidget.tsx
+++ b/src/features/today/widgets/ActionQueueTimelineWidget.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { Box, Typography, Skeleton } from '@mui/material';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import { ActionCard } from './ActionCard';
+import type { ActionCard as IActionCard } from '../domain/models/queue.types';
+
+export interface ActionQueueTimelineWidgetProps {
+  actionQueue: IActionCard[];
+  isLoading: boolean;
+  onActionClick?: (action: IActionCard) => void;
+}
+
+export const ActionQueueTimelineWidget: React.FC<ActionQueueTimelineWidgetProps> = ({
+  actionQueue,
+  isLoading,
+  onActionClick,
+}) => {
+  if (isLoading) {
+    return (
+      <Box sx={{ p: 2 }}>
+        <Skeleton variant="rectangular" height={80} sx={{ mb: 1.5, borderRadius: 2 }} />
+        <Skeleton variant="rectangular" height={80} sx={{ mb: 1.5, borderRadius: 2 }} />
+        <Skeleton variant="rectangular" height={80} sx={{ borderRadius: 2 }} />
+      </Box>
+    );
+  }
+
+  if (actionQueue.length === 0) {
+    return (
+      <Box
+        sx={{
+          py: 6,
+          textAlign: 'center',
+          borderRadius: 2,
+          bgcolor: 'rgba(255, 255, 255, 0.02)',
+        }}
+      >
+        <CheckCircleOutlineIcon sx={{ fontSize: 40, color: 'success.main', mb: 1 }} />
+        <Typography variant="body1" color="text.secondary" fontWeight="bold">
+          現在の待機アクションはありません
+        </Typography>
+        <Typography variant="body2" color="text.disabled" sx={{ mt: 1 }}>
+          すべての業務が完了しているか、直近のタスクがありません
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ p: 1 }}>
+      {actionQueue.map((action) => (
+        <ActionCard 
+          key={action.id} 
+          action={action} 
+          onClick={onActionClick} 
+        />
+      ))}
+    </Box>
+  );
+};

--- a/src/pages/TodayOpsPage.tsx
+++ b/src/pages/TodayOpsPage.tsx
@@ -22,6 +22,8 @@ import { useSceneNextAction } from '@/features/today/hooks/useSceneNextAction';
 import { useTodayScheduleLanes } from '@/features/today/hooks/useTodayScheduleLanes';
 import { useWorkflowPhases } from '@/features/today/hooks/useWorkflowPhases';
 import { useTodayLayoutProps } from '@/features/today/hooks/useTodayLayoutProps';
+import { useTodayActionQueue } from '@/features/today/hooks/useTodayActionQueue';
+import type { ActionCard } from '@/features/today/domain/models/queue.types';
 import { usePlanningSheetRepositories } from '@/features/planning-sheet/hooks/usePlanningSheetRepositories';
 import { TodayBentoLayout } from '@/features/today/layouts/TodayBentoLayout';
 import { recordAutoNextComplete, recordAutoNextSave } from '@/features/today/records/autoNextCounters';
@@ -92,6 +94,26 @@ export const TodayOpsPage: React.FC = () => {
     isServiceManager ? planningSheetRepo : null,
   );
 
+  // ── Timeline Action Queue (Phase 3) ──
+  const { actionQueue, isLoading: isQueueLoading } = useTodayActionQueue({
+    currentStaffId: 'staff-a', // 仮: ログインユーザーのIDを連携できるとベター
+  });
+
+  const handleActionClick = React.useCallback(
+    (action: ActionCard) => {
+      if (action.actionType === 'OPEN_DRAWER') {
+        quickRecord.openUnfilled();
+      } else if (action.actionType === 'NAVIGATE') {
+        const payload = action.payload as { path?: string };
+        if (payload?.path) navigate(payload.path);
+        else navigate('/schedules');
+      } else if (action.actionType === 'ACKNOWLEDGE') {
+        // No-op for now. Acknowledge handler can be hooked into an API action later.
+      }
+    },
+    [quickRecord.openUnfilled, navigate]
+  );
+
   // ── Schedule Detail Deep Link ──
   const scheduleDetailHref = useMemo(() => {
     const dateIso = toLocalDateISO();
@@ -118,6 +140,11 @@ export const TodayOpsPage: React.FC = () => {
 
   const layoutProps = useMemo(() => ({
     ...baseLayoutProps,
+    actionQueueTimeline: {
+      actionQueue,
+      isLoading: isQueueLoading,
+      onActionClick: handleActionClick,
+    },
     workflowCard: isServiceManager && workflowPhases.items.length > 0
       ? {
           items: workflowPhases.items,
@@ -127,7 +154,7 @@ export const TodayOpsPage: React.FC = () => {
           onNavigate: (href: string) => navigate(href),
         }
       : undefined,
-  }), [baseLayoutProps, isServiceManager, workflowPhases, navigate]);
+  }), [baseLayoutProps, isServiceManager, workflowPhases, navigate, actionQueue, isQueueLoading, handleActionClick]);
 
   // ── Save Success Handler (Quick Record auto-next) ──
   const [showCompletionToast, setShowCompletionToast] = React.useState(false);

--- a/tests/unit/pages/TodayOpsPage.spec.tsx
+++ b/tests/unit/pages/TodayOpsPage.spec.tsx
@@ -1,0 +1,165 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import TodayOpsPage from '../../../src/pages/TodayOpsPage';
+import { TodayBentoLayout } from '../../../src/features/today/layouts/TodayBentoLayout';
+import { useTodayActionQueue } from '../../../src/features/today/hooks/useTodayActionQueue';
+
+import type { ActionCard as IActionCard } from '../../../src/features/today/domain/models/queue.types';
+
+// Mocks for all the dependencies the page relies on
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useLocation: () => ({ pathname: '/today', search: '' }),
+  };
+});
+
+vi.mock('../../../src/features/auth/store', () => ({
+  useAuthStore: vi.fn(() => 'staff'),
+}));
+
+vi.mock('../../../src/features/today/domain', () => ({
+  useTodaySummary: vi.fn(() => ({})),
+}));
+
+vi.mock('../../../src/features/today/hooks/useApprovalFlow', () => ({
+  useApprovalFlow: vi.fn(() => ({ isOpen: false, close: vi.fn() })),
+}));
+
+vi.mock('../../../src/features/today/hooks/useNextAction', () => ({
+  useNextAction: vi.fn(() => ({})),
+}));
+
+vi.mock('../../../src/features/today/hooks/useSceneNextAction', () => ({
+  useSceneNextAction: vi.fn(() => ({})),
+}));
+
+vi.mock('../../../src/features/today/hooks/useTodayScheduleLanes', () => ({
+  useTodayScheduleLanes: vi.fn(() => ({ lanes: { staffLane: [], userLane: [], organizationLane: [] }, isLoading: false })),
+}));
+
+vi.mock('../../../src/features/today/hooks/useWorkflowPhases', () => ({
+  useWorkflowPhases: vi.fn(() => ({ items: [], counts: {}, topPriorityItem: null, isLoading: false })),
+}));
+
+vi.mock('../../../src/features/today/hooks/useTodayLayoutProps', () => ({
+  useTodayLayoutProps: vi.fn(() => ({})), // Minimal mock
+}));
+
+vi.mock('../../../src/features/today/layouts/TodayBentoLayout', () => ({
+  TodayBentoLayout: vi.fn(() => <div data-testid="bento-layout" />)
+}));
+
+vi.mock('../../../src/features/planning-sheet/hooks/usePlanningSheetRepositories', () => ({
+  usePlanningSheetRepositories: vi.fn(() => ({})),
+}));
+
+vi.mock('../../../src/features/today/transport', () => ({
+  useTransportStatus: vi.fn(() => ({ pending: [], inProgress: [], onArrived: vi.fn() })),
+}));
+
+const mockOpenUnfilled = vi.fn();
+vi.mock('../../../src/features/today/records/useQuickRecord', () => ({
+  useQuickRecord: vi.fn(() => ({
+    isOpen: false,
+    mode: 'test',
+    userId: 'user-1',
+    close: vi.fn(),
+    autoNextEnabled: false,
+    setAutoNextEnabled: vi.fn(),
+    openUnfilled: mockOpenUnfilled,
+  })),
+}));
+
+vi.mock('../../../src/features/today/hooks/useTodayActionQueue', () => ({
+  useTodayActionQueue: vi.fn(),
+}));
+
+describe('TodayOpsPage (ActionQueueTimeline integration)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const dummyActionQueue: IActionCard[] = [
+    {
+      id: 'act-nav',
+      title: 'Navigation Test',
+      priority: 'P1',
+      contextMessage: 'msg',
+      actionType: 'NAVIGATE',
+      requiresAttention: false,
+      isOverdue: false,
+      payload: { path: '/test-route' },
+    },
+    {
+      id: 'act-drawer',
+      title: 'Drawer Test',
+      priority: 'P2',
+      contextMessage: 'msg',
+      actionType: 'OPEN_DRAWER',
+      requiresAttention: false,
+      isOverdue: false,
+      payload: null,
+    },
+    {
+      id: 'act-ack',
+      title: 'Acknowledge Test',
+      priority: 'P3',
+      contextMessage: 'msg',
+      actionType: 'ACKNOWLEDGE',
+      requiresAttention: false,
+      isOverdue: false,
+      payload: null,
+    },
+  ];
+
+  it('passes actionQueue and correct click handlers to TodayBentoLayout', () => {
+    // Arrange
+    vi.mocked(useTodayActionQueue).mockReturnValue({
+      actionQueue: dummyActionQueue,
+      isLoading: false,
+      error: null,
+      refresh: vi.fn(),
+    });
+
+    // Act
+    render(
+      <MemoryRouter>
+        <TodayOpsPage />
+      </MemoryRouter>
+    );
+
+    // Assert layout received the queue timeline props
+    expect(TodayBentoLayout).toHaveBeenCalled();
+    const mockCalls = vi.mocked(TodayBentoLayout).mock.calls;
+    const props = mockCalls.length > 0 ? (mockCalls[mockCalls.length - 1]?.[0] as Record<string, unknown>) : {};
+    
+    expect(props.actionQueueTimeline).toBeDefined();
+    
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const timelineProps = props.actionQueueTimeline as any;
+    expect(timelineProps.actionQueue).toEqual(dummyActionQueue);
+    expect(timelineProps.isLoading).toBe(false);
+
+    // Act + Assert routing logic (NAVIGATE)
+    timelineProps.onActionClick(dummyActionQueue[0]);
+    expect(mockNavigate).toHaveBeenCalledWith('/test-route');
+
+    // Act + Assert drawer logic (OPEN_DRAWER)
+    timelineProps.onActionClick(dummyActionQueue[1]);
+    expect(mockOpenUnfilled).toHaveBeenCalled();
+
+    // Act + Assert no-op logic (ACKNOWLEDGE)
+    const prevNavCount = mockNavigate.mock.calls.length;
+    const prevOpenCount = mockOpenUnfilled.mock.calls.length;
+    timelineProps.onActionClick(dummyActionQueue[2]);
+    // Nav and Drawer should NOT be triggered
+    expect(mockNavigate).toHaveBeenCalledTimes(prevNavCount);
+    expect(mockOpenUnfilled).toHaveBeenCalledTimes(prevOpenCount);
+  });
+});


### PR DESCRIPTION
# 🚀 Feature: Today Action Engine Telemetry & HUD Integration (Phase 4-A / 4-B)

**Today Action Engine を、単なる判断エンジンから「観測可能な運用OSコンポーネント」へ昇格させました。**

## 💡 概要

Today の業務実行レイヤー（Action Queue）に対し、既存の純粋な優先度判断アルゴリズム（Engine）を全く汚染することなく、リアルタイムな業務負荷やタスク構成を観測できる Telemetry の流路を実装しました。これにより「意志決定系」と「観測系」が見事に並走・分離するアーキテクチャが完成しています。

## ✨ 実装のハイライト

1. **Telemetry Store の新設**
   - 揮発性の Ring Buffer（Zustand ベース）を用いてキューの状態を一定数キャッシュする `TodayQueueTelemetryStore` を実装。
   - `queueSize`, `p0Count`, `overdueCount` などの「業務の健康状態」を示す重要件数を `summarizeTodayQueue` 関数で集計します。
2. **Hook への観測点と重複送信ガード（Smart Push）の追加**
   - `useTodayActionQueue` でキューが算定された直後の最も信頼できるタイミングを観測点に設定。
   - **重複送信ガード機能**: 
     「UIの文言変化など意図しない再レンダリング」で Telemetry がスパムされないよう、各アイテムの `id + priority + isOverdue` 特徴量でシグネチャを生成。並び順と重要なタスク状態変化があった場合のみバッファへ記録します。
3. **Queue Diagnostics HUD パネル**
   - `HydrationHud` の診断セクション内に `<TodayQueueHudPanel />` を新規追加しました（dev-only でのみ表示）。
   - 「Store の Latest Sample をただ表示するだけ」の **極薄プレゼンテーション** に徹底し、HUD内での再集計は行いません。
   - これにより、Fetch Health / Circuit Breaker / Prefetch と合わせた包括的な監視をシームレスに行える環境が整いました。

## 🔧 Architecture / OS Principles

- **Engine の純粋防衛:** ロギング・バッファリングの責務を Hook に移譲したため、Engine 側での副作用はゼロです。
- **分離された情報公開:** HUD の表示は Diagnostics 環境に制約し、一般ユーザの画面（Production UI）には決して影響が出ない堅牢な仕様としています。

## 🎯 Next Steps (Options)

この基盤をベースに、今後は以下の展開が考えられます。
* **Phase 4-C: Priority Rule Table**
  現在のハードコードされた優先順位（Vital=P0, Incident=P1 等）を分離可能な外部ルールテーブル化し、施設/運用別のカスタマイズに備える。
* **Ops Dashboard Integration**
  今回整備された HUD 向けの Telemetry バッファを、本格的な本番運用向け運用OSダッシュボード（またはビッグデータ基盤）の入力源となるよう拡張する。
