### PR TITLE
feat(today): add telemetry to call log summary card

### DIFF
--- a/src/features/today/telemetry/recordCtaClick.spec.ts
+++ b/src/features/today/telemetry/recordCtaClick.spec.ts
@@ -107,7 +107,7 @@ describe('CTA_EVENTS', () => {
     }
   });
 
-  it('has 24 defined events', () => {
-    expect(Object.keys(CTA_EVENTS)).toHaveLength(24);
+  it('has 29 defined events', () => {
+    expect(Object.keys(CTA_EVENTS)).toHaveLength(29);
   });
 });

--- a/src/features/today/telemetry/recordCtaClick.ts
+++ b/src/features/today/telemetry/recordCtaClick.ts
@@ -42,6 +42,12 @@ export const CTA_EVENTS = {
   PROGRESS_RING_CONTACTS: 'today_progress_ring_contacts_clicked',
 
   // ── CallLog 再設計 ──────────────────────────────────────────
+  /** CallLog Summary カード全体クリック */
+  CALLLOG_SUMMARY_CLICKED: 'calllog_summary_clicked',
+  /** CallLog Summary 各種タイルクリック */
+  CALLLOG_SUMMARY_TILE_CLICKED: 'calllog_summary_tile_clicked',
+  /** CallLog Summary 新規登録アイコン */
+  CALLLOG_SUMMARY_NEW_CLICKED: 'calllog_summary_new_clicked',
   /** CallLog Hero「完了にする」 */
   CALLLOG_HERO_DONE: 'calllog_hero_done_clicked',
   /** CallLog Priority Queue 行クリック */

--- a/src/pages/TodayOpsPage.tsx
+++ b/src/pages/TodayOpsPage.tsx
@@ -347,9 +347,37 @@ export const TodayOpsPage: React.FC<TodayOpsPageProps> = ({
       myOpenCount: callLogsSummary.myOpenCount,
       overdueCount: callLogsSummary.overdueCount,
       isLoading: callLogsSummary.isLoading,
-      onNavigate: () => navigate('/call-logs'),
-      onNavigateWithFilter: (preset: CallLogFilterPreset) => navigate(buildCallLogFilterUrl(preset)),
-      onOpenDrawer: () => setCallLogDrawerOpen(true),
+      onNavigate: () => {
+        recordCtaClick({
+          ctaId: CTA_EVENTS.CALLLOG_SUMMARY_CLICKED,
+          sourceComponent: 'CallLogSummaryCard',
+          stateType: 'navigation',
+          targetUrl: '/call-logs',
+          userRole: role,
+        });
+        navigate('/call-logs');
+      },
+      onNavigateWithFilter: (preset: CallLogFilterPreset) => {
+        const targetUrl = buildCallLogFilterUrl(preset);
+        recordCtaClick({
+          ctaId: CTA_EVENTS.CALLLOG_SUMMARY_TILE_CLICKED,
+          sourceComponent: 'CallLogSummaryCard',
+          stateType: 'navigation',
+          scene: preset,
+          targetUrl,
+          userRole: role,
+        });
+        navigate(targetUrl);
+      },
+      onOpenDrawer: () => {
+        recordCtaClick({
+          ctaId: CTA_EVENTS.CALLLOG_SUMMARY_NEW_CLICKED,
+          sourceComponent: 'CallLogSummaryCard',
+          stateType: 'widget-action',
+          userRole: role,
+        });
+        setCallLogDrawerOpen(true);
+      },
     },
     // Phase 9: 高負荷日タイル
     highLoadTile: highLoadStatus.visible ? {


### PR DESCRIPTION
### Summary

Today ページの CallLogSummaryCard に telemetry を追加しました。

### Changes

- \CTA_EVENTS.CALLLOG_SUMMARY_CLICKED\: カード全体からの全件表示
- \CTA_EVENTS.CALLLOG_SUMMARY_TILE_CLICKED\: 個別タイルクリック（未対応、至急、折返し、自分宛、期限超過）。\scene\ parameter に preset を保存。
- \CTA_EVENTS.CALLLOG_SUMMARY_NEW_CLICKED\: 電話ログの新規登録用 Quick Drawer

### Background
Today が運用可能な観測入口として機能するようにするための観測ログ追加の一環。これで Today 主要導線の telemetry が補完されます。