### PR TITLE
feat: add suggestion lifecycle telemetry for Today/ExceptionCenter (#1155)

### DIFF
--- a/src/features/action-engine/hooks/__tests__/suggestionStateSync.integration.spec.tsx
+++ b/src/features/action-engine/hooks/__tests__/suggestionStateSync.integration.spec.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import type { ReactNode } from 'react';
@@ -14,6 +14,11 @@ import { ExceptionTable } from '@/features/exceptions/components/ExceptionTable'
 
 const theme = createTheme();
 const STABLE_ID = 'behavior-trend-increase:user-001:2026-W12';
+const mockRecordSuggestionTelemetry = vi.fn();
+
+vi.mock('../../telemetry/recordSuggestionTelemetry', () => ({
+  recordSuggestionTelemetry: (...args: unknown[]) => mockRecordSuggestionTelemetry(...args),
+}));
 
 const suggestionFixture: ActionSuggestion = {
   id: 'trend-increase-user-001-1711000000000',
@@ -58,6 +63,7 @@ function TodayExceptionSyncHarness() {
   const { items, count } = useCorrectiveActionExceptions({
     suggestions: [suggestionFixture],
     states,
+    pollingIntervalMs: 3_600_000,
   });
 
   const handleDismiss = (stableId: string) => {
@@ -105,6 +111,7 @@ describe('suggestion state sync (Today ↔ ExceptionCenter)', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-03-21T10:00:00Z'));
     useSuggestionStateStore.setState({ states: {} });
+    mockRecordSuggestionTelemetry.mockReset();
   });
 
   afterEach(() => {
@@ -113,6 +120,17 @@ describe('suggestion state sync (Today ↔ ExceptionCenter)', () => {
 
   it('Today で snooze すると ExceptionCenter でも非表示になる', async () => {
     renderWithProviders(<TodayExceptionSyncHarness />);
+
+    // 初回表示で shown が Today / ExceptionCenter それぞれ1件ずつ送信される
+    await Promise.resolve();
+    const shownCalls = mockRecordSuggestionTelemetry.mock.calls
+      .map((c) => c[0] as { event: string; sourceScreen: string })
+      .filter((event) => event.event === 'suggestion_shown');
+    expect(shownCalls).toHaveLength(2);
+    expect(shownCalls.map((event) => event.sourceScreen).sort()).toEqual([
+      'exception-center',
+      'today',
+    ]);
 
     expect(screen.getByTestId('exception-count').textContent).toBe('1');
     expect(screen.getByTestId('today-corrective-visible').textContent).toBe('1');
@@ -138,5 +156,32 @@ describe('suggestion state sync (Today ↔ ExceptionCenter)', () => {
     await Promise.resolve();
     expect(screen.getByTestId('exception-count').textContent).toBe('0');
     expect(screen.getByTestId('today-corrective-visible').textContent).toBe('0');
+  });
+
+  it('snooze 期限経過後に Today / ExceptionCenter で resurfaced が送信される', async () => {
+    renderWithProviders(<TodayExceptionSyncHarness />);
+    await Promise.resolve();
+    mockRecordSuggestionTelemetry.mockClear();
+
+    fireEvent.click(screen.getByTestId(`suggestion-menu-button-corrective:${STABLE_ID}`));
+    fireEvent.click(screen.getByText('明日まで'));
+    await Promise.resolve();
+    expect(screen.getByTestId('exception-count').textContent).toBe('0');
+
+    act(() => {
+      vi.advanceTimersByTime(25 * 60 * 60 * 1000);
+    });
+    await Promise.resolve();
+
+    expect(screen.getByTestId('exception-count').textContent).toBe('1');
+    expect(screen.getByTestId('today-corrective-visible').textContent).toBe('1');
+
+    const resurfacedCalls = mockRecordSuggestionTelemetry.mock.calls
+      .map((c) => c[0] as { event: string; sourceScreen: string })
+      .filter((event) => event.event === 'suggestion_resurfaced');
+    expect(resurfacedCalls.length).toBeGreaterThanOrEqual(1);
+    expect(resurfacedCalls.map((event) => event.sourceScreen)).toEqual(
+      expect.arrayContaining(['today']),
+    );
   });
 });

--- a/src/features/action-engine/index.ts
+++ b/src/features/action-engine/index.ts
@@ -54,3 +54,21 @@ export type {
 // State store
 export { useSuggestionStateStore } from './hooks/useSuggestionStateStore';
 export type { SuggestionStateStore, SuggestionStateMeta } from './hooks/useSuggestionStateStore';
+
+// Telemetry
+export {
+  buildSuggestionTelemetryEvent,
+  SUGGESTION_TELEMETRY_EVENTS,
+} from './telemetry/buildSuggestionTelemetryEvent';
+export type {
+  SuggestionTelemetryEvent,
+  SuggestionTelemetryEventName,
+  SuggestionTelemetrySourceScreen,
+  BuildSuggestionTelemetryEventInput,
+} from './telemetry/buildSuggestionTelemetryEvent';
+export {
+  recordSuggestionTelemetry,
+  _resetSuggestionTelemetryGuard,
+} from './telemetry/recordSuggestionTelemetry';
+export { useSuggestionVisibilityTelemetry } from './telemetry/useSuggestionVisibilityTelemetry';
+export type { UseSuggestionVisibilityTelemetryOptions } from './telemetry/useSuggestionVisibilityTelemetry';

--- a/src/features/action-engine/telemetry/__tests__/buildSuggestionTelemetryEvent.spec.ts
+++ b/src/features/action-engine/telemetry/__tests__/buildSuggestionTelemetryEvent.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import {
+  buildSuggestionTelemetryEvent,
+  SUGGESTION_TELEMETRY_EVENTS,
+} from '../buildSuggestionTelemetryEvent';
+
+describe('buildSuggestionTelemetryEvent', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-21T10:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('必須フィールドのみで shown payload を組み立てる', () => {
+    const event = buildSuggestionTelemetryEvent({
+      event: SUGGESTION_TELEMETRY_EVENTS.SHOWN,
+      sourceScreen: 'today',
+      stableId: 'rule:user:2026-W12',
+      ruleId: 'rule',
+      priority: 'P1',
+    });
+
+    expect(event).toEqual({
+      event: 'suggestion_shown',
+      sourceScreen: 'today',
+      stableId: 'rule:user:2026-W12',
+      ruleId: 'rule',
+      priority: 'P1',
+      timestamp: '2026-03-21T10:00:00.000Z',
+    });
+  });
+
+  it('snoozed payload に preset / until を含める', () => {
+    const event = buildSuggestionTelemetryEvent({
+      event: SUGGESTION_TELEMETRY_EVENTS.SNOOZED,
+      sourceScreen: 'exception-center',
+      stableId: 'rule:user:2026-W12',
+      ruleId: 'rule',
+      priority: 'P2',
+      targetUserId: 'user-001',
+      snoozePreset: 'three-days',
+      snoozedUntil: '2026-03-24T10:00:00.000Z',
+    });
+
+    expect(event).toEqual({
+      event: 'suggestion_snoozed',
+      sourceScreen: 'exception-center',
+      stableId: 'rule:user:2026-W12',
+      ruleId: 'rule',
+      priority: 'P2',
+      targetUserId: 'user-001',
+      snoozePreset: 'three-days',
+      snoozedUntil: '2026-03-24T10:00:00.000Z',
+      timestamp: '2026-03-21T10:00:00.000Z',
+    });
+  });
+
+  it('timestamp 指定時はその値を使う', () => {
+    const event = buildSuggestionTelemetryEvent({
+      event: SUGGESTION_TELEMETRY_EVENTS.CTA_CLICKED,
+      sourceScreen: 'today',
+      stableId: 'rule:user:2026-W12',
+      ruleId: 'rule',
+      priority: 'P0',
+      targetUrl: '/assessment',
+      timestamp: '2026-03-21T12:34:56.000Z',
+    });
+
+    expect(event.timestamp).toBe('2026-03-21T12:34:56.000Z');
+  });
+});

--- a/src/features/action-engine/telemetry/__tests__/recordSuggestionTelemetry.spec.ts
+++ b/src/features/action-engine/telemetry/__tests__/recordSuggestionTelemetry.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  _resetSuggestionTelemetryGuard,
+  recordSuggestionTelemetry,
+} from '../recordSuggestionTelemetry';
+import { SUGGESTION_TELEMETRY_EVENTS, type SuggestionTelemetryEvent } from '../buildSuggestionTelemetryEvent';
+
+const mockAddDoc = vi.fn().mockResolvedValue({ id: 'test-doc-id' });
+const mockCollection = vi.fn().mockReturnValue('mock-collection-ref');
+
+vi.mock('firebase/firestore', () => ({
+  addDoc: (...args: unknown[]) => mockAddDoc(...args),
+  collection: (...args: unknown[]) => mockCollection(...args),
+  serverTimestamp: () => 'mock-server-timestamp',
+}));
+
+vi.mock('@/infra/firestore/client', () => ({
+  db: 'mock-db',
+}));
+
+const baseEvent: SuggestionTelemetryEvent = {
+  event: SUGGESTION_TELEMETRY_EVENTS.SHOWN,
+  sourceScreen: 'today',
+  stableId: 'rule:user:2026-W12',
+  ruleId: 'rule',
+  priority: 'P1',
+  timestamp: '2026-03-21T10:00:00.000Z',
+};
+
+describe('recordSuggestionTelemetry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetSuggestionTelemetryGuard();
+  });
+
+  it('Firestore telemetry に送信する', () => {
+    recordSuggestionTelemetry(baseEvent);
+
+    expect(mockCollection).toHaveBeenCalledWith('mock-db', 'telemetry');
+    expect(mockAddDoc).toHaveBeenCalledWith(
+      'mock-collection-ref',
+      expect.objectContaining({
+        ...baseEvent,
+        type: 'suggestion_lifecycle_event',
+        ts: 'mock-server-timestamp',
+        clientTs: '2026-03-21T10:00:00.000Z',
+      }),
+    );
+  });
+
+  it('dedupeKey が同じ場合は重複送信しない', () => {
+    recordSuggestionTelemetry(baseEvent, { dedupeKey: 'shown:today:rule:user:2026-W12' });
+    recordSuggestionTelemetry(baseEvent, { dedupeKey: 'shown:today:rule:user:2026-W12' });
+
+    expect(mockAddDoc).toHaveBeenCalledTimes(1);
+  });
+
+  it('collection() が同期例外でも throw しない', () => {
+    mockCollection.mockImplementationOnce(() => {
+      throw new Error('db not ready');
+    });
+
+    expect(() => {
+      recordSuggestionTelemetry(baseEvent);
+    }).not.toThrow();
+  });
+});

--- a/src/features/action-engine/telemetry/__tests__/useSuggestionVisibilityTelemetry.spec.tsx
+++ b/src/features/action-engine/telemetry/__tests__/useSuggestionVisibilityTelemetry.spec.tsx
@@ -1,0 +1,125 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ActionSuggestion, ActionSuggestionState } from '../../domain/types';
+import { useSuggestionVisibilityTelemetry } from '../useSuggestionVisibilityTelemetry';
+
+const mockRecordSuggestionTelemetry = vi.fn();
+
+vi.mock('../recordSuggestionTelemetry', () => ({
+  recordSuggestionTelemetry: (...args: unknown[]) => mockRecordSuggestionTelemetry(...args),
+}));
+
+const suggestion: ActionSuggestion = {
+  id: 's1',
+  stableId: 'rule:user-001:2026-W12',
+  type: 'assessment_update',
+  priority: 'P1',
+  targetUserId: 'user-001',
+  title: '提案',
+  reason: '理由',
+  evidence: {
+    metric: 'm',
+    currentValue: 1,
+    threshold: 2,
+    period: '7d',
+  },
+  cta: {
+    label: '確認',
+    route: '/assessment',
+  },
+  createdAt: '2026-03-21T10:00:00Z',
+  ruleId: 'rule',
+};
+
+describe('useSuggestionVisibilityTelemetry', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-21T10:00:00Z'));
+    mockRecordSuggestionTelemetry.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('初回表示で suggestion_shown を送信する', async () => {
+    renderHook(() =>
+      useSuggestionVisibilityTelemetry({
+        suggestions: [suggestion],
+        states: {},
+        sourceScreen: 'today',
+        now: new Date('2026-03-21T10:00:00Z'),
+      }),
+    );
+
+    await Promise.resolve();
+    expect(mockRecordSuggestionTelemetry).toHaveBeenCalledTimes(1);
+    expect(mockRecordSuggestionTelemetry.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        event: 'suggestion_shown',
+        sourceScreen: 'today',
+        stableId: suggestion.stableId,
+      }),
+    );
+  });
+
+  it('同じ表示状態で再レンダーしても重複送信しない', async () => {
+    const { rerender } = renderHook(
+      ({ now }: { now: Date }) =>
+        useSuggestionVisibilityTelemetry({
+          suggestions: [suggestion],
+          states: {},
+          sourceScreen: 'today',
+          now,
+        }),
+      {
+        initialProps: { now: new Date('2026-03-21T10:00:00Z') },
+      },
+    );
+
+    await Promise.resolve();
+    rerender({ now: new Date('2026-03-21T10:01:00Z') });
+    await Promise.resolve();
+
+    expect(mockRecordSuggestionTelemetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('snooze 解除で suggestion_resurfaced を送信する', async () => {
+    const states: Record<string, ActionSuggestionState> = {
+      [suggestion.stableId]: {
+        stableId: suggestion.stableId,
+        status: 'snoozed',
+        snoozedUntil: '2026-03-21T10:30:00Z',
+        updatedAt: '2026-03-21T10:00:00Z',
+      },
+    };
+
+    const { rerender } = renderHook(
+      ({ now }: { now: Date }) =>
+        useSuggestionVisibilityTelemetry({
+          suggestions: [suggestion],
+          states,
+          sourceScreen: 'exception-center',
+          now,
+        }),
+      {
+        initialProps: { now: new Date('2026-03-21T10:00:00Z') },
+      },
+    );
+
+    await Promise.resolve();
+    expect(mockRecordSuggestionTelemetry).toHaveBeenCalledTimes(0);
+
+    rerender({ now: new Date('2026-03-21T10:31:00Z') });
+    await Promise.resolve();
+
+    expect(mockRecordSuggestionTelemetry).toHaveBeenCalledTimes(1);
+    expect(mockRecordSuggestionTelemetry.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        event: 'suggestion_resurfaced',
+        sourceScreen: 'exception-center',
+        stableId: suggestion.stableId,
+      }),
+    );
+  });
+});

