### PR TITLE
infra(sp): SharePoint リスト構造の Drift Management 基盤を追加

### DIFF
--- a/.github/workflows/monthly-audit.yml
+++ b/.github/workflows/monthly-audit.yml
@@ -15,3 +15,67 @@ jobs:
           node-version: 20
       - run: npm ci
       - run: npm audit --omit=dev
+
+  sp-manifest-lint:
+    name: SP Manifest vs ListKeys Consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm ci
+      - name: Run SP manifest lint
+        id: sp_audit
+        run: |
+          npm run sp:audit 2>&1 | tee /tmp/sp-audit-result.txt
+          echo "exit_code=${PIPESTATUS[0]}" >> $GITHUB_OUTPUT
+        continue-on-error: true
+      - name: Write step summary
+        run: |
+          echo "## SP Manifest Lint Results" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat /tmp/sp-audit-result.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          if [ "${{ steps.sp_audit.outputs.exit_code }}" != "0" ]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### ⚠️ Action Required" >> $GITHUB_STEP_SUMMARY
+            echo "See [monthly-sp-structure-audit.md](docs/runbook/monthly-sp-structure-audit.md) for remediation steps." >> $GITHUB_STEP_SUMMARY
+          fi
+      - name: Upload audit result artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sp-manifest-audit-${{ github.run_number }}
+          path: /tmp/sp-audit-result.txt
+          retention-days: 90
+      - name: Fail job if audit failed
+        if: steps.sp_audit.outputs.exit_code != '0'
+        run: exit 1
+      - name: Create GitHub Issue on failure
+        if: failure() && github.event_name == 'schedule'
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: "[sp:audit] SP manifest 整合エラー検出 — ${{ github.run_number }}"
+          content-filepath: /tmp/sp-audit-result.txt
+          labels: |
+            sp-drift
+            infra
+            priority-high
+          assignees: ${{ github.repository_owner }}
+          body: |
+            ## SP Manifest 整合エラーが検出されました
+
+            monthly-audit CI の `sp-manifest-lint` ジョブでエラーが発生しました。
+
+            **対処優先順位**: Mismatch/Unique > Missing/List > Missing/Field > Mismatch/Index
+
+            詳細は [Runbook](docs/runbook/monthly-sp-structure-audit.md) を参照してください。
+
+            ---
+
+            ### Audit 結果（自動取得）
+
+
+

--- a/docs/runbook/monthly-sp-structure-audit.md
+++ b/docs/runbook/monthly-sp-structure-audit.md
@@ -1,0 +1,133 @@
+# Monthly SP Structure Audit Runbook
+
+> **目的**: SP リスト構造のドリフト（コードと SharePoint の乖離）を月次で早期発見する  
+> **所要時間**: 約 10 分  
+> **実施頻度**: 毎月 1 日（GitHub Actions が自動起動）または任意タイミング
+
+---
+
+## ① CI 整合性チェック（コード層 — 常時稼働）
+
+PR マージ時・push 時に自動実行される。手動実行も可能。
+
+```bash
+npm run sp:audit
+```
+
+### チェック内容
+
+| チェック | 内容 |
+|---|---|
+| [A] | `ListKeys` の件数 === `LIST_CONFIG` の件数 |
+| [B] | `lists.manifest.json` の全エントリが `ListKeys` に存在するか |
+| [C] | `ListKeys` の全メンバーが manifest または `_excluded` に記録されているか |
+
+### 対処判断
+
+| 結果 | 対処 |
+|---|---|
+| **PASSED** | 変更不要 |
+| `[A]` エラー | `ListKeys` に追加した場合 `LIST_CONFIG` への登録漏れ |
+| `[B]` エラー | manifest に架空のリスト名がある → `ListKeys` へ追加 or manifest から削除 |
+| `[C]` Warning | `ListKeys` に登録されているが manifest 未掲載 → manifest に追加 or `_excluded` に記録 |
+
+---
+
+## ② SP 実体チェック（SharePoint 層 — 月次）
+
+### 手順
+
+**Step 1**: ブラウザで SharePoint サイトを開く
+
+```
+https://isogokatudouhome.sharepoint.com/sites/welfare
+```
+
+**Step 2**: F12 → コンソール → `scripts/sp-preprod/audit-browser-console.js` の内容を貼り付けて Enter
+
+**Step 3**: 結果を記録する
+
+```
+===== FINAL AUDIT =====
+Missing/List  : 0
+Missing/Field : 0
+Mismatch/Index: 0
+Mismatch/Uniq : 0
+OK            : XX
+=======================
+```
+
+### 対処優先順位
+
+```
+1位 Mismatch/Unique  ← 重複データ混入リスク。放置すると本番障害に直結
+2位 Missing/List     ← 機能自体が使えない状態
+3位 Missing/Field    ← 一部機能が不正データを返す可能性
+4位 Mismatch/Index   ← パフォーマンス劣化。即時影響は低い
+```
+
+> **判断原則**: 上位ほど緊急対応。1位・2位は当日中に対処、3位は週内、4位は次回月次でよい。
+
+### 対処内容
+
+| 優先 | カテゴリ | 対処 |
+|---|---|---|
+| 🔴 1 | **Mismatch/Unique** | 重複データが混入するリスク → **まず重複確認**してから制約追加 |
+| 🔴 2 | **Missing/List** | 新機能追加でコードには実装されているがSPに未作成 → provision コンソールスクリプトで作成 |
+| 🟡 3 | **Missing/Field** | リスト作成後にカスタムフィールドが追加されていない → フィールド追加コンソールスクリプトで対処 |
+| 🟢 4 | **Mismatch/Index** | パフォーマンス低下の懸念 → インデックス追加コンソールスクリプトで対処 |
+| ✅ — | **全件 OK** | 変更不要 |
+
+### Issue 起票（エラー検出時）
+
+```bash
+# Issue フォーマット付きで実行し、出力をコピーして gh issue create に使う
+npm run sp:audit -- --issue-format
+```
+
+---
+
+## ③ 記録方法
+
+月次チェック後、以下に結果を追記する:
+
+```
+docs/sharepoint/sp-structure-audit-log.md
+```
+
+### 記録フォーマット
+
+```markdown
+## YYYY-MM-DD
+
+- 実施者: XXX
+- SP lists found: XX
+- Missing/List  : 0
+- Missing/Field : 0
+- Mismatch/Index: 0
+- Mismatch/Uniq : 0
+- OK: XX
+- 対応事項: なし / [対応内容を記載]
+```
+
+---
+
+## ④ 異常時のエスカレーション基準
+
+| 状況 | 対応 |
+|---|---|
+| Missing/List が 1 件以上 | 直近のコミット差分を確認し、新規 `ListKeys` 追加がないか確認。ある場合は provision を実施。 |
+| Mismatch/Unique で重複データ検出 | **そのまま制約を設定しない**。重複データを手動で解消してから制約追加。 |
+| Missing/Field が 5 件以上 | manifest を確認し、フィールド定義（FIELD_MAP）と SP の乖離が大きい場合は /architect に相談。 |
+
+---
+
+## 関連ファイル
+
+| ファイル | 役割 |
+|---|---|
+| `scripts/sp-preprod/lists.manifest.json` | SP リスト定義の SSOT |
+| `scripts/sp-preprod/audit-browser-console.js` | SP 実体確認スクリプト |
+| `scripts/sp-manifest-lint.ts` | CI 整合性チェックスクリプト |
+| `src/sharepoint/fields/listRegistry.ts` | `ListKeys` / `LIST_CONFIG` 定義 |
+| `docs/sharepoint/sp-list-registry-policy.md` | SP リスト管理ポリシー |

