### PR TITLE
feat(exception-center): self-contained corrective actions via useAllCorrectiveActions

### DIFF
--- a/src/features/action-engine/hooks/useAllCorrectiveActions.ts
+++ b/src/features/action-engine/hooks/useAllCorrectiveActions.ts
@@ -1,0 +1,223 @@
+// ---------------------------------------------------------------------------
+// useAllCorrectiveActions — 全利用者分の是正提案を一括生成する hook
+//
+// ExceptionCenterPage が self-contained に動作するための最後の結線。
+// AnalysisDashboard (1 ユーザー) ベースの useActionSuggestions と異なり、
+// 全アクティブ利用者の行動データを一括フェッチし buildCorrectiveActions を回す。
+//
+// 設計意図:
+// - ExceptionCenterPage の props 注入依存を解消する
+// - useExceptionDataSources と同じ非同期パターンを踏襲
+// - 将来的にバッチ結果キャッシュへの移行が可能
+// ---------------------------------------------------------------------------
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useUsers } from '@/features/users/useUsers';
+import { getBehaviorRepository } from '@/features/daily/infra/behaviorRepositoryFactory';
+import type { BehaviorObservation } from '@/features/daily/domain/daily/types';
+import type { ActionSuggestion, CorrectiveActionInput, TrendSummary, HeatmapPeak } from '../domain/types';
+import { buildCorrectiveActions } from '../domain/buildCorrectiveActions';
+import {
+  extractHighIntensityEvents,
+  getLastRecordDate,
+} from './useActionSuggestions';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type AllCorrectiveActionsStatus = 'idle' | 'loading' | 'ready' | 'error';
+
+export interface UseAllCorrectiveActionsReturn {
+  /** 全利用者分の是正提案（フラット配列） */
+  suggestions: ActionSuggestion[];
+  /** ステータス（idle → loading → ready / error） */
+  status: AllCorrectiveActionsStatus;
+  /** エラーメッセージ */
+  error: string | null;
+  /** suggestions の件数 */
+  count: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ANALYSIS_DAYS = 30;
+
+/**
+ * 行動観察データから CorrectiveActionInput を組み立てる。
+ *
+ * useActionSuggestions の内部ロジックと同等だが、
+ * execution / heatmap は簡略化している（ExceptionCenter 向けは概要で十分）。
+ */
+function buildInputFromRecords(
+  userId: string,
+  records: BehaviorObservation[],
+): CorrectiveActionInput {
+  // 日別集計からトレンドサマリーを構築
+  const dailyMap = new Map<string, number>();
+  for (const r of records) {
+    const day = r.recordedAt.split('T')[0] ?? '';
+    dailyMap.set(day, (dailyMap.get(day) ?? 0) + 1);
+  }
+  const dailyCounts = Array.from(dailyMap.values()).sort();
+
+  const midpoint = Math.floor(dailyCounts.length / 2);
+  const recentHalf = dailyCounts.slice(midpoint);
+  const olderHalf = dailyCounts.slice(0, midpoint);
+  const recentAvg = recentHalf.length > 0
+    ? recentHalf.reduce((sum, c) => sum + c, 0) / recentHalf.length
+    : 0;
+  const previousAvg = olderHalf.length > 0
+    ? olderHalf.reduce((sum, c) => sum + c, 0) / olderHalf.length
+    : 0;
+  const changeRate = previousAvg > 0 ? recentAvg / previousAvg : 1;
+
+  const trend: TrendSummary = {
+    recentAvg: Number(recentAvg.toFixed(2)),
+    previousAvg: Number(previousAvg.toFixed(2)),
+    changeRate: Number(changeRate.toFixed(2)),
+  };
+
+  // ヒートマップピーク情報を構築
+  const hourCounts = new Array<number>(24).fill(0);
+  for (const r of records) {
+    const hour = new Date(r.recordedAt).getHours();
+    hourCounts[hour]! += 1;
+  }
+  const totalEvents = hourCounts.reduce((sum, c) => sum + c, 0);
+  let peakHour = 0;
+  let peakCount = 0;
+  for (let h = 0; h < 24; h++) {
+    if (hourCounts[h]! > peakCount) {
+      peakHour = h;
+      peakCount = hourCounts[h]!;
+    }
+  }
+  const heatmapPeak: HeatmapPeak = {
+    hour: peakHour,
+    count: peakCount,
+    totalEvents,
+    concentration: totalEvents > 0 ? Number((peakCount / totalEvents).toFixed(2)) : 0,
+  };
+
+  return {
+    targetUserId: userId,
+    trend,
+    execution: {
+      completed: 0,
+      triggered: 0,
+      skipped: 0,
+      total: 0,
+      completionRate: 0,
+    },
+    highIntensityEvents: extractHighIntensityEvents(records),
+    heatmapPeak,
+    activeBipCount: 0, // ExceptionCenter バッチでは BIP 情報を簡略化
+    totalIncidents: records.length,
+    lastRecordDate: getLastRecordDate(records),
+    analysisDays: ANALYSIS_DAYS,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * 全アクティブ利用者の行動データを取得し、是正提案を一括生成する。
+ *
+ * @returns 全利用者分の是正提案フラット配列と loading/error 状態
+ */
+export function useAllCorrectiveActions(): UseAllCorrectiveActionsReturn {
+  const { data: users } = useUsers();
+  const [allSuggestions, setAllSuggestions] = useState<ActionSuggestion[]>([]);
+  const [status, setStatus] = useState<AllCorrectiveActionsStatus>('idle');
+  const [error, setError] = useState<string | null>(null);
+
+  const activeUserIds = useMemo(() => {
+    return (users ?? [])
+      .filter((u) => u.IsActive !== false)
+      .map((u) => u.UserID ?? String(u.Id))
+      .filter(Boolean);
+  }, [users]);
+
+  const fetchAll = useCallback(async (userIds: string[]) => {
+    if (userIds.length === 0) {
+      setAllSuggestions([]);
+      setStatus('ready');
+      return;
+    }
+
+    setStatus('loading');
+    setError(null);
+
+    const repo = getBehaviorRepository();
+    const now = new Date();
+    const startDate = new Date();
+    startDate.setDate(now.getDate() - ANALYSIS_DAYS);
+
+    const results: ActionSuggestion[] = [];
+
+    try {
+      // 全ユーザーを並列で取得（Promise.allSettled で 1 件失敗しても止めない）
+      const settled = await Promise.allSettled(
+        userIds.map(async (userId) => {
+          const records = await repo.listByUser(userId, {
+            dateRange: {
+              from: startDate.toISOString(),
+              to: now.toISOString(),
+            },
+            order: 'asc',
+            limit: 500,
+          });
+          return { userId, records };
+        }),
+      );
+
+      for (const result of settled) {
+        if (result.status === 'fulfilled') {
+          const { userId, records } = result.value;
+          if (records.length > 0) {
+            const input = buildInputFromRecords(userId, records);
+            const suggestions = buildCorrectiveActions(input, now);
+            results.push(...suggestions);
+          }
+        }
+        // rejected は warn して skip
+        if (result.status === 'rejected') {
+          console.warn(
+            '[useAllCorrectiveActions] Failed to fetch for a user:',
+            result.reason,
+          );
+        }
+      }
+
+      setAllSuggestions(results);
+      setStatus('ready');
+    } catch (err) {
+      console.error('[useAllCorrectiveActions] Batch fetch failed:', err);
+      setError(err instanceof Error ? err.message : '是正提案の生成に失敗しました');
+      setStatus('error');
+    }
+  }, []);
+
+  useEffect(() => {
+    if (activeUserIds.length > 0) {
+      fetchAll(activeUserIds);
+    } else if (users !== undefined) {
+      // users が取得済みだがアクティブユーザーがいない場合
+      setAllSuggestions([]);
+      setStatus('ready');
+    }
+    // users が undefined (まだ取得中) の場合は idle のまま待機
+  }, [activeUserIds, fetchAll, users]);
+
+  return {
+    suggestions: allSuggestions,
+    status,
+    error,
+    count: allSuggestions.length,
+  };
+}

--- a/src/features/action-engine/index.ts
+++ b/src/features/action-engine/index.ts
@@ -51,6 +51,13 @@ export type {
   UseActionSuggestionsReturn,
 } from './hooks/useActionSuggestions';
 
+// Batch hook (Exception Center 向け)
+export { useAllCorrectiveActions } from './hooks/useAllCorrectiveActions';
+export type {
+  AllCorrectiveActionsStatus,
+  UseAllCorrectiveActionsReturn,
+} from './hooks/useAllCorrectiveActions';
+
 // State store
 export { useSuggestionStateStore } from './hooks/useSuggestionStateStore';
 export type { SuggestionStateStore, SuggestionStateMeta } from './hooks/useSuggestionStateStore';

--- a/src/pages/admin/ExceptionCenterPage.tsx
+++ b/src/pages/admin/ExceptionCenterPage.tsx
@@ -42,10 +42,10 @@ import { applyExceptionPreferences } from '@/features/exceptions/domain/applyExc
 import { useExceptionDataSources } from '@/features/exceptions/hooks/useExceptionDataSources';
 import { useCorrectiveActionExceptions } from '@/features/exceptions/hooks/useCorrectiveActionExceptions';
 import { useActiveExceptionPreferences } from '@/features/exceptions/hooks/useExceptionPreferences';
-import type { ActionSuggestion, ActionSuggestionState } from '@/features/action-engine/domain/types';
 import type { SnoozePreset } from '@/features/action-engine/domain/computeSnoozeUntil';
 import { computeSnoozeUntil } from '@/features/action-engine/domain/computeSnoozeUntil';
 import { useSuggestionStateStore } from '@/features/action-engine/hooks/useSuggestionStateStore';
+import { useAllCorrectiveActions } from '@/features/action-engine/hooks/useAllCorrectiveActions';
 import {
   buildSuggestionTelemetryEvent,
   SUGGESTION_TELEMETRY_EVENTS,
@@ -54,22 +54,14 @@ import { recordSuggestionTelemetry } from '@/features/action-engine/telemetry/re
 
 // ─── Component ────────────────────────────────────────────────
 
-export interface ExceptionCenterPageProps {
-  /** Action Engine が生成した全利用者分の提案（外部から注入） */
-  allSuggestions?: ActionSuggestion[];
-  /** 提案の dismiss/snooze 状態 */
-  suggestionStates?: Record<string, ActionSuggestionState>;
-}
-
-export default function ExceptionCenterPage({
-  allSuggestions = [],
-  suggestionStates,
-}: ExceptionCenterPageProps) {
+export default function ExceptionCenterPage() {
   const navigate = useNavigate();
-  const storeStates = useSuggestionStateStore((s) => s.states);
+
+  // Action Engine: 全利用者分の是正提案を自給自足
+  const { suggestions: allSuggestions, status: suggestionsStatus, error: suggestionsError } = useAllCorrectiveActions();
+  const suggestionStates = useSuggestionStateStore((s) => s.states);
   const dismissSuggestion = useSuggestionStateStore((s) => s.dismiss);
   const snoozeSuggestion = useSuggestionStateStore((s) => s.snooze);
-  const effectiveSuggestionStates = suggestionStates ?? storeStates;
 
   // Sprint-1 Phase B: 実データ接続
   const dataSources = useExceptionDataSources();
@@ -82,7 +74,7 @@ export default function ExceptionCenterPage({
   // Action Engine 提案 → ExceptionItem
   const { items: correctiveItems } = useCorrectiveActionExceptions({
     suggestions: allSuggestions,
-    states: effectiveSuggestionStates,
+    states: suggestionStates,
   });
 
   const handleDismissSuggestion = React.useCallback((stableId: string) => {
@@ -197,6 +189,9 @@ export default function ExceptionCenterPage({
     },
   ];
 
+  // 是正提案データの取得状況を loading に含める
+  const isLoading = dataSources.status === 'loading' || suggestionsStatus === 'loading';
+
   return (
     <Container maxWidth="lg" sx={{ py: 3 }} data-testid="exception-center-page">
       {/* ── Back Navigation ── */}
@@ -210,7 +205,7 @@ export default function ExceptionCenterPage({
       </Button>
 
       {/* ── Loading 状態 ── */}
-      {dataSources.status === 'loading' && (
+      {isLoading && (
         <Stack spacing={2}>
           <Skeleton variant="rectangular" height={80} sx={{ borderRadius: 2 }} />
           <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr 1fr', sm: '1fr 1fr 1fr 1fr' }, gap: 2 }}>
@@ -227,8 +222,15 @@ export default function ExceptionCenterPage({
         </Alert>
       )}
 
+      {/* ── 是正提案 Error 状態（他のデータソースとは独立） ── */}
+      {suggestionsStatus === 'error' && suggestionsError && (
+        <Alert severity="warning" sx={{ my: 1 }} data-testid="exception-center-suggestions-error">
+          是正提案の取得に失敗しました: {suggestionsError}
+        </Alert>
+      )}
+
       {/* ── Empty 状態 ── */}
-      {dataSources.status === 'empty' && (
+      {!isLoading && dataSources.status === 'empty' && allSuggestions.length === 0 && (
         <Paper variant="outlined" sx={{ p: 4, textAlign: 'center', borderRadius: 2 }} data-testid="exception-center-empty">
           <Typography variant="h5" sx={{ mb: 1 }}>✅</Typography>
           <Typography variant="h6" sx={{ fontWeight: 600 }}>例外は検出されていません</Typography>
@@ -239,7 +241,7 @@ export default function ExceptionCenterPage({
       )}
 
       {/* ── Ready 状態 ── */}
-      {dataSources.status === 'ready' && (
+      {(dataSources.status === 'ready' || (dataSources.status === 'empty' && allSuggestions.length > 0)) && (
       <Stack spacing={3}>
         {/* ════════════════════════════════════════════════════════════
             Header

--- a/tests/unit/pages/ExceptionCenterPage.suggestionTelemetry.spec.tsx
+++ b/tests/unit/pages/ExceptionCenterPage.suggestionTelemetry.spec.tsx
@@ -70,6 +70,17 @@ vi.mock('../../../src/features/action-engine/hooks/useSuggestionStateStore', () 
   }),
 }));
 
+// useAllCorrectiveActions mock — suggestion データの注入
+let mockAllSuggestions: ActionSuggestion[] = [];
+vi.mock('../../../src/features/action-engine/hooks/useAllCorrectiveActions', () => ({
+  useAllCorrectiveActions: vi.fn(() => ({
+    suggestions: mockAllSuggestions,
+    status: 'ready',
+    error: null,
+    count: mockAllSuggestions.length,
+  })),
+}));
+
 const mockRecordSuggestionTelemetry = vi.fn();
 vi.mock('../../../src/features/action-engine/telemetry/recordSuggestionTelemetry', () => ({
   recordSuggestionTelemetry: (...args: unknown[]) => mockRecordSuggestionTelemetry(...args),
@@ -80,6 +91,7 @@ describe('ExceptionCenterPage suggestion telemetry', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-03-21T10:00:00Z'));
     vi.clearAllMocks();
+    mockAllSuggestions = [];
   });
 
   afterEach(() => {
@@ -109,9 +121,12 @@ describe('ExceptionCenterPage suggestion telemetry', () => {
       ruleId: 'behavior-trend-increase',
     };
 
+    // useAllCorrectiveActions を通じてデータを注入
+    mockAllSuggestions = [suggestion];
+
     render(
       <MemoryRouter>
-        <ExceptionCenterPage allSuggestions={[suggestion]} suggestionStates={{}} />
+        <ExceptionCenterPage />
       </MemoryRouter>,
     );
 


### PR DESCRIPTION
## 概要

GAP-A 解消: ExceptionCenterPage を **self-contained 化**し、corrective action データの props 注入依存を解消。

## 変更内容

### 追加
- `useAllCorrectiveActions` hook — 全アクティブ利用者の行動データを並列取得（Promise.allSettled）し、`buildCorrectiveActions` で是正提案を一括生成
- action-engine/index.ts にバッチ hook のエクスポートを追加

### 変更
- `ExceptionCenterPage` — props (`allSuggestions`, `suggestionStates`) を除去、hook から自前取得に変更
- loading / error / empty 状態判定を両データソース対応に統一
- 是正提案取得の独立エラー表示を追加

### テスト更新
- `ExceptionCenterPage.suggestionTelemetry.spec.tsx` — `useAllCorrectiveActions` モック方式に移行

## 検証

| 項目 | 結果 |
|------|------|
| TypeCheck | ✅ pass |
| Test Files | ✅ 717 passed |
| Tests | ✅ 8491 passed |
| Lint (pre-commit) | ✅ pass |

## 関連

- GAP-B（ユーザー別グルーピング UI）は別 PR
- GAP-C（dismiss/snooze 永続化）は別 PR