### PR TITLE
fix(users): enforce auth-safe tab flow and list usability

### DIFF
--- a/src/features/users/UsersPanel/UsersList.tsx
+++ b/src/features/users/UsersPanel/UsersList.tsx
@@ -86,7 +86,7 @@ const UsersList: FC<UsersListProps> = ({
 
   const isRefreshing = busyId === -2;
   const [search, setSearch] = useState('');
-  const [onlyActive, setOnlyActive] = useState(false);
+  const [onlyActive, setOnlyActive] = useState(true);
   const [onlySevere, setOnlySevere] = useState(false);
   const [prioritySort, setPrioritySort] = useState(false);
 
@@ -316,12 +316,19 @@ const UsersList: FC<UsersListProps> = ({
             minWidth: { lg: 0 },
             borderRadius: 2,
             maxHeight: { lg: 'calc(100vh - 280px)' },
-            overflow: 'auto',
+            overflowX: 'auto',
+            overflowY: 'auto',
+            WebkitOverflowScrolling: 'touch',
           }}
           data-testid={TESTIDS['users-list-table']}
         >
           {/* ── ③ dense table ── */}
-          <Table stickyHeader size="small" aria-label="利用者一覧テーブル">
+          <Table
+            stickyHeader
+            size="small"
+            aria-label="利用者一覧テーブル"
+            sx={{ minWidth: { xs: 560, sm: 640 } }}
+          >
             <TableHead>
               <TableRow>
                 <TableCell
@@ -330,20 +337,47 @@ const UsersList: FC<UsersListProps> = ({
                     whiteSpace: 'nowrap',
                     fontWeight: 700,
                     fontSize: '0.8rem',
-                    bgcolor: 'grey.50',
+                    bgcolor: (theme) =>
+                      theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.08)' : 'grey.50',
                   }}
                 >
                   状態
                 </TableCell>
-                <TableCell sx={{ fontWeight: 700, fontSize: '0.8rem', bgcolor: 'grey.50' }}>
+                <TableCell
+                  sx={{
+                    minWidth: 96,
+                    whiteSpace: 'nowrap',
+                    fontWeight: 700,
+                    fontSize: '0.8rem',
+                    bgcolor: (theme) =>
+                      theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.08)' : 'grey.50',
+                  }}
+                >
                   ユーザーID
                 </TableCell>
-                <TableCell sx={{ fontWeight: 700, fontSize: '0.8rem', bgcolor: 'grey.50' }}>
+                <TableCell
+                  sx={{
+                    minWidth: 120,
+                    whiteSpace: 'nowrap',
+                    fontWeight: 700,
+                    fontSize: '0.8rem',
+                    bgcolor: (theme) =>
+                      theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.08)' : 'grey.50',
+                  }}
+                >
                   氏名
                 </TableCell>
                 <TableCell
                   align="center"
-                  sx={{ fontWeight: 700, fontSize: '0.8rem', bgcolor: 'grey.50', width: 120 }}
+                  sx={{
+                    minWidth: 120,
+                    width: 120,
+                    whiteSpace: 'nowrap',
+                    fontWeight: 700,
+                    fontSize: '0.8rem',
+                    bgcolor: (theme) =>
+                      theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.08)' : 'grey.50',
+                  }}
                 >
                   操作
                 </TableCell>
@@ -393,7 +427,7 @@ const UsersList: FC<UsersListProps> = ({
                         )}
                       </Stack>
                     </TableCell>
-                    <TableCell sx={{ py: 0.75, fontSize: '0.85rem' }}>
+                    <TableCell sx={{ py: 0.75, fontSize: '0.85rem', whiteSpace: 'nowrap' }}>
                       {user.UserID}
                     </TableCell>
                     <TableCell
@@ -517,7 +551,8 @@ const UsersList: FC<UsersListProps> = ({
                 alignItems: 'center',
                 justifyContent: 'center',
                 minHeight: 200,
-                bgcolor: 'grey.50',
+                bgcolor: (theme) =>
+                  theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.04)' : 'grey.50',
               }}
             >
               <PersonSearchRoundedIcon
