### PR TITLE
feat(today): add telemetry baseline runbook and quick-record start event

### DIFF
--- a/docs/ops/today-telemetry-baseline-runbook.md
+++ b/docs/ops/today-telemetry-baseline-runbook.md
@@ -1,0 +1,143 @@
+# /today Telemetry Baseline Runbook (PR-5)
+
+- 作成日: 2026-03-26
+- 対象: `/today` キオスク運用の初期ベースライン取得
+- 目的: 改善を「感覚」ではなく「数値」で判断できる状態にする
+
+## 0. 前提
+
+- 期間: 7日間（最低3日）
+- 粒度: 日次 + 全体集計
+- 対象: `/today` 利用セッション
+
+## 1. 収集イベント（実装名）
+
+`type = 'kiosk_ux_event'` のうち、以下を収集する。
+
+| Runbook名 | 実イベント名 (`event`) | 主な用途 |
+| --- | --- | --- |
+| `kiosk_session_start` | `ux_kiosk_session_started` | kiosk利用率 |
+| `kiosk_visible_refetch` | `ux_visible_refresh_completed` | visible復帰後遅延 |
+| `quick_record_start` | `ux_quick_record_started` | QuickRecord所要時間/離脱率の分母 |
+| `quick_record_save` | `ux_quick_record_save_completed` | QuickRecord所要時間 |
+| `quick_record_abandon` | `ux_quick_record_abandoned` | 保存前離脱率 |
+
+必須フィールド:
+
+- `ts` / `clientTs`（時刻）
+- `sessionId`
+- `role`（`staff` / `admin` / `unknown`）
+- `userId`（QuickRecord系）
+
+## 2. KPI定義（固定）
+
+### 2-1. kiosk利用率
+
+`kiosk_sessions / total_today_sessions`
+
+補足:
+
+- `kiosk_sessions = COUNT(event='ux_kiosk_session_started')`
+- `total_today_sessions` は landing 系イベント（例: `/today` 着地イベント）を利用
+
+### 2-2. visible復帰遅延
+
+`p50 / p90 of durationMs where event='ux_visible_refresh_completed'`
+
+### 2-3. QuickRecord時間
+
+`p50 / p90 of durationMs where event='ux_quick_record_save_completed'`
+
+### 2-4. 保存前離脱率
+
+`quick_record_abandon / quick_record_start`
+
+補足:
+
+- `quick_record_abandon = COUNT(event='ux_quick_record_abandoned')`
+- `quick_record_start = COUNT(event='ux_quick_record_started')`
+
+## 3. 集計クエリ例（BigQuery想定）
+
+### 3-1. kiosk利用率
+
+```sql
+SELECT
+  COUNTIF(event = 'ux_kiosk_session_started') / NULLIF(COUNTIF(event = 'today_landing'), 0) AS kiosk_rate
+FROM telemetry.events
+WHERE date BETWEEN @start AND @end;
+```
+
+### 3-2. visible復帰遅延
+
+```sql
+SELECT
+  APPROX_QUANTILES(durationMs, 100)[OFFSET(50)] AS p50_ms,
+  APPROX_QUANTILES(durationMs, 100)[OFFSET(90)] AS p90_ms
+FROM telemetry.events
+WHERE event = 'ux_visible_refresh_completed'
+  AND date BETWEEN @start AND @end;
+```
+
+### 3-3. QuickRecord時間
+
+```sql
+SELECT
+  APPROX_QUANTILES(durationMs, 100)[OFFSET(50)] AS p50_ms,
+  APPROX_QUANTILES(durationMs, 100)[OFFSET(90)] AS p90_ms
+FROM telemetry.events
+WHERE event = 'ux_quick_record_save_completed'
+  AND date BETWEEN @start AND @end;
+```
+
+### 3-4. 保存前離脱率
+
+```sql
+SELECT
+  COUNTIF(event = 'ux_quick_record_abandoned') /
+  NULLIF(COUNTIF(event = 'ux_quick_record_started'), 0) AS abandon_rate
+FROM telemetry.events
+WHERE date BETWEEN @start AND @end;
+```
+
+## 4. ベースライン記録フォーマット
+
+```md
+## /today Telemetry Baseline (Week 1)
+
+期間: YYYY-MM-DD ~ YYYY-MM-DD
+
+### 1. kiosk利用率
+- 平均: XX%
+- 傾向: ↑ / → / ↓
+
+### 2. visible復帰遅延
+- p50: XX ms
+- p90: XX ms
+
+### 3. QuickRecord時間
+- p50: XX 秒
+- p90: XX 秒
+
+### 4. 保存前離脱率
+- XX%
+
+### 所感
+- （例）kiosk率は想定より低く、入口導線の改善余地あり
+- （例）QuickRecord p90が長く、入力摩擦が残っている可能性
+```
+
+## 5. 合格ライン（仮）
+
+- kiosk率: > 60%
+- visible復帰: p90 < 1500ms
+- QuickRecord: p50 < 5秒 / p90 < 12秒
+- 離脱率: < 20%
+
+## 6. 次アクション判断
+
+- kiosk率が低い: 入口導線（ショートカット・固定起動）改善
+- visible復帰遅延が高い: refetch経路と依存クエリ見直し
+- QuickRecord時間が長い: 入力UI最適化
+- 離脱率が高い: Hero/初期フォーカス/遷移導線を再調整
+

