### PR TITLE
ci: capture untracked nightly patrol report changes

### DIFF
--- a/.github/workflows/nightly-patrol.yml
+++ b/.github/workflows/nightly-patrol.yml
@@ -137,11 +137,11 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          if git diff --quiet -- docs/nightly-patrol; then
+          if [ -z "$(git status --porcelain -- docs/nightly-patrol)" ]; then
             echo "No report changes"
             exit 0
           fi
 
-          git add docs/nightly-patrol
+          git add -A docs/nightly-patrol
           git commit -m "chore(ops): nightly patrol report"
           git push


### PR DESCRIPTION
## Summary
- fix Nightly Patrol report commit gate to detect untracked files under `docs/nightly-patrol`
- switch from `git diff --quiet -- docs/nightly-patrol` to `git status --porcelain -- docs/nightly-patrol`
- stage with `git add -A docs/nightly-patrol` so adds/deletes/updates are all included

## Why
- `git diff --quiet` can miss untracked report files
- this could skip committing newly generated nightly reports

## Validation
- `actionlint .github/workflows/nightly-patrol.yml`
