### PR TITLE
feat(nav): register exception center in navigation

### DIFF
--- a/src/app/config/navigationConfig.ts
+++ b/src/app/config/navigationConfig.ts
@@ -359,13 +359,24 @@ export function createNavItems(config: CreateNavItemsConfig): NavItem[] {
       group: 'ops' as NavGroupKey,
     });
 
+    // --- 拠点運営 (ops) --- 例外センター
+    items.push({
+      label: '例外センター',
+      to: '/admin/exception-center',
+      isActive: (pathname: string) => pathname.startsWith('/admin/exception-center'),
+      icon: undefined,
+      testId: TESTIDS.nav.exceptionCenter,
+      audience: NAV_AUDIENCE.admin,
+      group: 'ops' as NavGroupKey,
+    });
+
     // --- マスタ・管理 (admin) ---
     // 管理ツール（ハブ）1つに集約。
     // 自己点検・監査ログ・ナビ診断・モード切替・1日の流れ設定は /admin ハブページから到達可能。
     items.push({
       label: '管理ツール',
       to: '/admin',
-      isActive: (pathname: string) => pathname === '/admin' || pathname.startsWith('/admin/') || pathname.startsWith('/checklist') || pathname.startsWith('/audit') || pathname.startsWith('/settings/'),
+      isActive: (pathname: string) => (pathname === '/admin' || pathname.startsWith('/admin/') || pathname.startsWith('/checklist') || pathname.startsWith('/audit') || pathname.startsWith('/settings/')) && !pathname.startsWith('/admin/exception-center'),
       icon: undefined,
       audience: NAV_AUDIENCE.admin,
       group: 'admin' as NavGroupKey,

--- a/src/testids.ts
+++ b/src/testids.ts
@@ -23,6 +23,7 @@ const NAV_TESTIDS = {
   roomManagement: 'nav-room-management',
   operationFlowSettings: 'nav-operation-flow-settings',
   planningSheet: 'nav-planning-sheet',
+  exceptionCenter: 'nav-exception-center',
 } as const;
 
 const FOOTER_TESTIDS = {


### PR DESCRIPTION
## 概要

ExceptionCenterPage を navigationConfig.ts に正式登録。#1029 の残タスク完了。

## 変更内容

- testids.ts: NAV_TESTIDS に exceptionCenter 追加
- navigationConfig.ts: 例外センターのナビ項目追加 (ops / admin)
- 管理ツールの isActive から除外（二重ハイライト防止）

## テスト

- navigationConfig.test.ts 全3件 PASS
- navigationConfig.spec.ts 36/38 PASS（2件は既存不備、今回差分と無関係）

Closes remaining nav task of #1029