--- a/src/features/telemetry/components/sections/KioskUxTelemetrySection.tsx
+++ b/src/features/telemetry/components/sections/KioskUxTelemetrySection.tsx
@@ -9,6 +9,10 @@ export function KioskUxTelemetrySection({ kpis }: { kpis: KioskUxKpis | null }) 
     ? (kpis.openFabMenuCount / kpis.totalNavigateCount) * 100 
     : 0;
   const fabRate = Math.round(fabRateRaw * 10) / 10;
+  const quickRecordAbandonRateRaw = kpis.quickRecordStartCount > 0
+    ? (kpis.quickRecordAbandonCount / kpis.quickRecordStartCount) * 100
+    : 0;
+  const quickRecordAbandonRate = Math.round(quickRecordAbandonRateRaw * 10) / 10;
   
   // 閾値（15%）
   const isFabAlert = fabRate > 15 && kpis.totalNavigateCount >= 5;
@@ -80,6 +84,10 @@ export function KioskUxTelemetrySection({ kpis }: { kpis: KioskUxKpis | null }) 
                   </TableCell>
                 </TableRow>
                 <TableRow>
+                  <TableCell sx={{ color: '#64748b', fontWeight: 500 }}>QuickRecord 開始回数</TableCell>
+                  <TableCell align="right" sx={{ fontWeight: 700, color: '#1e293b' }}>{kpis.quickRecordStartCount}</TableCell>
+                </TableRow>
+                <TableRow>
                   <TableCell sx={{ color: '#64748b', fontWeight: 500 }}>QuickRecord 保存回数</TableCell>
                   <TableCell align="right" sx={{ fontWeight: 700, color: '#1e293b' }}>{kpis.quickRecordSaveCount}</TableCell>
                 </TableRow>
@@ -92,6 +100,12 @@ export function KioskUxTelemetrySection({ kpis }: { kpis: KioskUxKpis | null }) 
                 <TableRow>
                   <TableCell sx={{ color: '#64748b', fontWeight: 500 }}>QuickRecord 離脱回数</TableCell>
                   <TableCell align="right" sx={{ fontWeight: 700, color: '#1e293b' }}>{kpis.quickRecordAbandonCount}</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell sx={{ color: '#64748b', fontWeight: 500 }}>QuickRecord 離脱率</TableCell>
+                  <TableCell align="right" sx={{ fontWeight: 700, color: '#1e293b' }}>
+                    {kpis.quickRecordStartCount === 0 ? '—' : `${quickRecordAbandonRate}%`}
+                  </TableCell>
                 </TableRow>
               </TableBody>
             </Table>

--- a/src/features/today/telemetry/computeKioskUxKpis.spec.ts
+++ b/src/features/today/telemetry/computeKioskUxKpis.spec.ts
@@ -9,6 +9,7 @@ describe('computeKioskUxKpis', () => {
       { type: 'kiosk_ux_event', event: 'ux_return_to_today', source: 'header_back' },
       { type: 'kiosk_ux_event', event: 'ux_open_fab_menu', source: 'fab' },
       { type: 'kiosk_ux_event', event: 'ux_kiosk_session_started', source: 'today' },
+      { type: 'kiosk_ux_event', event: 'ux_quick_record_started', source: 'today' },
     ]);
 
     expect(result.navigateFromTodayBreakdown.schedules).toBe(2);