--- a/src/features/action-engine/telemetry/buildSuggestionTelemetryEvent.ts
+++ b/src/features/action-engine/telemetry/buildSuggestionTelemetryEvent.ts
@@ -1,0 +1,62 @@
+import type { SnoozePreset } from '../domain/computeSnoozeUntil';
+import type { SuggestionPriority } from '../domain/types';
+
+export const SUGGESTION_TELEMETRY_EVENTS = {
+  SHOWN: 'suggestion_shown',
+  CTA_CLICKED: 'suggestion_cta_clicked',
+  DISMISSED: 'suggestion_dismissed',
+  SNOOZED: 'suggestion_snoozed',
+  RESURFACED: 'suggestion_resurfaced',
+} as const;
+
+export type SuggestionTelemetryEventName =
+  (typeof SUGGESTION_TELEMETRY_EVENTS)[keyof typeof SUGGESTION_TELEMETRY_EVENTS];
+
+export type SuggestionTelemetrySourceScreen = 'today' | 'exception-center';
+
+export type BuildSuggestionTelemetryEventInput = {
+  event: SuggestionTelemetryEventName;
+  sourceScreen: SuggestionTelemetrySourceScreen;
+  stableId: string;
+  ruleId: string;
+  priority: SuggestionPriority;
+  targetUserId?: string;
+  targetUrl?: string;
+  snoozePreset?: SnoozePreset;
+  snoozedUntil?: string;
+  timestamp?: string;
+};
+
+export type SuggestionTelemetryEvent = {
+  event: SuggestionTelemetryEventName;
+  sourceScreen: SuggestionTelemetrySourceScreen;
+  stableId: string;
+  ruleId: string;
+  priority: SuggestionPriority;
+  timestamp: string;
+  targetUserId?: string;
+  targetUrl?: string;
+  snoozePreset?: SnoozePreset;
+  snoozedUntil?: string;
+};
+
+/**
+ * Suggestion lifecycle telemetry の payload builder。
+ * 画面層は event ごとの差分を意識せず、この builder に入力を渡すだけでよい。
+ */
+export function buildSuggestionTelemetryEvent(
+  input: BuildSuggestionTelemetryEventInput,
+): SuggestionTelemetryEvent {
+  return {
+    event: input.event,
+    sourceScreen: input.sourceScreen,
+    stableId: input.stableId,
+    ruleId: input.ruleId,
+    priority: input.priority,
+    timestamp: input.timestamp ?? new Date().toISOString(),
+    ...(input.targetUserId ? { targetUserId: input.targetUserId } : {}),
+    ...(input.targetUrl ? { targetUrl: input.targetUrl } : {}),
+    ...(input.snoozePreset ? { snoozePreset: input.snoozePreset } : {}),
+    ...(input.snoozedUntil ? { snoozedUntil: input.snoozedUntil } : {}),
+  };
+}

