### PR TITLE
test(copy): align UI label expectations across daily/support tests

### DIFF
--- a/src/features/daily/__tests__/BulkDailyRecordForm.test.tsx
+++ b/src/features/daily/__tests__/BulkDailyRecordForm.test.tsx
@@ -75,7 +75,7 @@ describe('BulkDailyRecordForm', () => {
     renderForm();
 
     expect(getDialog()).toBeInTheDocument();
-    expect(screen.getByText('複数利用者支援記録（ケース記録）作成')).toBeInTheDocument();
+    expect(screen.getByText('複数利用者日々の記録作成')).toBeInTheDocument();
     expect(screen.getByText('複数の利用者に対して共通の活動記録を効率的に作成できます')).toBeInTheDocument();
   });
 

--- a/src/features/support-plan-guide/components/__tests__/AdoptionMetricsPanel.spec.tsx
+++ b/src/features/support-plan-guide/components/__tests__/AdoptionMetricsPanel.spec.tsx
@@ -93,7 +93,7 @@ describe('AdoptionMetricsPanel', () => {
 
     expect(screen.getByText('採用 6件')).toBeDefined();
     expect(screen.getByText('却下 4件')).toBeDefined();
-    expect(screen.getByText('ISP反映 3件')).toBeDefined();
+    expect(screen.getByText('個別支援計画反映 3件')).toBeDefined();
   });
 
   it('採用率をパーセント表示する', () => {

--- a/tests/unit/a11y/RecordList.a11y.spec.tsx
+++ b/tests/unit/a11y/RecordList.a11y.spec.tsx
@@ -49,7 +49,7 @@ describe('RecordList Accessibility', () => {
 
   test('has no a11y violations (empty state)', async () => {
     const { container } = renderRecordList();
-    await screen.findByRole('heading', { name: '日次記録' });
+    await screen.findByRole('heading', { name: '日々の記録' });
 
     const results = await axe(container);
     expect(results).toHaveNoViolations();

--- a/tests/unit/features/daily/DailyPhaseHintBanner.spec.tsx
+++ b/tests/unit/features/daily/DailyPhaseHintBanner.spec.tsx
@@ -91,8 +91,8 @@ describe('getDailyPhaseHint', () => {
     expect(getDailyPhaseHint(at(7, 0)).suggestedAction).toBeNull();
     // 08:45 → staff_prep → preparation → 通所管理
     expect(getDailyPhaseHint(at(8, 45)).suggestedAction).toBe('通所管理');
-    expect(getDailyPhaseHint(at(10, 30)).suggestedAction).toBe('一覧形式ケース記録');
-    expect(getDailyPhaseHint(at(13, 0)).suggestedAction).toBe('一覧形式ケース記録');
+    expect(getDailyPhaseHint(at(10, 30)).suggestedAction).toBe('一覧形式の日々の記録');
+    expect(getDailyPhaseHint(at(13, 0)).suggestedAction).toBe('一覧形式の日々の記録');
     // 16:00 → record_wrapup → record-review → null
     expect(getDailyPhaseHint(at(16, 0)).suggestedAction).toBeNull();
     expect(getDailyPhaseHint(at(18, 0)).suggestedAction).toBeNull();


### PR DESCRIPTION
## 背景
main の既存失敗のうち、PR-B（copy/label expectation 修正）を分離して対応します。

## 変更点
- `tests/unit/a11y/RecordList.a11y.spec.tsx`
  - 見出し期待値を現行UI文言に合わせて更新（`日次記録` → `日々の記録`）
- `src/features/daily/__tests__/BulkDailyRecordForm.test.tsx`
  - ダイアログタイトル期待値を現行UI文言に合わせて更新
- `tests/unit/features/daily/DailyPhaseHintBanner.spec.tsx`
  - `suggestedAction` の期待値を現行表示文言に更新
- `src/features/support-plan-guide/components/__tests__/AdoptionMetricsPanel.spec.tsx`
  - ISP反映ラベル期待値を現行表示文言に更新

## 受け入れ観点
- 上記4ファイルの文言期待値が現行UIと一致する
- copy変更に起因する既存失敗が解消する

## 実行結果
- `npm run typecheck` ✅
- `npx eslint src/features/support-plan-guide/components/__tests__/AdoptionMetricsPanel.spec.tsx tests/unit/a11y/RecordList.a11y.spec.tsx src/features/daily/__tests__/BulkDailyRecordForm.test.tsx tests/unit/features/daily/DailyPhaseHintBanner.spec.tsx` ✅
- `npm test -- src/features/support-plan-guide/components/__tests__/AdoptionMetricsPanel.spec.tsx tests/unit/a11y/RecordList.a11y.spec.tsx src/features/daily/__tests__/BulkDailyRecordForm.test.tsx tests/unit/features/daily/DailyPhaseHintBanner.spec.tsx` ✅
