### PR TITLE
fix(rbac): relax reception routes for trial deployment

### DIFF
--- a/src/app/routes/recordRoutes.tsx
+++ b/src/app/routes/recordRoutes.tsx
@@ -28,7 +28,7 @@ export const recordRoutes: RouteObject[] = [
   {
     path: 'records/monthly',
     element: (
-      <RequireAudience requiredRole="reception">
+      <RequireAudience requiredRole="viewer">
         <SuspendedMonthlyRecordPage />
       </RequireAudience>
     ),
@@ -52,7 +52,7 @@ export const recordRoutes: RouteObject[] = [
   {
     path: 'records/service-provision',
     element: (
-      <RequireAudience requiredRole="reception">
+      <RequireAudience requiredRole="viewer">
         <SuspendedServiceProvisionFormPage />
       </RequireAudience>
     ),


### PR DESCRIPTION
## 問題

本番環境で AAD グループ ID が未設定のため、全ユーザーが viewer ロールに解決される。
reception 以上を要求するルートでスタッフが 403 Forbidden になる。

## 対応

試験運用期間中、以下のルートの requiredRole を viewer に緩和:

- records/service-provision: reception → viewer
- records/monthly: reception → viewer

## 変更しないもの

- billing: reception のまま（意図的に制限）
- admin 系ルート: admin のまま

## 次ステップ

AAD グループ ID を Cloudflare 環境変数に設定後、reception に戻す