### PR TITLE
style: strengthen visibility for P0 PDCA supplemental alerts

### DIFF
--- a/src/features/planning-sheet/components/PhaseNextStepBanner.tsx
+++ b/src/features/planning-sheet/components/PhaseNextStepBanner.tsx
@@ -84,6 +84,8 @@ const PRIORITY_COLORS: Record<NextStepAlertPriority, string> = {
   p2: 'text.secondary',
 };
 
+const P0_EMPHASIS_COLOR = 'error.dark';
+
 // ─── Component ────────────────────────────────────────────────
 
 export const PhaseNextStepBanner: React.FC<PhaseNextStepBannerProps> = ({
@@ -148,8 +150,10 @@ export const PhaseNextStepBanner: React.FC<PhaseNextStepBannerProps> = ({
                   component="li"
                   variant="caption"
                   color={PRIORITY_COLORS[alert.priority]}
+                  data-p0-emphasis={alert.priority === 'p0' ? 'true' : undefined}
                   sx={{
                     fontWeight: alert.priority === 'p0' ? 700 : 400,
+                    ...(alert.priority === 'p0' ? { color: P0_EMPHASIS_COLOR } : {}),
                   }}
                 >
                   [{PRIORITY_LABELS[alert.priority]}] {alert.message}（{alert.action}）

--- a/src/features/planning-sheet/components/__tests__/PhaseNextStepBanner.spec.tsx
+++ b/src/features/planning-sheet/components/__tests__/PhaseNextStepBanner.spec.tsx
@@ -60,6 +60,9 @@ describe('PhaseNextStepBanner', () => {
     expect(
       screen.getByText('[早急対応] モニタリング長期未実施（15日）（モニタリングへ）'),
     ).toBeInTheDocument();
+
+    const item = screen.getByRole('listitem');
+    expect(item).toHaveAttribute('data-p0-emphasis', 'true');
   });
 
   it('p1 ラベル（注意）を表示する', () => {
@@ -112,6 +115,8 @@ describe('PhaseNextStepBanner', () => {
     expect(items).toHaveLength(2);
     expect(items[0]).toHaveTextContent('[早急対応] モニタリング長期未実施（15日）（モニタリングへ）');
     expect(items[1]).toHaveTextContent('[注意] 支援状態に注意（PDCA確認）');
+    expect(items[0]).toHaveAttribute('data-p0-emphasis', 'true');
+    expect(items[1]).not.toHaveAttribute('data-p0-emphasis');
     expect(screen.getByText('モニタリング時期が近づいています')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
PDCA 補助アラートのうち P0 のみ、既存バナー構造と導線を維持したまま視認性を一段強化する。CTA/title/body および p1/p2 の表示仕様は変更しない。

## Changes
- `PhaseNextStepBanner` の補助アラート表示で、P0 のみ色強調を追加
- 既存 `PRIORITY_COLORS` は維持し、P0 分岐を最小追加
- テストを更新し、P0 のみ強調フラグが付与されることを確認

## Validation
- `npx eslint --max-warnings=0 src/features/planning-sheet/components/PhaseNextStepBanner.tsx src/features/planning-sheet/components/__tests__/PhaseNextStepBanner.spec.tsx`
- `npx vitest run src/features/planning-sheet/components/__tests__/PhaseNextStepBanner.spec.tsx src/domain/bridge/__tests__/nextStepBanner.spec.ts`

