### PR TITLE
feat(today): surface schedule high-load warnings

### DIFF
--- a/src/features/today/hooks/useTodayHighLoadWarnings.ts
+++ b/src/features/today/hooks/useTodayHighLoadWarnings.ts
@@ -1,0 +1,54 @@
+/**
+ * useTodayHighLoadWarnings — Today 向け高負荷警告の薄いファサード
+ *
+ * Schedule Ops の週間負荷スコアを算出し、high / critical な日だけを返す。
+ * Today ページは「件数 + 最初の日付」だけ表示し、詳細は /schedule-ops に誘導する。
+ *
+ * @see computeHighLoadWarnings (scheduleOpsLoadScore.ts)
+ */
+import { addDays, startOfWeek, endOfWeek } from 'date-fns';
+import { useMemo } from 'react';
+import { useScheduleOpsData } from '@/features/schedules/hooks/useScheduleOpsData';
+import { useScheduleOpsSummary } from '@/features/schedules/hooks/useScheduleOpsSummary';
+import { toDateKey } from '@/features/schedules/lib/dateKey';
+import { DEFAULT_OPS_FILTER } from '@/features/schedules/domain/scheduleOps';
+import type { HighLoadWarning } from '@/features/schedules/domain/scheduleOpsLoadScore';
+
+export type TodayHighLoadSummary = {
+  /** high / critical な日の件数 */
+  count: number;
+  /** 最も危険度が高い警告（スコア降順の先頭） */
+  top: HighLoadWarning | null;
+  /** 全警告リスト（スコア降順） */
+  warnings: readonly HighLoadWarning[];
+  /** データ取得中 */
+  isLoading: boolean;
+};
+
+export function useTodayHighLoadWarnings(): TodayHighLoadSummary {
+  const now = useMemo(() => new Date(), []);
+
+  const range = useMemo(() => {
+    const start = startOfWeek(now, { weekStartsOn: 1 });
+    return {
+      from: start.toISOString(),
+      to: endOfWeek(start, { weekStartsOn: 1 }).toISOString(),
+    };
+  }, [now]);
+
+  const weekDates = useMemo(() => {
+    const start = startOfWeek(now, { weekStartsOn: 1 });
+    return Array.from({ length: 7 }, (_, i) => toDateKey(addDays(start, i)));
+  }, [now]);
+
+  const { rawItems, isLoading } = useScheduleOpsData(range);
+
+  const { highLoadWarnings } = useScheduleOpsSummary(rawItems, DEFAULT_OPS_FILTER, weekDates);
+
+  return useMemo(() => ({
+    count: highLoadWarnings.length,
+    top: highLoadWarnings[0] ?? null,
+    warnings: highLoadWarnings,
+    isLoading,
+  }), [highLoadWarnings, isLoading]);
+}

--- a/src/features/today/layouts/TodayBentoLayout.tsx
+++ b/src/features/today/layouts/TodayBentoLayout.tsx
@@ -29,13 +29,16 @@
  */
 import { BentoCard, BentoContainer } from '@/components/ui/BentoGrid';
 import type { BriefingAlert } from '@/features/dashboard/sections/types';
