### PR TITLE
feat(today): 生活介護の担当項目を5区分へ変更

### DIFF
--- a/src/features/today/domain/buildServiceStructure.ts
+++ b/src/features/today/domain/buildServiceStructure.ts
@@ -6,9 +6,12 @@
  *
  * ── マッピングルール ──
  *  owner / jobTitle        → ServiceStructure スロット
- *  "受付"                  → returnAcceptStaff / intakeDeskStaff
+ *  "受付"                  → playroomStaff / intakeDeskStaff
  *  "看護" / "看護師"        → nurseNames / nursePresent
- *  "支援員" / "生活支援員"  → floorWatchStaff / activityLeadStaff / supportStaff
+ *  "支援員" / "生活支援員"  → firstWorkroomStaff / secondWorkroomStaff / supportStaff
+ *  "外活動" / "外出"        → outdoorActivityStaff
+ *  "和室"                  → japaneseRoomStaff
+ *  "プレイルーム"          → playroomStaff
  *  "栄養士" / "管理栄養士"  → mealStaff
  *  "サービス管理責任者"     → serviceManagerNames
  *  "所長" / "施設長"        → directorNames
@@ -30,6 +33,9 @@ type RoleCategory =
   | 'reception'
   | 'nurse'
   | 'support'
+  | 'outdoor'
+  | 'japaneseRoom'
+  | 'playroom'
   | 'nutrition'
   | 'manager'
   | 'director'
