### PR TITLE
test(nav): align hub definitions spec with planning entry policy

### DIFF
--- a/src/app/hubs/__tests__/hubDefinitions.spec.ts
+++ b/src/app/hubs/__tests__/hubDefinitions.spec.ts
@@ -69,7 +69,7 @@ describe('hubDefinitions', () => {
       'planning-sheet-list',
       'planning-assessment',
     ]);
-    expect(planningViewer.secondary).toHaveLength(0);
+    expect(planningViewer.secondary.map((entry) => entry.id)).toEqual(['planning-analysis']);
     expect(planningViewer.comingSoon).toHaveLength(0);
 
     const billingReception = resolveHubVisibleEntries('billing', 'reception');


### PR DESCRIPTION
## 背景
main の既存失敗のうち、PR-D（hub/policy 前提修正）に限定して対応します。

## 変更点
- `src/app/hubs/__tests__/hubDefinitions.spec.ts`
  - `planning` ハブの viewer 向け `secondary` 期待値を現行ポリシーに追従
  - `planning-analysis` が secondary に表示される前提へ更新

## 受け入れ観点
- hub entry policy（primary/secondary）の現行定義と spec が一致する
- `hubDefinitions.spec.ts` の既存失敗が解消する

## 実行結果
- `npx eslint src/app/hubs/__tests__/hubDefinitions.spec.ts` ✅
- `npm run typecheck` ✅
- `npm test -- src/app/hubs/__tests__/hubDefinitions.spec.ts` ✅
