### PR TITLE
refactor: split monitoringDailyAnalytics part2 (behavior aggregation)

### DIFF
--- a/src/features/monitoring/domain/monitoringDailyAnalytics.ts
+++ b/src/features/monitoring/domain/monitoringDailyAnalytics.ts
@@ -27,6 +27,7 @@ import { inferGoalTagLinks, assessGoalProgress } from './goalProgressUtils';
 import type { IspRecommendationSummary } from './ispRecommendationTypes';
 import { ISP_RECOMMENDATION_LABELS } from './ispRecommendationTypes';
 import { buildIspRecommendations } from './ispRecommendationUtils';
+import { aggregateMonitoringBehaviors } from './monitoringDailyBehaviors';
 import { buildMonitoringPeriodMetrics } from './monitoringDailyPeriod';
 
 // ─── 型定義 ──────────────────────────────────────────────
@@ -133,14 +134,6 @@ const LUNCH_LABELS: Record<LunchIntake, string> = {
   none: 'なし',
 };
 
-const BEHAVIOR_LABELS: Record<ProblemBehaviorType, string> = {
-  selfHarm: '自傷',
-  otherInjury: '他傷',
-  shouting: '大声',
-  pica: '異食',
-  other: 'その他',
-};
-
 const STABLE_INTAKES: LunchIntake[] = ['full', '80'];
 
 // ─── ヘルパー ────────────────────────────────────────────
@@ -149,18 +142,6 @@ const clean = (s: unknown): string => {
   const t = String(s ?? '').trim();
   return t || '';
 };