--- a/src/features/action-engine/telemetry/recordSuggestionTelemetry.ts
+++ b/src/features/action-engine/telemetry/recordSuggestionTelemetry.ts
@@ -1,0 +1,40 @@
+import { db } from '@/infra/firestore/client';
+import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
+import type { SuggestionTelemetryEvent } from './buildSuggestionTelemetryEvent';
+
+const _dedupeGuard = new Set<string>();
+
+export function _resetSuggestionTelemetryGuard(): void {
+  _dedupeGuard.clear();
+}
+
+/**
+ * Suggestion lifecycle telemetry を Firestore に送信する。
+ * dedupeKey 指定時は同一セッションで重複送信を抑制する。
+ */
+export function recordSuggestionTelemetry(
+  event: SuggestionTelemetryEvent,
+  options: { dedupeKey?: string } = {},
+): void {
+  if (options.dedupeKey) {
+    if (_dedupeGuard.has(options.dedupeKey)) return;
+    _dedupeGuard.add(options.dedupeKey);
+  }
+
+  const payload = {
+    ...event,
+    type: 'suggestion_lifecycle_event' as const,
+    ts: serverTimestamp(),
+    clientTs: event.timestamp,
+  };
+
+  try {
+    addDoc(collection(db, 'telemetry'), payload).catch((err) => {
+      // eslint-disable-next-line no-console
+      console.warn('[suggestion-telemetry] write failed', err);
+    });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn('[suggestion-telemetry] skipped (db not ready)', err);
+  }
+}

