### PR TITLE
refactor: split monitoringDailyAnalytics part1 (period metrics)

### DIFF
--- a/src/features/monitoring/domain/monitoringDailyAnalytics.ts
+++ b/src/features/monitoring/domain/monitoringDailyAnalytics.ts
@@ -27,6 +27,7 @@ import { inferGoalTagLinks, assessGoalProgress } from './goalProgressUtils';
 import type { IspRecommendationSummary } from './ispRecommendationTypes';
 import { ISP_RECOMMENDATION_LABELS } from './ispRecommendationTypes';
 import { buildIspRecommendations } from './ispRecommendationUtils';
+import { buildMonitoringPeriodMetrics } from './monitoringDailyPeriod';
 
 // ─── 型定義 ──────────────────────────────────────────────
 
@@ -148,14 +149,6 @@ const clean = (s: unknown): string => {
   const t = String(s ?? '').trim();
   return t || '';
 };
-
-/** YYYY-MM-DD 間の暦日数（inclusive） */
-function daysBetween(from: string, to: string): number {
-  const a = new Date(from + 'T00:00:00');
-  const b = new Date(to + 'T00:00:00');
-  const diff = b.getTime() - a.getTime();
-  return Math.max(1, Math.floor(diff / 86_400_000) + 1);
-}
 
 /** YYYY-MM-DD → 週番号文字列（月曜起点） */
 function toWeekKey(ymd: string): string {
@@ -537,17 +530,10 @@ export function buildMonitoringDailySummary(
 ): DailyMonitoringSummary | null {
   if (records.length === 0) return null;
 
-  // 期間を recordDate の min/max から算出
-  const dates = records.map((r) => r.recordDate).sort();
-  const from = dates[0];
-  const to = dates[dates.length - 1];
-  const totalDays = daysBetween(from, to);
-  const uniqueDates = new Set(dates);
-  const recordedDays = uniqueDates.size;
-  const recordRate = totalDays > 0 ? Math.round((recordedDays / totalDays) * 100) : 0;
+  const period = buildMonitoringPeriodMetrics(records);
 
   const result: DailyMonitoringSummary = {
-    period: { from, to, totalDays, recordedDays, recordRate },
+    period,
     activity: aggregateActivities(records),
     lunch: aggregateLunch(records),
     behavior: aggregateBehaviors(records),

--- a/src/features/monitoring/domain/monitoringDailyPeriod.spec.ts
+++ b/src/features/monitoring/domain/monitoringDailyPeriod.spec.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import type { DailyTableRecord } from '@/features/daily/infra/dailyTableRepository';
+import { buildMonitoringPeriodMetrics } from './monitoringDailyPeriod';
+
+const mkRecord = (
+  overrides: Partial<DailyTableRecord> & { recordDate: string },
+): DailyTableRecord => ({
+  userId: 'u1',
+  activities: {},
+  submittedAt: '2024-01-01T00:00:00Z',
+  ...overrides,
+});
+
+describe('buildMonitoringPeriodMetrics', () => {
+  it('空配列はゼロ値を返す', () => {
+    expect(buildMonitoringPeriodMetrics([])).toEqual({
+      from: '',
+      to: '',
+      totalDays: 0,
+      recordedDays: 0,
+      recordRate: 0,
+    });
+  });
+
+  it('重複日を除外して記録率を算出する', () => {
+    const records = [
+      mkRecord({ recordDate: '2024-01-01' }),
+      mkRecord({ recordDate: '2024-01-01' }),
+      mkRecord({ recordDate: '2024-01-03' }),
+    ];
+
+    expect(buildMonitoringPeriodMetrics(records)).toEqual({
+      from: '2024-01-01',
+      to: '2024-01-03',
+      totalDays: 3,
+      recordedDays: 2,
+      recordRate: 67,
+    });
+  });
+
+  it('入力順に依存せず最小日/最大日を使う', () => {
+    const records = [
+      mkRecord({ recordDate: '2024-01-10' }),
+      mkRecord({ recordDate: '2024-01-02' }),
+    ];
+
+    expect(buildMonitoringPeriodMetrics(records)).toEqual({
+      from: '2024-01-02',
+      to: '2024-01-10',
+      totalDays: 9,
+      recordedDays: 2,
+      recordRate: 22,
+    });
+  });
+});

--- a/src/features/monitoring/domain/monitoringDailyPeriod.ts
+++ b/src/features/monitoring/domain/monitoringDailyPeriod.ts
@@ -1,0 +1,35 @@
+import type { DailyTableRecord } from '@/features/daily/infra/dailyTableRepository';
+
+export interface MonitoringPeriodMetrics {
+  from: string;
+  to: string;
+  totalDays: number;
+  recordedDays: number;
+  recordRate: number;
+}
+
+/** YYYY-MM-DD 間の暦日数（inclusive） */
+function daysBetweenInclusive(from: string, to: string): number {
+  const a = new Date(from + 'T00:00:00');
+  const b = new Date(to + 'T00:00:00');
+  const diff = b.getTime() - a.getTime();
+  return Math.max(1, Math.floor(diff / 86_400_000) + 1);
+}
+
+export function buildMonitoringPeriodMetrics(
+  records: DailyTableRecord[],
+): MonitoringPeriodMetrics {
+  if (records.length === 0) {
+    return { from: '', to: '', totalDays: 0, recordedDays: 0, recordRate: 0 };
+  }
+
+  const dates = records.map((r) => r.recordDate).sort();
+  const from = dates[0];
+  const to = dates[dates.length - 1];
+  const totalDays = daysBetweenInclusive(from, to);
+  const recordedDays = new Set(dates).size;
+  const recordRate =
+    totalDays > 0 ? Math.round((recordedDays / totalDays) * 100) : 0;
+
+  return { from, to, totalDays, recordedDays, recordRate };
+}


### PR DESCRIPTION
## Summary
- #1175 part1 として `monitoringDailyAnalytics.ts` から期間計算の pure function 群を抽出
- `buildMonitoringDailySummary` の挙動は維持し、呼び出しを新規 module に委譲
- 抽出 module の単体テストを追加

## Boundary memo
### Cut in this PR
- 期間サマリー計算（from/to/totalDays/recordedDays/recordRate）
- `daysBetween` 相当の inclusive 日数計算

### Not cut in this PR
- 活動/昼食/問題行動/タグ/目標進捗/ISP提案ロジック
- 公開 API 変更（`buildMonitoringDailySummary` の返却形・呼び出し契約）

## Changes
- add: `src/features/monitoring/domain/monitoringDailyPeriod.ts`
- add: `src/features/monitoring/domain/monitoringDailyPeriod.spec.ts`
- update: `src/features/monitoring/domain/monitoringDailyAnalytics.ts`
  - 期間計算のインライン実装を削除
  - `buildMonitoringPeriodMetrics(records)` を利用

## Validation
- `npx vitest run src/features/monitoring/domain/monitoringDailyAnalytics.spec.ts src/features/monitoring/domain/monitoringDailyPeriod.spec.ts`
- `npm run typecheck`
