### PR TITLE
refactor(telemetry): split TelemetryDashboard into modular submodules

### DIFF
--- a/src/features/telemetry/components/charts/PhaseBar.tsx
+++ b/src/features/telemetry/components/charts/PhaseBar.tsx
@@ -1,0 +1,29 @@
+/**
+ * PhaseBar — フェーズ分布横棒
+ */
+
+export function PhaseBar({ label, count, maxCount }: { label: string; count: number; maxCount: number }) {
+  const pct = maxCount > 0 ? (count / maxCount) * 100 : 0;
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+      <div style={{ width: 90, fontSize: 13, color: '#475569', textAlign: 'right', flexShrink: 0 }}>
+        {label}
+      </div>
+      <div style={{ flex: 1, background: '#f1f5f9', borderRadius: 6, height: 24, overflow: 'hidden' }}>
+        <div
+          style={{
+            width: `${pct}%`,
+            height: '100%',
+            background: 'linear-gradient(90deg, #8b5cf6, #a78bfa)',
+            borderRadius: 6,
+            transition: 'width 0.5s ease',
+            minWidth: pct > 0 ? 4 : 0,
+          }}
+        />
+      </div>
+      <div style={{ width: 36, fontSize: 13, fontWeight: 600, color: '#334155', textAlign: 'right' }}>
+        {count}
+      </div>
+    </div>
+  );
+}

--- a/src/features/telemetry/components/charts/index.ts
+++ b/src/features/telemetry/components/charts/index.ts
@@ -1,0 +1,5 @@
+export { FlowDistributionChart } from './FlowDistributionChart';
+export { FunnelChart } from './FunnelChart';
+export { HeroQueueChart } from './HeroQueueChart';
+export { HourlyChart } from './HourlyChart';
+export { PhaseBar } from './PhaseBar';

--- a/src/features/telemetry/components/constants.ts
+++ b/src/features/telemetry/components/constants.ts
@@ -1,0 +1,50 @@
+/**
+ * Telemetry Dashboard — ラベル・カラー定数
+ *
+ * TelemetryDashboard.tsx から抽出。
+ * 各サブコンポーネントが共有参照する定数を一箇所に集約する。
+ */
+
+import type { DateRange } from '../hooks/useTelemetryDashboard';
+
+// ── Phase Labels ────────────────────────────────────────────────────────────
+
+export const PHASE_LABELS: Record<string, string> = {
+  'am-operation': '午前活動',
+  'pm-operation': '午後活動',
+  'night-operation': '夜間対応',
+  'reception': '受入・送迎',
+  'lunch': '昼食',
+  'break': '休憩',
+};
+
+// ── Type Labels ─────────────────────────────────────────────────────────────
+
+export const TYPE_LABELS: Record<string, string> = {
+  todayops_landing: '📍 ランディング',
+  todayops_cta_click: '👆 CTAクリック',
+  todayops_first_navigation: '🧭 初回ナビ',
+  operational_phase_event: '⚡ フェーズイベント',
+};
+
+export const TYPE_SHORT: Record<string, string> = {
+  todayops_landing: 'landing',
+  todayops_cta_click: 'cta',
+  todayops_first_navigation: 'nav',
+  operational_phase_event: 'phase',
+};
+
+export const TYPE_COLORS: Record<string, string> = {
+  todayops_landing: '#3b82f6',
+  todayops_cta_click: '#f59e0b',
+  todayops_first_navigation: '#10b981',
+  operational_phase_event: '#8b5cf6',
+};
+
+// ── Range Labels ────────────────────────────────────────────────────────────
+
+export const RANGE_LABELS: Record<DateRange, string> = {
+  today: '今日',
+  '7d': '7日間',
+  '30d': '30日間',
+};

