### PR TITLE
feat(isp): 生活介護対応コンプライアンスメタデータの統合とUI刷新

### DIFF
--- a/src/domain/isp/__tests__/schema.spec.ts
+++ b/src/domain/isp/__tests__/schema.spec.ts
@@ -66,6 +66,8 @@ import {
   ispDeliveryDetailSchema,
   ispReviewControlSchema,
   ispComplianceMetadataSchema,
+  ispMeetingDetailSchema,
+  ispConsultationSupportSchema,
   isIspReviewOverdue,
   computeIspReviewOverdueDays,
   validateStandardServiceHours,
@@ -1619,6 +1621,202 @@ describe('ISP コンプライアンスメタデータ (A-1)', () => {
 
     it('24.0 → null（ちょうど24は許容）', () => {
       expect(validateStandardServiceHours(24)).toBeNull();
+    });
+  });
+});
+
+// ─────────────────────────────────────────────
+// 更新パッチ: 追加項目（meeting / consultationSupport / 同意拡張 / base 追加5項目）
+// ─────────────────────────────────────────────
+
+describe('ISP 追加項目（更新パッチ）', () => {
+  describe('ispConsentDetailSchema 拡張 (proxyReason / consentMethod)', () => {
+    it('proxyReason / consentMethod なしでパースできる（後方互換）', () => {
+      const result = ispConsentDetailSchema.parse({
+        proxyName: '田中次郎',
+        proxyRelation: '兄',
+      });
+      expect(result.proxyName).toBe('田中次郎');
+      expect(result.proxyReason).toBeUndefined();
+      expect(result.consentMethod).toBeUndefined();
+    });
+
+    it('proxyReason / consentMethod を設定できる', () => {
+      const result = ispConsentDetailSchema.parse({
+        proxyName: '田中次郎',
+        proxyRelation: '兄',
+        proxyReason: '本人の意思表示が困難なため',
+        consentMethod: 'signature',
+      });
+      expect(result.proxyReason).toBe('本人の意思表示が困難なため');
+      expect(result.consentMethod).toBe('signature');
+    });
+
+    it('consentMethod の不正値はエラー', () => {
+      expect(() =>
+        ispConsentDetailSchema.parse({ consentMethod: 'fingerprint' }),
+      ).toThrow();
+    });
+  });
+
+  describe('ispMeetingDetailSchema', () => {
+    it('空オブジェクトからデフォルトが生成される', () => {
+      const result = ispMeetingDetailSchema.parse({});
+      expect(result).toEqual({
+        meetingDate: null,
+        meetingMinutes: '',
+        attendees: [],
+      });
+    });
+
+    it('会議情報を設定できる', () => {
+      const result = ispMeetingDetailSchema.parse({
+        meetingDate: '2026-04-10',
+        meetingMinutes: '長期目標を確認、家族同席',
+        attendees: ['サビ管 山田', '担当 鈴木', '本人', '母'],
+      });
+      expect(result.meetingDate).toBe('2026-04-10');
+      expect(result.attendees).toHaveLength(4);
+    });
+  });
+
+  describe('ispConsultationSupportSchema', () => {
+    it('空オブジェクトからデフォルトが生成される', () => {
+      const result = ispConsultationSupportSchema.parse({});
+      expect(result).toEqual({
+        agencyName: '',
+        officerName: '',
+        serviceUsePlanReceivedAt: null,
+        gapNotes: '',
+      });
+    });
+
+    it('相談支援情報を設定できる', () => {
+      const result = ispConsultationSupportSchema.parse({
+        agencyName: '相談支援センターA',
+        officerName: '相談員 佐藤',
+        serviceUsePlanReceivedAt: '2026-03-25',
+        gapNotes: '通所頻度の記載が ISP と相違',
+      });
+      expect(result.agencyName).toBe('相談支援センターA');
+      expect(result.serviceUsePlanReceivedAt).toBe('2026-03-25');
+    });
+  });
+
+  describe('ispComplianceMetadataSchema 拡張統合', () => {
+    it('meeting / consultationSupport なしでパースできる（既存データ互換）', () => {
+      const result = ispComplianceMetadataSchema.parse({
+        serviceType: 'daily_life_care',
+      });
+      expect(result.serviceType).toBe('daily_life_care');
+      // 修正後: optional() から .default() に変更したため、定義済みとなる
+      expect(result.meeting).toBeDefined();
+      expect(result.meeting?.meetingMinutes).toBe('');
+      expect(result.consultationSupport).toBeDefined();
+      expect(result.consultationSupport?.agencyName).toBe('');
+    });
+
+    it('ispComplianceMetadataSchema.parse({}) で完全なデフォルト値が返る (Requested B)', () => {
+      const result = ispComplianceMetadataSchema.parse({});
+      expect(result.meeting).toBeDefined();
+      expect(result.meeting?.attendees).toEqual([]);
+      expect(result.consultationSupport).toBeDefined();
+      expect(result.consultationSupport?.officerName).toBe('');
+    });
+
+    it('meeting / consultationSupport を含む完全入力を受け付ける', () => {
+      const result = ispComplianceMetadataSchema.parse({
+        serviceType: 'daily_life_care',
+        meeting: {
+          meetingDate: '2026-04-10',
+          meetingMinutes: '会議実施',
+          attendees: ['山田', '鈴木'],
+        },
+        consultationSupport: {
+          agencyName: '相談支援センターA',
+          officerName: '佐藤',
+          serviceUsePlanReceivedAt: '2026-03-25',
+          gapNotes: '',
+        },
+      });
+      expect(result.meeting?.meetingDate).toBe('2026-04-10');
+      expect(result.meeting?.attendees).toEqual(['山田', '鈴木']);
+      expect(result.consultationSupport?.agencyName).toBe('相談支援センターA');
+    });
+
+    it('部分的な meeting 入力でもデフォルトで補完される', () => {
+      const result = ispComplianceMetadataSchema.parse({
+        meeting: { meetingDate: '2026-04-10' },
+      });
+      expect(result.meeting?.meetingDate).toBe('2026-04-10');
+      expect(result.meeting?.meetingMinutes).toBe('');
+      expect(result.meeting?.attendees).toEqual([]);
+    });
+  });
+
+  describe('ispFormSchema 追加項目 (B-1)', () => {
+    it('追加5項目なしでパースできる（既存フォーム互換）', () => {
+      const input = makeIspFormInput();
+      const result = ispFormSchema.parse(input);
+      expect(result.medicalConsiderations).toBeUndefined();
+      expect(result.emergencyResponsePlan).toBeUndefined();
+      expect(result.rightsAdvocacy).toBeUndefined();
+      expect(result.serviceStartDate).toBeUndefined();
+      expect(result.firstServiceDate).toBeUndefined();
+    });
+
+    it('追加5項目を設定できる', () => {
+      const input = makeIspFormInput({
+        medicalConsiderations: 'てんかん発作時の対応',
+        emergencyResponsePlan: '主治医連絡 → 救急要請',
+        rightsAdvocacy: '本人の選好を最優先',
+        serviceStartDate: '2026-04-01',
+        firstServiceDate: '2026-04-03',
+      });
+      const result = ispFormSchema.parse(input);
+      expect(result.medicalConsiderations).toBe('てんかん発作時の対応');
+      expect(result.serviceStartDate).toBe('2026-04-01');
+      expect(result.firstServiceDate).toBe('2026-04-03');
+    });
+
+    it('serviceStartDate の不正フォーマットはエラー', () => {
+      const input = makeIspFormInput({ serviceStartDate: '2026/04/01' });
+      expect(() => ispFormSchema.parse(input)).toThrow();
+    });
+  });
+
+  describe('individualSupportPlanSchema 追加項目 (B-2)', () => {
+    it('追加5項目なしでパースできる（既存ドメイン互換）', () => {
+      const input = {
+        ...baseAudit,
+        userId: 'U001',
+        title: 'テスト計画',
+        planStartDate: '2026-04-01',
+        planEndDate: '2027-03-31',
+        userIntent: '意向',
+        familyIntent: '',
+        overallSupportPolicy: '方針',
+        qolIssues: '',
+        longTermGoals: ['目標'],
+        shortTermGoals: ['短期'],
+        supportSummary: '',
+        precautions: '',
+        consentAt: null,
+        deliveredAt: null,
+        monitoringSummary: '',
+        lastMonitoringAt: null,
+        nextReviewAt: null,
+        status: 'assessment' as const,
+        isCurrent: true,
+      };
+      const result = individualSupportPlanSchema.parse(input);
+      expect(result.medicalConsiderations).toBeUndefined();
+      expect(result.serviceStartDate).toBeUndefined();
+      expect(result.firstServiceDate).toBeUndefined();
+
+      // compliance は定義済みデフォルトが返る
+      expect(result.compliance).toBeDefined();
+      expect(result.compliance?.meeting).toBeDefined();
     });
   });
 });

