### PR TITLE
feat(exception-center): add week-1 priority telemetry signals

### DIFF
--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -17,6 +17,7 @@
 
 - [Corrective-Action Telemetry Review](./corrective-action-telemetry-review.md)
 - [ExceptionCenter Horizontal Rollout](./exception-center-horizontal-rollout.md)
+- [ExceptionCenter Priority Week-1 Review](./exception-center-priority-week1-review.md)
 - Weekly Review Issue Template: `.github/ISSUE_TEMPLATE/corrective-action-weekly-review.yml`
 
 ### ExceptionCenter 標準化状況

--- a/docs/runbooks/exception-center-priority-week1-review.md
+++ b/docs/runbooks/exception-center-priority-week1-review.md
@@ -1,0 +1,62 @@
+# ExceptionCenter Priority Week-1 Review
+
+ExceptionCenter の priority 導入直後 1 週間だけ実施する運用計測 runbook。
+
+## 目的
+
+- Top3 が実際に使われているかを確認する
+- deep link が遷移先まで到達しているかを確認する
+- CTA 後に dismiss/snooze まで進む速度を確認する
+
+## 対象データ
+
+- Firestore `telemetry`
+- `type == "suggestion_lifecycle_event"`
+- `sourceScreen == "exception-center"`
+- 直近 7 日（固定）
+
+## 利用イベント
+
+- `suggestion_shown`（Top3 は `ctaSurface == "priority-top3"`）
+- `suggestion_cta_clicked`（`ctaSurface: "table" | "priority-top3"`）
+- `suggestion_deep_link_arrived`
+- `suggestion_dismissed`
+- `suggestion_snoozed`
+
+## 指標定義
+
+1. Top3 クリック率
+   - 分子: `suggestion_cta_clicked` かつ `ctaSurface == "priority-top3"`
+   - 分母: `suggestion_shown` かつ `ctaSurface == "priority-top3"`
+   - 式: `top3Clicked / top3Shown`
+
+2. deep link 到達率
+   - 分子: `suggestion_deep_link_arrived`
+   - 分母: `suggestion_cta_clicked`
+   - 式: `arrived / clicked`
+
+3. dismiss/snooze 完了までの時間（分）
+   - 単位: `stableId`
+   - 開始: 最初の `suggestion_cta_clicked`
+   - 終了: 最初の `suggestion_dismissed` または `suggestion_snoozed`
+   - 集計: p50 / p90（週次）
+
+## 手順（週次 15 分）
+
+1. Firestore Console で `telemetry` を開く。
+2. `type == "suggestion_lifecycle_event"` かつ `sourceScreen == "exception-center"` で 7 日に絞る。
+3. 上記 3 指標を集計する。
+4. 週次ノートに `top3Clicked/top3Shown`, `arrived/clicked`, `p50/p90` を記録する。
+5. 1 週間終了時に重み調整要否を判定する（調整は 1 回のみ）。
+
+## 判定基準（初期値）
+
+- Top3 クリック率 < 15%: Top3 文言/並び見直し候補
+- deep link 到達率 < 90%: 導線不整合を調査
+- 完了時間 p50 > 60 分: 優先度重み見直し候補
+
+## 更新ルール
+
+- 閾値や指標を変えたら本 runbook を同時更新する。
+- 重み調整 PR にはこの runbook の集計結果を必ず添付する。
+

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -18,6 +18,7 @@ import { useKeyboardAwareScroll } from '@/hooks/useKeyboardAwareScroll';
 import { AppShellV2 } from '@/components/layout/AppShellV2';
 import { isDev } from '@/env';
 import { SettingsDialog } from '@/features/settings/SettingsDialog';
+import { useSuggestionDeepLinkArrivalTelemetry } from '@/features/action-engine/telemetry/useSuggestionDeepLinkArrivalTelemetry';
 import RouteHydrationListener from '@/hydration/RouteHydrationListener';
 import CloseFullscreenRoundedIcon from '@mui/icons-material/CloseFullscreenRounded';
 import Drawer from '@mui/material/Drawer';
