### PR TITLE
fix(ci): resolve integration-users workflow file issue (jobs=0)

### DIFF
--- a/.github/workflows/integration-users.yml
+++ b/.github/workflows/integration-users.yml
@@ -65,15 +65,19 @@ jobs:
           retention-days: 7
 
       - name: Notify Teams on failure
-        if: failure() && secrets.TEAMS_WEBHOOK_URL != ''
+        if: failure()
         env:
           TEAMS_WEBHOOK_URL: ${{ secrets.TEAMS_WEBHOOK_URL }}
         run: |
+          if [ -z "${TEAMS_WEBHOOK_URL:-}" ]; then
+            echo "TEAMS_WEBHOOK_URL is empty; skipping Teams notification."
+            exit 0
+          fi
           GUID=$(grep -RhoE 'sprequestguid[^A-Za-z0-9-]*[A-Za-z0-9-]+' test-results playwright-report 2>/dev/null | head -1 | sed -E 's/.*(sprequestguid[^A-Za-z0-9-]*)([A-Za-z0-9-]+).*/\2/' || true)
           [ -z "$GUID" ] && GUID="N/A"
           COMMIT_SHORT="${GITHUB_SHA:0:7}"
 
-          MSG=$(cat <<'JSON'
+          MSG=$(cat <<JSON
           {
             "@type": "MessageCard",
             "@context": "http://schema.org/extensions",


### PR DESCRIPTION
## Summary
Fix \.github/workflows/integration-users.yml parse/evaluation issue causing `workflow file issue` and `jobs=0` on main.

## Changes
- Remove invalid secrets context from step if condition:
  - from: `if: failure() && secrets.TEAMS_WEBHOOK_URL != ''`
  - to: `if: failure()`
- Add safe guard in script to skip notification when webhook is empty.
- Enable env var interpolation in Teams payload heredoc.

## Verification
- `actionlint .github/workflows/integration-users.yml` passes.
- Repository-wide expression error for this file is gone.

## Risk
Low. Changes are isolated to one failure-notification step in integration-users workflow.