@@ -16,6 +17,7 @@ describe('computeKioskUxKpis', () => {
     expect(result.openFabMenuCount).toBe(1);
     expect(result.totalNavigateCount).toBe(2);
     expect(result.kioskSessionCount).toBe(1);
+    expect(result.quickRecordStartCount).toBe(1);
   });
 
   it('calculates median metrics for visibility refresh and quick record save', () => {
@@ -26,6 +28,9 @@ describe('computeKioskUxKpis', () => {
       { type: 'kiosk_ux_event', event: 'ux_quick_record_save_completed', durationMs: 26000, source: 'today' },
       { type: 'kiosk_ux_event', event: 'ux_quick_record_save_completed', durationMs: 12000, source: 'today' },
       { type: 'kiosk_ux_event', event: 'ux_quick_record_abandoned', source: 'today' },
+      { type: 'kiosk_ux_event', event: 'ux_quick_record_started', source: 'today' },
+      { type: 'kiosk_ux_event', event: 'ux_quick_record_started', source: 'today' },
+      { type: 'kiosk_ux_event', event: 'ux_quick_record_started', source: 'today' },
     ]);
 
     expect(result.visibleRefreshCount).toBe(3);
@@ -33,6 +38,6 @@ describe('computeKioskUxKpis', () => {
     expect(result.quickRecordSaveCount).toBe(2);
     expect(result.quickRecordSaveMedianMs).toBe(19000);
     expect(result.quickRecordAbandonCount).toBe(1);
+    expect(result.quickRecordStartCount).toBe(3);
   });
 });
-

--- a/src/features/today/telemetry/computeKioskUxKpis.ts
+++ b/src/features/today/telemetry/computeKioskUxKpis.ts
@@ -11,6 +11,7 @@ export interface KioskUxKpis {
   quickRecordSaveCount: number;
   quickRecordSaveMedianMs: number | null;
   quickRecordAbandonCount: number;
+  quickRecordStartCount: number;
 }
 
 function median(values: number[]): number | null {
@@ -35,6 +36,7 @@ export function computeKioskUxKpis(events: Record<string, unknown>[]): KioskUxKp
     quickRecordSaveCount: 0,
     quickRecordSaveMedianMs: null,
     quickRecordAbandonCount: 0,
+    quickRecordStartCount: 0,
   };
 
   let totalNavigate = 0;
@@ -71,6 +73,8 @@ export function computeKioskUxKpis(events: Record<string, unknown>[]): KioskUxKp
       }
     } else if (eventName === 'ux_quick_record_abandoned') {
       kpis.quickRecordAbandonCount += 1;
+    } else if (eventName === 'ux_quick_record_started') {
+      kpis.quickRecordStartCount += 1;
     }
   }
 

--- a/src/features/today/telemetry/kioskNavigationTelemetry.types.ts
+++ b/src/features/today/telemetry/kioskNavigationTelemetry.types.ts
@@ -31,6 +31,9 @@ export const KIOSK_TELEMETRY_EVENTS = {
 
   /** QuickRecord を開始したが保存せずに閉じた */
   QUICK_RECORD_ABANDONED: 'ux_quick_record_abandoned',
+
+  /** QuickRecord を開始した */
+  QUICK_RECORD_STARTED: 'ux_quick_record_started',
 } as const;
 
 export type KioskTelemetryEventName =
@@ -60,8 +63,10 @@ export interface KioskNavigationPayload {
 
   /** 追加計測値（イベント種別に応じて使用） */
   durationMs?: number;
-  reason?: 'polling' | 'visibility_restore' | 'close_without_save' | 'save';
+  reason?: 'polling' | 'visibility_restore' | 'close_without_save' | 'save' | 'start';
   modeVariant?: 'user' | 'unfilled';
   autoNextEnabled?: boolean;
   userId?: string;
+  sessionId?: string;
+  role?: 'staff' | 'admin' | 'unknown';
 }

--- a/src/pages/TodayOpsPage.tsx
+++ b/src/pages/TodayOpsPage.tsx
@@ -72,6 +72,13 @@ export type TodayOpsPageProps = {
   correctiveActions?: ActionSuggestion[];
 };
 
