### PR TITLE
test: reduce act warnings in meeting guide page route tests (#1176)

### DIFF
--- a/src/pages/__tests__/MeetingGuidePage.test.tsx
+++ b/src/pages/__tests__/MeetingGuidePage.test.tsx
@@ -5,10 +5,51 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import MeetingGuidePage from '../MeetingGuidePage';
 
-const theme = createTheme();
+vi.mock('@/features/handoff/HandoffSummaryForMeeting', () => ({
+  default: () => <div data-testid="handoff-summary-stub" />,
+}));
+
+vi.mock('@/features/handoff/RegulatoryFindingsForMeeting', () => ({
+  default: () => <div data-testid="regulatory-findings-stub" />,
+}));
+
+vi.mock('@/features/meeting/useCurrentMeeting', () => ({
+  useCurrentMeeting: vi.fn((kind: 'morning' | 'evening') => ({
+    sessionKey: `2026-03-21_${kind}`,
+    session: {
+      sessionKey: `2026-03-21_${kind}`,
+      createdAt: '2026-03-21T09:00:00.000Z',
+      updatedAt: '2026-03-21T09:30:00.000Z',
+    },
+    steps: [
+      { id: `${kind}-1`, title: 'Safety HUD 確認', completed: false },
+      { id: `${kind}-2`, title: '引き継ぎ要点確認', completed: true },
+    ],
+    stats: {
+      completedCount: 1,
+      totalCount: 2,
+    },
+    toggleStep: vi.fn(async () => {}),
+    priorityUsers: [],
+    handoffAlert: null,
+    loading: false,
+    error: null,
+  })),
+}));
+
+const theme = createTheme({
+  components: {
+    MuiButtonBase: {
+      defaultProps: {
+        disableRipple: true,
+        disableTouchRipple: true,
+      },
+    },
+  },
+});
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
 });


### PR DESCRIPTION
## Summary
- target: `src/pages/__tests__/MeetingGuidePage.test.tsx` (test-only)
- isolated async side-effect sections as test doubles:
  - `HandoffSummaryForMeeting`
  - `RegulatoryFindingsForMeeting`
- mocked `useCurrentMeeting` with deterministic data to keep tab/checklist assertions stable
- applied no-ripple test theme (`MuiButtonBase` disableRipple + disableTouchRipple)
- production code unchanged

## Warning count (targeted)
- before: `21` (`not wrapped in act(...)`)
- after: `0`

## Verification
- `npx vitest run src/pages/__tests__/MeetingGuidePage.test.tsx --reporter=verbose --no-file-parallelism` ✅
- `npm run typecheck` ✅
- `npm run lint` ✅