--- a/docs/sharepoint/sp-list-registry-policy.md
+++ b/docs/sharepoint/sp-list-registry-policy.md
@@ -1,0 +1,167 @@
+# SharePoint リスト管理ポリシー — SSOT 運用ルール
+
+> **対象読者**: 開発者・本番前整備担当者  
+> **最終更新**: 2026-03-18  
+> **関連ファイル**: `src/sharepoint/fields/listRegistry.ts`, `src/sharepoint/spListRegistry.ts`, `scripts/sp-preprod/lists.manifest.json`
+
+---
+
+## 1. 基本原則：3-tier SSOT
+
+SP リスト名・フィールド内部名の **唯一の正** はコードの以下3層です。
+この順序で管理し、manifest・スクリプト・Power Automate はここを参照します。
+
+```
+ListKeys (enum)
+    ↓
+LIST_CONFIG (title マッピング)
+    ↓
+FIELD_MAP / *_FIELDS (フィールド内部名)
+    ↓
+  manifest / provision スクリプト / Power Automate フロー
+```
+
+**manifest や provision スクリプトを正として扱わないこと。**  
+manifest はコードから派生する成果物であり、コードが正です。
+
+---
+
+## 2. 変更記録（2026-03-18 本番前整備）
+
+### 2-A. `Schedules` を正式登録
+
+**問題**: `scheduleFields.ts` に実装があるにもかかわらず、`ListKeys` / `LIST_CONFIG` / `spListRegistry` に未登録だった。
+
+**影響**: `spListRegistry` の `schedule_events` エントリが文字列リテラル `'Schedules'` を直接ハードコードしており、rename 時に LIST_CONFIG と乖離するリスクがあった。
+
+**修正内容**:
+
+```typescript
+// src/sharepoint/fields/listRegistry.ts
+export enum ListKeys {
+  // ...
+  Schedules = 'Schedules',  // ← 追加（登録漏れ修正）
+}
+
+export const LIST_CONFIG: Record<ListKeys, { title: string }> = {
+  // ...
+  [ListKeys.Schedules]: { title: 'Schedules' },  // ← 追加
+};
+```
+
+```typescript
+// src/sharepoint/spListRegistry.ts
+{
+  key: 'schedule_events',
+  resolve: () => envOr('VITE_SP_LIST_SCHEDULES', fromConfig(ListKeys.Schedules)),  // ← fromConfig に変更
+  // ...
+}
+```
+
+---
+
+### 2-B. `support_record_daily` の架空名 `SupportRecord_Daily` を除去
+
+**問題**: `spListRegistry` の `support_record_daily` エントリが、`ListKeys` に存在しない `'SupportRecord_Daily'` をフォールバックとしてハードコードしていた。
+
+```typescript
+// ❌ 修正前（架空名）
+resolve: () => envOr('VITE_SP_LIST_DAILY', 'SupportRecord_Daily'),
+
+// ✅ 修正後（ListKeys の実名を参照）
+resolve: () => envOr('VITE_SP_LIST_PROCEDURE_RECORD', fromConfig(ListKeys.ProcedureRecordDaily)),
+```
+
+**背景**: この `SupportRecord_Daily` はツールキット生成時の架空名で、実際のシステムでは `SupportProcedureRecord_Daily`（ISP三層モデルの第3層）が対応リストです。
+
+**日次系の2リストの役割分担**:
+
+| リスト名 | ListKey | 用途 |
+|---|---|---|
+| `DailyActivityRecords` | `DailyActivityRecords` | タイムスライス単位の活動観察記録（observation/behavior/intensity） |
+| `SupportProcedureRecord_Daily` | `ProcedureRecordDaily` | 支援手順書兼記録（ISP三層モデル第3層・PlanningSheet連携） |
+
+---
+
+## 3. 本番前 manifest 管理ルール
+
+### 含めるリスト（必須条件）
+
+manifest に含めるリストは **以下を全て満たすもの** に限定します。
+
+- [ ] `ListKeys` に登録済み
+- [ ] `LIST_CONFIG` に title マッピングあり
+- [ ] 対応する `FIELD_MAP` または `*_FIELDS` が `src/sharepoint/fields/` に存在
+- [ ] `spListRegistry` の `SP_LIST_REGISTRY` に `key` エントリあり
+
+### 除外するリスト
+
+以下のいずれかに該当する場合は **manifest から除外し `_excluded` セクションに記録** します。
+
+- `ListKeys` 未登録
+- Repository（Adapter / Repository クラス）が未実装
+- `FIELD_MAP` 未定義
+- 運用ルール未確定
+
+### 除外リストの記録例
+
+```json
+"_excluded": {
+  "_reason": "コードに ListKeys / FIELD_MAP / Repository 実装が存在しないため、今回の本番前対象から除外",
+  "lists": ["Inquiries", "CoffeeOrderHistory", "MonthlyCoffeeBilling"]
+}
+```
+
+> **除外は削除ではありません。** 将来実装する際に「意図して除外した」判断が残るよう必ず記録してください。
+
+---
+
+## 4. 新規リスト追加の手順
+
+SP に新しいリストを追加する際は、**必ずコードを先に更新** してから manifest に追加します。
+
+```
+1. src/sharepoint/fields/<domain>Fields.ts に FIELD_MAP を定義
+2. src/sharepoint/fields/listRegistry.ts の ListKeys enum に追加
+3. src/sharepoint/fields/listRegistry.ts の LIST_CONFIG に追加
+4. src/sharepoint/fields/index.ts からバレル re-export
+5. src/sharepoint/spListRegistry.ts の SP_LIST_REGISTRY に SpListEntry 追加
+6. scripts/sp-preprod/lists.manifest.json に追加
+7. audit → dry run → provision
+```
+
+> ステップ 6 がステップ 1-5 より先になってはいけません。
+
+---
+
+## 5. よくある事故パターン
+
+### パターン A: 文字列リテラルの直打ち
+
+```typescript
+// ❌ 危険 — rename 時に LIST_CONFIG と乖離する
+resolve: () => 'SupportRecord_Daily'
+
+// ✅ 安全 — SSOT を参照
+resolve: () => fromConfig(ListKeys.ProcedureRecordDaily)
+```
+
+### パターン B: manifest をコードより先に更新する
+
+未実装のリストを manifest に追加して provision すると、
+「SP には存在するが、アプリのどこからも参照されない」リストが生まれます。
+これは後の監査で判断が難しくなる負債です。
+
+### パターン C: ListKeys 未登録のまま実装する
+
+`scheduleFields.ts` のように FIELD_MAP だけあって `ListKeys` に未登録の状態は、
+`LIST_CONFIG` 型チェック（`Record<ListKeys, ...>`）の恩恵を受けられません。
+新規実装時は必ず `ListKeys` → `LIST_CONFIG` → FIELD_MAP の順で揃えてください。
+
+---
+
+## 6. 関連ドキュメント
+
+- [support-plan-three-layer-lists.md](./support-plan-three-layer-lists.md) — ISP三層モデル（ISP_Master / SupportPlanningSheet_Master / SupportProcedureRecord_Daily）
+- [iceberg-pdca-list-schema.md](./iceberg-pdca-list-schema.md) — 氷山モデル列スキーマ
+- `scripts/sp-preprod/lists.manifest.json` — 本番前監査 manifest（現物ベース）

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dev:nurse": "VITE_SKIP_LOGIN=1 VITE_FORCE_SHAREPOINT=0 vite --port 5179",
     "dev:firestore": "VITE_FIRESTORE_USE_EMULATOR=1 VITE_FIRESTORE_EMULATOR_HOST=127.0.0.1 VITE_FIRESTORE_EMULATOR_PORT=8080 vite --host 127.0.0.1 --port 5173",
     "check:env": "tsx scripts/check-env.ts",
+    "sp:audit": "tsx scripts/sp-manifest-lint.ts",
     "firestore:emu": "npx firebase emulators:start --only firestore",
     "firestore:emu:export": "npx firebase emulators:start --only firestore --import .firebase/emulator-data --export-on-exit",
     "lint:cookies": "echo \"Skipping cookie check on Windows\"",

--- a/scripts/sp-manifest-lint.ts
+++ b/scripts/sp-manifest-lint.ts
@@ -1,0 +1,162 @@
+/**
+ * sp-manifest-lint.ts
+ *
+ * SP リスト管理の整合性を CI で検証するスクリプト。
+ * SP への接続なしで、コードと manifest.json の一貫性のみをチェックする。
+ *
+ * 検査内容:
+ *   [A] ListKeys の全メンバーが LIST_CONFIG に登録されているか
+ *   [B] lists.manifest.json の全エントリが ListKeys に存在するか
+ *   [C] ListKeys の全メンバーが manifest に含まれているか（または _excluded に記録されているか）
+ *
+ * 使い方:
+ *   npm run sp:audit
+ */
+
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { ListKeys, LIST_CONFIG } from '../src/sharepoint/fields/listRegistry.js';
+
+// ── manifest 読み込み ─────────────────────────────────────────────────────────
+const MANIFEST_PATH = resolve(process.cwd(), 'scripts/sp-preprod/lists.manifest.json');
+
+interface ManifestList {
+  listKey: string;
+  listTitle: string;
+}
+
+interface Manifest {
+  lists: ManifestList[];
+  _excluded?: { lists: string[] };
+}
+
+let manifest: Manifest;
+try {
+  manifest = JSON.parse(readFileSync(MANIFEST_PATH, 'utf-8'));
+} catch {
+  console.error(`[sp:audit] ERROR: manifest not found at ${MANIFEST_PATH}`);
+  process.exit(1);
+}
+
+// ── データ収集 ─────────────────────────────────────────────────────────────────
+
+// ListKeys の全 value（SP リスト名）
+const allListKeyValues = new Set(Object.values(ListKeys));
+
+// manifest に含まれるリストタイトル
+const manifestTitles = new Set(manifest.lists.map(l => l.listTitle));
+
+// manifest の _excluded に記録されているリスト
+const excludedTitles = new Set(manifest._excluded?.lists ?? []);
+
+// ── 検査 ──────────────────────────────────────────────────────────────────────
+
+const errors:   string[] = [];
+const warnings: string[] = [];
+
+// LIST_CONFIG は Record<ListKeys, {title}> なので型レベルで保証済み。
+// ただし enum の value 数と LIST_CONFIG の key 数を比較して漏れを検出する。
+const listKeysCount   = allListKeyValues.size;
+const listConfigCount = Object.keys(LIST_CONFIG).length;
+
+if (listKeysCount !== listConfigCount) {
+  errors.push(
+    `[A] ListKeys has ${listKeysCount} members but LIST_CONFIG has ${listConfigCount} entries. ` +
+    `Missing: check for enum members without LIST_CONFIG mapping.`
+  );
+} else {
+  // eslint-disable-next-line no-console
+  console.log(`[A] OK  ListKeys (${listKeysCount}) === LIST_CONFIG entries (${listConfigCount})`);
+}
+
+// [B] manifest のリストタイトルが ListKeys に存在するか
+for (const listDef of manifest.lists) {
+  const title = listDef.listTitle;
+  if (!allListKeyValues.has(title as ListKeys)) {
+    errors.push(`[B] manifest contains "${title}" but this is NOT in ListKeys. Remove or add to ListKeys.`);
+  }
+}
+
+const bOkCount = manifest.lists.filter(l => allListKeyValues.has(l.listTitle as ListKeys)).length;
+if (errors.filter(e => e.startsWith('[B]')).length === 0) {
+  // eslint-disable-next-line no-console
+  console.log(`[B] OK  All ${bOkCount} manifest entries exist in ListKeys`);
+}
+
+// [C] ListKeys 全メンバーが manifest か _excluded に記録されているか
+for (const title of allListKeyValues) {
+  if (!manifestTitles.has(title) && !excludedTitles.has(title)) {
+    warnings.push(
+      `[C] WARN "${title}" is in ListKeys but neither in manifest.lists nor _excluded. ` +
+      `Add to manifest or document in _excluded.`
+    );
+  }
+}
+
+const cOkCount = [...allListKeyValues].filter(t => manifestTitles.has(t) || excludedTitles.has(t)).length;
+if (warnings.filter(w => w.startsWith('[C]')).length === 0) {
+  // eslint-disable-next-line no-console
+  console.log(`[C] OK  All ${cOkCount} ListKeys members are accounted for in manifest or _excluded`);
+}
+
+// ── 結果出力 ──────────────────────────────────────────────────────────────────
+
+/* eslint-disable no-console */
+const isIssueFormat = process.argv.includes('--issue-format');
+
+if (warnings.length > 0) {
+  console.warn('\n===== WARNINGS =====');
+  warnings.forEach(w => console.warn(' ', w));
+}
+
+if (errors.length > 0) {
+  console.error('\n===== ERRORS =====');
+  errors.forEach(e => console.error(' ', e));
+
+  if (isIssueFormat) {
+    // GitHub Issue 用フォーマット（コピペして gh issue create に使える）
+    const issueTitle = `[sp:audit] SP manifest 整合エラー ${errors.length}件 — ${new Date().toISOString().slice(0, 10)}`;
+    const issueBody = [
+      '## 概要',
+      '',
+      '`npm run sp:audit` で SP manifest の整合エラーが検出されました。',
+      '対応が必要です。',
+      '',
+      '## エラー詳細',
+      '',
+      errors.map(e => `- ${e}`).join('\n'),
+      '',
+      ...(warnings.length > 0 ? [
+        '## 警告',
+        '',
+        warnings.map(w => `- ${w}`).join('\n'),
+        '',
+      ] : []),
+      '## 対処方針',
+      '',
+      '優先順位: **Mismatch/Unique > Missing/List > Missing/Field > Mismatch/Index**',
+      '',
+      '詳細は [monthly-sp-structure-audit.md](docs/runbook/monthly-sp-structure-audit.md) を参照。',
+      '',
+      '## 関連ファイル',
+      '',
+      '- `src/sharepoint/fields/listRegistry.ts` — ListKeys / LIST_CONFIG',
+      '- `scripts/sp-preprod/lists.manifest.json` — manifest',
+    ].join('\n');
+
+    console.error('\n===== ISSUE TEMPLATE =====');
+    console.error(`TITLE: ${issueTitle}`);
+    console.error('---');
+    console.error(issueBody);
+    console.error('===========================');
+  }
+
+  console.error(`\nsp:audit FAILED (${errors.length} error(s), ${warnings.length} warning(s))`);
+  process.exit(1);
+} else {
+  console.log('\n===== sp:audit PASSED =====');
+  if (warnings.length > 0) {
+    console.log(`  ${warnings.length} warning(s) — review above`);
+  }
+  process.exit(0);
+}