-
-/** YYYY-MM-DD → 週番号文字列（月曜起点） */
-function toWeekKey(ymd: string): string {
-  const d = new Date(ymd + 'T00:00:00');
-  const day = d.getDay();
-  // 月曜起点に補正
-  const monday = new Date(d);
-  monday.setDate(d.getDate() - ((day + 6) % 7));
-  const mm = String(monday.getMonth() + 1).padStart(2, '0');
-  const dd = String(monday.getDate()).padStart(2, '0');
-  return `${mm}/${dd}〜`;
-}
 
 function topN(counts: Record<string, number>, n: number): ActivityRank[] {
   return Object.entries(counts)
@@ -220,85 +201,7 @@ export function aggregateLunch(records: DailyTableRecord[]): LunchSummary {
 }
 
 export function aggregateBehaviors(records: DailyTableRecord[]): BehaviorSummary {
-  const typeCounts: Record<string, number> = {};
-  const weekCounts: Record<string, number> = {};
-  let totalDays = 0;
-
-  // 問題行動があるレコードのみ集計
-  const pbRecords: DailyTableRecord[] = [];
-
-  for (const r of records) {
-    const pbs = r.problemBehaviors ?? [];
-    if (pbs.length === 0) continue;
-    totalDays++;
-    pbRecords.push(r);
-
-    for (const pb of pbs) {
-      typeCounts[pb] = (typeCounts[pb] ?? 0) + 1;
-    }
-
-    const wk = toWeekKey(r.recordDate);
-    weekCounts[wk] = (weekCounts[wk] ?? 0) + 1;
-  }
-
-  const byType = Object.entries(typeCounts)
-    .sort((a, b) => b[1] - a[1])
-    .map(([type, count]) => ({
-      type: type as ProblemBehaviorType,
-      label: BEHAVIOR_LABELS[type as ProblemBehaviorType] ?? type,
-      count,
-    }));
-
-  const weeklyTrend = Object.entries(weekCounts)
-    .sort((a, b) => a[0].localeCompare(b[0]))
-    .map(([week, count]) => ({ week, count }));
-
-  // 直近変化: 全レコード期間の中間日を基準に前半/後半で比較
-  const { recentChange, changeRate } = computeRecentChange(pbRecords, records);
-
-  const recordedDays = records.length;
-  const rate = recordedDays > 0 ? Math.round((totalDays / recordedDays) * 100) : 0;
-
-  return { totalDays, rate, byType, weeklyTrend, recentChange, changeRate };
-}
-
-/**
- * 全レコードの日付範囲の中間日を基準に前半/後半の問題行動件数を比較する。
- */
-function computeRecentChange(
-  pbRecords: DailyTableRecord[],
-  allRecords: DailyTableRecord[],
-): { recentChange: 'up' | 'down' | 'flat'; changeRate: number } {
-  if (pbRecords.length < 2) return { recentChange: 'flat', changeRate: 0 };
-  if (allRecords.length < 2) return { recentChange: 'flat', changeRate: 0 };
-
-  // 全レコード期間の中間日を算出
-  const sortedDates = allRecords.map((r) => r.recordDate).sort();
-  const from = sortedDates[0];
-  const to = sortedDates[sortedDates.length - 1];
-  const fromMs = new Date(from + 'T00:00:00').getTime();
-  const toMs = new Date(to + 'T00:00:00').getTime();
-  const midMs = fromMs + (toMs - fromMs) / 2;
-  const midDate = new Date(midMs).toISOString().slice(0, 10);
-
-  let olderCount = 0;
-  let recentCount = 0;
-  for (const r of pbRecords) {
-    if (r.recordDate <= midDate) {
-      olderCount++;
-    } else {
-      recentCount++;
-    }
-  }
-
-  if (olderCount === 0 && recentCount === 0) return { recentChange: 'flat', changeRate: 0 };
-  if (olderCount === 0) return { recentChange: 'up', changeRate: 100 };
-
-  const changeRate = Math.round(((recentCount - olderCount) / olderCount) * 100);
-
-  if (changeRate > 10) return { recentChange: 'up', changeRate };
-  if (changeRate < -10) return { recentChange: 'down', changeRate };
-  return { recentChange: 'flat', changeRate };
+  return aggregateMonitoringBehaviors(records);
 }
 
 // ─── 行動タグ集計 ────────────────────────────────────────

--- a/src/features/monitoring/domain/monitoringDailyBehaviors.spec.ts
+++ b/src/features/monitoring/domain/monitoringDailyBehaviors.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import type { DailyTableRecord } from '@/features/daily/infra/dailyTableRepository';
+import { aggregateMonitoringBehaviors } from './monitoringDailyBehaviors';
+
+const mkRecord = (
+  overrides: Partial<DailyTableRecord> & { recordDate: string },
+): DailyTableRecord => ({
+  userId: 'u1',
+  activities: {},
+  submittedAt: '2024-01-01T00:00:00Z',
+  ...overrides,
+});
+
+describe('aggregateMonitoringBehaviors', () => {
+  it('空配列は問題行動なしを返す', () => {
+    expect(aggregateMonitoringBehaviors([])).toEqual({
+      totalDays: 0,
+      rate: 0,
+      byType: [],
+      weeklyTrend: [],
+      recentChange: 'flat',
+      changeRate: 0,
+    });
+  });
+
+  it('種別集計と recentChange を算出できる', () => {
+    const records = [
+      mkRecord({ recordDate: '2024-01-02', problemBehaviors: ['shouting'] }),
+      mkRecord({ recordDate: '2024-01-08' }),
+      mkRecord({ recordDate: '2024-01-15', problemBehaviors: ['shouting'] }),
+      mkRecord({ recordDate: '2024-01-16', problemBehaviors: ['shouting'] }),
+      mkRecord({ recordDate: '2024-01-22', problemBehaviors: ['shouting'] }),
+      mkRecord({ recordDate: '2024-01-23', problemBehaviors: ['selfHarm'] }),
+    ];
+
+    const result = aggregateMonitoringBehaviors(records);
+    expect(result.totalDays).toBe(5);
+    expect(result.rate).toBe(83);
+    expect(result.byType[0]).toEqual({ type: 'shouting', label: '大声', count: 4 });
+    expect(result.recentChange).toBe('up');
+  });
+});

--- a/src/features/monitoring/domain/monitoringDailyBehaviors.ts
+++ b/src/features/monitoring/domain/monitoringDailyBehaviors.ts
@@ -1,0 +1,111 @@
+import type {
+  DailyTableRecord,
+  ProblemBehaviorType,
+} from '@/features/daily/infra/dailyTableRepository';
+
+export interface MonitoringBehaviorSummary {
+  totalDays: number;
+  rate: number;
+  byType: { type: ProblemBehaviorType; label: string; count: number }[];
+  weeklyTrend: { week: string; count: number }[];
+  recentChange: 'up' | 'down' | 'flat';
+  changeRate: number;
+}
+
+const BEHAVIOR_LABELS: Record<ProblemBehaviorType, string> = {
+  selfHarm: '自傷',
+  otherInjury: '他傷',
+  shouting: '大声',
+  pica: '異食',
+  other: 'その他',
+};
+
+/** YYYY-MM-DD → 週番号文字列（月曜起点） */
+function toWeekKey(ymd: string): string {
+  const d = new Date(ymd + 'T00:00:00');
+  const day = d.getDay();
+  const monday = new Date(d);
+  monday.setDate(d.getDate() - ((day + 6) % 7));
+  const mm = String(monday.getMonth() + 1).padStart(2, '0');
+  const dd = String(monday.getDate()).padStart(2, '0');
+  return `${mm}/${dd}〜`;
+}
+
+/**
+ * 全レコードの日付範囲の中間日を基準に前半/後半の問題行動件数を比較する。
+ */
+function computeRecentChange(
+  pbRecords: DailyTableRecord[],
+  allRecords: DailyTableRecord[],
+): { recentChange: 'up' | 'down' | 'flat'; changeRate: number } {
+  if (pbRecords.length < 2) return { recentChange: 'flat', changeRate: 0 };
+  if (allRecords.length < 2) return { recentChange: 'flat', changeRate: 0 };
+
+  const sortedDates = allRecords.map((r) => r.recordDate).sort();
+  const from = sortedDates[0];
+  const to = sortedDates[sortedDates.length - 1];
+  const fromMs = new Date(from + 'T00:00:00').getTime();
+  const toMs = new Date(to + 'T00:00:00').getTime();
+  const midMs = fromMs + (toMs - fromMs) / 2;
+  const midDate = new Date(midMs).toISOString().slice(0, 10);
+
+  let olderCount = 0;
+  let recentCount = 0;
+  for (const r of pbRecords) {
+    if (r.recordDate <= midDate) {
+      olderCount++;
+    } else {
+      recentCount++;
+    }
+  }
+
+  if (olderCount === 0 && recentCount === 0) return { recentChange: 'flat', changeRate: 0 };
+  if (olderCount === 0) return { recentChange: 'up', changeRate: 100 };
+
+  const changeRate = Math.round(((recentCount - olderCount) / olderCount) * 100);
+  if (changeRate > 10) return { recentChange: 'up', changeRate };
+  if (changeRate < -10) return { recentChange: 'down', changeRate };
+  return { recentChange: 'flat', changeRate };
+}
+
+export function aggregateMonitoringBehaviors(
+  records: DailyTableRecord[],
+): MonitoringBehaviorSummary {
+  const typeCounts: Record<string, number> = {};
+  const weekCounts: Record<string, number> = {};
+  let totalDays = 0;
+
+  const pbRecords: DailyTableRecord[] = [];
+
+  for (const r of records) {
+    const pbs = r.problemBehaviors ?? [];
+    if (pbs.length === 0) continue;
+    totalDays++;
+    pbRecords.push(r);
+
+    for (const pb of pbs) {
+      typeCounts[pb] = (typeCounts[pb] ?? 0) + 1;
+    }
+
+    const wk = toWeekKey(r.recordDate);
+    weekCounts[wk] = (weekCounts[wk] ?? 0) + 1;
+  }
+
+  const byType = Object.entries(typeCounts)
+    .sort((a, b) => b[1] - a[1])
+    .map(([type, count]) => ({
+      type: type as ProblemBehaviorType,
+      label: BEHAVIOR_LABELS[type as ProblemBehaviorType] ?? type,
+      count,
+    }));
+
+  const weeklyTrend = Object.entries(weekCounts)
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([week, count]) => ({ week, count }));
+
+  const { recentChange, changeRate } = computeRecentChange(pbRecords, records);
+  const recordedDays = records.length;
+  const rate = recordedDays > 0 ? Math.round((totalDays / recordedDays) * 100) : 0;
+
+  return { totalDays, rate, byType, weeklyTrend, recentChange, changeRate };
+}