--- a/src/features/telemetry/components/formatters.ts
+++ b/src/features/telemetry/components/formatters.ts
@@ -1,0 +1,20 @@
+/**
+ * Telemetry Dashboard — 日時フォーマッタ
+ *
+ * TelemetryDashboard.tsx から抽出。
+ * TelemetryDoc の ts / clientTs を表示用に変換する純粋関数。
+ */
+
+import type { TelemetryDoc } from '../hooks/useTelemetryDashboard';
+
+export function formatTime(doc: TelemetryDoc): string {
+  const d = doc.ts ?? (doc.clientTs ? new Date(doc.clientTs) : null);
+  if (!d) return '—';
+  return d.toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
+
+export function formatDate(doc: TelemetryDoc): string {
+  const d = doc.ts ?? (doc.clientTs ? new Date(doc.clientTs) : null);
+  if (!d) return '';
+  return `${d.getMonth() + 1}/${d.getDate()}`;
+}

--- a/src/features/telemetry/components/ui/AlertSection.tsx
+++ b/src/features/telemetry/components/ui/AlertSection.tsx
@@ -1,0 +1,54 @@
+/**
+ * AlertChip + AlertSection — KPIアラート表示
+ */
+
+import type { KpiAlert } from '../../domain/computeCtaKpiDiff';
+import { SectionTitle } from './SectionTitle';
+
+function AlertChip({ alert }: { alert: KpiAlert }) {
+  const isCritical = alert.severity === 'critical';
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'flex-start',
+        gap: 10,
+        padding: '12px 16px',
+        borderRadius: 10,
+        background: isCritical ? '#fef2f2' : '#fffbeb',
+        border: `1px solid ${isCritical ? '#fecaca' : '#fed7aa'}`,
+      }}
+    >
+      <span style={{ fontSize: 16, lineHeight: 1.2, flexShrink: 0 }}>
+        {isCritical ? '🔴' : '🟡'}
+      </span>
+      <div style={{ flex: 1 }}>
+        <div style={{
+          fontSize: 13,
+          fontWeight: 600,
+          color: isCritical ? '#dc2626' : '#d97706',
+          marginBottom: 2,
+        }}>
+          {alert.label}
+        </div>
+        <div style={{ fontSize: 12, color: '#64748b', lineHeight: 1.4 }}>
+          {alert.message}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function AlertSection({ alerts }: { alerts: KpiAlert[] }) {
+  if (alerts.length === 0) return null;
+  return (
+    <section style={{ marginBottom: 20 }}>
+      <SectionTitle>⚠️ アラート ({alerts.length})</SectionTitle>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        {alerts.map((a) => (
+          <AlertChip key={a.id} alert={a} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/features/telemetry/components/ui/EventRankRow.tsx
+++ b/src/features/telemetry/components/ui/EventRankRow.tsx
@@ -1,0 +1,79 @@
+/**
+ * EventRankRow — イベント別ランキング行
+ */
+
+import type { EventRankItem } from '../../hooks/useTelemetryDashboard';
+import { TYPE_COLORS, TYPE_SHORT } from '../constants';
+
+export function EventRankRow({
+  item,
+  rank,
+  maxCount,
+}: {
+  item: EventRankItem;
+  rank: number;
+  maxCount: number;
+}) {
+  const pct = maxCount > 0 ? (item.count / maxCount) * 100 : 0;
+  const color = TYPE_COLORS[item.type] ?? '#94a3b8';
+  const typeLabel = TYPE_SHORT[item.type] ?? item.type;
+  const displayEvent = item.event === '(none)' ? '—' : item.event;
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
+      <div style={{
+        width: 20,
+        fontSize: 12,
+        fontWeight: 700,
+        color: rank <= 3 ? '#f59e0b' : '#94a3b8',
+        textAlign: 'right',
+        flexShrink: 0,
+      }}>
+        {rank}
+      </div>
+      <div style={{
+        width: 50,
+        flexShrink: 0,
+      }}>
+        <span style={{
+          display: 'inline-block',
+          padding: '1px 6px',
+          borderRadius: 8,
+          fontSize: 10,
+          fontWeight: 600,
+          color: '#fff',
+          background: color,
+          whiteSpace: 'nowrap',
+        }}>
+          {typeLabel}
+        </span>
+      </div>
+      <div style={{
+        width: 140,
+        fontSize: 12,
+        color: '#334155',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+        flexShrink: 0,
+      }}>
+        {displayEvent}
+      </div>
+      <div style={{ flex: 1, background: '#f1f5f9', borderRadius: 4, height: 18, overflow: 'hidden' }}>
+        <div
+          style={{
+            width: `${pct}%`,
+            height: '100%',
+            background: `${color}90`,
+            borderRadius: 4,
+            transition: 'width 0.5s ease',
+            minWidth: pct > 0 ? 4 : 0,
+          }}
+        />
+      </div>
+      <div style={{ width: 32, fontSize: 12, fontWeight: 600, color: '#334155', textAlign: 'right' }}>
+        {item.count}
+      </div>
+    </div>
+  );
+}

--- a/src/features/telemetry/components/ui/index.ts
+++ b/src/features/telemetry/components/ui/index.ts
@@ -1,0 +1,9 @@
+export { AlertSection } from './AlertSection';
+export { EmptyState } from './EmptyState';
+export { EventRankRow } from './EventRankRow';
+export { EventTypeChip } from './EventTypeChip';
+export { KpiCard } from './KpiCard';
+export { RangeTabs } from './RangeTabs';
+export { SectionCard } from './SectionCard';
+export { SectionTitle } from './SectionTitle';
+export { StatCard } from './StatCard';


### PR DESCRIPTION
## Summary

TelemetryDashboard.tsx (978行) を 17 のサブモジュールに分割し、メインコンポーネントを layout wiring のみ (369行) に縮小する。

Closes #1109

## Changes

### 新規ファイル

| カテゴリ | ファイル | 責務 |
|---------|---------|------|
| constants | `constants.ts` | PHASE_LABELS, TYPE_LABELS, TYPE_SHORT, TYPE_COLORS, RANGE_LABELS |
| formatters | `formatters.ts` | formatTime, formatDate |
| ui | `ui/RangeTabs.tsx` | 期間切替タブ |
| ui | `ui/SectionCard.tsx` | セクションコンテナ |
| ui | `ui/SectionTitle.tsx` | セクションタイトル |
| ui | `ui/EmptyState.tsx` | 空データ表示 |
| ui | `ui/KpiCard.tsx` | KPIサマリカード |
| ui | `ui/AlertSection.tsx` | アラート一覧 |
| ui | `ui/StatCard.tsx` | 統計カード |
| ui | `ui/EventTypeChip.tsx` | イベントタイプチップ |
| ui | `ui/EventRankRow.tsx` | ランキング行 |
| charts | `charts/FlowDistributionChart.tsx` | 導線分布バー |
| charts | `charts/HeroQueueChart.tsx` | Hero/Queue 比率 |
| charts | `charts/FunnelChart.tsx` | 完了ファネル |
| charts | `charts/HourlyChart.tsx` | 時間帯分布 |
| charts | `charts/PhaseBar.tsx` | フェーズ横棒 |

### 変更ファイル
- **TelemetryDashboard.tsx**: 978行 → 369行（wiring + layout のみ）

## Architecture

- [x] default export 維持（TelemetryDashboardPage.tsx 変更不要）
- [x] 機能変更なし（純粋な構造リファクタリング）
- [x] import パスは `../../domain` に統一
- [x] tsc / eslint 通過
