### PR TITLE
feat: add behavior-trend weekly effect review automation (#1166) [main-stack]

### DIFF
--- a/src/features/action-engine/index.ts
+++ b/src/features/action-engine/index.ts
@@ -134,3 +134,15 @@ export type {
   AssessmentStaleReviewResult,
   ComputeAssessmentStaleReviewResultInput,
 } from './telemetry/computeAssessmentStaleReviewResult';
+export {
+  computeBehaviorTrendReviewResult,
+  BEHAVIOR_TREND_RULE_ALIASES,
+  BEHAVIOR_TREND_REVIEW_MIN_SHOWN,
+  BEHAVIOR_TREND_REVIEW_CTA_DELTA_MIN_PT,
+} from './telemetry/computeBehaviorTrendReviewResult';
+export type {
+  BehaviorTrendReviewStatus,
+  BehaviorTrendLifecycleSnapshot,
+  BehaviorTrendReviewResult,
+  ComputeBehaviorTrendReviewResultInput,
+} from './telemetry/computeBehaviorTrendReviewResult';

--- a/src/features/action-engine/telemetry/__tests__/computeBehaviorTrendReviewResult.spec.ts
+++ b/src/features/action-engine/telemetry/__tests__/computeBehaviorTrendReviewResult.spec.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import type { SuggestionTelemetryByRule } from '../summarizeSuggestionTelemetry';
+import {
+  BEHAVIOR_TREND_REVIEW_CTA_DELTA_MIN_PT,
+  BEHAVIOR_TREND_REVIEW_MIN_SHOWN,
+  computeBehaviorTrendReviewResult,
+} from '../computeBehaviorTrendReviewResult';
+
+function row(
+  ruleId: string,
+  shown: number,
+  clicked: number,
+  dismissed: number,
+): SuggestionTelemetryByRule {
+  return {
+    ruleId,
+    shown,
+    clicked,
+    dismissed,
+    snoozed: 0,
+    resurfaced: 0,
+    rates: {
+      cta: shown > 0 ? clicked / shown : 0,
+      dismiss: shown > 0 ? dismissed / shown : 0,
+      snooze: 0,
+      resurfaced: 0,
+      noResponse: shown > 0 ? (shown - clicked - dismissed) / shown : 0,
+    },
+  };
+}
+
+describe('computeBehaviorTrendReviewResult', () => {
+  it('min shown 未満は NO_DATA', () => {
+    const result = computeBehaviorTrendReviewResult({
+      currentByRule: [row('behavior-trend-increase', 10, 2, 5)],
+      previousByRule: [row('behavior-trend-increase', 12, 2, 6)],
+    });
+
+    expect(result.status).toBe('NO_DATA');
+    expect(result.reasons.join('\n')).toContain('shown 件数が不足');
+  });
+
+  it('dismissRate 改善かつ ctaRate の悪化が許容内なら PASS', () => {
+    const result = computeBehaviorTrendReviewResult({
+      currentByRule: [row('behavior-trend-increase', 30, 11, 12)], // cta 36.7 / dismiss 40.0
+      previousByRule: [row('behavior-trend-increase', 30, 12, 15)], // cta 40.0 / dismiss 50.0
+    });
+
+    expect(result.status).toBe('PASS');
+    expect(result.reasons[0]).toContain('許容範囲内');
+  });
+
+  it('dismissRate が悪化すると FAIL', () => {
+    const result = computeBehaviorTrendReviewResult({
+      currentByRule: [row('behavior-trend-increase', 30, 12, 16)], // dismiss 53.3
+      previousByRule: [row('behavior-trend-increase', 30, 12, 15)], // dismiss 50.0
+    });
+
+    expect(result.status).toBe('FAIL');
+    expect(result.reasons.join('\n')).toContain('dismissRate が悪化');
+  });
+
+  it('ctaRate の悪化が閾値を下回ると FAIL', () => {
+    const result = computeBehaviorTrendReviewResult({
+      currentByRule: [row('behavior-trend-increase', 30, 7, 12)], // cta 23.3
+      previousByRule: [row('behavior-trend-increase', 30, 10, 12)], // cta 33.3
+      ctaRateDeltaMinPt: BEHAVIOR_TREND_REVIEW_CTA_DELTA_MIN_PT,
+    });
+
+    expect(result.status).toBe('FAIL');
+    expect(result.reasons.join('\n')).toContain('ctaRate が悪化');
+  });
+
+  it('対象 rule のみで評価する', () => {
+    const result = computeBehaviorTrendReviewResult({
+      currentByRule: [
+        row('behavior-trend-increase', 25, 9, 10),
+        row('assessment-stale', 500, 0, 500),
+      ],
+      previousByRule: [
+        row('behavior-trend-increase', 30, 12, 15),
+        row('assessment-stale', 500, 500, 0),
+      ],
+      minShownCount: BEHAVIOR_TREND_REVIEW_MIN_SHOWN,
+    });
+
+    expect(result.current.shown).toBe(25);
+    expect(result.previous.shown).toBe(30);
+    expect(result.status).toBe('PASS');
+  });
+});

--- a/src/features/action-engine/telemetry/computeBehaviorTrendReviewResult.ts
+++ b/src/features/action-engine/telemetry/computeBehaviorTrendReviewResult.ts
@@ -1,0 +1,122 @@
+import type { SuggestionTelemetryByRule } from './summarizeSuggestionTelemetry';
+
+export type BehaviorTrendReviewStatus = 'PASS' | 'FAIL' | 'NO_DATA';
+
+export type BehaviorTrendLifecycleSnapshot = {
+  shown: number;
+  clicked: number;
+  dismissed: number;
+  ctaRate: number;
+  dismissRate: number;
+};
+
+export type BehaviorTrendReviewResult = {
+  status: BehaviorTrendReviewStatus;
+  reasons: string[];
+  current: BehaviorTrendLifecycleSnapshot;
+  previous: BehaviorTrendLifecycleSnapshot;
+  deltas: {
+    shownCount: number;
+    ctaRatePt: number;
+    dismissRatePt: number;
+  };
+};
+
+export type ComputeBehaviorTrendReviewResultInput = {
+  currentByRule: SuggestionTelemetryByRule[];
+  previousByRule: SuggestionTelemetryByRule[];
+  minShownCount?: number;
+  ctaRateDeltaMinPt?: number;
+};
+
+export const BEHAVIOR_TREND_RULE_ALIASES = ['behavior-trend-increase'] as const;
+export const BEHAVIOR_TREND_REVIEW_MIN_SHOWN = 20;
+export const BEHAVIOR_TREND_REVIEW_CTA_DELTA_MIN_PT = -5;
+
+function buildSnapshot(
+  rows: SuggestionTelemetryByRule[],
+): BehaviorTrendLifecycleSnapshot {
+  const shown = rows.reduce((sum, row) => sum + row.shown, 0);
+  const clicked = rows.reduce((sum, row) => sum + row.clicked, 0);
+  const dismissed = rows.reduce((sum, row) => sum + row.dismissed, 0);
+
+  return {
+    shown,
+    clicked,
+    dismissed,
+    ctaRate: shown > 0 ? clicked / shown : 0,
+    dismissRate: shown > 0 ? dismissed / shown : 0,
+  };
+}
+
+/**
+ * #1166 behavior-trend-increase の週次効果を評価する。
+ * PASS 条件:
+ * - dismissRate が前期間以下
+ * - ctaRate の悪化が閾値以内（既定: -5pt まで許容）
+ */
+export function computeBehaviorTrendReviewResult(
+  input: ComputeBehaviorTrendReviewResultInput,
+): BehaviorTrendReviewResult {
+  const {
+    currentByRule,
+    previousByRule,
+    minShownCount = BEHAVIOR_TREND_REVIEW_MIN_SHOWN,
+    ctaRateDeltaMinPt = BEHAVIOR_TREND_REVIEW_CTA_DELTA_MIN_PT,
+  } = input;
+
+  const aliasSet = new Set<string>(BEHAVIOR_TREND_RULE_ALIASES);
+  const currentRows = currentByRule.filter((row) => aliasSet.has(row.ruleId));
+  const previousRows = previousByRule.filter((row) => aliasSet.has(row.ruleId));
+
+  const current = buildSnapshot(currentRows);
+  const previous = buildSnapshot(previousRows);
+  const deltas = {
+    shownCount: current.shown - previous.shown,
+    ctaRatePt: (current.ctaRate - previous.ctaRate) * 100,
+    dismissRatePt: (current.dismissRate - previous.dismissRate) * 100,
+  };
+
+  if (current.shown < minShownCount || previous.shown < minShownCount) {
+    return {
+      status: 'NO_DATA',
+      reasons: [
+        `shown 件数が不足（current=${current.shown}, previous=${previous.shown}, min=${minShownCount}）`,
+      ],
+      current,
+      previous,
+      deltas,
+    };
+  }
+
+  const failReasons: string[] = [];
+  if (current.dismissRate > previous.dismissRate) {
+    failReasons.push(
+      `dismissRate が悪化（${(previous.dismissRate * 100).toFixed(1)}% → ${(current.dismissRate * 100).toFixed(1)}%）`,
+    );
+  }
+
+  if (deltas.ctaRatePt < ctaRateDeltaMinPt) {
+    failReasons.push(
+      `ctaRate が悪化（Δ ${deltas.ctaRatePt.toFixed(1)}pt / 許容 >= ${ctaRateDeltaMinPt.toFixed(1)}pt）`,
+    );
+  }
+
+  if (failReasons.length === 0) {
+    return {
+      status: 'PASS',
+      reasons: ['dismissRate は前期間以下、ctaRate も許容範囲内'],
+      current,
+      previous,
+      deltas,
+    };
+  }
+
+  return {
+    status: 'FAIL',
+    reasons: failReasons,
+    current,
+    previous,
+    deltas,
+  };
+}

--- a/src/features/telemetry/components/SuggestionLifecycleSection.tsx
+++ b/src/features/telemetry/components/SuggestionLifecycleSection.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useRef } from 'react';
 import {
   computeAssessmentStaleReviewResult,
+  computeBehaviorTrendReviewResult,
   computeWeeklyReviewResult,
   detectSuggestionLifecycleAnomalies,
   useSuggestionLifecycleEvents,
@@ -160,6 +161,14 @@ export function SuggestionLifecycleSection({
   const assessmentStaleReview = useMemo(
     () =>
       computeAssessmentStaleReviewResult({
+        currentByRule: byRule,
+        previousByRule: previousByRule,
+      }),
+    [byRule, previousByRule],
+  );
+  const behaviorTrendReview = useMemo(
+    () =>
+      computeBehaviorTrendReviewResult({
         currentByRule: byRule,
         previousByRule: previousByRule,
       }),
@@ -387,6 +396,98 @@ export function SuggestionLifecycleSection({
                       assessmentStaleReview.status === 'PASS'
                         ? '#166534'
                         : assessmentStaleReview.status === 'FAIL'
+                          ? '#991b1b'
+                          : '#475569',
+                    lineHeight: 1.4,
+                  }}
+                >
+                  - {reason}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div
+            data-testid="suggestion-behavior-trend-review"
+            style={{
+              marginBottom: 12,
+              padding: 10,
+              borderRadius: 8,
+              border: `1px solid ${
+                behaviorTrendReview.status === 'PASS'
+                  ? '#86efac'
+                  : behaviorTrendReview.status === 'FAIL'
+                    ? '#fecaca'
+                    : '#cbd5e1'
+              }`,
+              background:
+                behaviorTrendReview.status === 'PASS'
+                  ? '#f0fdf4'
+                  : behaviorTrendReview.status === 'FAIL'
+                    ? '#fef2f2'
+                    : '#f8fafc',
+            }}
+          >
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                gap: 8,
+                marginBottom: 8,
+              }}
+            >
+              <div style={{ fontSize: 12, color: '#334155', fontWeight: 700 }}>
+                behavior-trend Review (#1166)
+              </div>
+              <div
+                style={{
+                  fontSize: 11,
+                  fontWeight: 700,
+                  padding: '2px 8px',
+                  borderRadius: 999,
+                  color:
+                    behaviorTrendReview.status === 'PASS'
+                      ? '#166534'
+                      : behaviorTrendReview.status === 'FAIL'
+                        ? '#991b1b'
+                        : '#334155',
+                  background:
+                    behaviorTrendReview.status === 'PASS'
+                      ? '#dcfce7'
+                      : behaviorTrendReview.status === 'FAIL'
+                        ? '#fee2e2'
+                        : '#e2e8f0',
+                }}
+              >
+                {behaviorTrendReview.status}
+              </div>
+            </div>
+
+            <div style={{ display: 'grid', gap: 4, fontSize: 12, color: '#475569', marginBottom: 8 }}>
+              <div>
+                shown: {behaviorTrendReview.current.shown} / 前期間 {behaviorTrendReview.previous.shown}
+              </div>
+              <div>
+                dismissRate: {formatRate(behaviorTrendReview.previous.dismissRate)} → {formatRate(behaviorTrendReview.current.dismissRate)}
+                {' '}({formatDeltaPt(behaviorTrendReview.deltas.dismissRatePt)})
+              </div>
+              <div>
+                ctaRate: {formatRate(behaviorTrendReview.previous.ctaRate)} → {formatRate(behaviorTrendReview.current.ctaRate)}
+                {' '}({formatDeltaPt(behaviorTrendReview.deltas.ctaRatePt)})
+              </div>
+            </div>
+
+            <div style={{ display: 'grid', gap: 4 }}>
+              {behaviorTrendReview.reasons.map((reason) => (
+                <div
+                  key={reason}
+                  style={{
+                    fontSize: 12,
+                    color:
+                      behaviorTrendReview.status === 'PASS'
+                        ? '#166534'
+                        : behaviorTrendReview.status === 'FAIL'
                           ? '#991b1b'
                           : '#475569',
                     lineHeight: 1.4,


### PR DESCRIPTION
## Summary
Recreates #1166 on top of the new `main`-based stack.

## Changes
- Adds `computeBehaviorTrendReviewResult` pure evaluator
  - statuses: `PASS` / `FAIL` / `NO_DATA`
  - checks dismiss deterioration and CTA deterioration tolerance
- Adds behavior-trend review card to `SuggestionLifecycleSection`
  - status badge
  - shown counts
  - dismiss/cta deltas
  - reasons
- Exports evaluator/types/constants from action-engine index
- Adds unit tests for threshold and rule filtering behavior

## Verification
- Originally validated in PR #1180 / local run:
  - `npm run typecheck` ✅
  - `npm run lint` ✅
  - `npm run test` ✅

## Notes
- Clean cherry-pick of commit `225238ed`.
- Base PR: #1182
