### PR TITLE
test: reduce act warnings in useStaffForm tests (#1176)

### DIFF
--- a/src/features/staff/__tests__/useStaffForm.spec.ts
+++ b/src/features/staff/__tests__/useStaffForm.spec.ts
@@ -483,7 +483,7 @@ describe('useStaffForm', () => {
       expect(onClose).not.toHaveBeenCalled();
     });
 
-    it('calls onClose when confirm dialog onConfirm is invoked', () => {
+    it('calls onClose when confirm dialog onConfirm is invoked', async () => {
       const onClose = vi.fn();
       const { result } = renderCreate({ onClose });
       act(() => {
@@ -493,8 +493,8 @@ describe('useStaffForm', () => {
         result.current.handleClose();
       });
       // Simulate user clicking confirm in the dialog
-      act(() => {
-        result.current.closeConfirmDialog.onConfirm();
+      await act(async () => {
+        await result.current.closeConfirmDialog.onConfirm();
       });
       expect(onClose).toHaveBeenCalledTimes(1);
     });


### PR DESCRIPTION
## Summary
- make confirm-dialog assertion in `useStaffForm` test async-aware by awaiting `onConfirm` inside `act(...)`
- keep the behavioral contract intact (`onClose` is called when confirm is executed)
- remove React act warning noise from async confirm-dialog state updates

## Scope
- test-only changes in one file
- no production code changes

## Validation
- targeted before: 2 warning blocks (`Warning: An update to ... not wrapped in act`)
- targeted after: 0 warning blocks
- npx vitest run src/features/staff/__tests__/useStaffForm.spec.ts --reporter=verbose --no-file-parallelism
- npm run typecheck
- npm run lint
