### PR TITLE
feat: add suggestion telemetry summary aggregators for dashboard

### DIFF
--- a/src/features/action-engine/index.ts
+++ b/src/features/action-engine/index.ts
@@ -72,3 +72,19 @@ export {
 } from './telemetry/recordSuggestionTelemetry';
 export { useSuggestionVisibilityTelemetry } from './telemetry/useSuggestionVisibilityTelemetry';
 export type { UseSuggestionVisibilityTelemetryOptions } from './telemetry/useSuggestionVisibilityTelemetry';
+export {
+  summarizeSuggestionTelemetry,
+  groupSuggestionTelemetryByRule,
+  groupSuggestionTelemetryByScreen,
+  groupSuggestionTelemetryByPriority,
+} from './telemetry/summarizeSuggestionTelemetry';
+export type {
+  SuggestionTelemetryRecord,
+  SuggestionTelemetryWindow,
+  SuggestionTelemetryCounts,
+  SuggestionTelemetryRates,
+  SuggestionTelemetrySummary,
+  SuggestionTelemetryByRule,
+  SuggestionTelemetryByScreen,
+  SuggestionTelemetryByPriority,
+} from './telemetry/summarizeSuggestionTelemetry';

--- a/src/features/action-engine/telemetry/__tests__/summarizeSuggestionTelemetry.spec.ts
+++ b/src/features/action-engine/telemetry/__tests__/summarizeSuggestionTelemetry.spec.ts
@@ -1,0 +1,386 @@
+import { describe, expect, it } from 'vitest';
+import { SUGGESTION_TELEMETRY_EVENTS } from '../buildSuggestionTelemetryEvent';
+import {
+  groupSuggestionTelemetryByPriority,
+  groupSuggestionTelemetryByRule,
+  groupSuggestionTelemetryByScreen,
+  summarizeSuggestionTelemetry,
+  type SuggestionTelemetryRecord,
+} from '../summarizeSuggestionTelemetry';
+
+const NOW = new Date('2026-03-21T12:00:00.000Z');
+
+function event(input: SuggestionTelemetryRecord): SuggestionTelemetryRecord {
+  return input;
+}
+
+describe('summarizeSuggestionTelemetry', () => {
+  it('shown/clicked/dismissed/snoozed/resurfaced と率を集計する（shown は stableId+screen で dedupe）', () => {
+    const events: SuggestionTelemetryRecord[] = [
+      event({
+        event: SUGGESTION_TELEMETRY_EVENTS.SHOWN,
+        sourceScreen: 'today',
+        stableId: 'rule-a:user-1:2026-W12',
+        ruleId: 'rule-a',
+        priority: 'P1',
+        timestamp: '2026-03-20T10:00:00.000Z',
+      }),
+      // duplicate shown (same stableId + same screen) -> ignored
+      event({
+        event: SUGGESTION_TELEMETRY_EVENTS.SHOWN,
+        sourceScreen: 'today',
+        stableId: 'rule-a:user-1:2026-W12',
+        ruleId: 'rule-a',
+        priority: 'P1',
+        timestamp: '2026-03-20T10:01:00.000Z',
+      }),
+      event({
+        event: SUGGESTION_TELEMETRY_EVENTS.SHOWN,
+        sourceScreen: 'today',
+        stableId: 'rule-b:user-2:2026-W12',
+        ruleId: 'rule-b',
+        priority: 'P2',
+        timestamp: '2026-03-20T11:00:00.000Z',
+      }),
+      event({
+        event: SUGGESTION_TELEMETRY_EVENTS.SHOWN,
+        sourceScreen: 'exception-center',
+        stableId: 'rule-c:user-3:2026-W12',
+        ruleId: 'rule-c',
+        priority: 'P0',
+        timestamp: '2026-03-20T12:00:00.000Z',
+      }),
+      event({
+        event: SUGGESTION_TELEMETRY_EVENTS.CTA_CLICKED,
+        sourceScreen: 'today',
+        stableId: 'rule-a:user-1:2026-W12',
+        ruleId: 'rule-a',
+        priority: 'P1',
+        timestamp: '2026-03-20T10:05:00.000Z',
+      }),
+      event({
+        event: SUGGESTION_TELEMETRY_EVENTS.DISMISSED,
+        sourceScreen: 'today',
+        stableId: 'rule-b:user-2:2026-W12',
+        ruleId: 'rule-b',
+        priority: 'P2',
+        timestamp: '2026-03-20T11:05:00.000Z',
+      }),
+      event({
+        event: SUGGESTION_TELEMETRY_EVENTS.SNOOZED,
+        sourceScreen: 'exception-center',
+        stableId: 'rule-c:user-3:2026-W12',
+        ruleId: 'rule-c',
+        priority: 'P0',
+        timestamp: '2026-03-20T12:05:00.000Z',
+      }),
+      event({
+        event: SUGGESTION_TELEMETRY_EVENTS.RESURFACED,
+        sourceScreen: 'exception-center',
+        stableId: 'rule-c:user-3:2026-W12',
+        ruleId: 'rule-c',
+        priority: 'P0',
+        timestamp: '2026-03-21T09:00:00.000Z',
+      }),
+    ];
+
+    const summary = summarizeSuggestionTelemetry(events, {
+      from: new Date('2026-03-19T00:00:00.000Z'),
+      to: new Date('2026-03-21T23:59:59.000Z'),
+    });
+
+    expect(summary.shown).toBe(3);
+    expect(summary.clicked).toBe(1);
+    expect(summary.dismissed).toBe(1);
+    expect(summary.snoozed).toBe(1);
+    expect(summary.resurfaced).toBe(1);
+
+    expect(summary.rates.cta).toBeCloseTo(1 / 3);
+    expect(summary.rates.dismiss).toBeCloseTo(1 / 3);
+    expect(summary.rates.snooze).toBeCloseTo(1 / 3);
+    expect(summary.rates.resurfaced).toBe(1);
+    expect(summary.rates.noResponse).toBe(0);
+  });
+
+  it('分母0では率を0にする（NaNを返さない）', () => {
+    const summary = summarizeSuggestionTelemetry([], {
+      from: new Date('2026-03-20T00:00:00.000Z'),
+      to: new Date('2026-03-21T00:00:00.000Z'),
+    });
+
+    expect(summary.shown).toBe(0);
+    expect(summary.clicked).toBe(0);
+    expect(summary.dismissed).toBe(0);
+    expect(summary.snoozed).toBe(0);
+    expect(summary.resurfaced).toBe(0);
+    expect(summary.rates).toEqual({
+      cta: 0,
+      dismiss: 0,
+      snooze: 0,
+      resurfaced: 0,
+      noResponse: 0,
+    });
+  });
+
+  it('window 未指定時は直近7日を使う', () => {
+    const events: SuggestionTelemetryRecord[] = [
+      event({
+        event: SUGGESTION_TELEMETRY_EVENTS.SHOWN,
+        sourceScreen: 'today',
+        stableId: 'rule-old:user:2026-W11',
+        ruleId: 'rule-old',
+        priority: 'P1',
+        timestamp: '2026-03-13T11:59:59.000Z',
+      }),
+      event({
+        event: SUGGESTION_TELEMETRY_EVENTS.SHOWN,
+        sourceScreen: 'today',
+        stableId: 'rule-new:user:2026-W12',
+        ruleId: 'rule-new',
+        priority: 'P1',
+        timestamp: '2026-03-18T00:00:00.000Z',
+      }),
+    ];
+
+    const summary = summarizeSuggestionTelemetry(events, { now: NOW });
+
+    expect(summary.shown).toBe(1);
+    expect(summary.window.from).toBe('2026-03-14T12:00:00.000Z');
+    expect(summary.window.to).toBe('2026-03-21T12:00:00.000Z');
+  });
+
+  it('window の from/to 境界を含み、無効 timestamp は除外する', () => {
+    const events: SuggestionTelemetryRecord[] = [
+      event({
+        event: SUGGESTION_TELEMETRY_EVENTS.SHOWN,
+        sourceScreen: 'today',
+        stableId: 'rule-a:user:2026-W12',
+        ruleId: 'rule-a',
+        priority: 'P1',
+        timestamp: '2026-03-20T00:00:00.000Z',
+      }),
+      event({
+        event: SUGGESTION_TELEMETRY_EVENTS.CTA_CLICKED,
+        sourceScreen: 'today',
+        stableId: 'rule-a:user:2026-W12',
+        ruleId: 'rule-a',
+        priority: 'P1',
+        timestamp: '2026-03-21T00:00:00.000Z',
+      }),
+      event({
+        event: SUGGESTION_TELEMETRY_EVENTS.SNOOZED,
+        sourceScreen: 'today',
+        stableId: 'rule-a:user:2026-W12',
+        ruleId: 'rule-a',
+        priority: 'P1',
+        timestamp: 'invalid-date',
+      }),
+      event({
+        event: 'unknown_event',
+        sourceScreen: 'today',
+        stableId: 'rule-a:user:2026-W12',
+        ruleId: 'rule-a',
+        priority: 'P1',
+        timestamp: '2026-03-20T10:00:00.000Z',
+      }),
+    ];
+
+    const summary = summarizeSuggestionTelemetry(events, {
+      from: new Date('2026-03-20T00:00:00.000Z'),
+      to: new Date('2026-03-21T00:00:00.000Z'),
+    });
+
+    expect(summary.shown).toBe(1);
+    expect(summary.clicked).toBe(1);
+    expect(summary.snoozed).toBe(0);
+  });
+});
+
+describe('groupSuggestionTelemetryByRule', () => {
+  it('ruleId 正規化 + shown 降順で返す', () => {
+    const events: SuggestionTelemetryRecord[] = [
+      event({
+        event: SUGGESTION_TELEMETRY_EVENTS.SHOWN,
+        sourceScreen: 'today',
+        stableId: 'a:1:2026-W12',
+        ruleId: 'Behavior_Trend',
+        priority: 'P1',
+        timestamp: '2026-03-20T10:00:00.000Z',
+      }),
+      event({
+        event: SUGGESTION_TELEMETRY_EVENTS.SHOWN,
+        sourceScreen: 'today',
+        stableId: 'a:2:2026-W12',
+        ruleId: 'behavior trend',
+        priority: 'P1',
+        timestamp: '2026-03-20T11:00:00.000Z',
+      }),
+      event({
+        event: SUGGESTION_TELEMETRY_EVENTS.CTA_CLICKED,
+        sourceScreen: 'today',
+        stableId: 'a:1:2026-W12',
+        ruleId: 'behavior_trend',
+        priority: 'P1',
+        timestamp: '2026-03-20T12:00:00.000Z',
+      }),
+      event({
+        event: SUGGESTION_TELEMETRY_EVENTS.SHOWN,
+        sourceScreen: 'exception-center',
+        stableId: 'b:1:2026-W12',
+        ruleId: 'high-intensity ',
+        priority: 'P0',
+        timestamp: '2026-03-20T13:00:00.000Z',
+      }),
+      event({
+        event: SUGGESTION_TELEMETRY_EVENTS.DISMISSED,
+        sourceScreen: 'exception-center',
+        stableId: 'b:1:2026-W12',
+        ruleId: 'high-intensity',
+        priority: 'P0',
+        timestamp: '2026-03-20T13:10:00.000Z',
+      }),
+    ];
+
+    const grouped = groupSuggestionTelemetryByRule(events, { now: NOW });
+
+    expect(grouped.map((g) => g.ruleId)).toEqual(['behavior-trend', 'high-intensity']);
+    expect(grouped[0].shown).toBe(2);
+    expect(grouped[0].clicked).toBe(1);
+    expect(grouped[1].shown).toBe(1);
+    expect(grouped[1].dismissed).toBe(1);
+  });
+});
+
+describe('groupSuggestionTelemetryByScreen', () => {
+  it('today / exception-center の両行を返し、率を計算する', () => {
+    const events: SuggestionTelemetryRecord[] = [
+      event({
+        event: SUGGESTION_TELEMETRY_EVENTS.SHOWN,
+        sourceScreen: 'today',
+        stableId: 'r1:u1:2026-W12',
+        ruleId: 'r1',
+        priority: 'P1',
+        timestamp: '2026-03-20T10:00:00.000Z',
+      }),
+      event({
+        event: SUGGESTION_TELEMETRY_EVENTS.SHOWN,
+        sourceScreen: 'today',
+        stableId: 'r2:u2:2026-W12',
+        ruleId: 'r2',
+        priority: 'P2',
+        timestamp: '2026-03-20T10:30:00.000Z',
+      }),
+      event({
+        event: SUGGESTION_TELEMETRY_EVENTS.CTA_CLICKED,
+        sourceScreen: 'today',
+        stableId: 'r1:u1:2026-W12',
+        ruleId: 'r1',
+        priority: 'P1',
+        timestamp: '2026-03-20T11:00:00.000Z',
+      }),
+      event({
+        event: SUGGESTION_TELEMETRY_EVENTS.DISMISSED,
+        sourceScreen: 'today',
+        stableId: 'r2:u2:2026-W12',
+        ruleId: 'r2',
+        priority: 'P2',
+        timestamp: '2026-03-20T11:30:00.000Z',
+      }),
+      event({
+        event: SUGGESTION_TELEMETRY_EVENTS.SHOWN,
+        sourceScreen: 'exception-center',
+        stableId: 'r3:u3:2026-W12',
+        ruleId: 'r3',
+        priority: 'P0',
+        timestamp: '2026-03-20T12:00:00.000Z',
+      }),
+      event({
+        event: SUGGESTION_TELEMETRY_EVENTS.SNOOZED,
+        sourceScreen: 'exception-center',
+        stableId: 'r3:u3:2026-W12',
+        ruleId: 'r3',
+        priority: 'P0',
+        timestamp: '2026-03-20T12:10:00.000Z',
+      }),
+      event({
+        event: SUGGESTION_TELEMETRY_EVENTS.RESURFACED,
+        sourceScreen: 'exception-center',
+        stableId: 'r3:u3:2026-W12',
+        ruleId: 'r3',
+        priority: 'P0',
+        timestamp: '2026-03-21T09:00:00.000Z',
+      }),
+    ];
+
+    const grouped = groupSuggestionTelemetryByScreen(events, { now: NOW });
+
+    expect(grouped).toHaveLength(2);
+
+    const today = grouped[0];
+    expect(today.sourceScreen).toBe('today');
+    expect(today.shown).toBe(2);
+    expect(today.clicked).toBe(1);
+    expect(today.dismissed).toBe(1);
+    expect(today.rates.cta).toBe(0.5);
+    expect(today.rates.dismiss).toBe(0.5);
+
+    const exceptionCenter = grouped[1];
+    expect(exceptionCenter.sourceScreen).toBe('exception-center');
+    expect(exceptionCenter.shown).toBe(1);
+    expect(exceptionCenter.snoozed).toBe(1);
+    expect(exceptionCenter.resurfaced).toBe(1);
+    expect(exceptionCenter.rates.snooze).toBe(1);
+    expect(exceptionCenter.rates.resurfaced).toBe(1);
+  });
+});
+
+describe('groupSuggestionTelemetryByPriority', () => {
+  it('P0 / P1 / P2 を固定順で返す（イベント0の優先度も含む）', () => {
+    const events: SuggestionTelemetryRecord[] = [
+      event({
+        event: SUGGESTION_TELEMETRY_EVENTS.SHOWN,
+        sourceScreen: 'today',
+        stableId: 'r1:u1:2026-W12',
+        ruleId: 'r1',
+        priority: 'P0',
+        timestamp: '2026-03-20T10:00:00.000Z',
+      }),
+      event({
+        event: SUGGESTION_TELEMETRY_EVENTS.CTA_CLICKED,
+        sourceScreen: 'today',
+        stableId: 'r1:u1:2026-W12',
+        ruleId: 'r1',
+        priority: 'P0',
+        timestamp: '2026-03-20T10:05:00.000Z',
+      }),
+      event({
+        event: SUGGESTION_TELEMETRY_EVENTS.SHOWN,
+        sourceScreen: 'exception-center',
+        stableId: 'r2:u2:2026-W12',
+        ruleId: 'r2',
+        priority: 'P2',
+        timestamp: '2026-03-20T11:00:00.000Z',
+      }),
+      event({
+        event: SUGGESTION_TELEMETRY_EVENTS.SNOOZED,
+        sourceScreen: 'exception-center',
+        stableId: 'r2:u2:2026-W12',
+        ruleId: 'r2',
+        priority: 'P2',
+        timestamp: '2026-03-20T11:10:00.000Z',
+      }),
+    ];
+
+    const grouped = groupSuggestionTelemetryByPriority(events, { now: NOW });
+
+    expect(grouped.map((g) => g.priority)).toEqual(['P0', 'P1', 'P2']);
+
+    expect(grouped[0].shown).toBe(1);
+    expect(grouped[0].clicked).toBe(1);
+    expect(grouped[1].shown).toBe(0);
+    expect(grouped[1].rates.cta).toBe(0);
+    expect(grouped[2].shown).toBe(1);
+    expect(grouped[2].snoozed).toBe(1);
+    expect(grouped[2].rates.snooze).toBe(1);
+  });
+});

