### PR TITLE
refactor(schedules): extract initial hydration orchestrator for create dialog

### DIFF
--- a/pr_action_body.md
+++ b/pr_action_body.md
@@ -1,0 +1,11 @@
+## Overview
+This PR completes the Phase 3-A Action Orchestrator refactoring by shifting **both Save and Delete orchestration** completely out of the UI components and ViewModels. This is a stacked PR onto #1328 (`refactor/schedules-pr-3-a-save-orchestrator`).
+
+### Key Changes
+* **Action Orchestrator Extraction**: Replaces `useScheduleSaveOrchestrator` with an expanded `useScheduleActionOrchestrator` that fully owns the `.handleSave()` and `.handleDelete()` domain side effects (including API execution, A11y notifications, error handling).
+* **Pure Form ViewModel**: Strips duplicate `onSubmit`, `onDelete`, `isSubmitting`, `isDeleting`, and A11y state management out of `useScheduleCreateForm`, leaving it strictly responsible for data mapping and visual states.
+* **UI Thinning**: Updates `ScheduleCreateDialog` to consume the orchestrator's state and handlers, entirely removing local API invocation and loading state calculation from the visual component.
+
+### Validation
+* `npx tsc --noEmit` is green.
+* `npx vitest run src/features/schedules` is green (335 tests passed).

--- a/pr_hydration_body.md
+++ b/pr_hydration_body.md
@@ -1,0 +1,11 @@
+## Overview
+This PR represents the first stage of Phase 3-B: Initial Hydration Extraction. It securely extracts the synchronous calculation of the Form's default values out of the ViewModels, setting the stage for future asynchronous remote event fetching. This is stacked onto PR #1329 (`refactor/schedules-pr-3-a-action-orchestrator`).
+
+### Key Changes
+* **Initial Hydration Orchestrator**: Introduces `useScheduleHydrationOrchestrator` to strictly isolate `mode === 'edit'` divergence, `initialOverride` merge resolution, `buildAutoTitle` execution, and `createInitialScheduleFormState` orchestration map.
+* **ViewModel Purification**: Removes all default value calculations from `useScheduleCreateForm`, mutating it to cleanly accept `initialFormState` directly.
+* **UI Thinning Continuation**: Refactors `ScheduleCreateDialog` to directly wire outputs from the Hydration Orchestrator into the inputs of the abstract Form ViewModel hook.
+
+### Validation
+* `npx tsc --noEmit` is cleanly passing.
+* `npx vitest run src/features/schedules` is completely green.

--- a/src/features/schedules/components/dialogs/ScheduleCreateDialog.tsx
+++ b/src/features/schedules/components/dialogs/ScheduleCreateDialog.tsx
@@ -50,6 +50,7 @@ import type { QuickTemplate } from '../../domain/builders/scheduleQuickTemplates
 import type { OrgOption } from '../../hooks/useOrgOptions';
 import { useScheduleCreateForm } from '../../hooks/orchestrators/useScheduleCreateForm';
 import { useScheduleActionOrchestrator } from '../../hooks/orchestrators/useScheduleActionOrchestrator';
+import { useScheduleHydrationOrchestrator } from '../../hooks/orchestrators/useScheduleHydrationOrchestrator';
 import { SCHEDULE_STATUS_OPTIONS } from '../../statusMetadata';
 
 type ScheduleCreateDialogBaseProps = {
@@ -104,9 +105,27 @@ export const ScheduleCreateDialog: React.FC<ScheduleCreateDialogProps> = (props)
     submitTestId,
     isSubmitting: externalIsSubmitting = false,
     isDeleting: externalIsDeleting = false,
+    initialDate,
+    initialStartTime,
+    initialEndTime,
+    defaultUser,
+    initialOverride,
   } = props;
 
