### PR TITLE
fix(diagnostics): align drift_events_log contract by dropping Severity from essentialFields

### DIFF
--- a/src/sharepoint/__tests__/driftProbeRegistry.spec.ts
+++ b/src/sharepoint/__tests__/driftProbeRegistry.spec.ts
@@ -43,7 +43,19 @@ describe('DriftProbeRegistry / Dynamic Discovery', () => {
     const targets = getDriftProbeTargets();
     const keys = targets.map(t => t.key);
     const uniqueKeys = new Set(keys);
-    
+
     expect(keys.length).toBe(uniqueKeys.size);
+  });
+
+  it('does not mark drift_events_log Severity as essential', () => {
+    // 診断契約と SharePointDriftEventRepository の実装契約を一致させるための回帰防止。
+    // Severity は repository が任意扱い（fail-open）で、本リストは lifecycle: 'optional'。
+    // Severity が essential に戻ると /admin/status が schema FAIL を出してしまう。
+    const entry = SP_LIST_REGISTRY.find(e => e.key === 'drift_events_log');
+
+    expect(entry).toBeDefined();
+    expect(entry?.lifecycle).toBe('optional');
+    expect(entry?.essentialFields).toEqual(['ListName', 'FieldName', 'DetectedAt']);
+    expect(entry?.essentialFields).not.toContain('Severity');
   });
 });

--- a/src/sharepoint/spListRegistry.ts
+++ b/src/sharepoint/spListRegistry.ts
@@ -695,7 +695,10 @@ export const SP_LIST_REGISTRY: readonly SpListEntry[] = [
     operations: ['R', 'W'],
     category: 'compliance',
     lifecycle: 'optional',
-    essentialFields: ['ListName', 'FieldName', 'DetectedAt', 'Severity'],
+    // Severity は SharePointDriftEventRepository が任意扱い（fail-open）で、
+    // かつ本リストは lifecycle: 'optional' な観測用途のため essential から除外する。
+    // 診断契約を実装契約に合わせ、宣言だけが厳しい状態を解消する。
+    essentialFields: ['ListName', 'FieldName', 'DetectedAt'],
     provisioningFields: [
       { internalName: 'ListName', type: 'Text', displayName: 'List Name', required: true, indexed: true },
       { internalName: 'FieldName', type: 'Text', displayName: 'Field Name', required: true, indexed: true },


### PR DESCRIPTION
## Summary
Align diagnostic contract with repository implementation for `drift_events_log`.

Removed `Severity` from `essentialFields` to resolve false FAIL caused by contract mismatch.

## Root Cause
- `spListRegistry.ts` declared `Severity` as essential
- `SharePointDriftEventRepository` treats `Severity` as optional
- `drift_events_log` lifecycle is `optional`
- Tenant does not have `Severity` column provisioned

This mismatch caused:
- schema category: 39 WARN + 1 FAIL
- overall status: FAIL

## Fix
```diff
- essentialFields: ['ListName', 'FieldName', 'DetectedAt', 'Severity']
+ essentialFields: ['ListName', 'FieldName', 'DetectedAt']
```

## Why this is correct
- Repository is fail-open and does not require `Severity`
- Drift logging works with 3 core fields
- `drift_events_log` is observational (non-critical)
- Provisioning `Severity` is not required for system continuity

## Impact
- FAIL -> 0
- overall status: FAIL -> WARN
- no runtime behavior change
- preserves future extensibility (`Severity` remains in `provisioningFields`)

## Validation
- `npx vitest run src/sharepoint/__tests__/driftProbeRegistry.spec.ts` (pass)

## Follow-ups (optional)
- Add/maintain regression guard to ensure optional lifecycle lists do not fail on missing non-critical fields