+import type { HighLoadWarning } from '@/features/schedules/domain/scheduleOpsLoadScore';
 import type { ServiceStructure } from '@/features/today/domain/serviceStructure.types';
 import type { TodayScene } from '@/features/today/domain/todayScene';
 import {
     Accordion,
     AccordionDetails,
     AccordionSummary,
+    Alert,
     Box,
+    Chip,
     Typography,
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
@@ -101,6 +104,11 @@ export type TodayBentoProps = {
   handoffPanel?: React.ReactNode;
   /** 電話・連絡ログ要約カード (undefined 時は非表示) */
   callLogSummary?: CallLogSummaryCardProps;
+  /** 高負荷警告タイル (undefined or empty → 非表示) */
+  highLoadTile?: {
+    warnings: readonly HighLoadWarning[];
+    onNavigate: (dateIso: string) => void;
+  };
 };
 
 // ─── Compact Section Title ───────────────────────────────────
@@ -154,6 +162,7 @@ export const TodayBentoLayout: React.FC<TodayBentoProps> = ({
   users,
   handoffPanel,
   callLogSummary,
+  highLoadTile,
 }) => {
   return (
     <Box
@@ -266,6 +275,40 @@ export const TodayBentoLayout: React.FC<TodayBentoProps> = ({
               <AttendanceSummaryCard {...attendance} />
             </BentoCard>
           </>
+        )}
+
+        {/* ── High Load Warning Tile (ZONE B 直後) ── */}
+        {highLoadTile && highLoadTile.warnings.length > 0 && (
+          <BentoCard
+            colSpan={{ xs: 1, sm: 2, md: 4 }}
+            variant="default"
+            testId="bento-high-load"
+            sx={{ p: 0 }}
+          >
+            <Alert
+              severity={highLoadTile.warnings.some(w => w.level === 'critical') ? 'error' : 'warning'}
+              sx={{ cursor: 'pointer', '& .MuiAlert-message': { width: '100%' } }}
+              onClick={() => highLoadTile.onNavigate(highLoadTile.warnings[0].dateIso)}
+            >
+              <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', width: '100%' }}>
+                <Typography variant="body2" fontWeight={600}>
+                  {'⚠️ 今週の高負荷日: '}
+                  <strong>{highLoadTile.warnings.length}日</strong>
+                </Typography>
+                <Box sx={{ display: 'flex', gap: 0.5 }}>
+                  {highLoadTile.warnings.slice(0, 3).map(w => (
+                    <Chip
+                      key={w.dateIso}
+                      label={`${w.dateIso.slice(5)} (${w.level === 'critical' ? '危険' : '注意'})`}
+                      size="small"
+                      color={w.level === 'critical' ? 'error' : 'warning'}
+                      onClick={(e) => { e.stopPropagation(); highLoadTile.onNavigate(w.dateIso); }}
+                    />
+                  ))}
+                </Box>
+              </Box>
+            </Alert>
+          </BentoCard>
         )}
 
         {/* ════════════════════════════════════════════════════

--- a/src/pages/TodayOpsPage.tsx
+++ b/src/pages/TodayOpsPage.tsx
@@ -24,6 +24,7 @@ import { useWorkflowPhases } from '@/features/today/hooks/useWorkflowPhases';
 import { useTodayLayoutProps } from '@/features/today/hooks/useTodayLayoutProps';
 import { useTodayActionQueue } from '@/features/today/hooks/useTodayActionQueue';
 import { useUserAlerts } from '@/features/today/hooks/useUserAlerts';
+import { useTodayHighLoadWarnings } from '@/features/today/hooks/useTodayHighLoadWarnings';
 import type { ActionCard } from '@/features/today/domain/models/queue.types';
 import { usePlanningSheetRepositories } from '@/features/planning-sheet/hooks/usePlanningSheetRepositories';
 import { TodayBentoLayout } from '@/features/today/layouts/TodayBentoLayout';
@@ -110,6 +111,9 @@ export const TodayOpsPage: React.FC = () => {
   const { actionQueue, isLoading: isQueueLoading } = useTodayActionQueue({
     currentStaffId: 'staff-a', // 仮: ログインユーザーのIDを連携できるとベター
   });
+
+  // ── High Load Warnings (PR-C) ──
+  const highLoadData = useTodayHighLoadWarnings();
 
   const handleActionClick = React.useCallback(
     (action: ActionCard) => {
@@ -304,8 +308,17 @@ export const TodayOpsPage: React.FC = () => {
       onNavigateWithFilter: (preset: CallLogFilterPreset) => navigate(buildCallLogFilterUrl(preset)),
       onOpenDrawer: () => setCallLogDrawerOpen(true),
     },
+    highLoadTile: highLoadData.count > 0
+      ? {
+          warnings: highLoadData.warnings,
+          onNavigate: (dateIso: string) => {
+            const params = new URLSearchParams({ date: dateIso, tab: 'day' });
+            navigate(`/schedules/week?${params.toString()}`);
+          },
+        }
+      : undefined,
     };
-  }, [baseLayoutProps, isServiceManager, workflowPhases, navigate, actionQueue, isQueueLoading, handleActionClick, callLogsSummary, handleOpenUserStatus, userStatusActions.todayStatusRecords]);
+  }, [baseLayoutProps, isServiceManager, workflowPhases, navigate, actionQueue, isQueueLoading, handleActionClick, callLogsSummary, handleOpenUserStatus, userStatusActions.todayStatusRecords, highLoadData]);
 
   // ── Save Success Handler (Quick Record auto-next) ──
   const [showCompletionToast, setShowCompletionToast] = React.useState(false);


### PR DESCRIPTION
### Summary

Schedule Ops の週間高負荷警告を Today ページに露出し、管理者が先回りで気づける導線を追加しました。

### Background

導線監査で、Schedule Ops に高負荷警告があっても Today からは見えないことが確認されました。
Today は「実行入口」であるため、判断に必要な警告は入口で視認できるべき、という方針に基づく改善です。

### Changes

* `useTodayHighLoadWarnings.ts`
  * 新規追加
  * 週間データ取得 → `computeHighLoadWarnings()` → `{ count, top, warnings }` を返す薄い hook
* `TodayBentoLayout.tsx`
  * `highLoadTile` prop を追加
  * ZONE B の直後に Alert + Chip タイルを表示
* `TodayOpsPage.tsx`
  * hook を呼び出して layout に接続
  * Chip クリックで `/schedules/week?date=...&tab=day` に遷移

### Display rules

* `high / critical` が 1件以上ある場合のみ表示
* `critical` を含む場合は `severity="error"`
* `critical` を含まない場合は `severity="warning"`
* 0件なら完全非表示
* 表示する日付 Chip は最大3件

### Design decisions

* `useScheduleOps` 全体ではなく、`useScheduleOpsData + useScheduleOpsSummary` の組み合わせで軽量に実装
* `DEFAULT_OPS_FILTER` を利用し、全件ベースでサマリーを計算
* 既存の `computeHighLoadWarnings()` をそのまま再利用
* 遷移先は `/schedules/week?date=YYYY-MM-DD&tab=day` とし、対象日を直接確認できるようにした

### Validation

* `scheduleOpsLoadScore.spec.ts`: **66/66 passed**
* lint: **pass**
* typecheck: **pass**

### Manual checks

- [ ] `high / critical` が 1件以上のとき、ZONE B 直後に高負荷タイルが表示される
- [ ] 0件のとき完全非表示になる
- [ ] Chip クリックで `/schedules/week?date=...&tab=day` に正しく遷移する
- [ ] Hero / workflowCard / 高負荷タイルが同時表示でもレイアウトが崩れない
