### PR TITLE
feat: automate corrective-action weekly review decisioning (#1168)

### DIFF
--- a/src/features/action-engine/index.ts
+++ b/src/features/action-engine/index.ts
@@ -113,3 +113,13 @@ export type {
   SuggestionLifecycleAnomalyThresholds,
   DetectSuggestionLifecycleAnomaliesInput,
 } from './telemetry/detectSuggestionLifecycleAnomalies';
+export {
+  computeWeeklyReviewResult,
+  WEEKLY_REVIEW_THRESHOLDS,
+} from './telemetry/computeWeeklyReviewResult';
+export type {
+  WeeklyReviewInputMetrics,
+  WeeklyReviewMetrics,
+  WeeklyReviewResult,
+  ComputeWeeklyReviewResultInput,
+} from './telemetry/computeWeeklyReviewResult';

--- a/src/features/action-engine/telemetry/__tests__/computeWeeklyReviewResult.spec.ts
+++ b/src/features/action-engine/telemetry/__tests__/computeWeeklyReviewResult.spec.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest';
+import {
+  computeWeeklyReviewResult,
+  WEEKLY_REVIEW_THRESHOLDS,
+  type WeeklyReviewInputMetrics,
+} from '../computeWeeklyReviewResult';
+import type { SuggestionLifecycleAnomaly } from '../detectSuggestionLifecycleAnomalies';
+
+function metrics(
+  overrides: Partial<WeeklyReviewInputMetrics> = {},
+): WeeklyReviewInputMetrics {
+  return {
+    dismissRate: 0.5,
+    resurfacedRate: 0.2,
+    shownCount: 100,
+    ...overrides,
+  };
+}
+
+function anomaly(
+  overrides: Partial<SuggestionLifecycleAnomaly> = {},
+): SuggestionLifecycleAnomaly {
+  return {
+    id: 'a-1',
+    type: 'drop',
+    severity: 'warning',
+    title: 'shown が急減',
+    message: 'warning anomaly',
+    currentShown: 10,
+    previousShown: 20,
+    dropRate: 0.5,
+    ...overrides,
+  };
+}
+
+describe('computeWeeklyReviewResult', () => {
+  it('全条件を満たすと PASS', () => {
+    const result = computeWeeklyReviewResult({
+      current: metrics({
+        dismissRate: 0.35, // -15pt
+        resurfacedRate: 0.1, // -10pt
+        shownCount: 80, // 80%
+      }),
+      previous: metrics(),
+    });
+
+    expect(result.status).toBe('PASS');
+    expect(result.metrics.deltas.dismissRatePt).toBeCloseTo(-15);
+    expect(result.metrics.deltas.resurfacedRatePt).toBeCloseTo(-10);
+    expect(result.metrics.deltas.shownCoverage).toBeCloseTo(0.8);
+  });
+
+  it('dismissRate の改善不足で FAIL', () => {
+    const result = computeWeeklyReviewResult({
+      current: metrics({ dismissRate: 0.45 }), // -5pt
+      previous: metrics(),
+    });
+
+    expect(result.status).toBe('FAIL');
+    expect(result.reasons.join('\n')).toContain('dismissRate の改善が不足');
+  });
+
+  it('resurfacedRate の改善不足で FAIL', () => {
+    const result = computeWeeklyReviewResult({
+      current: metrics({
+        dismissRate: 0.35,
+        resurfacedRate: 0.17, // -3pt
+      }),
+      previous: metrics(),
+    });
+
+    expect(result.status).toBe('FAIL');
+    expect(result.reasons.join('\n')).toContain('resurfacedRate の改善が不足');
+  });
+
+  it('shownCount 比率不足で FAIL', () => {
+    const result = computeWeeklyReviewResult({
+      current: metrics({
+        dismissRate: 0.35,
+        resurfacedRate: 0.1,
+        shownCount: 69,
+      }),
+      previous: metrics({ shownCount: 100 }),
+    });
+
+    expect(result.status).toBe('FAIL');
+    expect(result.reasons.join('\n')).toContain('shownCount が前期間比');
+  });
+
+  it('shownCount 最低件数不足で FAIL', () => {
+    const result = computeWeeklyReviewResult({
+      current: metrics({
+        dismissRate: 0.35,
+        resurfacedRate: 0.1,
+        shownCount: 19,
+      }),
+      previous: metrics({ shownCount: 20 }),
+    });
+
+    expect(result.status).toBe('FAIL');
+    expect(result.reasons.join('\n')).toContain('shownCount が 19 件');
+  });
+
+  it('閾値ちょうどは PASS（境界値）', () => {
+    const result = computeWeeklyReviewResult({
+      current: metrics({
+        dismissRate: 0.4, // -10pt
+        resurfacedRate: 0.15, // -5pt
+        shownCount: 70, // 70%
+      }),
+      previous: metrics({
+        dismissRate: 0.5,
+        resurfacedRate: 0.2,
+        shownCount: 100,
+      }),
+    });
+
+    expect(result.status).toBe('PASS');
+    expect(result.metrics.deltas.dismissRatePt).toBeCloseTo(
+      WEEKLY_REVIEW_THRESHOLDS.dismissRateDeltaPtMax,
+    );
+    expect(result.metrics.deltas.resurfacedRatePt).toBeCloseTo(
+      WEEKLY_REVIEW_THRESHOLDS.resurfacedRateDeltaPtMax,
+    );
+    expect(result.metrics.deltas.shownCoverage).toBeCloseTo(
+      WEEKLY_REVIEW_THRESHOLDS.shownCoverageMin,
+    );
+  });
+
+  it('critical anomaly があれば FAIL 寄り判定にする', () => {
+    const result = computeWeeklyReviewResult({
+      current: metrics({
+        dismissRate: 0.35,
+        resurfacedRate: 0.1,
+        shownCount: 80,
+      }),
+      previous: metrics(),
+      anomalies: [
+        anomaly({
+          severity: 'critical',
+          type: 'zero',
+        }),
+      ],
+    });
+
+    expect(result.status).toBe('FAIL');
+    expect(result.reasons.join('\n')).toContain('critical anomaly を検知');
+  });
+
+  it('warning anomaly のみなら PASS を維持し補助理由を出す', () => {
+    const result = computeWeeklyReviewResult({
+      current: metrics({
+        dismissRate: 0.35,
+        resurfacedRate: 0.1,
+        shownCount: 80,
+      }),
+      previous: metrics(),
+      anomalies: [anomaly()],
+    });
+
+    expect(result.status).toBe('PASS');
+    expect(result.reasons.join('\n')).toContain('warning anomaly を検知');
+  });
+});
+

--- a/src/features/action-engine/telemetry/computeWeeklyReviewResult.ts
+++ b/src/features/action-engine/telemetry/computeWeeklyReviewResult.ts
@@ -1,0 +1,121 @@
+import type { SuggestionLifecycleAnomaly } from './detectSuggestionLifecycleAnomalies';
+
+export type WeeklyReviewInputMetrics = {
+  dismissRate: number;
+  resurfacedRate: number;
+  shownCount: number;
+};
+
+export type WeeklyReviewMetrics = {
+  current: WeeklyReviewInputMetrics;
+  previous: WeeklyReviewInputMetrics;
+  deltas: {
+    dismissRatePt: number;
+    resurfacedRatePt: number;
+    shownCount: number;
+    shownCoverage: number;
+  };
+};
+
+export type WeeklyReviewResult = {
+  status: 'PASS' | 'FAIL';
+  reasons: string[];
+  metrics: WeeklyReviewMetrics;
+};
+
+export type ComputeWeeklyReviewResultInput = {
+  current: WeeklyReviewInputMetrics;
+  previous: WeeklyReviewInputMetrics;
+  anomalies?: SuggestionLifecycleAnomaly[];
+};
+
+export const WEEKLY_REVIEW_THRESHOLDS = {
+  dismissRateDeltaPtMax: -10,
+  resurfacedRateDeltaPtMax: -5,
+  shownCoverageMin: 0.7,
+  shownCurrentMin: 20,
+} as const;
+
+function toPercentPoint(rate: number): number {
+  return rate * 100;
+}
+
+/**
+ * corrective-action telemetry の週次レビュー結果を機械判定する。
+ */
+export function computeWeeklyReviewResult(
+  input: ComputeWeeklyReviewResultInput,
+): WeeklyReviewResult {
+  const { current, previous, anomalies = [] } = input;
+
+  const dismissRatePt = toPercentPoint(current.dismissRate)
+    - toPercentPoint(previous.dismissRate);
+  const resurfacedRatePt = toPercentPoint(current.resurfacedRate)
+    - toPercentPoint(previous.resurfacedRate);
+  const shownCoverage = previous.shownCount > 0
+    ? current.shownCount / previous.shownCount
+    : 1;
+  const shownCountDelta = current.shownCount - previous.shownCount;
+
+  const failReasons: string[] = [];
+  const infoReasons: string[] = [];
+
+  if (dismissRatePt > WEEKLY_REVIEW_THRESHOLDS.dismissRateDeltaPtMax) {
+    failReasons.push(
+      `dismissRate の改善が不足（Δ ${dismissRatePt.toFixed(1)}pt / 要件 <= ${WEEKLY_REVIEW_THRESHOLDS.dismissRateDeltaPtMax}pt）`,
+    );
+  }
+
+  if (resurfacedRatePt > WEEKLY_REVIEW_THRESHOLDS.resurfacedRateDeltaPtMax) {
+    failReasons.push(
+      `resurfacedRate の改善が不足（Δ ${resurfacedRatePt.toFixed(1)}pt / 要件 <= ${WEEKLY_REVIEW_THRESHOLDS.resurfacedRateDeltaPtMax}pt）`,
+    );
+  }
+
+  if (current.shownCount < previous.shownCount * WEEKLY_REVIEW_THRESHOLDS.shownCoverageMin) {
+    failReasons.push(
+      `shownCount が前期間比 ${Math.round(shownCoverage * 100)}%（要件 >= ${Math.round(WEEKLY_REVIEW_THRESHOLDS.shownCoverageMin * 100)}%）`,
+    );
+  }
+
+  if (current.shownCount < WEEKLY_REVIEW_THRESHOLDS.shownCurrentMin) {
+    failReasons.push(
+      `shownCount が ${current.shownCount} 件（要件 >= ${WEEKLY_REVIEW_THRESHOLDS.shownCurrentMin} 件）`,
+    );
+  }
+
+  const criticalAnomalies = anomalies.filter((a) => a.severity === 'critical');
+  if (criticalAnomalies.length > 0) {
+    failReasons.push(
+      `critical anomaly を検知（${criticalAnomalies.length}件）`,
+    );
+  }
+
+  const warningAnomalies = anomalies.filter((a) => a.severity === 'warning');
+  if (warningAnomalies.length > 0) {
+    infoReasons.push(
+      `warning anomaly を検知（${warningAnomalies.length}件）`,
+    );
+  }
+
+  const status: 'PASS' | 'FAIL' = failReasons.length === 0 ? 'PASS' : 'FAIL';
+  const reasons = status === 'PASS'
+    ? (infoReasons.length > 0 ? infoReasons : ['全ての週次レビュー条件を満たしています'])
+    : [...failReasons, ...infoReasons];
+
+  return {
+    status,
+    reasons,
+    metrics: {
+      current,
+      previous,
+      deltas: {
+        dismissRatePt,
+        resurfacedRatePt,
+        shownCount: shownCountDelta,
+        shownCoverage,
+      },
+    },
+  };
+}
+

--- a/src/features/telemetry/components/SuggestionLifecycleSection.tsx
+++ b/src/features/telemetry/components/SuggestionLifecycleSection.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useRef } from 'react';
 import {
+  computeWeeklyReviewResult,
   detectSuggestionLifecycleAnomalies,
   useSuggestionLifecycleEvents,
   useSuggestionTelemetrySummary,
@@ -28,6 +29,11 @@ type RateRow = {
   snooze: number;
   resurfaced: number;
 };
+
+function formatDeltaPt(value: number): string {
+  const rounded = Number(value.toFixed(1));
+  return `${rounded >= 0 ? '+' : ''}${rounded.toFixed(1)}pt`;
+}
 
 function SummaryRowTable({
   title,
@@ -129,6 +135,23 @@ export function SuggestionLifecycleSection({
       }),
     [summary, previousSummary, byRule, previousByRule],
   );
+  const weeklyReview = useMemo(
+    () =>
+      computeWeeklyReviewResult({
+        current: {
+          dismissRate: summary.rates.dismiss,
+          resurfacedRate: summary.rates.resurfaced,
+          shownCount: summary.shown,
+        },
+        previous: {
+          dismissRate: previousSummary.rates.dismiss,
+          resurfacedRate: previousSummary.rates.resurfaced,
+          shownCount: previousSummary.shown,
+        },
+        anomalies,
+      }),
+    [summary, previousSummary, anomalies],
+  );
 
   const screenRows: RateRow[] = byScreen.map((row) => ({
     key: row.sourceScreen,
@@ -210,6 +233,66 @@ export function SuggestionLifecycleSection({
 
       {!isEmpty && (
         <>
+          <div
+            data-testid="suggestion-weekly-review"
+            style={{
+              marginBottom: 12,
+              padding: 10,
+              borderRadius: 8,
+              border: `1px solid ${weeklyReview.status === 'PASS' ? '#86efac' : '#fecaca'}`,
+              background: weeklyReview.status === 'PASS' ? '#f0fdf4' : '#fef2f2',
+            }}
+          >
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                gap: 8,
+                marginBottom: 8,
+              }}
+            >
+              <div style={{ fontSize: 12, color: '#334155', fontWeight: 700 }}>
+                Weekly Review
+              </div>
+              <div
+                style={{
+                  fontSize: 11,
+                  fontWeight: 700,
+                  padding: '2px 8px',
+                  borderRadius: 999,
+                  color: weeklyReview.status === 'PASS' ? '#166534' : '#991b1b',
+                  background: weeklyReview.status === 'PASS' ? '#dcfce7' : '#fee2e2',
+                }}
+              >
+                {weeklyReview.status}
+              </div>
+            </div>
+
+            <div style={{ display: 'grid', gap: 4, fontSize: 12, color: '#475569', marginBottom: 8 }}>
+              <div>dismissRate Δ: {formatDeltaPt(weeklyReview.metrics.deltas.dismissRatePt)}</div>
+              <div>resurfacedRate Δ: {formatDeltaPt(weeklyReview.metrics.deltas.resurfacedRatePt)}</div>
+              <div>
+                shown: {summary.shown} / 前期間 {previousSummary.shown}（{Math.round(weeklyReview.metrics.deltas.shownCoverage * 100)}%）
+              </div>
+            </div>
+
+            <div style={{ display: 'grid', gap: 4 }}>
+              {weeklyReview.reasons.map((reason) => (
+                <div
+                  key={reason}
+                  style={{
+                    fontSize: 12,
+                    color: weeklyReview.status === 'PASS' ? '#166534' : '#991b1b',
+                    lineHeight: 1.4,
+                  }}
+                >
+                  - {reason}
+                </div>
+              ))}
+            </div>
+          </div>
+
           {anomalies.length > 0 && (
             <div
               data-testid="suggestion-lifecycle-anomalies"


### PR DESCRIPTION
## Summary
Implements #1168 weekly review automation for corrective-action lifecycle telemetry.

## Changes
- Added pure function `computeWeeklyReviewResult` for PASS/FAIL decisioning.
- Added deterministic thresholds:
  - dismissRate delta <= -10pt
  - resurfacedRate delta <= -5pt
  - shown current >= 70% of previous
  - shown current >= 20
- Added anomaly-aware bias:
  - critical anomalies force FAIL
  - warning anomalies are surfaced as review context
- Added Weekly Review UI to `SuggestionLifecycleSection`:
  - PASS/FAIL badge
  - key metric deltas
  - reasons list
- Exported weekly review API from action-engine index.
- Added unit tests for PASS/FAIL/boundary/anomaly cases.

## Why
#1088 made anomalies visible. This PR closes the loop by introducing machine-evaluable weekly review criteria so the team can run corrective-action telemetry in a repeatable PDCA cycle.

## Files
- `src/features/action-engine/telemetry/computeWeeklyReviewResult.ts`
- `src/features/action-engine/telemetry/__tests__/computeWeeklyReviewResult.spec.ts`
- `src/features/telemetry/components/SuggestionLifecycleSection.tsx`
- `src/features/action-engine/index.ts`

## Verification
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run test` ✅

## Notes
- This PR is stacked on top of #1088 and targets `feat/1088-suggestion-lifecycle-anomaly-detection` as base for clean review.
- Existing unrelated `act(...)` warnings remain (tracked separately in #1176).