@@ -526,10 +561,10 @@ const UsersList: FC<UsersListProps> = ({
               <Typography variant="subtitle2" color="text.secondary" sx={{ fontWeight: 600 }}>
                 利用者が未選択です
               </Typography>
-              <Typography variant="body2" color="text.disabled" textAlign="center" sx={{ mt: 0.5 }}>
+              <Typography variant="body2" color="text.secondary" textAlign="center" sx={{ mt: 0.5 }}>
                 一覧から利用者を選択すると、ここに詳細が表示されます
               </Typography>
-              <Typography variant="caption" color="text.disabled" sx={{ mt: 1 }}>
+              <Typography variant="caption" color="text.secondary" sx={{ mt: 1 }}>
                 ⌘/Ctrl + クリックで新しいタブに開きます
               </Typography>
             </Paper>

--- a/src/features/users/UsersPanel/UsersMenu.tsx
+++ b/src/features/users/UsersPanel/UsersMenu.tsx
@@ -10,12 +10,14 @@ type UsersMenuProps = {
   onNavigateToList: () => void;
   onNavigateToCreate: () => void;
   onExportMonthlySummary?: () => void;
+  canNavigateToCreate?: boolean;
 };
 
 const UsersMenu: FC<UsersMenuProps> = ({
   onNavigateToList,
   onNavigateToCreate,
-  onExportMonthlySummary
+  onExportMonthlySummary,
+  canNavigateToCreate = true,
 }) => (
   <Stack spacing={2.5}>
     <BoxHeading />
@@ -32,11 +34,17 @@ const UsersMenu: FC<UsersMenuProps> = ({
         fullWidth
         variant="contained"
         startIcon={<PersonAddRoundedIcon />}
+        disabled={!canNavigateToCreate}
         onClick={onNavigateToCreate}
       >
         新規利用者登録
       </Button>
     </Stack>
+    {!canNavigateToCreate && (
+      <Typography variant="caption" color="text.secondary">
+        新規利用者登録には編集モードが必要です。
+      </Typography>
+    )}
 
     <Stack spacing={1.5}>
       <Typography variant="subtitle2" component="h4" sx={{ fontWeight: 600 }}>

--- a/src/features/users/UsersPanel/index.tsx
+++ b/src/features/users/UsersPanel/index.tsx
@@ -32,7 +32,7 @@ import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import UserForm from '../UserForm';
 import UsersCreateForm from './UsersCreateForm';
 import UsersList from './UsersList';
@@ -79,6 +79,13 @@ const UsersPanel = () => {
   // 管理者承認による一時的な編集権限
   const { isOverrideActive, requestOverride, revokeOverride, remainingMs } = useAdminOverride();
   const canEdit = isAdmin || isOverrideActive;
+  const safeActiveTab: UsersTab = activeTab === 'create' && !canEdit ? 'list' : activeTab;
+
+  useEffect(() => {
+    if (activeTab === 'create' && !canEdit) {
+      setActiveTab('list');
+    }
+  }, [activeTab, canEdit, setActiveTab]);
 
   // PIN 入力ダイアログ
   const [pinDialogOpen, setPinDialogOpen] = useState(false);
@@ -140,8 +147,15 @@ const UsersPanel = () => {
 
       <Paper variant="outlined" sx={{ mb: 3 }}>
         <Tabs
-          value={activeTab}
-          onChange={(_, value) => setActiveTab(value as UsersTab)}
+          value={safeActiveTab}
+          onChange={(_, value) => {
+            const nextTab = value as UsersTab;
+            if (nextTab === 'create' && !canEdit) {
+              setActiveTab('list');
+              return;
+            }
+            setActiveTab(nextTab);
+          }}
           variant="scrollable"
           scrollButtons="auto"
           aria-label="利用者タブメニュー"
@@ -165,14 +179,21 @@ const UsersPanel = () => {
         </Tabs>
         <Divider />
         <Box sx={{ p: { xs: 2.5, md: 3 } }}>
-          {activeTab === 'menu' && (
+          {safeActiveTab === 'menu' && (
             <UsersMenu
               onNavigateToList={() => setActiveTab('list')}
-              onNavigateToCreate={() => setActiveTab('create')}
+              onNavigateToCreate={() => {
+                if (!canEdit) {
+                  setActiveTab('list');
+                  return;
+                }
+                setActiveTab('create');
+              }}
               onExportMonthlySummary={handleExportMonthlySummary}
+              canNavigateToCreate={canEdit}
             />
           )}
-          {activeTab === 'list' && (
+          {safeActiveTab === 'list' && (
             <>
               <UsersList
                 users={data}
@@ -210,7 +231,7 @@ const UsersPanel = () => {
               )}
             </>
           )}
-          {canEdit && activeTab === 'create' && (
+          {canEdit && safeActiveTab === 'create' && (
             <UsersCreateForm
               isSubmitting={isCreatePending}
               onCreate={handleCreate}

--- a/src/features/users/UsersPanel/utils.ts
+++ b/src/features/users/UsersPanel/utils.ts
@@ -6,11 +6,11 @@ import { AuthRequiredError } from '../../../lib/errors';
 export const buildErrorMessage = (error: unknown): string => {
   if (!error) return '原因不明のエラーが発生しました。';
   if (error instanceof AuthRequiredError) {
-    return 'サインインが必要です。上部の「Sign in」を押して認証を完了してください。';
+    return 'サインインが必要です。上部の「サインイン」を押して認証を完了してください。';
   }
   if (error instanceof Error) {
     if (error.message === 'AUTH_REQUIRED') {
-      return 'サインインが必要です。上部の「Sign in」を押して認証を完了してください。';
+      return 'サインインが必要です。上部の「サインイン」を押して認証を完了してください。';
     }
     return error.message;
   }

--- a/src/features/users/infra/RestApiUserRepository.ts
+++ b/src/features/users/infra/RestApiUserRepository.ts
@@ -121,7 +121,8 @@ export class RestApiUserRepository implements UserRepository {
     try {
       items = await this.fetchItems(path, selectMode);
     } catch (e) {
-      if (this.isSelectError(e)) {
+      const shouldRetryWithoutSelect = path.includes('$select=');
+      if (this.isSelectError(e) || this.isLikelySelectQueryFailure(e, path) || shouldRetryWithoutSelect) {
         usersSelectSupported = false;
         // Fallback: $select を外して全列取得（存在しないフィールドを含んでいても安全）
         auditLog.warn('users', 'rest_api_repo.select_error_retry', { error: String(e) });
@@ -176,7 +177,8 @@ export class RestApiUserRepository implements UserRepository {
       if (this.isNotFoundError(error)) {
         return null;
       }
-      if (this.isSelectError(error)) {
+      const shouldRetryWithoutSelect = path.includes('$select=');
+      if (this.isSelectError(error) || this.isLikelySelectQueryFailure(error, path) || shouldRetryWithoutSelect) {
         usersSelectSupported = false;
         auditLog.warn('users', 'rest_api_repo.select_error_getbyid_retry', { error: String(error) });
         try {
@@ -495,12 +497,37 @@ export class RestApiUserRepository implements UserRepository {
         msg.includes('property') ||
         msg.includes('column') ||
         msg.includes('field') ||
+        msg.includes('invalidclientqueryexception') ||
+        msg.includes('$select') ||
+        (msg.includes('query') && msg.includes('invalid')) ||
+        (msg.includes('expression') && msg.includes('not valid')) ||
         msg.includes('存在しません') ||
         msg.includes('フィールド') ||
-        msg.includes('プロパティ')
+        msg.includes('プロパティ') ||
+        (msg.includes('クエリ') && msg.includes('無効')) ||
+        (msg.includes('式') && msg.includes('無効'))
       );
     }
     return false;
+  }
+
+  private isLikelySelectQueryFailure(error: unknown, path: string): boolean {
+    if (!path.includes('$select=')) {
+      return false;
+    }
+    const status = this.extractErrorStatus(error);
+    return status === 400;
+  }
+
+  private extractErrorStatus(error: unknown): number | null {
+    if (!error || typeof error !== 'object') {
+      return null;
+    }
+    const status = (error as { status?: unknown }).status;
+    if (typeof status === 'number' && Number.isFinite(status)) {
+      return status;
+    }
+    return null;
   }
 
   private isNotFoundError(error: unknown): boolean {


### PR DESCRIPTION
## 変更内容
- Users 画面の auth-safe なタブ遷移（未サインイン時の不正到達防止）を修正
- Users 一覧の操作性/表示の改善を反映

## 変更しない範囲
- CallLogs / Today / ExceptionCenter のロジックは変更しない

## 依存
- base: #1 (`stack/pr1-docs-test`)

## 確認ポイント
- 未サインイン時に create 到達で空白化しないこと
- URL直打ち/状態遷移時にも安全に fallback すること
- Users 既存回帰テストが通ること