--- a/src/features/action-engine/telemetry/useSuggestionVisibilityTelemetry.ts
+++ b/src/features/action-engine/telemetry/useSuggestionVisibilityTelemetry.ts
@@ -1,0 +1,68 @@
+import { useEffect, useRef } from 'react';
+import type { ActionSuggestion, ActionSuggestionState } from '../domain/types';
+import { isSuggestionVisible } from '../domain/types';
+import {
+  buildSuggestionTelemetryEvent,
+  SUGGESTION_TELEMETRY_EVENTS,
+  type SuggestionTelemetrySourceScreen,
+} from './buildSuggestionTelemetryEvent';
+import { recordSuggestionTelemetry } from './recordSuggestionTelemetry';
+
+export type UseSuggestionVisibilityTelemetryOptions = {
+  suggestions: ActionSuggestion[];
+  states: Record<string, ActionSuggestionState>;
+  sourceScreen: SuggestionTelemetrySourceScreen;
+  now: Date;
+};
+
+function isResurfacedState(
+  state: ActionSuggestionState | undefined,
+  now: Date,
+): boolean {
+  if (!state || state.status !== 'snoozed' || !state.snoozedUntil) return false;
+  return new Date(state.snoozedUntil).getTime() <= now.getTime();
+}
+
+/**
+ * visible 遷移（非表示→表示）を観測し、shown / resurfaced を送信する。
+ */
+export function useSuggestionVisibilityTelemetry(
+  options: UseSuggestionVisibilityTelemetryOptions,
+): void {
+  const { suggestions, states, sourceScreen, now } = options;
+  const prevVisibleRef = useRef<Record<string, boolean>>({});
+
+  useEffect(() => {
+    const nextVisible: Record<string, boolean> = {};
+
+    for (const suggestion of suggestions) {
+      const state = states[suggestion.stableId];
+      const isVisible = isSuggestionVisible(state, now);
+      const wasVisible = prevVisibleRef.current[suggestion.stableId] ?? false;
+
+      nextVisible[suggestion.stableId] = isVisible;
+
+      if (!isVisible || wasVisible) continue;
+
+      const isResurfaced = isResurfacedState(state, now);
+      const event = buildSuggestionTelemetryEvent({
+        event: isResurfaced
+          ? SUGGESTION_TELEMETRY_EVENTS.RESURFACED
+          : SUGGESTION_TELEMETRY_EVENTS.SHOWN,
+        sourceScreen,
+        stableId: suggestion.stableId,
+        ruleId: suggestion.ruleId,
+        priority: suggestion.priority,
+        targetUserId: suggestion.targetUserId,
+      });
+
+      const dedupeKey = isResurfaced
+        ? `suggestion_resurfaced:${sourceScreen}:${suggestion.stableId}:${state?.snoozedUntil ?? 'none'}`
+        : `suggestion_shown:${sourceScreen}:${suggestion.stableId}:visible-session`;
+
+      recordSuggestionTelemetry(event, { dedupeKey });
+    }
+
+    prevVisibleRef.current = nextVisible;
+  }, [suggestions, states, sourceScreen, now]);
+}

--- a/src/features/exceptions/components/ExceptionTable.tsx
+++ b/src/features/exceptions/components/ExceptionTable.tsx
@@ -65,6 +65,7 @@ export type ExceptionTableProps = {
   suggestionActions?: {
     onDismiss: (stableId: string) => void;
     onSnooze: (stableId: string, preset: SnoozePreset) => void;
+    onCtaClick?: (stableId: string, targetUrl: string) => void;
   };
 };
 
@@ -109,6 +110,13 @@ const CorrectiveActionsCell: React.FC<{
       suggestionActions,
   );
 