--- a/scripts/sp-preprod/audit-browser-console.js
+++ b/scripts/sp-preprod/audit-browser-console.js
@@ -1,0 +1,151 @@
+/* eslint-disable no-console, no-undef, no-restricted-globals */
+/**
+ * SP List Audit — Browser Console Script
+ *
+ * 使い方:
+ *   1. https://isogokatudouhome.sharepoint.com/sites/welfare を Chrome/Edge で開く
+ *   2. F12 → コンソールタブ
+ *   3. このスクリプト全体をコピー → コンソールに貼り付け → Enter
+ *   4. 結果がコンソールに表示される（JSON キャプチャ可能）
+ *
+ * ※ CSP 制限で fetch が弾かれる場合は _spPageContextInfo.webAbsoluteUrl が
+ *    正しいサイトURLを指しているか確認してください。
+ */
+
+(async () => {
+
+  // ── manifest (インライン版) ────────────────────────────────────────────────
+  // lists.manifest.json の lists 配列をここに貼ります（ファイルから自動生成）
+
+  const MANIFEST_LISTS = [
+    { listTitle: "Users_Master",                 indexes: [{ field: "UserID", unique: true }, { field: "IsActive", unique: false }] },
+    { listTitle: "Holiday_Master",               indexes: [{ field: "Date", unique: false }, { field: "FiscalYear", unique: false }] },
+    { listTitle: "SupportTemplates",             indexes: [{ field: "UserCode0", unique: false }] },
+    { listTitle: "Schedules",                    indexes: [{ field: "cr014_dayKey", unique: false }, { field: "MonthKey", unique: false }, { field: "RowKey", unique: false }, { field: "cr014_personId", unique: false }] },
+    { listTitle: "DailyActivityRecords",         indexes: [{ field: "UserCode", unique: false }, { field: "RecordDate", unique: false }] },
+    { listTitle: "SupportProcedureRecord_Daily", indexes: [{ field: "UserCode", unique: false }, { field: "RecordDate", unique: false }, { field: "PlanningSheetId", unique: false }] },
+    { listTitle: "ISP_Master",                   indexes: [{ field: "UserCode", unique: false }, { field: "IsCurrent", unique: false }] },
+    { listTitle: "SupportPlanningSheet_Master",  indexes: [{ field: "UserCode", unique: false }, { field: "ISPId", unique: false }, { field: "IsCurrent", unique: false }] },
+    { listTitle: "SupportPlans",                 indexes: [] },
+    { listTitle: "PlanGoals",                    indexes: [] },
+    { listTitle: "MeetingMinutes",               indexes: [] },
+    { listTitle: "Staff_Attendance",             indexes: [] },
+    { listTitle: "AttendanceUsers",              indexes: [] },
+    { listTitle: "AttendanceDaily",              indexes: [] },
+    { listTitle: "Daily_Attendance",             indexes: [] },
+    { listTitle: "Transport_Log",                indexes: [] },
+    { listTitle: "Iceberg_PDCA",                 indexes: [] },
+    { listTitle: "Iceberg_Analysis",             indexes: [{ field: "EntryHash", unique: true }, { field: "SessionId", unique: false }, { field: "UserId", unique: false }] },
+    { listTitle: "Compliance_CheckRules",        indexes: [] },
+    { listTitle: "Diagnostics_Reports",          indexes: [] },
+    { listTitle: "FormsResponses_Tokusei",       indexes: [] },
+    { listTitle: "NurseObservations",            indexes: [] },
+    { listTitle: "PdfOutput_Log",               indexes: [] },
+  ];
+
+  // ── ヘルパー ───────────────────────────────────────────────────────────────
+  const siteUrl = (typeof _spPageContextInfo !== 'undefined' && _spPageContextInfo.webAbsoluteUrl)
+    || 'https://isogokatudouhome.sharepoint.com/sites/welfare';
+
+  const headers = {
+    'Accept': 'application/json;odata=nometadata',
+    'Content-Type': 'application/json;odata=nometadata',
+  };
+
+  async function apiFetch(endpoint) {
+    const res = await fetch(`${siteUrl}/_api/${endpoint}`, { headers });
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText} — ${endpoint}`);
+    return res.json();
+  }
+
+  // ── SP リスト一覧取得 ─────────────────────────────────────────────────────
+  console.log('%c[AUDIT] Fetching SP list inventory...', 'color: cyan');
+  const listsData = await apiFetch('web/lists?$select=Title,Hidden&$filter=Hidden eq false');
+  const spListTitles = new Set(listsData.value.map(l => l.Title));
+  console.log(`%c[AUDIT] ${spListTitles.size} lists found in SP`, 'color: cyan');
+
+  // ── 監査 ──────────────────────────────────────────────────────────────────
+  const results = [];
+
+  for (const listDef of MANIFEST_LISTS) {
+    const title = listDef.listTitle;
+
+    // 1. リスト存在チェック
+    if (!spListTitles.has(title)) {
+      console.warn(`[MISSING/List] ${title}`);
+      results.push({ list: title, category: 'Missing', sub: 'List', field: '', message: `List "${title}" not found in SP` });
+      continue;
+    }
+
+    console.log(`%c[OK] List exists: ${title}`, 'color: green');
+
+    // 2. フィールド・インデックス取得
+    let fields;
+    try {
+      const fd = await apiFetch(
+        `web/lists/getbytitle('${encodeURIComponent(title)}')/fields?$select=InternalName,Indexed,EnforceUniqueValues`
+      );
+      fields = new Map(fd.value.map(f => [f.InternalName, f]));
+    } catch (e) {
+      console.error(`[ERROR] Failed to fetch fields for ${title}:`, e.message);
+      results.push({ list: title, category: 'Error', sub: 'FieldFetch', field: '', message: e.message });
+      continue;
+    }
+
+    // 3. インデックス・ユニーク監査
+    for (const idx of (listDef.indexes || [])) {
+      const f = fields.get(idx.field);
+
+      if (!f) {
+        console.warn(`[MISSING/Field] ${title} :: ${idx.field}`);
+        results.push({ list: title, category: 'Missing', sub: 'Field', field: idx.field, message: `Field "${idx.field}" not found` });
+        continue;
+      }
+
+      if (!f.Indexed) {
+        console.warn(`[MISMATCH/Index] ${title} :: ${idx.field}`);
+        results.push({ list: title, category: 'Mismatch', sub: 'Indexed', field: idx.field, message: `Field "${idx.field}" has no index` });
+      } else {
+        results.push({ list: title, category: 'OK', sub: 'Indexed', field: idx.field, message: 'OK' });
+      }
+
+      if (idx.unique && !f.EnforceUniqueValues) {
+        console.warn(`[MISMATCH/Unique] ${title} :: ${idx.field}`);
+        results.push({ list: title, category: 'Mismatch', sub: 'Unique', field: idx.field, message: `Field "${idx.field}" has no unique constraint` });
+      } else if (idx.unique) {
+        results.push({ list: title, category: 'OK', sub: 'Unique', field: idx.field, message: 'OK' });
+      }
+    }
+  }
+
+  // ── サマリー表示 ──────────────────────────────────────────────────────────
+  const missingList  = results.filter(r => r.category === 'Missing'  && r.sub === 'List');
+  const missingField = results.filter(r => r.category === 'Missing'  && r.sub === 'Field');
+  const mismatchIdx  = results.filter(r => r.category === 'Mismatch' && r.sub === 'Indexed');
+  const mismatchUniq = results.filter(r => r.category === 'Mismatch' && r.sub === 'Unique');
+  const oks          = results.filter(r => r.category === 'OK');
+
+  console.log('%c\n========== AUDIT SUMMARY ==========', 'color: cyan; font-weight: bold');
+  console.log(`%cMissing / List  : ${missingList.length}`,  missingList.length  ? 'color: red'    : 'color: green');
+  console.log(`%cMissing / Field : ${missingField.length}`, missingField.length ? 'color: red'    : 'color: green');
+  console.log(`%cMismatch/Index  : ${mismatchIdx.length}`,  mismatchIdx.length  ? 'color: orange' : 'color: green');
+  console.log(`%cMismatch/Unique : ${mismatchUniq.length}`, mismatchUniq.length ? 'color: orange' : 'color: green');
+  console.log(`%cOK              : ${oks.length}`,          'color: green');
+  console.log('%c====================================\n', 'color: cyan');
+
+  if (missingList.length)  { console.group('%cMissing Lists', 'color:red');    missingList.forEach(r  => console.log(r.list));         console.groupEnd(); }
+  if (missingField.length) { console.group('%cMissing Fields', 'color:red');   missingField.forEach(r => console.log(`${r.list} :: ${r.field}`)); console.groupEnd(); }
+  if (mismatchIdx.length)  { console.group('%cNo Index', 'color:orange');      mismatchIdx.forEach(r  => console.log(`${r.list} :: ${r.field}`)); console.groupEnd(); }
+  if (mismatchUniq.length) { console.group('%cNo Unique', 'color:orange');     mismatchUniq.forEach(r => console.log(`${r.list} :: ${r.field}`)); console.groupEnd(); }
+
+  // ── JSON 出力（コピー用）────────────────────────────────────────────────
+  console.log('%c\n[AUDIT] Full results (copy below):', 'color: cyan');
+  console.log(JSON.stringify(results, null, 2));
+
+  // グローバル変数に保存（後から参照できる）
+  window._auditResults = results;
+  console.log('%c[AUDIT] Results saved to window._auditResults', 'color: cyan');
+
+  return results;
+
+})();

--- a/scripts/sp-preprod/audit-sharepoint-lists.ps1
+++ b/scripts/sp-preprod/audit-sharepoint-lists.ps1
@@ -1,0 +1,457 @@
+<#
+.SYNOPSIS
+    SharePoint List Audit Script - compares manifest with SP site and outputs diff
+
+.PARAMETER SiteUrl
+    Target SharePoint site URL
+
+.PARAMETER ManifestPath
+    Path to lists.manifest.json
+
+.PARAMETER OutputDir
+    Output directory for audit results (created if not exists)
+
+.PARAMETER UseWebLogin
+    Browser-based login using legacy web login (no App Registration required).
+    Recommended for personal tenants or when no Entra ID app is registered.
+
+.PARAMETER InteractiveLogin
+    Use PnP Interactive login (requires Entra ID App Registration with -ClientId).
+
+.PARAMETER ClientId
+    Entra ID App Registration Client ID (required when using -InteractiveLogin).
+
+.PARAMETER Credential
+    PSCredential for service account login
+
+.EXAMPLE
+    # Simplest: no App Registration needed
+    .\audit-sharepoint-lists.ps1 `
+        -SiteUrl "https://tenant.sharepoint.com/sites/mysite" `
+        -ManifestPath ".\scripts\sp-preprod\lists.manifest.json" `
+        -OutputDir ".\out\sp-audit" `
+        -UseWebLogin
+
+    # With App Registration
+    .\audit-sharepoint-lists.ps1 `
+        -SiteUrl "https://tenant.sharepoint.com/sites/mysite" `
+        -ManifestPath ".\scripts\sp-preprod\lists.manifest.json" `
+        -OutputDir ".\out\sp-audit" `
+        -InteractiveLogin -ClientId "your-client-id"
+#>
+
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$SiteUrl,
+
+    [Parameter(Mandatory)]
+    [string]$ManifestPath,
+
+    [Parameter(Mandatory)]
+    [string]$OutputDir,
+
+    # Use PnP Management Shell (no app registration required) - DEFAULT
+    [switch]$InteractiveLogin,
+
+    # Use device code flow (for environments where browser cannot open)
+    [switch]$DeviceLogin,
+
+    # Custom Entra ID App ClientId (optional - defaults to PnP Management Shell)
+    [string]$ClientId,
+
+    [PSCredential]$Credential
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# PnP Management Shell official multi-tenant ClientId (no app registration required)
+$PNP_MANAGEMENT_SHELL_CLIENTID = '31359c7f-bd7e-475c-86db-fdb8c937548e'
+# Helpers
+function Write-Step([string]$msg) { Write-Host ">> $msg" -ForegroundColor Cyan }
+function Write-Ok([string]$msg)   { Write-Host "  [OK] $msg" -ForegroundColor Green }
+function Write-Warn([string]$msg) { Write-Host "  [WARN] $msg" -ForegroundColor Yellow }
+function Write-Miss([string]$msg) { Write-Host "  [MISSING] $msg" -ForegroundColor Red }
+
+# Check PnP.PowerShell
+Write-Step "Checking PnP.PowerShell..."
+if (-not (Get-Module -ListAvailable -Name PnP.PowerShell)) {
+    Write-Error "PnP.PowerShell is not installed. Run: Install-Module PnP.PowerShell -Scope CurrentUser"
+    exit 1
+}
+Import-Module PnP.PowerShell -ErrorAction Stop
+
+# Resolve ClientId (fall back to PnP Management Shell)
+$resolvedClientId = if ($ClientId) { $ClientId } else { $PNP_MANAGEMENT_SHELL_CLIENTID }
+
+# Connect
+Write-Step "Connecting to SharePoint: $SiteUrl"
+if ($DeviceLogin) {
+    # Device code flow - browser not required, opens code in terminal
+    Connect-PnPOnline -Url $SiteUrl -DeviceLogin -ClientId $resolvedClientId
+} elseif ($Credential) {
+    Connect-PnPOnline -Url $SiteUrl -Credentials $Credential
+} else {
+    # Default: Interactive browser login via PnP Management Shell (no app registration needed)
+    Connect-PnPOnline -Url $SiteUrl -Interactive -ClientId $resolvedClientId
+}
+Write-Ok "Connected"
+
+# Load manifest
+Write-Step "Loading manifest: $ManifestPath"
+if (-not (Test-Path $ManifestPath)) {
+    Write-Error "Manifest not found: $ManifestPath"
+    exit 1
+}
+$manifest = Get-Content $ManifestPath -Encoding UTF8 | ConvertFrom-Json
+Write-Ok "Manifest loaded ($($manifest.lists.Count) lists)"
+
+# Prepare output dir
+if (-not (Test-Path $OutputDir)) {
+    New-Item -ItemType Directory -Path $OutputDir | Out-Null
+}
+$timestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+$csvPath   = Join-Path $OutputDir "sp-list-audit-results_$timestamp.csv"
+$mdPath    = Join-Path $OutputDir "sp-list-audit-report_$timestamp.md"
+$latestCsv = Join-Path $OutputDir "sp-list-audit-results.csv"
+$latestMd  = Join-Path $OutputDir "sp-list-audit-report.md"
+
+$results = [System.Collections.Generic.List[PSCustomObject]]::new()
+
+# Get SP lists (cached)
+Write-Step "Fetching SP list inventory..."
+$spLists = Get-PnPList | Where-Object { -not $_.Hidden } | Group-Object Title -AsHashTable -AsString
+Write-Ok "SP lists fetched ($($spLists.Count) lists)"
+
+# Audit loop
+foreach ($listDef in $manifest.lists) {
+    $listTitle = $listDef.listTitle
+    Write-Step "Auditing [$listTitle]..."
+
+    # 1. List existence
+    if (-not $spLists.ContainsKey($listTitle)) {
+        Write-Miss "List not found: $listTitle"
+        $results.Add([PSCustomObject]@{
+            ListTitle   = $listTitle
+            Category    = 'Missing'
+            SubCategory = 'List'
+            FieldName   = ''
+            Expected    = $listTitle
+            Actual      = '(not found)'
+            Message     = "List '$listTitle' does not exist in SP"
+        })
+        continue
+    }
+
+    Write-Ok "List exists: $listTitle"
+
+    # 2. Field inventory
+    $spFields = Get-PnPField -List $listTitle | Group-Object InternalName -AsHashTable -AsString
+
+    # 3. Field audit
+    foreach ($fieldDef in $listDef.requiredFields) {
+        $internalName = $fieldDef.internalName
+
+        # Skip SP built-in fields
+        if ($internalName -in @('Id', 'Title', 'Created', 'Modified', 'Author', 'Editor')) {
+            continue
+        }
+
+        if (-not $spFields.ContainsKey($internalName)) {
+            Write-Miss "Field missing: $internalName"
+            $results.Add([PSCustomObject]@{
+                ListTitle   = $listTitle
+                Category    = 'Missing'
+                SubCategory = 'Field'
+                FieldName   = $internalName
+                Expected    = $fieldDef.type
+                Actual      = '(not found)'
+                Message     = "Field '$internalName' missing (expected type: $($fieldDef.type))"
+            })
+            continue
+        }
+
+        $spField = $spFields[$internalName]
+
+        # Type check (loose match)
+        $spTypeName   = $spField.TypeAsString
+        $expectedType = $fieldDef.type
+        $typeOk = switch ($expectedType) {
+            'Text'     { $spTypeName -in @('Text', 'Choice', 'Computed') }
+            'Note'     { $spTypeName -eq 'Note' }
+            'Number'   { $spTypeName -eq 'Number' }
+            'Boolean'  { $spTypeName -eq 'Boolean' }
+            'DateTime' { $spTypeName -eq 'DateTime' }
+            'Choice'   { $spTypeName -in @('Choice', 'MultiChoice') }
+            'Lookup'   { $spTypeName -in @('Lookup', 'LookupMulti') }
+            'URL'      { $spTypeName -eq 'URL' }
+            default    { $true }
+        }
+
+        if (-not $typeOk) {
+            Write-Warn "Type mismatch: $internalName (expected: $expectedType / actual: $spTypeName)"
+            $results.Add([PSCustomObject]@{
+                ListTitle   = $listTitle
+                Category    = 'Mismatch'
+                SubCategory = 'FieldType'
+                FieldName   = $internalName
+                Expected    = $expectedType
+                Actual      = $spTypeName
+                Message     = "Field type mismatch: expected=$expectedType, actual=$spTypeName"
+            })
+        } else {
+            $results.Add([PSCustomObject]@{
+                ListTitle   = $listTitle
+                Category    = 'OK'
+                SubCategory = 'Field'
+                FieldName   = $internalName
+                Expected    = $expectedType
+                Actual      = $spTypeName
+                Message     = 'OK'
+            })
+        }
+
+        # Required check
+        if ($fieldDef.required -eq $true -and $spField.Required -ne $true) {
+            Write-Warn "Required mismatch: $internalName"
+            $results.Add([PSCustomObject]@{
+                ListTitle   = $listTitle
+                Category    = 'Mismatch'
+                SubCategory = 'Required'
+                FieldName   = $internalName
+                Expected    = 'true'
+                Actual      = $spField.Required.ToString()
+                Message     = "Required flag mismatch: manifest=true, SP=$($spField.Required)"
+            })
+        }
+    }
+
+    # 4. Index / Unique audit
+    if ($listDef.indexes -and $listDef.indexes.Count -gt 0) {
+        $spIndexedFields = $spFields.Values |
+            Where-Object { $_.Indexed -eq $true } |
+            Select-Object -ExpandProperty InternalName
+
+        foreach ($idxDef in $listDef.indexes) {
+            $idxField = $idxDef.field
+
+            if ($idxField -notin $spIndexedFields) {
+                Write-Warn "Index missing: $idxField"
+                $results.Add([PSCustomObject]@{
+                    ListTitle   = $listTitle
+                    Category    = 'Mismatch'
+                    SubCategory = 'Indexed'
+                    FieldName   = $idxField
+                    Expected    = 'Indexed'
+                    Actual      = 'Not Indexed'
+                    Message     = "Field '$idxField' has no index"
+                })
+            } else {
+                Write-Ok "Index OK: $idxField"
+                $results.Add([PSCustomObject]@{
+                    ListTitle   = $listTitle
+                    Category    = 'OK'
+                    SubCategory = 'Indexed'
+                    FieldName   = $idxField
+                    Expected    = 'Indexed'
+                    Actual      = 'Indexed'
+                    Message     = 'OK'
+                })
+            }
+
+            # Unique constraint
+            if ($idxDef.unique -eq $true) {
+                $spFieldObj = $spFields[$idxField]
+                if ($spFieldObj -and $spFieldObj.EnforceUniqueValues -ne $true) {
+                    Write-Warn "Unique constraint missing: $idxField"
+                    $results.Add([PSCustomObject]@{
+                        ListTitle   = $listTitle
+                        Category    = 'Mismatch'
+                        SubCategory = 'Unique'
+                        FieldName   = $idxField
+                        Expected    = 'Unique=true'
+                        Actual      = 'Unique=false'
+                        Message     = "Field '$idxField' has no unique constraint"
+                    })
+                } else {
+                    $results.Add([PSCustomObject]@{
+                        ListTitle   = $listTitle
+                        Category    = 'OK'
+                        SubCategory = 'Unique'
+                        FieldName   = $idxField
+                        Expected    = 'Unique=true'
+                        Actual      = 'Unique=true'
+                        Message     = 'OK'
+                    })
+                }
+            }
+        }
+    }
+
+    Write-Ok "[$listTitle] audit complete"
+}
+
+# Export CSV
+Write-Step "Exporting CSV: $csvPath"
+$results | Export-Csv -Path $csvPath -Encoding UTF8 -NoTypeInformation
+Copy-Item $csvPath $latestCsv -Force
+Write-Ok "CSV exported"
+
+# Build Markdown report
+Write-Step "Building Markdown report: $mdPath"
+$now          = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+$missing      = $results | Where-Object { $_.Category -eq 'Missing' }
+$mismatches   = $results | Where-Object { $_.Category -eq 'Mismatch' }
+$oks          = $results | Where-Object { $_.Category -eq 'OK' }
+$missingList  = $missing    | Where-Object { $_.SubCategory -eq 'List' }
+$missingField = $missing    | Where-Object { $_.SubCategory -eq 'Field' }
+$mismatchType = $mismatches | Where-Object { $_.SubCategory -eq 'FieldType' }
+$mismatchReq  = $mismatches | Where-Object { $_.SubCategory -eq 'Required' }
+$mismatchIdx  = $mismatches | Where-Object { $_.SubCategory -eq 'Indexed' }
+$mismatchUniq = $mismatches | Where-Object { $_.SubCategory -eq 'Unique' }
+
+$lines = [System.Collections.Generic.List[string]]::new()
+$lines.Add("# SP List Audit Report")
+$lines.Add("")
+$lines.Add("- **Date**: $now")
+$lines.Add("- **Site**: $SiteUrl")
+$lines.Add("- **Manifest**: $ManifestPath")
+$lines.Add("- **Lists in manifest**: $($manifest.lists.Count)")
+$lines.Add("")
+$lines.Add("---")
+$lines.Add("")
+$lines.Add("## Summary")
+$lines.Add("")
+$lines.Add("| Category | Count | Action |")
+$lines.Add("|---|---|---|")
+$lines.Add("| Missing / List | $($missingList.Count) | provision candidate |")
+$lines.Add("| Missing / Field | $($missingField.Count) | provision candidate |")
+$lines.Add("| Mismatch / Indexed | $($mismatchIdx.Count) | provision candidate |")
+$lines.Add("| Mismatch / Unique | $($mismatchUniq.Count) | provision candidate |")
+$lines.Add("| Mismatch / FieldType | $($mismatchType.Count) | **manual review** |")
+$lines.Add("| Mismatch / Required | $($mismatchReq.Count) | **manual review** |")
+$lines.Add("| OK | $($oks.Count) | - |")
+$lines.Add("")
+$lines.Add("---")
+$lines.Add("")
+
+# Missing / List
+$lines.Add("## Missing / List (provision candidate)")
+$lines.Add("")
+if ($missingList.Count -eq 0) {
+    $lines.Add("> **None** - all lists exist in SP")
+} else {
+    $lines.Add("| List | Message |")
+    $lines.Add("|---|---|")
+    foreach ($r in $missingList) { $lines.Add("| ``$($r.ListTitle)`` | $($r.Message) |") }
+}
+$lines.Add("")
+
+# Missing / Field
+$lines.Add("## Missing / Field (provision candidate)")
+$lines.Add("")
+if ($missingField.Count -eq 0) {
+    $lines.Add("> **None**")
+} else {
+    $lines.Add("| List | Field | Expected Type | Message |")
+    $lines.Add("|---|---|---|---|")
+    foreach ($r in $missingField) { $lines.Add("| ``$($r.ListTitle)`` | ``$($r.FieldName)`` | $($r.Expected) | $($r.Message) |") }
+}
+$lines.Add("")
+
+# Mismatch / Indexed
+$lines.Add("## Mismatch / Indexed (provision candidate)")
+$lines.Add("")
+if ($mismatchIdx.Count -eq 0) {
+    $lines.Add("> **None**")
+} else {
+    $lines.Add("| List | Field | Message |")
+    $lines.Add("|---|---|---|")
+    foreach ($r in $mismatchIdx) { $lines.Add("| ``$($r.ListTitle)`` | ``$($r.FieldName)`` | $($r.Message) |") }
+}
+$lines.Add("")
+
+# Mismatch / Unique
+$lines.Add("## Mismatch / Unique (provision candidate)")
+$lines.Add("")
+if ($mismatchUniq.Count -eq 0) {
+    $lines.Add("> **None**")
+} else {
+    $lines.Add("| List | Field | Message |")
+    $lines.Add("|---|---|---|")
+    foreach ($r in $mismatchUniq) { $lines.Add("| ``$($r.ListTitle)`` | ``$($r.FieldName)`` | $($r.Message) |") }
+}
+$lines.Add("")
+
+# Mismatch / FieldType
+$lines.Add("## Mismatch / FieldType (manual review required)")
+$lines.Add("")
+if ($mismatchType.Count -eq 0) {
+    $lines.Add("> **None**")
+} else {
+    $lines.Add("> Existing data/app impact - do NOT auto-fix. Review each case individually.")
+    $lines.Add("")
+    $lines.Add("| List | Field | Expected | Actual | Message |")
+    $lines.Add("|---|---|---|---|---|")
+    foreach ($r in $mismatchType) { $lines.Add("| ``$($r.ListTitle)`` | ``$($r.FieldName)`` | $($r.Expected) | $($r.Actual) | $($r.Message) |") }
+}
+$lines.Add("")
+
+# Mismatch / Required
+$lines.Add("## Mismatch / Required (manual review required)")
+$lines.Add("")
+if ($mismatchReq.Count -eq 0) {
+    $lines.Add("> **None**")
+} else {
+    $lines.Add("| List | Field | Message |")
+    $lines.Add("|---|---|---|")
+    foreach ($r in $mismatchReq) { $lines.Add("| ``$($r.ListTitle)`` | ``$($r.FieldName)`` | $($r.Message) |") }
+}
+$lines.Add("")
+$lines.Add("---")
+$lines.Add("")
+$lines.Add("## Next Steps")
+$lines.Add("")
+$lines.Add("After reviewing provision candidates, run:")
+$lines.Add("")
+$lines.Add('```powershell')
+$lines.Add("# dry run")
+$lines.Add(".\\scripts\\sp-preprod\\provision-missing-lists.ps1 ``")
+$lines.Add("    -SiteUrl `"$SiteUrl`" ``")
+$lines.Add("    -ManifestPath `".\\scripts\\sp-preprod\\lists.manifest.json`" ``")
+$lines.Add("    -InteractiveLogin ``")
+$lines.Add("    -WhatIfMode")
+$lines.Add("")
+$lines.Add("# actual run")
+$lines.Add(".\\scripts\\sp-preprod\\provision-missing-lists.ps1 ``")
+$lines.Add("    -SiteUrl `"$SiteUrl`" ``")
+$lines.Add("    -ManifestPath `".\\scripts\\sp-preprod\\lists.manifest.json`" ``")
+$lines.Add("    -InteractiveLogin")
+$lines.Add('```')
+$lines.Add("")
+$lines.Add("Always re-run the audit after provisioning.")
+
+$lines -join "`n" | Out-File -FilePath $mdPath -Encoding UTF8
+Copy-Item $mdPath $latestMd -Force
+Write-Ok "Markdown report exported"
+
+# Final summary
+Write-Host ""
+Write-Host "================================================" -ForegroundColor Cyan
+Write-Host " AUDIT COMPLETE" -ForegroundColor Cyan
+Write-Host "================================================" -ForegroundColor Cyan
+Write-Host "  Missing / List  : $($missingList.Count)"  -ForegroundColor $(if ($missingList.Count -gt 0)  { 'Red' }     else { 'Green' })
+Write-Host "  Missing / Field : $($missingField.Count)" -ForegroundColor $(if ($missingField.Count -gt 0) { 'Red' }     else { 'Green' })
+Write-Host "  Mismatch/Indexed: $($mismatchIdx.Count)"  -ForegroundColor $(if ($mismatchIdx.Count -gt 0)  { 'Yellow' }  else { 'Green' })
+Write-Host "  Mismatch/Unique : $($mismatchUniq.Count)" -ForegroundColor $(if ($mismatchUniq.Count -gt 0) { 'Yellow' }  else { 'Green' })
+Write-Host "  Mismatch/Type   : $($mismatchType.Count)" -ForegroundColor $(if ($mismatchType.Count -gt 0) { 'Magenta' } else { 'Green' })
+Write-Host "  Mismatch/Req    : $($mismatchReq.Count)"  -ForegroundColor $(if ($mismatchReq.Count -gt 0)  { 'Magenta' } else { 'Green' })
+Write-Host "  OK              : $($oks.Count)"           -ForegroundColor Green
+Write-Host "------------------------------------------------" -ForegroundColor Cyan
+Write-Host "  CSV : $latestCsv"
+Write-Host "  MD  : $latestMd"
+Write-Host "================================================" -ForegroundColor Cyan
+
+Disconnect-PnPOnline

--- a/scripts/sp-preprod/lists.manifest.json
+++ b/scripts/sp-preprod/lists.manifest.json
@@ -1,0 +1,450 @@
+{
+  "_comment": "SP本番前監査マニフェスト — リポジトリ ListKeys / FIELD_MAP を正として生成 (2026-03-18)",
+  "schemaVersion": "2026-03-18",
+  "generatedAt": "2026-03-18T10:10:00+09:00",
+  "_version": "2.0.0",
+  "_generator": "aligned to src/sharepoint/fields/listRegistry.ts",
+  "lists": [
+
+    {
+      "listTitle": "Users_Master",
+      "listKey": "UsersMaster",
+      "description": "利用者マスタ",
+      "category": "master",
+      "requiredFields": [
+        { "internalName": "Id",                          "type": "Number",   "required": true  },
+        { "internalName": "Title",                       "type": "Text",     "required": true  },
+        { "internalName": "UserID",                      "type": "Text",     "required": true  },
+        { "internalName": "FullName",                    "type": "Text",     "required": true  },
+        { "internalName": "Furigana",                    "type": "Text",     "required": false },
+        { "internalName": "FullNameKana",                "type": "Text",     "required": false },
+        { "internalName": "IsActive",                    "type": "Boolean",  "required": true  },
+        { "internalName": "severeFlag",                  "type": "Boolean",  "required": false },
+        { "internalName": "IsHighIntensitySupportTarget","type": "Boolean",  "required": false },
+        { "internalName": "IsSupportProcedureTarget",    "type": "Boolean",  "required": false },
+        { "internalName": "ServiceStartDate",            "type": "DateTime", "required": false },
+        { "internalName": "ServiceEndDate",              "type": "DateTime", "required": false },
+        { "internalName": "ContractDate",                "type": "DateTime", "required": false },
+        { "internalName": "AttendanceDays",              "type": "Text",     "required": false },
+        { "internalName": "UsageStatus",                 "type": "Text",     "required": false },
+        { "internalName": "GrantMunicipality",           "type": "Text",     "required": false },
+        { "internalName": "GrantPeriodStart",            "type": "DateTime", "required": false },
+        { "internalName": "GrantPeriodEnd",              "type": "DateTime", "required": false },
+        { "internalName": "DisabilitySupportLevel",      "type": "Text",     "required": false },
+        { "internalName": "GrantedDaysPerMonth",         "type": "Text",     "required": false },
+        { "internalName": "UserCopayLimit",              "type": "Text",     "required": false },
+        { "internalName": "TransportAdditionType",       "type": "Text",     "required": false },
+        { "internalName": "MealAddition",                "type": "Text",     "required": false },
+        { "internalName": "CopayPaymentMethod",          "type": "Text",     "required": false },
+        { "internalName": "RecipientCertNumber",         "type": "Text",     "required": false },
+        { "internalName": "RecipientCertExpiry",         "type": "DateTime", "required": false },
+        { "internalName": "LastAssessmentDate",          "type": "DateTime", "required": false },
+        { "internalName": "BehaviorScore",               "type": "Number",   "required": false },
+        { "internalName": "ChildBehaviorScore",          "type": "Number",   "required": false },
+        { "internalName": "ServiceTypesJson",            "type": "Note",     "required": false },
+        { "internalName": "EligibilityCheckedAt",        "type": "DateTime", "required": false }
+      ],
+      "indexes": [
+        { "field": "UserID",   "unique": true },
+        { "field": "IsActive", "unique": false }
+      ]
+    },
+
+    {
+      "listTitle": "Holiday_Master",
+      "listKey": "HolidayMaster",
+      "description": "祝日・休業日マスタ",
+      "category": "master",
+      "requiredFields": [
+        { "internalName": "Id",         "type": "Number",   "required": true  },
+        { "internalName": "Title",      "type": "Text",     "required": true  },
+        { "internalName": "Date",       "type": "DateTime", "required": true  },
+        { "internalName": "Label",      "type": "Text",     "required": false },
+        { "internalName": "Type",       "type": "Choice",   "required": true,
+          "choices": ["national", "company", "special"] },
+        { "internalName": "FiscalYear", "type": "Text",     "required": true  },
+        { "internalName": "IsActive",   "type": "Boolean",  "required": true  }
+      ],
+      "indexes": [
+        { "field": "Date",       "unique": false },
+        { "field": "FiscalYear", "unique": false }
+      ]
+    },
+
+    {
+      "listTitle": "SupportTemplates",
+      "listKey": "SupportTemplates",
+      "description": "支援手順テンプレート（旧称 SupportTemplate_TEMPL から修正）",
+      "category": "master",
+      "_note": "内部名に '0' サフィックスが付く列が存在する（SharePoint の重複列名回避による）",
+      "requiredFields": [
+        { "internalName": "Id",              "type": "Number", "required": true  },
+        { "internalName": "Title",           "type": "Text",   "required": true  },
+        { "internalName": "UserCode0",       "type": "Text",   "required": false },
+        { "internalName": "RowNo0",          "type": "Number", "required": false },
+        { "internalName": "TimeSlot0",       "type": "Text",   "required": false },
+        { "internalName": "Activity0",       "type": "Text",   "required": false },
+        { "internalName": "PersonManual0",   "type": "Note",   "required": false },
+        { "internalName": "SupporterManual0","type": "Note",   "required": false }
+      ],
+      "indexes": [
+        { "field": "UserCode0", "unique": false }
+      ]
+    },
+
+    {
+      "listTitle": "Schedules",
+      "listKey": "Schedules",
+      "description": "スケジュール（scheduleFields.ts 実装済み、ListKeys 登録漏れを今回修正）",
+      "category": "schedule",
+      "requiredFields": [
+        { "internalName": "Id",                      "type": "Number",   "required": true  },
+        { "internalName": "Title",                   "type": "Text",     "required": true  },
+        { "internalName": "EventDate",               "type": "DateTime", "required": true  },
+        { "internalName": "EndDate",                 "type": "DateTime", "required": true  },
+        { "internalName": "Status",                  "type": "Choice",   "required": true  },
+        { "internalName": "ServiceType",             "type": "Text",     "required": false },
+        { "internalName": "cr014_personType",        "type": "Choice",   "required": false,
+          "choices": ["User", "Staff", "Org"] },
+        { "internalName": "cr014_personId",          "type": "Text",     "required": false },
+        { "internalName": "cr014_personName",        "type": "Text",     "required": false },
+        { "internalName": "AssignedStaffId",         "type": "Text",     "required": false },
+        { "internalName": "TargetUserId",            "type": "Text",     "required": false },
+        { "internalName": "RowKey",                  "type": "Text",     "required": false },
+        { "internalName": "cr014_dayKey",            "type": "DateTime", "required": false },
+        { "internalName": "MonthKey",                "type": "Text",     "required": false },
+        { "internalName": "cr014_fiscalYear",        "type": "Text",     "required": false },
+        { "internalName": "EntryHash",               "type": "Text",     "required": false },
+        { "internalName": "Note",                    "type": "Note",     "required": false },
+        { "internalName": "cr014_staffIds",          "type": "Text",     "required": false },
+        { "internalName": "cr014_staffNames",        "type": "Text",     "required": false },
+        { "internalName": "BillingFlags",            "type": "Text",     "required": false },
+        { "internalName": "SubType",                 "type": "Text",     "required": false },
+        { "internalName": "cr014_orgAudience",       "type": "Text",     "required": false },
+        { "internalName": "cr014_dayPart",           "type": "Text",     "required": false },
+        { "internalName": "CreatedAt",               "type": "DateTime", "required": false },
+        { "internalName": "UpdatedAt",               "type": "DateTime", "required": false }
+      ],
+      "indexes": [
+        { "field": "cr014_dayKey",    "unique": false },
+        { "field": "MonthKey",        "unique": false },
+        { "field": "RowKey",          "unique": false },
+        { "field": "cr014_personId",  "unique": false }
+      ]
+    },
+
+    {
+      "listTitle": "DailyActivityRecords",
+      "listKey": "DailyActivityRecords",
+      "description": "日次活動記録（観察・行動・タイムスライス単位）",
+      "category": "daily",
+      "_note": "intensity→'version'、duration→'duration' は小文字の SharePoint レガシースキーマ（変更不可）",
+      "requiredFields": [
+        { "internalName": "Id",             "type": "Number",   "required": true  },
+        { "internalName": "Title",          "type": "Text",     "required": false },
+        { "internalName": "UserCode",       "type": "Text",     "required": true  },
+        { "internalName": "RecordDate",     "type": "DateTime", "required": true  },
+        { "internalName": "TimeSlot",       "type": "Text",     "required": false },
+        { "internalName": "PlanSlotKey",    "type": "Text",     "required": false },
+        { "internalName": "PlannedActivity","type": "Text",     "required": false },
+        { "internalName": "RecordedAtText", "type": "Text",     "required": false },
+        { "internalName": "Observation",    "type": "Note",     "required": false },
+        { "internalName": "Behavior",       "type": "Note",     "required": false },
+        { "internalName": "version",        "type": "Text",     "required": false, "_logicalName": "intensity" },
+        { "internalName": "duration",       "type": "Number",   "required": false },
+        { "internalName": "Order",          "type": "Number",   "required": false }
+      ],
+      "indexes": [
+        { "field": "UserCode",   "unique": false },
+        { "field": "RecordDate", "unique": false }
+      ]
+    },
+
+    {
+      "listTitle": "SupportProcedureRecord_Daily",
+      "listKey": "ProcedureRecordDaily",
+      "description": "支援手順書兼記録（日次）— ISP三層モデルの最下層。PlanningSheetと連携",
+      "category": "daily",
+      "requiredFields": [
+        { "internalName": "Id",                      "type": "Number",   "required": true  },
+        { "internalName": "Title",                   "type": "Text",     "required": true  },
+        { "internalName": "UserCode",                "type": "Text",     "required": true  },
+        { "internalName": "ISPLookupId",             "type": "Number",   "required": false },
+        { "internalName": "ISPId",                   "type": "Text",     "required": false },
+        { "internalName": "PlanningSheetLookupId",   "type": "Number",   "required": false },
+        { "internalName": "PlanningSheetId",         "type": "Text",     "required": false },
+        { "internalName": "RecordDate",              "type": "DateTime", "required": true  },
+        { "internalName": "TimeSlot",                "type": "Text",     "required": false },
+        { "internalName": "Activity",                "type": "Text",     "required": false },
+        { "internalName": "ProcedureText",           "type": "Note",     "required": true  },
+        { "internalName": "ExecutionStatus",         "type": "Choice",   "required": true  },
+        { "internalName": "UserResponse",            "type": "Note",     "required": false },
+        { "internalName": "SpecialNotes",            "type": "Note",     "required": false },
+        { "internalName": "HandoffNotes",            "type": "Note",     "required": false },
+        { "internalName": "PerformedBy",             "type": "Text",     "required": true  },
+        { "internalName": "PerformedAt",             "type": "DateTime", "required": true  }
+      ],
+      "indexes": [
+        { "field": "UserCode",          "unique": false },
+        { "field": "RecordDate",        "unique": false },
+        { "field": "PlanningSheetId",   "unique": false }
+      ]
+    },
+
+    {
+      "listTitle": "ISP_Master",
+      "listKey": "IspMaster",
+      "description": "個別支援計画本体（ISP三層モデル 第1層）",
+      "category": "plan",
+      "requiredFields": [
+        { "internalName": "Id",                      "type": "Number",   "required": true  },
+        { "internalName": "Title",                   "type": "Text",     "required": true  },
+        { "internalName": "UserCode",                "type": "Text",     "required": true  },
+        { "internalName": "PlanStartDate",           "type": "DateTime", "required": true  },
+        { "internalName": "PlanEndDate",             "type": "DateTime", "required": true  },
+        { "internalName": "Status",                  "type": "Choice",   "required": true  },
+        { "internalName": "VersionNo",               "type": "Number",   "required": true  },
+        { "internalName": "IsCurrent",               "type": "Boolean",  "required": true  },
+        { "internalName": "ConsentAt",               "type": "DateTime", "required": false },
+        { "internalName": "DeliveredAt",             "type": "DateTime", "required": false },
+        { "internalName": "LastMonitoringAt",        "type": "DateTime", "required": false },
+        { "internalName": "NextReviewAt",            "type": "DateTime", "required": false },
+        { "internalName": "FormDataJson",            "type": "Note",     "required": false },
+        { "internalName": "UserSnapshotJson",        "type": "Note",     "required": false }
+      ],
+      "indexes": [
+        { "field": "UserCode",  "unique": false },
+        { "field": "IsCurrent", "unique": false }
+      ]
+    },
+
+    {
+      "listTitle": "SupportPlanningSheet_Master",
+      "listKey": "PlanningSheetMaster",
+      "description": "支援計画シート（ISP三層モデル 第2層）",
+      "category": "plan",
+      "requiredFields": [
+        { "internalName": "Id",                          "type": "Number",   "required": true  },
+        { "internalName": "Title",                       "type": "Text",     "required": true  },
+        { "internalName": "UserCode",                    "type": "Text",     "required": true  },
+        { "internalName": "ISPLookupId",                 "type": "Number",   "required": false },
+        { "internalName": "ISPId",                       "type": "Text",     "required": false },
+        { "internalName": "Status",                      "type": "Choice",   "required": true  },
+        { "internalName": "VersionNo",                   "type": "Number",   "required": true  },
+        { "internalName": "IsCurrent",                   "type": "Boolean",  "required": true  },
+        { "internalName": "AppliedFrom",                 "type": "DateTime", "required": false },
+        { "internalName": "NextReviewAt",                "type": "DateTime", "required": false },
+        { "internalName": "FormDataJson",                "type": "Note",     "required": false },
+        { "internalName": "AuthoredByStaffId",           "type": "Text",     "required": false },
+        { "internalName": "AuthoredByQualification",     "type": "Text",     "required": false },
+        { "internalName": "AuthoredAt",                  "type": "DateTime", "required": false },
+        { "internalName": "ApplicableServiceType",       "type": "Text",     "required": false },
+        { "internalName": "DeliveredToUserAt",           "type": "DateTime", "required": false },
+        { "internalName": "ReviewedAt",                  "type": "DateTime", "required": false },
+        { "internalName": "HasMedicalCoordination",      "type": "Boolean",  "required": false },
+        { "internalName": "HasEducationCoordination",    "type": "Boolean",  "required": false },
+        { "internalName": "IntakeJson",                  "type": "Note",     "required": false },
+        { "internalName": "AssessmentJson",              "type": "Note",     "required": false },
+        { "internalName": "PlanningJson",                "type": "Note",     "required": false }
+      ],
+      "indexes": [
+        { "field": "UserCode",  "unique": false },
+        { "field": "ISPId",     "unique": false },
+        { "field": "IsCurrent", "unique": false }
+      ]
+    },
+
+    {
+      "listTitle": "SupportPlans",
+      "listKey": "SupportPlans",
+      "description": "個別支援計画（旧モデル・後方互換）",
+      "category": "plan",
+      "requiredFields": [
+        { "internalName": "Id",    "type": "Number", "required": true },
+        { "internalName": "Title", "type": "Text",   "required": true }
+      ],
+      "indexes": []
+    },
+
+    {
+      "listTitle": "PlanGoals",
+      "listKey": "PlanGoals",
+      "description": "支援計画目標（ISP旧モデル）",
+      "category": "plan",
+      "requiredFields": [
+        { "internalName": "Id",    "type": "Number", "required": true },
+        { "internalName": "Title", "type": "Text",   "required": true }
+      ],
+      "indexes": []
+    },
+
+    {
+      "listTitle": "MeetingMinutes",
+      "listKey": "MeetingMinutes",
+      "description": "議事録",
+      "category": "meeting",
+      "requiredFields": [
+        { "internalName": "Id",    "type": "Number", "required": true },
+        { "internalName": "Title", "type": "Text",   "required": true }
+      ],
+      "indexes": []
+    },
+
+    {
+      "listTitle": "Staff_Attendance",
+      "listKey": "StaffAttendance",
+      "description": "職員出勤管理",
+      "category": "attendance",
+      "requiredFields": [
+        { "internalName": "Id",    "type": "Number", "required": true },
+        { "internalName": "Title", "type": "Text",   "required": true }
+      ],
+      "indexes": []
+    },
+
+    {
+      "listTitle": "AttendanceUsers",
+      "listKey": "AttendanceUsers",
+      "description": "出席管理ユーザー",
+      "category": "attendance",
+      "requiredFields": [
+        { "internalName": "Id",    "type": "Number", "required": true },
+        { "internalName": "Title", "type": "Text",   "required": true }
+      ],
+      "indexes": []
+    },
+
+    {
+      "listTitle": "AttendanceDaily",
+      "listKey": "AttendanceDaily",
+      "description": "日次出席詳細",
+      "category": "attendance",
+      "requiredFields": [
+        { "internalName": "Id",    "type": "Number", "required": true },
+        { "internalName": "Title", "type": "Text",   "required": true }
+      ],
+      "indexes": []
+    },
+
+    {
+      "listTitle": "Daily_Attendance",
+      "listKey": "DailyAttendance",
+      "description": "日次出欠（監査 P1-3 追加）",
+      "category": "attendance",
+      "requiredFields": [
+        { "internalName": "Id",    "type": "Number", "required": true },
+        { "internalName": "Title", "type": "Text",   "required": true }
+      ],
+      "indexes": []
+    },
+
+    {
+      "listTitle": "Transport_Log",
+      "listKey": "TransportLog",
+      "description": "送迎ステータスログ",
+      "category": "attendance",
+      "requiredFields": [
+        { "internalName": "Id",    "type": "Number", "required": true },
+        { "internalName": "Title", "type": "Text",   "required": true }
+      ],
+      "indexes": []
+    },
+
+    {
+      "listTitle": "Iceberg_PDCA",
+      "listKey": "IcebergPdca",
+      "description": "氷山モデル PDCA",
+      "category": "analysis",
+      "requiredFields": [
+        { "internalName": "Id",    "type": "Number", "required": true },
+        { "internalName": "Title", "type": "Text",   "required": true }
+      ],
+      "indexes": []
+    },
+
+    {
+      "listTitle": "Iceberg_Analysis",
+      "listKey": "IcebergAnalysis",
+      "description": "氷山モデル分析（EntryHash で重複検知）",
+      "category": "analysis",
+      "requiredFields": [
+        { "internalName": "Id",         "type": "Number", "required": true  },
+        { "internalName": "Title",      "type": "Text",   "required": true  },
+        { "internalName": "EntryHash",  "type": "Text",   "required": true  },
+        { "internalName": "SessionId",  "type": "Text",   "required": true  },
+        { "internalName": "UserId",     "type": "Text",   "required": true  },
+        { "internalName": "PayloadJson","type": "Note",   "required": true  }
+      ],
+      "indexes": [
+        { "field": "EntryHash", "unique": true },
+        { "field": "SessionId", "unique": false },
+        { "field": "UserId",    "unique": false }
+      ]
+    },
+
+    {
+      "listTitle": "Compliance_CheckRules",
+      "listKey": "ComplianceCheckRules",
+      "description": "監査チェックルール",
+      "category": "compliance",
+      "requiredFields": [
+        { "internalName": "Id",    "type": "Number", "required": true },
+        { "internalName": "Title", "type": "Text",   "required": true }
+      ],
+      "indexes": []
+    },
+
+    {
+      "listTitle": "Diagnostics_Reports",
+      "listKey": "DiagnosticsReports",
+      "description": "環境診断レポート",
+      "category": "compliance",
+      "requiredFields": [
+        { "internalName": "Id",    "type": "Number", "required": true },
+        { "internalName": "Title", "type": "Text",   "required": true }
+      ],
+      "indexes": []
+    },
+
+    {
+      "listTitle": "FormsResponses_Tokusei",
+      "listKey": "SurveyTokusei",
+      "description": "特性アンケート（Forms 連携）",
+      "category": "analysis",
+      "requiredFields": [
+        { "internalName": "Id",    "type": "Number", "required": true },
+        { "internalName": "Title", "type": "Text",   "required": true }
+      ],
+      "indexes": []
+    },
+
+    {
+      "listTitle": "NurseObservations",
+      "listKey": "NurseObservations",
+      "description": "看護観察記録（監査 P1-3 追加）",
+      "category": "daily",
+      "requiredFields": [
+        { "internalName": "Id",    "type": "Number", "required": true },
+        { "internalName": "Title", "type": "Text",   "required": true }
+      ],
+      "indexes": []
+    },
+
+    {
+      "listTitle": "PdfOutput_Log",
+      "listKey": "PdfOutputLog",
+      "description": "帳票出力ログ（監査 P1-2 追加）",
+      "category": "compliance",
+      "requiredFields": [
+        { "internalName": "Id",    "type": "Number", "required": true },
+        { "internalName": "Title", "type": "Text",   "required": true }
+      ],
+      "indexes": []
+    }
+  ],
+
+  "_excluded": {
+    "_reason": "コードに ListKeys / FIELD_MAP / Repository 実装が存在しないため、今回の本番前対象から除外",
+    "lists": ["Inquiries", "CoffeeOrderHistory", "MonthlyCoffeeBilling", "SupportRecord_Daily（架空名）"]
+  }
+}

--- a/scripts/sp-preprod/provision-missing-lists.ps1
+++ b/scripts/sp-preprod/provision-missing-lists.ps1
@@ -1,0 +1,312 @@
+<#
+.SYNOPSIS
+    SharePoint List Provisioning Script - creates missing lists/fields/indexes/unique constraints
+
+.DESCRIPTION
+    Reads lists.manifest.json and creates only elements that do not exist in SP.
+    Does NOT modify existing fields (no type change, no Choice removal, no Lookup change).
+
+    Operations:
+      [YES] Create missing List
+      [YES] Add missing Field
+      [YES] Add missing Index
+      [YES] Set missing Unique constraint
+      [NO]  Change FieldType (manual action required)
+      [NO]  Change Required flag (manual action required)
+      [NO]  Remove Choice values (manual action required)
+
+.PARAMETER SiteUrl
+    Target SharePoint site URL
+
+.PARAMETER ManifestPath
+    Path to lists.manifest.json
+
+.PARAMETER UseWebLogin
+    Browser-based login using legacy web login (no App Registration required).
+    Recommended for personal tenants.
+
+.PARAMETER InteractiveLogin
+    Use PnP Interactive login (requires Entra ID App Registration with -ClientId).
+
+.PARAMETER ClientId
+    Entra ID App Registration Client ID (required when using -InteractiveLogin).
+
+.PARAMETER Credential
+    PSCredential for service account login
+
+.PARAMETER WhatIfMode
+    Dry run - shows what would be done without making any changes
+
+.EXAMPLE
+    # dry run (no App Registration needed)
+    .\provision-missing-lists.ps1 `
+        -SiteUrl "https://tenant.sharepoint.com/sites/mysite" `
+        -ManifestPath ".\scripts\sp-preprod\lists.manifest.json" `
+        -UseWebLogin `
+        -WhatIfMode
+
+    # actual run
+    .\provision-missing-lists.ps1 `
+        -SiteUrl "https://tenant.sharepoint.com/sites/mysite" `
+        -ManifestPath ".\scripts\sp-preprod\lists.manifest.json" `
+        -UseWebLogin
+#>
+
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [Parameter(Mandatory)]
+    [string]$SiteUrl,
+
+    [Parameter(Mandatory)]
+    [string]$ManifestPath,
+
+    [switch]$DeviceLogin,
+
+    [string]$ClientId,
+
+    [PSCredential]$Credential,
+
+    [switch]$WhatIfMode
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Helpers
+function Write-Step([string]$msg) { Write-Host ">> $msg" -ForegroundColor Cyan }
+function Write-Ok([string]$msg)   { Write-Host "  [OK] $msg" -ForegroundColor Green }
+function Write-Dry([string]$msg)  { Write-Host "  [DRY] $msg" -ForegroundColor Yellow }
+function Write-Act([string]$msg)  { Write-Host "  [ACT] $msg" -ForegroundColor Magenta }
+function Write-Skip([string]$msg) { Write-Host "  [SKIP] $msg" -ForegroundColor Gray }
+
+$actionLog = [System.Collections.Generic.List[PSCustomObject]]::new()
+
+function Log-Action([string]$list, [string]$action, [string]$target, [string]$status, [string]$detail = '') {
+    $actionLog.Add([PSCustomObject]@{
+        ListTitle = $list
+        Action    = $action
+        Target    = $target
+        Status    = $status
+        Detail    = $detail
+    })
+}
+
+function Get-FieldType([string]$manifestType) {
+    switch ($manifestType) {
+        'Text'     { return 'Text' }
+        'Note'     { return 'Note' }
+        'Number'   { return 'Number' }
+        'Boolean'  { return 'Boolean' }
+        'DateTime' { return 'DateTime' }
+        'Choice'   { return 'Choice' }
+        'Lookup'   { return 'Lookup' }
+        'URL'      { return 'URL' }
+        default    { return 'Text' }
+    }
+}
+
+# Check PnP.PowerShell
+Write-Step "Checking PnP.PowerShell..."
+if (-not (Get-Module -ListAvailable -Name PnP.PowerShell)) {
+    Write-Error "PnP.PowerShell is not installed. Run: Install-Module PnP.PowerShell -Scope CurrentUser"
+    exit 1
+}
+Import-Module PnP.PowerShell -ErrorAction Stop
+
+if ($WhatIfMode) {
+    Write-Host ""
+    Write-Host "============================================" -ForegroundColor Yellow
+    Write-Host "  DRY RUN MODE - no changes will be made  " -ForegroundColor Yellow
+    Write-Host "============================================" -ForegroundColor Yellow
+    Write-Host ""
+}
+
+# PnP Management Shell official multi-tenant ClientId (no app registration required)
+$PNP_MANAGEMENT_SHELL_CLIENTID = '31359c7f-bd7e-475c-86db-fdb8c937548e'
+$resolvedClientId = if ($ClientId) { $ClientId } else { $PNP_MANAGEMENT_SHELL_CLIENTID }
+
+# Connect
+Write-Step "Connecting to SharePoint: $SiteUrl"
+if ($DeviceLogin) {
+    Connect-PnPOnline -Url $SiteUrl -DeviceLogin -ClientId $resolvedClientId
+} elseif ($Credential) {
+    Connect-PnPOnline -Url $SiteUrl -Credentials $Credential
+} else {
+    # Default: Interactive browser login via PnP Management Shell
+    Connect-PnPOnline -Url $SiteUrl -Interactive -ClientId $resolvedClientId
+}
+Write-Ok "Connected"
+
+# Load manifest
+Write-Step "Loading manifest: $ManifestPath"
+if (-not (Test-Path $ManifestPath)) {
+    Write-Error "Manifest not found: $ManifestPath"
+    exit 1
+}
+$manifest = Get-Content $ManifestPath -Encoding UTF8 | ConvertFrom-Json
+Write-Ok "Manifest loaded ($($manifest.lists.Count) lists)"
+
+# Get SP list cache
+Write-Step "Fetching SP list inventory..."
+$spLists = Get-PnPList | Where-Object { -not $_.Hidden } | Group-Object Title -AsHashTable -AsString
+
+# Provisioning loop
+foreach ($listDef in $manifest.lists) {
+    $listTitle = $listDef.listTitle
+    Write-Step "Processing [$listTitle]..."
+
+    # 1. Create list if missing
+    if (-not $spLists.ContainsKey($listTitle)) {
+        if ($WhatIfMode) {
+            Write-Dry "Would create list: $listTitle"
+            Log-Action $listTitle 'Create List' $listTitle 'DRY_RUN' $listDef.description
+        } else {
+            Write-Act "Creating list: $listTitle"
+            $null = New-PnPList -Title $listTitle -Template GenericList -OnQuickLaunch
+            Write-Ok "List created: $listTitle"
+            Log-Action $listTitle 'Create List' $listTitle 'DONE' $listDef.description
+            $spLists[$listTitle] = Get-PnPList -Identity $listTitle
+        }
+    } else {
+        Write-Skip "List already exists: $listTitle"
+        Log-Action $listTitle 'Create List' $listTitle 'SKIPPED' 'already exists'
+    }
+
+    # 2. Add missing fields
+    if ($listDef.requiredFields -and $listDef.requiredFields.Count -gt 0) {
+        $spFields = Get-PnPField -List $listTitle | Group-Object InternalName -AsHashTable -AsString
+
+        foreach ($fieldDef in $listDef.requiredFields) {
+            $internalName = $fieldDef.internalName
+
+            if ($internalName -in @('Id', 'Title', 'Created', 'Modified', 'Author', 'Editor')) {
+                continue
+            }
+
+            if ($spFields.ContainsKey($internalName)) {
+                Write-Skip "Field already exists: $internalName"
+                continue
+            }
+
+            $pnpType = Get-FieldType $fieldDef.type
+
+            if ($WhatIfMode) {
+                Write-Dry "Would add field: $internalName ($pnpType)"
+                Log-Action $listTitle 'Add Field' $internalName 'DRY_RUN' "type=$pnpType"
+            } else {
+                Write-Act "Adding field: $internalName ($pnpType)"
+                try {
+                    if ($pnpType -eq 'Choice' -and $fieldDef.choices) {
+                        $choiceXml = ($fieldDef.choices | ForEach-Object { "<CHOICE>$_</CHOICE>" }) -join ''
+                        $req = if ($fieldDef.required) { 'TRUE' } else { 'FALSE' }
+                        $xmlSchema = "<Field Type='Choice' DisplayName='$internalName' Name='$internalName' StaticName='$internalName' Required='$req'><CHOICES>$choiceXml</CHOICES></Field>"
+                        Add-PnPFieldFromXml -List $listTitle -FieldXml $xmlSchema | Out-Null
+                    } else {
+                        Add-PnPField -List $listTitle `
+                            -InternalName $internalName `
+                            -DisplayName $internalName `
+                            -Type $pnpType `
+                            -Required:($fieldDef.required -eq $true) | Out-Null
+                    }
+                    Write-Ok "Field added: $internalName"
+                    Log-Action $listTitle 'Add Field' $internalName 'DONE' "type=$pnpType"
+                } catch {
+                    Write-Warning "Failed to add field: $internalName - $($_.Exception.Message)"
+                    Log-Action $listTitle 'Add Field' $internalName 'ERROR' $_.Exception.Message
+                }
+            }
+        }
+    }
+
+    # 3. Add indexes and unique constraints
+    if ($listDef.indexes -and $listDef.indexes.Count -gt 0) {
+        $spFields = Get-PnPField -List $listTitle | Group-Object InternalName -AsHashTable -AsString
+
+        foreach ($idxDef in $listDef.indexes) {
+            $idxField = $idxDef.field
+
+            if (-not $spFields.ContainsKey($idxField)) {
+                Write-Warning "Index target field not found, skipping: $idxField"
+                Log-Action $listTitle 'Add Index' $idxField 'SKIPPED' 'field not found'
+                continue
+            }
+
+            $spField = $spFields[$idxField]
+
+            # Index
+            if ($spField.Indexed -ne $true) {
+                if ($WhatIfMode) {
+                    Write-Dry "Would add index: $idxField"
+                    Log-Action $listTitle 'Add Index' $idxField 'DRY_RUN' ''
+                } else {
+                    Write-Act "Adding index: $idxField"
+                    try {
+                        Set-PnPField -List $listTitle -Identity $idxField -Values @{ Indexed = $true }
+                        Write-Ok "Index added: $idxField"
+                        Log-Action $listTitle 'Add Index' $idxField 'DONE' ''
+                    } catch {
+                        Write-Warning "Failed to add index: $idxField - $($_.Exception.Message)"
+                        Log-Action $listTitle 'Add Index' $idxField 'ERROR' $_.Exception.Message
+                    }
+                }
+            } else {
+                Write-Skip "Index already exists: $idxField"
+            }
+
+            # Unique constraint
+            if ($idxDef.unique -eq $true -and $spField.EnforceUniqueValues -ne $true) {
+                if ($WhatIfMode) {
+                    Write-Dry "Would set unique constraint: $idxField"
+                    Log-Action $listTitle 'Set Unique' $idxField 'DRY_RUN' ''
+                } else {
+                    Write-Act "Setting unique constraint: $idxField"
+                    try {
+                        Set-PnPField -List $listTitle -Identity $idxField -Values @{
+                            Indexed             = $true
+                            EnforceUniqueValues = $true
+                        }
+                        Write-Ok "Unique constraint set: $idxField"
+                        Log-Action $listTitle 'Set Unique' $idxField 'DONE' ''
+                    } catch {
+                        Write-Warning "Failed to set unique constraint: $idxField - $($_.Exception.Message) (check for duplicate values first)"
+                        Log-Action $listTitle 'Set Unique' $idxField 'ERROR' $_.Exception.Message
+                    }
+                }
+            }
+        }
+    }
+
+    Write-Ok "[$listTitle] done"
+}
+
+# Export log
+$timestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+$mode      = if ($WhatIfMode) { 'dryrun' } else { 'actual' }
+$logPath   = Join-Path (Split-Path $ManifestPath) "provision-log_${mode}_${timestamp}.csv"
+$actionLog | Export-Csv -Path $logPath -Encoding UTF8 -NoTypeInformation
+
+# Final summary
+$doneCount  = ($actionLog | Where-Object { $_.Status -eq 'DONE' }).Count
+$dryCount   = ($actionLog | Where-Object { $_.Status -eq 'DRY_RUN' }).Count
+$skipCount  = ($actionLog | Where-Object { $_.Status -eq 'SKIPPED' }).Count
+$errorCount = ($actionLog | Where-Object { $_.Status -eq 'ERROR' }).Count
+
+Write-Host ""
+Write-Host "================================================" -ForegroundColor Cyan
+Write-Host " PROVISIONING COMPLETE$(if ($WhatIfMode) { ' [DRY RUN]' })" -ForegroundColor Cyan
+Write-Host "================================================" -ForegroundColor Cyan
+Write-Host "  Done    : $doneCount"  -ForegroundColor Green
+if ($WhatIfMode) {
+    Write-Host "  Planned : $dryCount" -ForegroundColor Yellow
+}
+Write-Host "  Skipped : $skipCount"  -ForegroundColor Gray
+Write-Host "  Errors  : $errorCount" -ForegroundColor $(if ($errorCount -gt 0) { 'Red' } else { 'Green' })
+Write-Host "------------------------------------------------" -ForegroundColor Cyan
+Write-Host "  Log: $logPath"
+if (-not $WhatIfMode) {
+    Write-Host ""
+    Write-Host "  Re-run the audit to verify all gaps are resolved." -ForegroundColor Yellow
+}
+Write-Host "================================================" -ForegroundColor Cyan
+
+Disconnect-PnPOnline

--- a/src/sharepoint/fields/listRegistry.ts
+++ b/src/sharepoint/fields/listRegistry.ts
@@ -33,6 +33,8 @@ export enum ListKeys {
   PdfOutputLog = 'PdfOutput_Log',
   NurseObservations = 'NurseObservations',
   DailyAttendance = 'Daily_Attendance',
+  // ── スケジュール（登録漏れ修正） ──
+  Schedules = 'Schedules',
 }
 
 export const LIST_CONFIG: Record<ListKeys, { title: string }> = {
@@ -63,4 +65,6 @@ export const LIST_CONFIG: Record<ListKeys, { title: string }> = {
   [ListKeys.PdfOutputLog]: { title: 'PdfOutput_Log' },
   [ListKeys.NurseObservations]: { title: 'NurseObservations' },
   [ListKeys.DailyAttendance]: { title: 'Daily_Attendance' },
+  // ── スケジュール（登録漏れ修正） ──
+  [ListKeys.Schedules]: { title: 'Schedules' },
 };

--- a/src/sharepoint/spListRegistry.ts
+++ b/src/sharepoint/spListRegistry.ts
@@ -90,8 +90,8 @@ export const SP_LIST_REGISTRY: readonly SpListEntry[] = [
   // ── 2. 日々の記録系 ─────────────────────────────────────
   {
     key: 'support_record_daily',
-    displayName: '日次支援記録',
-    resolve: () => envOr('VITE_SP_LIST_DAILY', 'SupportRecord_Daily'),
+    displayName: '日次支援記録 (支援手順書兼記録)',
+    resolve: () => envOr('VITE_SP_LIST_PROCEDURE_RECORD', fromConfig(ListKeys.ProcedureRecordDaily)),
     operations: ['R', 'W'],
     category: 'daily',
   },
@@ -158,7 +158,7 @@ export const SP_LIST_REGISTRY: readonly SpListEntry[] = [
   {
     key: 'schedule_events',
     displayName: 'スケジュール',
-    resolve: () => envOr('VITE_SP_LIST_SCHEDULES', 'Schedules'),
+    resolve: () => envOr('VITE_SP_LIST_SCHEDULES', fromConfig(ListKeys.Schedules)),
     operations: ['R', 'W', 'D'],
     category: 'schedule',
   },


### PR DESCRIPTION
## 概要

SharePoint リスト構造の変化（ドリフト）を継続的に検出・修復・記録するための運用基盤を構築。

## 変更内容

- audit-browser-console.js: ブラウザコンソール監査ツール
- sp-manifest-lint.ts: CI静的整合チェック (npm run sp:audit)
- monthly-audit.yml: 月次自動監査 + artifact保存 + Issue自動起票
- monthly-sp-structure-audit.md: 優先順位付き運用Runbook
- sp-list-registry-policy.md: SSSTポリシー
- listRegistry.ts: Schedules 正式登録, 架空名除去
- lists.manifest.json: schemaVersion 世代管理

## SP実体作業（実施済み）

リスト作成11件、インデックス追加12件、Unique制約1件