### PR TITLE
feat(data-source): add banner/store foundation for data source status

### DIFF
--- a/src/app/components/DataSourceBanner.tsx
+++ b/src/app/components/DataSourceBanner.tsx
@@ -1,0 +1,116 @@
+/**
+ * DataSourceBanner — グローバルデータ状態バナー（軽量版 v2）
+ *
+ * 開発環境・本番環境ともに、一部データがフォールバックで
+ * 動作している可能性がある場合にさりげなく表示する。
+ *
+ * ## 表示条件
+ * - isDev() === true（開発環境）→ 常に表示
+ * - isDemoModeEnabled() === true（デモモード）→ 常に表示
+ * - それ以外 → 非表示（本番完全運用時）
+ *
+ * ## 設計方針
+ * - 既存フックを一切変更しない
+ * - env.ts の関数のみで判断
+ * - ユーザーは×で閉じられる
+ */
+import React, { useCallback, useState } from 'react';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import Typography from '@mui/material/Typography';
+import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import { getAppConfig, isDemoModeEnabled } from '@/lib/env';
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export const DataSourceBanner: React.FC = () => {
+  const { isDev } = getAppConfig();
+  const isDemo = isDemoModeEnabled();
+  const [dismissed, setDismissed] = useState(false);
+
+  const handleDismiss = useCallback(() => {
+    setDismissed(true);
+  }, []);
+
+  // 本番完全運用 & デモモードOFF → 非表示
+  const shouldShow = (isDev || isDemo) && !dismissed;
+  if (!shouldShow) return null;
+
+  const message = isDemo
+    ? '一部サンプルデータを表示しています'
+    : '通信状況によりサンプル表示に切り替わる場合があります';
+
+  return (
+    <Box
+      data-testid="data-source-banner"
+      role="status"
+      aria-live="polite"
+      sx={{
+        position: 'relative',
+        zIndex: 1,
+        mx: -2,
+        mt: -2,
+        mb: 1,
+      }}
+    >
+      <Alert
+        severity="info"
+        icon={<InfoOutlinedIcon sx={{ fontSize: 16 }} />}
+        action={
+          <IconButton
+            size="small"
+            aria-label="バナーを閉じる"
+            onClick={handleDismiss}
+            color="inherit"
+          >
+            <CloseRoundedIcon sx={{ fontSize: 16 }} />
+          </IconButton>
+        }
+        sx={{
+          py: 0,
+          px: 2,
+          borderRadius: 0,
+          '& .MuiAlert-message': {
+            py: 0.5,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 0.5,
+          },
+          '& .MuiAlert-icon': {
+            py: 0.5,
+            mr: 0,
+          },
+          '& .MuiAlert-action': {
+            py: 0,
+            mr: 0,
+          },
+          backgroundColor: (theme) =>
+            theme.palette.mode === 'dark'
+              ? 'rgba(41, 182, 246, 0.08)'
+              : 'rgba(41, 182, 246, 0.06)',
+          borderBottom: (theme) =>
+            `1px solid ${
+              theme.palette.mode === 'dark'
+                ? 'rgba(41, 182, 246, 0.2)'
+                : 'rgba(41, 182, 246, 0.15)'
+            }`,
+        }}
+      >
+        <Typography
+          variant="caption"
+          sx={{
+            fontSize: '0.75rem',
+            fontWeight: 500,
+            color: 'text.secondary',
+          }}
+        >
+          {message}
+        </Typography>
+      </Alert>
+    </Box>
+  );
+};
+
+export default DataSourceBanner;

