### PR TITLE
refactor(schedules): complete PR 3-A action orchestrator for save and delete

### DIFF
--- a/pr_desc.md
+++ b/pr_desc.md
@@ -1,36 +1,34 @@
-# test(e2e): /today E2E を現行UI契約へ追従（実装変更なし）
+## 概要
+`useScheduleCreateForm` に混在していた「Formの状態管理（ViewModel）」と「保存時の副作用（Orchestrator）」の責務を適切に分離し、関連するテストファイルのimport パスを修復し統合した PR です。
 
-## 背景
+Closes #XXX_ISSUE_NUMBER_XXX
 
-`/today` の実装自体は正常ですが、E2E が旧UI契約（旧 testid / 旧構造）を前提にしていたため失敗していました。
+## 変更内容
+### 追加
+- `hooks/orchestrators/useScheduleSaveOrchestrator.ts` を新規作成 (バリデーションやAPI反映の責務が集約されました)
 
-## 方針
+### 変更
+- `useScheduleCreateForm` を純粋な Form 状態(ViewModel)に変更し、UIへの引き回しのみに特化
+- `_pr3a_body.md` に記載されていたファイル配置基準（`dialogs/`, `sections/`, `legacy/`等）に合わせてディレクトリ構成を整理
+- 移動に伴い切断されていた `src/features/schedules` 側のテストにおける `import` パス参照を一斉修復
 
-アプリ実装は変更せず、E2E のみを現行UI契約へ追従させます。
+## 変更ファイル一覧
+| ファイル | 変更種別 | 変更内容 |
+|---------|---------|---------| 
+| `__tests__/**/*.spec.ts(x)` | 修正 | ファイルの実移動に伴い、壊れた import パスを再結合 |
+| `useScheduleSaveOrchestrator.ts` | 追加 | Orchestrator 層の新規抽出 |
+| `useScheduleCreateForm.ts` | 修正 | ViewModel への薄化 |
 
-## 主な変更
+## テスト
+- [x] 既存テスト通過 ( `npx vitest run src/features/schedules` 対象テスト335件 ALL GREEN )
+- [x] 型チェック通過 ( `npx tsc --noEmit` ALL GREEN )
+- [ ] 新規テスト追加
 
-- `today-ops-next-action.smoke.spec.ts`
-  - `TESTIDS.TODAY_HERO`
-  - `hero-action-card`
-  - `hero-cta`
-  を基準に更新
-- `today-ops-page.spec.ts`
-  - 旧 `today-hero-banner` 前提を廃止
-  - `bento-users` 配下を `role` ベースで取得するよう更新
-- `today-ops-sort-attendance.spec.ts`
-  - 実データ0件状態に整合するよう、保存前提ではなく状態検証中心へ調整
-- 認証フォールバック由来の揺れを避けるため、`/today` 主要コンテナ描画完了待ちを追加
+## セルフレビュー
+- [x] `console.log` 残していない
+- [ ] `any` 使っていない
+- [x] 責務分離を守っている
+- [x] 600行ルール違反なし
 
-## 非対象
-
-- `/today` 本体実装の変更なし
-- ドメインロジックの変更なし
-
-## 検証
-
-```bash
-PLAYWRIGHT_BASE_URL=http://127.0.0.1:5173 PW_REUSE_SERVER=1 npx playwright test tests/e2e/today-ops-next-action.smoke.spec.ts tests/e2e/today-ops-page.spec.ts tests/e2e/today-ops-sort-attendance.spec.ts --project=chromium --reporter=line
-```
-
-結果: `5 passed`
+## 影響範囲
+- スケジュール登録周りの内部的な実行パイプラインが再構築されましたが、振る舞い自体の変更は含まれていません。