--- a/src/domain/isp/schema/ispBaseSchema.ts
+++ b/src/domain/isp/schema/ispBaseSchema.ts
@@ -9,17 +9,13 @@
 
 import { z } from 'zod';
 import { userSnapshotSchema } from '@/domain/user/userRelation';
-import { ispComplianceMetadataSchema } from './ispComplianceSchema';
+import { ispComplianceMetadataSchema, isoDateString } from './ispComplianceSchema';
+
+export { isoDateString };
 
 // ─────────────────────────────────────────────
 // 共通
 // ─────────────────────────────────────────────
-
-/** ISO 8601 日付文字列（簡易バリデーション） */
-export const isoDateString = z.string().regex(
-  /^\d{4}-\d{2}-\d{2}/,
-  'ISO 8601 日付形式（YYYY-MM-DD...）が必要です',
-);
 
 /** 監査証跡の共通スキーマ */
 export const baseAuditFieldsSchema = z.object({
@@ -126,6 +122,18 @@ export const ispFormSchema = z.object({
   supportSummary: z.string().max(2000).default(''),
   precautions: z.string().max(2000).default(''),
 
+  // ── 生活介護 追加項目（更新パッチ B-1） ──
+  /** 医療的配慮事項 */
+  medicalConsiderations: z.string().max(2000).optional(),
+  /** 緊急時対応計画 */
+  emergencyResponsePlan: z.string().max(2000).optional(),
+  /** 権利擁護に関する記載 */
+  rightsAdvocacy: z.string().max(2000).optional(),
+  /** 契約上のサービス開始日（planStartDate と区別） */
+  serviceStartDate: isoDateString.optional(),
+  /** 実際の初回サービス提供日 */
+  firstServiceDate: isoDateString.optional(),
+
   status: ispStatusSchema.default('assessment'),
 
   // ── 生活介護コンプライアンスメタデータ ──
@@ -155,6 +163,13 @@ export const individualSupportPlanSchema = baseAuditFieldsSchema.extend({
 
   supportSummary: z.string().default(''),
   precautions: z.string().default(''),
+
+  // ── 生活介護 追加項目（更新パッチ B-2） ──
+  medicalConsiderations: z.string().optional(),
+  emergencyResponsePlan: z.string().optional(),
+  rightsAdvocacy: z.string().optional(),
+  serviceStartDate: isoDateString.optional(),
+  firstServiceDate: isoDateString.optional(),
 
   consentAt: z.string().nullable().default(null),
   deliveredAt: z.string().nullable().default(null),

--- a/src/domain/isp/schema/ispComplianceSchema.ts
+++ b/src/domain/isp/schema/ispComplianceSchema.ts
@@ -13,20 +13,32 @@ import { z } from 'zod';
 // コンプライアンスメタデータ構成要素
 // ─────────────────────────────────────────────
 
+/** ISO 8601 日付文字列（簡易バリデーション） */
+export const isoDateString = z.string().regex(
+  /^\d{4}-\d{2}-\d{2}/,
+  'ISO 8601 日付形式（YYYY-MM-DD...）が必要です',
+);
+
 /** 同意記録の詳細（生活介護制度要件） */
 export const ispConsentDetailSchema = z.object({
   /** 説明実施日（ISO 8601） */
-  explainedAt: z.string().nullable().default(null),
+  explainedAt: isoDateString.nullable().default(null),
   /** 説明実施者名 */
   explainedBy: z.string().default(''),
   /** 同意取得日（ISO 8601） */
-  consentedAt: z.string().nullable().default(null),
+  consentedAt: isoDateString.nullable().default(null),
   /** 同意者名 */
   consentedBy: z.string().default(''),
   /** 代理人名（家族等が同意した場合） */
   proxyName: z.string().default(''),
   /** 代理人続柄 */
   proxyRelation: z.string().default(''),
+  /** 代理同意の理由（proxyRelation がある場合に推奨） */
+  proxyReason: z.string().optional(),
+  /** 同意取得方法 */
+  consentMethod: z
+    .enum(['signature', 'seal', 'electronic', 'other'])
+    .optional(),
   /** 備考 */
   notes: z.string().default(''),
 }).default({
@@ -44,7 +56,7 @@ export type IspConsentDetail = z.infer<typeof ispConsentDetailSchema>;
 /** 交付記録の詳細（生活介護制度要件） */
 export const ispDeliveryDetailSchema = z.object({
   /** 交付日（ISO 8601） */
-  deliveredAt: z.string().nullable().default(null),
+  deliveredAt: isoDateString.nullable().default(null),
   /** 本人へ交付済み */
   deliveredToUser: z.boolean().default(false),
   /** 相談支援専門員へ交付済み */
@@ -65,12 +77,12 @@ export type IspDeliveryDetail = z.infer<typeof ispDeliveryDetailSchema>;
 
 /** 見直し制御（6か月ルール） */
 export const ispReviewControlSchema = z.object({
-  /** 見直し周期（日） — 生活介護は原則 180日（6か月） */
+  /**見直し周期（日） — 生活介護は原則 180日（6か月） */
   reviewCycleDays: z.number().int().min(1).default(180),
   /** 前回見直し実施日（ISO 8601） */
-  lastReviewedAt: z.string().nullable().default(null),
+  lastReviewedAt: isoDateString.nullable().default(null),
   /** 次回見直し期限（ISO 8601） */
-  nextReviewDueAt: z.string().nullable().default(null),
+  nextReviewDueAt: isoDateString.nullable().default(null),
   /** 見直し理由 */
   reviewReason: z.string().default(''),
 }).default({
@@ -87,7 +99,7 @@ export const ispApprovalSchema = z.object({
   /** 承認者 UPN (email) */
   approvedBy: z.string().nullable().default(null),
   /** 承認日時 (ISO 8601) */
-  approvedAt: z.string().nullable().default(null),
+  approvedAt: isoDateString.nullable().default(null),
   /** 承認ステータス */
   approvalStatus: z.enum(['draft', 'approved']).default('draft'),
 }).default({
@@ -97,6 +109,46 @@ export const ispApprovalSchema = z.object({
 });
 
 export type IspApproval = z.infer<typeof ispApprovalSchema>;
+
+/**
+ * 会議記録の詳細（ISP 会議実施の証跡 — status: 'meeting' に対応）
+ */
+export const ispMeetingDetailSchema = z.object({
+  /** 会議実施日（ISO 8601） */
+  meetingDate: isoDateString.nullable().default(null),
+  /** 会議議事要旨 */
+  meetingMinutes: z.string().default(''),
+  /**
+   * 出席者名簿（氏名配列）
+   * 将来 role/所属 付き構造 `{ name: string; role?: string }` への拡張余地あり
+   */
+  attendees: z.array(z.string()).default([]),
+}).default({
+  meetingDate: null,
+  meetingMinutes: '',
+  attendees: [],
+});
+
+export type IspMeetingDetail = z.infer<typeof ispMeetingDetailSchema>;
+
+/** 相談支援事業所との連携情報（サービス等利用計画との整合） */
+export const ispConsultationSupportSchema = z.object({
+  /** 相談支援事業所名 */
+  agencyName: z.string().default(''),
+  /** 相談支援専門員名 */
+  officerName: z.string().default(''),
+  /** サービス等利用計画の受領日（ISO 8601） */
+  serviceUsePlanReceivedAt: isoDateString.nullable().default(null),
+  /** サービス等利用計画と ISP の差分・不整合メモ */
+  gapNotes: z.string().default(''),
+}).default({
+  agencyName: '',
+  officerName: '',
+  serviceUsePlanReceivedAt: null,
+  gapNotes: '',
+});
+
+export type IspConsultationSupport = z.infer<typeof ispConsultationSupportSchema>;
 
 /** ISP コンプライアンスメタデータ（生活介護 ISP の監査対応項目を集約） */
 export const ispComplianceMetadataSchema = z.object({
@@ -120,6 +172,10 @@ export const ispComplianceMetadataSchema = z.object({
   reviewControl: ispReviewControlSchema,
   /** 承認記録（F-1: サビ管承認の電子的証跡） */
   approval: ispApprovalSchema,
+  /** 会議記録（status: 'meeting' の証跡） */
+  meeting: ispMeetingDetailSchema,
+  /** 相談支援事業所との連携情報 */
+  consultationSupport: ispConsultationSupportSchema,
 }).default({
   serviceType: 'other',
   standardServiceHours: null,
@@ -149,6 +205,17 @@ export const ispComplianceMetadataSchema = z.object({
     approvedBy: null,
     approvedAt: null,
     approvalStatus: 'draft',
+  },
+  meeting: {
+    meetingDate: null,
+    meetingMinutes: '',
+    attendees: [],
+  },
+  consultationSupport: {
+    agencyName: '',
+    officerName: '',
+    serviceUsePlanReceivedAt: null,
+    gapNotes: '',
   },
 });
 

--- a/src/features/support-plan-guide/components/tabs/ComplianceTab.tsx
+++ b/src/features/support-plan-guide/components/tabs/ComplianceTab.tsx
@@ -8,12 +8,14 @@
  * EditableComplianceSection + ApprovalSection のラッパ。
  * useComplianceForm フックからデータ・ハンドラを受け取る。
  */
-import Stack from '@mui/material/Stack';
 import React from 'react';
+import Stack from '@mui/material/Stack';
 
 import type { UseComplianceFormReturn } from '../../hooks/useComplianceForm';
 import ApprovalSection from './ApprovalSection';
+import ConsultationSupportSection from './ConsultationSupportSection';
 import EditableComplianceSection from './EditableComplianceSection';
+import MeetingDetailSection from './MeetingDetailSection';
 
 export type ComplianceTabProps = {
   isAdmin: boolean;
@@ -27,6 +29,8 @@ const ComplianceTab: React.FC<ComplianceTabProps> = ({ isAdmin, complianceForm, 
     compliance,
     updateConsent,
     updateDelivery,
+    updateMeeting,
+    updateConsultation,
     updateServiceHours,
     missingFields,
     approvalState,
@@ -50,6 +54,20 @@ const ComplianceTab: React.FC<ComplianceTabProps> = ({ isAdmin, complianceForm, 
         onConsentChange={updateConsent}
         onDeliveryChange={updateDelivery}
         onServiceHoursChange={updateServiceHours}
+      />
+
+      {/* A-2: サービス担当者会議記録 */}
+      <MeetingDetailSection
+        meeting={compliance.meeting}
+        isAdmin={isAdmin}
+        onChange={updateMeeting}
+      />
+
+      {/* A-2: 相談支援専門員との連携 */}
+      <ConsultationSupportSection
+        consultation={compliance.consultationSupport}
+        isAdmin={isAdmin}
+        onChange={updateConsultation}
       />
 
       {/* F-1: サビ管承認セクション */}

--- a/src/features/support-plan-guide/components/tabs/ConsultationSupportSection.tsx
+++ b/src/features/support-plan-guide/components/tabs/ConsultationSupportSection.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import Paper from '@mui/material/Paper';
+import TextField from '@mui/material/TextField';
+import type { IspConsultationSupport } from '@/domain/isp/schema';
+
+export type ConsultationSupportSectionProps = {
+  consultation: IspConsultationSupport;
+  isAdmin: boolean;
+  onChange: (updates: Partial<IspConsultationSupport>) => void;
+};
+
+const ConsultationSupportSection: React.FC<ConsultationSupportSectionProps> = ({
+  consultation,
+  isAdmin,
+  onChange,
+}) => {
+  const readOnly = !isAdmin;
+
+  return (
+    <Paper variant="outlined" sx={{ p: 2 }}>
+      <Stack spacing={2}>
+        <Typography variant="subtitle1" fontWeight="bold" color="primary">
+          🏢 相談支援事業所との連携
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          サービス等利用計画との整合性、および指定相談支援事業所との情報共有状況を記録します。
+        </Typography>
+
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+          <TextField
+            size="small"
+            label="相談支援事業所名"
+            value={consultation.agencyName}
+            onChange={(e) => onChange({ agencyName: e.target.value })}
+            disabled={readOnly}
+            placeholder="例: あおぞら相談支援センター"
+            sx={{ flex: 1 }}
+            data-testid="compliance-consultation-agency"
+          />
+          <TextField
+            size="small"
+            label="相談支援専門員名"
+            value={consultation.officerName}
+            onChange={(e) => onChange({ officerName: e.target.value })}
+            disabled={readOnly}
+            placeholder="例: 佐藤 健二"
+            sx={{ flex: 1 }}
+            data-testid="compliance-consultation-officer"
+          />
+        </Stack>
+
+        <TextField
+          type="date"
+          size="small"
+          label="サービス等利用計画の受領日"
+          value={consultation.serviceUsePlanReceivedAt ?? ''}
+          onChange={(e) => onChange({ serviceUsePlanReceivedAt: e.target.value || null })}
+          disabled={readOnly}
+          slotProps={{ inputLabel: { shrink: true } }}
+          sx={{ maxWidth: 240 }}
+          data-testid="compliance-consultation-received-at"
+        />
+
+        <TextField
+          size="small"
+          label="利用計画と ISP の差分・不整合（特記事項）"
+          value={consultation.gapNotes}
+          onChange={(e) => onChange({ gapNotes: e.target.value })}
+          disabled={readOnly}
+          multiline
+          minRows={2}
+          placeholder="例: 利用計画の目標に基づき、当事業所では生活スキルの向上に焦点を当てた計画を作成。"
+          data-testid="compliance-consultation-gap-notes"
+        />
+      </Stack>
+    </Paper>
+  );
+};
+
+export default React.memo(ConsultationSupportSection);

--- a/src/features/support-plan-guide/components/tabs/EditableComplianceSection.tsx
+++ b/src/features/support-plan-guide/components/tabs/EditableComplianceSection.tsx
@@ -177,30 +177,65 @@ const EditableComplianceSection: React.FC<EditableComplianceSectionProps> = ({
           </Stack>
 
           {/* Row 3: 代理人 */}
-          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
-            <TextField
-              size="small"
-              label="代理人名（家族等）"
-              value={consent.proxyName}
-              onChange={(e) => onConsentChange({ proxyName: e.target.value })}
-              disabled={readOnly}
-              placeholder="例: 鈴木 一郎"
-              sx={{ flex: 1 }}
-              data-testid="compliance-proxy-name"
-            />
-            <TextField
-              size="small"
-              label="代理人続柄"
-              value={consent.proxyRelation}
-              onChange={(e) => onConsentChange({ proxyRelation: e.target.value })}
-              disabled={readOnly}
-              placeholder="例: 父"
-              sx={{ minWidth: 120 }}
-              data-testid="compliance-proxy-relation"
-            />
+          <Stack spacing={2}>
+            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+              <TextField
+                size="small"
+                label="代理人名（家族等）"
+                value={consent.proxyName}
+                onChange={(e) => onConsentChange({ proxyName: e.target.value })}
+                disabled={readOnly}
+                placeholder="例: 鈴木 一郎"
+                sx={{ flex: 1 }}
+                data-testid="compliance-proxy-name"
+              />
+              <TextField
+                size="small"
+                label="代理人続柄"
+                value={consent.proxyRelation}
+                onChange={(e) => onConsentChange({ proxyRelation: e.target.value })}
+                disabled={readOnly}
+                placeholder="例: 父"
+                sx={{ minWidth: 120 }}
+                data-testid="compliance-proxy-relation"
+              />
+            </Stack>
+            {(consent.proxyName || consent.proxyRelation) && (
+              <TextField
+                size="small"
+                label="代理同意の理由（本人同意が困難な理由等）"
+                value={consent.proxyReason ?? ''}
+                onChange={(e) => onConsentChange({ proxyReason: e.target.value })}
+                disabled={readOnly}
+                placeholder="例: 本人による署名が困難なため、父が代筆。"
+                data-testid="compliance-proxy-reason"
+              />
+            )}
           </Stack>
 
-          {/* Row 4: 備考 */}
+          {/* Row 4: 同意方法 */}
+          <TextField
+             select
+             size="small"
+             label="同意取得方法"
+             value={consent.consentMethod ?? ''}
+             onChange={(e) =>
+               onConsentChange({
+                 consentMethod: (e.target.value || undefined) as IspConsentDetail['consentMethod'],
+               })
+             }
+             disabled={readOnly}
+             slotProps={{ select: { native: true } }}
+             data-testid="compliance-consent-method"
+          >
+            <option value="">未選択</option>
+            <option value="signature">署名</option>
+            <option value="seal">記名押印</option>
+            <option value="electronic">電子署名</option>
+            <option value="other">その他</option>
+          </TextField>
+
+          {/* Row 5: 備考 */}
           <TextField
             size="small"
             label="同意に関する備考"

--- a/src/features/support-plan-guide/components/tabs/MeetingDetailSection.tsx
+++ b/src/features/support-plan-guide/components/tabs/MeetingDetailSection.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import Paper from '@mui/material/Paper';
+import TextField from '@mui/material/TextField';
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import type { IspMeetingDetail } from '@/domain/isp/schema';
+
+export type MeetingDetailSectionProps = {
+  meeting: IspMeetingDetail;
+  isAdmin: boolean;
+  onChange: (updates: Partial<IspMeetingDetail>) => void;
+};
+
+const MeetingDetailSection: React.FC<MeetingDetailSectionProps> = ({
+  meeting,
+  isAdmin,
+  onChange,
+}) => {
+  const [newAttendee, setNewAttendee] = React.useState('');
+  const readOnly = !isAdmin;
+
+  const handleAddAttendee = () => {
+    if (!newAttendee.trim()) return;
+    onChange({
+      attendees: [...meeting.attendees, newAttendee.trim()],
+    });
+    setNewAttendee('');
+  };
+
+  const handleRemoveAttendee = (index: number) => {
+    const next = [...meeting.attendees];
+    next.splice(index, 1);
+    onChange({ attendees: next });
+  };
+
+  return (
+    <Paper variant="outlined" sx={{ p: 2 }}>
+      <Stack spacing={2}>
+        <Typography variant="subtitle1" fontWeight="bold" color="primary">
+          🤝 サービス担当者会議・照会記録
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          計画作成にあたって実施した会議の実施日、議事内容、出席者を記録します。
+        </Typography>
+
+        <TextField
+          type="date"
+          size="small"
+          label="会議実施日"
+          value={meeting.meetingDate ?? ''}
+          onChange={(e) => onChange({ meetingDate: e.target.value || null })}
+          disabled={readOnly}
+          slotProps={{ inputLabel: { shrink: true } }}
+          sx={{ maxWidth: 200 }}
+          data-testid="compliance-meeting-date"
+        />
+
+        <TextField
+          size="small"
+          label="出席者名簿"
+          placeholder="例: 山田太郎、田中花子..."
+          value={newAttendee}
+          onChange={(e) => setNewAttendee(e.target.value)}
+          disabled={readOnly}
+          onKeyPress={(e) => e.key === 'Enter' && handleAddAttendee()}
+          helperText="氏名を入力してEnterで追加"
+          data-testid="compliance-meeting-attendees-input"
+        />
+
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+          {meeting.attendees.map((name, i) => (
+            <Chip
+              key={`${name}-${i}`}
+              label={name}
+              onDelete={readOnly ? undefined : () => handleRemoveAttendee(i)}
+              size="small"
+            />
+          ))}
+          {meeting.attendees.length === 0 && (
+            <Typography variant="caption" color="text.disabled">
+              出席者が登録されていません
+            </Typography>
+          )}
+        </Box>
+
+        <TextField
+          size="small"
+          label="会議議事要旨"
+          value={meeting.meetingMinutes}
+          onChange={(e) => onChange({ meetingMinutes: e.target.value })}
+          disabled={readOnly}
+          multiline
+          minRows={3}
+          placeholder="例: 本人の移行を再確認し、短期目標の活動頻度について合意した。相談支援事業所よりモニタリング期間の調整あり。"
+          data-testid="compliance-meeting-minutes"
+        />
+      </Stack>
+    </Paper>
+  );
+};
+
+export default React.memo(MeetingDetailSection);

--- a/src/features/support-plan-guide/hooks/useComplianceForm.ts
+++ b/src/features/support-plan-guide/hooks/useComplianceForm.ts
@@ -17,11 +17,13 @@ import type {
   IspComplianceMetadata,
   IspConsentDetail,
   IspDeliveryDetail,
+  IspMeetingDetail,
+  IspConsultationSupport,
 } from '@/domain/isp/schema';
 import {
   ispComplianceMetadataSchema,
 } from '@/domain/isp/schema';
-import type { SupportPlanDraft } from '../types';
+import type { SupportPlanDraft, SupportPlanForm } from '../types';
 
 // ────────────────────────────────────────────
 // Types
@@ -59,6 +61,10 @@ export type UseComplianceFormReturn = {
   updateConsent: (updates: Partial<IspConsentDetail>) => void;
   /** 交付詳細の部分更新 */
   updateDelivery: (updates: Partial<IspDeliveryDetail>) => void;
+  /** 会議詳細の部分更新 */
+  updateMeeting: (updates: Partial<IspMeetingDetail>) => void;
+  /** 相談支援詳細の部分更新 */
+  updateConsultation: (updates: Partial<IspConsultationSupport>) => void;
   /** 標準的提供時間の更新 */
   updateServiceHours: (hours: number | null) => void;
   /** 未入力警告の件数 */
@@ -96,17 +102,42 @@ function extractCompliance(draft: SupportPlanDraft | undefined): ComplianceFormS
 }
 
 /**
- * 監査上重要な未入力フィールドを検出する
+ * 監査上重要な未入力フィールドや不整合を検出する
  */
-function detectMissingFields(compliance: ComplianceFormState): string[] {
+function detectMissingFields(compliance: ComplianceFormState, formData?: Partial<SupportPlanForm>): string[] {
   const missing: string[] = [];
-  const { consent, delivery } = compliance;
+  const { consent, delivery, meeting, consultationSupport, standardServiceHours } = compliance;
 
+  // 同意・交付（最重要）
   if (!consent.explainedAt) missing.push('説明実施日');
   if (!consent.consentedAt) missing.push('同意取得日');
   if (!consent.consentedBy) missing.push('同意者名');
   if (!delivery.deliveredAt) missing.push('交付日');
   if (!delivery.deliveredToUser) missing.push('本人への交付');
+
+  // 代理同意時の理由（監査指摘対策）
+  if ((consent.proxyName || consent.proxyRelation) && !consent.proxyReason) {
+    missing.push('代理同意の理由');
+  }
+
+  // 会議・連携（制度要件）
+  if (!meeting.meetingDate) missing.push('会議実施日');
+  if (!consultationSupport.agencyName) missing.push('相談支援事業所名');
+  if (!consultationSupport.officerName) missing.push('相談支援専門員名');
+  if (!consultationSupport.serviceUsePlanReceivedAt) {
+    missing.push('相談支援からのサービス等利用計画の受領日');
+  }
+
+  // 提供時間
+  if (standardServiceHours === null) missing.push('標準的な支援提供時間');
+
+  // B-1項目: サービス開始日と初回提供日の不整合チェック
+  if (formData?.serviceStartDate && formData?.firstServiceDate) {
+    // 文字列のまま比較可能（YYYY-MM-DD形式想定）
+    if (formData.serviceStartDate > formData.firstServiceDate) {
+      missing.push('⚠️ 契約開始日より前に初回提供日が設定されています');
+    }
+  }
 
   return missing;
 }
@@ -177,6 +208,28 @@ export function useComplianceForm({
     [updateCompliance],
   );
 
+  // ── Meeting updater ──
+  const updateMeeting = React.useCallback(
+    (updates: Partial<IspMeetingDetail>) => {
+      updateCompliance((prev) => ({
+        ...prev,
+        meeting: { ...prev.meeting, ...updates },
+      }));
+    },
+    [updateCompliance],
+  );
+
+  // ── Consultation updater ──
+  const updateConsultation = React.useCallback(
+    (updates: Partial<IspConsultationSupport>) => {
+      updateCompliance((prev) => ({
+        ...prev,
+        consultationSupport: { ...prev.consultationSupport, ...updates },
+      }));
+    },
+    [updateCompliance],
+  );
+
   // ── Service hours updater ──
   const updateServiceHours = React.useCallback(
     (hours: number | null) => {
@@ -190,8 +243,8 @@ export function useComplianceForm({
 
   // ── Missing fields ──
   const missingFields = React.useMemo(
-    () => detectMissingFields(compliance),
-    [compliance],
+    () => detectMissingFields(compliance, activeDraft?.data),
+    [compliance, activeDraft?.data],
   );
 
   // ── Approval state ──
@@ -226,6 +279,8 @@ export function useComplianceForm({
     compliance,
     updateConsent,
     updateDelivery,
+    updateMeeting,
+    updateConsultation,
     updateServiceHours,
     missingFieldCount: missingFields.length,
     missingFields,

--- a/src/features/support-plan-guide/types.ts
+++ b/src/features/support-plan-guide/types.ts
@@ -25,6 +25,16 @@ export type SupportPlanForm = {
   complianceControls: string;
   improvementIdeas: string;
   lastMonitoringDate: string; // 直近のモニタ実施日 (YYYY/MM/DD)
+  /** 医療的配慮事項 */
+  medicalConsiderations: string;
+  /** 緊急時対応計画 */
+  emergencyResponsePlan: string;
+  /** 権利擁護に関する記載 */
+  rightsAdvocacy: string;
+  /** 契約上のサービス開始日 */
+  serviceStartDate: string;
+  /** 実際の初回サービス提供日 */
+  firstServiceDate: string;
   /** 構造化目標データ */
   goals: GoalItem[];
   /**
@@ -155,6 +165,11 @@ export const defaultFormState: SupportPlanForm = {
   complianceControls: '',
   improvementIdeas: '',
   lastMonitoringDate: '',
+  medicalConsiderations: '',
+  emergencyResponsePlan: '',
+  rightsAdvocacy: '',
+  serviceStartDate: '',
+  firstServiceDate: '',
   goals: [],
 };
 
@@ -172,6 +187,11 @@ export const FIELD_LIMITS: Record<SupportPlanStringFieldKey, number> = {
   complianceControls: 700,
   improvementIdeas: 900,
   lastMonitoringDate: 20,
+  medicalConsiderations: 2000,
+  emergencyResponsePlan: 2000,
+  rightsAdvocacy: 2000,
+  serviceStartDate: 20,
+  firstServiceDate: 20,
 };
 
 export const REQUIRED_FIELDS: SupportPlanStringFieldKey[] = [

--- a/src/features/support-plan-guide/utils/helpers.ts
+++ b/src/features/support-plan-guide/utils/helpers.ts
@@ -151,6 +151,11 @@ export const sanitizeForm = (data: Partial<SupportPlanForm> | undefined): Suppor
     sanitized.goals = data.goals;
   }
 
+  // コンプライアンスメタデータの保持
+  if (data.compliance) {
+    sanitized.compliance = data.compliance;
+  }
+
   return sanitized;
 };
 
@@ -197,6 +202,25 @@ export const SECTIONS: SectionConfig[] = [
         placeholder: '例: 2025/04/01 〜 2026/03/31（12か月）',
         helper: '初回は契約後1か月以内の作成、以降6か月以内を目安に更新します。',
         quickPhrases: ['初回作成:  年 月 日 ／ 次回見直し目安:  年 月 日'],
+      },
+      {
+        key: 'serviceStartDate',
+        label: '契約上のサービス開始日',
+        placeholder: 'YYYY-MM-DD',
+        helper: '重要事項説明書等で合意された契約日。',
+      },
+      {
+        key: 'firstServiceDate',
+        label: '実際のサービス初回提供日',
+        placeholder: 'YYYY-MM-DD',
+        helper: '実際にサービス提供を開始した日。',
+      },
+      {
+        key: 'medicalConsiderations',
+        label: '医療的配慮事項',
+        minRows: 3,
+        placeholder: '例: 注入時の排気、嚥下状態に応じた食事提供、吸引頻度…',
+        helper: '主治医等の指示に基づき、安全なサービス提供のために必要な配慮。',
       },
     ],
   },
@@ -314,6 +338,20 @@ export const SECTIONS: SectionConfig[] = [
         placeholder: '例: 初回30日以内未作成 → 契約アラート設定／議事録テンプレ活用…',
         helper: '遅延、本人不参加、同意未取得、モニタ未実施などの対策を列挙。',
         quickPhrases: ['リスク: 作成遅延／対策: タスク自動通知', 'リスク: 同意書未保管／対策: 電子署名ログ保存'],
+      },
+      {
+        key: 'emergencyResponsePlan',
+        label: '緊急時対応計画',
+        minRows: 3,
+        placeholder: '例: 喘息発作時は吸入器を使用、家族・主治医へ即時連絡…',
+        helper: '急変時、パニック時等の具体的な連絡先と対応手順。',
+      },
+      {
+        key: 'rightsAdvocacy',
+        label: '権利擁護・虐待防止',
+        minRows: 2,
+        placeholder: '例: 身体拘束の禁止を徹底、セルフプランの推奨…',
+        helper: '虐待防止、セルフネグレクト対応、意思決定支援の具体的な取り組み。',
       },
       {
         key: 'complianceControls',

--- a/src/features/support-plan-guide/utils/markdownExport.ts
+++ b/src/features/support-plan-guide/utils/markdownExport.ts
@@ -65,7 +65,10 @@ function buildFormSections(form: SupportPlanForm): MdSection[] {
       lines: [
         form.serviceUserName && `- 利用者名: ${form.serviceUserName}`,
         form.supportLevel && `- 支援区分 / 医療等: ${form.supportLevel}`,
+        form.serviceStartDate && `- 契約開始日: ${form.serviceStartDate}`,
+        form.firstServiceDate && `- 実際の初回提供日: ${form.firstServiceDate}`,
         form.planPeriod && `- 計画期間: ${form.planPeriod}`,
+        form.medicalConsiderations && `\n**医療的配慮事項**\n${form.medicalConsiderations}`,
       ].filter(Boolean) as string[],
     },
     {
@@ -99,9 +102,11 @@ function buildFormSections(form: SupportPlanForm): MdSection[] {
       ].filter(Boolean) as string[],
     },
     {
-      title: '減算リスク対策',
+      title: '減算リスク対策・緊急対応',
       lines: [
         form.riskManagement && `リスク管理: ${form.riskManagement}`,
+        form.emergencyResponsePlan && `緊急時対応計画: ${form.emergencyResponsePlan}`,
+        form.rightsAdvocacy && `権利擁護: ${form.rightsAdvocacy}`,
         form.complianceControls && `コンプラ対策: ${form.complianceControls}`,
       ].filter(Boolean) as string[],
     },
@@ -145,8 +150,13 @@ function buildComplianceSection(compliance: IspComplianceMetadata | null): MdSec
     return { title: '制度適合（コンプライアンス）', lines: [] };
   }
 
-  const { consent, delivery, approval } = compliance;
+  const { consent, delivery, approval, meeting, consultationSupport, standardServiceHours } = compliance;
   const lines: string[] = [];
+
+  // 基本サービス
+  if (standardServiceHours) {
+    lines.push(`- 標準支援提供時間: ${standardServiceHours}時間`);
+  }
 
   // 同意記録
   lines.push('### 同意記録');
@@ -156,6 +166,16 @@ function buildComplianceSection(compliance: IspComplianceMetadata | null): MdSec
   if (consent.consentedBy) lines.push(`- 同意者: ${consent.consentedBy}`);
   if (consent.proxyName) {
     lines.push(`- 代理人: ${consent.proxyName}${consent.proxyRelation ? `（${consent.proxyRelation}）` : ''}`);
+    if (consent.proxyReason) lines.push(`  - 代理同意理由: ${consent.proxyReason}`);
+  }
+  if (consent.consentMethod) {
+    const methods: Record<string, string> = {
+      signature: '署名',
+      seal: '記名押印',
+      electronic: '電子署名',
+      other: 'その他',
+    };
+    lines.push(`- 同意方法: ${methods[consent.consentMethod] || consent.consentMethod}`);
   }
   if (consent.notes) lines.push(`- 備考: ${consent.notes}`);
 
@@ -166,6 +186,19 @@ function buildComplianceSection(compliance: IspComplianceMetadata | null): MdSec
   lines.push(`- 相談支援専門員への交付: ${delivery.deliveredToConsultationSupport ? '✓ 済' : '✗ 未'}`);
   if (delivery.deliveryMethod) lines.push(`- 交付方法: ${delivery.deliveryMethod}`);
   if (delivery.notes) lines.push(`- 備考: ${delivery.notes}`);
+
+  // 会議記録
+  lines.push('### サービス担当者会議記録');
+  lines.push(`- 実施日: ${formatIsoDate(meeting.meetingDate)}`);
+  if (meeting.attendees.length > 0) lines.push(`- 出席者: ${meeting.attendees.join(', ')}`);
+  if (meeting.meetingMinutes) lines.push(`- 議事要旨: ${meeting.meetingMinutes}`);
+
+  // 相談支援連携
+  lines.push('### 相談支援連携');
+  if (consultationSupport.agencyName) lines.push(`- 相談支援事業所: ${consultationSupport.agencyName}`);
+  if (consultationSupport.officerName) lines.push(`- 相談支援専門員: ${consultationSupport.officerName}`);
+  lines.push(`- 利用計画受領日: ${formatIsoDate(consultationSupport.serviceUsePlanReceivedAt)}`);
+  if (consultationSupport.gapNotes) lines.push(`- 利用計画との不整合メモ: ${consultationSupport.gapNotes}`);
 
   // 承認記録
   lines.push('### 承認記録');


### PR DESCRIPTION
## Scope
⚠️ **Notice**: この PR の作業ブランチ名は `feat/analysis-dashboard-stabilization` ですが、含まれる変更の主目的は **「ISP コンプライアンスメタデータの統合と監査証跡 UI の刷新」** です。既存のダッシュボード機能への影響はなく、ISP 機能の非破壊的な増強のみを含みます。

## Summary
- 生活介護の実務で必要な監査証跡を、既存 ISP 実装を壊さずに追加
- `compliance` の保存・復元経路を補強し、構造化データのサイレントドロップを防止
- コンプライアンスタブを「同意・交付」「会議記録」「相談支援連携」の 3 セクションに整理
- 保存ブロックではなく Warning ベースで、監査上の未記録や整合性不備を可視化

## What changed

### Schema / Domain
- ISP 本文に以下を追加 (`medicalConsiderations`, `emergencyResponsePlan`, `rightsAdvocacy`, `serviceStartDate`, `firstServiceDate`)
- Compliance metadata を拡張 (`consent.proxyReason`, `consent.consentMethod`, `meeting`, `consultationSupport`)
- 既存データ互換を維持するため、新規項目は default 補完対応
- SharePoint の列スキーマ変更はなし

### Mapping / Serialization
- `sanitizeForm` を更新し、`compliance` を明示的に保持
- `FIELD_LIMITS` を更新し、新規項目を編集可能に反映

### UI / Warning Logic
- コンプライアンスタブを 3 セクションに再編し、出席者管理（Chip形式）を導入
- 以下の不整合・不足を Warning 表示
  - 代理同意時の理由欠落 / 会議実施日の未入力
  - 相談支援からの計画受領日未入力 
  - 契約開始日 > 初回提供日の日付逆転

## Backward compatibility
- 既存のドラフトデータは引き続きパース可能（オートアップデート）
- SharePoint 側の追加列変更・migration 不要

## Validation
- `npx vitest src/domain/isp/__tests__/schema.spec.ts` (191 tests passed)
- 既存 payload の復元および、whitelist 点検による保全動作を確認済