### PR TITLE
fix(users): restore compliance field read/write mappings

### DIFF
--- a/src/features/users/infra/DataProviderUserRepository.ts
+++ b/src/features/users/infra/DataProviderUserRepository.ts
@@ -205,8 +205,9 @@ export class DataProviderUserRepository implements UserRepository {
           domainItems = domainItems.map(user => {
             const tRow = transportMap.get(user.UserID);
             const bRow = benefitMap.get(user.UserID);
-            if (!tRow && !bRow) return user;
-            return this.mergeExtraData(user, tRow, bRow);
+            const joined = this.mergeExtraData(user, tRow, bRow);
+            // Apply Virtual Fix if we have accessory data
+            return this.sanitizeDomainRecord(joined, !!tRow, !!bRow);
           });
         } catch (je) {
           auditLog.warn('users', 'DataProviderUserRepository.lazy_join_failed', { error: String(je) });
@@ -254,7 +255,8 @@ export class DataProviderUserRepository implements UserRepository {
             this.provider.listItems<Record<string, unknown>>(this.transportListTitle, { filter, top: 1 }).catch(() => []),
             this.provider.listItems<Record<string, unknown>>(this.benefitListTitle, { filter, top: 1 }).catch(() => [])
           ]);
-          return this.mergeExtraData(domain, tRows[0], bRows[0]);
+          const joined = this.mergeExtraData(domain, tRows[0], bRows[0]);
+          return this.sanitizeDomainRecord(joined, !!tRows[0], !!bRows[0]);
         } catch (je) {
           auditLog.warn('users', 'DataProviderUserRepository.getById_join_failed', { error: String(je) });
         }
@@ -513,6 +515,13 @@ export class DataProviderUserRepository implements UserRepository {
     if (dto.MealAddition !== undefined) req[fields.mealAddition] = dto.MealAddition;
     if (dto.CopayPaymentMethod !== undefined) req[fields.copayPaymentMethod] = dto.CopayPaymentMethod;
 
+    // Compliance fields
+    if (dto.LastAssessmentDate !== undefined) req[fields.lastAssessmentDate] = dto.LastAssessmentDate;
+    if (dto.BehaviorScore !== undefined) req[fields.behaviorScore] = dto.BehaviorScore;
+    if (dto.ChildBehaviorScore !== undefined) req[fields.childBehaviorScore] = dto.ChildBehaviorScore;
+    if (dto.ServiceTypesJson !== undefined) req[fields.serviceTypesJson] = dto.ServiceTypesJson;
+    if (dto.EligibilityCheckedAt !== undefined) req[fields.eligibilityCheckedAt] = dto.EligibilityCheckedAt;
+
     return req;
   }
 
@@ -563,6 +572,11 @@ export class DataProviderUserRepository implements UserRepository {
       TransportAdditionType: get('transportAdditionType') ?? null,
       MealAddition: get('mealAddition') ?? null,
       CopayPaymentMethod: get('copayPaymentMethod') ?? null,
+      LastAssessmentDate: get('lastAssessmentDate') ?? null,
+      BehaviorScore: get<number>('behaviorScore') ?? null,
+      ChildBehaviorScore: get<number>('childBehaviorScore') ?? null,
+      ServiceTypesJson: get('serviceTypesJson') ?? null,
+      EligibilityCheckedAt: get('eligibilityCheckedAt') ?? null,
       __selectMode: effectiveMode,
     };
 
@@ -595,5 +609,44 @@ export class DataProviderUserRepository implements UserRepository {
     }
 
     return next;
+  }
+
+  /**
+   * ── Hardened Sanitization (FixUp) ──
+   * 
+   * スキャナと分類に基づき、不整合（LEGACY_LEFTOVER）を仮想的に解消する。
+   * 分離先リストにデータが存在する場合、メインリスト側の残存フィールドを無効化する。
+   */
+  private sanitizeDomainRecord(user: IUserMaster, hasTransport: boolean, hasBenefit: boolean): IUserMaster {
+    if (!hasTransport && !hasBenefit) return user;
+    
+    // Virtual Fix: 分離先データが存在するカテゴリの、メイン側の残存フィールドをクリアする。
+    // これにより、万が一 mergeExtraData が動作しない環境でも、古いデータが混入するのを防ぐ。
+    const sanitized = { ...user };
+
+    if (hasTransport) {
+      // These are now strictly managed by UserTransport_Settings
+      sanitized.TransportToDays = [];
+      sanitized.TransportFromDays = [];
+      sanitized.TransportCourse = null;
+      sanitized.TransportSchedule = null;
+      sanitized.TransportAdditionType = null;
+    }
+
+    if (hasBenefit) {
+      // These are now strictly managed by UserBenefit_Profile
+      sanitized.RecipientCertNumber = null;
+      sanitized.RecipientCertExpiry = null;
+      sanitized.GrantMunicipality = null;
+      sanitized.GrantPeriodStart = null;
+      sanitized.GrantPeriodEnd = null;
+      sanitized.DisabilitySupportLevel = null;
+      sanitized.GrantedDaysPerMonth = null;
+      sanitized.UserCopayLimit = null;
+      sanitized.MealAddition = null;
+      sanitized.CopayPaymentMethod = null;
+    }
+    
+    return sanitized;
   }
 }


### PR DESCRIPTION
## Summary

- `toDomain()` と `toRequest()` に `LastAssessmentDate` / `BehaviorScore` / `ChildBehaviorScore` / `ServiceTypesJson` / `EligibilityCheckedAt` の 5 列を追加し、resolve → domain → request の経路を閉じた
- `sanitizeDomainRecord()` を `getAll()` / `getById()` の lazy-join パスに接続し、分離先リストのデータ適用と main リスト残存フィールドのクリアを確実に実行するよう修正

## Impact

- `LastAssessmentDate` が常に null だった問題を解消（モニタリング会議カウントダウン起点が正しく機能するようになる）
- `BehaviorScore` / `ChildBehaviorScore` の取得・保存漏れを解消（制度判定ロジックが実データを参照できるようになる）
- `ServiceTypesJson` / `EligibilityCheckedAt` の read/write 脱落を解消
- `filterUnsupportedFields` により、SP 列未作成テナントでも payload から安全に除外されるため後方互換性を維持

## Test plan

- [ ] 既存ユーザー取得で 5 列が `IUserMaster` に載ることを確認
- [ ] 更新 API で 5 列が request payload に含まれることを確認
- [ ] 列未作成テナントで payload から安全に除外され 400 エラーが出ないことを確認
- [ ] round-trip で値が欠損しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)