### PR TITLE
test: reduce act warnings in daily table route test (#1176)

### DIFF
--- a/tests/rtl/daily.table-route.test.tsx
+++ b/tests/rtl/daily.table-route.test.tsx
@@ -6,6 +6,47 @@ import { describe, expect, it, vi } from 'vitest';
 import TableDailyRecordPage from '@/features/daily/table/TableDailyRecordPage';
 import { TESTIDS } from '@/testids';
 
+vi.mock('@/features/daily/table/useTableDailyRecordViewModel', () => ({
+  useTableDailyRecordViewModel: () => ({
+    open: true,
+    title: '一覧形式ケース記録',
+    backTo: '/today',
+    testId: TESTIDS['daily-table-record-page'],
+    onClose: vi.fn(),
+    onSave: vi.fn(async () => {}),
+  }),
+}));
+
+vi.mock('@/features/daily/hooks/useTableDailyRecordForm', () => ({
+  useTableDailyRecordForm: () =>
+    ({
+      header: {
+        formData: {
+          date: '2026-03-23',
+          reporter: { name: '', role: '生活支援員' },
+        },
+        setFormData: vi.fn(),
+      },
+      picker: {
+        selectedUserIds: [],
+      },
+      table: {
+        unsentRowCount: 0,
+        showUnsentOnly: false,
+        setShowUnsentOnly: vi.fn(),
+      },
+      draft: {
+        hasDraft: false,
+        draftSavedAt: null,
+        handleSaveDraft: vi.fn(),
+      },
+      actions: {
+        saving: false,
+        handleSave: vi.fn(async () => {}),
+      },
+    }) as unknown,
+}));
+
 vi.mock('@/features/daily/forms/TableDailyRecordForm', () => ({
   TableDailyRecordForm: () => (
     <div data-testid={TESTIDS['daily-table-record-form']}>mock-table-form</div>


### PR DESCRIPTION
## Summary
- isolate route test from form/viewmodel hook side effects by mocking `useTableDailyRecordViewModel` and `useTableDailyRecordForm`
- keep the route contract assertion unchanged (`/daily/table` renders table form)
- remove `act(...)` warning noise without touching production code

## Scope
- test-only changes in one file
- no production code changes

## Validation
- targeted before: 3 warning blocks (`Warning: An update to ... not wrapped in act`)
- targeted after: 0 warning blocks
- npx vitest run tests/rtl/daily.table-route.test.tsx --reporter=verbose --no-file-parallelism
- npm run typecheck
- npm run lint
