### PR TITLE
feat(today): add CTA telemetry for ProgressRings (P0)

### DIFF
--- a/src/features/today/components/ProgressRings.tsx
+++ b/src/features/today/components/ProgressRings.tsx
@@ -1,12 +1,13 @@
 /**
- * ProgressRings — 3指標のコンパクト進捗表示
+ * ProgressRings — 4指標のコンパクト進捗表示
  *
- * Step 3: ZONE B を「3つの小さな証拠」に圧縮する。
+ * Step 3: ZONE B を「4つの小さな証拠」に圧縮する。
  *
  * 表示する指標:
- * 1. 記録   → 完了率リング (completed / total)
- * 2. 出欠   → 完了率リング (attended / scheduled)
- * 3. 連絡   → 件数モード可 (count only, no percentage)
+ * 1. 支援手順   → 完了率リング (completed / total)
+ * 2. ケース記録 → 完了率リング (completed / total)
+ * 3. 出欠       → 完了率リング (attended / scheduled)
+ * 4. 連絡       → 件数モード可 (count only, no percentage)
  *
  * ⚠️ データ取得や計算ロジックは追加しない。
  *    Props で受け取った値をそのまま表示する。
@@ -23,7 +24,7 @@ import React from 'react';
 // ─── Types ───────────────────────────────────────────────────
 
 export type ProgressRingItem = {
-  key: 'records' | 'attendance' | 'contacts';
+  key: 'records' | 'caseRecords' | 'attendance' | 'contacts';
   label: string;
   /** 表示テキスト: "5 / 12" や "2件" */
   valueText: string;

--- a/src/features/today/telemetry/recordCtaClick.spec.ts
+++ b/src/features/today/telemetry/recordCtaClick.spec.ts
@@ -107,7 +107,7 @@ describe('CTA_EVENTS', () => {
     }
   });
 
-  it('has 9 defined events', () => {
-    expect(Object.keys(CTA_EVENTS)).toHaveLength(9);
+  it('has 11 defined events', () => {
+    expect(Object.keys(CTA_EVENTS)).toHaveLength(11);
   });
 });

--- a/src/features/today/telemetry/recordCtaClick.ts
+++ b/src/features/today/telemetry/recordCtaClick.ts
@@ -32,6 +32,10 @@ export const CTA_EVENTS = {
   PROGRESS_CHIP_ATTENDANCE: 'today_progress_chip_attendance_clicked',
   /** ProgressStatusBar 申し送りチップ */
   PROGRESS_CHIP_BRIEFING: 'today_progress_chip_briefing_clicked',
+  /** ProgressRings ケース記録リング */
+  PROGRESS_RING_CASE_RECORD: 'today_progress_ring_case_record_clicked',
+  /** ProgressRings 連絡リング */
+  PROGRESS_RING_CONTACTS: 'today_progress_ring_contacts_clicked',
 } as const;
 
 export type CtaEventName = (typeof CTA_EVENTS)[keyof typeof CTA_EVENTS];

--- a/src/pages/TodayOpsPage.tsx
+++ b/src/pages/TodayOpsPage.tsx
@@ -31,6 +31,7 @@ import { QuickRecordDrawer } from '@/features/today/records/QuickRecordDrawer';
 import { resolveNextUser } from '@/features/today/records/resolveNextUser';
 import { useQuickRecord } from '@/features/today/records/useQuickRecord';
 import { recordLanding } from '@/features/today/telemetry/recordLanding';
+import { CTA_EVENTS, recordCtaClick } from '@/features/today/telemetry/recordCtaClick';
 import { useTransportStatus } from '@/features/today/transport';
 import { ApprovalDialog } from '@/features/today/widgets/ApprovalDialog';
 import { toLocalDateISO } from '@/utils/getNow';
