### PR TITLE
feat: 全ロールにサイドメニュー全項目を開放

### DIFF
--- a/src/app/config/navigationConfig.helpers.ts
+++ b/src/app/config/navigationConfig.helpers.ts
@@ -24,15 +24,20 @@ import {
 /**
  * Determines whether a navigation item should be visible to a given audience.
  *
- * @param item - Navigation item to evaluate
- * @param navAudience - The current user's audience level
- * @returns true if the item should be shown
+ * 運用初期は全ロールに全メニューを開放。
+ * 運用後レビューで audience フィルタを再有効化する。
+ *
+ * @param _item - Navigation item to evaluate (currently unused)
+ * @param _navAudience - The current user's audience level (currently unused)
+ * @returns always true (全開放中)
  */
-export function isNavVisible(item: NavItem, navAudience: NavAudience): boolean {
-  const audienceList = Array.isArray(item.audience) ? item.audience : [item.audience ?? 'all'];
-  if (audienceList.includes('all')) return true;
-  if (navAudience === 'admin') return true;
-  return audienceList.includes(navAudience);
+export function isNavVisible(_item: NavItem, _navAudience: NavAudience): boolean {
+  // TODO: 運用後レビューで再有効化
+  // const audienceList = Array.isArray(item.audience) ? item.audience : [item.audience ?? 'all'];
+  // if (audienceList.includes('all')) return true;
+  // if (navAudience === 'admin') return true;
+  // return audienceList.includes(navAudience);
+  return true;
 }
 
 // ============================================================================

--- a/src/app/config/navigationConfig.ts
+++ b/src/app/config/navigationConfig.ts
@@ -64,7 +64,7 @@ export function createNavItems(config: CreateNavItemsConfig): NavItem[] {
     icebergPdcaEnabled: _icebergPdcaEnabled,
     staffAttendanceEnabled,
     todayOpsEnabled,
-    isAdmin,
+    isAdmin: _isAdmin, // TODO: 運用後レビューで再有効化
     authzReady,
     navAudience,
     skipLogin = false,
@@ -325,7 +325,9 @@ export function createNavItems(config: CreateNavItemsConfig): NavItem[] {
     });
   }
 
-  if (isAdmin && (authzReady || skipLogin)) {
+  // TODO: 運用後レビューで isAdmin ガードを再有効化
+  // 元の条件: if (isAdmin && (authzReady || skipLogin))
+  if (authzReady || skipLogin) {
     items.push({
       label: '職員勤怠管理',
       to: '/admin/staff-attendance',


### PR DESCRIPTION
## 概要

運用初期は全ロール（viewer / reception / staff / admin）に全メニューを開放。
実際の利用パターンを観測した後、運用後レビューで権限を絞る方針。

### 変更内容

**Gate 2 (isNavVisible)**
- `isNavVisible()` を常に `true` を返すように変更
- 元の audience フィルタロジックはコメントで保存

**Gate 1 (createNavItems)**
- `isAdmin && (authzReady || skipLogin)` → `authzReady || skipLogin` に変更
- 管理系メニュー（管理ツール, 職員勤怠管理, 統合カレンダー, 部屋管理）が全ロールで生成される

### 復元方法
各変更箇所に `TODO: 運用後レビューで再有効化` コメントを残しています。

### テスト
- eslint ✅
- typecheck ✅
- navigationConfig.test.ts 3/3 pass ✅