### PR TITLE
test: reduce act warnings in meeting guide page tests (#1176)

### DIFF
--- a/tests/unit/MeetingGuidePage.spec.tsx
+++ b/tests/unit/MeetingGuidePage.spec.tsx
@@ -3,7 +3,46 @@ import { TESTIDS } from '@/testids';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/features/handoff/HandoffSummaryForMeeting', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/features/handoff/RegulatoryFindingsForMeeting', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/features/meeting/useCurrentMeeting', () => ({
+  useCurrentMeeting: () => ({
+    sessionKey: '2026-03-22_morning',
+    kind: 'morning',
+    session: null,
+    steps: [
+      {
+        id: 1,
+        title: 'Safety HUD 確認',
+        description: '今日の安全インジケーター・予定の重なり状況',
+        completed: false,
+        timeSpent: 0,
+      },
+    ],
+    stats: {
+      totalCount: 1,
+      completedCount: 0,
+      progressPercentage: 0,
+    },
+    toggleStep: vi.fn(),
+    priorityUsers: [],
+    handoffAlert: {
+      criticalCount: 0,
+      totalActiveCount: 0,
+      hasAlerts: false,
+    },
+    loading: false,
+    error: null,
+  }),
+}));
 
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },


### PR DESCRIPTION
## Summary
Reduce `act(...)` warning noise in `tests/unit/MeetingGuidePage.spec.tsx` for #1176.

## Why
This suite verifies page structure and default visible content, but async updates from `useCurrentMeeting` and handoff summary widgets were producing repeated `act(...)` warnings unrelated to the test responsibility.

## Changes
- [x] Added test doubles for:
  - `@/features/handoff/HandoffSummaryForMeeting`
  - `@/features/handoff/RegulatoryFindingsForMeeting`
- [x] Mocked `@/features/meeting/useCurrentMeeting` with deterministic static data
- [x] Kept assertions unchanged and scope limited to one test file (test-only)

## Verification
- [x] Required checks are green (local)
- [ ] (If relevant) Smoke E2E passed
- [ ] (If relevant) Artifacts confirmed (trace/screenshot/log)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run test -- tests/unit/MeetingGuidePage.spec.tsx`

Warning count (target cluster):
- before: 10
- after: 0

---

## 🧭 AI Skills（[Protocol](docs/ai-skills-protocol.md)）

- Skills: N/A
- Scope: `tests/unit/MeetingGuidePage.spec.tsx`

### Evidence Pack（`hardening-*` ラベル時は必須）

- [x] Unit: `npm run test -- tests/unit/MeetingGuidePage.spec.tsx` PASS
- [ ] E2E: 該当 smoke PASS（N/A 可）
- [ ] Observability: ログ/イベント追加 or 紐付け
- [ ] ADR/Doc: 変更記録リンク → N/A

### Hardening Exit Criteria（`hardening-*` ラベル時のみ）

- [ ] 新規 Observability イベントが追加されている
- [ ] 再発防止テストが追加されている
- [ ] ADR or Runbook が更新されている

---

## ✅ Pre-Merge Checklist

### All PRs
- [x] Self-review: コード品質、型安全性、エラーハンドリング確認
- [x] テスト: ローカル `npm run preflight` が通過
- [x] ドキュメント: 必要に応じて README / docs を更新

### UI Changes
- [ ] **状態管理**: UIコンポーネントは状態を持ちすぎていない（hooksに逃がした）
- [ ] **副作用の分離**: API/Storage/Telemetryがコンポーネントに漏れていない（adapter/clientへ）
- [ ] **状態駆動**: 分岐は操作ではなく状態で表現されている
- [ ] **エラー処理**: エラーが分類され、ユーザーへの救済導線がある
- [ ] **レイアウト規約**: 新規ルートは `viewportMode`（`fixed` / `adaptive`）を明示し、[docs/layout/viewport-mode.md](docs/layout/viewport-mode.md) に従っている
- [ ] (詳細: [docs/ui-architecture.md](docs/ui-architecture.md))

### Navigation Changes
- [ ] **所属グループ**: `group` が業務目的に合致して指定されているか（`daily` `assessment` `record` `ops` `admin`）
- [ ] **並び順**: 対象グループ内で「現場での使用順・頻度順」に配置されているか（末尾にただ追加していないか）
- [ ] **権限・表示**: `navAudience` や `ALWAYS_VISIBLE_GROUPS` の意図（ロックアウト防止等）を守れているか
- [ ] (詳細なレビュー観点: [nav-review-checklist.md](.gemini/antigravity/brain/b9eabdec-d770-4d06-9271-4f866e1c1821/artifacts/nav-review-checklist.md) 参照)

### CI/Infra Changes
- [ ] Rollback Plan: 失敗時の戻し方を記述済み
- [ ] Required checks green
- [ ] Runbook 更新（必要な場合）

---

## Rollback Plan
- [x] Revert this PR
- [ ] (If applicable) Remove workflow gate / step

## Notes
- This PR is test-only and intentionally isolates asynchronous side effects outside this suite's concern.
- Existing unrelated warnings remain tracked under #1176.

---

## 関連Issue/PR
- #1176
