### PR TITLE
feat: add URL-based user selection entrypoint (#1226)

### DIFF
--- a/src/features/users/UsersPanel.smoke.test.tsx
+++ b/src/features/users/UsersPanel.smoke.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { createMemoryRouter, MemoryRouter, RouterProvider } from 'react-router-dom';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { usersStoreMock } from './testUtils/usersStoreMock';
 import UsersPanel from './UsersPanel/index';
@@ -8,6 +8,15 @@ describe('UsersPanel smoke test', () => {
   beforeEach(() => {
     usersStoreMock.reset();
   });
+
+  const renderOnUsersRoute = (path = '/users') => {
+    const router = createMemoryRouter(
+      [{ path: '/users', element: <UsersPanel /> }],
+      { initialEntries: [path] },
+    );
+    render(<RouterProvider router={router} />);
+    return router;
+  };
 
   it('allows creating and deleting a user with list refresh', async () => {
     render(
@@ -64,10 +73,10 @@ describe('UsersPanel smoke test', () => {
       </MemoryRouter>
     );
 
-  fireEvent.click(screen.getAllByRole('tab', { name: /利用者一覧/ })[0]);
+    fireEvent.click(screen.getAllByRole('tab', { name: /利用者一覧/ })[0]);
 
-  const detailLink = screen.getByRole('link', { name: '詳細' });
-  fireEvent.click(detailLink);
+    const detailLink = screen.getByRole('link', { name: '詳細' });
+    fireEvent.click(detailLink);
 
     expect(await screen.findByRole('button', { name: '詳細表示を閉じる' })).toBeInTheDocument();
     expect(screen.getAllByText(/inline-001/).length).toBeGreaterThan(0);
@@ -75,6 +84,62 @@ describe('UsersPanel smoke test', () => {
     fireEvent.click(screen.getByRole('button', { name: '詳細表示を閉じる' }));
     await waitFor(() => {
       expect(screen.queryByRole('button', { name: '詳細表示を閉じる' })).toBeNull();
+    });
+  });
+
+  it('restores selected detail from URL query', async () => {
+    usersStoreMock.reset([
+      {
+        Id: 101,
+        UserID: 'inline-001',
+        FullName: '埋め込み太郎',
+        IsActive: true,
+      },
+    ]);
+
+    const router = renderOnUsersRoute('/users?tab=list&selected=inline-001');
+
+    expect(await screen.findByRole('button', { name: '詳細表示を閉じる' })).toBeInTheDocument();
+    expect(screen.getAllByText(/inline-001/).length).toBeGreaterThan(0);
+    expect(router.state.location.search).toContain('selected=inline-001');
+  });
+
+  it('clears invalid selected query and keeps panel stable', async () => {
+    usersStoreMock.reset([
+      {
+        Id: 101,
+        UserID: 'inline-001',
+        FullName: '埋め込み太郎',
+        IsActive: true,
+      },
+    ]);
+
+    const router = renderOnUsersRoute('/users?tab=list&selected=U-999');
+
+    await waitFor(() => {
+      expect(router.state.location.search).toBe('?tab=list');
+    });
+
+    expect(await screen.findByText('利用者が未選択です')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '詳細表示を閉じる' })).toBeNull();
+  });
+
+  it('writes selected query when detail is opened from list', async () => {
+    usersStoreMock.reset([
+      {
+        Id: 101,
+        UserID: 'inline-001',
+        FullName: '埋め込み太郎',
+        IsActive: true,
+      },
+    ]);
+
+    const router = renderOnUsersRoute('/users?tab=list');
+
+    fireEvent.click(screen.getByRole('link', { name: '詳細' }));
+
+    await waitFor(() => {
+      expect(router.state.location.search).toContain('selected=inline-001');
     });
   });
 });

--- a/src/features/users/UsersPanel/UsersList.tsx
+++ b/src/features/users/UsersPanel/UsersList.tsx
@@ -495,7 +495,7 @@ const UsersList: FC<UsersListProps> = ({
                 sx={{ fontSize: 48, color: 'text.disabled', mb: 1.5 }}
               />
               <Typography variant="subtitle2" color="text.secondary" sx={{ fontWeight: 600 }}>
-                利用者詳細
+                利用者が未選択です
               </Typography>
               <Typography variant="body2" color="text.disabled" textAlign="center" sx={{ mt: 0.5 }}>
                 一覧から利用者を選択すると、ここに詳細が表示されます

--- a/src/features/users/UsersPanel/hooks/useUsersPanelTabs.ts
+++ b/src/features/users/UsersPanel/hooks/useUsersPanelTabs.ts
@@ -4,7 +4,7 @@
  * タブ管理 + 詳細ユーザー選択 + URL同期
  */
 import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { resolveUserIdentifier } from '../../UserDetailSections/helpers';
 import type { IUserMaster } from '../../types';
 
@@ -21,8 +21,12 @@ export type UseUsersPanelTabsReturn = {
   handleDetailClose: () => void;
 };
 
-export function useUsersPanelTabs(data: IUserMaster[]): UseUsersPanelTabsReturn {
+export function useUsersPanelTabs(
+  data: IUserMaster[],
+  status: string,
+): UseUsersPanelTabsReturn {
   const location = useLocation();
+  const navigate = useNavigate();
 
   // ---- Tab state ----
   const isUsersTab = useCallback(
@@ -39,6 +43,46 @@ export function useUsersPanelTabs(data: IUserMaster[]): UseUsersPanelTabsReturn 
     if (isUsersTab(queryTab)) return queryTab;
     return null;
   }, [isUsersTab, location.search, location.state]);
+
+  const readSelectedFromLocation = useCallback((): string | null => {
+    const params = new URLSearchParams(location.search ?? '');
+    const raw = (params.get('selected') ?? '').trim();
+    return raw || null;
+  }, [location.search]);
+
+  const syncSelectedInUrl = useCallback(
+    (selectedKey: string | null) => {
+      const currentSelected = readSelectedFromLocation();
+      const nextSelected = selectedKey?.trim() || null;
+
+      const params = new URLSearchParams(location.search ?? '');
+      if (nextSelected) {
+        params.set('selected', nextSelected);
+        // selected 指定時は一覧タブを明示
+        if (!isUsersTab(params.get('tab'))) {
+          params.set('tab', 'list');
+        }
+      } else {
+        params.delete('selected');
+      }
+
+      const nextSearch = params.toString();
+      const next = nextSearch ? `?${nextSearch}` : '';
+
+      if (currentSelected === nextSelected && next === (location.search || '')) {
+        return;
+      }
+
+      navigate(
+        {
+          pathname: location.pathname,
+          search: next,
+        },
+        { replace: true },
+      );
+    },
+    [isUsersTab, location.pathname, location.search, navigate, readSelectedFromLocation],
+  );
 
   const [activeTab, setActiveTab] = useState<UsersTab>(() => readTabFromLocation() ?? 'menu');
   const handledLocationRef = useRef<{ key: string; tab: UsersTab | null }>({
@@ -71,9 +115,13 @@ export function useUsersPanelTabs(data: IUserMaster[]): UseUsersPanelTabsReturn 
   }, [activeTab, location.key, readTabFromLocation]);
 
   // ---- Detail user ----
-  const [detailUserKey, setDetailUserKey] = useState<string | null>(null);
+  const [detailUserKey, setDetailUserKey] = useState<string | null>(readSelectedFromLocation);
   const detailSectionRef = useRef<HTMLDivElement | null>(null);
   const panelOpenButtonRef = useRef<HTMLButtonElement | null>(null);
+  const handledSelectedRef = useRef<{ key: string; selected: string | null }>({
+    key: location.key,
+    selected: readSelectedFromLocation(),
+  });
 
   const detailUser = useMemo(() => {
     if (!detailUserKey) return null;
@@ -81,9 +129,35 @@ export function useUsersPanelTabs(data: IUserMaster[]): UseUsersPanelTabsReturn 
   }, [data, detailUserKey]);
 
   useEffect(() => {
+    const selectedFromLocation = readSelectedFromLocation();
+    const handled = handledSelectedRef.current;
+    const keyChanged = location.key !== handled.key;
+    const selectedChanged = selectedFromLocation !== handled.selected;
+
+    if (!keyChanged && !selectedChanged) {
+      return;
+    }
+
+    handledSelectedRef.current = {
+      key: location.key,
+      selected: selectedFromLocation,
+    };
+
+    if (selectedFromLocation !== detailUserKey) {
+      setDetailUserKey(selectedFromLocation);
+    }
+    if (selectedFromLocation && activeTab !== 'list') {
+      setActiveTab('list');
+    }
+  }, [activeTab, detailUserKey, location.key, readSelectedFromLocation]);
+
+  useEffect(() => {
     if (!detailUserKey) return;
+    if (status === 'loading') return;
+
     if (!detailUser) {
       setDetailUserKey(null);
+      syncSelectedInUrl(null);
       return;
     }
 
@@ -95,7 +169,7 @@ export function useUsersPanelTabs(data: IUserMaster[]): UseUsersPanelTabsReturn 
         }
       });
     }
-  }, [detailUser, detailUserKey]);
+  }, [detailUser, detailUserKey, status, syncSelectedInUrl]);
 
   // ---- Detail handlers ----
   const handleDetailSelect = useCallback(
@@ -105,15 +179,18 @@ export function useUsersPanelTabs(data: IUserMaster[]): UseUsersPanelTabsReturn 
       }
       event.preventDefault();
       const key = user.UserID || String(user.Id);
