### PR TITLE
test: reduce act warnings in temperature keypad tests (#1176)

### DIFF
--- a/src/features/attendance/components/__tests__/TemperatureKeypad.spec.tsx
+++ b/src/features/attendance/components/__tests__/TemperatureKeypad.spec.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -17,64 +17,78 @@ const baseProps: TemperatureKeypadProps = {
   onCancel: vi.fn(),
 };
 
+const noRippleTheme = createTheme({
+  components: {
+    MuiButtonBase: {
+      defaultProps: {
+        disableRipple: true,
+        disableTouchRipple: true,
+      },
+    },
+  },
+});
+
+const renderWithNoRipple = (ui: JSX.Element) =>
+  render(<ThemeProvider theme={noRippleTheme}>{ui}</ThemeProvider>);
+
 describe('TemperatureKeypad', () => {
   it('renders dialog with user name when open', () => {
-    render(<TemperatureKeypad {...baseProps} />);
+    renderWithNoRipple(<TemperatureKeypad {...baseProps} />);
     expect(screen.getByText(/検温/)).toBeInTheDocument();
     expect(screen.getByText(/田中太郎/)).toBeInTheDocument();
   });
 
   it('does not render when closed', () => {
-    render(<TemperatureKeypad {...baseProps} open={false} />);
+    renderWithNoRipple(<TemperatureKeypad {...baseProps} open={false} />);
     expect(screen.queryByTestId('temperature-keypad-dialog')).not.toBeInTheDocument();
   });
 
   it('renders all integer buttons (35-42)', () => {
-    render(<TemperatureKeypad {...baseProps} />);
+    renderWithNoRipple(<TemperatureKeypad {...baseProps} />);
     for (const n of INTEGER_OPTIONS) {
       expect(screen.getByTestId(`integer-btn-${n}`)).toBeInTheDocument();
     }
   });
 
   it('renders all decimal buttons (.0-.9)', () => {
-    render(<TemperatureKeypad {...baseProps} />);
+    renderWithNoRipple(<TemperatureKeypad {...baseProps} />);
     for (const d of DECIMAL_OPTIONS) {
       expect(screen.getByTestId(`decimal-btn-${d}`)).toBeInTheDocument();
     }
   });
 
   it('defaults to 36 as selected integer', () => {
-    render(<TemperatureKeypad {...baseProps} />);
+    renderWithNoRipple(<TemperatureKeypad {...baseProps} />);
     expect(screen.getByTestId('temperature-preview').textContent).toContain('36._');
   });
 
-  it('calls onConfirm with correct value when decimal is tapped (36.5)', async () => {
+  it('calls onConfirm with correct value when decimal is tapped (36.5)', () => {
     const onConfirm = vi.fn();
-    render(<TemperatureKeypad {...baseProps} onConfirm={onConfirm} />);
+    renderWithNoRipple(<TemperatureKeypad {...baseProps} onConfirm={onConfirm} />);
 
     // 36 is default, just tap .5
-    await userEvent.click(screen.getByTestId('decimal-btn-5'));
+    fireEvent.click(screen.getByTestId('decimal-btn-5'));
     expect(onConfirm).toHaveBeenCalledWith(36.5);
   });
 
-  it('allows changing integer before decimal tap (37.2)', async () => {
+  it('allows changing integer before decimal tap (37.2)', () => {
     const onConfirm = vi.fn();
-    render(<TemperatureKeypad {...baseProps} onConfirm={onConfirm} />);
+    renderWithNoRipple(<TemperatureKeypad {...baseProps} onConfirm={onConfirm} />);
 
-    await userEvent.click(screen.getByTestId('integer-btn-37'));
+    fireEvent.click(screen.getByTestId('integer-btn-37'));
     expect(screen.getByTestId('temperature-preview').textContent).toContain('37._');
 
-    await userEvent.click(screen.getByTestId('decimal-btn-2'));
+    fireEvent.click(screen.getByTestId('decimal-btn-2'));
     expect(onConfirm).toHaveBeenCalledWith(37.2);
   });
 
-  it('handles edge cases: 35.0 and 42.9', async () => {
+  it('handles edge cases: 35.0 and 42.9', () => {
     const onConfirm = vi.fn();
-    render(<TemperatureKeypad {...baseProps} onConfirm={onConfirm} />);
+    renderWithNoRipple(<TemperatureKeypad {...baseProps} onConfirm={onConfirm} />);
 
     // 35.0
-    await userEvent.click(screen.getByTestId('integer-btn-35'));
-    await userEvent.click(screen.getByTestId('decimal-btn-0'));
+    fireEvent.click(screen.getByTestId('integer-btn-35'));
+    fireEvent.click(screen.getByTestId('decimal-btn-0'));
     expect(onConfirm).toHaveBeenCalledWith(35.0);
 
     // Reopen mentally — we'll test 42.9 in isolation
@@ -82,24 +96,24 @@ describe('TemperatureKeypad', () => {
   });
 
   it('uses initialValue to pre-select integer', () => {
-    render(<TemperatureKeypad {...baseProps} initialValue={38.1} />);
+    renderWithNoRipple(<TemperatureKeypad {...baseProps} initialValue={38.1} />);
     expect(screen.getByTestId('temperature-preview').textContent).toContain('38._');
   });
 
   it('falls back to default when initialValue is out of range', () => {
-    render(<TemperatureKeypad {...baseProps} initialValue={44} />);
+    renderWithNoRipple(<TemperatureKeypad {...baseProps} initialValue={44} />);
     expect(screen.getByTestId('temperature-preview').textContent).toContain(`${DEFAULT_INTEGER}._`);
   });
 
-  it('calls onCancel when cancel button is clicked', async () => {
+  it('calls onCancel when cancel button is clicked', () => {
     const onCancel = vi.fn();
-    render(<TemperatureKeypad {...baseProps} onCancel={onCancel} />);
-    await userEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
+    renderWithNoRipple(<TemperatureKeypad {...baseProps} onCancel={onCancel} />);
+    fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
 
   it('shows step labels for guidance', () => {
-    render(<TemperatureKeypad {...baseProps} />);
+    renderWithNoRipple(<TemperatureKeypad {...baseProps} />);
     expect(screen.getByText('整数部を選択')).toBeInTheDocument();
     expect(screen.getByText('小数部をタップして確定')).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
Reduce `act(...)` warning noise in `TemperatureKeypad` test cluster for #1176.

## Changes
- Updated `src/features/attendance/components/__tests__/TemperatureKeypad.spec.tsx`
- Replaced `userEvent.click` interactions with deterministic `fireEvent.click`
- Added test-only `noRippleTheme` (`disableRipple`, `disableTouchRipple`)
- Added `renderWithNoRipple(...)` helper and routed renders through it
- Removed unnecessary async/await in click-only tests

## Why
`TemperatureKeypad` tests produced repeated MUI ButtonBase/TouchRipple transition updates that surfaced as `act(...)` warnings. This change isolates those side effects in tests without touching production code.

## Verification
- Targeted:
  - `npx vitest run src/features/attendance/components/__tests__/TemperatureKeypad.spec.tsx --reporter=verbose --no-file-parallelism`
  - `before_warning_blocks=42`
  - `after_warning_blocks=0`
- Full checks:
  - `npm run typecheck` ✅
  - `npm run lint` ✅
  - `npm run test` ✅

## Notes
- Test-only change
- Production code unchanged
