### PR TITLE
ops: add nightly act warning monitoring

### DIFF
--- a/.github/workflows/nightly-patrol.yml
+++ b/.github/workflows/nightly-patrol.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
 
 concurrency:
   group: nightly-patrol
@@ -16,7 +17,7 @@ concurrency:
 jobs:
   patrol:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     steps:
       - name: Checkout
@@ -28,17 +29,108 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Prepare directories
         run: |
           mkdir -p docs/nightly-patrol
           mkdir -p scripts/ops
 
+      - name: Nightly act warning scan
+        id: act_scan
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          npm run test:ci:required 2>&1 | tee /tmp/vitest-nightly-act.log
+          node scripts/ci/check-act-warnings.mjs /tmp/vitest-nightly-act.log --json --json-output /tmp/act-warnings-nightly.json
+
+      - name: Create/Update act warning regression issue
+        if: ${{ always() }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/ci/create-act-warning-issue.mjs \
+            --summary /tmp/act-warnings-nightly.json \
+            --repo "${{ github.repository }}" \
+            --workflow "${{ github.workflow }}" \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --branch "${{ github.ref_name }}" \
+            --sha "${{ github.sha }}"
+
+      - name: Detect open act warning issue
+        id: act_issue
+        if: ${{ always() }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          json=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --state open \
+            --search 'in:title "CI: act(...) warning regression detected"' \
+            --limit 1 \
+            --json number,url)
+          count=$(node -e "const d=JSON.parse(process.argv[1]);console.log(d.length);" "$json")
+          url=$(node -e "const d=JSON.parse(process.argv[1]);console.log(d[0]?.url || '');" "$json")
+          echo "open_count=${count}" >> "$GITHUB_OUTPUT"
+          echo "open_url=${url}" >> "$GITHUB_OUTPUT"
+
       - name: Run patrol scan
+        env:
+          ACT_WARNING_SUMMARY_PATH: /tmp/act-warnings-nightly.json
+          ACT_WARNING_OPEN_ISSUE_COUNT: ${{ steps.act_issue.outputs.open_count }}
+          ACT_WARNING_OPEN_ISSUE_URL: ${{ steps.act_issue.outputs.open_url }}
         run: node scripts/ops/nightly-patrol.mjs
 
       - name: Generate metrics dashboard
         run: node scripts/ops/os-metrics.mjs
+
+      - name: Upload nightly act warning artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-act-warning-${{ github.run_number }}
+          path: |
+            /tmp/act-warnings-nightly.json
+            /tmp/vitest-nightly-act.log
+          if-no-files-found: warn
+
+      - name: Nightly act warning summary
+        if: ${{ always() }}
+        run: |
+          echo "## Nightly act(...) warning monitor" >> "$GITHUB_STEP_SUMMARY"
+          if [ -f /tmp/act-warnings-nightly.json ]; then
+            node - <<'NODE' >> "$GITHUB_STEP_SUMMARY"
+          const fs = require('node:fs');
+          const p = '/tmp/act-warnings-nightly.json';
+          const s = JSON.parse(fs.readFileSync(p, 'utf8'));
+          const total = Number(s.totalWarnings || 0);
+          const affected = Number(s.affectedFiles || 0);
+          const maxFile = s.maxWarningsFile || 'none';
+          const maxCount = Number(s.maxWarningsPerFile || 0);
+          console.log(`- totalWarnings: **${total}**`);
+          console.log(`- affectedFiles: **${affected}**`);
+          console.log(`- maxWarningsFile: **${maxFile}**`);
+          console.log(`- maxWarningsPerFile: **${maxCount}**`);
+          NODE
+          else
+            echo "- summary: unavailable" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo "- openIssueCount: **${{ steps.act_issue.outputs.open_count || '0' }}**" >> "$GITHUB_STEP_SUMMARY"
+          if [ -n "${{ steps.act_issue.outputs.open_url }}" ]; then
+            echo "- openIssue: ${{ steps.act_issue.outputs.open_url }}" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "- openIssue: none" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          if [ -f /tmp/act-warnings-nightly.json ]; then
+            total=$(node -e "const s=require('/tmp/act-warnings-nightly.json');console.log(Number(s.totalWarnings||0));")
+            if [ "$total" -eq 0 ]; then
+              echo "" >> "$GITHUB_STEP_SUMMARY"
+              echo "✅ 0件維持を確認しました。" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          fi
 
       - name: Commit report if changed
         run: |

--- a/scripts/ops/nightly-patrol.mjs
+++ b/scripts/ops/nightly-patrol.mjs
@@ -32,6 +32,22 @@ const mm = String(today.getUTCMonth() + 1).padStart(2, '0');
 const dd = String(today.getUTCDate()).padStart(2, '0');
 const stamp = `${yyyy}-${mm}-${dd}`;
 
+// --- Optional CI Inputs (act warning monitor) ---
+
+const ACT_WARNING_SUMMARY_PATH = process.env.ACT_WARNING_SUMMARY_PATH || '';
+const ACT_WARNING_OPEN_ISSUE_COUNT = Number(process.env.ACT_WARNING_OPEN_ISSUE_COUNT || '0');
+const ACT_WARNING_OPEN_ISSUE_URL = process.env.ACT_WARNING_OPEN_ISSUE_URL || '';
+
+let actWarningSummary = null;
+if (ACT_WARNING_SUMMARY_PATH && fs.existsSync(ACT_WARNING_SUMMARY_PATH)) {
+  try {
+    const raw = fs.readFileSync(ACT_WARNING_SUMMARY_PATH, 'utf8');
+    actWarningSummary = JSON.parse(raw);
+  } catch {
+    actWarningSummary = null;
+  }
+}
+
 // --- File Walking ---
 
 const IGNORED_DIRS = new Set([
@@ -235,6 +251,56 @@ function status(count, warnThreshold, errorThreshold) {
   return '🟢';
 }
 
+function toNonNegativeNumber(value) {
+  const n = Number(value);
+  return Number.isFinite(n) && n >= 0 ? n : null;
+}
+
+const actTotalWarnings = toNonNegativeNumber(actWarningSummary?.totalWarnings);
+const actAffectedFiles = toNonNegativeNumber(actWarningSummary?.affectedFiles);
+const actMaxWarningsPerFile = toNonNegativeNumber(actWarningSummary?.maxWarningsPerFile);
+const actMaxWarningsFile = typeof actWarningSummary?.maxWarningsFile === 'string'
+  ? actWarningSummary.maxWarningsFile
+  : null;
+const actCountsByFile = actWarningSummary && typeof actWarningSummary.countsByFile === 'object'
+  ? actWarningSummary.countsByFile
+  : {};
+
+const actCountsEntries = Object.entries(actCountsByFile)
+  .map(([file, count]) => ({ file, count: toNonNegativeNumber(count) ?? 0 }))
+  .sort((a, b) => b.count - a.count || a.file.localeCompare(b.file))
+  .slice(0, 30);
+
+const actStatusIcon = actTotalWarnings === null
+  ? '⚪'
+  : actTotalWarnings > 0
+    ? '🔴'
+    : '🟢';
+
+const actStatusCountLabel = actTotalWarnings === null
+  ? 'n/a'
+  : `${actTotalWarnings}`;
+
+const actOpenIssueState = ACT_WARNING_OPEN_ISSUE_COUNT > 0
+  ? `あり (${ACT_WARNING_OPEN_ISSUE_COUNT})`
+  : 'なし';
+
+const actWarningSection = actTotalWarnings === null
+  ? 'ℹ️ act warning summary は未提供です（Nightly workflow の入力未設定または読み取り失敗）。'
+  : [
+    `- totalWarnings: **${actTotalWarnings}**`,
+    `- affectedFiles: **${actAffectedFiles ?? 0}**`,
+    `- maxWarningsFile: **${actMaxWarningsFile ?? 'none'}**`,
+    `- maxWarningsPerFile: **${actMaxWarningsPerFile ?? 0}**`,
+    `- openIssue: **${actOpenIssueState}**${ACT_WARNING_OPEN_ISSUE_URL ? ` (${ACT_WARNING_OPEN_ISSUE_URL})` : ''}`,
+    '',
+    actCountsEntries.length === 0
+      ? '✅ countsByFile: なし'
+      : `| Count | File |
+| ---: | --- |
+${actCountsEntries.map((x) => `| ${x.count} | \`${x.file}\` |`).join('\n')}`,
+  ].join('\n');
+
 // --- Report Generation ---
 
 console.log('  Generating report...');
@@ -260,6 +326,7 @@ const report = `# 🔍 Nightly Patrol Report — ${stamp}
 | TODO/FIXME/HACK | ${status(todoHits.length, 20, 50)} | ${todoHits.length} |
 | テスト未整備 feature | ${status(untestedFeatures.length, 2, 5)} | ${untestedFeatures.length} |
 | Handoff | ${lastHandoffInfo.includes('No ') ? '🟡' : '🟢'} | — |
+| act(...) warning (nightly) | ${actStatusIcon} | ${actStatusCountLabel} |
 
 ---
 
@@ -317,6 +384,12 @@ ${lastHandoffInfo}
 
 ---
 
+## 6. act(...) warning monitor
+
+${actWarningSection}
+
+---
+
 ## Suggested Next Actions
 
 ${[
@@ -331,6 +404,12 @@ ${[
     : null,
   untestedFeatures.length > 0
     ? `- 🟡 テスト未整備 ${untestedFeatures.length} feature を \`/test-design\` で設計`
+    : null,
+  actTotalWarnings !== null && actTotalWarnings > 0
+    ? `- 🔴 act(...) warning 再発 (${actTotalWarnings}件) を 1 file = 1 PR で解消`
+    : null,
+  actTotalWarnings === 0
+    ? '- ✅ act(...) warning は 0件維持（Nightly確認）'
     : null,
   lastHandoffInfo.includes('No ')
     ? '- 🟡 Handoff ファイルを作成 (`/handoff`)'
@@ -358,6 +437,11 @@ console.log(`  any hits:        ${anyHits.length}`);
 console.log(`  TODO/FIXME:      ${todoHits.length}`);
 console.log(`  Untested feat:   ${untestedFeatures.length}`);
 console.log(`  Handoff:         ${lastHandoffInfo}`);
+if (actTotalWarnings !== null) {
+  console.log(`  act warnings:    ${actTotalWarnings} (files=${actAffectedFiles ?? 0}, max=${actMaxWarningsPerFile ?? 0})`);
+} else {
+  console.log('  act warnings:    n/a');
+}
 console.log('');
 
 // --- Phase B: Issue Draft Generation ---
@@ -381,4 +465,3 @@ if (drafts.length === 0) {
   console.log(`  📄 Written: docs/nightly-patrol/issue-drafts-${stamp}.md`);
 }
 console.log('');
-


### PR DESCRIPTION
## Summary
- extend Nightly Patrol workflow to monitor `act(...) warning` daily
- run nightly scan:
  - `npm run test:ci:required` (log to `/tmp/vitest-nightly-act.log`)
  - `check-act-warnings.mjs --json-output /tmp/act-warnings-nightly.json`
- connect Phase 2 automation in nightly:
  - run `create-act-warning-issue.mjs` (create or append)
  - detect open regression issue count/url for reporting
- upload nightly artifacts:
  - `/tmp/act-warnings-nightly.json`
  - `/tmp/vitest-nightly-act.log`
- write nightly run summary (`GITHUB_STEP_SUMMARY`) with:
  - totalWarnings
  - affectedFiles
  - maxWarningsFile
  - maxWarningsPerFile
  - open issue status
  - explicit `0件維持` note when total is zero
- enrich `scripts/ops/nightly-patrol.mjs` report with a new section:
  - status row for nightly act warnings
  - detailed act warning monitor block
  - open issue state
  - suggested next action depending on warning count

## Workflow details
- file: `.github/workflows/nightly-patrol.yml`
- added permissions: `issues: write`
- increased timeout to 30 min
- added dependency install step (`npm ci`)
- nightly scan step uses `continue-on-error: true` to keep patrol/reporting flow alive

## Validation
- `node --check scripts/ops/nightly-patrol.mjs`
- `actionlint .github/workflows/nightly-patrol.yml`
- local run with sample summary:
  - `ACT_WARNING_SUMMARY_PATH=/tmp/act-warnings-nightly-sample.json node scripts/ops/nightly-patrol.mjs`
  - confirms report generation and `act warnings: 0` summary output