--- a/src/features/action-engine/telemetry/summarizeSuggestionTelemetry.ts
+++ b/src/features/action-engine/telemetry/summarizeSuggestionTelemetry.ts
@@ -1,0 +1,322 @@
+import type { SuggestionPriority } from '../domain/types';
+import {
+  SUGGESTION_TELEMETRY_EVENTS,
+  type SuggestionTelemetryEventName,
+  type SuggestionTelemetrySourceScreen,
+} from './buildSuggestionTelemetryEvent';
+
+const DEFAULT_WINDOW_DAYS = 7;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+const SCREEN_ORDER: SuggestionTelemetrySourceScreen[] = ['today', 'exception-center'];
+const PRIORITY_ORDER: SuggestionPriority[] = ['P0', 'P1', 'P2'];
+
+const EVENT_SET = new Set<string>(Object.values(SUGGESTION_TELEMETRY_EVENTS));
+
+export type SuggestionTelemetryRecord = {
+  event: SuggestionTelemetryEventName | string;
+  sourceScreen: SuggestionTelemetrySourceScreen | string;
+  stableId: string;
+  ruleId: string;
+  priority: SuggestionPriority | string;
+  timestamp: string;
+};
+
+export type SuggestionTelemetryWindow = {
+  from?: Date;
+  to?: Date;
+  now?: Date;
+};
+
+export type SuggestionTelemetryCounts = {
+  shown: number;
+  clicked: number;
+  dismissed: number;
+  snoozed: number;
+  resurfaced: number;
+};
+
+export type SuggestionTelemetryRates = {
+  cta: number;
+  dismiss: number;
+  snooze: number;
+  resurfaced: number;
+  noResponse: number;
+};
+
+export type SuggestionTelemetrySummary = SuggestionTelemetryCounts & {
+  rates: SuggestionTelemetryRates;
+  window: {
+    from: string;
+    to: string;
+  };
+};
+
+export type SuggestionTelemetryByRule = SuggestionTelemetryCounts & {
+  ruleId: string;
+  rates: SuggestionTelemetryRates;
+};
+
+export type SuggestionTelemetryByScreen = SuggestionTelemetryCounts & {
+  sourceScreen: SuggestionTelemetrySourceScreen;
+  rates: SuggestionTelemetryRates;
+};
+
+export type SuggestionTelemetryByPriority = SuggestionTelemetryCounts & {
+  priority: SuggestionPriority;
+  rates: SuggestionTelemetryRates;
+};
+
+type PreparedSuggestionTelemetryEvent = {
+  event: SuggestionTelemetryEventName;
+  sourceScreen: SuggestionTelemetrySourceScreen;
+  stableId: string;
+  ruleId: string;
+  priority: SuggestionPriority;
+};
+
+type ResolvedWindow = {
+  from: Date;
+  to: Date;
+};
+
+function createEmptyCounts(): SuggestionTelemetryCounts {
+  return {
+    shown: 0,
+    clicked: 0,
+    dismissed: 0,
+    snoozed: 0,
+    resurfaced: 0,
+  };
+}
+
+function safeRate(numerator: number, denominator: number): number {
+  if (denominator <= 0) return 0;
+  return numerator / denominator;
+}
+
+function computeRates(counts: SuggestionTelemetryCounts): SuggestionTelemetryRates {
+  const noResponseCount = Math.max(
+    counts.shown - counts.clicked - counts.dismissed - counts.snoozed,
+    0,
+  );
+
+  return {
+    cta: safeRate(counts.clicked, counts.shown),
+    dismiss: safeRate(counts.dismissed, counts.shown),
+    snooze: safeRate(counts.snoozed, counts.shown),
+    resurfaced: safeRate(counts.resurfaced, counts.snoozed),
+    noResponse: safeRate(noResponseCount, counts.shown),
+  };
+}
+
+function isKnownEvent(event: string): event is SuggestionTelemetryEventName {
+  return EVENT_SET.has(event);
+}
+
+function isKnownSourceScreen(
+  sourceScreen: string,
+): sourceScreen is SuggestionTelemetrySourceScreen {
+  return sourceScreen === 'today' || sourceScreen === 'exception-center';
+}
+
+function isKnownPriority(priority: string): priority is SuggestionPriority {
+  return priority === 'P0' || priority === 'P1' || priority === 'P2';
+}
+
+function normalizeRuleId(ruleId: string): string {
+  const normalized = ruleId
+    .trim()
+    .toLowerCase()
+    .replace(/[_\s]+/g, '-')
+    .replace(/-+/g, '-');
+  return normalized || 'unknown-rule';
+}
+
+function resolveWindow(window?: SuggestionTelemetryWindow): ResolvedWindow {
+  const to = window?.to ?? window?.now ?? new Date();
+  const from =
+    window?.from ?? new Date(to.getTime() - DEFAULT_WINDOW_DAYS * MS_PER_DAY);
+
+  if (from.getTime() <= to.getTime()) {
+    return { from, to };
+  }
+
+  return { from: to, to: from };
+}
+
+function isWithinWindow(timestamp: string, window: ResolvedWindow): boolean {
+  const ts = new Date(timestamp).getTime();
+  if (Number.isNaN(ts)) return false;
+  return ts >= window.from.getTime() && ts <= window.to.getTime();
+}
+
+function prepareSuggestionTelemetryEvents(
+  events: SuggestionTelemetryRecord[],
+  window?: SuggestionTelemetryWindow,
+): { prepared: PreparedSuggestionTelemetryEvent[]; resolvedWindow: ResolvedWindow } {
+  const resolvedWindow = resolveWindow(window);
+  const prepared: PreparedSuggestionTelemetryEvent[] = [];
+  const shownDedupe = new Set<string>();
+
+  for (const event of events) {
+    if (!event.stableId) continue;
+    if (!isKnownEvent(event.event)) continue;
+    if (!isKnownSourceScreen(event.sourceScreen)) continue;
+    if (!isKnownPriority(event.priority)) continue;
+    if (!isWithinWindow(event.timestamp, resolvedWindow)) continue;
+
+    if (event.event === SUGGESTION_TELEMETRY_EVENTS.SHOWN) {
+      const dedupeKey = `${event.stableId}:${event.sourceScreen}`;
+      if (shownDedupe.has(dedupeKey)) continue;
+      shownDedupe.add(dedupeKey);
+    }
+
+    prepared.push({
+      event: event.event,
+      sourceScreen: event.sourceScreen,
+      stableId: event.stableId,
+      ruleId: normalizeRuleId(event.ruleId),
+      priority: event.priority,
+    });
+  }
+
+  return { prepared, resolvedWindow };
+}
+
+function accumulateCounts(
+  counts: SuggestionTelemetryCounts,
+  eventName: SuggestionTelemetryEventName,
+): void {
+  if (eventName === SUGGESTION_TELEMETRY_EVENTS.SHOWN) {
+    counts.shown += 1;
+    return;
+  }
+  if (eventName === SUGGESTION_TELEMETRY_EVENTS.CTA_CLICKED) {
+    counts.clicked += 1;
+    return;
+  }
+  if (eventName === SUGGESTION_TELEMETRY_EVENTS.DISMISSED) {
+    counts.dismissed += 1;
+    return;
+  }
+  if (eventName === SUGGESTION_TELEMETRY_EVENTS.SNOOZED) {
+    counts.snoozed += 1;
+    return;
+  }
+  if (eventName === SUGGESTION_TELEMETRY_EVENTS.RESURFACED) {
+    counts.resurfaced += 1;
+  }
+}
+
+function toSummaryCounts(
+  counts: SuggestionTelemetryCounts,
+): SuggestionTelemetryCounts & { rates: SuggestionTelemetryRates } {
+  return {
+    ...counts,
+    rates: computeRates(counts),
+  };
+}
+
+/**
+ * suggestion lifecycle telemetry を集計する。
+ * デフォルトは直近7日 window。
+ */
+export function summarizeSuggestionTelemetry(
+  events: SuggestionTelemetryRecord[],
+  window?: SuggestionTelemetryWindow,
+): SuggestionTelemetrySummary {
+  const { prepared, resolvedWindow } = prepareSuggestionTelemetryEvents(events, window);
+  const counts = createEmptyCounts();
+
+  for (const event of prepared) {
+    accumulateCounts(counts, event.event);
+  }
+
+  return {
+    ...toSummaryCounts(counts),
+    window: {
+      from: resolvedWindow.from.toISOString(),
+      to: resolvedWindow.to.toISOString(),
+    },
+  };
+}
+
+/** ruleId ごとの lifecycle 集計（shown 降順） */
+export function groupSuggestionTelemetryByRule(
+  events: SuggestionTelemetryRecord[],
+  window?: SuggestionTelemetryWindow,
+): SuggestionTelemetryByRule[] {
+  const { prepared } = prepareSuggestionTelemetryEvents(events, window);
+  const grouped = new Map<string, SuggestionTelemetryCounts>();
+
+  for (const event of prepared) {
+    const counts = grouped.get(event.ruleId) ?? createEmptyCounts();
+    accumulateCounts(counts, event.event);
+    grouped.set(event.ruleId, counts);
+  }
+
+  return Array.from(grouped.entries())
+    .map(([ruleId, counts]) => ({
+      ruleId,
+      ...toSummaryCounts(counts),
+    }))
+    .sort((a, b) => {
+      if (b.shown !== a.shown) return b.shown - a.shown;
+      return a.ruleId.localeCompare(b.ruleId);
+    });
+}
+
+/** sourceScreen ごとの lifecycle 集計 */
+export function groupSuggestionTelemetryByScreen(
+  events: SuggestionTelemetryRecord[],
+  window?: SuggestionTelemetryWindow,
+): SuggestionTelemetryByScreen[] {
+  const { prepared } = prepareSuggestionTelemetryEvents(events, window);
+  const grouped = new Map<SuggestionTelemetrySourceScreen, SuggestionTelemetryCounts>();
+
+  for (const sourceScreen of SCREEN_ORDER) {
+    grouped.set(sourceScreen, createEmptyCounts());
+  }
+
+  for (const event of prepared) {
+    const counts = grouped.get(event.sourceScreen) ?? createEmptyCounts();
+    accumulateCounts(counts, event.event);
+    grouped.set(event.sourceScreen, counts);
+  }
+
+  return SCREEN_ORDER.map((sourceScreen) => {
+    const counts = grouped.get(sourceScreen) ?? createEmptyCounts();
+    return {
+      sourceScreen,
+      ...toSummaryCounts(counts),
+    };
+  });
+}
+
+/** priority ごとの lifecycle 集計 */
+export function groupSuggestionTelemetryByPriority(
+  events: SuggestionTelemetryRecord[],
+  window?: SuggestionTelemetryWindow,
+): SuggestionTelemetryByPriority[] {
+  const { prepared } = prepareSuggestionTelemetryEvents(events, window);
+  const grouped = new Map<SuggestionPriority, SuggestionTelemetryCounts>();
+
+  for (const priority of PRIORITY_ORDER) {
+    grouped.set(priority, createEmptyCounts());
+  }
+
+  for (const event of prepared) {
+    const counts = grouped.get(event.priority) ?? createEmptyCounts();
+    accumulateCounts(counts, event.event);
+    grouped.set(event.priority, counts);
+  }
+
+  return PRIORITY_ORDER.map((priority) => {
+    const counts = grouped.get(priority) ?? createEmptyCounts();
+    return {
+      priority,
+      ...toSummaryCounts(counts),
+    };
+  });
+}


### PR DESCRIPTION
## Summary
- add pure aggregators for suggestion lifecycle telemetry
  - `summarizeSuggestionTelemetry(events, { from, to, now })`
  - `groupSuggestionTelemetryByRule(events, window)`
  - `groupSuggestionTelemetryByScreen(events, window)`
  - `groupSuggestionTelemetryByPriority(events, window)`
- define summary/breakdown types for dashboard wiring
- export new telemetry summary APIs from action-engine public index

## Spec Locked
- default time window is last 7 days when `from/to` is omitted
- shown is deduped by `stableId + sourceScreen`
- all rate divisions return `0` when denominator is `0`
- rule grouping is normalized (`Behavior_Trend` -> `behavior-trend`) and sorted by shown desc

## Tests
- add unit tests for counts/rates, dedupe, range filtering, zero-denominator, rule/screen/priority breakdowns
- ran: `npm run -s test -- src/features/action-engine/telemetry/__tests__`
- ran: `npm run -s typecheck`