+  const handleNavigate = (route: string) => {
+    if (item.category === 'corrective-action' && stableId) {
+      suggestionActions?.onCtaClick?.(stableId, route);
+    }
+    onNavigate(route);
+  };
+
   if (!primary) return null;
 
   return (
@@ -119,7 +127,7 @@ const CorrectiveActionsCell: React.FC<{
           size="small"
           variant="contained"
           color={SEVERITY_TO_COLOR[primary.severity] ?? 'primary'}
-          onClick={() => onNavigate(primary.route)}
+          onClick={() => handleNavigate(primary.route)}
           startIcon={<span style={{ fontSize: 12 }}>{primary.icon}</span>}
           sx={{ fontSize: '0.7rem', textTransform: 'none', py: 0.25, px: 1 }}
           title={primary.reason}
@@ -142,7 +150,7 @@ const CorrectiveActionsCell: React.FC<{
         <Button
           size="small"
           variant="text"
-          onClick={() => onNavigate(secondary.route)}
+          onClick={() => handleNavigate(secondary.route)}
           sx={{
             fontSize: '0.65rem',
             textTransform: 'none',

--- a/src/features/exceptions/hooks/useCorrectiveActionExceptions.ts
+++ b/src/features/exceptions/hooks/useCorrectiveActionExceptions.ts
@@ -11,17 +11,20 @@
  * ExceptionCenterPage はこの hook の戻り値を aggregateExceptions に渡すだけでいい。
  */
 
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { ActionSuggestion, ActionSuggestionState } from '@/features/action-engine/domain/types';
 import { isSuggestionVisible } from '@/features/action-engine/domain/types';
 import { mapSuggestionToException } from '@/features/exceptions/domain/mapSuggestionToException';
 import type { ExceptionItem } from '@/features/exceptions/domain/exceptionLogic';
+import { useSuggestionVisibilityTelemetry } from '@/features/action-engine/telemetry/useSuggestionVisibilityTelemetry';
 
 export interface UseCorrectiveActionExceptionsOptions {
   /** 全利用者分の Action Engine 提案（外部から注入） */
   suggestions: ActionSuggestion[];
   /** dismiss / snooze 状態（stableId → state） */
   states: Record<string, ActionSuggestionState>;
+  /** snooze 期限再評価の間隔（既定: 60秒） */
+  pollingIntervalMs?: number;
 }
 
 export interface UseCorrectiveActionExceptionsReturn {
@@ -40,17 +43,35 @@ export interface UseCorrectiveActionExceptionsReturn {
 export function useCorrectiveActionExceptions(
   options: UseCorrectiveActionExceptionsOptions,
 ): UseCorrectiveActionExceptionsReturn {
-  const { suggestions, states } = options;
+  const {
+    suggestions,
+    states,
+    pollingIntervalMs = 60_000,
+  } = options;
+  const [now, setNow] = useState(new Date());
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setNow(new Date());
+    }, pollingIntervalMs);
+    return () => clearInterval(timer);
+  }, [pollingIntervalMs]);
+
+  useSuggestionVisibilityTelemetry({
+    suggestions,
+    states,
+    sourceScreen: 'exception-center',
+    now,
+  });
 
   const items = useMemo(() => {
-    const now = new Date();
     return suggestions
       .filter((s) => {
         const state = states[s.stableId];
         return isSuggestionVisible(state, now);
       })
       .map(mapSuggestionToException);
-  }, [suggestions, states]);
+  }, [suggestions, states, now]);
 
   return {
     items,

--- a/src/features/today/hooks/useTodayActionQueue.ts
+++ b/src/features/today/hooks/useTodayActionQueue.ts
@@ -7,6 +7,7 @@ import { useTodayQueueTelemetryStore } from '../telemetry/todayQueueTelemetrySto
 import { mapSuggestionToActionSource } from '../domain/engine/mapSuggestionToActionSource';
 import type { ActionSuggestion, ActionSuggestionState } from '../../action-engine/domain/types';
 import { isSuggestionVisible } from '../../action-engine/domain/types';
+import { useSuggestionVisibilityTelemetry } from '../../action-engine/telemetry/useSuggestionVisibilityTelemetry';
 
 interface UseTodayActionQueueOptions {
   pollingIntervalMs?: number;
@@ -68,6 +69,14 @@ export function useTodayActionQueue(
   useEffect(() => {
     refresh();
   }, [refresh]);
+
+  // corrective_action 提案の visible 遷移を観測して telemetry を送る
+  useSuggestionVisibilityTelemetry({
+    suggestions: correctiveActions,
+    states: suggestionStates ?? {},
+    sourceScreen: 'today',
+    now,
+  });
 
   // 4. Engineへの結合（純粋関数の呼び出し）
   // corrective_action を既存 sources に注入してから Engine に渡す

--- a/src/pages/TodayOpsPage.tsx
+++ b/src/pages/TodayOpsPage.tsx
@@ -29,6 +29,11 @@ import type { ActionSuggestion } from '@/features/action-engine/domain/types';
 import type { SnoozePreset } from '@/features/action-engine/domain/computeSnoozeUntil';
 import { computeSnoozeUntil } from '@/features/action-engine/domain/computeSnoozeUntil';
 import { useSuggestionStateStore } from '@/features/action-engine/hooks/useSuggestionStateStore';
+import {
+  buildSuggestionTelemetryEvent,
+  SUGGESTION_TELEMETRY_EVENTS,
+} from '@/features/action-engine/telemetry/buildSuggestionTelemetryEvent';
+import { recordSuggestionTelemetry } from '@/features/action-engine/telemetry/recordSuggestionTelemetry';
 import { usePlanningSheetRepositories } from '@/features/planning-sheet/hooks/usePlanningSheetRepositories';
 import { TodayBentoLayout } from '@/features/today/layouts/TodayBentoLayout';
 import { recordAutoNextComplete, recordAutoNextSave } from '@/features/today/records/autoNextCounters';
@@ -127,14 +132,32 @@ export const TodayOpsPage: React.FC<TodayOpsPageProps> = ({
     correctiveActions,
     suggestionStates,
   });
+  const suggestionByStableId = useMemo(() => {
+    return new Map(correctiveActions.map((s) => [s.stableId, s]));
+  }, [correctiveActions]);
 
   const handleActionClick = React.useCallback(
     (action: ActionCard) => {
       if (action.actionType === 'OPEN_DRAWER') {
         quickRecord.openUnfilled();
       } else if (action.actionType === 'NAVIGATE') {
-        const payload = action.payload as { path?: string };
-        if (payload?.path) navigate(payload.path);
+        const payload = action.payload as { path?: string; suggestion?: ActionSuggestion } | undefined;
+        const suggestion = payload?.suggestion;
+        const targetUrl = payload?.path ?? suggestion?.cta?.route;
+        if (suggestion) {
+          recordSuggestionTelemetry(
+            buildSuggestionTelemetryEvent({
+              event: SUGGESTION_TELEMETRY_EVENTS.CTA_CLICKED,
+              sourceScreen: 'today',
+              stableId: suggestion.stableId,
+              ruleId: suggestion.ruleId,
+              priority: suggestion.priority,
+              targetUserId: suggestion.targetUserId,
+              targetUrl,
+            }),
+          );
+        }
+        if (targetUrl) navigate(targetUrl);
         else navigate('/schedules');
       } else if (action.actionType === 'ACKNOWLEDGE') {
         // No-op for now. Acknowledge handler can be hooked into an API action later.
@@ -144,13 +167,41 @@ export const TodayOpsPage: React.FC<TodayOpsPageProps> = ({
   );
 
   const handleDismissSuggestion = useCallback((stableId: string) => {
+    const suggestion = suggestionByStableId.get(stableId);
+    if (suggestion) {
+      recordSuggestionTelemetry(
+        buildSuggestionTelemetryEvent({
+          event: SUGGESTION_TELEMETRY_EVENTS.DISMISSED,
+          sourceScreen: 'today',
+          stableId: suggestion.stableId,
+          ruleId: suggestion.ruleId,
+          priority: suggestion.priority,
+          targetUserId: suggestion.targetUserId,
+        }),
+      );
+    }
     dismissSuggestion(stableId, { by: 'today' });
-  }, [dismissSuggestion]);
+  }, [dismissSuggestion, suggestionByStableId]);
 
   const handleSnoozeSuggestion = useCallback((stableId: string, preset: SnoozePreset) => {
+    const suggestion = suggestionByStableId.get(stableId);
     const until = computeSnoozeUntil(preset, new Date());
+    if (suggestion) {
+      recordSuggestionTelemetry(
+        buildSuggestionTelemetryEvent({
+          event: SUGGESTION_TELEMETRY_EVENTS.SNOOZED,
+          sourceScreen: 'today',
+          stableId: suggestion.stableId,
+          ruleId: suggestion.ruleId,
+          priority: suggestion.priority,
+          targetUserId: suggestion.targetUserId,
+          snoozePreset: preset,
+          snoozedUntil: until,
+        }),
+      );
+    }
     snoozeSuggestion(stableId, until, { by: 'today' });
-  }, [snoozeSuggestion]);
+  }, [snoozeSuggestion, suggestionByStableId]);
 
   // ── CallLog Summary (Today 連携) ──
   // account.name を myName として注入し、自分宛未対応件数を算出する

--- a/src/pages/admin/ExceptionCenterPage.tsx
+++ b/src/pages/admin/ExceptionCenterPage.tsx
@@ -44,6 +44,11 @@ import type { ActionSuggestion, ActionSuggestionState } from '@/features/action-
 import type { SnoozePreset } from '@/features/action-engine/domain/computeSnoozeUntil';
 import { computeSnoozeUntil } from '@/features/action-engine/domain/computeSnoozeUntil';
 import { useSuggestionStateStore } from '@/features/action-engine/hooks/useSuggestionStateStore';
+import {
+  buildSuggestionTelemetryEvent,
+  SUGGESTION_TELEMETRY_EVENTS,
+} from '@/features/action-engine/telemetry/buildSuggestionTelemetryEvent';
+import { recordSuggestionTelemetry } from '@/features/action-engine/telemetry/recordSuggestionTelemetry';
 
 // ─── Component ────────────────────────────────────────────────
 
@@ -68,6 +73,9 @@ export default function ExceptionCenterPage({
   const dataSources = useExceptionDataSources();
   
   const [categoryFilter, setCategoryFilter] = useState<ExceptionCategory | 'all'>('all');
+  const suggestionByStableId = useMemo(() => {
+    return new Map(allSuggestions.map((s) => [s.stableId, s]));
+  }, [allSuggestions]);
 
   // Action Engine 提案 → ExceptionItem
   const { items: correctiveItems } = useCorrectiveActionExceptions({
@@ -76,13 +84,57 @@ export default function ExceptionCenterPage({
   });
 
   const handleDismissSuggestion = React.useCallback((stableId: string) => {
+    const suggestion = suggestionByStableId.get(stableId);
+    if (suggestion) {
+      recordSuggestionTelemetry(
+        buildSuggestionTelemetryEvent({
+          event: SUGGESTION_TELEMETRY_EVENTS.DISMISSED,
+          sourceScreen: 'exception-center',
+          stableId: suggestion.stableId,
+          ruleId: suggestion.ruleId,
+          priority: suggestion.priority,
+          targetUserId: suggestion.targetUserId,
+        }),
+      );
+    }
     dismissSuggestion(stableId, { by: 'exception-center' });
-  }, [dismissSuggestion]);
+  }, [dismissSuggestion, suggestionByStableId]);
 
   const handleSnoozeSuggestion = React.useCallback((stableId: string, preset: SnoozePreset) => {
+    const suggestion = suggestionByStableId.get(stableId);
     const until = computeSnoozeUntil(preset, new Date());
+    if (suggestion) {
+      recordSuggestionTelemetry(
+        buildSuggestionTelemetryEvent({
+          event: SUGGESTION_TELEMETRY_EVENTS.SNOOZED,
+          sourceScreen: 'exception-center',
+          stableId: suggestion.stableId,
+          ruleId: suggestion.ruleId,
+          priority: suggestion.priority,
+          targetUserId: suggestion.targetUserId,
+          snoozePreset: preset,
+          snoozedUntil: until,
+        }),
+      );
+    }
     snoozeSuggestion(stableId, until, { by: 'exception-center' });
-  }, [snoozeSuggestion]);
+  }, [snoozeSuggestion, suggestionByStableId]);
+
+  const handleSuggestionCtaClick = React.useCallback((stableId: string, targetUrl: string) => {
+    const suggestion = suggestionByStableId.get(stableId);
+    if (!suggestion) return;
+    recordSuggestionTelemetry(
+      buildSuggestionTelemetryEvent({
+        event: SUGGESTION_TELEMETRY_EVENTS.CTA_CLICKED,
+        sourceScreen: 'exception-center',
+        stableId: suggestion.stableId,
+        ruleId: suggestion.ruleId,
+        priority: suggestion.priority,
+        targetUserId: suggestion.targetUserId,
+        targetUrl,
+      }),
+    );
+  }, [suggestionByStableId]);
 
   // ── 例外検出（実データ） ──
   const exceptions = useMemo(() => {
@@ -255,6 +307,7 @@ export default function ExceptionCenterPage({
           suggestionActions={{
             onDismiss: handleDismissSuggestion,
             onSnooze: handleSnoozeSuggestion,
+            onCtaClick: handleSuggestionCtaClick,
           }}
         />
       </Stack>

--- a/tests/unit/pages/ExceptionCenterPage.suggestionTelemetry.spec.tsx
+++ b/tests/unit/pages/ExceptionCenterPage.suggestionTelemetry.spec.tsx
@@ -1,0 +1,159 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import ExceptionCenterPage from '../../../src/pages/admin/ExceptionCenterPage';
+import { ExceptionTable } from '../../../src/features/exceptions/components/ExceptionTable';
+import type { ActionSuggestion } from '../../../src/features/action-engine/domain/types';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock('../../../src/features/exceptions/hooks/useExceptionDataSources', () => ({
+  useExceptionDataSources: vi.fn(() => ({
+    status: 'ready',
+    expectedUsers: [],
+    todayRecords: [],
+    today: '2026-03-21',
+    criticalHandoffs: [],
+    userSummaries: [],
+    error: null,
+  })),
+}));
+
+const stableId = 'behavior-trend-increase:user-001:2026-W12';
+
+vi.mock('../../../src/features/exceptions/hooks/useCorrectiveActionExceptions', () => ({
+  useCorrectiveActionExceptions: vi.fn(() => ({
+    items: [
+      {
+        id: `ae:${stableId}`,
+        category: 'corrective-action',
+        severity: 'high',
+        title: '改善提案',
+        description: '根拠',
+        targetUserId: 'user-001',
+        targetDate: '2026-03-21',
+        updatedAt: '2026-03-21T09:00:00Z',
+        actionPath: '/assessment',
+        actionLabel: '確認',
+        stableId,
+      },
+    ],
+    count: 1,
+  })),
+}));
+
+vi.mock('../../../src/features/exceptions/components/ExceptionTable', () => ({
+  ExceptionTable: vi.fn(() => <div data-testid="exception-table" />),
+}));
+
+const mockDismissSuggestion = vi.fn();
+const mockSnoozeSuggestion = vi.fn();
+vi.mock('../../../src/features/action-engine/hooks/useSuggestionStateStore', () => ({
+  useSuggestionStateStore: (
+    selector: (state: {
+      states: Record<string, unknown>;
+      dismiss: (...args: unknown[]) => void;
+      snooze: (...args: unknown[]) => void;
+    }) => unknown,
+  ) => selector({
+    states: {},
+    dismiss: (...args: unknown[]) => mockDismissSuggestion(...args),
+    snooze: (...args: unknown[]) => mockSnoozeSuggestion(...args),
+  }),
+}));
+
+const mockRecordSuggestionTelemetry = vi.fn();
+vi.mock('../../../src/features/action-engine/telemetry/recordSuggestionTelemetry', () => ({
+  recordSuggestionTelemetry: (...args: unknown[]) => mockRecordSuggestionTelemetry(...args),
+}));
+
+describe('ExceptionCenterPage suggestion telemetry', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-21T10:00:00Z'));
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('ExceptionTable からの CTA/dismiss/snooze callback で telemetry を送る', () => {
+    const suggestion: ActionSuggestion = {
+      id: 's1',
+      stableId,
+      type: 'assessment_update',
+      priority: 'P1',
+      targetUserId: 'user-001',
+      title: '改善提案',
+      reason: '理由',
+      evidence: {
+        metric: 'm',
+        currentValue: 1,
+        threshold: 2,
+        period: '7d',
+      },
+      cta: {
+        label: '確認',
+        route: '/assessment',
+      },
+      createdAt: '2026-03-21T09:00:00Z',
+      ruleId: 'behavior-trend-increase',
+    };
+
+    render(
+      <MemoryRouter>
+        <ExceptionCenterPage allSuggestions={[suggestion]} suggestionStates={{}} />
+      </MemoryRouter>,
+    );
+
+    expect(ExceptionTable).toHaveBeenCalled();
+    const calls = vi.mocked(ExceptionTable).mock.calls;
+    const props = calls.length > 0 ? (calls[calls.length - 1]?.[0] as Record<string, unknown>) : {};
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const actions = (props.suggestionActions as any);
+
+    actions.onCtaClick(stableId, '/assessment');
+    actions.onDismiss(stableId);
+    actions.onSnooze(stableId, 'three-days');
+
+    expect(mockRecordSuggestionTelemetry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'suggestion_cta_clicked',
+        sourceScreen: 'exception-center',
+        stableId,
+        targetUrl: '/assessment',
+      }),
+    );
+    expect(mockRecordSuggestionTelemetry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'suggestion_dismissed',
+        sourceScreen: 'exception-center',
+        stableId,
+      }),
+    );
+    expect(mockRecordSuggestionTelemetry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'suggestion_snoozed',
+        sourceScreen: 'exception-center',
+        stableId,
+        snoozePreset: 'three-days',
+      }),
+    );
+
+    expect(mockDismissSuggestion).toHaveBeenCalledWith(stableId, { by: 'exception-center' });
+    expect(mockSnoozeSuggestion).toHaveBeenCalledWith(
+      stableId,
+      expect.any(String),
+      { by: 'exception-center' },
+    );
+  });
+});

--- a/tests/unit/pages/TodayOpsPage.spec.tsx
+++ b/tests/unit/pages/TodayOpsPage.spec.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react';
 import React from 'react';
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ToastProvider } from '../../../src/hooks/useToast';
@@ -9,6 +9,7 @@ import { TodayBentoLayout } from '../../../src/features/today/layouts/TodayBento
 import { useTodayActionQueue } from '../../../src/features/today/hooks/useTodayActionQueue';
 
 import type { ActionCard as IActionCard } from '../../../src/features/today/domain/models/queue.types';
+import type { ActionSuggestion } from '../../../src/features/action-engine/domain/types';
 
 // Mocks for all the dependencies the page relies on
 const mockNavigate = vi.fn();
@@ -82,10 +83,42 @@ vi.mock('../../../src/features/today/hooks/useTodayActionQueue', () => ({
   useTodayActionQueue: vi.fn(),
 }));
 
+const mockRecordSuggestionTelemetry = vi.fn();
+vi.mock('../../../src/features/action-engine/telemetry/recordSuggestionTelemetry', () => ({
+  recordSuggestionTelemetry: (...args: unknown[]) => mockRecordSuggestionTelemetry(...args),
+}));
+
 describe('TodayOpsPage (ActionQueueTimeline integration)', () => {
   beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-21T10:00:00Z'));
     vi.clearAllMocks();
   });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const correctiveSuggestion: ActionSuggestion = {
+    id: 's1',
+    stableId: 'behavior-trend-increase:user-001:2026-W12',
+    type: 'assessment_update',
+    priority: 'P1',
+    targetUserId: 'user-001',
+    title: '改善提案',
+    reason: '理由',
+    evidence: {
+      metric: 'm',
+      currentValue: 1,
+      threshold: 2,
+      period: '7d',
+    },
+    cta: {
+      label: '確認',
+      route: '/assessment',
+    },
+    createdAt: '2026-03-21T09:00:00Z',
+    ruleId: 'behavior-trend-increase',
+  };
 
   const dummyActionQueue: IActionCard[] = [
     {
@@ -118,6 +151,16 @@ describe('TodayOpsPage (ActionQueueTimeline integration)', () => {
       isOverdue: false,
       payload: null,
     },
+    {
+      id: `corrective:${correctiveSuggestion.stableId}`,
+      title: 'Corrective Test',
+      priority: 'P1',
+      contextMessage: 'msg',
+      actionType: 'NAVIGATE',
+      requiresAttention: true,
+      isOverdue: false,
+      payload: { suggestion: correctiveSuggestion },
+    },
   ];
 
   it('passes actionQueue and correct click handlers to TodayBentoLayout', () => {
@@ -137,7 +180,7 @@ describe('TodayOpsPage (ActionQueueTimeline integration)', () => {
       <QueryClientProvider client={queryClient}>
         <ToastProvider>
           <MemoryRouter>
-            <TodayOpsPage />
+            <TodayOpsPage correctiveActions={[correctiveSuggestion]} />
           </MemoryRouter>
         </ToastProvider>
       </QueryClientProvider>
@@ -170,5 +213,36 @@ describe('TodayOpsPage (ActionQueueTimeline integration)', () => {
     // Nav and Drawer should NOT be triggered
     expect(mockNavigate).toHaveBeenCalledTimes(prevNavCount);
     expect(mockOpenUnfilled).toHaveBeenCalledTimes(prevOpenCount);
+
+    // Corrective CTA click emits telemetry and navigates to suggestion route
+    timelineProps.onActionClick(dummyActionQueue[3]);
+    expect(mockNavigate).toHaveBeenCalledWith('/assessment');
+    expect(mockRecordSuggestionTelemetry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'suggestion_cta_clicked',
+        sourceScreen: 'today',
+        stableId: correctiveSuggestion.stableId,
+      }),
+    );
+
+    // Dismiss / Snooze emits telemetry from shared callback
+    timelineProps.onDismissSuggestion(correctiveSuggestion.stableId);
+    timelineProps.onSnoozeSuggestion(correctiveSuggestion.stableId, 'tomorrow');
+
+    expect(mockRecordSuggestionTelemetry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'suggestion_dismissed',
+        sourceScreen: 'today',
+        stableId: correctiveSuggestion.stableId,
+      }),
+    );
+    expect(mockRecordSuggestionTelemetry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'suggestion_snoozed',
+        sourceScreen: 'today',
+        stableId: correctiveSuggestion.stableId,
+        snoozePreset: 'tomorrow',
+      }),
+    );
   });
 });


