### PR TITLE
test: reduce act warnings in color preset control tests (#1176)

### DIFF
--- a/src/features/settings/components/__tests__/ColorPresetControl.spec.tsx
+++ b/src/features/settings/components/__tests__/ColorPresetControl.spec.tsx
@@ -1,13 +1,27 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { ColorPresetControl } from '../ColorPresetControl';
+
+const noRippleTheme = createTheme({
+  components: {
+    MuiButtonBase: {
+      defaultProps: {
+        disableRipple: true,
+        disableTouchRipple: true,
+      },
+    },
+  },
+});
+
+const renderWithNoRipple = (ui: React.ReactElement) =>
+  render(<ThemeProvider theme={noRippleTheme}>{ui}</ThemeProvider>);
 
 describe('ColorPresetControl', () => {
   describe('Rendering', () => {
     it('should render the color preset control with all options', () => {
       const onChange = vi.fn();
-      render(<ColorPresetControl value="default" onChange={onChange} />);
+      renderWithNoRipple(<ColorPresetControl value="default" onChange={onChange} />);
 
       expect(screen.getByText('カラープリセット')).toBeInTheDocument();
       expect(screen.getByText('デフォルト')).toBeInTheDocument();
@@ -16,7 +30,7 @@ describe('ColorPresetControl', () => {
 
     it('should render radio buttons for each color preset option', () => {
       const onChange = vi.fn();
-      render(<ColorPresetControl value="default" onChange={onChange} />);
+      renderWithNoRipple(<ColorPresetControl value="default" onChange={onChange} />);
 
       const radioGroup = screen.getByTestId('color-preset-radio-group');
       expect(radioGroup).toBeInTheDocument();
@@ -27,7 +41,7 @@ describe('ColorPresetControl', () => {
 
     it('should render descriptions for each color preset option', () => {
       const onChange = vi.fn();
-      render(<ColorPresetControl value="default" onChange={onChange} />);
+      renderWithNoRipple(<ColorPresetControl value="default" onChange={onChange} />);
 
       expect(screen.getByText('MUI 標準カラー')).toBeInTheDocument();
       expect(screen.getByText('最大コントラスト（アクセシビリティ重視）')).toBeInTheDocument();
@@ -35,7 +49,7 @@ describe('ColorPresetControl', () => {
 
     it('should render color preview swatches', () => {
       const onChange = vi.fn();
-      render(<ColorPresetControl value="default" onChange={onChange} />);
+      renderWithNoRipple(<ColorPresetControl value="default" onChange={onChange} />);
 
       expect(screen.getByText('プレビュー:')).toBeInTheDocument();
       expect(screen.getByText('Primary / Secondary')).toBeInTheDocument();
@@ -43,7 +57,7 @@ describe('ColorPresetControl', () => {
 
     it('should display color swatches for selected preset', () => {
       const onChange = vi.fn();
-      const { rerender } = render(
+      const { rerender } = renderWithNoRipple(
         <ColorPresetControl value="default" onChange={onChange} />
       );
 
@@ -51,7 +65,11 @@ describe('ColorPresetControl', () => {
       const previewSwatches = screen.queryAllByTitle(/Primary|Secondary/);
       expect(previewSwatches.length).toBeGreaterThan(0);
 
-      rerender(<ColorPresetControl value="highContrast" onChange={onChange} />);
+      rerender(
+        <ThemeProvider theme={noRippleTheme}>
+          <ColorPresetControl value="highContrast" onChange={onChange} />
+        </ThemeProvider>,
+      );
       const swatchesUpdated = screen.queryAllByTitle(/Primary|Secondary/);
       expect(swatchesUpdated.length).toBeGreaterThan(0);
     });
@@ -60,7 +78,7 @@ describe('ColorPresetControl', () => {
   describe('Selection State', () => {
     it('should have radio buttons with correct values', () => {
       const onChange = vi.fn();
-      render(<ColorPresetControl value="default" onChange={onChange} />);
+      renderWithNoRipple(<ColorPresetControl value="default" onChange={onChange} />);
 
       const radios = screen.getAllByRole('radio');
       expect(radios[0]).toHaveAttribute('value', 'default');
@@ -69,61 +87,66 @@ describe('ColorPresetControl', () => {
 
     it('should display different presets as selected', () => {
       const onChange = vi.fn();
-      const { rerender } = render(
+      const { rerender } = renderWithNoRipple(
         <ColorPresetControl value="default" onChange={onChange} />
       );
 
       const defaultRadio = screen.getByTestId('color-preset-radio-default') as HTMLInputElement;
       expect(defaultRadio).toBeInTheDocument();
 
-      rerender(<ColorPresetControl value="highContrast" onChange={onChange} />);
+      rerender(
+        <ThemeProvider theme={noRippleTheme}>
+          <ColorPresetControl value="highContrast" onChange={onChange} />
+        </ThemeProvider>,
+      );
       const highContrastRadio = screen.getByTestId('color-preset-radio-highContrast');
       expect(highContrastRadio).toBeInTheDocument();
     });
   });
 
   describe('Interactions', () => {
-    it('should call onChange when selecting a different preset', async () => {
+    it('should call onChange when selecting a different preset', () => {
       const onChange = vi.fn();
-      const user = userEvent.setup();
 
-      render(<ColorPresetControl value="default" onChange={onChange} />);
+      renderWithNoRipple(<ColorPresetControl value="default" onChange={onChange} />);
 
       const highContrastRadio = screen.getByTestId('color-preset-radio-highContrast');
-      await user.click(highContrastRadio);
+      fireEvent.click(highContrastRadio);
 
       expect(onChange).toHaveBeenCalledWith('highContrast');
       expect(onChange).toHaveBeenCalledTimes(1);
     });
 
-    it('should call onChange with correct value for each option', async () => {
+    it('should call onChange with correct value for each option', () => {
       const onChange = vi.fn();
-      const user = userEvent.setup();
 
-      const { rerender } = render(
+      const { rerender } = renderWithNoRipple(
         <ColorPresetControl value="default" onChange={onChange} />
       );
 
       const highContrastRadio = screen.getByTestId('color-preset-radio-highContrast');
-      await user.click(highContrastRadio);
+      fireEvent.click(highContrastRadio);
       expect(onChange).toHaveBeenCalledWith('highContrast');
 
       onChange.mockClear();
-      rerender(<ColorPresetControl value="highContrast" onChange={onChange} />);
+      rerender(
+        <ThemeProvider theme={noRippleTheme}>
+          <ColorPresetControl value="highContrast" onChange={onChange} />
+        </ThemeProvider>,
+      );
 
       const defaultRadio = screen.getByTestId('color-preset-radio-default');
-      await user.click(defaultRadio);
+      fireEvent.click(defaultRadio);
       expect(onChange).toHaveBeenCalledWith('default');
     });
 
-    it('should handle rapid changes between presets', async () => {
+    it('should handle rapid changes between presets', () => {
       const onChange = vi.fn();
-      const user = userEvent.setup();
 
-      render(<ColorPresetControl value="default" onChange={onChange} />);
+      renderWithNoRipple(<ColorPresetControl value="default" onChange={onChange} />);
 
       const highContrastRadio = screen.getByTestId('color-preset-radio-highContrast');
-      await user.click(highContrastRadio);
+      fireEvent.click(highContrastRadio);
 
       expect(onChange).toHaveBeenCalledTimes(1);
       expect(onChange).toHaveBeenLastCalledWith('highContrast');
@@ -133,7 +156,7 @@ describe('ColorPresetControl', () => {
   describe('Color Swatches', () => {
     it('should show correct colors for default preset', () => {
       const onChange = vi.fn();
-      render(<ColorPresetControl value="default" onChange={onChange} />);
+      renderWithNoRipple(<ColorPresetControl value="default" onChange={onChange} />);
 
       const swatchDivs = screen.getAllByTitle(/Primary|Secondary/);
       expect(swatchDivs.length).toBeGreaterThanOrEqual(2);
@@ -141,7 +164,7 @@ describe('ColorPresetControl', () => {
 
     it('should show correct colors for highContrast preset', () => {
       const onChange = vi.fn();
-      render(<ColorPresetControl value="highContrast" onChange={onChange} />);
+      renderWithNoRipple(<ColorPresetControl value="highContrast" onChange={onChange} />);
 
       const swatchDivs = screen.getAllByTitle(/Primary|Secondary/);
       expect(swatchDivs.length).toBeGreaterThanOrEqual(2);
@@ -149,14 +172,18 @@ describe('ColorPresetControl', () => {
 
     it('should update swatches when preset changes', () => {
       const onChange = vi.fn();
-      const { rerender } = render(
+      const { rerender } = renderWithNoRipple(
         <ColorPresetControl value="default" onChange={onChange} />
       );
 
       const swatchesDefault = screen.getAllByTitle(/Primary|Secondary/);
       expect(swatchesDefault.length).toBeGreaterThanOrEqual(2);
 
-      rerender(<ColorPresetControl value="highContrast" onChange={onChange} />);
+      rerender(
+        <ThemeProvider theme={noRippleTheme}>
+          <ColorPresetControl value="highContrast" onChange={onChange} />
+        </ThemeProvider>,
+      );
       const swatchesHighContrast = screen.getAllByTitle(/Primary|Secondary/);
       expect(swatchesHighContrast.length).toBeGreaterThanOrEqual(2);
     });
@@ -165,7 +192,7 @@ describe('ColorPresetControl', () => {
   describe('Accessibility', () => {
     it('should have proper form control labels', () => {
       const onChange = vi.fn();
-      render(<ColorPresetControl value="default" onChange={onChange} />);
+      renderWithNoRipple(<ColorPresetControl value="default" onChange={onChange} />);
 
       const formControl = screen.getByRole('group');
       expect(formControl).toBeInTheDocument();
@@ -173,7 +200,7 @@ describe('ColorPresetControl', () => {
 
     it('should have proper radio button roles', () => {
       const onChange = vi.fn();
-      render(<ColorPresetControl value="default" onChange={onChange} />);
+      renderWithNoRipple(<ColorPresetControl value="default" onChange={onChange} />);
 
       const radios = screen.getAllByRole('radio');
       expect(radios.length).toBeGreaterThanOrEqual(2);
@@ -183,7 +210,7 @@ describe('ColorPresetControl', () => {
 
     it('should maintain label associations', () => {
       const onChange = vi.fn();
-      render(<ColorPresetControl value="default" onChange={onChange} />);
+      renderWithNoRipple(<ColorPresetControl value="default" onChange={onChange} />);
 
       const radios = screen.getAllByRole('radio');
       radios.forEach((radio) => {
@@ -194,7 +221,7 @@ describe('ColorPresetControl', () => {
 
     it('should have ARIA labels for accessibility', () => {
       const onChange = vi.fn();
-      render(<ColorPresetControl value="default" onChange={onChange} />);
+      renderWithNoRipple(<ColorPresetControl value="default" onChange={onChange} />);
 
       const legend = screen.getByText('カラープリセット');
       expect(legend).toBeInTheDocument();
@@ -210,7 +237,7 @@ describe('ColorPresetControl', () => {
   describe('Visual States', () => {
     it('should render selected preset option', () => {
       const onChange = vi.fn();
-      render(<ColorPresetControl value="default" onChange={onChange} />);
+      renderWithNoRipple(<ColorPresetControl value="default" onChange={onChange} />);
 
       const defaultRadio = screen.getByTestId('color-preset-radio-default');
       expect(defaultRadio).toBeInTheDocument();
@@ -218,26 +245,29 @@ describe('ColorPresetControl', () => {
 
     it('should display different selected preset', () => {
       const onChange = vi.fn();
-      const { rerender } = render(
+      const { rerender } = renderWithNoRipple(
         <ColorPresetControl value="default" onChange={onChange} />
       );
 
       expect(screen.getByTestId('color-preset-radio-default')).toBeInTheDocument();
 
-      rerender(<ColorPresetControl value="highContrast" onChange={onChange} />);
+      rerender(
+        <ThemeProvider theme={noRippleTheme}>
+          <ColorPresetControl value="highContrast" onChange={onChange} />
+        </ThemeProvider>,
+      );
       expect(screen.getByTestId('color-preset-radio-highContrast')).toBeInTheDocument();
     });
   });
 
   describe('Edge Cases', () => {
-    it('should handle preset change', async () => {
+    it('should handle preset change', () => {
       const onChange = vi.fn();
-      const user = userEvent.setup();
 
-      render(<ColorPresetControl value="default" onChange={onChange} />);
+      renderWithNoRipple(<ColorPresetControl value="default" onChange={onChange} />);
 
       const highContrastRadio = screen.getByTestId('color-preset-radio-highContrast');
-      await user.click(highContrastRadio);
+      fireEvent.click(highContrastRadio);
 
       expect(onChange).toHaveBeenCalledTimes(1);
       expect(onChange).toHaveBeenCalledWith('highContrast');
@@ -245,11 +275,15 @@ describe('ColorPresetControl', () => {
 
     it('should maintain onChange callback reference', () => {
       const onChange = vi.fn();
-      const { rerender } = render(
+      const { rerender } = renderWithNoRipple(
         <ColorPresetControl value="default" onChange={onChange} />
       );
 
-      rerender(<ColorPresetControl value="default" onChange={onChange} />);
+      rerender(
+        <ThemeProvider theme={noRippleTheme}>
+          <ColorPresetControl value="default" onChange={onChange} />
+        </ThemeProvider>,
+      );
       expect(onChange).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
## Summary
Reduce `act(...)` warning noise in `ColorPresetControl` test cluster for #1176.

## Changes
- Updated `src/features/settings/components/__tests__/ColorPresetControl.spec.tsx`
- Replaced click interactions from `userEvent` to deterministic `fireEvent`
- Added test-only no-ripple theme (`disableRipple`, `disableTouchRipple`)
- Added `renderWithNoRipple(...)` helper and routed renders through it
- Kept rerender flows wrapped in `ThemeProvider` to preserve the same render context
- Removed unnecessary async test signatures after interaction simplification

## Why
`ColorPresetControl` tests emitted repeated MUI Radio/ButtonBase/TouchRipple transition updates as `act(...)` warnings. This change isolates those side effects in tests without changing production behavior.

## Verification
- Targeted:
  - `npx vitest run src/features/settings/components/__tests__/ColorPresetControl.spec.tsx --reporter=verbose --no-file-parallelism`
  - `before_warning_blocks=38`
  - `after_warning_blocks=0`
- Full checks:
  - `npm run typecheck` ✅
  - `npm run lint` ✅
  - `npm run test` ✅

## Notes
- Test-only change
- Production code unchanged
