### PR TITLE
feat: add minimal telemetry anomaly status UI (#1088 phase2)

### DIFF
--- a/src/features/telemetry/components/TelemetryDashboard.tsx
+++ b/src/features/telemetry/components/TelemetryDashboard.tsx
@@ -7,6 +7,7 @@ import { RangeTabs } from './ui/RangeTabs';
 import { useTelemetryDashboard } from '../hooks/useTelemetryDashboard';
 import { KpiTabContent } from './sections/KpiTabContent';
 import { RawTabContent } from './sections/RawTabContent';
+import { AnomalyStatusChip, deriveAnomalyUiStatus } from './ui/AnomalyStatusChip';
 
 type DashboardTab = 'kpi' | 'raw';
 
@@ -82,6 +83,12 @@ export default function TelemetryDashboard() {
 
   if (!stats) return null;
 
+  const warningCount = kpiDiffs?.alerts.length ?? 0;
+  const anomalyStatus = deriveAnomalyUiStatus({
+    totalEvents: stats.total,
+    warningCount,
+  });
+
   return (
     <div style={{ padding: 16, maxWidth: 900, margin: '0 auto' }}>
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 16, flexWrap: 'wrap', gap: 8 }}>
@@ -95,6 +102,7 @@ export default function TelemetryDashboard() {
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <RangeTabs current={range} onChange={setRange} disabled={loading} />
+          <AnomalyStatusChip status={anomalyStatus} count={warningCount} label="anomaly" />
           <button
             type="button"
             onClick={refresh}

--- a/src/features/telemetry/components/ui/AnomalyStatusChip.spec.ts
+++ b/src/features/telemetry/components/ui/AnomalyStatusChip.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { deriveAnomalyUiStatus } from './AnomalyStatusChip';
+
+describe('deriveAnomalyUiStatus', () => {
+  it('totalEvents=0 は unknown を返す', () => {
+    expect(deriveAnomalyUiStatus({ totalEvents: 0, warningCount: 0 })).toBe('unknown');
+  });
+
+  it('warningCount>0 は warning を返す', () => {
+    expect(deriveAnomalyUiStatus({ totalEvents: 10, warningCount: 1 })).toBe('warning');
+  });
+
+  it('イベントあり + warning 0 は ok を返す', () => {
+    expect(deriveAnomalyUiStatus({ totalEvents: 10, warningCount: 0 })).toBe('ok');
+  });
+});

--- a/src/features/telemetry/components/ui/AnomalyStatusChip.tsx
+++ b/src/features/telemetry/components/ui/AnomalyStatusChip.tsx
@@ -1,0 +1,60 @@
+export type AnomalyStatus = 'ok' | 'warning' | 'unknown';
+
+type AnomalyStatusChipProps = {
+  status: AnomalyStatus;
+  count?: number;
+  label?: string;
+};
+
+type DeriveStatusInput = {
+  totalEvents: number;
+  warningCount: number;
+};
+
+export function deriveAnomalyUiStatus({
+  totalEvents,
+  warningCount,
+}: DeriveStatusInput): AnomalyStatus {
+  if (totalEvents <= 0) return 'unknown';
+  if (warningCount > 0) return 'warning';
+  return 'ok';
+}
+
+export function AnomalyStatusChip({
+  status,
+  count,
+  label = 'Anomaly',
+}: AnomalyStatusChipProps) {
+  const isWarning = status === 'warning';
+  const isUnknown = status === 'unknown';
+
+  const icon = isWarning ? '⚠️' : isUnknown ? '❔' : '✅';
+  const text = isWarning ? 'warning' : isUnknown ? 'unknown' : 'ok';
+  const bg = isWarning ? '#fff7ed' : isUnknown ? '#f8fafc' : '#ecfdf5';
+  const fg = isWarning ? '#b45309' : isUnknown ? '#64748b' : '#065f46';
+  const border = isWarning ? '#fdba74' : isUnknown ? '#cbd5e1' : '#86efac';
+  const countLabel = isWarning && typeof count === 'number' ? ` (${count})` : '';
+
+  return (
+    <span
+      aria-label={`${label} ${text}`}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 6,
+        padding: '5px 10px',
+        borderRadius: 999,
+        border: `1px solid ${border}`,
+        background: bg,
+        color: fg,
+        fontSize: 12,
+        fontWeight: 600,
+        lineHeight: 1,
+        whiteSpace: 'nowrap',
+      }}
+    >
+      <span aria-hidden="true">{icon}</span>
+      <span>{label}: {text}{countLabel}</span>
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary
- add a minimal presentational component `AnomalyStatusChip` for anomaly status display
- show anomaly status (`ok` / `warning` / `unknown`) in Telemetry dashboard header
- derive display status only from existing data (`stats.total`, `kpiDiffs.alerts.length`)
- add unit tests for status derivation

## Scope
- UI only
- no anomaly detection logic changes
- no threshold changes
- no notification/settings/history changes

## Validation
- `npx vitest run src/features/telemetry/components/ui/AnomalyStatusChip.spec.ts`
- `npx eslint src/features/telemetry/components/TelemetryDashboard.tsx src/features/telemetry/components/ui/AnomalyStatusChip.tsx src/features/telemetry/components/ui/AnomalyStatusChip.spec.ts --max-warnings=0`
- `npm run typecheck`

## Issue
- refs #1088