### PR DESCRIPTION
## Summary
Implements #1155 by adding lifecycle telemetry for Action Engine suggestions and wiring it into both Today and ExceptionCenter.

## What changed
1. Telemetry core (pure builder + adapter)
- Added `buildSuggestionTelemetryEvent(...)` as a pure payload builder.
- Added `recordSuggestionTelemetry(...)` adapter for Firestore (`telemetry` collection).
- Added dedupe support via `dedupeKey` and test helper `_resetSuggestionTelemetryGuard()`.

2. Visibility telemetry (shown / resurfaced)
- Added `useSuggestionVisibilityTelemetry(...)`.
- Emits:
  - `suggestion_shown` on invisible -> visible transition
  - `suggestion_resurfaced` when snoozed suggestion becomes visible after `snoozedUntil`
- Dedupe strategy:
  - shown: `stableId + sourceScreen + visible-session`
  - resurfaced: `stableId + sourceScreen + snoozedUntil`

3. Hook integration points
- `useTodayActionQueue` now invokes visibility telemetry with `sourceScreen: 'today'`.
- `useCorrectiveActionExceptions` now:
  - keeps internal `now` ticker (default 60s)
  - invokes visibility telemetry with `sourceScreen: 'exception-center'`.

4. Action telemetry (cta / dismiss / snooze)
- Today (`TodayOpsPage`)
  - emits `suggestion_cta_clicked` when corrective action CTA is clicked
  - emits `suggestion_dismissed` / `suggestion_snoozed` from menu actions
  - corrective action navigation now resolves route from `payload.suggestion.cta.route` when `payload.path` is absent