+function createKioskSessionId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `kiosk-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
 export const TodayOpsPage: React.FC<TodayOpsPageProps> = ({
   correctiveActions = [],
 }) => {
@@ -81,9 +88,11 @@ export const TodayOpsPage: React.FC<TodayOpsPageProps> = ({
   const { settings } = useSettingsContext();
   const isKioskMode = settings.layoutMode === 'kiosk';
   const role = useAuthStore((s) => s.currentUserRole);
+  const telemetryRole = role === 'admin' || role === 'staff' ? role : 'unknown';
   const suggestionStates = useSuggestionStateStore((s) => s.states);
   const dismissSuggestion = useSuggestionStateStore((s) => s.dismiss);
   const snoozeSuggestion = useSuggestionStateStore((s) => s.snooze);
+  const kioskSessionIdRef = useRef(createKioskSessionId());
   const kioskSessionLoggedRef = useRef(false);
   const quickRecordSessionRef = useRef<{
     startedAt: number;
@@ -109,6 +118,7 @@ export const TodayOpsPage: React.FC<TodayOpsPageProps> = ({
   useEffect(() => {
     if (!isKioskMode || !location.pathname.startsWith('/today')) {
       kioskSessionLoggedRef.current = false;
+      kioskSessionIdRef.current = createKioskSessionId();
       return;
     }
     if (kioskSessionLoggedRef.current) return;
@@ -116,8 +126,10 @@ export const TodayOpsPage: React.FC<TodayOpsPageProps> = ({
     recordKioskTelemetry(KIOSK_TELEMETRY_EVENTS.KIOSK_SESSION_STARTED, {
       mode: 'kiosk',
       source: 'today',
+      sessionId: kioskSessionIdRef.current,
+      role: telemetryRole,
     });
-  }, [isKioskMode, location.pathname]);
+  }, [isKioskMode, location.pathname, telemetryRole]);
 
   // ── Data Fetching (Facade) ──
   const summary = useTodaySummary();
@@ -289,6 +301,8 @@ export const TodayOpsPage: React.FC<TodayOpsPageProps> = ({
         source: 'today',
         reason: 'visibility_restore',
         durationMs,
+        sessionId: kioskSessionIdRef.current,
+        role: telemetryRole,
       });
     },
   });
@@ -312,6 +326,8 @@ export const TodayOpsPage: React.FC<TodayOpsPageProps> = ({
           durationMs: Math.max(0, Date.now() - session.startedAt),
           modeVariant: session.mode ?? undefined,
           userId: session.userId ?? undefined,
+          sessionId: kioskSessionIdRef.current,
+          role: telemetryRole,
         });
       }
 
@@ -329,12 +345,22 @@ export const TodayOpsPage: React.FC<TodayOpsPageProps> = ({
         mode,
         userId,
       };
+      recordKioskTelemetry(KIOSK_TELEMETRY_EVENTS.QUICK_RECORD_STARTED, {
+        mode: 'kiosk',
+        source: 'today',
+        reason: 'start',
+        modeVariant: mode ?? undefined,
+        userId: userId ?? undefined,
+        autoNextEnabled: quickRecord.autoNextEnabled,
+        sessionId: kioskSessionIdRef.current,
+        role: telemetryRole,
+      });
     }
 
     if (quickRecordSavedRef.current) {
       quickRecordSavedRef.current = false;
     }
-  }, [isKioskMode, quickRecord.isOpen, quickRecord.mode, quickRecord.userId]);
+  }, [isKioskMode, quickRecord.isOpen, quickRecord.mode, quickRecord.userId, quickRecord.autoNextEnabled, telemetryRole]);
 
   // ── User Alerts (直近7日の注意点) ──
   const alertUserIds = useMemo(
@@ -596,6 +622,8 @@ export const TodayOpsPage: React.FC<TodayOpsPageProps> = ({
         modeVariant: session.mode ?? undefined,
         userId: session.userId ?? undefined,
         autoNextEnabled: quickRecord.autoNextEnabled,
+        sessionId: kioskSessionIdRef.current,
+        role: telemetryRole,
       });
       quickRecordSavedRef.current = true;
     }
@@ -619,7 +647,7 @@ export const TodayOpsPage: React.FC<TodayOpsPageProps> = ({
       setShowCompletionToast(true);
       recordAutoNextComplete();
     }
-  }, [summary?.dailyRecordStatus?.pendingUserIds, quickRecord, exceptionsQueue, isKioskMode]);
+  }, [summary?.dailyRecordStatus?.pendingUserIds, quickRecord, exceptionsQueue, isKioskMode, telemetryRole]);
 
   // ── Render ──
   return (


### PR DESCRIPTION
## 背景

PR-5（#1311）で `/today` のキオスク運用KPI計測は入ったが、
ベースライン取得Runbookと `quick_record_start` イベントが未整備で、
離脱率（abandon/start）の分母が明示されていなかった。

## 変更内容

### 1. Telemetryイベント補完

- `ux_quick_record_started` を追加
- `/today` で QuickRecord開始時にイベント送信
- kiosk telemetry payload に共通メタを追加
  - `sessionId`
  - `role`

### 2. KPI集計と表示の補完

- `computeKioskUxKpis` に `quickRecordStartCount` を追加
- `KioskUxTelemetrySection` に `QuickRecord 開始回数` を追加
- 離脱率を `abandon / start` で表示（startが0の場合は `-`）

### 3. Runbook追加

- `docs/ops/today-telemetry-baseline-runbook.md` を追加
- 7日ベースラインの収集手順、KPI定義、記録テンプレ、暫定合格ラインを明文化

## 検証

- `vitest`:
  - `src/features/today/telemetry/computeKioskUxKpis.spec.ts`
  - `tests/unit/pages/TodayOpsPage.spec.tsx`
  - pass
- `test:hydration`: pass（58）
- `typecheck`: pass
- `npx eslint`（変更ファイル限定）: pass

## 影響範囲

`/today` telemetry と運用ドキュメントに限定。業務データの read/write 契約変更なし。