--- a/src/stores/__tests__/useDataSourceStore.spec.ts
+++ b/src/stores/__tests__/useDataSourceStore.spec.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  useDataSourceStore,
+  selectHasFallback,
+  selectFallbackSources,
+  selectSummary,
+} from '../useDataSourceStore';
+
+describe('useDataSourceStore', () => {
+  beforeEach(() => {
+    useDataSourceStore.getState().clearAll();
+  });
+
+  it('starts with empty sources', () => {
+    const state = useDataSourceStore.getState();
+    expect(state.sources).toEqual({});
+    expect(selectHasFallback(state)).toBe(false);
+  });
+
+  it('report() adds a data source entry with timestamp', () => {
+    const { report } = useDataSourceStore.getState();
+
+    report('holidays', { label: '祝日マスタ', status: 'live' });
+
+    const state = useDataSourceStore.getState();
+    expect(state.sources.holidays).toBeDefined();
+    expect(state.sources.holidays.label).toBe('祝日マスタ');
+    expect(state.sources.holidays.status).toBe('live');
+    expect(state.sources.holidays.updatedAt).toBeTruthy();
+  });
+
+  it('report() updates existing entry', () => {
+    const { report } = useDataSourceStore.getState();
+
+    report('holidays', { label: '祝日マスタ', status: 'live' });
+    report('holidays', { label: '祝日マスタ', status: 'fallback', reason: '通信エラー' });
+
+    const state = useDataSourceStore.getState();
+    expect(state.sources.holidays.status).toBe('fallback');
+    expect(state.sources.holidays.reason).toBe('通信エラー');
+  });
+
+  it('selectHasFallback returns true when any source is fallback', () => {
+    const { report } = useDataSourceStore.getState();
+
+    report('holidays', { label: '祝日マスタ', status: 'live' });
+    report('schedules', { label: 'スケジュール', status: 'fallback' });
+
+    expect(selectHasFallback(useDataSourceStore.getState())).toBe(true);
+  });
+
+  it('selectHasFallback returns false when all sources are live', () => {
+    const { report } = useDataSourceStore.getState();
+
+    report('holidays', { label: '祝日マスタ', status: 'live' });
+    report('schedules', { label: 'スケジュール', status: 'live' });
+
+    expect(selectHasFallback(useDataSourceStore.getState())).toBe(false);
+  });
+
+  it('selectFallbackSources returns only fallback entries', () => {
+    const { report } = useDataSourceStore.getState();
+
+    report('holidays', { label: '祝日マスタ', status: 'live' });
+    report('schedules', { label: 'スケジュール', status: 'fallback' });
+    report('users', { label: '利用者マスタ', status: 'fallback', reason: 'デモデータ' });
+
+    const fallbacks = selectFallbackSources(useDataSourceStore.getState());
+    expect(fallbacks).toHaveLength(2);
+    expect(fallbacks.map((f) => f.label)).toEqual(
+      expect.arrayContaining(['スケジュール', '利用者マスタ']),
+    );
+  });
+
+  it('selectSummary provides correct counts', () => {
+    const { report } = useDataSourceStore.getState();
+
+    report('holidays', { label: '祝日マスタ', status: 'live' });
+    report('schedules', { label: 'スケジュール', status: 'fallback' });
+    report('users', { label: '利用者マスタ', status: 'loading' });
+    report('staff', { label: '職員', status: 'error' });
+
+    const summary = selectSummary(useDataSourceStore.getState());
+    expect(summary).toEqual({
+      total: 4,
+      live: 1,
+      fallback: 1,
+      loading: 1,
+      error: 1,
+    });
+  });
+
+  it('clear() removes a specific source', () => {
+    const { report, clear } = useDataSourceStore.getState();
+
+    report('holidays', { label: '祝日マスタ', status: 'live' });
+    report('schedules', { label: 'スケジュール', status: 'fallback' });
+
+    clear('holidays');
+
+    const state = useDataSourceStore.getState();
+    expect(state.sources.holidays).toBeUndefined();
+    expect(state.sources.schedules).toBeDefined();
+  });
+
+  it('clearAll() removes all sources', () => {
+    const { report, clearAll } = useDataSourceStore.getState();
+
+    report('holidays', { label: '祝日マスタ', status: 'live' });
+    report('schedules', { label: 'スケジュール', status: 'fallback' });
+
+    clearAll();
+
+    const state = useDataSourceStore.getState();
+    expect(state.sources).toEqual({});
+  });
+});