@@ -176,6 +177,7 @@ const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) => {
 
   // ── キーボード対策（キオスクモード時のみ） ────────────────────────────
   useKeyboardAwareScroll(isKioskMode);
+  useSuggestionDeepLinkArrivalTelemetry();
 
   // ── Slots ──────────────────────────────────────────────────────────────────
 

--- a/src/features/action-engine/telemetry/__tests__/buildSuggestionTelemetryEvent.spec.ts
+++ b/src/features/action-engine/telemetry/__tests__/buildSuggestionTelemetryEvent.spec.ts
@@ -71,4 +71,26 @@ describe('buildSuggestionTelemetryEvent', () => {
 
     expect(event.timestamp).toBe('2026-03-21T12:34:56.000Z');
   });
+
+  it('CTA surface を含めた payload を組み立てる', () => {
+    const event = buildSuggestionTelemetryEvent({
+      event: SUGGESTION_TELEMETRY_EVENTS.CTA_CLICKED,
+      sourceScreen: 'exception-center',
+      stableId: 'rule:user:2026-W12',
+      ruleId: 'rule',
+      priority: 'P1',
+      targetUrl: '/assessment',
+      ctaSurface: 'priority-top3',
+    });
+
+    expect(event).toEqual(
+      expect.objectContaining({
+        event: 'suggestion_cta_clicked',
+        sourceScreen: 'exception-center',
+        stableId: 'rule:user:2026-W12',
+        targetUrl: '/assessment',
+        ctaSurface: 'priority-top3',
+      }),
+    );
+  });
 });

--- a/src/features/action-engine/telemetry/__tests__/suggestionDeepLinkTracker.spec.ts
+++ b/src/features/action-engine/telemetry/__tests__/suggestionDeepLinkTracker.spec.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  buildSuggestionTelemetryEvent,
+  SUGGESTION_TELEMETRY_EVENTS,
+} from '../buildSuggestionTelemetryEvent';
+import {
+  clearPendingSuggestionDeepLink,
+  queuePendingSuggestionDeepLink,
+  takeMatchingPendingSuggestionDeepLink,
+} from '../suggestionDeepLinkTracker';
+
+describe('suggestionDeepLinkTracker', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    vi.spyOn(Date, 'now').mockReturnValue(
+      new Date('2026-03-25T10:00:00.000Z').getTime(),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    sessionStorage.clear();
+  });
+
+  it('CTA click を pending 保存し、一致ルートで到達を consume できる', () => {
+    const cta = buildSuggestionTelemetryEvent({
+      event: SUGGESTION_TELEMETRY_EVENTS.CTA_CLICKED,
+      sourceScreen: 'exception-center',
+      stableId: 'stable-1',
+      ruleId: 'rule-1',
+      priority: 'P1',
+      targetUserId: 'user-001',
+      targetUrl: '/daily/activity?userId=user-001&date=2026-03-25',
+      ctaSurface: 'priority-top3',
+      timestamp: '2026-03-25T10:00:00.000Z',
+    });
+
+    queuePendingSuggestionDeepLink(cta);
+
+    const matched = takeMatchingPendingSuggestionDeepLink(
+      '/daily/activity',
+      '?userId=user-001&date=2026-03-25',
+    );
+
+    expect(matched).not.toBeNull();
+    expect(matched?.stableId).toBe('stable-1');
+    expect(matched?.ctaSurface).toBe('priority-top3');
+
+    const consumed = takeMatchingPendingSuggestionDeepLink(
+      '/daily/activity',
+      '?userId=user-001&date=2026-03-25',
+    );
+    expect(consumed).toBeNull();
+  });
+
+  it('不一致ルートでは pending を維持し、一致時に消費する', () => {
+    const cta = buildSuggestionTelemetryEvent({
+      event: SUGGESTION_TELEMETRY_EVENTS.CTA_CLICKED,
+      sourceScreen: 'exception-center',
+      stableId: 'stable-2',
+      ruleId: 'rule-2',
+      priority: 'P0',
+      targetUrl: '/handoff-timeline?range=day&date=2026-03-25&handoffId=hf-1',
+    });
+    queuePendingSuggestionDeepLink(cta);
+
+    expect(
+      takeMatchingPendingSuggestionDeepLink(
+        '/handoff-timeline',
+        '?range=week&date=2026-03-25&handoffId=hf-1',
+      ),
+    ).toBeNull();
+
+    const matched = takeMatchingPendingSuggestionDeepLink(
+      '/handoff-timeline',
+      '?range=day&date=2026-03-25&handoffId=hf-1',
+    );
+    expect(matched?.stableId).toBe('stable-2');
+  });
+
+  it('TTL 経過後の pending は破棄される', () => {
+    const cta = buildSuggestionTelemetryEvent({
+      event: SUGGESTION_TELEMETRY_EVENTS.CTA_CLICKED,
+      sourceScreen: 'exception-center',
+      stableId: 'stable-3',
+      ruleId: 'rule-3',
+      priority: 'P2',
+      targetUrl: '/assessment',
+      timestamp: '2026-03-25T10:00:00.000Z',
+    });
+    queuePendingSuggestionDeepLink(cta);
+
+    vi.spyOn(Date, 'now').mockReturnValue(
+      new Date('2026-03-25T10:11:00.000Z').getTime(),
+    );
+
+    expect(takeMatchingPendingSuggestionDeepLink('/assessment', '')).toBeNull();
+  });
+
+  it('non-CTA event は pending を保存しない', () => {
+    clearPendingSuggestionDeepLink();
+    const shown = buildSuggestionTelemetryEvent({
+      event: SUGGESTION_TELEMETRY_EVENTS.SHOWN,
+      sourceScreen: 'exception-center',
+      stableId: 'stable-4',
+      ruleId: 'rule-4',
+      priority: 'P1',
+    });
+    queuePendingSuggestionDeepLink(shown);
+
+    expect(takeMatchingPendingSuggestionDeepLink('/assessment', '')).toBeNull();
+  });
+});
+

