### PR TITLE
feat(navigation): introduce Planning visibility policy B with one-time migration and telemetry

### DIFF
--- a/docs/navigation-planning-visibility-policy-options.md
+++ b/docs/navigation-planning-visibility-policy-options.md
@@ -1,0 +1,70 @@
+# Planning表示ポリシー比較（3案）
+
+> 作成日: 2026-04-09  
+> 対象: サイドメニュー `planning` グループの表示ポリシー
+
+## 背景
+
+2026-04-09 時点で以下は対応済み:
+
+- `survey/tokusei` の nav/route 権限不一致を解消（`admin` に統一）
+- `Planning` ハブと配下ページの二重 active を解消
+
+未決事項は、`planning` グループを「常時表示固定」に寄せるかどうか。
+
+## 比較対象
+
+| 案 | 方針 | メリット | リスク | 実装影響 |
+|---|---|---|---|---|
+| A. 常時固定 | `today` / `platform` と同様に `planning` を非表示不可にする（staff以上） | 導線喪失を防ぎやすい。教育コストが低い | 現場によってはメニュー肥大感が増える | `NavGroupVisibilityControl` の固定対象追加、設定UI文言見直し |
+| B. 初期ON（推奨） | `planning` を staff以上で初期表示ONにするが、個人設定でOFFは許容 | 導線を維持しつつ現場裁量を残せる | 非表示にされるケースは残る | 設定初期化/マイグレーション追加、利用実態の計測追加 |
+| C. 現状維持 + 代替導線 | `planning` は任意表示のまま。主要画面に代替CTAを追加 | 既存UXへの影響が最小 | サイドメニューとしての一貫性は弱い | Today/Hub/Users詳細などに補助導線を追加 |
+
+## 評価軸
+
+1. 業務クリティカル導線の消失率（`planning` 到達率の低下有無）
+2. 画面ノイズ増加の許容度（現場ヒアリング）
+3. ロール別運用負荷（staff/reception/admin）
+4. kiosk 運用との整合（`today` 集中方針を崩さないこと）
+
+## 推奨
+
+`B. 初期ON（推奨）` を先行採用し、2〜4週間の運用データで固定化可否を判定する。
+
+- 理由: 安全性（導線確保）と柔軟性（現場裁量）のバランスが最も良い
+- kiosk は現行維持（`today` のみ表示）を前提とする
+
+## B案マイグレーション契約（確定）
+
+- 対象は `hiddenNavGroups` に `planning` の明示設定が存在しないユーザーのみ
+- 既に `planning` を明示的に非表示にしているユーザー設定は尊重する
+- `kiosk` は例外で、従来どおり `today` 以外を非表示のままとする
+- 初期ON付与は一度きりの後方互換マイグレーションとして扱う
+- マイグレーション後の表示変更は通常の個人設定操作に委ねる
+
+## 受け入れ条件
+
+- `planning` 未設定ユーザーでは初回のみ表示ONになる
+- `planning` を既にOFFにしているユーザーはOFFのまま
+- `kiosk` では `planning` は表示されない
+- 設定画面でのON/OFF操作は従来どおり有効
+- telemetry は初回露出・到達・設定変更・7日後維持を継続して欠損なく送る
+
+## 実装メモ（B案）
+
+1. `settingsModel` にナビポリシー版を持たせる（例: `navPolicyVersion`）
+2. 読み込み時マイグレーションで、staff以上の `hiddenNavGroups` から `planning` を初期解除  
+   明示的にユーザーがOFFした場合は保持
+3. `planning` グループ表示切替をテレメトリ送信（ON/OFF、role、mode）
+4. 2〜4週間後に以下を見て A/B/C を再判定
+
+- `planning` 到達率
+- `planning` 非表示率
+- 導線迷子系の問い合わせ件数
+
+## 影響ファイル（想定）
+
+- `src/features/settings/settingsModel.ts`
+- `src/features/settings/useSettings.ts`（または設定ロード処理）
+- `src/features/settings/components/NavGroupVisibilityControl.tsx`
+- `src/app/useAppShellState.ts`（必要に応じてテレメトリ連携）

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -46,3 +46,8 @@
 2. **ナビ構成登録**: `src/app/config/navigationConfig.ts` の `createNavItems()`
 3. **アイコン対応**: `src/app/navIconMap.ts`
 4. **テスト作成**: `tests/unit/app/config/navigationConfig.spec.ts`
+
+## 関連ドキュメント
+
+- `docs/navigation-structure.md` — 三系統導線の責務分離
+- `docs/navigation-planning-visibility-policy-options.md` — Planning表示ポリシー比較（3案）

