### PR TITLE
chore(planning-sheet): 局所ガイド文を履歴・更新情報付近に再掲

### DIFF
--- a/src/pages/SupportPlanningSheetPage.tsx
+++ b/src/pages/SupportPlanningSheetPage.tsx
@@ -563,6 +563,9 @@ export default function SupportPlanningSheetPage() {
             <Typography variant="subtitle2" sx={{ mb: 1, fontWeight: 700 }}>
               モニタリング履歴 / 取込履歴
             </Typography>
+            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
+              モニタリング取込後の反映履歴はこのセクションで確認できます。
+            </Typography>
             <ImportHistoryTimeline records={auditRecords} compact />
           </Box>
         ) : (
@@ -683,6 +686,9 @@ export default function SupportPlanningSheetPage() {
 
         {/* ── メタ情報フッター ── */}
         <Paper variant="outlined" sx={{ p: 2 }}>
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
+            編集後は更新日・更新者を確認し、意図した内容で保存されていることを確認してください。
+          </Typography>
           <Stack direction="row" spacing={3} flexWrap="wrap" useFlexGap>
             <Typography variant="caption" color="text.secondary">
               作成日: {formatDateTimeIntl(sheet.createdAt, { year: 'numeric', month: '2-digit', day: '2-digit' })}


### PR DESCRIPTION
## 概要
SupportPlanningSheetPage の操作ガイドを、参照先の近くでも迷いにくいように局所再掲しました。

## 変更内容
- `モニタリング履歴 / 取込履歴` 見出し直下に補助説明を追加
- メタ情報フッター（更新日・更新者表示）直上に確認案内を追加

## 意図
- 画面上部のガイドを見た後にスクロールしても、確認ポイントをその場で思い出せるようにする
- 業務ロジックや既存導線には影響を与えない

## 検証
- `npm run typecheck`
- `npx eslint --max-warnings=0 src/pages/SupportPlanningSheetPage.tsx`
- `npx vitest run src/features/planning-sheet/components/__tests__/PhaseNextStepBanner.spec.tsx`
