### PR TITLE
fix: fallback handoff select fields when SP schema read is unauthorized

### DIFF
--- a/src/features/handoff/__tests__/handoffApi.spec.ts
+++ b/src/features/handoff/__tests__/handoffApi.spec.ts
@@ -200,6 +200,23 @@ describe('HandoffApi', () => {
 
       expect(records).toEqual([]);
     });
+
+    it('フィールド一覧取得が権限エラーでも fallback select で継続する', async () => {
+      const items = [createSpItem({ Id: 99, Title: 'fallback' })];
+      mockSP.getListFieldInternalNames.mockRejectedValueOnce(
+        new Error('Attempted to perform an unauthorized operation.')
+      );
+      mockSP.spFetch.mockResolvedValueOnce(mockResponse({ value: items }));
+
+      const api = createHandoffApi(mockSP as never);
+      const records = await api.getHandoffRecords('today', 'all');
+
+      expect(records).toHaveLength(1);
+      expect(records[0].id).toBe(99);
+      expect(mockSP.spFetch).toHaveBeenCalledTimes(1);
+      const queryPath = String(mockSP.spFetch.mock.calls[0][0]);
+      expect(queryPath).toContain('$select=');
+    });
   });
 
   // ─── キャッシュ ─────────────────────────────────────────
@@ -376,6 +393,26 @@ describe('HandoffApi', () => {
       await vi.runAllTimersAsync();
 
       await expect(promise).rejects.toThrow('申し送り記録の更新に失敗しました');
+    });
+
+    it('更新後再取得のフィールド一覧取得が権限エラーでも fallback select で再取得できる', async () => {
+      const patchResponse = mockResponse({}, 200);
+      const updatedItem = createSpItem({ Id: 7, Status: '対応済' });
+      const refetchResponse = mockResponse(updatedItem);
+
+      mockSP.getListFieldInternalNames.mockRejectedValueOnce(
+        new Error('Attempted to perform an unauthorized operation.')
+      );
+      mockSP.spFetch
+        .mockResolvedValueOnce(patchResponse)
+        .mockResolvedValueOnce(refetchResponse);
+
+      const api = createHandoffApi(mockSP as never);
+      const record = await api.updateHandoffRecord('7', { status: '対応済' });
+
+      expect(record.id).toBe(7);
+      expect(record.status).toBe('対応済');
+      expect(mockSP.spFetch).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/src/features/handoff/handoffApi.ts
+++ b/src/features/handoff/handoffApi.ts
@@ -55,6 +55,25 @@ class HandoffApi {
   }
 
   /**
+   * Resolve $select fields for handoff list.
+   * Falls back to static safe fields when list schema introspection is blocked
+   * (e.g. account has item read permission but no schema read permission).
+   */
+  private async resolveSelectFields(context: string): Promise<string> {
+    try {
+      const existingFields = await this.sp.getListFieldInternalNames(handoffConfig.listTitle);
+      return buildHandoffSelectFields(Array.from(existingFields)).join(',');
+    } catch (error) {
+      auditLog.warn('handoff', 'api.select_fields_fallback', {
+        context,
+        listTitle: handoffConfig.listTitle,
+        error: toErrorMessage(error),
+      });
+      return buildHandoffSelectFields().join(',');
+    }
+  }
+
+  /**
    * エラーリトライ機能付きの SP クライアント呼び出し
    */
   private async callWithRetry<T>(
@@ -136,9 +155,7 @@ class HandoffApi {
       }
 
       // 🔥 動的フィールド取得：テナント差分に完全対応
-      const existingFields = await this.sp.getListFieldInternalNames(handoffConfig.listTitle);
-      const selectArray = buildHandoffSelectFields(Array.from(existingFields));
-      const selectFields = selectArray.join(',');
+      const selectFields = await this.resolveSelectFields('getHandoffRecords');
       let query = `?$select=${selectFields}&$orderby=CreatedAt desc`;
 
       if (filterQuery) {
@@ -247,9 +264,7 @@ class HandoffApi {
       });
 
       // 更新後のデータを取得
-      const existingFields = await this.sp.getListFieldInternalNames(handoffConfig.listTitle);
-      const selectArray = buildHandoffSelectFields(Array.from(existingFields));
-      const selectFields = selectArray.join(',');
+      const selectFields = await this.resolveSelectFields('updateHandoffRecord');
       const response = await this.sp.spFetch(
         `lists/getbytitle('${handoffConfig.listTitle}')/items(${id})?$select=${selectFields}`
       );
@@ -334,9 +349,7 @@ class HandoffApi {
         filterQuery += ` and TimeBand eq '${timeFilter}'`;
       }
 
-      const existingFields = await this.sp.getListFieldInternalNames(handoffConfig.listTitle);
-      const selectArray = buildHandoffSelectFields(Array.from(existingFields));
-      const selectFields = selectArray.join(',');
+      const selectFields = await this.resolveSelectFields('getUserHandoffRecords');
       const query = `?$select=${selectFields}&$filter=${filterQuery}&$orderby=CreatedAt desc`;
 
       const response = await this.sp.spFetch(`lists/getbytitle('${handoffConfig.listTitle}')/items${query}`);
@@ -358,9 +371,7 @@ class HandoffApi {
   async getMeetingHandoffRecords(meetingSessionKey: string): Promise<HandoffRecord[]> {
     try {
       const filterQuery = `MeetingSessionKey eq '${meetingSessionKey}'`;
-      const existingFields = await this.sp.getListFieldInternalNames(handoffConfig.listTitle);
-      const selectArray = buildHandoffSelectFields(Array.from(existingFields));
-      const selectFields = selectArray.join(',');
+      const selectFields = await this.resolveSelectFields('getMeetingHandoffRecords');
       const query = `?$select=${selectFields}&$filter=${filterQuery}&$orderby=CreatedAt desc`;
 
       const response = await this.sp.spFetch(`lists/getbytitle('${handoffConfig.listTitle}')/items${query}`);
@@ -430,9 +441,7 @@ class HandoffApi {
 
       const filterQuery = `CreatedAt ge '${cutoff.toISOString()}'`;
 
-      const existingFields = await this.sp.getListFieldInternalNames(handoffConfig.listTitle);
-      const selectArray = buildHandoffSelectFields(Array.from(existingFields));
-      const selectFields = selectArray.join(',');
+      const selectFields = await this.resolveSelectFields('getHandoffRecordsForAnalysis');
       const query = `?$select=${selectFields}&$filter=${filterQuery}&$orderby=CreatedAt desc&$top=5000`;
 
       const response = await this.sp.spFetch(`lists/getbytitle('${handoffConfig.listTitle}')/items${query}`);


### PR DESCRIPTION
## Summary
Fixes `/handoff-timeline` failing for some signed-in accounts with SharePoint error `Attempted to perform an unauthorized operation.`

## Cause
Handoff API always called `getListFieldInternalNames()` first. Accounts that can read items but cannot read list schema (`/fields`) failed before data fetch.

## Changes
- Add `resolveSelectFields()` in `handoffApi`.
- If schema read fails, fallback to static safe fields (`buildHandoffSelectFields()` fallback) and continue.
- Apply the fallback path to all handoff fetch/read-after-write flows.
- Add unit tests for unauthorized schema-read fallback.

## Verification
- `npm run -s test -- src/features/handoff/__tests__/handoffApi.spec.ts` ✅
- `npm run -s typecheck` ✅
- `npm run -s lint` ✅

## Impact
- `/handoff-timeline` can open even when schema read is blocked for that account.
- No production behavior change for accounts with full permissions.