-  // 1. Setup Orchestrator for Save & Delete flow
+  // 1. Setup Hydration Orchestrator
+  const hydration = useScheduleHydrationOrchestrator({
+    open,
+    mode,
+    eventId,
+    users,
+    defaultUser,
+    initialDate,
+    initialStartTime,
+    initialEndTime,
+    initialOverride,
+  });
+
+  // 2. Setup Orchestrator for Save & Delete flow
   const actionOrchestrator = useScheduleActionOrchestrator({
     mode,
     eventId,
@@ -118,6 +137,8 @@ export const ScheduleCreateDialog: React.FC<ScheduleCreateDialogProps> = (props)
 
   const vm = useScheduleCreateForm({
     ...props,
+    initialFormState: hydration.initialFormState,
+    resolvedDefaultTitle: hydration.resolvedDefaultTitle,
     externalErrors: actionOrchestrator.saveErrors,
   });
 

--- a/src/features/schedules/hooks/orchestrators/useScheduleCreateForm.ts
+++ b/src/features/schedules/hooks/orchestrators/useScheduleCreateForm.ts
@@ -9,7 +9,6 @@ import type {
 } from '../../data';
 import {
     buildAutoTitle,
-    createInitialScheduleFormState,
     type ScheduleFormState,
     type ScheduleUserOption,
 } from '../../domain/scheduleFormState';
@@ -22,15 +21,11 @@ export type UseScheduleCreateFormInput = {
   open: boolean;
   onClose: () => void;
   users: ScheduleUserOption[];
-  initialDate?: Date | string;
-  initialStartTime?: string;
-  initialEndTime?: string;
-  defaultUser?: ScheduleUserOption | null;
   mode: 'create' | 'edit';
-  eventId?: string;
-  initialOverride?: Partial<ScheduleFormState> | null;
   dialogTestId?: string;
   externalErrors?: string[];
+  initialFormState: ScheduleFormState;
+  resolvedDefaultTitle: string;
 };
 
 // ===== ViewModel =====
@@ -88,65 +83,19 @@ export function useScheduleCreateForm(input: UseScheduleCreateFormInput): Schedu
     open,
     onClose,
     users,
-    initialDate,
-    initialStartTime,
-    initialEndTime,
-    defaultUser,
     mode,
-    eventId,
-    initialOverride,
     dialogTestId,
     externalErrors = [],
+    initialFormState,
+    resolvedDefaultTitle,
   } = input;
 
   const resolvedDialogTestId = dialogTestId ?? TESTIDS['schedule-create-dialog'];
   const headingId = `${resolvedDialogTestId}-heading`;
   const descriptionId = `${resolvedDialogTestId}-description`;
 
-  // ── Resolved default title ──────────────────────────────────────────────
-  const resolvedDefaultTitle = useMemo(() => {
-    if (initialOverride?.title?.trim()) return initialOverride.title;
-    const candidateUserId = initialOverride?.userId ?? defaultUser?.id;
-    const matchedUser = candidateUserId ? users.find((candidate: any) => candidate.id === candidateUserId) : undefined;
-    if (mode === 'edit') {
-      return matchedUser
-        ? buildAutoTitle({
-            userName: matchedUser.name,
-            serviceType: initialOverride?.serviceType ?? '',
-            assignedStaffId: initialOverride?.assignedStaffId ?? '',
-            vehicleId: initialOverride?.vehicleId ?? '',
-          })
-        : '';
-    }
-    return buildAutoTitle({
-      userName: matchedUser?.name ?? defaultUser?.name ?? undefined,
-      serviceType: initialOverride?.serviceType ?? '',
-      assignedStaffId: initialOverride?.assignedStaffId ?? '',
-      vehicleId: initialOverride?.vehicleId ?? '',
-    });
-  }, [
-    defaultUser?.id,
-    defaultUser?.name,
-    initialOverride?.title,
-    initialOverride?.userId,
-    initialOverride?.serviceType,
-    initialOverride?.assignedStaffId,
-    initialOverride?.vehicleId,
-    mode,
-    users
-  ]);
-
   // ── Core state ──────────────────────────────────────────────────────────
-  const [form, setForm] = useState<ScheduleFormState>(() =>
-    createInitialScheduleFormState({
-      initialDate,
-      initialStartTime,
-      initialEndTime,
-      defaultUserId: defaultUser?.id,
-      defaultTitle: resolvedDefaultTitle,
-      override: initialOverride ?? undefined
-    })
-  );
+  const [form, setForm] = useState<ScheduleFormState>(initialFormState);
   const [showFacilityGuide, setShowFacilityGuide] = useState(false);
 
   // ── Refs ─────────────────────────────────────────────────────────────────
@@ -220,22 +169,15 @@ export function useScheduleCreateForm(input: UseScheduleCreateFormInput): Schedu
   // Reset form when dialog opens
   useEffect(() => {
     if (open) {
-      setForm((prev: any) => {
-        const next = createInitialScheduleFormState({
-          initialDate,
-          initialStartTime,
-          initialEndTime,
-          defaultUserId: defaultUser?.id,
-          defaultTitle: resolvedDefaultTitle,
-          override: initialOverride ?? undefined
-        });
+      setForm((prev: ScheduleFormState) => {
+        const next = { ...initialFormState };
         if (mode === 'create' && prev.title && prev.title.trim() && prev.title !== resolvedDefaultTitle) {
           next.title = prev.title;
         }
         return next;
       });
     }
-  }, [open, eventId, initialDate, initialStartTime, initialEndTime, defaultUser?.id, initialOverride, mode, resolvedDefaultTitle]);
+  }, [open, mode, initialFormState, resolvedDefaultTitle]);
 
   // Focus management on open/close
   useEffect(() => {

--- a/src/features/schedules/hooks/orchestrators/useScheduleHydrationOrchestrator.ts
+++ b/src/features/schedules/hooks/orchestrators/useScheduleHydrationOrchestrator.ts
@@ -1,0 +1,92 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  buildAutoTitle,
+  createInitialScheduleFormState,
+  type ScheduleFormState,
+  type ScheduleUserOption,
+} from '../../domain/scheduleFormState';
+
+export type UseScheduleHydrationInput = {
+  open: boolean;
+  mode: 'create' | 'edit';
+  eventId?: string;
+  users: ScheduleUserOption[];
+  defaultUser?: ScheduleUserOption | null;
+  initialDate?: Date | string;
+  initialStartTime?: string;
+  initialEndTime?: string;
+  initialOverride?: Partial<ScheduleFormState> | null;
+};
+
+export type ScheduleHydrationState = {
+  hydrated: boolean;
+  initialFormState: ScheduleFormState;
+  resolvedDefaultTitle: string;
+};
+
+export function useScheduleHydrationOrchestrator(input: UseScheduleHydrationInput): ScheduleHydrationState {
+  const {
+    open,
+    mode,
+    users,
+    defaultUser,
+    initialDate,
+    initialStartTime,
+    initialEndTime,
+    initialOverride,
+  } = input;
+
+  const [hydrated, setHydrated] = useState(false);
+
+  // 1. Resolve default Title
+  const resolvedDefaultTitle = useMemo(() => {
+    if (initialOverride?.title?.trim()) return initialOverride.title;
+    const candidateUserId = initialOverride?.userId ?? defaultUser?.id;
+    const matchedUser = candidateUserId ? users.find((u) => u.id === candidateUserId) : undefined;
+    if (mode === 'edit') {
+      return matchedUser
+        ? buildAutoTitle({
+            userName: matchedUser.name,
+            serviceType: initialOverride?.serviceType ?? '',
+            assignedStaffId: initialOverride?.assignedStaffId ?? '',
+            vehicleId: initialOverride?.vehicleId ?? '',
+          })
+        : '';
+    }
+    return buildAutoTitle({
+      userName: matchedUser?.name ?? defaultUser?.name ?? undefined,
+      serviceType: initialOverride?.serviceType ?? '',
+      assignedStaffId: initialOverride?.assignedStaffId ?? '',
+      vehicleId: initialOverride?.vehicleId ?? '',
+    });
+  }, [defaultUser?.id, defaultUser?.name, initialOverride, mode, users]);
+
+  // 2. Build combined initial state
+  const initialFormState = useMemo(() =>
+    createInitialScheduleFormState({
+      initialDate,
+      initialStartTime,
+      initialEndTime,
+      defaultUserId: defaultUser?.id,
+      defaultTitle: resolvedDefaultTitle,
+      override: initialOverride ?? undefined,
+    }),
+    [initialDate, initialStartTime, initialEndTime, defaultUser?.id, resolvedDefaultTitle, initialOverride]
+  );
+
+  // 3. Hydration lifecycle
+  useEffect(() => {
+    if (open) {
+      // Simulate ready state (will be expanded when real API fetching is added)
+      setHydrated(true);
+    } else {
+      setHydrated(false);
+    }
+  }, [open, initialFormState]);
+
+  return {
+    hydrated,
+    initialFormState,
+    resolvedDefaultTitle,
+  };
+}


### PR DESCRIPTION
## Overview
This PR represents the first stage of Phase 3-B: Initial Hydration Extraction. It securely extracts the synchronous calculation of the Form's default values out of the ViewModels, setting the stage for future asynchronous remote event fetching. This is stacked onto PR #1329 (`refactor/schedules-pr-3-a-action-orchestrator`).

### Key Changes
* **Initial Hydration Orchestrator**: Introduces `useScheduleHydrationOrchestrator` to strictly isolate `mode === 'edit'` divergence, `initialOverride` merge resolution, `buildAutoTitle` execution, and `createInitialScheduleFormState` orchestration map.
* **ViewModel Purification**: Removes all default value calculations from `useScheduleCreateForm`, mutating it to cleanly accept `initialFormState` directly.
* **UI Thinning Continuation**: Refactors `ScheduleCreateDialog` to directly wire outputs from the Hydration Orchestrator into the inputs of the abstract Form ViewModel hook.

### Validation
* `npx tsc --noEmit` is cleanly passing.
* `npx vitest run src/features/schedules` is completely green.
