### PR TITLE
test: reduce act warnings in schedules week route state test (#1176)

### DIFF
--- a/tests/rtl/schedules-week-route-state.test.tsx
+++ b/tests/rtl/schedules-week-route-state.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { describe, expect, it } from 'vitest';
@@ -60,9 +60,8 @@ describe('useWeekPageRouteState', () => {
   });
 
   it('clears q/cat params when filter is reset', async () => {
-    const user = userEvent.setup();
     renderWithRoute('/schedules/week?date=2026-02-09&cat=User&q=foo');
-    await user.click(screen.getByTestId('clear-filter'));
+    fireEvent.click(screen.getByTestId('clear-filter'));
     await waitFor(() => {
       const search = screen.getByTestId('search').textContent ?? '';
       expect(search).toBe('?date=2026-02-09');


### PR DESCRIPTION
## Summary
- replace `userEvent.click` with `fireEvent.click` in the filter-reset route-state test
- keep route-state contract assertion unchanged (`?date=...` remains and `q/cat` are removed)
- remove MemoryRouter act-warning noise from URL update path

## Scope
- test-only changes in one file
- no production code changes

## Validation
- targeted before: 1 warning block (`Warning: An update to ... not wrapped in act`)
- targeted after: 0 warning blocks
- npx vitest run tests/rtl/schedules-week-route-state.test.tsx --reporter=verbose --no-file-parallelism
- npm run typecheck
- npm run lint