--- a/src/features/action-engine/telemetry/__tests__/useSuggestionDeepLinkArrivalTelemetry.spec.tsx
+++ b/src/features/action-engine/telemetry/__tests__/useSuggestionDeepLinkArrivalTelemetry.spec.tsx
@@ -1,0 +1,79 @@
+import { renderHook } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useSuggestionDeepLinkArrivalTelemetry } from '../useSuggestionDeepLinkArrivalTelemetry';
+
+const mockRecordSuggestionTelemetry = vi.fn();
+const mockTakeMatchingPendingSuggestionDeepLink = vi.fn();
+
+vi.mock('../recordSuggestionTelemetry', () => ({
+  recordSuggestionTelemetry: (...args: unknown[]) =>
+    mockRecordSuggestionTelemetry(...args),
+}));
+
+vi.mock('../suggestionDeepLinkTracker', () => ({
+  takeMatchingPendingSuggestionDeepLink: (...args: unknown[]) =>
+    mockTakeMatchingPendingSuggestionDeepLink(...args),
+}));
+
+describe('useSuggestionDeepLinkArrivalTelemetry', () => {
+  beforeEach(() => {
+    mockRecordSuggestionTelemetry.mockReset();
+    mockTakeMatchingPendingSuggestionDeepLink.mockReset();
+  });
+
+  it('一致する pending deep link がある場合に到達 telemetry を送る', () => {
+    mockTakeMatchingPendingSuggestionDeepLink.mockReturnValue({
+      sourceScreen: 'exception-center',
+      stableId: 'stable-1',
+      ruleId: 'rule-1',
+      priority: 'P1',
+      targetUserId: 'user-001',
+      targetUrl: '/daily/activity?userId=user-001&date=2026-03-25',
+      targetPathWithSearch: '/daily/activity?userId=user-001&date=2026-03-25',
+      ctaSurface: 'priority-top3',
+      clickedAt: '2026-03-25T10:00:00.000Z',
+      expiresAtMs: Date.now() + 60_000,
+    });
+
+    renderHook(() => useSuggestionDeepLinkArrivalTelemetry(), {
+      wrapper: ({ children }) => (
+        <MemoryRouter
+          initialEntries={['/daily/activity?userId=user-001&date=2026-03-25']}
+        >
+          {children}
+        </MemoryRouter>
+      ),
+    });
+
+    expect(mockTakeMatchingPendingSuggestionDeepLink).toHaveBeenCalledWith(
+      '/daily/activity',
+      '?userId=user-001&date=2026-03-25',
+    );
+    expect(mockRecordSuggestionTelemetry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'suggestion_deep_link_arrived',
+        sourceScreen: 'exception-center',
+        stableId: 'stable-1',
+        ctaSurface: 'priority-top3',
+      }),
+      expect.objectContaining({
+        dedupeKey: expect.stringContaining('suggestion_deep_link_arrived'),
+      }),
+    );
+  });
+
+  it('pending がない場合は telemetry を送らない', () => {
+    mockTakeMatchingPendingSuggestionDeepLink.mockReturnValue(null);
+
+    renderHook(() => useSuggestionDeepLinkArrivalTelemetry(), {
+      wrapper: ({ children }) => (
+        <MemoryRouter initialEntries={['/assessment']}>{children}</MemoryRouter>
+      ),
+    });
+
+    expect(mockRecordSuggestionTelemetry).not.toHaveBeenCalled();
+  });
+});
+

