### PR TITLE
refactor(monitoring): introduce repository factory for monitoring meeting data

### DIFF
--- a/src/features/monitoring/repositories/__tests__/createMonitoringMeetingRepository.spec.ts
+++ b/src/features/monitoring/repositories/__tests__/createMonitoringMeetingRepository.spec.ts
@@ -1,0 +1,47 @@
+// ---------------------------------------------------------------------------
+// createMonitoringMeetingRepository.spec.ts
+//
+// テスト観点:
+//   1. mode 'local' → localMonitoringMeetingRepository を返す
+//   2. mode 未指定 → デフォルトで local を返す
+//   3. mode 'sharepoint' → 未実装エラーを投げる
+//   4. 返却された repository が Port 契約を満たす
+// ---------------------------------------------------------------------------
+
+import { describe, it, expect } from 'vitest';
+
+import { createMonitoringMeetingRepository } from '../createMonitoringMeetingRepository';
+import { localMonitoringMeetingRepository } from '@/infra/localStorage/localMonitoringMeetingRepository';
+
+describe('createMonitoringMeetingRepository', () => {
+  // ── 1. mode 'local' → local repo ──
+  it('returns localMonitoringMeetingRepository when mode is "local"', () => {
+    const repo = createMonitoringMeetingRepository('local');
+    expect(repo).toBe(localMonitoringMeetingRepository);
+  });
+
+  // ── 2. デフォルト → local repo ──
+  it('defaults to local mode when no argument is provided', () => {
+    const repo = createMonitoringMeetingRepository();
+    expect(repo).toBe(localMonitoringMeetingRepository);
+  });
+
+  // ── 3. mode 'sharepoint' → 未実装エラー ──
+  it('throws when sharepoint mode is requested (not yet implemented)', () => {
+    expect(() => createMonitoringMeetingRepository('sharepoint')).toThrow(
+      /sharepoint mode is not yet implemented/,
+    );
+  });
+
+  // ── 4. Port 契約 ──
+  it('returned repository fulfills MonitoringMeetingRepository interface', () => {
+    const repo = createMonitoringMeetingRepository();
+
+    expect(typeof repo.save).toBe('function');
+    expect(typeof repo.getAll).toBe('function');
+    expect(typeof repo.getById).toBe('function');
+    expect(typeof repo.listByUser).toBe('function');
+    expect(typeof repo.listByIsp).toBe('function');
+    expect(typeof repo.delete).toBe('function');
+  });
+});

--- a/src/features/monitoring/repositories/createMonitoringMeetingRepository.ts
+++ b/src/features/monitoring/repositories/createMonitoringMeetingRepository.ts
@@ -1,0 +1,67 @@
+// ---------------------------------------------------------------------------
+// createMonitoringMeetingRepository — Repository Factory
+//
+// モニタリング会議記録の永続化先を、mode に応じて切り替える唯一の注入点。
+// UI コンポーネントは直接 localStorage / SharePoint 実装を import しない。
+//
+// 使い方:
+//   const repo = createMonitoringMeetingRepository();          // default: local
+//   const repo = createMonitoringMeetingRepository('local');
+//   const repo = createMonitoringMeetingRepository('sharepoint'); // 将来
+//
+// @see src/domain/isp/monitoringMeetingRepository.ts (Port)
+// ---------------------------------------------------------------------------
+
+import type { MonitoringMeetingRepository } from '@/domain/isp/monitoringMeetingRepository';
+import { localMonitoringMeetingRepository } from '@/infra/localStorage/localMonitoringMeetingRepository';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Repository の実装モード。
+ *
+ * - `'local'`      — localStorage ベース（開発・デモ用）
+ * - `'sharepoint'` — SharePoint リスト（本番用、未実装）
+ */
+export type MonitoringRepositoryMode = 'local' | 'sharepoint';
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * mode に応じた MonitoringMeetingRepository を返す。
+ *
+ * デフォルトは `'local'`。
+ * SharePoint 実装が追加されたら、ここに分岐を1行足すだけで切替完了。
+ *
+ * @example
+ * ```ts
+ * // UI 側
+ * const repo = createMonitoringMeetingRepository();
+ * useLatestBehaviorMonitoring(userId, { repository: repo });
+ * ```
+ */
+export function createMonitoringMeetingRepository(
+  mode: MonitoringRepositoryMode = 'local',
+): MonitoringMeetingRepository {
+  switch (mode) {
+    case 'local':
+      return localMonitoringMeetingRepository;
+
+    case 'sharepoint':
+      // TODO: SharePoint 実装が完成したら差し替え
+      // return spMonitoringMeetingRepository;
+      throw new Error(
+        '[createMonitoringMeetingRepository] sharepoint mode is not yet implemented. ' +
+        'Use "local" until spMonitoringMeetingRepository is available.',
+      );
+
+    default: {
+      const _exhaustive: never = mode;
+      throw new Error(`Unknown repository mode: ${_exhaustive}`);
+    }
+  }
+}

--- a/src/features/planning-sheet/components/new-form/NewPlanningSheetForm.tsx
+++ b/src/features/planning-sheet/components/new-form/NewPlanningSheetForm.tsx
@@ -54,7 +54,7 @@ import type { ImportPreviewResult } from '../../buildImportPreview';
 import { ImportPreviewDialog } from '../ImportPreviewDialog';
 import { ImportMonitoringDialog } from '../ImportMonitoringDialog';
 import { useLatestBehaviorMonitoring } from '../../hooks/useLatestBehaviorMonitoring';