+      const next = detailUserKey === key ? null : key;
       setActiveTab('list');
-      setDetailUserKey((prev) => (prev === key ? null : key));
+      setDetailUserKey(next);
+      syncSelectedInUrl(next);
     },
-    [],
+    [detailUserKey, syncSelectedInUrl],
   );
 
   const handleDetailClose = useCallback(() => {
     setDetailUserKey(null);
-  }, []);
+    syncSelectedInUrl(null);
+  }, [syncSelectedInUrl]);
 
   return {
     activeTab,

--- a/src/features/users/UsersPanel/useUsersPanel.ts
+++ b/src/features/users/UsersPanel/useUsersPanel.ts
@@ -81,7 +81,7 @@ export function useUsersPanel(): UseUsersPanelReturn {
   const crud = useUsersPanelCrud(setActiveTabRef);
 
   // 2) Tabs — タブ管理 + 詳細ユーザー選択（CRUD のデータを受け取る）
-  const tabs = useUsersPanelTabs(crud.data);
+  const tabs = useUsersPanelTabs(crud.data, crud.status);
 
   // ref を接続（Tabs の setActiveTab を CRUD が使えるようにする）
   setActiveTabRef.current = tabs.setActiveTab;


### PR DESCRIPTION
## Summary
- #1226 として、`/users` で URL の `selected` クエリに基づく利用者詳細選択を追加
- 選択操作時に URL を `?selected=...` と同期し、再読み込み時に復元可能にした
- 無効な `selected` は安全にクリアし、一覧表示を壊さないフォールバックを追加

## Boundary memo
### Cut in this PR
- UsersPanel の URL 選択同期（`selected` クエリ）
- 無効 `selected` の自動クリア
- ルーティング契約 smoke テスト追加

### Not cut in this PR
- `/users/:userId` ルート設計変更
- UsersPanel 以外の画面導線変更
- データ取得/ストア設計の再編

## Changes
- update: `src/features/users/UsersPanel/hooks/useUsersPanelTabs.ts`
  - URL `selected` 読み取り
  - 選択状態との双方向同期（open/close）
  - 無効値検出時のクエリ除去（replace navigation）
- update: `src/features/users/UsersPanel/useUsersPanel.ts`
  - `status` を tabs hook に伝搬（ロード中判定用）
- update: `src/features/users/UsersPanel/UsersList.tsx`
  - 未選択フォールバック文言を明示（`利用者が未選択です`）
- update: `src/features/users/UsersPanel.smoke.test.tsx`
  - URL復元 / 無効値クリア / クリック時URL反映 の3ケースを追加

## Validation
- `npx vitest run src/features/users/UsersPanel.smoke.test.tsx`
- `npm run typecheck`
- `npx eslint src/features/users/UsersPanel/hooks/useUsersPanelTabs.ts src/features/users/UsersPanel/useUsersPanel.ts src/features/users/UsersPanel/UsersList.tsx src/features/users/UsersPanel.smoke.test.tsx`
