### PR TITLE
ci: auto-create issue on act warning regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
+      issues: write
     env:
       VITE_MSAL_CLIENT_ID: dummy-client-id
       VITE_MSAL_TENANT_ID: dummy-tenant-id
@@ -81,6 +82,19 @@ jobs:
           npm run test:ci 2>&1 | tee /tmp/vitest-ci.log
           node scripts/ci/check-act-warnings.mjs /tmp/vitest-ci.log --json --json-output /tmp/act-warnings-ci.json
           echo "✅ Tests completed successfully"
+
+      - name: Create/Update act warning regression issue
+        if: ${{ failure() }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/ci/create-act-warning-issue.mjs \
+            --summary /tmp/act-warnings-ci.json \
+            --repo "${{ github.repository }}" \
+            --workflow "${{ github.workflow }}" \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --branch "${{ github.ref_name }}" \
+            --sha "${{ github.sha }}"
       
       - name: Summary
         if: always()

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -84,6 +84,9 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      issues: write
     needs: [lint, typecheck]
     if: |
       always() &&
@@ -104,6 +107,18 @@ jobs:
           set -o pipefail
           TZ=Asia/Tokyo npm run test:ci 2>&1 | tee /tmp/vitest-smoke.log
           node scripts/ci/check-act-warnings.mjs /tmp/vitest-smoke.log --json --json-output /tmp/act-warnings-smoke.json
+      - name: Create/Update act warning regression issue
+        if: ${{ failure() }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/ci/create-act-warning-issue.mjs \
+            --summary /tmp/act-warnings-smoke.json \
+            --repo "${{ github.repository }}" \
+            --workflow "${{ github.workflow }}" \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --branch "${{ github.ref_name }}" \
+            --sha "${{ github.sha }}"
       - name: Upload test coverage on failure
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,9 @@ jobs:
       ci_full: ${{ steps.changes.outputs.ci_full }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
+      issues: write
     env:
       # Phase 2: E2E feature flag guards
       E2E_FEATURE_SCHEDULE_NAV: "1"
@@ -105,12 +108,36 @@ jobs:
           set -o pipefail
           npm run test:ci:required 2>&1 | tee /tmp/vitest-required.log
           node scripts/ci/check-act-warnings.mjs /tmp/vitest-required.log --json --json-output /tmp/act-warnings-required.json
+      - name: Create/Update act warning regression issue (PR)
+        if: ${{ failure() && github.event_name == 'pull_request' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/ci/create-act-warning-issue.mjs \
+            --summary /tmp/act-warnings-required.json \
+            --repo "${{ github.repository }}" \
+            --workflow "${{ github.workflow }}" \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --branch "${{ github.ref_name }}" \
+            --sha "${{ github.sha }}"
       - name: Test (coverage)
         if: ${{ github.event_name != 'pull_request' }}
         run: |
           set -o pipefail
           npm run test:coverage -- --reporter=default 2>&1 | tee /tmp/vitest-coverage.log
           node scripts/ci/check-act-warnings.mjs /tmp/vitest-coverage.log --json --json-output /tmp/act-warnings-coverage.json
+      - name: Create/Update act warning regression issue (coverage)
+        if: ${{ failure() && github.event_name != 'pull_request' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/ci/create-act-warning-issue.mjs \
+            --summary /tmp/act-warnings-coverage.json \
+            --repo "${{ github.repository }}" \
+            --workflow "${{ github.workflow }}" \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --branch "${{ github.ref_name }}" \
+            --sha "${{ github.sha }}"
       - name: Free port 5173 (best-effort, lsof OR fuser)
         if: github.event_name == 'workflow_dispatch' || (github.ref == 'refs/heads/main' && steps.changes.outputs.playwright == 'true')
         run: |
@@ -236,6 +263,9 @@ jobs:
     if: ${{ github.event_name == 'pull_request' && needs.quality.outputs.ci_full == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
+      issues: write
     env:
       E2E_FEATURE_SCHEDULE_NAV: "1"
       E2E_FEATURE_SCHEDULE_ACCEPTANCE: "1"
@@ -255,6 +285,18 @@ jobs:
           set -o pipefail
           npm run test:ci 2>&1 | tee /tmp/vitest-full.log
           node scripts/ci/check-act-warnings.mjs /tmp/vitest-full.log --json --json-output /tmp/act-warnings-full.json
+      - name: Create/Update act warning regression issue (ci full)
+        if: ${{ failure() }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/ci/create-act-warning-issue.mjs \
+            --summary /tmp/act-warnings-full.json \
+            --repo "${{ github.repository }}" \
+            --workflow "${{ github.workflow }}" \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --branch "${{ github.ref_name }}" \
+            --sha "${{ github.sha }}"
 
   canary:
     runs-on: ubuntu-latest

--- a/scripts/ci/create-act-warning-issue.mjs
+++ b/scripts/ci/create-act-warning-issue.mjs
@@ -1,0 +1,311 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+const ISSUE_TITLE = "CI: act(...) warning regression detected";
+const ISSUE_MARKER = "<!-- act-warning-regression -->";
+const SEARCH_API_BASE = "https://api.github.com";
+
+function printUsage() {
+  console.error(
+    [
+      "Usage:",
+      "  node scripts/ci/create-act-warning-issue.mjs --summary <path> [--repo <owner/repo>]",
+      "    [--workflow <name>] [--run-url <url>] [--branch <name>] [--sha <sha>]",
+    ].join("\n"),
+  );
+}
+
+function parseArgs(argv) {
+  const options = {
+    branch: process.env.GITHUB_REF_NAME ?? "",
+    repo: process.env.GITHUB_REPOSITORY ?? "",
+    runUrl:
+      process.env.GITHUB_SERVER_URL && process.env.GITHUB_REPOSITORY && process.env.GITHUB_RUN_ID
+        ? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
+        : "",
+    sha: process.env.GITHUB_SHA ?? "",
+    summaryPath: "",
+    workflow: process.env.GITHUB_WORKFLOW ?? "",
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--summary") {
+      options.summaryPath = argv[i + 1] ?? "";
+      i += 1;
+      continue;
+    }
+    if (arg === "--repo") {
+      options.repo = argv[i + 1] ?? "";
+      i += 1;
+      continue;
+    }
+    if (arg === "--workflow") {
+      options.workflow = argv[i + 1] ?? "";
+      i += 1;
+      continue;
+    }
+    if (arg === "--run-url") {
+      options.runUrl = argv[i + 1] ?? "";
+      i += 1;
+      continue;
+    }
+    if (arg === "--branch") {
+      options.branch = argv[i + 1] ?? "";
+      i += 1;
+      continue;
+    }
+    if (arg === "--sha") {
+      options.sha = argv[i + 1] ?? "";
+      i += 1;
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      printUsage();
+      process.exit(0);
+    }
+  }
+
+  return options;
+}
+
+function parseRepo(repo) {
+  const [owner, name] = repo.split("/");
+  if (!owner || !name) return null;
+  return { name, owner };
+}
+
+function toSortedCounts(countsByFile) {
+  return Object.entries(countsByFile ?? {})
+    .map(([file, count]) => ({
+      count: Number.isFinite(Number(count)) ? Number(count) : 0,
+      file,
+    }))
+    .sort((a, b) => {
+      if (b.count !== a.count) return b.count - a.count;
+      return a.file.localeCompare(b.file);
+    });
+}
+
+function buildCountsMarkdown(summary) {
+  const entries = toSortedCounts(summary.countsByFile);
+  if (entries.length === 0) return "- (none)";
+
+  return [
+    "| Count | File |",
+    "| ---: | --- |",
+    ...entries.map((entry) => `| ${entry.count} | \`${entry.file}\` |`),
+  ].join("\n");
+}
+
+function buildMetadataBlock(meta) {
+  const lines = [];
+  lines.push(`- detectedAt: \`${new Date().toISOString()}\``);
+  lines.push(`- workflow: \`${meta.workflow || "unknown"}\``);
+  lines.push(`- run: ${meta.runUrl || "(missing run url)"}`);
+  lines.push(`- branch: \`${meta.branch || "unknown"}\``);
+  lines.push(`- sha: \`${meta.sha || "unknown"}\``);
+  return lines.join("\n");
+}
+
+function buildSummaryBlock(summary) {
+  return [
+    "- totalWarnings: **" + summary.totalWarnings + "**",
+    "- affectedFiles: **" + summary.affectedFiles + "**",
+    "- maxWarningsFile: **" + (summary.maxWarningsFile ?? "none") + "**",
+    "- maxWarningsPerFile: **" + summary.maxWarningsPerFile + "**",
+  ].join("\n");
+}
+
+function buildIssueBody(summary, meta) {
+  return [
+    ISSUE_MARKER,
+    "",
+    "## CI detected `act(...)` warning regression",
+    "",
+    buildMetadataBlock(meta),
+    "",
+    "### Summary",
+    buildSummaryBlock(summary),
+    "",
+    "### countsByFile",
+    buildCountsMarkdown(summary),
+    "",
+    "### Response Rule (fixed)",
+    "- `1 file = 1 PR`",
+    "- `test-only`",
+    "- `production code 無変更`",
+  ].join("\n");
+}
+
+function buildIssueComment(summary, meta) {
+  return [
+    "## Regression detected again",
+    "",
+    buildMetadataBlock(meta),
+    "",
+    "### Summary",
+    buildSummaryBlock(summary),
+    "",
+    "### countsByFile",
+    buildCountsMarkdown(summary),
+    "",
+    "### Response Rule (fixed)",
+    "- `1 file = 1 PR`",
+    "- `test-only`",
+    "- `production code 無変更`",
+  ].join("\n");
+}
+
+async function githubRequest({ token, method, path, body }) {
+  const response = await fetch(`${SEARCH_API_BASE}${path}`, {
+    body: body ? JSON.stringify(body) : undefined,
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+    method,
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`${method} ${path} failed: ${response.status} ${response.statusText} ${text}`);
+  }
+
+  if (response.status === 204) return null;
+  return response.json();
+}
+
+async function findOpenIssue({ token, owner, repo }) {
+  const query = `repo:${owner}/${repo} is:issue is:open in:title "${ISSUE_TITLE}"`;
+  const encoded = encodeURIComponent(query);
+  const data = await githubRequest({
+    method: "GET",
+    path: `/search/issues?q=${encoded}&per_page=10&sort=updated&order=desc`,
+    token,
+  });
+
+  const exact = (data.items ?? []).find((item) => item.title === ISSUE_TITLE);
+  return exact ?? null;
+}
+
+async function hasCommentWithRunUrl({ token, owner, repo, issueNumber, runUrl }) {
+  if (!runUrl) return false;
+
+  const comments = await githubRequest({
+    method: "GET",
+    path: `/repos/${owner}/${repo}/issues/${issueNumber}/comments?per_page=100`,
+    token,
+  });
+
+  return (comments ?? []).some((comment) => typeof comment.body === "string" && comment.body.includes(runUrl));
+}
+
+function safeReadJson(path) {
+  try {
+    const raw = fs.readFileSync(path, "utf8");
+    return JSON.parse(raw);
+  } catch (error) {
+    console.error(`[act-warning-issue] failed to read summary JSON: ${path}`);
+    console.error(error instanceof Error ? error.message : String(error));
+    return null;
+  }
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (!opts.summaryPath) {
+    printUsage();
+    process.exit(2);
+  }
+
+  if (!fs.existsSync(opts.summaryPath)) {
+    console.log(`[act-warning-issue] summary file not found, skipping: ${opts.summaryPath}`);
+    process.exit(0);
+  }
+
+  const summary = safeReadJson(opts.summaryPath);
+  if (!summary) process.exit(0);
+
+  const totalWarnings = Number(summary.totalWarnings ?? 0);
+  if (!Number.isFinite(totalWarnings) || totalWarnings <= 0) {
+    console.log("[act-warning-issue] totalWarnings is 0, no issue action needed.");
+    process.exit(0);
+  }
+
+  const repoInfo = parseRepo(opts.repo);
+  if (!repoInfo) {
+    console.log(`[act-warning-issue] invalid repo value: ${opts.repo}`);
+    process.exit(0);
+  }
+
+  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  if (!token) {
+    console.log("[act-warning-issue] missing GITHUB_TOKEN/GH_TOKEN, skipping.");
+    process.exit(0);
+  }
+
+  const meta = {
+    branch: opts.branch,
+    runUrl: opts.runUrl,
+    sha: opts.sha,
+    workflow: opts.workflow,
+  };
+
+  try {
+    const existing = await findOpenIssue({
+      owner: repoInfo.owner,
+      repo: repoInfo.name,
+      token,
+    });
+
+    if (!existing) {
+      const created = await githubRequest({
+        body: {
+          body: buildIssueBody(summary, meta),
+          title: ISSUE_TITLE,
+        },
+        method: "POST",
+        path: `/repos/${repoInfo.owner}/${repoInfo.name}/issues`,
+        token,
+      });
+      console.log(`[act-warning-issue] created issue #${created.number}: ${created.html_url}`);
+      process.exit(0);
+    }
+
+    const duplicatedRun = await hasCommentWithRunUrl({
+      issueNumber: existing.number,
+      owner: repoInfo.owner,
+      repo: repoInfo.name,
+      runUrl: meta.runUrl,
+      token,
+    });
+
+    if (duplicatedRun) {
+      console.log(
+        `[act-warning-issue] existing issue #${existing.number} already has this run URL; skipping comment.`,
+      );
+      process.exit(0);
+    }
+
+    await githubRequest({
+      body: {
+        body: buildIssueComment(summary, meta),
+      },
+      method: "POST",
+      path: `/repos/${repoInfo.owner}/${repoInfo.name}/issues/${existing.number}/comments`,
+      token,
+    });
+    console.log(`[act-warning-issue] appended comment to issue #${existing.number}: ${existing.html_url}`);
+    process.exit(0);
+  } catch (error) {
+    console.error("[act-warning-issue] GitHub API operation failed; not blocking workflow.");
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(0);
+  }
+}
+
+await main();


### PR DESCRIPTION
## Summary
- add `scripts/ci/create-act-warning-issue.mjs`
  - reads `check-act-warnings` JSON summary
  - no-op when `totalWarnings = 0`
  - deduplicates by open issue title: `CI: act(...) warning regression detected`
  - appends comment (instead of creating duplicate) when open issue exists
  - skips duplicate comments for the same run URL
- wire issue automation into CI failure paths after act-warning guard steps:
  - `.github/workflows/test.yml` (`quality`, `quality_extended`)
  - `.github/workflows/smoke.yml` (`vitest` job)
  - `.github/workflows/ci.yml` (`typecheck-and-test` job)
- add `issues: write` permission to jobs that can create/update issues

## Issue payload includes
- detectedAt
- workflow / run URL
- branch / sha
- `totalWarnings`
- `affectedFiles`
- `countsByFile`
- `maxWarningsFile`
- `maxWarningsPerFile`
- fixed response rule (`1 file = 1 PR / test-only / production code 無変更`)

## Validation
- `node --check scripts/ci/create-act-warning-issue.mjs`
- local dry run with `totalWarnings=0` summary -> no-op
- local dry run with `totalWarnings>0` and missing token -> safe skip (non-blocking)
