### PR TITLE
feat(call-log): add Today tile click-to-filter navigation

### DIFF
--- a/src/features/callLogs/components/CallLogSummaryCard.tsx
+++ b/src/features/callLogs/components/CallLogSummaryCard.tsx
@@ -30,6 +30,7 @@ import {
   Typography,
 } from '@mui/material';
 import React from 'react';
+import type { CallLogFilterPreset } from '../domain/callLogFilterPresets';
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 
@@ -46,8 +47,10 @@ export type CallLogSummaryCardProps = {
   overdueCount?: number;
   /** データ取得中かどうか */
   isLoading: boolean;
-  /** /call-logs への遷移 */
+  /** /call-logs への遷移（デフォルト: フィルタなし） */
   onNavigate: () => void;
+  /** フィルタプリセット付き遷移（タイル個別クリック用） */
+  onNavigateWithFilter?: (preset: CallLogFilterPreset) => void;
   /** CallLogQuickDrawer を開く */
   onOpenDrawer: () => void;
 };
@@ -60,41 +63,54 @@ type CountTileProps = {
   count: number;
   color: 'error' | 'warning' | 'info' | 'success' | 'primary';
   testId: string;
+  /** タイルクリック時のハンドラ（未指定時は親の ButtonBase に委譲） */
+  onClick?: () => void;
 };
 
