### PR TITLE
feat: add assessment-stale weekly review evaluator (#1167) [main-v2]

### DIFF
--- a/src/features/action-engine/index.ts
+++ b/src/features/action-engine/index.ts
@@ -123,3 +123,14 @@ export type {
   WeeklyReviewResult,
   ComputeWeeklyReviewResultInput,
 } from './telemetry/computeWeeklyReviewResult';
+export {
+  computeAssessmentStaleReviewResult,
+  ASSESSMENT_STALE_RULE_ALIASES,
+  ASSESSMENT_STALE_REVIEW_MIN_SHOWN,
+} from './telemetry/computeAssessmentStaleReviewResult';
+export type {
+  AssessmentStaleReviewStatus,
+  AssessmentStaleLifecycleSnapshot,
+  AssessmentStaleReviewResult,
+  ComputeAssessmentStaleReviewResultInput,
+} from './telemetry/computeAssessmentStaleReviewResult';

--- a/src/features/action-engine/telemetry/__tests__/computeAssessmentStaleReviewResult.spec.ts
+++ b/src/features/action-engine/telemetry/__tests__/computeAssessmentStaleReviewResult.spec.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import type { SuggestionTelemetryByRule } from '../summarizeSuggestionTelemetry';
+import {
+  ASSESSMENT_STALE_REVIEW_MIN_SHOWN,
+  computeAssessmentStaleReviewResult,
+} from '../computeAssessmentStaleReviewResult';
+
+function row(
+  ruleId: string,
+  shown: number,
+  dismissed: number,
+  snoozed: number,
+  resurfaced: number,
+): SuggestionTelemetryByRule {
+  return {
+    ruleId,
+    shown,
+    clicked: 0,
+    dismissed,
+    snoozed,
+    resurfaced,
+    rates: {
+      cta: 0,
+      dismiss: shown > 0 ? dismissed / shown : 0,
+      snooze: shown > 0 ? snoozed / shown : 0,
+      resurfaced: snoozed > 0 ? resurfaced / snoozed : 0,
+      noResponse: 0,
+    },
+  };
+}
+
+describe('computeAssessmentStaleReviewResult', () => {
+  it('min shown 未満は NO_DATA', () => {
+    const result = computeAssessmentStaleReviewResult({
+      currentByRule: [row('data-insufficiency', 10, 1, 2, 1)],
+      previousByRule: [row('data-insufficiency', 12, 1, 2, 1)],
+    });
+
+    expect(result.status).toBe('NO_DATA');
+    expect(result.reasons.join('\n')).toContain('shown 件数が不足');
+  });
+
+  it('snoozeRate/resurfacedRate がともに改善または維持なら PASS', () => {
+    const result = computeAssessmentStaleReviewResult({
+      currentByRule: [
+        row('data-insufficiency', 30, 6, 6, 2), // 20%, 33.3%
+      ],
+      previousByRule: [
+        row('data-insufficiency', 30, 6, 9, 4), // 30%, 44.4%
+      ],
+    });
+
+    expect(result.status).toBe('PASS');
+    expect(result.reasons[0]).toContain('前期間以下');
+  });
+
+  it('snoozeRate が悪化すると FAIL', () => {
+    const result = computeAssessmentStaleReviewResult({
+      currentByRule: [
+        row('assessment-stale', 30, 4, 12, 3), // 40%
+      ],
+      previousByRule: [
+        row('assessment-stale', 30, 4, 9, 3), // 30%
+      ],
+    });
+
+    expect(result.status).toBe('FAIL');
+    expect(result.reasons.join('\n')).toContain('snoozeRate が悪化');
+  });
+
+  it('resurfacedRate が悪化すると FAIL', () => {
+    const result = computeAssessmentStaleReviewResult({
+      currentByRule: [
+        row('data-insufficiency', 30, 4, 10, 6), // 60%
+      ],
+      previousByRule: [
+        row('data-insufficiency', 30, 4, 10, 4), // 40%
+      ],
+    });
+
+    expect(result.status).toBe('FAIL');
+    expect(result.reasons.join('\n')).toContain('resurfacedRate が悪化');
+  });
+
+  it('assessment-stale と data-insufficiency を合算評価する', () => {
+    const result = computeAssessmentStaleReviewResult({
+      currentByRule: [
+        row('assessment-stale', 10, 1, 2, 1),
+        row('data-insufficiency', 15, 2, 3, 1),
+      ],
+      previousByRule: [
+        row('assessment-stale', 12, 1, 4, 2),
+        row('data-insufficiency', 18, 2, 5, 3),
+      ],
+      minShownCount: ASSESSMENT_STALE_REVIEW_MIN_SHOWN,
+    });
+
+    expect(result.status).toBe('PASS');
+    expect(result.current.shown).toBe(25);
+    expect(result.previous.shown).toBe(30);
+  });
+});
+

--- a/src/features/action-engine/telemetry/computeAssessmentStaleReviewResult.ts
+++ b/src/features/action-engine/telemetry/computeAssessmentStaleReviewResult.ts
@@ -1,0 +1,128 @@
+import type { SuggestionTelemetryByRule } from './summarizeSuggestionTelemetry';
+
+export type AssessmentStaleReviewStatus = 'PASS' | 'FAIL' | 'NO_DATA';
+
+export type AssessmentStaleLifecycleSnapshot = {
+  shown: number;
+  dismissed: number;
+  snoozed: number;
+  resurfaced: number;
+  dismissRate: number;
+  snoozeRate: number;
+  resurfacedRate: number;
+};
+
+export type AssessmentStaleReviewResult = {
+  status: AssessmentStaleReviewStatus;
+  reasons: string[];
+  current: AssessmentStaleLifecycleSnapshot;
+  previous: AssessmentStaleLifecycleSnapshot;
+  deltas: {
+    shownCount: number;
+    snoozeRatePt: number;
+    resurfacedRatePt: number;
+  };
+};
+
+export type ComputeAssessmentStaleReviewResultInput = {
+  currentByRule: SuggestionTelemetryByRule[];
+  previousByRule: SuggestionTelemetryByRule[];
+  minShownCount?: number;
+};
+
+export const ASSESSMENT_STALE_RULE_ALIASES = [
+  'assessment-stale',
+  'data-insufficiency',
+] as const;
+
+export const ASSESSMENT_STALE_REVIEW_MIN_SHOWN = 20;
+
+function buildSnapshot(
+  rows: SuggestionTelemetryByRule[],
+): AssessmentStaleLifecycleSnapshot {
+  const shown = rows.reduce((sum, row) => sum + row.shown, 0);
+  const dismissed = rows.reduce((sum, row) => sum + row.dismissed, 0);
+  const snoozed = rows.reduce((sum, row) => sum + row.snoozed, 0);
+  const resurfaced = rows.reduce((sum, row) => sum + row.resurfaced, 0);
+
+  return {
+    shown,
+    dismissed,
+    snoozed,
+    resurfaced,
+    dismissRate: shown > 0 ? dismissed / shown : 0,
+    snoozeRate: shown > 0 ? snoozed / shown : 0,
+    resurfacedRate: snoozed > 0 ? resurfaced / snoozed : 0,
+  };
+}
+
+/**
+ * #1167 assessment-stale（alias: data-insufficiency）の週次効果を評価する。
+ * PASS 条件:
+ * - snoozeRate が前期間以下
+ * - resurfacedRate が前期間以下
+ */
+export function computeAssessmentStaleReviewResult(
+  input: ComputeAssessmentStaleReviewResultInput,
+): AssessmentStaleReviewResult {
+  const {
+    currentByRule,
+    previousByRule,
+    minShownCount = ASSESSMENT_STALE_REVIEW_MIN_SHOWN,
+  } = input;
+
+  const aliasSet = new Set<string>(ASSESSMENT_STALE_RULE_ALIASES);
+  const currentRows = currentByRule.filter((row) => aliasSet.has(row.ruleId));
+  const previousRows = previousByRule.filter((row) => aliasSet.has(row.ruleId));
+
+  const current = buildSnapshot(currentRows);
+  const previous = buildSnapshot(previousRows);
+  const deltas = {
+    shownCount: current.shown - previous.shown,
+    snoozeRatePt: (current.snoozeRate - previous.snoozeRate) * 100,
+    resurfacedRatePt: (current.resurfacedRate - previous.resurfacedRate) * 100,
+  };
+
+  if (current.shown < minShownCount || previous.shown < minShownCount) {
+    return {
+      status: 'NO_DATA',
+      reasons: [
+        `shown 件数が不足（current=${current.shown}, previous=${previous.shown}, min=${minShownCount}）`,
+      ],
+      current,
+      previous,
+      deltas,
+    };
+  }
+
+  const failReasons: string[] = [];
+  if (current.snoozeRate > previous.snoozeRate) {
+    failReasons.push(
+      `snoozeRate が悪化（${(previous.snoozeRate * 100).toFixed(1)}% → ${(current.snoozeRate * 100).toFixed(1)}%）`,
+    );
+  }
+  if (current.resurfacedRate > previous.resurfacedRate) {
+    failReasons.push(
+      `resurfacedRate が悪化（${(previous.resurfacedRate * 100).toFixed(1)}% → ${(current.resurfacedRate * 100).toFixed(1)}%）`,
+    );
+  }
+
+  if (failReasons.length === 0) {
+    return {
+      status: 'PASS',
+      reasons: ['snoozeRate / resurfacedRate ともに前期間以下'],
+      current,
+      previous,
+      deltas,
+    };
+  }
+
+  return {
+    status: 'FAIL',
+    reasons: failReasons,
+    current,
+    previous,
+    deltas,
+  };
+}
+

--- a/src/features/telemetry/components/SuggestionLifecycleSection.tsx
+++ b/src/features/telemetry/components/SuggestionLifecycleSection.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useRef } from 'react';
 import {
+  computeAssessmentStaleReviewResult,
   computeWeeklyReviewResult,
   detectSuggestionLifecycleAnomalies,
   useSuggestionLifecycleEvents,
@@ -33,6 +34,10 @@ type RateRow = {
 function formatDeltaPt(value: number): string {
   const rounded = Number(value.toFixed(1));
   return `${rounded >= 0 ? '+' : ''}${rounded.toFixed(1)}pt`;
+}
+
+function formatRate(value: number): string {
+  return `${(value * 100).toFixed(1)}%`;
 }
 
 function SummaryRowTable({
@@ -151,6 +156,14 @@ export function SuggestionLifecycleSection({
         anomalies,
       }),
     [summary, previousSummary, anomalies],
+  );
+  const assessmentStaleReview = useMemo(
+    () =>
+      computeAssessmentStaleReviewResult({
+        currentByRule: byRule,
+        previousByRule: previousByRule,
+      }),
+    [byRule, previousByRule],
   );
 
   const screenRows: RateRow[] = byScreen.map((row) => ({
@@ -284,6 +297,98 @@ export function SuggestionLifecycleSection({
                   style={{
                     fontSize: 12,
                     color: weeklyReview.status === 'PASS' ? '#166534' : '#991b1b',
+                    lineHeight: 1.4,
+                  }}
+                >
+                  - {reason}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div
+            data-testid="suggestion-assessment-stale-review"
+            style={{
+              marginBottom: 12,
+              padding: 10,
+              borderRadius: 8,
+              border: `1px solid ${
+                assessmentStaleReview.status === 'PASS'
+                  ? '#86efac'
+                  : assessmentStaleReview.status === 'FAIL'
+                    ? '#fecaca'
+                    : '#cbd5e1'
+              }`,
+              background:
+                assessmentStaleReview.status === 'PASS'
+                  ? '#f0fdf4'
+                  : assessmentStaleReview.status === 'FAIL'
+                    ? '#fef2f2'
+                    : '#f8fafc',
+            }}
+          >
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                gap: 8,
+                marginBottom: 8,
+              }}
+            >
+              <div style={{ fontSize: 12, color: '#334155', fontWeight: 700 }}>
+                assessment-stale Review (#1167)
+              </div>
+              <div
+                style={{
+                  fontSize: 11,
+                  fontWeight: 700,
+                  padding: '2px 8px',
+                  borderRadius: 999,
+                  color:
+                    assessmentStaleReview.status === 'PASS'
+                      ? '#166534'
+                      : assessmentStaleReview.status === 'FAIL'
+                        ? '#991b1b'
+                        : '#334155',
+                  background:
+                    assessmentStaleReview.status === 'PASS'
+                      ? '#dcfce7'
+                      : assessmentStaleReview.status === 'FAIL'
+                        ? '#fee2e2'
+                        : '#e2e8f0',
+                }}
+              >
+                {assessmentStaleReview.status}
+              </div>
+            </div>
+
+            <div style={{ display: 'grid', gap: 4, fontSize: 12, color: '#475569', marginBottom: 8 }}>
+              <div>
+                shown: {assessmentStaleReview.current.shown} / 前期間 {assessmentStaleReview.previous.shown}
+              </div>
+              <div>
+                snoozeRate: {formatRate(assessmentStaleReview.previous.snoozeRate)} → {formatRate(assessmentStaleReview.current.snoozeRate)}
+                {' '}({formatDeltaPt(assessmentStaleReview.deltas.snoozeRatePt)})
+              </div>
+              <div>
+                resurfacedRate: {formatRate(assessmentStaleReview.previous.resurfacedRate)} → {formatRate(assessmentStaleReview.current.resurfacedRate)}
+                {' '}({formatDeltaPt(assessmentStaleReview.deltas.resurfacedRatePt)})
+              </div>
+            </div>
+
+            <div style={{ display: 'grid', gap: 4 }}>
+              {assessmentStaleReview.reasons.map((reason) => (
+                <div
+                  key={reason}
+                  style={{
+                    fontSize: 12,
+                    color:
+                      assessmentStaleReview.status === 'PASS'
+                        ? '#166534'
+                        : assessmentStaleReview.status === 'FAIL'
+                          ? '#991b1b'
+                          : '#475569',
                     lineHeight: 1.4,
                   }}
                 >


### PR DESCRIPTION
Supersedes stack-only landing of #1182.\n\nThis PR is a clean cherry-pick of commit 09e14919 onto origin/main to ensure #1167 reaches main directly.\n\nValidation was completed in prior runs (typecheck/lint/test all green).