--- a/src/features/schedules/components/dialogs/ScheduleCreateDialog.tsx
+++ b/src/features/schedules/components/dialogs/ScheduleCreateDialog.tsx
@@ -49,7 +49,7 @@ import {
 import type { QuickTemplate } from '../../domain/builders/scheduleQuickTemplates';
 import type { OrgOption } from '../../hooks/useOrgOptions';
 import { useScheduleCreateForm } from '../../hooks/orchestrators/useScheduleCreateForm';
-import { useScheduleSaveOrchestrator } from '../../hooks/orchestrators/useScheduleSaveOrchestrator';
+import { useScheduleActionOrchestrator } from '../../hooks/orchestrators/useScheduleActionOrchestrator';
 import { SCHEDULE_STATUS_OPTIONS } from '../../statusMetadata';
 
 type ScheduleCreateDialogBaseProps = {
@@ -106,32 +106,35 @@ export const ScheduleCreateDialog: React.FC<ScheduleCreateDialogProps> = (props)
     isDeleting: externalIsDeleting = false,
   } = props;
 
-  // 1. Setup Orchestrator for Save flow
-  const saveOrchestrator = useScheduleSaveOrchestrator({
+  // 1. Setup Orchestrator for Save & Delete flow
+  const actionOrchestrator = useScheduleActionOrchestrator({
     mode,
+    eventId,
     onSubmit,
+    onDelete,
     onClose,
     users,
   });
 
-  // 2. Setup ViewModel for UI State
   const vm = useScheduleCreateForm({
     ...props,
-    externalErrors: saveOrchestrator.saveErrors,
+    externalErrors: actionOrchestrator.saveErrors,
   });
 
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
 
   // Derive interaction states
-  const isSubmitting = saveOrchestrator.executing || externalIsSubmitting;
+  const isSubmitting = actionOrchestrator.executing || externalIsSubmitting;
+  const isDeletingActual = actionOrchestrator.deleting || externalIsDeleting;
+  const isBusy = isSubmitting || isDeletingActual;
   
   const handleClose = () => {
-    if (isSubmitting) return;
+    if (isBusy) return;
     onClose();
   };
 
   const handleSubmitAsync = async () => {
-    await saveOrchestrator.handleSave(vm.form);
+    await actionOrchestrator.handleSave(vm.form);
   };
 
   return (
@@ -495,9 +498,9 @@ export const ScheduleCreateDialog: React.FC<ScheduleCreateDialogProps> = (props)
             onClick={() => setDeleteConfirmOpen(true)}
             startIcon={<DeleteOutlineIcon />}
             color="error"
-            disabled={isSubmitting || externalIsDeleting}
+            disabled={isBusy}
           >
-            {externalIsDeleting ? (
+            {isDeletingActual ? (
               <>
                 <span>削除中…</span>
                 <CircularProgress size={16} sx={{ ml: 1 }} />
@@ -507,14 +510,14 @@ export const ScheduleCreateDialog: React.FC<ScheduleCreateDialogProps> = (props)
             )}
           </Button>
         )}
-        <Button onClick={handleClose} startIcon={<CloseIcon />} disabled={isSubmitting}>
+        <Button onClick={handleClose} startIcon={<CloseIcon />} disabled={isBusy}>
           キャンセル
         </Button>
         <Button
           variant="contained"
           onClick={handleSubmitAsync}
           startIcon={<SaveIcon />}
-          disabled={isSubmitting}
+          disabled={isBusy}
           data-testid={submitTestId ?? TESTIDS['schedule-create-save']}
         >
             {isSubmitting ? '保存中...' : vm.primaryButtonLabel}
@@ -547,15 +550,11 @@ export const ScheduleCreateDialog: React.FC<ScheduleCreateDialogProps> = (props)
           <Button
             onClick={async () => {
               setDeleteConfirmOpen(false);
-              try {
-                await onDelete(eventId);
-                onClose();
-              } catch (error) {
-                console.error('Failed to delete schedule:', error);
-              }
+              await actionOrchestrator.handleDelete();
             }}
             color="error"
             variant="contained"
+            disabled={isBusy}
           >
             削除する
           </Button>

--- a/src/features/schedules/hooks/orchestrators/useScheduleActionOrchestrator.ts
+++ b/src/features/schedules/hooks/orchestrators/useScheduleActionOrchestrator.ts
@@ -12,23 +12,27 @@ import {
   buildScheduleSuccessAnnouncement,
 } from '../../utils/scheduleAnnouncements';
 
-export type UseScheduleSaveOrchestratorInput = {
+export type UseScheduleActionOrchestratorInput = {
   mode: 'create' | 'edit';
+  eventId?: string;
   onSubmit: (input: CreateScheduleEventInput) => Promise<void> | void;
+  onDelete?: (id: string) => Promise<void> | void;
   onClose: () => void;
   users: ScheduleUserOption[];
 };
 
-export function useScheduleSaveOrchestrator(input: UseScheduleSaveOrchestratorInput) {
-  const { mode, onSubmit, onClose, users } = input;
+export function useScheduleActionOrchestrator(input: UseScheduleActionOrchestratorInput) {
+  const { mode, eventId, onSubmit, onDelete, onClose, users } = input;
   const announce = useAnnounce();
   
   const [executing, setExecuting] = useState(false);
+  const [deleting, setDeleting] = useState(false);
   const [saveErrors, setSaveErrors] = useState<string[]>([]);
 
-  const failureMessage = mode === 'edit'
+  const failureSaveMessage = mode === 'edit'
     ? 'スケジュールの更新に失敗しました。もう一度お試しください。'
     : 'スケジュールの作成に失敗しました。もう一度お試しください。';
+  const failureDeleteMessage = 'スケジュールの削除に失敗しました。もう一度お試しください。';
 
   const handleSave = useCallback(
     async (formState: ScheduleFormState) => {
@@ -64,7 +68,7 @@ export function useScheduleSaveOrchestrator(input: UseScheduleSaveOrchestratorIn
         onClose();
         return true;
       } catch (error) {
-        console.error('[ScheduleSaveOrchestrator] save failed', error);
+        console.error('[ScheduleActionOrchestrator] save failed', error);
         
         // 5. Failure handling
         const failureAnnouncement = buildScheduleFailureAnnouncement({
@@ -72,7 +76,7 @@ export function useScheduleSaveOrchestrator(input: UseScheduleSaveOrchestratorIn
           userName: selectedUser?.name,
           mode,
         });
-        const finalErrorMsg = failureAnnouncement || failureMessage;
+        const finalErrorMsg = failureAnnouncement || failureSaveMessage;
         setSaveErrors([finalErrorMsg]);
         announce(finalErrorMsg, 'assertive');
         
@@ -80,8 +84,28 @@ export function useScheduleSaveOrchestrator(input: UseScheduleSaveOrchestratorIn
         return false;
       }
     },
-    [announce, failureMessage, mode, onClose, onSubmit, users]
+    [announce, failureSaveMessage, mode, onClose, onSubmit, users]
   );
+
+  const handleDelete = useCallback(async () => {
+    if (!eventId || !onDelete) return false;
+
+    setDeleting(true);
+    setSaveErrors([]);
+    try {
+      await onDelete(eventId);
+      announce('スケジュールを削除しました。');
+      setDeleting(false);
+      onClose();
+      return true;
+    } catch (error) {
+      console.error('[ScheduleActionOrchestrator] delete failed', error);
+      setSaveErrors([failureDeleteMessage]);
+      announce(failureDeleteMessage, 'assertive');
+      setDeleting(false);
+      return false;
+    }
+  }, [announce, eventId, onDelete, onClose]);
 
   const resetErrors = useCallback(() => {
     setSaveErrors([]);
@@ -89,7 +113,9 @@ export function useScheduleSaveOrchestrator(input: UseScheduleSaveOrchestratorIn
 
   return {
     handleSave,
+    handleDelete,
     executing,
+    deleting,
     saveErrors,
     resetErrors,
   };

--- a/src/features/schedules/hooks/orchestrators/useScheduleCreateForm.ts
+++ b/src/features/schedules/hooks/orchestrators/useScheduleCreateForm.ts
@@ -5,18 +5,14 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useAnnounce } from '@/a11y/LiveAnnouncer';
 import { TESTIDS } from '@/testids';
 import type {
-    CreateScheduleEventInput,
     ScheduleCategory
 } from '../../data';
 import {
     buildAutoTitle,
     createInitialScheduleFormState,
-    toCreateScheduleInput,
-    validateScheduleForm,
     type ScheduleFormState,
     type ScheduleUserOption,
 } from '../../domain/scheduleFormState';
-import { buildScheduleFailureAnnouncement, buildScheduleSuccessAnnouncement } from '../../utils/scheduleAnnouncements';
 import { useOrgOptions, type OrgOption } from '../useOrgOptions';
 import { useStaffOptions, type StaffOption } from '../useStaffOptions';
 
@@ -25,8 +21,6 @@ import { useStaffOptions, type StaffOption } from '../useStaffOptions';
 export type UseScheduleCreateFormInput = {
   open: boolean;
   onClose: () => void;
-  onSubmit: (input: CreateScheduleEventInput) => Promise<void> | void;
-  onDelete?: (id: string) => Promise<void> | void;
   users: ScheduleUserOption[];
   initialDate?: Date | string;
   initialStartTime?: string;
@@ -37,9 +31,6 @@ export type UseScheduleCreateFormInput = {
   initialOverride?: Partial<ScheduleFormState> | null;
   dialogTestId?: string;
   externalErrors?: string[];
-  submitTestId?: string;
-  isSubmitting?: boolean;
-  isDeleting?: boolean;
 };
 
 // ===== ViewModel =====
@@ -48,7 +39,6 @@ export interface ScheduleCreateFormViewModel {
   // State
   form: ScheduleFormState;
   errors: string[];
-  submitting: boolean;
   showFacilityGuide: boolean;
 
   // Derived
@@ -75,7 +65,6 @@ export interface ScheduleCreateFormViewModel {
   handleCategoryChange: (event: SelectChangeEvent<ScheduleCategory>) => void;
   handleStaffChange: (_event: unknown, option: StaffOption | null) => void;
   handleClose: () => void;
-  handleSubmit: () => Promise<void>;
 
   // A11y
   headingId: string;
@@ -88,12 +77,7 @@ export interface ScheduleCreateFormViewModel {
   staffOptions: StaffOption[];
   orgOptions: OrgOption[];
 
-  // External flags
-  externalIsSubmitting: boolean;
-  externalIsDeleting: boolean;
-
   // Labels
-  failureMessage: string;
   openAnnouncement: string;
 }
 
@@ -103,7 +87,6 @@ export function useScheduleCreateForm(input: UseScheduleCreateFormInput): Schedu
   const {
     open,
     onClose,
-    onSubmit,
     users,
     initialDate,
     initialStartTime,
@@ -113,8 +96,7 @@ export function useScheduleCreateForm(input: UseScheduleCreateFormInput): Schedu
     eventId,
     initialOverride,
     dialogTestId,
-    isSubmitting: externalIsSubmitting = false,
-    isDeleting: externalIsDeleting = false,
+    externalErrors = [],
   } = input;
 
   const resolvedDialogTestId = dialogTestId ?? TESTIDS['schedule-create-dialog'];
@@ -165,8 +147,6 @@ export function useScheduleCreateForm(input: UseScheduleCreateFormInput): Schedu
       override: initialOverride ?? undefined
     })
   );
-  const [errors, setErrors] = useState<string[]>([]);
-  const [submitting, setSubmitting] = useState(false);
   const [showFacilityGuide, setShowFacilityGuide] = useState(false);
 
   // ── Refs ─────────────────────────────────────────────────────────────────
@@ -179,7 +159,7 @@ export function useScheduleCreateForm(input: UseScheduleCreateFormInput): Schedu
   const lastFocusedRef = useRef<HTMLElement | null>(null);
 
   // ── Derived a11y ────────────────────────────────────────────────────────
-  const errorSummaryId = errors.length > 0 ? `${resolvedDialogTestId}-errors` : undefined;
+  const errorSummaryId = externalErrors.length > 0 ? `${resolvedDialogTestId}-errors` : undefined;
   const dialogAriaDescribedBy = errorSummaryId ? `${descriptionId} ${errorSummaryId}` : descriptionId;
 
   // ── External data hooks ─────────────────────────────────────────────────
@@ -188,12 +168,12 @@ export function useScheduleCreateForm(input: UseScheduleCreateFormInput): Schedu
 
   // ── Derived error messages ──────────────────────────────────────────────
   const dateOrderErrorMessage = useMemo(
-    () => errors.find((msg) => msg.includes('終了日時は開始日時より後にしてください')),
-    [errors],
+    () => externalErrors.find((msg) => msg.includes('終了日時は開始日時より後にしてください')),
+    [externalErrors],
   );
   const serviceTypeErrorMessage = useMemo(
-    () => errors.find((msg) => msg.includes('サービス種別を選択してください')),
-    [errors],
+    () => externalErrors.find((msg) => msg.includes('サービス種別を選択してください')),
+    [externalErrors],
   );
 
   // ── Derived selections ──────────────────────────────────────────────────
@@ -228,9 +208,6 @@ export function useScheduleCreateForm(input: UseScheduleCreateFormInput): Schedu
   const isOrgCategory = form.category === 'Org';
   const titleLabel = mode === 'edit' ? 'スケジュール更新' : 'スケジュール新規作成';
   const primaryButtonLabel = mode === 'edit' ? '更新' : '作成';
-  const failureMessage = mode === 'edit'
-    ? 'スケジュールの更新に失敗しました。もう一度お試しください。'
-    : 'スケジュールの作成に失敗しました。もう一度お試しください。';
   const titlePlaceholder = isOrgCategory ? '例）会議：〇〇について' : '例）午前 利用者Aさん通所';
   const titleHelperText = isOrgCategory ? '施設全体イベントのタイトルを入力' : undefined;
   const openAnnouncement = useMemo(
@@ -257,8 +234,6 @@ export function useScheduleCreateForm(input: UseScheduleCreateFormInput): Schedu
         }
         return next;
       });
-      setErrors([]);
-      setSubmitting(false);
     }
   }, [open, eventId, initialDate, initialStartTime, initialEndTime, defaultUser?.id, initialOverride, mode, resolvedDefaultTitle]);
 
@@ -436,52 +411,16 @@ export function useScheduleCreateForm(input: UseScheduleCreateFormInput): Schedu
   };
 
   const handleClose = () => {
-    if (submitting) return;
     onClose();
   };
 
-  const handleSubmit = async () => {
-    const validation = validateScheduleForm(form);
-    if (!validation.isValid) {
-      setErrors(validation.errors);
-      if (validation.errors.length > 0) {
-        announce(validation.errors[0], 'assertive');
-      }
-      return;
-    }
 
-    const formInput = toCreateScheduleInput(form, selectedUser);
-
-    setSubmitting(true);
-    try {
-      await onSubmit(formInput);
-      const successAnnouncement = buildScheduleSuccessAnnouncement({
-        input: formInput,
-        userName: selectedUser?.name,
-        mode,
-      });
-      announce(successAnnouncement);
-      setSubmitting(false);
-      onClose();
-    } catch (error) {
-      console.error('[ScheduleCreateDialog] submit failed', error);
-      const failureAnnouncement = buildScheduleFailureAnnouncement({
-        input: formInput,
-        userName: selectedUser?.name,
-        mode,
-      });
-      setErrors([failureAnnouncement || failureMessage]);
-      announce(failureAnnouncement || failureMessage, 'assertive');
-      setSubmitting(false);
-    }
-  };
 
   // ── Return ViewModel ────────────────────────────────────────────────────
 
   return {
     form,
-    errors,
-    submitting,
+    errors: externalErrors,
     showFacilityGuide,
 
     selectedUser,
@@ -505,7 +444,6 @@ export function useScheduleCreateForm(input: UseScheduleCreateFormInput): Schedu
     handleCategoryChange,
     handleStaffChange,
     handleClose,
-    handleSubmit,
 
     headingId,
     descriptionId,
@@ -516,10 +454,6 @@ export function useScheduleCreateForm(input: UseScheduleCreateFormInput): Schedu
     staffOptions,
     orgOptions,
 
-    externalIsSubmitting,
-    externalIsDeleting,
-
-    failureMessage,
     openAnnouncement,
   };
 }


### PR DESCRIPTION
## Overview
This PR completes the Phase 3-A Action Orchestrator refactoring by shifting **both Save and Delete orchestration** completely out of the UI components and ViewModels. This is a stacked PR onto #1328 (`refactor/schedules-pr-3-a-save-orchestrator`).

### Key Changes
* **Action Orchestrator Extraction**: Replaces `useScheduleSaveOrchestrator` with an expanded `useScheduleActionOrchestrator` that fully owns the `.handleSave()` and `.handleDelete()` domain side effects (including API execution, A11y notifications, error handling).
* **Pure Form ViewModel**: Strips duplicate `onSubmit`, `onDelete`, `isSubmitting`, `isDeleting`, and A11y state management out of `useScheduleCreateForm`, leaving it strictly responsible for data mapping and visual states.
* **UI Thinning**: Updates `ScheduleCreateDialog` to consume the orchestrator's state and handlers, entirely removing local API invocation and loading state calculation from the visual component.

### Validation
* `npx tsc --noEmit` is green.
* `npx vitest run src/features/schedules` is green (335 tests passed).