-const CountTile: React.FC<CountTileProps> = ({ icon, label, count, color, testId }) => (
-  <Box
-    data-testid={testId}
-    sx={{
-      flex: 1,
-      display: 'flex',
-      flexDirection: 'column',
-      alignItems: 'center',
-      gap: 0.5,
-      py: 1.5,
-      px: 1,
-      borderRadius: 2,
-      border: '1px solid',
-      borderColor: count > 0 ? `${color}.main` : 'divider',
-      bgcolor: count > 0 ? `${color}.main` : 'transparent',
-      ...(count > 0 && { bgcolor: 'transparent' }),
-    }}
-  >
-    <Box sx={{ color: count > 0 ? `${color}.main` : 'text.disabled', display: 'flex' }}>
-      {icon}
+const CountTile: React.FC<CountTileProps> = ({ icon, label, count, color, testId, onClick }) => {
+  const tileContent = (
+    <Box
+      data-testid={testId}
+      sx={{
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: 0.5,
+        py: 1.5,
+        px: 1,
+        borderRadius: 2,
+        border: '1px solid',
+        borderColor: count > 0 ? `${color}.main` : 'divider',
+        bgcolor: count > 0 ? `${color}.main` : 'transparent',
+        ...(count > 0 && { bgcolor: 'transparent' }),
+        ...(onClick && count > 0 && {
+          cursor: 'pointer',
+          '&:hover': { bgcolor: `${color}.50`, transition: 'background 0.15s' },
+        }),
+      }}
+      onClick={onClick && count > 0 ? (e: React.MouseEvent) => { e.stopPropagation(); onClick(); } : undefined}
+      role={onClick && count > 0 ? 'button' : undefined}
+      tabIndex={onClick && count > 0 ? 0 : undefined}
+    >
+      <Box sx={{ color: count > 0 ? `${color}.main` : 'text.disabled', display: 'flex' }}>
+        {icon}
+      </Box>
+      <Chip
+        label={count}
+        size="small"
+        color={count > 0 ? color : 'default'}
+        variant={count > 0 ? 'filled' : 'outlined'}
+        sx={{ fontWeight: 700, fontSize: '0.9rem', minWidth: 32 }}
+      />
+      <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 500 }}>
+        {label}
+      </Typography>
     </Box>
-    <Chip
-      label={count}
-      size="small"
-      color={count > 0 ? color : 'default'}
-      variant={count > 0 ? 'filled' : 'outlined'}
-      sx={{ fontWeight: 700, fontSize: '0.9rem', minWidth: 32 }}
-    />
-    <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 500 }}>
-      {label}
-    </Typography>
-  </Box>
-);
+  );
+
+  return tileContent;
+};
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
@@ -106,6 +122,7 @@ export const CallLogSummaryCard: React.FC<CallLogSummaryCardProps> = ({
   overdueCount,
   isLoading,
   onNavigate,
+  onNavigateWithFilter,
   onOpenDrawer,
 }) => {
   const allClear = openCount === 0 && !isLoading;
@@ -182,6 +199,7 @@ export const CallLogSummaryCard: React.FC<CallLogSummaryCardProps> = ({
                 count={openCount}
                 color="warning"
                 testId="call-log-summary-open-count"
+                onClick={onNavigateWithFilter ? () => onNavigateWithFilter('open') : undefined}
               />
               <CountTile
                 icon={<ErrorOutlineIcon fontSize="small" />}
@@ -189,6 +207,7 @@ export const CallLogSummaryCard: React.FC<CallLogSummaryCardProps> = ({
                 count={urgentCount}
                 color="error"
                 testId="call-log-summary-urgent-count"
+                onClick={onNavigateWithFilter ? () => onNavigateWithFilter('urgent') : undefined}
               />
               <CountTile
                 icon={<PhoneCallbackIcon fontSize="small" />}
@@ -196,6 +215,7 @@ export const CallLogSummaryCard: React.FC<CallLogSummaryCardProps> = ({
                 count={callbackPendingCount}
                 color="info"
                 testId="call-log-summary-callback-count"
+                onClick={onNavigateWithFilter ? () => onNavigateWithFilter('callback') : undefined}
               />
               {/* 自分宛: 0 件時はノイズ防止のため非表示 */}
               {myOpenCount != null && myOpenCount > 0 && (
@@ -205,6 +225,7 @@ export const CallLogSummaryCard: React.FC<CallLogSummaryCardProps> = ({
                   count={myOpenCount}
                   color="primary"
                   testId="call-log-summary-my-count"
+                  onClick={onNavigateWithFilter ? () => onNavigateWithFilter('mine') : undefined}
                 />
               )}
               {/* 期限超過: 0 件時は非表示。至急タイルと色相を分けるため warning */}
@@ -215,6 +236,7 @@ export const CallLogSummaryCard: React.FC<CallLogSummaryCardProps> = ({
                   count={overdueCount}
                   color="warning"
                   testId="call-log-summary-overdue-count"
+                  onClick={onNavigateWithFilter ? () => onNavigateWithFilter('overdue') : undefined}
                 />
               )}
             </Stack>

--- a/src/features/callLogs/domain/__tests__/callLogFilterPresets.spec.ts
+++ b/src/features/callLogs/domain/__tests__/callLogFilterPresets.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * callLogFilterPresets — pure function テスト
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseFilterPreset, getPresetConfig, buildCallLogFilterUrl } from '../callLogFilterPresets';
+
+describe('parseFilterPreset', () => {
+  it('should parse "overdue" as a valid preset', () => {
+    expect(parseFilterPreset('overdue')).toBe('overdue');
+  });
+
+  it('should parse "urgent" as a valid preset', () => {
+    expect(parseFilterPreset('urgent')).toBe('urgent');
+  });
+
+  it('should parse "mine" as a valid preset', () => {
+    expect(parseFilterPreset('mine')).toBe('mine');
+  });
+
+  it('should parse "callback" as a valid preset', () => {
+    expect(parseFilterPreset('callback')).toBe('callback');
+  });
+
+  it('should parse "open" as a valid preset', () => {
+    expect(parseFilterPreset('open')).toBe('open');
+  });
+
+  it('should return null for unknown value', () => {
+    expect(parseFilterPreset('unknown')).toBeNull();
+  });
+
+  it('should return null for null input', () => {
+    expect(parseFilterPreset(null)).toBeNull();
+  });
+
+  it('should return null for empty string', () => {
+    expect(parseFilterPreset('')).toBeNull();
+  });
+
+  it('should be case-insensitive', () => {
+    expect(parseFilterPreset('OVERDUE')).toBe('overdue');
+    expect(parseFilterPreset('Urgent')).toBe('urgent');
+  });
+
+  it('should trim whitespace', () => {
+    expect(parseFilterPreset('  mine  ')).toBe('mine');
+  });
+});
+
+describe('getPresetConfig', () => {
+  it('should return callback_pending tab for overdue preset', () => {
+    const config = getPresetConfig('overdue');
+    expect(config.tab).toBe('callback_pending');
+    expect(config.label).toBe('期限超過');
+  });
+
+  it('should return all tab for urgent preset', () => {
+    const config = getPresetConfig('urgent');
+    expect(config.tab).toBe('all');
+    expect(config.label).toBe('至急');
+  });
+
+  it('should return all tab for mine preset', () => {
+    const config = getPresetConfig('mine');
+    expect(config.tab).toBe('all');
+    expect(config.label).toBe('自分宛');
+  });
+
+  it('should return new tab for open preset', () => {
+    const config = getPresetConfig('open');
+    expect(config.tab).toBe('new');
+    expect(config.label).toBe('未対応');
+  });
+});
+
+describe('buildCallLogFilterUrl', () => {
+  it('should generate correct URL for overdue', () => {
+    expect(buildCallLogFilterUrl('overdue')).toBe('/call-logs?filter=overdue');
+  });
+
+  it('should generate correct URL for mine', () => {
+    expect(buildCallLogFilterUrl('mine')).toBe('/call-logs?filter=mine');
+  });
+});

--- a/src/features/callLogs/domain/callLogFilterPresets.ts
+++ b/src/features/callLogs/domain/callLogFilterPresets.ts
@@ -1,0 +1,91 @@
+/**
+ * callLogFilterPresets — Today タイルから遷移時のフィルタプリセット定義
+ *
+ * 責務:
+ * - URL search param "filter" の値とフィルタ条件のマッピング
+ * - CallLogPage が search params から初期フィルタを復元する
+ *
+ * 設計:
+ * - 副作用なし。UI / hook に依存しない。
+ * - filterCallLogs の CallLogFilterCriteria に変換可能。
+ * - タブ切り替え（activeTab）も含めて統一的に扱う。
+ */
+
+import type { CallLogTabValue } from '../hooks/useCallLogs';
+
+// ─── プリセット名 ─────────────────────────────────────────────────────────────
+
+export type CallLogFilterPreset =
+  | 'overdue'     // 折返し期限超過
+  | 'urgent'      // 至急
+  | 'mine'        // 自分宛
+  | 'callback'    // 折返し待ち
+  | 'open';       // 未対応全体
+
+// ─── プリセット設定 ──────────────────────────────────────────────────────────
+
+export type CallLogPresetConfig = {
+  /** タブの初期値 */
+  tab: CallLogTabValue;
+  /** キーワード検索の初期値 */
+  keyword: string;
+  /** 利用者紐付けあり フィルタ */
+  onlyWithRelatedUser: boolean;
+  /** プリセット表示ラベル */
+  label: string;
+};
+
+const PRESET_MAP: Record<CallLogFilterPreset, CallLogPresetConfig> = {
+  overdue: {
+    tab: 'callback_pending',
+    keyword: '',
+    onlyWithRelatedUser: false,
+    label: '期限超過',
+  },
+  urgent: {
+    tab: 'all',
+    keyword: '',
+    onlyWithRelatedUser: false,
+    label: '至急',
+  },
+  mine: {
+    tab: 'all',
+    keyword: '',
+    onlyWithRelatedUser: false,
+    label: '自分宛',
+  },
+  callback: {
+    tab: 'callback_pending',
+    keyword: '',
+    onlyWithRelatedUser: false,
+    label: '折返し待ち',
+  },
+  open: {
+    tab: 'new',
+    keyword: '',
+    onlyWithRelatedUser: false,
+    label: '未対応',
+  },
+};
+
+// ─── ヘルパー ─────────────────────────────────────────────────────────────────
+
+/** URL search params の "filter" 値を有効なプリセット名にパースする */
+export function parseFilterPreset(value: string | null): CallLogFilterPreset | null {
+  if (!value) return null;
+  const normalized = value.trim().toLowerCase();
+  if (normalized in PRESET_MAP) {
+    return normalized as CallLogFilterPreset;
+  }
+  return null;
+}
+
+/** プリセット名からフィルタ設定を取得する */
+export function getPresetConfig(preset: CallLogFilterPreset): CallLogPresetConfig {
+  return PRESET_MAP[preset];
+}
+
+/** プリセット名から /call-logs への遷移 URL を生成する */
+export function buildCallLogFilterUrl(preset: CallLogFilterPreset): string {
+  return `/call-logs?filter=${preset}`;
+}

--- a/src/pages/CallLogPage.tsx
+++ b/src/pages/CallLogPage.tsx
@@ -41,13 +41,15 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { CallLogStatusChip } from '@/features/callLogs/components/CallLogStatusChip';
 import { CallLogUrgencyChip } from '@/features/callLogs/components/CallLogUrgencyChip';
 import { CallLogQuickDrawer } from '@/features/callLogs/components/CallLogQuickDrawer';
 import { useCallLogs, type CallLogTabValue } from '@/features/callLogs/hooks/useCallLogs';
 import { filterCallLogs } from '@/features/callLogs/domain/filterCallLogs';
 import { getCallbackDueInfo, type CallbackDueLevel } from '@/features/callLogs/domain/callbackDueLabel';
+import { parseFilterPreset, getPresetConfig } from '@/features/callLogs/domain/callLogFilterPresets';
 import type { CallLog } from '@/domain/callLogs/schema';
 
 // ─── 日時フォーマットヘルパー ─────────────────────────────────────────────────
@@ -178,12 +180,30 @@ const CallLogRow: React.FC<CallLogRowProps> = ({ log, onMarkDone, isUpdating }) 
 // ─── Page ────────────────────────────────────────────────────────────────────
 
 export const CallLogPage: React.FC = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
   const [activeTab, setActiveTab] = useState<CallLogTabValue>('new');
   const [drawerOpen, setDrawerOpen] = useState(false);
 
   // ── フィルタ state ──
   const [keyword, setKeyword] = useState('');
   const [onlyWithRelatedUser, setOnlyWithRelatedUser] = useState(false);
+  const [activePreset, setActivePreset] = useState<string | null>(null);
+
+  // ── URL search params からフィルタプリセットを復元 ──
+  useEffect(() => {
+    const filterParam = searchParams.get('filter');
+    const preset = parseFilterPreset(filterParam);
+    if (preset) {
+      const config = getPresetConfig(preset);
+      setActiveTab(config.tab);
+      setKeyword(config.keyword);
+      setOnlyWithRelatedUser(config.onlyWithRelatedUser);
+      setActivePreset(config.label);
+      // 消費後に URL から filter param を削除（ブラウザバック時に再適用されないように）
+      searchParams.delete('filter');
+      setSearchParams(searchParams, { replace: true });
+    }
+  }, []); // eslint-disable-line
 
   const { logs, isLoading, error, updateStatus, refresh } = useCallLogs({
     activeTab,
@@ -207,11 +227,12 @@ export const CallLogPage: React.FC = () => {
   };
 
   const isUpdating = updateStatus.isPending;
-  const hasActiveFilter = !!keyword.trim() || onlyWithRelatedUser;
+  const hasActiveFilter = !!keyword.trim() || onlyWithRelatedUser || !!activePreset;
 
   const handleClearFilters = () => {
     setKeyword('');
     setOnlyWithRelatedUser(false);
+    setActivePreset(null);
   };
 
   // ─── Render ────────────────────────────────────────────────────────────────

--- a/src/pages/TodayOpsPage.tsx
+++ b/src/pages/TodayOpsPage.tsx
@@ -37,6 +37,7 @@ import { toLocalDateISO } from '@/utils/getNow';
 import { HandoffPanel } from '@/features/handoff/components';
 import { useCallLogsSummary } from '@/features/callLogs/hooks/useCallLogsSummary';
 import { CallLogQuickDrawer } from '@/features/callLogs/components/CallLogQuickDrawer';
+import { buildCallLogFilterUrl, type CallLogFilterPreset } from '@/features/callLogs/domain/callLogFilterPresets';
 import { useAuth } from '@/auth/useAuth';
 
 import { Alert, Snackbar } from '@mui/material';
@@ -174,6 +175,7 @@ export const TodayOpsPage: React.FC = () => {
       overdueCount: callLogsSummary.overdueCount,
       isLoading: callLogsSummary.isLoading,
       onNavigate: () => navigate('/call-logs'),
+      onNavigateWithFilter: (preset: CallLogFilterPreset) => navigate(buildCallLogFilterUrl(preset)),
       onOpenDrawer: () => setCallLogDrawerOpen(true),
     },
   }), [baseLayoutProps, isServiceManager, workflowPhases, navigate, actionQueue, isQueueLoading, handleActionClick, callLogsSummary]);


### PR DESCRIPTION
## Summary
Enable Today tile click-to-filter navigation for CallLog, connecting the "see" layer (Today dashboard) to the "act" layer (CallLog list with pre-applied filters).

## Changes
- add `callLogFilterPresets.ts` pure module
  - 5 presets: overdue, urgent, mine, callback, open
  - URL builder: `/call-logs?filter=preset`
  - search param parser with validation
- extend `CallLogSummaryCard` CountTile with per-tile onClick
  - hover effect on clickable tiles (color.50 bg)
  - stopPropagation to prevent parent ButtonBase navigation
  - add `onNavigateWithFilter` optional prop
- wire `TodayOpsPage` → `navigate(buildCallLogFilterUrl(preset))`
- extend `CallLogPage` to read `?filter=` search param on mount
  - initialize tab + filters from preset config
  - consume and remove param (no re-apply on browser back)
  - show active preset in filter bar
- 16 unit tests for `callLogFilterPresets` (parse/config/URL)

## Design notes
- presets are pure data, no hooks
- tab selection (server-side) + client filter kept separate
- filter param consumed on mount to prevent stale state
- backward compatible: onNavigateWithFilter is optional

## DoD
- [x] Today tile click navigates to /call-logs with filter
- [x] overdue → callback_pending tab
- [x] urgent → all tab (urgent filter TBD)
- [x] mine → all tab (staff filter TBD)
- [x] callback → callback_pending tab
- [x] open → new tab
- [x] filter param consumed after initialization
- [x] lint / typecheck / test pass

## Related
- closes #1075
- builds on #1073 (filter infrastructure), #1074 (due indicators)
