### PR TITLE
[codex] harden nightly runtime patrol

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,22 +1,32 @@
 name: actionlint
+
 on:
   pull_request:
     paths:
-      - .github/workflows/**
+      - '.github/workflows/**'
   push:
     branches:
       - main
       - develop
     paths:
-      - .github/workflows/**
+      - '.github/workflows/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   lint:
+    name: Workflow Lint
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v4
-      - uses: reviewdog/action-actionlint@v1
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run actionlint
+        uses: reviewdog/action-actionlint@v1
         with:
-          reporter: github-pr-review
+          reporter: github-check
           filter_mode: nofilter
           actionlint_flags: -shellcheck=

--- a/.github/workflows/integration-dailyops.yml
+++ b/.github/workflows/integration-dailyops.yml
@@ -68,6 +68,12 @@ jobs:
         if: failure()
         env:
           TEAMS_WEBHOOK_URL: ${{ secrets.TEAMS_WEBHOOK_URL }}
+          NOTIFY_REPOSITORY: ${{ github.repository }}
+          NOTIFY_WORKFLOW: ${{ github.workflow }}
+          NOTIFY_RUN_ID: ${{ github.run_id }}
+          NOTIFY_RUN_NUMBER: ${{ github.run_number }}
+          NOTIFY_REF_NAME: ${{ github.ref_name }}
+          NOTIFY_SHA: ${{ github.sha }}
         run: |
           if [ -z "$TEAMS_WEBHOOK_URL" ]; then
             echo "TEAMS_WEBHOOK_URL not configured, skipping notification"
@@ -75,9 +81,9 @@ jobs:
           fi
           GUID=$(grep -RhoE 'sprequestguid[^A-Za-z0-9-]*[A-Za-z0-9-]+' test-results playwright-report 2>/dev/null | head -1 | sed -E 's/.*(sprequestguid[^A-Za-z0-9-]*)([A-Za-z0-9-]+).*/\2/' || true)
           [ -z "$GUID" ] && GUID="N/A"
-          COMMIT_SHORT="${GITHUB_SHA:0:7}"
+          COMMIT_SHORT="${NOTIFY_SHA:0:7}"
 