-import { localMonitoringMeetingRepository } from '@/infra/localStorage/localMonitoringMeetingRepository';
+import { createMonitoringMeetingRepository } from '@/features/monitoring/repositories/createMonitoringMeetingRepository';
 
 // ── Local (split) ──
 import type { NewPlanningSheetFormProps, UserOption, FormState } from './types';
@@ -106,14 +106,15 @@ export const NewPlanningSheetForm: React.FC<NewPlanningSheetFormProps> = ({
 
   // ── モニタリング読込 ──
   // NOTE:
-  // Latest monitoring record is resolved via useLatestBehaviorMonitoring hook.
-  // Do not fetch monitoring data directly in this component.
-  // This keeps /new and edit flows consistent.
+  // Repository is resolved via createMonitoringMeetingRepository factory.
+  // Do not import localMonitoringMeetingRepository directly in UI components.
+  // This keeps /new and edit flows consistent and enables future SP swap.
+  const monitoringRepo = React.useMemo(() => createMonitoringMeetingRepository(), []);
   const {
     record: latestMonitoringRecord,
     isLoading: isMonitoringLoading,
   } = useLatestBehaviorMonitoring(selectedUser?.id ?? null, {
-    repository: localMonitoringMeetingRepository,
+    repository: monitoringRepo,
     planningSheetId: 'new',
   });
   const [monitoringDialogOpen, setMonitoringDialogOpen] = React.useState(false);

--- a/src/pages/SupportPlanningSheetPage.tsx
+++ b/src/pages/SupportPlanningSheetPage.tsx
@@ -19,7 +19,7 @@ import { ImportAssessmentDialog } from '@/features/planning-sheet/components/Imp
 import { ImportMonitoringDialog } from '@/features/planning-sheet/components/ImportMonitoringDialog';
 import type { MonitoringToPlanningResult } from '@/features/planning-sheet/monitoringToPlanningBridge';
 import { useLatestBehaviorMonitoring } from '@/features/planning-sheet/hooks/useLatestBehaviorMonitoring';
-import { localMonitoringMeetingRepository } from '@/infra/localStorage/localMonitoringMeetingRepository';
+import { createMonitoringMeetingRepository } from '@/features/monitoring/repositories/createMonitoringMeetingRepository';
 import { ImportHistoryTimeline } from '@/features/planning-sheet/components/ImportHistoryTimeline';
 import { ProvenancePanel } from '@/features/planning-sheet/components/ProvenanceBadge';
 import type { AssessmentBridgeResult, ProvenanceEntry } from '@/features/planning-sheet/assessmentBridge';
@@ -229,13 +229,14 @@ export default function SupportPlanningSheetPage() {
 
   // ── 行動モニタリング取込 ──
   // NOTE:
-  // Latest monitoring record is resolved via useLatestBehaviorMonitoring hook.
-  // Do not fetch monitoring data directly in this component.
-  // This keeps /new and edit flows consistent.
+  // Repository is resolved via createMonitoringMeetingRepository factory.
+  // Do not import localMonitoringMeetingRepository directly in UI components.
+  // This keeps /new and edit flows consistent and enables future SP swap.
+  const monitoringRepo = React.useMemo(() => createMonitoringMeetingRepository(), []);
   const {
     record: latestMonitoringRecord,
   } = useLatestBehaviorMonitoring(sheet?.userId ?? null, {
-    repository: localMonitoringMeetingRepository,
+    repository: monitoringRepo,
     planningSheetId: planningSheetId ?? 'new',
   });
 


### PR DESCRIPTION
## Summary

Introduces `createMonitoringMeetingRepository` factory to centralize repository instantiation and eliminate direct infra-layer imports from UI components.

## Depends on

> ⚠️ **This PR is stacked on #1066.** Merge #1066 first.

## Changes

### New: Repository Factory

```ts
// src/features/monitoring/repositories/createMonitoringMeetingRepository.ts
createMonitoringMeetingRepository(mode?: 'local' | 'sharepoint')
```

- `'local'` (default) → returns `localMonitoringMeetingRepository`
- `'sharepoint'` → throws with descriptive error until implementation is ready
- Exhaustive `switch` with `never` check — adding a new mode without handling it is a compile error

### Updated: UI Components

Both pages now use the factory instead of importing `localMonitoringMeetingRepository` directly:

```tsx
// Before (direct infra dependency)
import { localMonitoringMeetingRepository } from '@/infra/localStorage/...';
useLatestBehaviorMonitoring(userId, { repository: localMonitoringMeetingRepository });

// After (factory-resolved)
import { createMonitoringMeetingRepository } from '@/features/monitoring/repositories/...';
const monitoringRepo = React.useMemo(() => createMonitoringMeetingRepository(), []);
useLatestBehaviorMonitoring(userId, { repository: monitoringRepo });
```

## Architecture

```
UI Components (/new, edit)
        │
        │ createMonitoringMeetingRepository(mode)
        ▼
┌─── Factory ───────────────────────────┐
│ 'local'      → localStorage impl     │
│ 'sharepoint' → (future) SP impl      │
└───────────────────────────────────────┘
        │
        ▼
MonitoringMeetingRepository (Port)
```

## Future SharePoint Swap

When `spMonitoringMeetingRepository` is ready, the change is exactly:

```diff
case 'sharepoint':
-  throw new Error('...');
+  return spMonitoringMeetingRepository;
```

No UI changes needed.

## Tests

- Factory unit tests: **4 passed**
  - mode 'local' returns correct instance
  - default returns local
  - sharepoint throws with message
  - returned repo fulfills Port interface
- Planning-sheet tests: **174 passed** (no regressions)