--- a/src/app/config/navigationConfig.ts
+++ b/src/app/config/navigationConfig.ts
@@ -66,12 +66,13 @@ type HubNavItemOverrides = {
   prefetchKey?: NavItem['prefetchKey'];
   prefetchKeys?: NavItem['prefetchKeys'];
   tier?: NavTier;
+  isActive?: NavItem['isActive'];
 };
 
 const createHubNavItem = (hubId: HubId, overrides: HubNavItemOverrides = {}): NavItem => ({
   label: overrides.label ?? getHubNavLabel(hubId),
   to: getHubRootPath(hubId),
-  isActive: (pathname) => isHubPathActive(hubId, pathname),
+  isActive: overrides.isActive ?? ((pathname) => isHubPathActive(hubId, pathname)),
   icon: undefined,
   testId: overrides.testId,
   prefetchKey: overrides.prefetchKey,
@@ -185,7 +186,10 @@ export function createNavItems(config: CreateNavItemsConfig): NavItem[] {
 
     // --- 2. 支援計画・アセスメント (assessment) ---
     // 順序: ISP作成・更新 → 支援計画シート → アセスメント系 → 分析系 → アンケート
-    createHubNavItem('planning'),
+    createHubNavItem('planning', {
+      // Hub 自体の active は /planning 配下に限定し、配下業務画面との二重 active を避ける。
+      isActive: (pathname) => pathname === '/planning' || pathname.startsWith('/planning/'),
+    }),
     {
       label: '分析ワークスペース',
       to: '/analysis/dashboard',

--- a/src/app/navigation/__tests__/planningNavTelemetry.spec.ts
+++ b/src/app/navigation/__tests__/planningNavTelemetry.spec.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  PLANNING_NAV_STORAGE_KEYS,
+  PLANNING_NAV_TELEMETRY_EVENTS,
+  markPlanningNavInitialExposure,
+  maybeRecordPlanningNavRetention,
+  recordPlanningNavTelemetry,
+  type PlanningNavTelemetryEvent,
+} from '../planningNavTelemetry';
+
+const mockAddDoc = vi.fn().mockResolvedValue({ id: 'planning-nav-event-id' });
+const mockCollection = vi.fn().mockReturnValue('mock-collection-ref');
+let firestoreWriteAvailable = true;
+
+vi.mock('firebase/firestore', () => ({
+  addDoc: (...args: unknown[]) => mockAddDoc(...args),
+  collection: (...args: unknown[]) => mockCollection(...args),
+  serverTimestamp: () => 'mock-server-timestamp',
+}));
+
+vi.mock('@/infra/firestore/client', () => ({
+  getDb: () => 'mock-db',
+  isFirestoreWriteAvailable: () => firestoreWriteAvailable,
+}));
+
+describe('planningNavTelemetry', () => {
+  beforeEach(() => {
+    firestoreWriteAvailable = true;
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('records planning navigation telemetry payload', () => {
+    const event: PlanningNavTelemetryEvent = {
+      eventName: PLANNING_NAV_TELEMETRY_EVENTS.VISIBILITY_CHANGED,
+      role: 'admin',
+      navAudience: 'admin',
+      mode: 'normal',
+      pathname: '/today',
+      visible: true,
+      source: 'appshell',
+      trigger: 'state_change',
+    };
+
+    recordPlanningNavTelemetry(event);
+
+    expect(mockCollection).toHaveBeenCalledWith('mock-db', 'telemetry');
+    expect(mockAddDoc).toHaveBeenCalledWith(
+      'mock-collection-ref',
+      expect.objectContaining({
+        type: 'planning_nav_telemetry',
+        event: PLANNING_NAV_TELEMETRY_EVENTS.VISIBILITY_CHANGED,
+        eventName: PLANNING_NAV_TELEMETRY_EVENTS.VISIBILITY_CHANGED,
+        role: 'admin',
+        navAudience: 'admin',
+        visible: true,
+        ts: 'mock-server-timestamp',
+      }),
+    );
+  });
+
+  it('is no-op when Firestore write is unavailable', () => {
+    firestoreWriteAvailable = false;
+    recordPlanningNavTelemetry({
+      eventName: PLANNING_NAV_TELEMETRY_EVENTS.PAGE_ARRIVED,
+      role: 'viewer',
+      pathname: '/planning-sheet-list',
+      source: 'appshell',
+      trigger: 'route_change',
+    });
+    expect(mockCollection).not.toHaveBeenCalled();
+    expect(mockAddDoc).not.toHaveBeenCalled();
+  });
+
+  it('marks initial exposure only once', () => {
+    const now = Date.parse('2026-04-09T00:00:00.000Z');
+    markPlanningNavInitialExposure(
+      {
+        role: 'viewer',
+        navAudience: 'staff',
+        mode: 'normal',
+        pathname: '/today',
+        search: '',
+      },
+      now,
+    );
+    markPlanningNavInitialExposure(
+      {
+        role: 'viewer',
+        navAudience: 'staff',
+        mode: 'normal',
+        pathname: '/today',
+        search: '',
+      },
+      now + 1_000,
+    );
+
+    expect(localStorage.getItem(PLANNING_NAV_STORAGE_KEYS.FIRST_VISIBLE_AT_MS)).toBe(String(now));
+    expect(mockAddDoc).toHaveBeenCalledTimes(1);
+    expect(mockAddDoc).toHaveBeenCalledWith(
+      'mock-collection-ref',
+      expect.objectContaining({
+        event: PLANNING_NAV_TELEMETRY_EVENTS.INITIAL_EXPOSED,
+      }),
+    );
+  });
+
+  it('emits retention event once after the retention window', () => {
+    const firstVisibleAt = Date.parse('2026-04-01T00:00:00.000Z');
+    const now = Date.parse('2026-04-10T00:00:00.000Z');
+    localStorage.setItem(
+      PLANNING_NAV_STORAGE_KEYS.FIRST_VISIBLE_AT_MS,
+      String(firstVisibleAt),
+    );
+
+    maybeRecordPlanningNavRetention(
+      {
+        role: 'viewer',
+        navAudience: 'staff',
+        mode: 'normal',
+        pathname: '/planning-sheet-list',
+        search: '',
+      },
+      { nowMs: now, retentionWindowDays: 7 },
+    );
+    maybeRecordPlanningNavRetention(
+      {
+        role: 'viewer',
+        navAudience: 'staff',
+        mode: 'normal',
+        pathname: '/planning-sheet-list',
+        search: '',
+      },
+      { nowMs: now + 24 * 60 * 60 * 1000, retentionWindowDays: 7 },
+    );
+
+    expect(localStorage.getItem(PLANNING_NAV_STORAGE_KEYS.RETENTION_EMITTED)).toBe('1');
+    expect(mockAddDoc).toHaveBeenCalledTimes(1);
+    expect(mockAddDoc).toHaveBeenCalledWith(
+      'mock-collection-ref',
+      expect.objectContaining({
+        event: PLANNING_NAV_TELEMETRY_EVENTS.RETAINED_AFTER_INITIAL,
+        retentionWindowDays: 7,
+      }),
+    );
+  });
+
+  it('does not emit retention event before the retention window', () => {
+    const firstVisibleAt = Date.parse('2026-04-08T00:00:00.000Z');
+    const now = Date.parse('2026-04-10T00:00:00.000Z');
+    localStorage.setItem(
+      PLANNING_NAV_STORAGE_KEYS.FIRST_VISIBLE_AT_MS,
+      String(firstVisibleAt),
+    );
+
+    maybeRecordPlanningNavRetention(
+      {
+        role: 'viewer',
+        navAudience: 'staff',
+        mode: 'normal',
+        pathname: '/planning-sheet-list',
+        search: '',
+      },
+      { nowMs: now, retentionWindowDays: 7 },
+    );
+
+    expect(localStorage.getItem(PLANNING_NAV_STORAGE_KEYS.RETENTION_EMITTED)).toBeNull();
+    expect(mockAddDoc).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/navigation/planningNavTelemetry.ts
+++ b/src/app/navigation/planningNavTelemetry.ts
@@ -1,0 +1,168 @@
+import type { NavAudience } from '@/app/config/navigationConfig.types';
+import type { Role } from '@/auth/roles';
+import { getDb, isFirestoreWriteAvailable } from '@/infra/firestore/client';
+import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
+
+export const PLANNING_NAV_TELEMETRY_EVENTS = {
+  VISIBILITY_CHANGED: 'planning_nav_visibility_changed',
+  PAGE_ARRIVED: 'planning_nav_page_arrived',
+  SETTINGS_TOGGLED: 'planning_nav_settings_toggled',
+  INITIAL_EXPOSED: 'planning_nav_initial_exposed',
+  RETAINED_AFTER_INITIAL: 'planning_nav_retained_after_initial',
+} as const;
+
+export type PlanningNavTelemetryEventName =
+  (typeof PLANNING_NAV_TELEMETRY_EVENTS)[keyof typeof PLANNING_NAV_TELEMETRY_EVENTS];
+
+type PlanningNavTelemetryTrigger =
+  | 'init'
+  | 'state_change'
+  | 'initial_load'
+  | 'route_change'
+  | 'user_toggle';
+
+type PlanningNavTelemetrySource = 'appshell' | 'settings';
+
+export type PlanningNavTelemetryEvent = {
+  eventName: PlanningNavTelemetryEventName;
+  role: Role | 'unknown';
+  navAudience?: NavAudience;
+  mode?: 'normal' | 'focus' | 'kiosk';
+  pathname?: string;
+  search?: string;
+  targetPath?: string;
+  fromPath?: string;
+  visible?: boolean;
+  action?: 'show' | 'hide';
+  source?: PlanningNavTelemetrySource;
+  trigger?: PlanningNavTelemetryTrigger;
+  hiddenBySetting?: boolean;
+  hiddenByKiosk?: boolean;
+  firstVisibleAt?: string;
+  daysSinceFirstVisible?: number;
+  retentionWindowDays?: number;
+};
+
+export const PLANNING_NAV_STORAGE_KEYS = {
+  FIRST_VISIBLE_AT_MS: 'audit:planning-nav:first-visible-at-ms:v1',
+  RETENTION_EMITTED: 'audit:planning-nav:retention-emitted:v1',
+} as const;
+
+const DEFAULT_RETENTION_DAYS = 7;
+
+const readNumberFromStorage = (key: string): number | null => {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return null;
+    const parsed = Number.parseInt(raw, 10);
+    return Number.isFinite(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+};
+
+const readBooleanFromStorage = (key: string): boolean => {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.localStorage.getItem(key) === '1';
+  } catch {
+    return false;
+  }
+};
+
+const writeToStorage = (key: string, value: string): void => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    // localStorage unavailable: silently ignore telemetry state persistence
+  }
+};
+
+/**
+ * Fire-and-forget telemetry for Planning navigation exposure/usage.
+ * Failure is intentionally swallowed to avoid blocking UI interactions.
+ */
+export function recordPlanningNavTelemetry(event: PlanningNavTelemetryEvent): void {
+  if (!isFirestoreWriteAvailable()) {
+    return;
+  }
+
+  const payload = {
+    ...event,
+    event: event.eventName,
+    type: 'planning_nav_telemetry' as const,
+    ts: serverTimestamp(),
+    clientTs: new Date().toISOString(),
+  };
+
+  try {
+    addDoc(collection(getDb(), 'telemetry'), payload).catch((err) => {
+      // eslint-disable-next-line no-console
+      console.warn('[planning-nav:telemetry] write failed', err);
+    });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn('[planning-nav:telemetry] skipped (db not ready)', err);
+  }
+}
+
+type PlanningNavContext = Pick<
+  PlanningNavTelemetryEvent,
+  'role' | 'navAudience' | 'mode' | 'pathname' | 'search'
+>;
+
+/**
+ * Marks the first time the Planning group is effectively visible.
+ * Idempotent per browser profile.
+ */
+export function markPlanningNavInitialExposure(
+  context: PlanningNavContext,
+  nowMs: number = Date.now(),
+): void {
+  const existing = readNumberFromStorage(PLANNING_NAV_STORAGE_KEYS.FIRST_VISIBLE_AT_MS);
+  if (existing !== null) return;
+
+  writeToStorage(PLANNING_NAV_STORAGE_KEYS.FIRST_VISIBLE_AT_MS, String(nowMs));
+  recordPlanningNavTelemetry({
+    eventName: PLANNING_NAV_TELEMETRY_EVENTS.INITIAL_EXPOSED,
+    ...context,
+    visible: true,
+    source: 'appshell',
+    trigger: 'init',
+    firstVisibleAt: new Date(nowMs).toISOString(),
+  });
+}
+
+/**
+ * Emits retention event once when Planning remains visible after the configured window.
+ */
+export function maybeRecordPlanningNavRetention(
+  context: PlanningNavContext,
+  opts: { nowMs?: number; retentionWindowDays?: number } = {},
+): void {
+  const firstVisibleAtMs = readNumberFromStorage(PLANNING_NAV_STORAGE_KEYS.FIRST_VISIBLE_AT_MS);
+  if (firstVisibleAtMs === null) return;
+  if (readBooleanFromStorage(PLANNING_NAV_STORAGE_KEYS.RETENTION_EMITTED)) return;
+
+  const nowMs = opts.nowMs ?? Date.now();
+  const retentionWindowDays = opts.retentionWindowDays ?? DEFAULT_RETENTION_DAYS;
+  const windowMs = retentionWindowDays * 24 * 60 * 60 * 1000;
+  const elapsedMs = nowMs - firstVisibleAtMs;
+  if (elapsedMs < windowMs) return;
+
+  const daysSinceFirstVisible = Math.floor(elapsedMs / (24 * 60 * 60 * 1000));
+  writeToStorage(PLANNING_NAV_STORAGE_KEYS.RETENTION_EMITTED, '1');
+  recordPlanningNavTelemetry({
+    eventName: PLANNING_NAV_TELEMETRY_EVENTS.RETAINED_AFTER_INITIAL,
+    ...context,
+    visible: true,
+    source: 'appshell',
+    trigger: 'state_change',
+    firstVisibleAt: new Date(firstVisibleAtMs).toISOString(),
+    daysSinceFirstVisible,
+    retentionWindowDays,
+  });
+}
+

--- a/src/app/routes/analysisRoutes.tsx
+++ b/src/app/routes/analysisRoutes.tsx
@@ -91,7 +91,7 @@ export const analysisRoutes: RouteObject[] = [
   {
     path: 'survey/tokusei',
     element: (
-      <RequireAudience requiredRole="viewer">
+      <RequireAudience requiredRole="admin">
         <SuspendedTokuseiSurveyResultsPage />
       </RequireAudience>
     ),

--- a/src/app/useAppShellState.ts
+++ b/src/app/useAppShellState.ts
@@ -11,8 +11,14 @@ import {
     splitNavItemsByTier,
     type NavAudience,
 } from '@/app/config/navigationConfig';
-import { resolveHubRouteMetadata } from '@/app/hubs/hubDefinitions';
+import { isHubPathActive, resolveHubRouteMetadata } from '@/app/hubs/hubDefinitions';
 import { navIconMap } from '@/app/navIconMap';
+import {
+  PLANNING_NAV_TELEMETRY_EVENTS,
+  markPlanningNavInitialExposure,
+  maybeRecordPlanningNavRetention,
+  recordPlanningNavTelemetry,
+} from '@/app/navigation/planningNavTelemetry';
 import { canAccess } from '@/auth/roles';
 import { useUserAuthz } from '@/auth/useUserAuthz';
 import { useFeatureFlags } from '@/config/featureFlags';
@@ -22,7 +28,7 @@ import { useSettingsContext } from '@/features/settings/SettingsContext';
 import { shouldSkipLogin } from '@/lib/env';
 import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 const SKIP_LOGIN = shouldSkipLogin();
@@ -184,6 +190,90 @@ export function useAppShellState() {
     return filterNavItems(visibleNavItems, navQuery);
   }, [visibleNavItems, navQuery]);
   const groupedNavItems = useMemo(() => groupNavItems(filteredNavItems, isAdmin), [filteredNavItems, isAdmin]);
+  const isPlanningGroupVisible = useMemo(
+    () => visibleNavItems.some((item) => item.group === 'planning'),
+    [visibleNavItems],
+  );
+
+  const previousPlanningVisibilityRef = useRef<boolean | null>(null);
+  useEffect(() => {
+    const prevVisible = previousPlanningVisibilityRef.current;
+    const trigger =
+      prevVisible === null
+        ? 'init'
+        : prevVisible === isPlanningGroupVisible
+          ? null
+          : 'state_change';
+
+    if (trigger) {
+      recordPlanningNavTelemetry({
+        eventName: PLANNING_NAV_TELEMETRY_EVENTS.VISIBILITY_CHANGED,
+        role,
+        navAudience,
+        mode: settings.layoutMode,
+        pathname: location.pathname,
+        search: location.search,
+        visible: isPlanningGroupVisible,
+        source: 'appshell',
+        trigger,
+        hiddenBySetting: settings.hiddenNavGroups.includes('planning'),
+        hiddenByKiosk: settings.layoutMode === 'kiosk',
+      });
+    }
+
+    if (isPlanningGroupVisible) {
+      markPlanningNavInitialExposure({
+        role,
+        navAudience,
+        mode: settings.layoutMode,
+        pathname: location.pathname,
+        search: location.search,
+      });
+      maybeRecordPlanningNavRetention({
+        role,
+        navAudience,
+        mode: settings.layoutMode,
+        pathname: location.pathname,
+        search: location.search,
+      });
+    }
+
+    previousPlanningVisibilityRef.current = isPlanningGroupVisible;
+  }, [
+    isPlanningGroupVisible,
+    role,
+    navAudience,
+    settings.layoutMode,
+    settings.hiddenNavGroups,
+    location.pathname,
+    location.search,
+  ]);
+
+  const wasPlanningPathRef = useRef<boolean | null>(null);
+  const previousPathnameRef = useRef<string | null>(null);
+  useEffect(() => {
+    const isPlanningPath = isHubPathActive('planning', location.pathname);
+    const wasPlanningPath = wasPlanningPathRef.current;
+    const arrivedToPlanning = isPlanningPath && (wasPlanningPath === null || wasPlanningPath === false);
+
+    if (arrivedToPlanning) {
+      recordPlanningNavTelemetry({
+        eventName: PLANNING_NAV_TELEMETRY_EVENTS.PAGE_ARRIVED,
+        role,
+        navAudience,
+        mode: settings.layoutMode,
+        pathname: location.pathname,
+        search: location.search,
+        targetPath: location.pathname,
+        fromPath: previousPathnameRef.current ?? undefined,
+        source: 'appshell',
+        trigger: wasPlanningPath === null ? 'initial_load' : 'route_change',
+      });
+    }
+
+    wasPlanningPathRef.current = isPlanningPath;
+    previousPathnameRef.current = location.pathname;
+  }, [location.pathname, location.search, role, navAudience, settings.layoutMode]);
 
   // ── Callbacks ──────────────────────────────────────────────────────────────
 

--- a/src/features/settings/SettingsDialog.tsx
+++ b/src/features/settings/SettingsDialog.tsx
@@ -1,4 +1,9 @@
 import type { NavGroupKey, NavItem } from '@/app/config/navigationConfig.types';
+import {
+  PLANNING_NAV_TELEMETRY_EVENTS,
+  recordPlanningNavTelemetry,
+} from '@/app/navigation/planningNavTelemetry';
+import type { NavGroupVisibilityPreferences } from '@/features/settings/settingsModel';
 import { ColorModeContext } from '@/app/theme';
 import Brightness4Icon from '@mui/icons-material/Brightness4';
 import Brightness7Icon from '@mui/icons-material/Brightness7';
@@ -13,6 +18,7 @@ import Stack from '@mui/material/Stack';
 import Switch from '@mui/material/Switch';
 import Typography from '@mui/material/Typography';
 import React, { useCallback, useContext } from 'react';
+import { useLocation } from 'react-router-dom';
 import { useSettingsContext } from './SettingsContext';
 import { ColorPresetControl, DensityControl, FontSizeControl, NavGroupVisibilityControl } from './components';
 
@@ -27,6 +33,7 @@ interface SettingsDialogProps {
 export const SettingsDialog: React.FC<SettingsDialogProps> = ({ open, onClose, navItems = [], disablePortal }) => {
   const { mode, toggle } = useContext(ColorModeContext);
   const { settings, updateSettings } = useSettingsContext();
+  const location = useLocation();
 
   const handleDensityChange = useCallback((newDensity: 'compact' | 'comfortable' | 'spacious') => {
     updateSettings({ density: newDensity });
@@ -41,8 +48,41 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({ open, onClose, n
   }, [updateSettings]);
 
   const handleNavGroupVisibilityChange = useCallback((hiddenGroups: NavGroupKey[]) => {
-    updateSettings({ hiddenNavGroups: hiddenGroups });
-  }, [updateSettings]);
+    const wasPlanningHidden = settings.hiddenNavGroups.includes('planning');
+    const isPlanningHidden = hiddenGroups.includes('planning');
+    let nextNavGroupVisibilityPrefs: NavGroupVisibilityPreferences | undefined;
+    if (wasPlanningHidden !== isPlanningHidden) {
+      recordPlanningNavTelemetry({
+        eventName: PLANNING_NAV_TELEMETRY_EVENTS.SETTINGS_TOGGLED,
+        role: 'unknown',
+        mode: settings.layoutMode,
+        pathname: location.pathname,
+        search: location.search,
+        source: 'settings',
+        trigger: 'user_toggle',
+        visible: !isPlanningHidden,
+        action: isPlanningHidden ? 'hide' : 'show',
+        hiddenBySetting: isPlanningHidden,
+      });
+      nextNavGroupVisibilityPrefs = {
+        ...settings.navGroupVisibilityPrefs,
+        planning: isPlanningHidden ? 'hide' : 'show',
+      };
+    }
+    updateSettings({
+      hiddenNavGroups: hiddenGroups,
+      ...(nextNavGroupVisibilityPrefs
+        ? { navGroupVisibilityPrefs: nextNavGroupVisibilityPrefs }
+        : {}),
+    });
+  }, [
+    updateSettings,
+    settings.hiddenNavGroups,
+    settings.layoutMode,
+    settings.navGroupVisibilityPrefs,
+    location.pathname,
+    location.search,
+  ]);
 
   const handleNavItemVisibilityChange = useCallback((hiddenItems: string[]) => {
     updateSettings({ hiddenNavItems: hiddenItems });

--- a/src/features/settings/__tests__/settingsModel.spec.ts
+++ b/src/features/settings/__tests__/settingsModel.spec.ts
@@ -8,6 +8,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
     DEFAULT_SETTINGS,
+    NAV_POLICY_VERSION,
     loadSettingsFromStorage,
     mergeSettings,
     saveSettingsToStorage,
@@ -50,7 +51,9 @@ describe('settingsModel', () => {
         colorPreset: 'highContrast',
         layoutMode: 'normal',
         hiddenNavGroups: [],
+        navGroupVisibilityPrefs: {},
         hiddenNavItems: [],
+        navPolicyVersion: NAV_POLICY_VERSION,
         lastModified: 1234567890,
       };
       localVault.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(settings));
@@ -96,7 +99,9 @@ describe('settingsModel', () => {
         colorPreset: 'default',
         layoutMode: 'kiosk',
         hiddenNavGroups: [],
+        navGroupVisibilityPrefs: {},
         hiddenNavItems: [],
+        navPolicyVersion: NAV_POLICY_VERSION,
         lastModified: Date.now(),
       };
       localVault.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(settings));
@@ -118,6 +123,101 @@ describe('settingsModel', () => {
       const loaded = loadSettingsFromStorage();
       expect(loaded.layoutMode).toBe('normal');
     });
+
+    it('migrates unset planning visibility to initial ON once', () => {
+      const legacy = {
+        colorMode: 'light',
+        density: 'comfortable',
+        fontSize: 'medium',
+        colorPreset: 'default',
+        layoutMode: 'normal',
+        hiddenNavGroups: [],
+        hiddenNavItems: [],
+        lastModified: 1,
+      };
+      localVault.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(legacy));
+
+      const loaded = loadSettingsFromStorage();
+      expect(loaded.hiddenNavGroups).not.toContain('planning');
+      expect(loaded.navGroupVisibilityPrefs.planning).toBe('show');
+      expect(loaded.navPolicyVersion).toBe(NAV_POLICY_VERSION);
+
+      const saved = JSON.parse(localVault.getItem(SETTINGS_STORAGE_KEY)!);
+      expect(saved.navGroupVisibilityPrefs?.planning).toBe('show');
+      expect(saved.navPolicyVersion).toBe(NAV_POLICY_VERSION);
+    });
+
+    it('preserves explicit OFF state for planning on migration', () => {
+      const legacy = {
+        colorMode: 'light',
+        density: 'comfortable',
+        fontSize: 'medium',
+        colorPreset: 'default',
+        layoutMode: 'normal',
+        hiddenNavGroups: ['planning'],
+        hiddenNavItems: [],
+        lastModified: 1,
+      };
+      localVault.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(legacy));
+
+      const loaded = loadSettingsFromStorage();
+      expect(loaded.hiddenNavGroups).toContain('planning');
+      expect(loaded.navGroupVisibilityPrefs.planning).toBe('hide');
+      expect(loaded.navPolicyVersion).toBe(NAV_POLICY_VERSION);
+    });
+
+    it('respects explicit planning show/hide preferences over hiddenNavGroups inconsistencies', () => {
+      const inconsistentShow = {
+        colorMode: 'light',
+        density: 'comfortable',
+        fontSize: 'medium',
+        colorPreset: 'default',
+        layoutMode: 'normal',
+        hiddenNavGroups: ['planning'],
+        navGroupVisibilityPrefs: { planning: 'show' },
+        hiddenNavItems: [],
+        navPolicyVersion: NAV_POLICY_VERSION,
+        lastModified: 1,
+      };
+      localVault.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(inconsistentShow));
+      const loadedShow = loadSettingsFromStorage();
+      expect(loadedShow.hiddenNavGroups).not.toContain('planning');
+      expect(loadedShow.navGroupVisibilityPrefs.planning).toBe('show');
+
+      const inconsistentHide = {
+        ...inconsistentShow,
+        hiddenNavGroups: [],
+        navGroupVisibilityPrefs: { planning: 'hide' },
+      };
+      localVault.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(inconsistentHide));
+      const loadedHide = loadSettingsFromStorage();
+      expect(loadedHide.hiddenNavGroups).toContain('planning');
+      expect(loadedHide.navGroupVisibilityPrefs.planning).toBe('hide');
+    });
+
+    it('does not reapply planning migration when navPolicyVersion is current', () => {
+      const current = {
+        colorMode: 'light',
+        density: 'comfortable',
+        fontSize: 'medium',
+        colorPreset: 'default',
+        layoutMode: 'normal',
+        hiddenNavGroups: [],
+        navGroupVisibilityPrefs: {},
+        hiddenNavItems: [],
+        navPolicyVersion: NAV_POLICY_VERSION,
+        lastModified: 1234567890,
+      };
+      localVault.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(current));
+      const before = localVault.getItem(SETTINGS_STORAGE_KEY);
+
+      const loaded = loadSettingsFromStorage();
+
+      expect(loaded.navPolicyVersion).toBe(NAV_POLICY_VERSION);
+      expect(loaded.navGroupVisibilityPrefs.planning).toBeUndefined();
+      expect(loaded.lastModified).toBe(1234567890);
+      expect(localVault.getItem(SETTINGS_STORAGE_KEY)).toBe(before);
+    });
   });
 
   describe('saveSettingsToStorage', () => {
@@ -129,7 +229,9 @@ describe('settingsModel', () => {
         colorPreset: 'default',
         layoutMode: 'normal',
         hiddenNavGroups: [],
+        navGroupVisibilityPrefs: {},
         hiddenNavItems: [],
+        navPolicyVersion: NAV_POLICY_VERSION,
         lastModified: 1234567890,
       };
 

--- a/src/features/settings/settingsModel.ts
+++ b/src/features/settings/settingsModel.ts
@@ -4,7 +4,17 @@
  * Persisted to localStorage for session continuity
  */
 
-import type { NavGroupKey } from '@/app/config/navigationConfig.types';
+import {
+  NAV_GROUP_ORDER,
+  type NavGroupKey,
+} from '@/app/config/navigationConfig.types';
+
+export type NavGroupVisibilityPreference = 'show' | 'hide';
+export type NavGroupVisibilityPreferences = Partial<
+  Record<NavGroupKey, NavGroupVisibilityPreference>
+>;
+
+export const NAV_POLICY_VERSION = 1;
 
 /** User display preferences */
 export type UserSettings = {
@@ -26,8 +36,14 @@ export type UserSettings = {
   // Hidden navigation groups (sidebar menu visibility)
   hiddenNavGroups: NavGroupKey[];
 
+  // Explicit group-level visibility preferences (used for migration safety)
+  navGroupVisibilityPrefs: NavGroupVisibilityPreferences;
+
   // Hidden individual navigation items (by path)
   hiddenNavItems: string[];
+
+  // Settings migration version for navigation policy changes
+  navPolicyVersion: number;
 
   // Timestamp for sync validation
   lastModified: number;
@@ -41,12 +57,107 @@ export const DEFAULT_SETTINGS: UserSettings = {
   colorPreset: 'default',
   layoutMode: 'normal',
   hiddenNavGroups: [],
+  navGroupVisibilityPrefs: {},
   hiddenNavItems: [],
+  navPolicyVersion: NAV_POLICY_VERSION,
   lastModified: Date.now(),
 };
 
 /** localStorage key */
 export const SETTINGS_STORAGE_KEY = 'audit:settings:v1';
+
+const NAV_GROUP_KEY_SET: ReadonlySet<NavGroupKey> = new Set(NAV_GROUP_ORDER);
+
+function isNavGroupKey(value: unknown): value is NavGroupKey {
+  return typeof value === 'string' && NAV_GROUP_KEY_SET.has(value as NavGroupKey);
+}
+
+function parseHiddenNavGroups(raw: unknown): NavGroupKey[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((group): group is NavGroupKey => isNavGroupKey(group));
+}
+
+function parseHiddenNavItems(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((item): item is string => typeof item === 'string');
+}
+
+function parseNavGroupVisibilityPrefs(raw: unknown): NavGroupVisibilityPreferences {
+  if (!raw || typeof raw !== 'object') return {};
+  const prefs: NavGroupVisibilityPreferences = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (!isNavGroupKey(key)) continue;
+    if (value === 'show' || value === 'hide') {
+      prefs[key] = value;
+    }
+  }
+  return prefs;
+}
+
+function applyPlanningPreferenceConsistency(
+  hiddenNavGroups: NavGroupKey[],
+  navGroupVisibilityPrefs: NavGroupVisibilityPreferences,
+): NavGroupKey[] {
+  const planningPref = navGroupVisibilityPrefs.planning;
+  const planningHidden = hiddenNavGroups.includes('planning');
+  if (planningPref === 'hide' && !planningHidden) {
+    return [...hiddenNavGroups, 'planning'];
+  }
+  if (planningPref === 'show' && planningHidden) {
+    return hiddenNavGroups.filter((group) => group !== 'planning');
+  }
+  return hiddenNavGroups;
+}
+
+function migratePlanningInitialOn(settings: UserSettings): {
+  migrated: UserSettings;
+  didMutate: boolean;
+} {
+  const hasPlanningPreference = settings.navGroupVisibilityPrefs.planning !== undefined;
+  let nextHiddenGroups = settings.hiddenNavGroups;
+  let nextPrefs = settings.navGroupVisibilityPrefs;
+  let didMutate = false;
+
+  // B案 migration:
+  // - planning preference unset users only
+  // - preserve existing explicit OFF (hiddenNavGroups includes planning)
+  if (settings.navPolicyVersion < NAV_POLICY_VERSION && !hasPlanningPreference) {
+    const isPlanningHidden = settings.hiddenNavGroups.includes('planning');
+    nextPrefs = {
+      ...settings.navGroupVisibilityPrefs,
+      planning: isPlanningHidden ? 'hide' : 'show',
+    };
+    nextHiddenGroups = isPlanningHidden
+      ? settings.hiddenNavGroups
+      : settings.hiddenNavGroups.filter((group) => group !== 'planning');
+    didMutate = true;
+  }
+
+  const consistentHiddenGroups = applyPlanningPreferenceConsistency(
+    nextHiddenGroups,
+    nextPrefs,
+  );
+  if (consistentHiddenGroups !== nextHiddenGroups) {
+    didMutate = true;
+  }
+
+  const migrated: UserSettings = {
+    ...settings,
+    hiddenNavGroups: consistentHiddenGroups,
+    navGroupVisibilityPrefs: nextPrefs,
+    navPolicyVersion:
+      settings.navPolicyVersion < NAV_POLICY_VERSION
+        ? NAV_POLICY_VERSION
+        : settings.navPolicyVersion,
+    lastModified: didMutate ? Date.now() : settings.lastModified,
+  };
+
+  if (settings.navPolicyVersion < NAV_POLICY_VERSION) {
+    didMutate = true;
+  }
+
+  return { migrated, didMutate };
+}
 
 /**
  * Load settings from localStorage with fallback
@@ -70,7 +181,7 @@ export function loadSettingsFromStorage(): UserSettings {
       return DEFAULT_SETTINGS;
     }
 
-    return {
+    const loaded: UserSettings = {
       colorMode: parsed.colorMode as UserSettings['colorMode'],
       density: parsed.density as UserSettings['density'],
       fontSize: parsed.fontSize as UserSettings['fontSize'],
@@ -78,10 +189,20 @@ export function loadSettingsFromStorage(): UserSettings {
       layoutMode: (['normal', 'focus', 'kiosk'] as const).includes(parsed.layoutMode)
         ? parsed.layoutMode
         : 'normal',
-      hiddenNavGroups: Array.isArray(parsed.hiddenNavGroups) ? parsed.hiddenNavGroups : [],
-      hiddenNavItems: Array.isArray(parsed.hiddenNavItems) ? parsed.hiddenNavItems : [],
+      hiddenNavGroups: parseHiddenNavGroups(parsed.hiddenNavGroups),
+      navGroupVisibilityPrefs: parseNavGroupVisibilityPrefs(parsed.navGroupVisibilityPrefs),
+      hiddenNavItems: parseHiddenNavItems(parsed.hiddenNavItems),
+      navPolicyVersion:
+        typeof parsed.navPolicyVersion === 'number' ? parsed.navPolicyVersion : 0,
       lastModified: parsed.lastModified || Date.now(),
     };
+
+    const { migrated, didMutate } = migratePlanningInitialOn(loaded);
+    if (didMutate) {
+      saveSettingsToStorage(migrated);
+    }
+
+    return migrated;
   } catch (error) {
     console.error('[settings] Parse error, using defaults:', error);
     return DEFAULT_SETTINGS;

--- a/tests/unit/app/config/navigationConfig.spec.ts
+++ b/tests/unit/app/config/navigationConfig.spec.ts
@@ -218,6 +218,18 @@ describe('navigationConfig', () => {
       expect(items.some((item) => item.testId === TESTIDS.nav.schedules)).toBe(false);
     });
 
+    it('should mark Planning hub as active only on /planning routes', () => {
+      const items = createNavItems(baseConfig);
+      const planningHub = items.find((item) => item.to === '/planning');
+
+      expect(planningHub).toBeDefined();
+      expect(planningHub?.isActive('/planning')).toBe(true);
+      expect(planningHub?.isActive('/planning/overview')).toBe(true);
+      expect(planningHub?.isActive('/support-plan-guide')).toBe(false);
+      expect(planningHub?.isActive('/assessment')).toBe(false);
+      expect(planningHub?.isActive('/analysis/dashboard')).toBe(false);
+    });
+
     it('should include compliance form when flag is enabled', () => {
       const items = createNavItems({
         ...baseConfig,


### PR DESCRIPTION
## 背景
Planning 表示ポリシーを B案（初期ON・固定化しない）で導入。  
先行して観測基盤を追加し、後方互換付きで安全に移行する。

## 変更点
- `navPolicyVersion` と `planning` 明示設定（show/hide）を settings に追加
- 一度きりマイグレーション実装
  - 条件: `navPolicyVersion < 1` かつ `planning` 明示設定なし
  - `planning` 明示OFFユーザーは維持
  - `navPolicyVersion >= 1` では再適用しない
- 設定画面の Planning ON/OFF を明示設定へ連動
- telemetry を追加
  - 表示ON/OFF、到達、設定変更、初回露出、7日後維持
- 前段修正を反映
  - `survey/tokusei` 権限を nav/route とも `admin` に統一
  - Planning ハブ active を `/planning` 系に限定
- マイグレーションは「未設定ユーザーのみ」に限定し、既存設定を破壊しない

## 受け入れ条件
- 未設定ユーザーは初回のみ Planning ON
- 明示OFFユーザーは OFF 維持
- kiosk では Planning 非表示維持
- 設定変更が明示設定に反映
- telemetry 継続送信
- `navPolicyVersion >= 1` で再適用なし
- 不要な `lastModified` 更新/再書込なし

## テスト
- typecheck / eslint / 対象ユニットテスト通過

## 既知事項
- `src/app/__tests__/AppShell.navigation.spec.tsx:76` は既存別件（本PRでは未対応）

## レビュアー向けチェック観点
- B案契約どおり、`planning` は「未設定ユーザーのみ初期ON」になっているか
- 既存の `planning` 明示OFF設定を壊していないか
- `navPolicyVersion >= 1` でマイグレーションが再適用されないか
- `kiosk` で従来どおり `planning` 非表示が維持されるか
- Settings の ON/OFF 操作が 明示設定 と telemetry に正しく反映されるか
- `survey/tokusei` の nav / route 権限が `admin` で一致しているか
- Planning ハブ active が `/planning` 系だけに限定され、子項目との二重 active が解消されているか

※ 既存別件失敗 `src/app/__tests__/AppShell.navigation.spec.tsx:76` は #1433 で分離管理しています
