### PR TITLE
feat(planning-sheet): add empty-state CTA for monitoring history import

### DIFF
--- a/src/pages/SupportPlanningSheetPage.tsx
+++ b/src/pages/SupportPlanningSheetPage.tsx
@@ -282,6 +282,7 @@ export default function SupportPlanningSheetPage() {
     repository: monitoringRepo,
     planningSheetId: planningSheetId ?? 'new',
   });
+  const canImportMonitoring = !!latestMonitoringRecord;
 
   const handleMonitoringImport = React.useCallback(
     (result: MonitoringToPlanningResult, selectedCandidateIds: string[]) => {
@@ -378,6 +379,11 @@ export default function SupportPlanningSheetPage() {
     const history = document.getElementById('monitoring-history-timeline');
     history?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   }, []);
+
+  const handleOpenMonitoringImport = React.useCallback(() => {
+    if (!canImportMonitoring) return;
+    setMonitoringDialogOpen(true);
+  }, [canImportMonitoring]);
 
   // ── Evidence Click Navigation (Phase 4-C) ──
   const handleEvidenceClick = React.useCallback((type: EvidenceLinkType, referenceId: string) => {
@@ -569,9 +575,28 @@ export default function SupportPlanningSheetPage() {
             <ImportHistoryTimeline records={auditRecords} compact />
           </Box>
         ) : (
-          <Alert severity="info" variant="outlined" id="monitoring-history-timeline">
-            モニタリング履歴はまだありません。モニタリング取込後に履歴が表示されます。
-          </Alert>
+          <Box id="monitoring-history-timeline">
+            <Alert severity="info" variant="outlined">
+              モニタリング履歴はまだありません。モニタリング取込後に履歴が表示されます。
+            </Alert>
+            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
+              まだモニタリング履歴がありません。最新の記録を取り込んで反映できます。
+            </Typography>
+            <Button
+              size="small"
+              variant="contained"
+              onClick={handleOpenMonitoringImport}
+              disabled={!canImportMonitoring}
+              sx={{ mt: 1 }}
+            >
+              モニタリングを取り込む
+            </Button>
+            {!canImportMonitoring && (
+              <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+                取り込み可能な最新モニタリング記録がありません。
+              </Typography>
+            )}
+          </Box>
         )}
 
         {/* ── タブ ── */}


### PR DESCRIPTION
## 概要
モニタリング履歴が0件の場合に、次に行うべき操作（取込）へ誘導するCTAを追加しました。

## 変更内容
- 履歴0件時の空状態UIを拡張
  - 補助テキストを追加
  - `モニタリングを取り込む` ボタンを追加
- ボタンは既存の取込導線（モニタリング取込ダイアログ）を開く
- 取込可能な最新モニタリング記録がない場合はボタンを無効化し、補助文言を表示

## ねらい
- 空状態で操作が止まることを防ぐ
- モニタリング履歴の初回反映までの導線を短縮する
- 「何もない」状態を「次の行動」へ変換する

## スコープ
- UIのみ変更（業務ロジック変更なし）
- 既存導線・既存CTAは維持

## 検証
- `npm run typecheck`
- `npx eslint --max-warnings=0 src/pages/SupportPlanningSheetPage.tsx`
- `npx vitest run src/features/planning-sheet/components/__tests__/PhaseNextStepBanner.spec.tsx`