### PR DESCRIPTION
## Summary
- #1175 part2 として `monitoringDailyAnalytics.ts` から問題行動集計グループを抽出
- `aggregateBehaviors` の公開契約は維持し、内部を新規 pure module に委譲
- 抽出先の最小 unit spec を追加

## Boundary memo
### Cut in this PR
- 問題行動集計グループ
  - `aggregateBehaviors`
  - 週次キー生成
  - recentChange 判定

### Not cut in this PR
- 活動集計 / 昼食集計 / 行動タグ集計
- goalProgress / ISP提案 / insight文生成
- 既存公開APIの変更

## Changes
- add: `src/features/monitoring/domain/monitoringDailyBehaviors.ts`
- add: `src/features/monitoring/domain/monitoringDailyBehaviors.spec.ts`
- update: `src/features/monitoring/domain/monitoringDailyAnalytics.ts`
  - `aggregateBehaviors` を `aggregateMonitoringBehaviors` 委譲へ変更

## Validation
- `npx vitest run src/features/monitoring/domain/monitoringDailyAnalytics.spec.ts src/features/monitoring/domain/monitoringDailyBehaviors.spec.ts src/features/monitoring/domain/monitoringDailyPeriod.spec.ts`
- `npm run typecheck`
- `npx eslint src/features/monitoring/domain/monitoringDailyAnalytics.ts src/features/monitoring/domain/monitoringDailyBehaviors.ts src/features/monitoring/domain/monitoringDailyBehaviors.spec.ts`