--- a/src/features/action-engine/telemetry/buildSuggestionTelemetryEvent.ts
+++ b/src/features/action-engine/telemetry/buildSuggestionTelemetryEvent.ts
@@ -4,6 +4,7 @@ import type { SuggestionPriority } from '../domain/types';
 export const SUGGESTION_TELEMETRY_EVENTS = {
   SHOWN: 'suggestion_shown',
   CTA_CLICKED: 'suggestion_cta_clicked',
+  DEEP_LINK_ARRIVED: 'suggestion_deep_link_arrived',
   DISMISSED: 'suggestion_dismissed',
   SNOOZED: 'suggestion_snoozed',
   RESURFACED: 'suggestion_resurfaced',
@@ -13,6 +14,7 @@ export type SuggestionTelemetryEventName =
   (typeof SUGGESTION_TELEMETRY_EVENTS)[keyof typeof SUGGESTION_TELEMETRY_EVENTS];
 
 export type SuggestionTelemetrySourceScreen = 'today' | 'exception-center';
+export type SuggestionTelemetryCtaSurface = 'table' | 'priority-top3';
 
 export type BuildSuggestionTelemetryEventInput = {
   event: SuggestionTelemetryEventName;
@@ -22,6 +24,7 @@ export type BuildSuggestionTelemetryEventInput = {
   priority: SuggestionPriority;
   targetUserId?: string;
   targetUrl?: string;
+  ctaSurface?: SuggestionTelemetryCtaSurface;
   snoozePreset?: SnoozePreset;
   snoozedUntil?: string;
   timestamp?: string;
@@ -36,6 +39,7 @@ export type SuggestionTelemetryEvent = {
   timestamp: string;
   targetUserId?: string;
   targetUrl?: string;
+  ctaSurface?: SuggestionTelemetryCtaSurface;
   snoozePreset?: SnoozePreset;
   snoozedUntil?: string;
 };
@@ -56,6 +60,7 @@ export function buildSuggestionTelemetryEvent(
     timestamp: input.timestamp ?? new Date().toISOString(),
     ...(input.targetUserId ? { targetUserId: input.targetUserId } : {}),
     ...(input.targetUrl ? { targetUrl: input.targetUrl } : {}),
+    ...(input.ctaSurface ? { ctaSurface: input.ctaSurface } : {}),
     ...(input.snoozePreset ? { snoozePreset: input.snoozePreset } : {}),
     ...(input.snoozedUntil ? { snoozedUntil: input.snoozedUntil } : {}),
   };

--- a/src/features/action-engine/telemetry/suggestionDeepLinkTracker.ts
+++ b/src/features/action-engine/telemetry/suggestionDeepLinkTracker.ts
@@ -1,0 +1,133 @@
+import type { SuggestionPriority } from '../domain/types';
+import {
+  SUGGESTION_TELEMETRY_EVENTS,
+  type SuggestionTelemetryCtaSurface,
+  type SuggestionTelemetryEvent,
+  type SuggestionTelemetrySourceScreen,
+} from './buildSuggestionTelemetryEvent';
+
+const PENDING_DEEP_LINK_STORAGE_KEY = 'suggestion-deep-link-pending-v1';
+const PENDING_DEEP_LINK_TTL_MS = 10 * 60 * 1000;
+
+export type PendingSuggestionDeepLink = {
+  sourceScreen: SuggestionTelemetrySourceScreen;
+  stableId: string;
+  ruleId: string;
+  priority: SuggestionPriority;
+  targetUserId?: string;
+  targetUrl: string;
+  targetPathWithSearch: string;
+  ctaSurface?: SuggestionTelemetryCtaSurface;
+  clickedAt: string;
+  expiresAtMs: number;
+};
+
+function isStorageAvailable(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.sessionStorage !== 'undefined'
+  );
+}
+
+function normalizePathWithSearch(rawUrl: string): string | null {
+  if (!rawUrl) return null;
+
+  try {
+    const origin =
+      typeof window !== 'undefined' && window.location?.origin
+        ? window.location.origin
+        : 'https://example.invalid';
+    const parsed = new URL(rawUrl, origin);
+    return `${parsed.pathname}${parsed.search}`;
+  } catch {
+    return null;
+  }
+}
+
+function readPendingFromStorage(): PendingSuggestionDeepLink | null {
+  if (!isStorageAvailable()) return null;
+  try {
+    const raw = window.sessionStorage.getItem(PENDING_DEEP_LINK_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as PendingSuggestionDeepLink;
+    if (
+      typeof parsed?.sourceScreen !== 'string' ||
+      typeof parsed?.stableId !== 'string' ||
+      typeof parsed?.ruleId !== 'string' ||
+      typeof parsed?.priority !== 'string' ||
+      typeof parsed?.targetUrl !== 'string' ||
+      typeof parsed?.targetPathWithSearch !== 'string' ||
+      typeof parsed?.clickedAt !== 'string' ||
+      typeof parsed?.expiresAtMs !== 'number'
+    ) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function clearPendingSuggestionDeepLink(): void {
+  if (!isStorageAvailable()) return;
+  try {
+    window.sessionStorage.removeItem(PENDING_DEEP_LINK_STORAGE_KEY);
+  } catch {
+    // noop
+  }
+}
+
+export function queuePendingSuggestionDeepLink(
+  event: SuggestionTelemetryEvent,
+): void {
+  if (!isStorageAvailable()) return;
+  if (event.event !== SUGGESTION_TELEMETRY_EVENTS.CTA_CLICKED) return;
+  if (!event.targetUrl) return;
+
+  const targetPathWithSearch = normalizePathWithSearch(event.targetUrl);
+  if (!targetPathWithSearch) return;
+
+  const pending: PendingSuggestionDeepLink = {
+    sourceScreen: event.sourceScreen,
+    stableId: event.stableId,
+    ruleId: event.ruleId,
+    priority: event.priority,
+    targetUserId: event.targetUserId,
+    targetUrl: event.targetUrl,
+    targetPathWithSearch,
+    ctaSurface: event.ctaSurface,
+    clickedAt: event.timestamp,
+    expiresAtMs: Date.now() + PENDING_DEEP_LINK_TTL_MS,
+  };
+
+  try {
+    window.sessionStorage.setItem(
+      PENDING_DEEP_LINK_STORAGE_KEY,
+      JSON.stringify(pending),
+    );
+  } catch {
+    // noop
+  }
+}
+
+export function takeMatchingPendingSuggestionDeepLink(
+  pathname: string,
+  search: string,
+): PendingSuggestionDeepLink | null {
+  const pending = readPendingFromStorage();
+  if (!pending) return null;
+
+  if (pending.expiresAtMs <= Date.now()) {
+    clearPendingSuggestionDeepLink();
+    return null;
+  }
+
+  const currentPathWithSearch = `${pathname}${search}`;
+  if (currentPathWithSearch !== pending.targetPathWithSearch) {
+    return null;
+  }
+
+  clearPendingSuggestionDeepLink();
+  return pending;
+}
+

--- a/src/features/action-engine/telemetry/useSuggestionDeepLinkArrivalTelemetry.ts
+++ b/src/features/action-engine/telemetry/useSuggestionDeepLinkArrivalTelemetry.ts
@@ -1,0 +1,47 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import {
+  buildSuggestionTelemetryEvent,
+  SUGGESTION_TELEMETRY_EVENTS,
+} from './buildSuggestionTelemetryEvent';
+import { recordSuggestionTelemetry } from './recordSuggestionTelemetry';
+import { takeMatchingPendingSuggestionDeepLink } from './suggestionDeepLinkTracker';
+
+/**
+ * ExceptionCenter CTA で遷移した deep link 到達を route change で検知し、
+ * suggestion_deep_link_arrived telemetry を1回だけ送信する。
+ */
+export function useSuggestionDeepLinkArrivalTelemetry(): void {
+  const location = useLocation();
+
+  useEffect(() => {
+    const pending = takeMatchingPendingSuggestionDeepLink(
+      location.pathname,
+      location.search,
+    );
+    if (!pending) return;
+
+    recordSuggestionTelemetry(
+      buildSuggestionTelemetryEvent({
+        event: SUGGESTION_TELEMETRY_EVENTS.DEEP_LINK_ARRIVED,
+        sourceScreen: pending.sourceScreen,
+        stableId: pending.stableId,
+        ruleId: pending.ruleId,
+        priority: pending.priority,
+        targetUserId: pending.targetUserId,
+        targetUrl: pending.targetUrl,
+        ctaSurface: pending.ctaSurface,
+      }),
+      {
+        dedupeKey: [
+          'suggestion_deep_link_arrived',
+          pending.sourceScreen,
+          pending.stableId,
+          pending.targetPathWithSearch,
+          pending.ctaSurface ?? 'table',
+        ].join(':'),
+      },
+    );
+  }, [location.pathname, location.search]);
+}
+

--- a/src/features/exceptions/components/ExceptionTable.tsx
+++ b/src/features/exceptions/components/ExceptionTable.tsx
@@ -76,6 +76,7 @@ import {
 
 export type ExceptionTableSortOrder = 'severity' | 'newest' | 'oldest';
 export type ExceptionTableSortMode = 'default' | 'priority';
+type SuggestionCtaSurface = 'table' | 'priority-top3';
 
 type ExceptionDisplayRow =
   | {
@@ -117,7 +118,12 @@ export type ExceptionTableProps = {
   suggestionActions?: {
     onDismiss: (stableId: string) => void;
     onSnooze: (stableId: string, preset: SnoozePreset) => void;
-    onCtaClick?: (stableId: string, targetUrl: string) => void;
+    onCtaClick?: (
+      stableId: string,
+      targetUrl: string,
+      ctaSurface?: SuggestionCtaSurface,
+    ) => void;
+    onPriorityTopShown?: (stableIds: string[]) => void;
   };
 };
 
@@ -286,7 +292,7 @@ const CorrectiveActionsCell: React.FC<{
 
   const handleNavigate = (route: string) => {
     if (item.category === 'corrective-action' && stableId) {
-      suggestionActions?.onCtaClick?.(stableId, route);
+      suggestionActions?.onCtaClick?.(stableId, route, 'table');
     }
     onNavigate(route);
   };
@@ -527,10 +533,33 @@ export const ExceptionTable: React.FC<ExceptionTableProps> = ({
       });
   }, [displayRows, sortMode, displayMode]);
 
+  const shownTopStableIdsRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (sortMode !== 'priority') return;
+    if (!suggestionActions?.onPriorityTopShown) return;
+
+    const stableIds = priorityTopItems
+      .map((item) => item.stableId)
+      .filter((stableId): stableId is string => typeof stableId === 'string');
+
+    const unseen = stableIds.filter((stableId) => !shownTopStableIdsRef.current.has(stableId));
+    if (unseen.length === 0) return;
+
+    for (const stableId of unseen) {
+      shownTopStableIdsRef.current.add(stableId);
+    }
+    suggestionActions.onPriorityTopShown(unseen);
+  }, [priorityTopItems, sortMode, suggestionActions]);
+
   const handlePriorityTopAction = useCallback((item: PriorityTopItem) => {
     if (!item.actionPath) return;
     if (item.category === 'corrective-action' && item.stableId) {
-      suggestionActions?.onCtaClick?.(item.stableId, item.actionPath);
+      suggestionActions?.onCtaClick?.(
+        item.stableId,
+        item.actionPath,
+        'priority-top3',
+      );
     }
     navigate(item.actionPath);
   }, [navigate, suggestionActions]);

--- a/src/features/exceptions/components/__tests__/ExceptionTable.spec.tsx
+++ b/src/features/exceptions/components/__tests__/ExceptionTable.spec.tsx
@@ -26,7 +26,12 @@ const renderTable = (
   suggestionActions?: {
     onDismiss: (stableId: string) => void;
     onSnooze: (stableId: string, preset: 'tomorrow' | 'three-days' | 'end-of-week') => void;
-    onCtaClick?: (stableId: string, targetUrl: string) => void;
+    onCtaClick?: (
+      stableId: string,
+      targetUrl: string,
+      ctaSurface?: 'table' | 'priority-top3',
+    ) => void;
+    onPriorityTopShown?: (stableIds: string[]) => void;
   },
 ) => {
   render(
@@ -164,6 +169,59 @@ describe('ExceptionTable', () => {
       'exception-row-child-sync',
       'exception-row-parent-normal',
     ]);
+  });
+
+  it('priority Top3 の shown/click は suggestionActions に surface 付きで通知する', async () => {
+    const onDismiss = vi.fn();
+    const onSnooze = vi.fn();
+    const onCtaClick = vi.fn();
+    const onPriorityTopShown = vi.fn();
+
+    const items: ExceptionItem[] = [
+      makeException({
+        id: 'p1',
+        stableId: 'stable-p1',
+        severity: 'critical',
+        title: '最優先提案',
+        actionPath: '/assessment?u=1',
+      }),
+      makeException({
+        id: 'p2',
+        stableId: 'stable-p2',
+        severity: 'high',
+        title: '次点提案',
+        actionPath: '/assessment?u=2',
+      }),
+      makeException({
+        id: 'p3',
+        stableId: 'stable-p3',
+        severity: 'medium',
+        title: '3番目提案',
+        actionPath: '/assessment?u=3',
+      }),
+    ];
+
+    renderTable(items, {
+      onDismiss,
+      onSnooze,
+      onCtaClick,
+      onPriorityTopShown,
+    });
+
+    const sortMode = screen.getByTestId('exception-sort-mode');
+    fireEvent.mouseDown(within(sortMode).getByRole('combobox'));
+    fireEvent.click(await screen.findByRole('option', { name: '優先度順' }));
+
+    expect(onPriorityTopShown).toHaveBeenCalled();
+    const shownStableIds = onPriorityTopShown.mock.calls.flatMap((args) => args[0] as string[]);
+    expect(shownStableIds).toEqual(expect.arrayContaining(['stable-p1', 'stable-p2', 'stable-p3']));
+
+    fireEvent.click(screen.getByTestId('exception-priority-top3-action-p1'));
+    expect(onCtaClick).toHaveBeenCalledWith(
+      'stable-p1',
+      '/assessment?u=1',
+      'priority-top3',
+    );
   });
 
   it('フラット表示から dismiss/snooze が実行できる', async () => {

--- a/src/pages/admin/ExceptionCenterPage.tsx
+++ b/src/pages/admin/ExceptionCenterPage.tsx
@@ -49,9 +49,11 @@ import { useSuggestionStateStore } from '@/features/action-engine/hooks/useSugge
 import { useAllCorrectiveActions } from '@/features/action-engine/hooks/useAllCorrectiveActions';
 import {
   buildSuggestionTelemetryEvent,
+  type SuggestionTelemetryCtaSurface,
   SUGGESTION_TELEMETRY_EVENTS,
 } from '@/features/action-engine/telemetry/buildSuggestionTelemetryEvent';
 import { recordSuggestionTelemetry } from '@/features/action-engine/telemetry/recordSuggestionTelemetry';
+import { queuePendingSuggestionDeepLink } from '@/features/action-engine/telemetry/suggestionDeepLinkTracker';
 
 // ─── Component ────────────────────────────────────────────────
 
@@ -126,20 +128,46 @@ export default function ExceptionCenterPage() {
     snoozeSuggestion(stableId, until, { by: 'exception-center' });
   }, [snoozeSuggestion, suggestionByStableId]);
 
-  const handleSuggestionCtaClick = React.useCallback((stableId: string, targetUrl: string) => {
+  const handleSuggestionCtaClick = React.useCallback((
+    stableId: string,
+    targetUrl: string,
+    ctaSurface: SuggestionTelemetryCtaSurface = 'table',
+  ) => {
     const suggestion = suggestionByStableId.get(stableId);
     if (!suggestion) return;
-    recordSuggestionTelemetry(
-      buildSuggestionTelemetryEvent({
-        event: SUGGESTION_TELEMETRY_EVENTS.CTA_CLICKED,
-        sourceScreen: 'exception-center',
-        stableId: suggestion.stableId,
-        ruleId: suggestion.ruleId,
-        priority: suggestion.priority,
-        targetUserId: suggestion.targetUserId,
-        targetUrl,
-      }),
-    );
+    const event = buildSuggestionTelemetryEvent({
+      event: SUGGESTION_TELEMETRY_EVENTS.CTA_CLICKED,
+      sourceScreen: 'exception-center',
+      stableId: suggestion.stableId,
+      ruleId: suggestion.ruleId,
+      priority: suggestion.priority,
+      targetUserId: suggestion.targetUserId,
+      targetUrl,
+      ctaSurface,
+    });
+    recordSuggestionTelemetry(event);
+    queuePendingSuggestionDeepLink(event);
+  }, [suggestionByStableId]);
+
+  const handlePriorityTopShown = React.useCallback((stableIds: string[]) => {
+    for (const stableId of stableIds) {
+      const suggestion = suggestionByStableId.get(stableId);
+      if (!suggestion) continue;
+      recordSuggestionTelemetry(
+        buildSuggestionTelemetryEvent({
+          event: SUGGESTION_TELEMETRY_EVENTS.SHOWN,
+          sourceScreen: 'exception-center',
+          stableId: suggestion.stableId,
+          ruleId: suggestion.ruleId,
+          priority: suggestion.priority,
+          targetUserId: suggestion.targetUserId,
+          ctaSurface: 'priority-top3',
+        }),
+        {
+          dedupeKey: `suggestion_shown:exception-center:${suggestion.stableId}:priority-top3`,
+        },
+      );
+    }
   }, [suggestionByStableId]);
 
   const { dismissedStableIds, snoozedStableIds } = useActiveExceptionPreferences();
@@ -333,6 +361,7 @@ export default function ExceptionCenterPage() {
             onDismiss: handleDismissSuggestion,
             onSnooze: handleSnoozeSuggestion,
             onCtaClick: handleSuggestionCtaClick,
+            onPriorityTopShown: handlePriorityTopShown,
           }}
         />
       </Stack>

--- a/tests/unit/pages/ExceptionCenterPage.suggestionTelemetry.spec.tsx
+++ b/tests/unit/pages/ExceptionCenterPage.suggestionTelemetry.spec.tsx
@@ -167,6 +167,7 @@ describe('ExceptionCenterPage suggestion telemetry', () => {
         sourceScreen: 'exception-center',
         stableId,
         targetUrl: '/assessment',
+        ctaSurface: 'table',
       }),
     );
     expect(mockRecordSuggestionTelemetry).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- add `ctaSurface` (`table` / `priority-top3`) to suggestion lifecycle telemetry payloads
- add deep-link arrival tracking via pending CTA marker + route-match hook (`suggestion_deep_link_arrived`)
- instrument ExceptionCenter Top3 with shown tracking and surface-aware CTA tracking
- add runbook for 7-day priority metrics (`Top3 CTR`, `deep-link arrival`, `dismiss/snooze lead time`)

## Why
After merging the priority UX, week-1 operations needs measurable signals before one-time score tuning.
This PR adds the minimum telemetry to evaluate:
1. Top3 is used
2. deep links are actually reached
3. CTA leads to completion speed

## Changes
- `src/features/action-engine/telemetry/buildSuggestionTelemetryEvent.ts`
  - add `SUGGESTION_TELEMETRY_EVENTS.DEEP_LINK_ARRIVED`
  - add optional `ctaSurface`
- `src/features/action-engine/telemetry/suggestionDeepLinkTracker.ts` (new)
  - queue/take/clear pending deep-link markers in `sessionStorage`
- `src/features/action-engine/telemetry/useSuggestionDeepLinkArrivalTelemetry.ts` (new)
  - emit arrival event when current route matches pending target
- `src/app/AppShell.tsx`
  - mount deep-link arrival telemetry hook once
- `src/features/exceptions/components/ExceptionTable.tsx`
  - pass CTA surface (`table` / `priority-top3`)
  - notify `onPriorityTopShown` for Top3 shown telemetry
- `src/pages/admin/ExceptionCenterPage.tsx`
  - queue pending deep link on CTA click
  - emit Top3 shown events with dedupe key
- docs
  - add `docs/runbooks/exception-center-priority-week1-review.md`
  - link from `docs/runbooks/README.md`

## Tests
- `npx vitest run src/features/action-engine/telemetry/__tests__/buildSuggestionTelemetryEvent.spec.ts src/features/action-engine/telemetry/__tests__/suggestionDeepLinkTracker.spec.ts src/features/action-engine/telemetry/__tests__/useSuggestionDeepLinkArrivalTelemetry.spec.tsx src/features/exceptions/components/__tests__/ExceptionTable.spec.tsx tests/unit/pages/ExceptionCenterPage.suggestionTelemetry.spec.tsx`
- `npx vitest run src/app/AppShell.role-sync.spec.tsx`
- `npm run typecheck`
- `npx eslint src/features/action-engine/telemetry/buildSuggestionTelemetryEvent.ts src/features/action-engine/telemetry/suggestionDeepLinkTracker.ts src/features/action-engine/telemetry/useSuggestionDeepLinkArrivalTelemetry.ts src/app/AppShell.tsx src/features/exceptions/components/ExceptionTable.tsx src/pages/admin/ExceptionCenterPage.tsx src/features/action-engine/telemetry/__tests__/suggestionDeepLinkTracker.spec.ts src/features/action-engine/telemetry/__tests__/useSuggestionDeepLinkArrivalTelemetry.spec.tsx src/features/exceptions/components/__tests__/ExceptionTable.spec.tsx tests/unit/pages/ExceptionCenterPage.suggestionTelemetry.spec.tsx`
