### PR TITLE
refactor: split SupportPlanningSheetPage part1 (status section)

### DIFF
--- a/src/pages/SupportPlanningSheetPage.tsx
+++ b/src/pages/SupportPlanningSheetPage.tsx
@@ -22,13 +22,11 @@ import { useAuth } from '@/auth/useAuth';
 import { createSharePointIspRepository } from '@/data/isp/sharepoint/SharePointIspRepository';
 import { determineWorkflowPhase, type WorkflowPhase } from '@/domain/bridge/workflowPhase';
 import { useHandoffData } from '@/features/handoff/hooks/useHandoffData';
-import { AbcEvidencePanel } from '@/features/ibd/analysis/pdca/components/AbcEvidencePanel';
 import { useIcebergEvidence } from '@/features/ibd/analysis/pdca/queries/useIcebergEvidence';
 import { usePlanningSheetData } from '@/features/planning-sheet/hooks/usePlanningSheetData';
 import { usePlanningSheetForm } from '@/features/planning-sheet/hooks/usePlanningSheetForm';
 import { usePlanningSheetRepositories } from '@/features/planning-sheet/hooks/usePlanningSheetRepositories';
 import { NewPlanningSheetForm } from '@/features/planning-sheet/components/NewPlanningSheetForm';
-import { ProvenancePanel } from '@/features/planning-sheet/components/ProvenanceBadge';
 import type { ProvenanceEntry } from '@/features/planning-sheet/assessmentBridge';
 import { useAssessmentStore } from '@/features/assessment/stores/assessmentStore';
 import { useImportAuditStore } from '@/features/planning-sheet/stores/importAuditStore';
@@ -52,6 +50,7 @@ import { ContextPanelSection } from './support-planning-sheet/sections/ContextPa
 import { ImportDialogsSection } from './support-planning-sheet/sections/ImportDialogsSection';
 import { ImportHistorySection } from './support-planning-sheet/sections/ImportHistorySection';
 import { PlanningTabsSection } from './support-planning-sheet/sections/PlanningTabsSection';
+import { PlanningStatusSection } from './support-planning-sheet/sections/PlanningStatusSection';
 import { TagAnalyticsAccordionSection } from './support-planning-sheet/sections/TagAnalyticsAccordionSection';
 import { useImportHandlers } from './support-planning-sheet/hooks/useImportHandlers';
 import { usePlanningEvidenceState } from './support-planning-sheet/hooks/usePlanningEvidenceState';
@@ -256,18 +255,12 @@ export default function SupportPlanningSheetPage() {
             onJumpToPlanningTab={() => setActiveTab('planning')}
             onStartEditing={() => setIsEditing(true)}
           />
-
-          {sheet.userId && <AbcEvidencePanel userId={sheet.userId} />}
-
-          {isEditing && Object.keys(form.validationErrors).length > 0 && (
-            <Alert severity="warning" variant="outlined">
-              入力にエラーがあります: {Object.values(form.validationErrors).filter(Boolean).join(' / ')}
-            </Alert>
-          )}
-
-          {isEditing && allProvenanceEntries.length > 0 && (
-            <ProvenancePanel entries={allProvenanceEntries} defaultExpanded={false} />
-          )}
+          <PlanningStatusSection
+            userId={sheet.userId}
+            isEditing={isEditing}
+            validationErrors={form.validationErrors}
+            provenanceEntries={allProvenanceEntries}
+          />
 
           <ImportHistorySection
             auditRecords={auditRecords}

--- a/src/pages/support-planning-sheet/sections/PlanningStatusSection.tsx
+++ b/src/pages/support-planning-sheet/sections/PlanningStatusSection.tsx
@@ -1,0 +1,35 @@
+import Alert from '@mui/material/Alert';
+
+import { AbcEvidencePanel } from '@/features/ibd/analysis/pdca/components/AbcEvidencePanel';
+import { ProvenancePanel } from '@/features/planning-sheet/components/ProvenanceBadge';
+import type { ProvenanceEntry } from '@/features/planning-sheet/assessmentBridge';
+
+type PlanningStatusSectionProps = {
+  userId: string;
+  isEditing: boolean;
+  validationErrors: Record<string, string | undefined>;
+  provenanceEntries: ProvenanceEntry[];
+};
+
+export function PlanningStatusSection({
+  userId,
+  isEditing,
+  validationErrors,
+  provenanceEntries,
+}: PlanningStatusSectionProps) {
+  return (
+    <>
+      <AbcEvidencePanel userId={userId} />
+
+      {isEditing && Object.keys(validationErrors).length > 0 && (
+        <Alert severity="warning" variant="outlined">
+          入力にエラーがあります: {Object.values(validationErrors).filter(Boolean).join(' / ')}
+        </Alert>
+      )}
+
+      {isEditing && provenanceEntries.length > 0 && (
+        <ProvenancePanel entries={provenanceEntries} defaultExpanded={false} />
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- `SupportPlanningSheetPage.tsx` から表示専用ブロックを `PlanningStatusSection` として切り出し
- 切り出し対象:
  - `AbcEvidencePanel`
  - 編集時の入力エラー Alert
  - 編集時の ProvenancePanel
- 親コンポーネントには state / side effect / data fetch を残置（挙動変更なし）

## Boundary Memo (part1)
- 今回どこまで切るか:
  - 表示専用の1セクションのみ外出し
- 今回切らないもの:
  - `usePlanningSheetData` / `usePlanningSheetForm` などのフック構成
  - ルーティング契約・import/export フロー・タブの挙動

## Why
- #1172 の part1 として、最小差分で安全に分割を開始するため
- 1 PR = 1目的（presentational section extraction）を維持するため

## Scope
- test-only ではなく refactor（production behavior unchanged）
- app behavior changes: none

## Validation
- `npm run typecheck`
- `npx vitest run tests/unit/dateFormat-phase3-integration.spec.ts`
- commit hooks passed (`lint`, `typecheck`, `lint:cookies`)