- ExceptionCenter (`ExceptionCenterPage` + `ExceptionTable`)
  - emits `suggestion_cta_clicked` from corrective action buttons
  - emits `suggestion_dismissed` / `suggestion_snoozed` from shared menu actions

## Event coverage
- `suggestion_shown`
- `suggestion_cta_clicked`
- `suggestion_dismissed`
- `suggestion_snoozed`
- `suggestion_resurfaced`

## Tests
Added/updated tests for:
- payload builder
- recorder + dedupe guard
- visibility transitions (shown/resurfaced)
- Today <-> ExceptionCenter integration (including resurfaced)
- Today page telemetry callbacks
- ExceptionCenter page telemetry callbacks

Executed:
- `npx vitest run src/features/action-engine/telemetry/__tests__/buildSuggestionTelemetryEvent.spec.ts src/features/action-engine/telemetry/__tests__/recordSuggestionTelemetry.spec.ts src/features/action-engine/telemetry/__tests__/useSuggestionVisibilityTelemetry.spec.tsx src/features/action-engine/hooks/__tests__/suggestionStateSync.integration.spec.tsx tests/unit/pages/TodayOpsPage.spec.tsx tests/unit/pages/ExceptionCenterPage.suggestionTelemetry.spec.tsx src/features/today/hooks/__tests__/useTodayActionQueue.spec.ts src/features/today/widgets/ActionCard.spec.tsx`
- `npx eslint src/features/action-engine/telemetry src/features/action-engine/hooks/__tests__/suggestionStateSync.integration.spec.tsx src/features/action-engine/index.ts src/features/exceptions/components/ExceptionTable.tsx src/features/exceptions/hooks/useCorrectiveActionExceptions.ts src/features/today/hooks/useTodayActionQueue.ts src/pages/TodayOpsPage.tsx src/pages/admin/ExceptionCenterPage.tsx tests/unit/pages/TodayOpsPage.spec.tsx tests/unit/pages/ExceptionCenterPage.suggestionTelemetry.spec.tsx`
- `npm run -s typecheck`

## Notes
- This PR is stacked on top of #1154 (`base: feat/suggestion-dismiss-snooze-loop`).
- Persistence remains out of scope; this is telemetry wiring only.

Refs #1155
