### PR TITLE
fix(auth): gracefully handle MSAL interaction_required on sleep resume

### DIFF
--- a/src/app/ProtectedRoute.tsx
+++ b/src/app/ProtectedRoute.tsx
@@ -57,6 +57,17 @@ export default function ProtectedRoute({ flag, children, fallbackPath = '/' }: P
   const pendingPath = useMemo(() => `${location.pathname}${location.search ?? ''}`, [location.pathname, location.search]);
   const signInAttemptedRef = useRef(false);
   const [listGate, setListGate] = useState<ListGate>('idle');
+  const [forceReauth, setForceReauth] = useState(false);
+
+  useEffect(() => {
+    const handleReauth = () => {
+      debug('msal-interaction-required event caught. Forcing AuthRequiredNotice.');
+      setForceReauth(true);
+    };
+    window.addEventListener('msal-interaction-required', handleReauth);
+    return () => window.removeEventListener('msal-interaction-required', handleReauth);
+  }, []);
+
   const isMsalInProgress = inProgress !== InteractionStatus.None && inProgress !== 'none';
   const corrIdRef = useRef<string | null>(null);
   const lastDiagCodeRef = useRef<AuthDiagSummary['code'] | null>(null);
@@ -312,7 +323,7 @@ export default function ProtectedRoute({ flag, children, fallbackPath = '/' }: P
     );
   }
 
-  if (!isAuthenticated) {
+  if (!isAuthenticated || forceReauth) {
     const summary = summarizeAuthBlockReason({
       inProgress,
       isAuthenticated,

--- a/src/auth/useAuth.ts
+++ b/src/auth/useAuth.ts
@@ -215,7 +215,10 @@ export const useAuth = () => {
         msalError?.errorCode === 'consent_required' ||
         msalError?.errorCode === 'login_required';
       if (interactionRequired) {
-        debugLog('acquireTokenSilent requires interaction; suppressing auto-redirect');
+        debugLog('acquireTokenSilent requires interaction; suppressing auto-redirect and emitting event');
+        if (typeof window !== 'undefined') {
+          window.dispatchEvent(new CustomEvent('msal-interaction-required'));
+        }
       } else {
         debugLog('acquireTokenSilent failed without interaction-required error');
       }


### PR DESCRIPTION
## Overview
When testing the "Long Sleep Resume" QA scenario on tablets, it was discovered that MSAL's `acquireTokenSilent` iframe times out or fails with `refresh_token_expired`. Because `isAuthenticated` checks the cached account metadata rather than token validity, the router incorrectly believes the user is fully authenticated, attempting to render child API calls which subsequently fail with `AUTH_REQUIRED`. This leaves the application screen in a completely unrecoverable broken state, forcing users to reload manually.

## Changes
- **Graceful Fallback**: Added an event dispatcher (`msal-interaction-required`) directly to `useAuth.ts` when MSAL encounters an `interaction_required`, `consent_required`, or `login_required` failure.
- **Safety Intercept**: Updated `ProtectedRoute.tsx` to observe this event via a new `forceReauth` state. When triggered, the router safely downgrades the active view to `<AuthRequiredNotice />` without infinite loops, allowing users to gracefully interact and recover their active session.
