### PR TITLE
fix(sp): use 'eq true' for Boolean columns in OData filters

### DIFF
--- a/src/data/isp/sharepoint/SharePointIspRepository.ts
+++ b/src/data/isp/sharepoint/SharePointIspRepository.ts
@@ -93,7 +93,7 @@ export function createSharePointIspRepository(client: UseSP): IspRepository {
     async getCurrentByUser(userId: string): Promise<IndividualSupportPlan | null> {
       const rows = await client.listItems<SpIspMasterRow>(ISP_MASTER_LIST_TITLE, {
         select: SELECT,
-        filter: `UserCode eq '${escapeOData(userId)}' and IsCurrent eq 1`,
+        filter: `UserCode eq '${escapeOData(userId)}' and IsCurrent eq true`,
         top: 1,
         orderby: 'PlanStartDate desc',
       });

--- a/src/data/isp/sharepoint/SharePointPlanningSheetRepository.ts
+++ b/src/data/isp/sharepoint/SharePointPlanningSheetRepository.ts
@@ -82,7 +82,7 @@ export function createSharePointPlanningSheetRepository(client: UseSP): Planning
     async listCurrentByUser(userId: string): Promise<PlanningSheetListItem[]> {
       const rows = await client.listItems<SpPlanningSheetRow>(PLANNING_SHEET_LIST_TITLE, {
         select: SELECT,
-        filter: `UserCode eq '${escapeOData(userId)}' and IsCurrent eq 1`,
+        filter: `UserCode eq '${escapeOData(userId)}' and IsCurrent eq true`,
         orderby: 'Created desc',
       });
 

--- a/src/data/isp/sharepoint/__tests__/repository.spec.ts
+++ b/src/data/isp/sharepoint/__tests__/repository.spec.ts
@@ -232,7 +232,7 @@ describe('SharePointIspRepository', () => {
       expect(client.listItems).toHaveBeenCalledWith(
         'ISP_Master',
         expect.objectContaining({
-          filter: "UserCode eq 'U001' and IsCurrent eq 1",
+          filter: "UserCode eq 'U001' and IsCurrent eq true",
         }),
       );
     });
@@ -350,7 +350,7 @@ describe('SharePointPlanningSheetRepository', () => {
       expect(client.listItems).toHaveBeenCalledWith(
         'SupportPlanningSheet_Master',
         expect.objectContaining({
-          filter: "UserCode eq 'U001' and IsCurrent eq 1",
+          filter: "UserCode eq 'U001' and IsCurrent eq true",
         }),
       );
     });

--- a/src/features/attendance/infra/attendanceUsersRepository.ts
+++ b/src/features/attendance/infra/attendanceUsersRepository.ts
@@ -73,7 +73,7 @@ export async function getActiveUsers(
   listTitle: string = ATTENDANCE_USERS_LIST_TITLE
 ): Promise<AttendanceUserItem[]> {
   const select = [...ATTENDANCE_USERS_SELECT_FIELDS];
-  const filter = `${ATTENDANCE_USERS_FIELDS.isActive} eq 1`;
+  const filter = `${ATTENDANCE_USERS_FIELDS.isActive} eq true`;
   const orderby = ATTENDANCE_USERS_FIELDS.userCode;
 
   try {

--- a/src/features/meeting-minutes/sp/__tests__/buildFilter.spec.ts
+++ b/src/features/meeting-minutes/sp/__tests__/buildFilter.spec.ts
@@ -8,7 +8,7 @@
  * - from / to は境界値を含む（ge / le）
  * - 複数条件は ' and ' で結合する
  * - category: 'ALL' は条件なし扱い
- * - publishedOnly は isPublished eq 1
+ * - publishedOnly は isPublished eq true
  *
  * ## local matchesSearch との対応
  * | 条件     | SP buildFilter   | local matchesSearch       |
@@ -51,9 +51,9 @@ describe('buildFilter', () => {
   // ── 単一条件 ────────────────────────────────────────────────
 
   describe('publishedOnly', () => {
-    it('should include isPublished eq 1 when publishedOnly is true', () => {
+    it('should include isPublished eq true when publishedOnly is true', () => {
       const result = buildFilter({ publishedOnly: true });
-      expect(result).toBe(`${F.isPublished} eq 1`);
+      expect(result).toBe(`${F.isPublished} eq true`);
     });
 
     it('should not include isPublished filter when publishedOnly is false', () => {
@@ -114,7 +114,7 @@ describe('buildFilter', () => {
     it('should NOT include q even in combination with other params', () => {
       const result = buildFilter({ q: '計画', publishedOnly: true });
       // publishedOnly は残る、q は含まれない
-      expect(result).toBe(`${F.isPublished} eq 1`);
+      expect(result).toBe(`${F.isPublished} eq true`);
       expect(result).not.toContain('計画');
     });
   });
@@ -154,7 +154,7 @@ describe('buildFilter', () => {
     it('should join publishedOnly and category with AND', () => {
       const result = buildFilter({ publishedOnly: true, category: '職員会議' });
       expect(result).toBe(
-        `${F.isPublished} eq 1 and ${F.category} eq '職員会議'`
+        `${F.isPublished} eq true and ${F.category} eq '職員会議'`
       );
     });
   });
@@ -168,7 +168,7 @@ describe('buildFilter', () => {
         to: '2026-12-31',
       });
       expect(result).toBe(
-        `${F.isPublished} eq 1 and ` +
+        `${F.isPublished} eq true and ` +
         `${F.category} eq '職員会議' and ` +
         `${F.meetingDate} ge '2026-01-01' and ` +
         `${F.meetingDate} le '2026-12-31'`
@@ -186,7 +186,7 @@ describe('buildFilter', () => {
       });
       expect(result).not.toContain('検索ワード');
       expect(result).not.toContain('タグ');
-      expect(result).toContain(`${F.isPublished} eq 1`);
+      expect(result).toContain(`${F.isPublished} eq true`);
     });
   });
 });

--- a/src/features/meeting-minutes/sp/sharepointRepository.ts
+++ b/src/features/meeting-minutes/sp/sharepointRepository.ts
@@ -83,7 +83,7 @@ export function buildFilter(params: MinutesSearchParams): string {
   const filters: string[] = [];
 
   if (params.publishedOnly) {
-    filters.push(`${F.isPublished} eq 1`);
+    filters.push(`${F.isPublished} eq true`);
   }
   if (params.category && params.category !== 'ALL') {
     filters.push(`${F.category} eq '${escapeODataString(params.category)}'`);

--- a/src/sharepoint/__tests__/holidayLoader.spec.ts
+++ b/src/sharepoint/__tests__/holidayLoader.spec.ts
@@ -64,7 +64,7 @@ describe('holidayLoader', () => {
 
       expect(mockListItems).toHaveBeenCalledWith('Holiday_Master', {
         select: expect.arrayContaining(['Id']),
-        filter: "IsActive eq 1 and FiscalYear eq '2026'",
+        filter: "IsActive eq true and FiscalYear eq '2026'",
         top: 500,
       });
     });

--- a/src/sharepoint/holidayLoader.ts
+++ b/src/sharepoint/holidayLoader.ts
@@ -55,7 +55,7 @@ export async function loadHolidaysFromSharePoint(
     // OData フィルター構築
     const filters: string[] = [];
     if (activeOnly) {
-      filters.push(`${HOLIDAY_MASTER_FIELDS.isActive} eq 1`);
+      filters.push(`${HOLIDAY_MASTER_FIELDS.isActive} eq true`);
     }
     if (fiscalYear) {
       filters.push(`${HOLIDAY_MASTER_FIELDS.fiscalYear} eq '${fiscalYear}'`);


### PR DESCRIPTION
## 概要

SP Online の Yes/No (Boolean) 列に対する OData `$filter` で `eq 1` を使用していたのを `eq true` に修正。

## 背景

本番 SP テナント (`/sites/welfare`) の REST API で型を直接確認済み:

| リスト | 列 | TypeAsString |
|--------|------|-------------|
| ISP_Master | IsCurrent | **Boolean** |
| Holiday_Master | IsActive | **Boolean** |
| AttendanceUsers | IsActive | **Boolean** |
| MeetingMinutes | IsPublished | **(未作成 → Phase A で Yes/No 追加予定)** |

SP Online の Boolean 列は `eq 1` ではフィルタされず 400 エラーになる。`eq true` が正しい構文。

## 変更内容

### 本体コード (5ファイル)
- `SharePointIspRepository.ts`: `IsCurrent eq 1` → `eq true`
- `SharePointPlanningSheetRepository.ts`: `IsCurrent eq 1` → `eq true`
- `holidayLoader.ts`: `IsActive eq 1` → `eq true`
- `sharepointRepository.ts` (meeting-minutes): `isPublished eq 1` → `eq true`
- `attendanceUsersRepository.ts`: `isActive eq 1` → `eq true`

### テスト (3ファイル)
- `repository.spec.ts`: 2箇所
- `holidayLoader.spec.ts`: 1箇所
- `buildFilter.spec.ts`: 6箇所

## テスト結果
- ✅ 64 tests passed
- ✅ build 成功
- ✅ lint + typecheck 通過

## Refs
Production Recovery Runbook Phase B-3