### PR TITLE
test: reduce act warnings in app shell theme toggle tests (#1176)

### DIFF
--- a/tests/unit/AppShell.theme-toggle.spec.tsx
+++ b/tests/unit/AppShell.theme-toggle.spec.tsx
@@ -1,5 +1,4 @@
-import { screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { fireEvent, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
 import { SettingsDialog } from '@/features/settings/SettingsDialog';
@@ -14,8 +13,7 @@ import { renderWithAppProviders } from '../helpers/renderWithAppProviders';
  * SettingsDialog 内の Switch に移行されたため、テスト対象を更新。
  */
 describe('SettingsDialog theme toggle accessibility', () => {
-  it('toggles dark mode when the theme switch is clicked', async () => {
-    const user = userEvent.setup();
+  it('toggles dark mode when the theme switch is clicked', () => {
     const onClose = () => {};
 
     renderWithAppProviders(
@@ -35,11 +33,11 @@ describe('SettingsDialog theme toggle accessibility', () => {
     expect(themeSwitch).not.toBeChecked();
 
     // ダークモードに切り替え
-    await user.click(themeSwitch);
+    fireEvent.click(themeSwitch);
     expect(themeSwitch).toBeChecked();
 
     // ライトモードに戻す
-    await user.click(themeSwitch);
+    fireEvent.click(themeSwitch);
     expect(themeSwitch).not.toBeChecked();
   });
 });


### PR DESCRIPTION
## Summary
- switch AppShell theme-toggle unit test interactions from userEvent to fireEvent
- keep the same assertions while avoiding async pointer/ripple update noise from MUI Switch internals
- retain test intent (light/dark toggle state contract) with test-only changes

## Scope
- test-only changes in one file
- no production code changes

## Validation
- targeted rescan (before): tests/unit/AppShell.theme-toggle.spec.tsx -> 11 warning blocks
- targeted run (after): 0 warning blocks
- npx vitest run tests/unit/AppShell.theme-toggle.spec.tsx --reporter=verbose --no-file-parallelism
- npm run typecheck
- npm run lint