-          MSG=$(cat <<'JSON'
+          MSG=$(cat <<JSON
           {
             "@type": "MessageCard",
             "@context": "http://schema.org/extensions",
@@ -86,10 +92,10 @@ jobs:
             "title": "❌ DailyOpsSignals integration failed",
             "sections": [
               { "facts": [
-                { "name": "Repo", "value": "${GITHUB_REPOSITORY}" },
-                { "name": "Workflow", "value": "${GITHUB_WORKFLOW}" },
-                { "name": "Run", "value": "${GITHUB_RUN_NUMBER}" },
-                { "name": "Branch", "value": "${GITHUB_REF_NAME}" },
+                { "name": "Repo", "value": "${NOTIFY_REPOSITORY}" },
+                { "name": "Workflow", "value": "${NOTIFY_WORKFLOW}" },
+                { "name": "Run", "value": "${NOTIFY_RUN_NUMBER}" },
+                { "name": "Branch", "value": "${NOTIFY_REF_NAME}" },
                 { "name": "Commit", "value": "${COMMIT_SHORT}" },
                 { "name": "sprequestguid", "value": "${GUID}" }
               ]}
@@ -102,7 +108,7 @@ jobs:
                 "targets": [
                   {
                     "os": "default",
-                    "uri": "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+                    "uri": "https://github.com/${NOTIFY_REPOSITORY}/actions/runs/${NOTIFY_RUN_ID}"
                   }
                 ]
               }

--- a/.github/workflows/integration-staff.yml
+++ b/.github/workflows/integration-staff.yml
@@ -68,6 +68,12 @@ jobs:
         if: failure()
         env:
           TEAMS_WEBHOOK_URL: ${{ secrets.TEAMS_WEBHOOK_URL }}
+          NOTIFY_REPOSITORY: ${{ github.repository }}
+          NOTIFY_WORKFLOW: ${{ github.workflow }}
+          NOTIFY_RUN_ID: ${{ github.run_id }}
+          NOTIFY_RUN_NUMBER: ${{ github.run_number }}
+          NOTIFY_REF_NAME: ${{ github.ref_name }}
+          NOTIFY_SHA: ${{ github.sha }}
         run: |
           if [ -z "$TEAMS_WEBHOOK_URL" ]; then
             echo "TEAMS_WEBHOOK_URL not configured, skipping notification"
@@ -75,9 +81,9 @@ jobs:
           fi
           GUID=$(grep -RhoE 'sprequestguid[^A-Za-z0-9-]*[A-Za-z0-9-]+' test-results playwright-report 2>/dev/null | head -1 | sed -E 's/.*(sprequestguid[^A-Za-z0-9-]*)([A-Za-z0-9-]+).*/\2/' || true)
           [ -z "$GUID" ] && GUID="N/A"
-          COMMIT_SHORT="${GITHUB_SHA:0:7}"
+          COMMIT_SHORT="${NOTIFY_SHA:0:7}"
 
-          MSG=$(cat <<'JSON'
+          MSG=$(cat <<JSON
           {
             "@type": "MessageCard",
             "@context": "http://schema.org/extensions",
@@ -86,10 +92,10 @@ jobs:
             "title": "❌ Staff_Master integration failed",
             "sections": [
               { "facts": [
-                { "name": "Repo", "value": "${GITHUB_REPOSITORY}" },
-                { "name": "Workflow", "value": "${GITHUB_WORKFLOW}" },
-                { "name": "Run", "value": "${GITHUB_RUN_NUMBER}" },
-                { "name": "Branch", "value": "${GITHUB_REF_NAME}" },
+                { "name": "Repo", "value": "${NOTIFY_REPOSITORY}" },
+                { "name": "Workflow", "value": "${NOTIFY_WORKFLOW}" },
+                { "name": "Run", "value": "${NOTIFY_RUN_NUMBER}" },
+                { "name": "Branch", "value": "${NOTIFY_REF_NAME}" },
                 { "name": "Commit", "value": "${COMMIT_SHORT}" },
                 { "name": "sprequestguid", "value": "${GUID}" }
               ]}
@@ -102,7 +108,7 @@ jobs:
                 "targets": [
                   {
                     "os": "default",
-                    "uri": "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+                    "uri": "https://github.com/${NOTIFY_REPOSITORY}/actions/runs/${NOTIFY_RUN_ID}"
                   }
                 ]
               }

--- a/.github/workflows/integration-users.yml
+++ b/.github/workflows/integration-users.yml
@@ -68,6 +68,12 @@ jobs:
         if: failure()
         env:
           TEAMS_WEBHOOK_URL: ${{ secrets.TEAMS_WEBHOOK_URL }}
+          NOTIFY_REPOSITORY: ${{ github.repository }}
+          NOTIFY_WORKFLOW: ${{ github.workflow }}
+          NOTIFY_RUN_ID: ${{ github.run_id }}
+          NOTIFY_RUN_NUMBER: ${{ github.run_number }}
+          NOTIFY_REF_NAME: ${{ github.ref_name }}
+          NOTIFY_SHA: ${{ github.sha }}
         run: |
           if [ -z "${TEAMS_WEBHOOK_URL:-}" ]; then
             echo "TEAMS_WEBHOOK_URL is empty; skipping Teams notification."
@@ -75,7 +81,7 @@ jobs:
           fi
           GUID=$(grep -RhoE 'sprequestguid[^A-Za-z0-9-]*[A-Za-z0-9-]+' test-results playwright-report 2>/dev/null | head -1 | sed -E 's/.*(sprequestguid[^A-Za-z0-9-]*)([A-Za-z0-9-]+).*/\2/' || true)
           [ -z "$GUID" ] && GUID="N/A"
-          COMMIT_SHORT="${GITHUB_SHA:0:7}"
+          COMMIT_SHORT="${NOTIFY_SHA:0:7}"
 
           MSG=$(cat <<JSON
           {
@@ -86,10 +92,10 @@ jobs:
             "title": "❌ Users_Master integration failed",
             "sections": [
               { "facts": [
-                { "name": "Repo", "value": "${GITHUB_REPOSITORY}" },
-                { "name": "Workflow", "value": "${GITHUB_WORKFLOW}" },
-                { "name": "Run", "value": "${GITHUB_RUN_NUMBER}" },
-                { "name": "Branch", "value": "${GITHUB_REF_NAME}" },
+                { "name": "Repo", "value": "${NOTIFY_REPOSITORY}" },
+                { "name": "Workflow", "value": "${NOTIFY_WORKFLOW}" },
+                { "name": "Run", "value": "${NOTIFY_RUN_NUMBER}" },
+                { "name": "Branch", "value": "${NOTIFY_REF_NAME}" },
                 { "name": "Commit", "value": "${COMMIT_SHORT}" },
                 { "name": "sprequestguid", "value": "${GUID}" }
               ]}
@@ -102,7 +108,7 @@ jobs:
                 "targets": [
                   {
                     "os": "default",
-                    "uri": "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+                    "uri": "https://github.com/${NOTIFY_REPOSITORY}/actions/runs/${NOTIFY_RUN_ID}"
                   }
                 ]
               }

--- a/.github/workflows/nightly-runtime-patrol.yml
+++ b/.github/workflows/nightly-runtime-patrol.yml
@@ -87,6 +87,9 @@ jobs:
           VITE_SP_SITE_URL: ${{ secrets.SHAREPOINT_SITE }}
           TEAMS_WEBHOOK_URL: ${{ secrets.TEAMS_WEBHOOK_URL }}
           TEAMS_MENTION_UPN: ${{ secrets.TEAMS_MENTION_UPN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_API_URL: ${{ github.api_url }}
         run: npx tsx scripts/ops/nightly-runtime-patrol.ts
 
       - name: Upload Patrol Artifacts

--- a/scripts/ops/__tests__/nightly-runtime-patrol.spec.ts
+++ b/scripts/ops/__tests__/nightly-runtime-patrol.spec.ts
@@ -2,10 +2,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { 
+  deriveTransientFailureEvents,
+  formatStepSummary,
   sendTeamsNotification, 
   aggregateEvents, 
   type NightlySummary, 
-  type RawEvent 
+  type RawEvent,
+  type GitHubWorkflowRun,
 } from '../nightly-runtime-patrol';
 
 // ── fetch mock ───────────────────────────────────────────────────────────────
@@ -29,6 +32,7 @@ function makeSummary(overrides: Partial<NightlySummary> = {}): NightlySummary {
     bundledCount: 0,
     countsBySeverity: { critical: 0, action_required: 0, watch: 0, silent: 0 },
     events: [],
+    reasonCodeSummary: [],
     ...overrides,
   };
 }
@@ -167,6 +171,187 @@ describe('aggregateEvents / severity ordering', () => {
   });
 });
 
+describe('aggregateEvents / transient failures', () => {
+  it('treats transient_failure as watch', () => {
+    const summary = aggregateEvents([
+      makeEvent({
+        eventType: 'transient_failure',
+        reasonCode: 'transient_failure',
+        resourceKey: 'Staff_Master',
+        message: 'Recovered by Nightly Runtime Patrol after integration failure',
+      }),
+    ]);
+
+    expect(summary.events).toHaveLength(1);
+    expect(summary.events[0]?.severity).toBe('watch');
+    expect(summary.countsBySeverity.watch).toBe(1);
+  });
+
+  it('builds reasonCode summary with count and resources', () => {
+    const summary = aggregateEvents([
+      makeEvent({
+        id: 'a',
+        eventType: 'transient_failure',
+        reasonCode: 'transient_failure',
+        resourceKey: 'Users_Master',
+      }),
+      makeEvent({
+        id: 'b',
+        eventType: 'transient_failure',
+        reasonCode: 'transient_failure',
+        resourceKey: 'Staff_Master',
+      }),
+      makeEvent({
+        id: 'c',
+        eventType: 'http_429',
+        reasonCode: 'rate_limit',
+        resourceKey: 'SharePoint_API',
+      }),
+    ]);
+
+    expect(summary.reasonCodeSummary[0]).toEqual({
+      reasonCode: 'transient_failure',
+      count: 2,
+      resources: ['Staff_Master', 'Users_Master'],
+    });
+    expect(summary.reasonCodeSummary[1]).toEqual({
+      reasonCode: 'rate_limit',
+      count: 1,
+      resources: ['SharePoint_API'],
+    });
+  });
+});
+
+describe('deriveTransientFailureEvents', () => {
+  it('creates watch events for recent failed integration runs when target is recovered', () => {
+    const runs: GitHubWorkflowRun[] = [
+      {
+        name: 'integration (staff)',
+        status: 'completed',
+        conclusion: 'failure',
+        created_at: '2026-04-07T02:50:00Z',
+        html_url: 'https://github.com/example/repo/actions/runs/123',
+        run_number: 123,
+      },
+    ];
+
+    const events = deriveTransientFailureEvents(runs, [], new Date('2026-04-07T06:22:00Z'), 6);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.eventType).toBe('transient_failure');
+    expect(events[0]?.resourceKey).toBe('Staff_Master');
+    expect(events[0]?.reasonCode).toBe('transient_failure');
+  });
+
+  it('escalates to repeated_transient_failure when the same target failed for 3 consecutive nights', () => {
+    const runs: GitHubWorkflowRun[] = [
+      {
+        name: 'integration (dailyops)',
+        status: 'completed',
+        conclusion: 'failure',
+        created_at: '2026-04-07T17:31:00Z',
+        run_number: 100,
+      },
+      {
+        name: 'integration (dailyops)',
+        status: 'completed',
+        conclusion: 'failure',
+        created_at: '2026-04-08T17:32:00Z',
+        run_number: 101,
+      },
+      {
+        name: 'integration (dailyops)',
+        status: 'completed',
+        conclusion: 'failure',
+        created_at: '2026-04-09T17:33:00Z',
+        run_number: 102,
+      },
+    ];
+
+    const events = deriveTransientFailureEvents(runs, [], new Date('2026-04-09T21:22:00Z'), 6);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.resourceKey).toBe('DailyOpsSignals');
+    expect(events[0]?.reasonCode).toBe('repeated_transient_failure');
+
+    const summary = aggregateEvents(events);
+    expect(summary.events[0]?.severity).toBe('action_required');
+    expect(summary.countsBySeverity.action_required).toBe(1);
+  });
+
+  it('does not create transient events when the same target still has blocking failures', () => {
+    const runs: GitHubWorkflowRun[] = [
+      {
+        name: 'integration (users)',
+        status: 'completed',
+        conclusion: 'failure',
+        created_at: '2026-04-07T02:49:00Z',
+        run_number: 45,
+      },
+    ];
+
+    const existingEvents: RawEvent[] = [
+      makeEvent({
+        eventType: 'health_fail',
+        reasonCode: 'essential_resource_unavailable',
+        resourceKey: 'Users_Master',
+        message: 'Users_Master is still unavailable',
+      }),
+    ];
+
+    const events = deriveTransientFailureEvents(runs, existingEvents, new Date('2026-04-07T06:22:00Z'), 6);
+    expect(events).toHaveLength(0);
+  });
+});
+
+describe('formatStepSummary', () => {
+  it('renders overall counts and reason code summary for GitHub step summary', () => {
+    const output = formatStepSummary(
+      makeSummary({
+        countsBySeverity: { critical: 0, action_required: 1, watch: 1, silent: 0 },
+        reasonCodeSummary: [
+          { reasonCode: 'repeated_transient_failure', count: 1, resources: ['Users_Master'] },
+          { reasonCode: 'transient_failure', count: 1, resources: ['DailyOpsSignals'] },
+        ],
+        events: [
+          {
+            fingerprint: 'repeat123',
+            severity: 'action_required',
+            eventType: 'transient_failure',
+            area: 'Runtime',
+            resourceKey: 'Users_Master',
+            reasonCode: 'repeated_transient_failure',
+            occurrences: 1,
+            firstSeen: '2026-04-10T06:22:00Z',
+            lastSeen: '2026-04-10T06:22:00Z',
+            nextAction: 'check auth',
+            sampleMessage: 'Repeated transient failure',
+          },
+          {
+            fingerprint: 'watch123',
+            severity: 'watch',
+            eventType: 'transient_failure',
+            area: 'Runtime',
+            resourceKey: 'DailyOpsSignals',
+            reasonCode: 'transient_failure',
+            occurrences: 1,
+            firstSeen: '2026-04-10T06:22:00Z',
+            lastSeen: '2026-04-10T06:22:00Z',
+            nextAction: 'watch',
+            sampleMessage: 'Recovered transient failure',
+          },
+        ],
+      }),
+    );
+
+    expect(output).toContain('Overall: **🟠 Action Required**');
+    expect(output).toContain('Reason Code Summary');
+    expect(output).toContain('`repeated_transient_failure`: 1 (Users_Master)');
+    expect(output).toContain('Recovered Transient Failures: **1**');
+    expect(output).toContain('Repeated Transient Failures: **1**');
+  });
+});
+
 // ── sendTeamsNotification — persistent_drift section ────────────────────────
 
 describe('sendTeamsNotification — persistent_drift section', () => {
@@ -251,5 +436,68 @@ describe('sendTeamsNotification — persistent_drift section', () => {
 
     expect(result).toBe(false);
     expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('includes recovered transient failures section when watch items were recovered by nightly', async () => {
+    const summary = makeSummary({
+      countsBySeverity: { critical: 0, action_required: 0, watch: 1, silent: 0 },
+      reasonCodeSummary: [
+        { reasonCode: 'transient_failure', count: 1, resources: ['DailyOpsSignals'] },
+      ],
+      events: [
+        {
+          fingerprint: 'abc12345',
+          severity: 'watch',
+          eventType: 'transient_failure',
+          area: 'Runtime',
+          resourceKey: 'DailyOpsSignals',
+          occurrences: 1,
+          firstSeen: '2026-04-07T06:22:00Z',
+          lastSeen: '2026-04-07T06:22:00Z',
+          nextAction: 'watch',
+          sampleMessage: 'Recovered by Nightly Runtime Patrol',
+        },
+      ],
+    });
+
+    await sendTeamsNotification(summary, WEBHOOK);
+
+    const text = cardText(capturedCard());
+    expect(text).toContain('Recovered transient failures');
+    expect(text).toContain('DailyOpsSignals');
+    expect(text).toContain('"color":"Warning"');
+  });
+
+  it('includes repeated transient failures section when transient failures repeat for 3 nights', async () => {
+    const summary = makeSummary({
+      countsBySeverity: { critical: 0, action_required: 1, watch: 0, silent: 0 },
+      reasonCodeSummary: [
+        { reasonCode: 'repeated_transient_failure', count: 1, resources: ['Users_Master'] },
+      ],
+      events: [
+        {
+          fingerprint: 'repeat123',
+          severity: 'action_required',
+          eventType: 'transient_failure',
+          area: 'Runtime',
+          resourceKey: 'Users_Master',
+          reasonCode: 'repeated_transient_failure',
+          occurrences: 1,
+          firstSeen: '2026-04-10T06:22:00Z',
+          lastSeen: '2026-04-10T06:22:00Z',
+          nextAction: 'watch',
+          sampleMessage: 'Repeated transient failure',
+        },
+      ],
+    });
+
+    await sendTeamsNotification(summary, WEBHOOK);
+
+    const text = cardText(capturedCard());
+    expect(text).toContain('Repeated transient failures');
+    expect(text).toContain('Users_Master');
+    expect(text).toContain('SharePoint');
+    expect(text).toContain('Reason Code Summary');
+    expect(text).toContain('repeated_transient_failure');
   });
 });

--- a/scripts/ops/nightly-runtime-patrol.ts
+++ b/scripts/ops/nightly-runtime-patrol.ts
@@ -19,6 +19,16 @@ import { getDriftProbeTargets } from '../../src/sharepoint/driftProbeRegistry';
 
 export type SeverityLevel = 'silent' | 'watch' | 'action_required' | 'critical';
 
+export interface GitHubWorkflowRun {
+  name?: string;
+  status?: string | null;
+  conclusion?: string | null;
+  created_at?: string;
+  updated_at?: string;
+  html_url?: string;
+  run_number?: number;
+}
+
 export interface RawEvent {
   id: string;
   timestamp: string; // ISO8601
@@ -30,7 +40,8 @@ export interface RawEvent {
     | 'http_500'
     | 'health_fail'
     | 'index_pressure'
-    | 'remediation';
+    | 'remediation'
+    | 'transient_failure';
   area: string; // e.g. 'UserBenefit', 'StaffAttendance', 'Platform'
   resourceKey: string; // List name or logic module name
   fieldKey?: string; // Target field if applicable
@@ -44,6 +55,7 @@ export interface BundledEvent {
   eventType: string;
   area: string;
   resourceKey: string;
+  reasonCode: string;
   occurrences: number;
   firstSeen: string;
   lastSeen: string;
@@ -57,9 +69,23 @@ export interface NightlySummary {
   bundledCount: number;
   countsBySeverity: Record<SeverityLevel, number>;
   events: BundledEvent[];
+  reasonCodeSummary: Array<{
+    reasonCode: string;
+    count: number;
+    resources: string[];
+  }>;
   /** Phase B+: sp:field_skipped streak results. Top entries by streak, window-filtered. */
   fieldSkipStreaks?: FieldSkipRankEntry[];
 }
+
+const TRANSIENT_FAILURE_WORKFLOW_TARGETS: Record<string, string> = {
+  'integration (users)': 'Users_Master',
+  'integration (staff)': 'Staff_Master',
+  'integration (dailyops)': 'DailyOpsSignals',
+};
+
+const DEFAULT_TRANSIENT_FAILURE_WINDOW_HOURS = 6;
+const REPEATED_TRANSIENT_FAILURE_THRESHOLD = 3;
 
 // --- Engine Logic ---
 
@@ -97,6 +123,7 @@ function classifySeverity(event: RawEvent): SeverityLevel {
   if (event.eventType === 'http_500') return 'action_required';
   // Remediation Failure
   if (event.eventType === 'remediation' && (event.message.includes('fail') || event.message.includes('失敗'))) return 'action_required';
+  if (event.eventType === 'transient_failure' && event.reasonCode === 'repeated_transient_failure') return 'action_required';
 
   // 3. Silent
   if (event.eventType === 'provision_skipped:block') return 'silent';
@@ -106,6 +133,7 @@ function classifySeverity(event: RawEvent): SeverityLevel {
     return 'silent';
 
   // 4. Watch
+  if (event.eventType === 'transient_failure' || event.reasonCode === 'transient_failure') return 'watch';
   // Pending Candidate Index (default warn/info)
   if (event.eventType === 'index_pressure') return 'watch';
   return 'watch';
@@ -115,6 +143,9 @@ function classifySeverity(event: RawEvent): SeverityLevel {
  * NextAction の決定 (読んで終わらせないため)
  */
 function determineNextAction(severity: SeverityLevel, event: RawEvent): string {
+  if (event.eventType === 'transient_failure') {
+    return `[${event.resourceKey}] は Nightly Runtime Patrol 時点で回復しています。再発頻度を監視し、連日発生する場合は action_required へ昇格してください。`;
+  }
   if (event.eventType === 'index_pressure') {
     return event.message.includes('(CRITICAL)') 
       ? `【至急】[${event.resourceKey}] で必須インデックスが不足しています。システム停止を防ぐため、Index Advisor で修復を実行してください。`
@@ -143,6 +174,127 @@ function determineNextAction(severity: SeverityLevel, event: RawEvent): string {
   return `[${event.resourceKey}] で異常が検出されました。管理画面の状態ページを確認してください。`;
 }
 
+function parseEnvInteger(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function parseRunDate(run: GitHubWorkflowRun): Date | null {
+  const raw = run.updated_at || run.created_at;
+  if (!raw) return null;
+  const date = new Date(raw);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function shiftDateStamp(dateStamp: string, daysDelta: number): string {
+  const base = new Date(`${dateStamp}T00:00:00Z`);
+  base.setUTCDate(base.getUTCDate() + daysDelta);
+  return base.toISOString().slice(0, 10);
+}
+
+export function deriveTransientFailureEvents(
+  workflowRuns: GitHubWorkflowRun[],
+  existingRawEvents: RawEvent[],
+  now = new Date(),
+  windowHours = DEFAULT_TRANSIENT_FAILURE_WINDOW_HOURS,
+): RawEvent[] {
+  const windowStartMs = now.getTime() - windowHours * 60 * 60 * 1000;
+  const unresolvedResources = new Set(
+    existingRawEvents
+      .filter((event) => {
+        const severity = classifySeverity(event);
+        return severity === 'critical' || severity === 'action_required';
+      })
+      .map((event) => event.resourceKey),
+  );
+
+  const latestFailures = new Map<string, { target: string; run: GitHubWorkflowRun; observedAt: Date }>();
+  const failedRunDaysByTarget = new Map<string, Set<string>>();
+
+  for (const run of workflowRuns) {
+    const workflowName = typeof run.name === 'string' ? run.name : '';
+    const target = TRANSIENT_FAILURE_WORKFLOW_TARGETS[workflowName];
+    if (!target || unresolvedResources.has(target)) continue;
+
+    const status = `${run.status ?? ''}`.toLowerCase();
+    const conclusion = `${run.conclusion ?? ''}`.toLowerCase();
+    if (status !== 'completed' || conclusion !== 'failure') continue;
+
+    const observedAt = parseRunDate(run);
+    if (!observedAt) continue;
+
+    const daySet = failedRunDaysByTarget.get(target) ?? new Set<string>();
+    daySet.add(toJstDateString(observedAt));
+    failedRunDaysByTarget.set(target, daySet);
+
+    if (observedAt.getTime() < windowStartMs) continue;
+
+    const existing = latestFailures.get(target);
+    if (!existing || observedAt.getTime() > existing.observedAt.getTime()) {
+      latestFailures.set(target, { target, run, observedAt });
+    }
+  }
+
+  return Array.from(latestFailures.values()).map(({ target, run, observedAt }) => {
+    const todayJst = toJstDateString(now);
+    const consecutiveDays = Array.from({ length: REPEATED_TRANSIENT_FAILURE_THRESHOLD }, (_, index) =>
+      shiftDateStamp(todayJst, -index),
+    );
+    const failedDays = failedRunDaysByTarget.get(target) ?? new Set<string>();
+    const hasRepeatedTransientFailure = consecutiveDays.every((day) => failedDays.has(day));
+    const runNumber = Number.isFinite(run.run_number) ? `#${run.run_number}` : 'unknown';
+    const runLink = run.html_url ? ` (${run.html_url})` : '';
+    const reasonCode = hasRepeatedTransientFailure ? 'repeated_transient_failure' : 'transient_failure';
+    const repeatedText = hasRepeatedTransientFailure
+      ? ` and has repeated for ${REPEATED_TRANSIENT_FAILURE_THRESHOLD} consecutive nights`
+      : '';
+    return {
+      id: `transient-${target}-${observedAt.getTime()}`,
+      timestamp: now.toISOString(),
+      eventType: 'transient_failure',
+      area: 'Runtime',
+      resourceKey: target,
+      reasonCode,
+      message: `${target} recovered by Nightly Runtime Patrol after ${run.name} failed at ${observedAt.toISOString()} (${runNumber})${runLink}${repeatedText}`,
+    };
+  });
+}
+
+async function fetchTransientFailureEvents(existingRawEvents: RawEvent[]): Promise<RawEvent[]> {
+  const repo = process.env.GITHUB_REPOSITORY;
+  const token = process.env.GITHUB_TOKEN;
+  if (!repo || !token) {
+    return [];
+  }
+
+  const apiBase = process.env.GITHUB_API_URL || 'https://api.github.com';
+  const perPage = parseEnvInteger('NIGHTLY_TRANSIENT_FAILURE_GITHUB_RUNS_LIMIT', 100);
+  const windowHours = parseEnvInteger('NIGHTLY_TRANSIENT_FAILURE_WINDOW_HOURS', DEFAULT_TRANSIENT_FAILURE_WINDOW_HOURS);
+
+  try {
+    const response = await globalThis.fetch(`${apiBase}/repos/${repo}/actions/runs?per_page=${perPage}`, {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${token}`,
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    });
+
+    if (!response.ok) {
+      console.warn(`⚠️ Failed to fetch GitHub workflow runs: ${response.status} ${response.statusText}`);
+      return [];
+    }
+
+    const payload = (await response.json()) as { workflow_runs?: GitHubWorkflowRun[] };
+    return deriveTransientFailureEvents(payload.workflow_runs ?? [], existingRawEvents, new Date(), windowHours);
+  } catch (error) {
+    console.warn(`⚠️ Failed to derive transient failures from GitHub workflow runs: ${error instanceof Error ? error.message : error}`);
+    return [];
+  }
+}
+
 /**
  * 生イベントを束ねて評価するコアエンジン
  */
@@ -160,6 +312,7 @@ export function aggregateEvents(rawEvents: RawEvent[]): NightlySummary {
         eventType: event.eventType,
         area: event.area,
         resourceKey: event.resourceKey,
+        reasonCode: event.reasonCode,
         occurrences: 1,
         firstSeen: event.timestamp,
         lastSeen: event.timestamp,
@@ -196,12 +349,33 @@ export function aggregateEvents(rawEvents: RawEvent[]): NightlySummary {
     summaryCounter[b.severity] += 1;
   });
 
+  const reasonCodeSummary = Array.from(
+    bundledArray.reduce((acc, event) => {
+      const current = acc.get(event.reasonCode) ?? {
+        reasonCode: event.reasonCode,
+        count: 0,
+        resources: new Set<string>(),
+      };
+      current.count += 1;
+      current.resources.add(event.resourceKey);
+      acc.set(event.reasonCode, current);
+      return acc;
+    }, new Map<string, { reasonCode: string; count: number; resources: Set<string> }>()),
+  )
+    .map(([, entry]) => ({
+      reasonCode: entry.reasonCode,
+      count: entry.count,
+      resources: Array.from(entry.resources).sort(),
+    }))
+    .sort((a, b) => b.count - a.count || a.reasonCode.localeCompare(b.reasonCode));
+
   return {
     reportDate: new Date().toISOString().split('T')[0],
     totalEvents: rawEvents.length,
     bundledCount: bundledArray.length,
     countsBySeverity: summaryCounter,
     events: bundledArray,
+    reasonCodeSummary,
   };
 }
 
@@ -222,8 +396,20 @@ export function formatMarkdown(summary: NightlySummary): string {
 ---
 `;
 
+  const reasonCodeSummaryMarkdown = summary.reasonCodeSummary.length === 0
+    ? '_No reason codes recorded._'
+    : `| Reason Code | Count | Resources |\n| --- | :---: | --- |\n${summary.reasonCodeSummary
+        .map((entry) => `| \`${entry.reasonCode}\` | ${entry.count} | ${entry.resources.join(', ')} |`)
+        .join('\n')}`;
+
   // Silentはレポート本体を汚さないために分離
-  const displayEvents = summary.events.filter((e) => e.severity !== 'silent');
+  const repeatedTransientEvents = summary.events.filter(
+    (e) => e.eventType === 'transient_failure' && e.reasonCode === 'repeated_transient_failure',
+  );
+  const transientEvents = summary.events.filter(
+    (e) => e.eventType === 'transient_failure' && e.reasonCode !== 'repeated_transient_failure',
+  );
+  const displayEvents = summary.events.filter((e) => e.severity !== 'silent' && e.eventType !== 'transient_failure');
   const silentEvents = summary.events.filter((e) => e.severity === 'silent');
 
   const createTable = (events: BundledEvent[]) => {
@@ -243,6 +429,15 @@ export function formatMarkdown(summary: NightlySummary): string {
   };
 
   const body = `
+## 🧾 Reason Code Summary
+${reasonCodeSummaryMarkdown}
+
+## 🔁 Repeated Transient Failures
+${createTable(repeatedTransientEvents)}
+
+## ♻️ Recovered Transient Failures
+${createTable(transientEvents)}
+
 ## 🚨 Requires Attention (Critical & Action Required & Watch)
 ${createTable(displayEvents)}
 
@@ -264,6 +459,83 @@ ${silentEvents
 `;
 
   return header + body;
+}
+
+export function formatStepSummary(summary: NightlySummary): string {
+  const repeatedTransientEvents = summary.events.filter(
+    (e) => e.eventType === 'transient_failure' && e.reasonCode === 'repeated_transient_failure',
+  );
+  const transientEvents = summary.events.filter(
+    (e) => e.eventType === 'transient_failure' && e.reasonCode !== 'repeated_transient_failure',
+  );
+  const attentionEvents = summary.events.filter(
+    (e) => e.severity === 'critical' || e.severity === 'action_required',
+  );
+  const watchEvents = summary.events.filter((e) => e.severity === 'watch');
+
+  const overall =
+    summary.countsBySeverity.critical > 0
+      ? '🔴 Action Required'
+      : summary.countsBySeverity.action_required > 0
+        ? '🟠 Action Required'
+        : summary.countsBySeverity.watch > 0
+          ? '🟡 Watch'
+          : '✅ Healthy';
+
+  const listOrNone = (lines: string[]): string =>
+    lines.length > 0 ? lines.join('\n') : '- なし';
+
+  const reasonCodeLines = summary.reasonCodeSummary.map(
+    (entry) => `- \`${entry.reasonCode}\`: ${entry.count}${entry.resources.length > 0 ? ` (${entry.resources.join(', ')})` : ''}`,
+  );
+  const attentionLines = attentionEvents.map(
+    (event) => `- **${event.resourceKey}** — \`${event.reasonCode}\``,
+  );
+  const watchLines = watchEvents.map(
+    (event) => `- **${event.resourceKey}** — \`${event.reasonCode}\``,
+  );
+  const transientLines = transientEvents.map(
+    (event) => `- **${event.resourceKey}** — recovered (\`${event.reasonCode}\`)`,
+  );
+  const repeatedTransientLines = repeatedTransientEvents.map(
+    (event) => `- **${event.resourceKey}** — repeated (\`${event.reasonCode}\`)`,
+  );
+
+  return `## Nightly Runtime Patrol
+
+- Overall: **${overall}**
+- Action Required: **${summary.countsBySeverity.action_required}**
+- Watch: **${summary.countsBySeverity.watch}**
+- Recovered Transient Failures: **${transientEvents.length}**
+- Repeated Transient Failures: **${repeatedTransientEvents.length}**
+
+### Requires Attention
+${listOrNone(attentionLines)}
+
+### Watch
+${listOrNone(watchLines)}
+
+### Reason Code Summary
+${listOrNone(reasonCodeLines)}
+
+### Recovered Transient Failures
+${listOrNone(transientLines)}
+
+### Repeated Transient Failures
+${listOrNone(repeatedTransientLines)}
+`;
+}
+
+async function writeStepSummary(summary: NightlySummary): Promise<void> {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryPath) return;
+
+  try {
+    await fs.appendFile(summaryPath, `${formatStepSummary(summary)}\n`, 'utf-8');
+    console.log(`  └ GitHub Step Summary written: ${summaryPath}`);
+  } catch (error) {
+    console.warn(`  ⚠️ Failed to write GitHub Step Summary: ${error instanceof Error ? error.message : error}`);
+  }
 }
 
 // --- Data Ingestion ---
@@ -534,6 +806,12 @@ async function run() {
   // 実データの取得（失敗時や設定がない場合はモックへフォールバック）
   const rawEvents = await fetchRealEvents(mockRawEvents);
 
+  const transientFailureEvents = await fetchTransientFailureEvents(rawEvents);
+  if (transientFailureEvents.length > 0) {
+    rawEvents.push(...transientFailureEvents);
+    console.log(`  └ Transient failures recovered by Nightly: ${transientFailureEvents.length}`);
+  }
+
   // ── Nightly Index Remediation (Mode B: guarded add only) ──────────────────
   const token = process.env.VITE_SP_TOKEN;
   const siteUrl = process.env.VITE_SP_SITE_URL;
@@ -612,8 +890,22 @@ async function run() {
         },
         body: JSON.stringify({
           Title: 'runtime-summary',
-          Overall: summary.countsBySeverity.critical > 0 ? 'fail' : (summary.countsBySeverity.action_required > 0 ? 'warn' : 'pass'),
-          TopIssue: summary.countsBySeverity.critical > 0 ? 'Critical failures detected' : (summary.fieldSkipStreaks?.length ? 'Persistent drifts detected' : 'Healthy'),
+          Overall:
+            summary.countsBySeverity.critical > 0
+              ? 'fail'
+              : (summary.countsBySeverity.action_required > 0 ||
+                  summary.countsBySeverity.watch > 0 ||
+                  (summary.fieldSkipStreaks?.length ?? 0) > 0)
+                ? 'warn'
+                : 'pass',
+          TopIssue:
+            summary.countsBySeverity.critical > 0
+              ? 'Critical failures detected'
+              : (summary.fieldSkipStreaks?.length ?? 0) > 0
+                ? 'Persistent drifts detected'
+                : summary.events.some((event) => event.eventType === 'transient_failure')
+                  ? 'Recovered transient failures detected'
+                  : 'Healthy',
           SummaryText: jsonOutput, // PayloadJson として使用
         }),
       });
@@ -629,6 +921,8 @@ async function run() {
 
   console.log(`  - Silent count: ${summary.countsBySeverity.silent}`);
   console.log('Results written to .nightly/runtime-summary.{json,md}');
+
+  await writeStepSummary(summary);
 
   // Teams通知の実行
   await sendTeamsNotification(summary);
@@ -647,11 +941,18 @@ export async function sendTeamsNotification(summary: NightlySummary, webhookUrl?
 
   const hasCritical = summary.countsBySeverity.critical > 0;
   const hasAction = summary.countsBySeverity.action_required > 0;
+  const hasWatch = summary.countsBySeverity.watch > 0;
   const persistentDrifts = (summary.fieldSkipStreaks ?? []).filter((e) => e.status === 'persistent_drift');
   const hasPersistentDrift = persistentDrifts.length > 0;
+  const repeatedTransientFailures = summary.events
+    .filter((event) => event.eventType === 'transient_failure' && event.reasonCode === 'repeated_transient_failure')
+    .slice(0, 5);
+  const transientFailures = summary.events
+    .filter((event) => event.eventType === 'transient_failure' && event.reasonCode !== 'repeated_transient_failure')
+    .slice(0, 5);
 
-  const statusColor = (hasCritical || hasPersistentDrift) ? 'Attention' : (hasAction ? 'Warning' : 'Good');
-  const statusEmoji = hasCritical ? '🔴 CRITICAL' : (hasAction ? '🟠 Action Required' : '✅ Healthy');
+  const statusColor = (hasCritical || hasPersistentDrift) ? 'Attention' : ((hasAction || hasWatch) ? 'Warning' : 'Good');
+  const statusEmoji = hasCritical ? '🔴 CRITICAL' : (hasAction ? '🟠 Action Required' : (hasWatch ? '🟡 Watch' : '✅ Healthy'));
 
   // 重要度の高いイベントのみを抽出（Adaptive Card の制限内に収める）
   const highlightEvents = summary.events
@@ -679,8 +980,29 @@ export async function sendTeamsNotification(summary: NightlySummary, webhookUrl?
         { title: '🟡 Watch', value: `${summary.countsBySeverity.watch}` },
         { title: '🟢 Silent', value: `${summary.countsBySeverity.silent}` }
       ]
-    }
-  ];
+      }
+    ];
+
+  if (summary.reasonCodeSummary.length > 0) {
+    cardItems.push({
+      type: 'TextBlock',
+      text: '🧾 **Reason Code Summary**',
+      separator: true,
+      wrap: true,
+      weight: 'Bolder',
+    });
+
+    summary.reasonCodeSummary.slice(0, 5).forEach((entry) => {
+      const resourceLabel = entry.resources.slice(0, 3).join(', ');
+      cardItems.push({
+        type: 'TextBlock',
+        text: `\`${entry.reasonCode}\`: ${entry.count}${resourceLabel ? ` (${resourceLabel})` : ''}`,
+        wrap: true,
+        size: 'Small',
+        isSubtle: true,
+      });
+    });
+  }
 
   if (highlightEvents.length > 0) {
     cardItems.push({
@@ -716,9 +1038,50 @@ export async function sendTeamsNotification(summary: NightlySummary, webhookUrl?
   } else {
     cardItems.push({
       type: 'TextBlock',
-      text: '✅ **No Critical or Action Required issues detected.**',
+      text: hasWatch
+        ? '🟡 **No Critical or Action Required issues detected, but watch items remain.**'
+        : '✅ **No Critical or Action Required issues detected.**',
       separator: true,
       wrap: true
+    });
+  }
+
+  if (transientFailures.length > 0) {
+    cardItems.push({
+      type: 'TextBlock',
+      text: '♻️ **Recovered transient failures**',
+      separator: true,
+      wrap: true,
+      weight: 'Bolder',
+    });
+    transientFailures.forEach((event) => {
+      cardItems.push({
+        type: 'TextBlock',
+        text: `**${event.resourceKey}** — Nightly が一時障害を吸収しました。再発頻度を監視してください。`,
+        wrap: true,
+        size: 'Small',
+        color: 'Warning',
+      });
+    });
+  }
+
+  if (repeatedTransientFailures.length > 0) {
+    cardItems.push({
+      type: 'TextBlock',
+      text: '🔁 **Repeated transient failures**',
+      separator: true,
+      wrap: true,
+      weight: 'Bolder',
+      color: 'Attention',
+    });
+    repeatedTransientFailures.forEach((event) => {
+      cardItems.push({
+        type: 'TextBlock',
+        text: `**${event.resourceKey}** — 3夜連続で一時障害を吸収しています。認証・スロットリング・SharePoint 到達性を確認してください。`,
+        wrap: true,
+        size: 'Small',
+        color: 'Attention',
+      });
     });
   }
 


### PR DESCRIPTION
## What changed
- fixed GitHub Actions Teams failure notifications so repo/workflow/run/branch/commit metadata is always populated
- hardened Nightly Runtime Patrol with transient failure detection, repeated transient escalation, and shared reason-code summaries
- added GitHub Step Summary output so the nightly run page shows the same operational decision data as Markdown, Teams, and Diagnostics
- tightened workflow linting so actionlint runs as a GitHub check on workflow changes

## Why
- Teams integration alerts were losing workflow metadata because shell interpolation was inconsistent across workflows
- nightly failures needed to distinguish active outages from recovered transient instability and repeated transient instability
- operators needed one consistent source of truth across all reporting surfaces

## Impact
- workflow failure alerts are traceable again
- nightly patrol now classifies recovered transient failures as `watch/transient_failure`
- repeated transient failures escalate to `action_required/repeated_transient_failure`
- the GitHub Actions run summary now includes overall state, action-required/watch counts, transient sections, and reason-code summaries

## Root cause
- two integration workflows used a quoted heredoc (`<<'JSON'`) that prevented environment variable expansion in Teams payloads
- nightly patrol previously had no structured way to translate transient GitHub Actions failures into operational severity over time

## Validation
- `npm test -- --run scripts/ops/__tests__/nightly-runtime-patrol.spec.ts`
- pre-commit checks during commit: `eslint`, `tsc -p tsconfig.build.json --noEmit`, `lint:cookies`
- push hook: eslint on changed files vs `origin/main`