@@ -152,7 +153,7 @@ export const TodayOpsPage: React.FC = () => {
   });
 
   const layoutProps = useMemo(() => {
-    // ── Step 3: ProgressRings — 既存データから3指標を投影 ──
+    // ── Step 3: ProgressRings — 既存データから4指標を投影 ──
     // Guard: テストmock等で progress が未定義の場合はリング生成をスキップ
     const progressData = baseLayoutProps.progress;
     const attendanceData = baseLayoutProps.attendance;
@@ -162,10 +163,18 @@ export const TodayOpsPage: React.FC = () => {
     if (progressData?.summary && attendanceData) {
       const { summary: progressSummary, onChipClick } = progressData;
 
+      // ── 支援手順記録 (todayRecordCompletion 起点) ──
       const recordTotal = progressSummary.totalRecordCount || 1;
       const recordCompleted = Math.max(0, recordTotal - progressSummary.pendingRecordCount);
       const recordPct = Math.round((recordCompleted / recordTotal) * 100);
 
+      // ── ケース記録 (dailyRecordStatus — Dashboard 起点) ──
+      const caseRecordStatus = summary.dailyRecordStatus;
+      const caseTotal = caseRecordStatus?.total || (summary.users?.length ?? 0) || 1;
+      const caseCompleted = caseRecordStatus?.completed ?? 0;
+      const casePct = Math.round((caseCompleted / caseTotal) * 100);
+
+      // ── 出欠 ──
       const attScheduled = attendanceData.scheduledCount || 1;
       const attPresent = attendanceData.facilityAttendees || 0;
       const attPct = Math.round((attPresent / attScheduled) * 100);
@@ -175,11 +184,28 @@ export const TodayOpsPage: React.FC = () => {
       progressRings = [
         {
           key: 'records',
-          label: '記録',
+          label: '支援手順',
           valueText: `${recordCompleted}/${recordTotal}`,
           progress: recordPct,
           status: recordPct >= 100 ? 'complete' : recordPct >= 50 ? 'in_progress' : 'attention',
           onClick: () => onChipClick?.('record'),
+        },
+        {
+          key: 'caseRecords',
+          label: 'ケース記録',
+          valueText: `${caseCompleted}/${caseTotal}`,
+          progress: casePct,
+          status: casePct >= 100 ? 'complete' : casePct >= 50 ? 'in_progress' : 'attention',
+          onClick: () => {
+            recordCtaClick({
+              ctaId: CTA_EVENTS.PROGRESS_RING_CASE_RECORD,
+              sourceComponent: 'ProgressRings',
+              stateType: 'navigation',
+              targetUrl: '/daily/table',
+              userRole: role,
+            });
+            navigate('/daily/table');
+          },
         },
         {
           key: 'attendance',
@@ -195,7 +221,16 @@ export const TodayOpsPage: React.FC = () => {
           valueText: `${contactCount}件`,
           progress: undefined,
           status: contactCount === 0 ? 'complete' : contactCount <= 2 ? 'in_progress' : 'attention',
-          onClick: () => navigate('/call-logs'),
+          onClick: () => {
+            recordCtaClick({
+              ctaId: CTA_EVENTS.PROGRESS_RING_CONTACTS,
+              sourceComponent: 'ProgressRings',
+              stateType: 'navigation',
+              targetUrl: '/call-logs',
+              userRole: role,
+            });
+            navigate('/call-logs');
+          },
         },
       ];
     }


### PR DESCRIPTION
## 概要
Today ページの ProgressRings（ケース記録・連絡）に CTA クリック率テレメトリを追加する P0 実装。

## 変更内容
- `recordCtaClick.ts`: `PROGRESS_RING_CASE_RECORD` と `PROGRESS_RING_CONTACTS` イベント追加
- `TodayOpsPage.tsx`: ProgressRings の onClick に `recordCtaClick` 呼び出しを追加（fire-and-forget）
- `ProgressRings.tsx`: 4つ目のリング（ケース記録）追加
- `recordCtaClick.spec.ts`: イベント数アサーション更新（9 → 11）

## 設計判断
- **既存基盤の活用**: 新しい計測基盤を作らず、既存の `recordCtaClick` を拡張
- **UI 層で閉じている**: ドメイン・ファサードに変更なし
- **record → navigate 順序**: 既存パターンを遵守
- **fire-and-forget**: テレメトリが UI をブロックしない

## 計測可能になる指標
- Hero が主導線になっているか（`NEXT_ACTION_PRIMARY / landing`）
- ケース記録リングの利用率（`PROGRESS_RING_CASE_RECORD / landing`）
- 連絡リングの利用率（`PROGRESS_RING_CONTACTS / landing`）

## テスト
- `npm run typecheck` ✅
- `npm run test` ✅（recordCtaClick.spec.ts 更新済み）