--- a/src/stores/useDataSourceStore.ts
+++ b/src/stores/useDataSourceStore.ts
@@ -1,0 +1,89 @@
+/**
+ * useDataSourceStore — 各データソースの状態を一元管理する Zustand ストア
+ *
+ * アプリ全体で「今どのデータソースが本番 / デモ / エラー」かを追跡し、
+ * DataSourceBanner 等の UI で表示するための状態基盤。
+ *
+ * ## 設計方針
+ * - report() をデータ取得フックから呼ぶだけで状態が更新される
+ * - 各データソースは一意の key で識別（例: 'holidays', 'schedules', 'users'）
+ * - 'live' = 本番 SP データ、'fallback' = デモ/静的フォールバック
+ */
+import { create } from 'zustand';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type DataSourceStatus = 'live' | 'fallback' | 'loading' | 'error';
+
+export interface DataSourceEntry {
+  /** 表示用ラベル (例: '祝日マスタ', 'スケジュール') */
+  label: string;
+  /** 現在の状態 */
+  status: DataSourceStatus;
+  /** 最終更新時刻 (ISO) */
+  updatedAt: string;
+  /** フォールバック時の理由（任意） */
+  reason?: string;
+}
+
+interface DataSourceState {
+  /** key → entry マップ */
+  sources: Record<string, DataSourceEntry>;
+
+  /** データソースの状態を報告する */
+  report: (key: string, entry: Omit<DataSourceEntry, 'updatedAt'>) => void;
+
+  /** 特定のデータソースをクリア */
+  clear: (key: string) => void;
+
+  /** 全クリア */
+  clearAll: () => void;
+}
+
+// ─── Store ────────────────────────────────────────────────────────────────────
+
+export const useDataSourceStore = create<DataSourceState>((set) => ({
+  sources: {},
+
+  report: (key, entry) =>
+    set((state) => ({
+      sources: {
+        ...state.sources,
+        [key]: {
+          ...entry,
+          updatedAt: new Date().toISOString(),
+        },
+      },
+    })),
+
+  clear: (key) =>
+    set((state) => {
+      const next = { ...state.sources };
+      delete next[key];
+      return { sources: next };
+    }),
+
+  clearAll: () => set({ sources: {} }),
+}));
+
+// ─── Derived selectors ───────────────────────────────────────────────────────
+
+/** fallback 状態のデータソースがあるか */
+export const selectHasFallback = (state: DataSourceState): boolean =>
+  Object.values(state.sources).some((s) => s.status === 'fallback');
+
+/** fallback 状態のデータソース一覧 */
+export const selectFallbackSources = (state: DataSourceState): DataSourceEntry[] =>
+  Object.values(state.sources).filter((s) => s.status === 'fallback');
+
+/** 全データソースの件数サマリ */
+export const selectSummary = (state: DataSourceState) => {
+  const entries = Object.values(state.sources);
+  return {
+    total: entries.length,
+    live: entries.filter((s) => s.status === 'live').length,
+    fallback: entries.filter((s) => s.status === 'fallback').length,
+    loading: entries.filter((s) => s.status === 'loading').length,
+    error: entries.filter((s) => s.status === 'error').length,
+  };
+};


### PR DESCRIPTION
## Summary
- Add useDataSourceStore (Zustand) for tracking data source status (live/fallback/loading/error)
- Add dismissible DataSourceBanner component for dev/demo environments
- Add unit tests for all store actions and selectors (9 tests)

## Scope
This PR adds the **foundation only**.
It does not yet wire the banner into AppShell or connect real data hooks via report().

## Why
Keeps the first step small and reviewable, so UI integration and real source reporting can follow in separate PRs.

## Files
| File | Description |
|------|-------------|
| src/stores/useDataSourceStore.ts | Zustand store with report/clear/clearAll + 3 derived selectors |
| src/app/components/DataSourceBanner.tsx | Dismissible info banner (dev/demo only) |
| src/stores/__tests__/useDataSourceStore.spec.ts | 9 unit tests covering all store behavior |

## Checklist
- [x] TypeCheck passes
- [x] Lint passes
- [x] Unit tests pass (9/9)
- [x] Pre-commit hooks pass