@@ -41,6 +47,9 @@ function classifyOwner(owner: string): RoleCategory {
   const o = owner.trim();
   if (/受付/.test(o)) return 'reception';
   if (/看護/.test(o)) return 'nurse';
+  if (/外活動|外出|屋外|散歩/.test(o)) return 'outdoor';
+  if (/和室|畳/.test(o)) return 'japaneseRoom';
+  if (/プレイルーム|プレイ|遊び/.test(o)) return 'playroom';
   if (/支援員|支援|介護|世話人/.test(o)) return 'support';
   if (/栄養/.test(o)) return 'nutrition';
   if (/サービス管理|サビ管/.test(o)) return 'manager';
@@ -96,21 +105,31 @@ export function buildServiceStructure(
     byRole.get(cat) ?? staffByRole.get(cat) ?? [];
 
   const hasAny = (cat: RoleCategory): boolean => resolve(cat).length > 0;
+  const unique = (values: string[]): string[] => Array.from(new Set(values.filter(Boolean)));
 
   // ── 3. ServiceStructure を組み立て ──
   const supportStaff = resolve('support');
+  const japaneseRoomStaff = unique([
+    ...resolve('japaneseRoom'),
+    ...supportStaff.slice(4, 5),
+  ]);
+  const playroomStaff = unique([
+    ...resolve('playroom'),
+    ...supportStaff.slice(5),
+    ...resolve('reception'),
+    ...resolve('nutrition'),
+    ...resolve('other'),
+  ]);
 
   return {
     dayCare: {
-      floorWatchStaff: supportStaff.slice(0, 2),
-      activityLeadStaff: supportStaff.slice(2, 3),
-      mealSupportStaff: resolve('nutrition').slice(0, 1).length > 0
-        ? resolve('nutrition').slice(0, 1)
-        : supportStaff.slice(3, 4),
-      recordCheckStaff: supportStaff.slice(4, 5).length > 0
-        ? supportStaff.slice(4, 5)
-        : supportStaff.slice(0, 1),
-      returnAcceptStaff: resolve('reception'),
+      firstWorkroomStaff: supportStaff.slice(0, 2),
+      secondWorkroomStaff: supportStaff.slice(2, 4),
+      outdoorActivityStaff: resolve('outdoor').length > 0
+        ? resolve('outdoor')
+        : resolve('transport').slice(0, 1),
+      japaneseRoomStaff,
+      playroomStaff,
     },
     lifeSupport: {
       shortStayCount: 0,   // スケジュールからは不明 — 0 でフォールバック

--- a/src/features/today/domain/serviceStructure.types.ts
+++ b/src/features/today/domain/serviceStructure.types.ts
@@ -7,13 +7,13 @@
  * @see Issue 3: TodayServiceStructureCard
  */
 
-/** 生活介護: 集団対応の配置・役割 */
+/** 生活介護: 現場配置（第一作業室 / 第二作業室 / 外活動 / 和室 / プレイルーム） */
 export type DayCareStructure = {
-  floorWatchStaff: string[];
-  activityLeadStaff: string[];
-  mealSupportStaff: string[];
-  recordCheckStaff: string[];
-  returnAcceptStaff: string[];
+  firstWorkroomStaff: string[];
+  secondWorkroomStaff: string[];
+  outdoorActivityStaff: string[];
+  japaneseRoomStaff: string[];
+  playroomStaff: string[];
 };
 
 /** 生活支援: ショートステイ・一時ケアの受け入れ体制 */

--- a/src/features/today/widgets/TodayServiceStructureCard.spec.tsx
+++ b/src/features/today/widgets/TodayServiceStructureCard.spec.tsx
@@ -7,11 +7,11 @@ import { TodayServiceStructureCard } from './TodayServiceStructureCard';
 
 const fullStructure: ServiceStructure = {
   dayCare: {
-    floorWatchStaff: ['山田', '佐藤'],
-    activityLeadStaff: ['鈴木'],
-    mealSupportStaff: ['田中'],
-    recordCheckStaff: ['村上'],
-    returnAcceptStaff: ['中村'],
+    firstWorkroomStaff: ['山田', '佐藤'],
+    secondWorkroomStaff: ['鈴木'],
+    outdoorActivityStaff: ['田中'],
+    japaneseRoomStaff: ['村上'],
+    playroomStaff: ['中村'],
   },
   lifeSupport: {
     shortStayCount: 1,
@@ -70,10 +70,14 @@ describe('TodayServiceStructureCard — 生活介護', () => {
     render(<TodayServiceStructureCard serviceStructure={fullStructure} />);
 
     const section = within(screen.getByTestId('section-daycare'));
-    expect(section.getByText('フロア見守り')).toBeInTheDocument();
+    expect(section.getByText('第一作業室')).toBeInTheDocument();
     expect(section.getByText('山田、佐藤')).toBeInTheDocument();
-    expect(section.getByText('活動進行')).toBeInTheDocument();
+    expect(section.getByText('第二作業室')).toBeInTheDocument();
     expect(section.getByText('鈴木')).toBeInTheDocument();
+    expect(section.getByText('和室')).toBeInTheDocument();
+    expect(section.getByText('村上')).toBeInTheDocument();
+    expect(section.getByText('プレイルーム')).toBeInTheDocument();
+    expect(section.getByText('中村')).toBeInTheDocument();
   });
 });
 

--- a/src/features/today/widgets/TodayServiceStructureCard.tsx
+++ b/src/features/today/widgets/TodayServiceStructureCard.tsx
@@ -4,7 +4,7 @@
  * 「担当表」ではなく「業務体制」を可視化する。
  * 4セクション: 生活介護 / 生活支援 / 判断窓口 / 運営サポート
  *
- * - 生活介護: 集団対応の配置・役割
+ * - 生活介護: 第一作業室 / 第二作業室 / 外活動 / 和室 / プレイルーム
  * - 生活支援: ショートステイ・一時ケア受け入れ体制
  * - 判断窓口: 所長・サビ管・ナースの在席（管理者・専門職）
  * - 運営サポート: 会計・給食・送迎・ボランティア・来客の配置
@@ -104,11 +104,11 @@ export const TodayServiceStructureCard: React.FC<TodayServiceStructureCardProps>
   const { dayCare, lifeSupport, decisionSupport, operationalSupport } = serviceStructure;
 
   const hasDayCareStaff =
-    dayCare.floorWatchStaff.length > 0 ||
-    dayCare.activityLeadStaff.length > 0 ||
-    dayCare.mealSupportStaff.length > 0 ||
-    dayCare.recordCheckStaff.length > 0 ||
-    dayCare.returnAcceptStaff.length > 0;
+    dayCare.firstWorkroomStaff.length > 0 ||
+    dayCare.secondWorkroomStaff.length > 0 ||
+    dayCare.outdoorActivityStaff.length > 0 ||
+    dayCare.japaneseRoomStaff.length > 0 ||
+    dayCare.playroomStaff.length > 0;
 
   const hasLifeSupport = lifeSupport.shortStayCount > 0 || lifeSupport.temporaryCareCount > 0;
 
@@ -127,11 +127,11 @@ export const TodayServiceStructureCard: React.FC<TodayServiceStructureCardProps>
           <SectionHeader emoji="🟢" title="生活介護" />
           {hasDayCareStaff ? (
             <Box data-testid="section-daycare">
-              <RoleRow label="フロア見守り" names={dayCare.floorWatchStaff} />
-              <RoleRow label="活動進行" names={dayCare.activityLeadStaff} />
-              <RoleRow label="食事対応" names={dayCare.mealSupportStaff} />
-              <RoleRow label="記録確認" names={dayCare.recordCheckStaff} />
-              <RoleRow label="送迎戻り受入" names={dayCare.returnAcceptStaff} />
+              <RoleRow label="第一作業室" names={dayCare.firstWorkroomStaff} />
+              <RoleRow label="第二作業室" names={dayCare.secondWorkroomStaff} />
+              <RoleRow label="外活動" names={dayCare.outdoorActivityStaff} />
+              <RoleRow label="和室" names={dayCare.japaneseRoomStaff} />
+              <RoleRow label="プレイルーム" names={dayCare.playroomStaff} />
             </Box>
           ) : (
             <EmptyStateBlock


### PR DESCRIPTION
## 概要
生活介護の業務体制の担当項目を以下の5項目に変更しました。
- 第一作業室
- 第二作業室
- 外活動
- 和室
- プレイルーム

## 変更内容
- `DayCareStructure` の型を5項目へ更新
- `buildServiceStructure` の割り当てロジックを5項目へ更新
- `TodayServiceStructureCard` の表示項目を5項目へ更新
- テストを5項目に合わせて更新

## 動作確認
- `npx vitest run src/features/today/widgets/TodayServiceStructureCard.spec.tsx`
- `npm run -s typecheck`
