### PR TITLE
feat: ExceptionCenterのcorrective-actionを利用者単位で展開表示

### DIFF
--- a/src/features/exceptions/components/ExceptionTable.tsx
+++ b/src/features/exceptions/components/ExceptionTable.tsx
@@ -46,6 +46,10 @@ import {
 } from '../domain/exceptionLogic';
 import { buildCorrectiveActions } from '../domain/correctiveActions';
 import {
+  groupExceptionsByUser,
+  type UserExceptionGroup,
+} from '../domain/groupByUser';
+import {
   TEMPERATURE_LABELS,
   severityToPriority,
 } from '../domain/mapSuggestionToException';
@@ -53,6 +57,21 @@ import {
 // ─── Props ──────────────────────────────────────────────────
 
 export type ExceptionTableSortOrder = 'severity' | 'newest' | 'oldest';
+
+type ExceptionDisplayRow =
+  | {
+      kind: 'item';
+      item: ExceptionItem;
+      sortDate: number;
+      sortSeverity: ExceptionSeverity;
+    }
+  | {
+      kind: 'corrective-group';
+      group: UserExceptionGroup;
+      representative: ExceptionItem;
+      sortDate: number;
+      sortSeverity: ExceptionSeverity;
+    };
 
 export type ExceptionTableProps = {
   items: ExceptionItem[];
@@ -84,6 +103,13 @@ const SEVERITY_ORDER: Record<ExceptionSeverity, number> = {
   medium: 3,
   low: 4,
 };
+
+function getExceptionSortDate(item: ExceptionItem): number {
+  const dateStr = item.targetDate ?? item.updatedAt;
+  if (!dateStr) return 0;
+  const ts = new Date(dateStr).getTime();
+  return Number.isNaN(ts) ? 0 : ts;
+}
 
 // ─── CorrectiveActionsCell (MVP-012 Phase B) ─────────────────
 // ExceptionTable の前に定義して「使用前宣言」エラーを回避する
@@ -185,6 +211,9 @@ export const ExceptionTable: React.FC<ExceptionTableProps> = ({
   const [internalCategoryFilter, setInternalCategoryFilter] = useState<ExceptionCategory | 'all'>('all');
   const [internalSeverityFilter, setInternalSeverityFilter] = useState<ExceptionSeverity | 'all'>('all');
   const [sortOrder, setSortOrder] = useState<ExceptionTableSortOrder>('severity');
+  const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>(
+    {},
+  );
 
   const categoryFilter = externalCategoryFilter !== undefined ? externalCategoryFilter : internalCategoryFilter;
   const severityFilter = externalSeverityFilter !== undefined ? externalSeverityFilter : internalSeverityFilter;
@@ -199,36 +228,74 @@ export const ExceptionTable: React.FC<ExceptionTableProps> = ({
     else setInternalSeverityFilter(val);
   };
 
-  const filteredAndSortedItems = useMemo(() => {
+  const displayRows = useMemo<ExceptionDisplayRow[]>(() => {
     // 1. Filter
     const filtered = items.filter((item) => {
       if (categoryFilter !== 'all' && item.category !== categoryFilter) return false;
       if (severityFilter !== 'all' && item.severity !== severityFilter) return false;
       return true;
     });
-    // 2. Sort
-    return filtered.sort((a, b) => {
-      const dateStrA = a.targetDate ?? a.updatedAt;
-      const dateStrB = b.targetDate ?? b.updatedAt;
-      const dateA = dateStrA ? new Date(dateStrA).getTime() : 0;
-      const dateB = dateStrB ? new Date(dateStrB).getTime() : 0;
 
+    // 2. Corrective-action だけ利用者単位に集約
+    const correctiveItems = filtered.filter(
+      (item) => item.category === 'corrective-action',
+    );
+    const nonCorrectiveRows: ExceptionDisplayRow[] = filtered
+      .filter((item) => item.category !== 'corrective-action')
+      .map((item) => ({
+        kind: 'item',
+        item,
+        sortDate: getExceptionSortDate(item),
+        sortSeverity: item.severity,
+      }));
+
+    const correctiveRows: ExceptionDisplayRow[] = groupExceptionsByUser(
+      correctiveItems,
+    ).map((group) => {
+      const sortedItems = [...group.items].sort((a, b) => {
+        const severityDiff = SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity];
+        if (severityDiff !== 0) return severityDiff;
+        return getExceptionSortDate(b) - getExceptionSortDate(a);
+      });
+      const representative = sortedItems[0] ?? group.items[0];
+
+      return {
+        kind: 'corrective-group',
+        group: { ...group, items: sortedItems },
+        representative,
+        sortDate: getExceptionSortDate(representative),
+        sortSeverity: group.highestSeverity,
+      };
+    });
+
+    const rows = [...nonCorrectiveRows, ...correctiveRows];
+
+    // 3. Sort
+    return rows.sort((a, b) => {
       if (sortOrder === 'severity') {
-        const sevDiff = SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity];
-        if (sevDiff !== 0) return sevDiff;
-        return dateB - dateA;
+        const severityDiff =
+          SEVERITY_ORDER[a.sortSeverity] - SEVERITY_ORDER[b.sortSeverity];
+        if (severityDiff !== 0) return severityDiff;
+        return b.sortDate - a.sortDate;
       }
       if (sortOrder === 'newest') {
-        if (dateA !== dateB) return dateB - dateA;
-        return SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity];
+        if (a.sortDate !== b.sortDate) return b.sortDate - a.sortDate;
+        return SEVERITY_ORDER[a.sortSeverity] - SEVERITY_ORDER[b.sortSeverity];
       }
       if (sortOrder === 'oldest') {
-        if (dateA !== dateB) return dateA - dateB;
-        return SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity];
+        if (a.sortDate !== b.sortDate) return a.sortDate - b.sortDate;
+        return SEVERITY_ORDER[a.sortSeverity] - SEVERITY_ORDER[b.sortSeverity];
       }
       return 0;
     });
   }, [items, categoryFilter, severityFilter, sortOrder]);
+
+  const toggleGroup = (groupId: string) => {
+    setExpandedGroups((prev) => ({
+      ...prev,
+      [groupId]: !prev[groupId],
+    }));
+  };
 
   return (
     <Box data-testid="exception-table">
@@ -299,7 +366,7 @@ export const ExceptionTable: React.FC<ExceptionTableProps> = ({
       )}
 
       {/* Table or Empty */}
-      {filteredAndSortedItems.length === 0 ? (
+      {displayRows.length === 0 ? (
         <EmptyStateAction
           icon={items.length === 0 ? '🎉' : '🔍'}
           title={items.length === 0 ? '例外なし — すべて正常です' : 'フィルタ条件に一致する例外はありません'}
@@ -325,78 +392,208 @@ export const ExceptionTable: React.FC<ExceptionTableProps> = ({
               </TableRow>
             </TableHead>
             <TableBody>
-              {filteredAndSortedItems.map((item) => {
-                const catMeta = EXCEPTION_CATEGORIES[item.category];
-                const sevConfig = SEVERITY_CONFIG[item.severity];
-                return (
-                  <TableRow
-                    key={item.id}
-                    hover
-                    sx={{
-                      borderLeft: 4,
-                      borderLeftColor: catMeta.color,
-                      '&:last-child td': { borderBottom: 0 },
-                    }}
-                    data-testid={`exception-row-${item.id}`}
-                  >
-                    <TableCell>
-                      <Chip
-                        label={
-                          item.category === 'corrective-action'
-                            ? (TEMPERATURE_LABELS[severityToPriority(item.severity) ?? 'P2'] ?? sevConfig.label)
-                            : sevConfig.label
-                        }
-                        size="small"
-                        color={sevConfig.color}
-                        sx={{ fontWeight: 600, fontSize: '0.7rem' }}
-                      />
-                    </TableCell>
-                    <TableCell>
-                      <Stack direction="row" spacing={0.5} alignItems="center">
-                        <Box sx={{ fontSize: 14 }}>{catMeta.icon}</Box>
-                        <Typography variant="caption" sx={{ fontWeight: 600 }}>
-                          {catMeta.label}
-                        </Typography>
-                      </Stack>
-                    </TableCell>
-                    <TableCell>
-                      <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                        {item.title}
-                      </Typography>
-                      <Typography variant="caption" color="text.secondary">
-                        {item.description}
-                      </Typography>
-                    </TableCell>
-                    <TableCell>
-                      {item.targetUserId ? (
-                        <Button
-                          variant="text"
+              {displayRows.map((row) => {
+                if (row.kind === 'item') {
+                  const item = row.item;
+                  const catMeta = EXCEPTION_CATEGORIES[item.category];
+                  const sevConfig = SEVERITY_CONFIG[item.severity];
+                  return (
+                    <TableRow
+                      key={item.id}
+                      hover
+                      sx={{
+                        borderLeft: 4,
+                        borderLeftColor: catMeta.color,
+                        '&:last-child td': { borderBottom: 0 },
+                      }}
+                      data-testid={`exception-row-${item.id}`}
+                    >
+                      <TableCell>
+                        <Chip
+                          label={
+                            item.category === 'corrective-action'
+                              ? (TEMPERATURE_LABELS[severityToPriority(item.severity) ?? 'P2'] ?? sevConfig.label)
+                              : sevConfig.label
+                          }
                           size="small"
-                          sx={{ textTransform: 'none', p: 0, minWidth: 'auto', fontWeight: 600 }}
-                          onClick={() => navigate(`/users/${item.targetUserId}`)}
-                          data-testid={`exception-user-link-${item.id}`}
-                        >
-                          {item.targetUser ?? '—'}
-                        </Button>
-                      ) : (
-                        <Typography variant="body2">
-                          {item.targetUser ?? '—'}
+                          color={sevConfig.color}
+                          sx={{ fontWeight: 600, fontSize: '0.7rem' }}
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <Stack direction="row" spacing={0.5} alignItems="center">
+                          <Box sx={{ fontSize: 14 }}>{catMeta.icon}</Box>
+                          <Typography variant="caption" sx={{ fontWeight: 600 }}>
+                            {catMeta.label}
+                          </Typography>
+                        </Stack>
+                      </TableCell>
+                      <TableCell>
+                        <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                          {item.title}
                         </Typography>
-                      )}
-                    </TableCell>
-                    <TableCell>
-                      <Typography variant="caption" color="text.secondary">
-                        {item.targetDate ?? item.updatedAt}
-                      </Typography>
-                    </TableCell>
-                    <TableCell sx={{ minWidth: 160 }}>
-                      <CorrectiveActionsCell
-                        item={item}
-                        onNavigate={navigate}
-                        suggestionActions={suggestionActions}
-                      />
-                    </TableCell>
-                  </TableRow>
+                        <Typography variant="caption" color="text.secondary">
+                          {item.description}
+                        </Typography>
+                      </TableCell>
+                      <TableCell>
+                        {item.targetUserId ? (
+                          <Button
+                            variant="text"
+                            size="small"
+                            sx={{ textTransform: 'none', p: 0, minWidth: 'auto', fontWeight: 600 }}
+                            onClick={() => navigate(`/users/${item.targetUserId}`)}
+                            data-testid={`exception-user-link-${item.id}`}
+                          >
+                            {item.targetUser ?? '—'}
+                          </Button>
+                        ) : (
+                          <Typography variant="body2">
+                            {item.targetUser ?? '—'}
+                          </Typography>
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        <Typography variant="caption" color="text.secondary">
+                          {item.targetDate ?? item.updatedAt}
+                        </Typography>
+                      </TableCell>
+                      <TableCell sx={{ minWidth: 160 }}>
+                        <CorrectiveActionsCell
+                          item={item}
+                          onNavigate={navigate}
+                          suggestionActions={suggestionActions}
+                        />
+                      </TableCell>
+                    </TableRow>
+                  );
+                }
+
+                const { group, representative } = row;
+                const catMeta = EXCEPTION_CATEGORIES['corrective-action'];
+                const sevConfig = SEVERITY_CONFIG[representative.severity];
+                const isExpanded = expandedGroups[group.userId] ?? false;
+                const canExpand = group.items.length > 1;
+                const userName = group.userName ?? representative.targetUser ?? '—';
+                const canOpenUser = group.userId !== '__unknown__';
+
+                return (
+                  <React.Fragment key={`group-${group.userId}`}>
+                    <TableRow
+                      hover
+                      sx={{
+                        borderLeft: 4,
+                        borderLeftColor: catMeta.color,
+                      }}
+                      data-testid={`exception-row-${representative.id}`}
+                    >
+                      <TableCell>
+                        <Chip
+                          label={TEMPERATURE_LABELS[severityToPriority(representative.severity) ?? 'P2'] ?? sevConfig.label}
+                          size="small"
+                          color={sevConfig.color}
+                          sx={{ fontWeight: 600, fontSize: '0.7rem' }}
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <Stack direction="row" spacing={0.5} alignItems="center">
+                          <Box sx={{ fontSize: 14 }}>{catMeta.icon}</Box>
+                          <Typography variant="caption" sx={{ fontWeight: 600 }}>
+                            {catMeta.label}
+                          </Typography>
+                        </Stack>
+                      </TableCell>
+                      <TableCell>
+                        <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                          {userName} の改善提案 ({group.count}件)
+                        </Typography>
+                        <Typography variant="caption" color="text.secondary">
+                          {representative.description}
+                          {group.count > 1 ? ` / 他 ${group.count - 1} 件` : ''}
+                        </Typography>
+                      </TableCell>
+                      <TableCell>
+                        {canOpenUser ? (
+                          <Button
+                            variant="text"
+                            size="small"
+                            sx={{ textTransform: 'none', p: 0, minWidth: 'auto', fontWeight: 600 }}
+                            onClick={() => navigate(`/users/${group.userId}`)}
+                            data-testid={`exception-user-link-${representative.id}`}
+                          >
+                            {userName}
+                          </Button>
+                        ) : (
+                          <Typography variant="body2">{userName}</Typography>
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        <Typography variant="caption" color="text.secondary">
+                          {representative.targetDate ?? representative.updatedAt}
+                        </Typography>
+                      </TableCell>
+                      <TableCell sx={{ minWidth: 180 }}>
+                        <Stack spacing={0.5} alignItems="flex-start">
+                          <CorrectiveActionsCell
+                            item={representative}
+                            onNavigate={navigate}
+                            suggestionActions={suggestionActions}
+                          />
+                          {canExpand && (
+                            <Button
+                              size="small"
+                              variant="text"
+                              sx={{ textTransform: 'none', p: 0, minHeight: 'auto' }}
+                              onClick={() => toggleGroup(group.userId)}
+                              data-testid={`exception-group-toggle-${group.userId}`}
+                            >
+                              {isExpanded ? '個別提案を隠す' : '個別提案を表示'} ({group.count})
+                            </Button>
+                          )}
+                        </Stack>
+                      </TableCell>
+                    </TableRow>
+                    {canExpand && isExpanded && (
+                      <TableRow data-testid={`exception-group-details-${group.userId}`}>
+                        <TableCell colSpan={6} sx={{ bgcolor: 'grey.50', py: 1.25 }}>
+                          <Stack spacing={1}>
+                            {group.items.map((item) => {
+                              const detailConfig = SEVERITY_CONFIG[item.severity];
+                              return (
+                                <Paper
+                                  key={item.id}
+                                  variant="outlined"
+                                  sx={{ p: 1, borderRadius: 1, bgcolor: 'background.paper' }}
+                                >
+                                  <Stack spacing={0.75}>
+                                    <Stack direction="row" spacing={0.75} alignItems="center">
+                                      <Chip
+                                        label={TEMPERATURE_LABELS[severityToPriority(item.severity) ?? 'P2'] ?? detailConfig.label}
+                                        size="small"
+                                        color={detailConfig.color}
+                                        sx={{ fontWeight: 600, fontSize: '0.65rem' }}
+                                      />
+                                      <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                                        {item.title}
+                                      </Typography>
+                                    </Stack>
+                                    <Typography variant="caption" color="text.secondary">
+                                      {item.description}
+                                    </Typography>
+                                    <CorrectiveActionsCell
+                                      item={item}
+                                      onNavigate={navigate}
+                                      suggestionActions={suggestionActions}
+                                    />
+                                  </Stack>
+                                </Paper>
+                              );
+                            })}
+                          </Stack>
+                        </TableCell>
+                      </TableRow>
+                    )}
+                  </React.Fragment>
                 );
               })}
             </TableBody>

--- a/src/features/exceptions/components/__tests__/ExceptionTable.spec.tsx
+++ b/src/features/exceptions/components/__tests__/ExceptionTable.spec.tsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import type { ExceptionItem } from '../../domain/exceptionLogic';
+import { ExceptionTable } from '../ExceptionTable';
+
+const makeException = (overrides: Partial<ExceptionItem> = {}): ExceptionItem => ({
+  id: 'ae-1',
+  category: 'corrective-action',
+  severity: 'high',
+  title: '提案A',
+  description: 'evidence A',
+  targetUser: '山田 花子',
+  targetUserId: 'U-001',
+  targetDate: '2026-03-20',
+  updatedAt: '2026-03-20T09:00:00.000Z',
+  actionLabel: '改善アクションを実行',
+  actionPath: '/users/U-001',
+  stableId: 'stable-1',
+  ...overrides,
+});
+
+const renderTable = (
+  items: ExceptionItem[],
+  suggestionActions?: {
+    onDismiss: (stableId: string) => void;
+    onSnooze: (stableId: string, preset: 'tomorrow' | 'three-days' | 'end-of-week') => void;
+    onCtaClick?: (stableId: string, targetUrl: string) => void;
+  },
+) => {
+  render(
+    <MemoryRouter>
+      <ExceptionTable items={items} suggestionActions={suggestionActions} />
+    </MemoryRouter>,
+  );
+};
+
+describe('ExceptionTable', () => {
+  it('corrective-action を利用者単位で集約し、展開トグルで個別提案を表示できる', () => {
+    const items: ExceptionItem[] = [
+      makeException({
+        id: 'ae-1',
+        stableId: 'stable-1',
+        title: '提案A',
+        description: 'evidence A',
+        severity: 'high',
+      }),
+      makeException({
+        id: 'ae-2',
+        stableId: 'stable-2',
+        title: '提案B',
+        description: 'evidence B',
+        severity: 'medium',
+      }),
+      makeException({
+        id: 'ae-3',
+        stableId: 'stable-3',
+        title: '提案C',
+        description: 'evidence C',
+        targetUser: '佐藤 次郎',
+        targetUserId: 'U-002',
+      }),
+      makeException({
+        id: 'missing-1',
+        category: 'missing-record',
+        severity: 'high',
+        title: '記録未入力',
+        description: '日次記録が未入力です',
+        targetUser: '高橋 三郎',
+        targetUserId: 'U-003',
+        updatedAt: '2026-03-19',
+        actionLabel: '記録を作成',
+        actionPath: '/daily/activity?userId=U-003',
+        stableId: undefined,
+      }),
+    ];
+
+    renderTable(items);
+
+    expect(screen.getByText('山田 花子 の改善提案 (2件)')).toBeInTheDocument();
+    expect(screen.getByText('記録未入力')).toBeInTheDocument();
+
+    const toggle = screen.getByTestId('exception-group-toggle-U-001');
+    expect(screen.queryByTestId('exception-group-details-U-001')).not.toBeInTheDocument();
+
+    fireEvent.click(toggle);
+
+    const details = screen.getByTestId('exception-group-details-U-001');
+    expect(within(details).getByText('提案A')).toBeInTheDocument();
+    expect(within(details).getByText('提案B')).toBeInTheDocument();
+
+    fireEvent.click(toggle);
+    expect(screen.queryByTestId('exception-group-details-U-001')).not.toBeInTheDocument();
+  });
+
+  it('集約行の代表提案は highest priority を使う', () => {
+    const items: ExceptionItem[] = [
+      makeException({
+        id: 'ae-medium',
+        stableId: 'stable-medium',
+        severity: 'medium',
+        title: '観察提案',
+        description: 'medium evidence',
+      }),
+      makeException({
+        id: 'ae-critical',
+        stableId: 'stable-critical',
+        severity: 'critical',
+        title: '即対応提案',
+        description: 'critical evidence',
+      }),
+    ];
+
+    renderTable(items);
+
+    expect(screen.getByTestId('exception-row-ae-critical')).toBeInTheDocument();
+    expect(screen.getByText('即対応推奨')).toBeInTheDocument();
+    expect(screen.getByText(/critical evidence/)).toBeInTheDocument();
+  });
+
+  it('集約行・展開行のどちらでも dismiss/snooze を実行できる', async () => {
+    const onDismiss = vi.fn();
+    const onSnooze = vi.fn();
+    const items: ExceptionItem[] = [
+      makeException({
+        id: 'ae-1',
+        stableId: 'stable-1',
+        severity: 'high',
+        title: '提案A',
+      }),
+      makeException({
+        id: 'ae-2',
+        stableId: 'stable-2',
+        severity: 'medium',
+        title: '提案B',
+      }),
+    ];
+
+    renderTable(items, {
+      onDismiss,
+      onSnooze,
+    });
+
+    fireEvent.click(screen.getByTestId('suggestion-menu-button-ae-1'));
+    fireEvent.click(await screen.findByText('対応済みにする'));
+    expect(onDismiss).toHaveBeenCalledWith('stable-1');
+
+    fireEvent.click(screen.getByTestId('exception-group-toggle-U-001'));
+    fireEvent.click(screen.getByTestId('suggestion-menu-button-ae-2'));
+    fireEvent.click(await screen.findByText('明日まで'));
+    expect(onSnooze).toHaveBeenCalledWith('stable-2', 'tomorrow');
+  });
+});


### PR DESCRIPTION
## 概要
- ExceptionCenter の `ExceptionTable` で `corrective-action` を利用者単位に集約
- 代表1行（highest priority + 最新順）で表示し、`個別提案を表示` トグルで詳細を展開
- 展開行でも既存 `CorrectiveActionsCell` / `DismissSnoozeMenu` を再利用し、dismiss/snooze/CTA の導線を維持

## 変更点
- `ExceptionTable` に `displayRows`（通常行 + corrective-action group行）を導入
- `groupExceptionsByUser` をUI接続し、代表提案の選定ロジックを追加
- グループ展開 state（`expandedGroups`）と詳細行レンダリングを追加
- `ExceptionTable` コンポーネントテストを新規追加（3ケース）

## テスト
- `npx vitest run src/features/exceptions/components/__tests__/ExceptionTable.spec.tsx src/features/exceptions/domain/__tests__/groupByUser.spec.ts src/features/exceptions/domain/__tests__/mapSuggestionToException.spec.ts src/features/exceptions/domain/__tests__/correctiveActions.spec.ts src/features/action-engine/hooks/__tests__/suggestionStateSync.integration.spec.tsx`
- `npx eslint src/features/exceptions/components/ExceptionTable.tsx src/features/exceptions/components/__tests__/ExceptionTable.spec.tsx`
- `npm run typecheck -- --pretty false`
