### PR TITLE
feat(sp): emit provision_partial telemetry with failed field details

### DIFF
--- a/src/lib/sp/spListSchema.ts
+++ b/src/lib/sp/spListSchema.ts
@@ -24,6 +24,8 @@ import type {
     EnsureListOptions,
     EnsureListResult,
     ExistingFieldShape,
+    FailedFieldInfo,
+    FailedFieldReason,
     FieldsCacheEntry,
     SharePointListMetadata,
     SpFieldDef,
@@ -231,23 +233,63 @@ export async function getListFieldInternalNames(
  * Detects SharePoint 8KB row size limit errors.
  * Includes both English and Japanese error strings seen in production.
  */
+/**
+ * Detects SharePoint indexed-column-count limit errors.
+ * Distinct from row-size limit: caused by exceeding the max number of indexed columns per list (~20).
+ */
+function isIndexedColumnLimitError(errText: string): boolean {
+  return (
+    errText.includes('indexed columns') && errText.includes('maximum') ||
+    errText.includes('インデックス処理されている列の数が最大限') ||
+    errText.includes('この列をインデックス処理できません')
+  );
+}
+
+function classifyFieldError(errText: string): FailedFieldReason {
+  if (isIndexedColumnLimitError(errText)) return 'indexed_column_limit';
+  if (isRowSizeLimitError(errText)) return 'row_size_limit';
+  return 'http_error';
+}
+
+function extractHttpStatus(error: unknown): number | undefined {
+  if (typeof error === 'object' && error && 'status' in error) {
+    const s = (error as { status?: unknown }).status;
+    if (typeof s === 'number') return s;
+  }
+  return undefined;
+}
+
 function isRowSizeLimitError(errText: string): boolean {
   return (
     errText.includes('maximum for this list') ||
     errText.includes('reached the limit') ||
     errText.includes('合計サイズが制限を超えている') ||
-    errText.includes('制限を超えているので、列を追加できません')
+    errText.includes('制限を超えているので、列を追加できません') ||
+    errText.includes('まず、他の列をいくつか削除')
   );
+}
+
+export type AddFieldStatus = 'success' | 'limit_reached' | 'indexed_limit' | 'error';
+
+export interface AddFieldResult {
+  status: AddFieldStatus;
+  reason?: FailedFieldReason;
+  httpStatus?: number;
+  detail?: string;
 }
 
 /**
  * Add a single field to a list using the CreateFieldAsXml endpoint.
+ *
+ * Note: `spFetch` raises on non-OK responses, so classification happens in the catch
+ * block. The `if (!res.ok)` branch below is defensive in case spFetch is ever changed
+ * to return without throwing.
  */
 export async function addFieldToList(
   spFetch: SpFetchFn,
   listTitle: string,
   field: SpFieldDef,
-): Promise<"success" | "limit_reached" | "error"> {
+): Promise<AddFieldResult> {
   const base = resolveListPath(listTitle);
   const schema = buildFieldSchema(field);
   const body = {
@@ -269,27 +311,43 @@ export async function addFieldToList(
     });
     if (!res.ok) {
       const errText = await res.text().catch(() => '');
-      const isLimit = isRowSizeLimitError(errText);
-      const isConflict = errText.includes('already exists') || errText.includes('in use');
-      
-      if (isLimit || res.status === 400 || res.status === 500) {
-        auditLog.warn('sp:fields', 'schema_provision_failed', { 
-          listTitle, 
-          field: field.internalName,
-          status: res.status,
-          isLimit,
-          isConflict,
-          detail: errText.slice(0, 500)
-        });
-        return isLimit ? "limit_reached" : "error";
-      }
-
-      return "error";
+      const reason = classifyFieldError(errText);
+      auditLog.warn('sp:fields', 'schema_provision_failed', {
+        listTitle,
+        field: field.internalName,
+        status: res.status,
+        reason,
+        detail: errText.slice(0, 500),
+      });
+      return {
+        status: reason === 'row_size_limit' ? 'limit_reached'
+              : reason === 'indexed_column_limit' ? 'indexed_limit'
+              : 'error',
+        reason,
+        httpStatus: res.status,
+        detail: errText.slice(0, 500),
+      };
     }
-    return "success";
+    return { status: 'success' };
   } catch (error) {
-    console.error(`[addFieldToList] Unexpected error adding field "${field.internalName}":`, error);
-    return "error";
+    const message = error instanceof Error ? error.message : String(error);
+    const reason = classifyFieldError(message);
+    const httpStatus = extractHttpStatus(error);
+    auditLog.warn('sp:fields', 'schema_provision_failed', {
+      listTitle,
+      field: field.internalName,
+      status: httpStatus,
+      reason,
+      detail: message.slice(0, 500),
+    });
+    return {
+      status: reason === 'row_size_limit' ? 'limit_reached'
+            : reason === 'indexed_column_limit' ? 'indexed_limit'
+            : 'error',
+      reason,
+      httpStatus,
+      detail: message.slice(0, 500),
+    };
   }
 }
 
@@ -397,6 +455,7 @@ export async function ensureListExists(
   }
 
   let isLimitReached = false;
+  const failedFields: FailedFieldInfo[] = [];
 
   if (fields.length && !options.preventPhysicalCreation) {
     const existing = await fetchExistingFields(spFetch, listTitle);
@@ -420,33 +479,51 @@ export async function ensureListExists(
       const fieldResult = resolution.fieldStatus[field.internalName];
       if (fieldResult?.resolvedName) {
         // Drift detected! Use existing suffixed or truncated column instead of proliferating
-        auditLog.warn('sp:fields', 'schema_drift_detected', { 
-          listTitle, 
-          expected: field.internalName, 
+        auditLog.warn('sp:fields', 'schema_drift_detected', {
+          listTitle,
+          expected: field.internalName,
           actual: fieldResult.resolvedName,
           driftType: fieldResult.driftType
         });
         continue;
       }
 
+      const isRequired = Boolean(field.required || field.forceCreate);
+
       // 3. Physical creation (Only if truly unknown after drift check)
-      if ((!field.required && !field.forceCreate) || isLimitReached) {
-        auditLog.warn('sp:fields', 'provisioning_blocked', { 
-          listTitle, 
+      if (!isRequired || isLimitReached) {
+        auditLog.warn('sp:fields', 'provisioning_blocked', {
+          listTitle,
           field: field.internalName,
-          cause: isLimitReached ? "row_limit" : "optional_field"
+          cause: isLimitReached ? 'row_limit' : 'optional_field',
         });
+        if (isLimitReached && isRequired) {
+          failedFields.push({
+            internalName: field.internalName,
+            required: true,
+            reason: 'row_size_limit',
+            detail: 'Skipped because a prior field in the same list hit the row-size limit.',
+          });
+        }
         continue;
       }
 
-      console.error('[DEBUG] ensureListExists: about to add field', field.internalName);
       const result = await addFieldToList(spFetch, listTitle, field);
-      console.error('[DEBUG] ensureListExists: addFieldToList result', result);
-      if (result === "limit_reached") {
+      if (result.status === 'success') continue;
+
+      if (result.status === 'limit_reached') {
         isLimitReached = true;
       }
+      failedFields.push({
+        internalName: field.internalName,
+        required: isRequired,
+        reason: result.reason ?? 'unknown',
+        status: result.httpStatus,
+        detail: result.detail,
+      });
     }
   }
 
-  return ensured ?? { listId: '', title: listTitle };
+  const base = ensured ?? { listId: '', title: listTitle };
+  return failedFields.length ? { ...base, failedFields } : base;
 }

--- a/src/lib/sp/spProvisioningService.ts
+++ b/src/lib/sp/spProvisioningService.ts
@@ -19,6 +19,10 @@ export class SpProvisioningService {
 
   /**
    * リストの存在を保証し、必要に応じて作成・フィールド追加を行う。
+   *
+   * 物理的な列追加が一部失敗した場合、`ensureListExists` は throw せずに
+   * `failedFields` を返す。必須列が失敗した場合は `sp:provision_partial` を発火し、
+   * 観測性を保ったまま fail-soft を維持する。
    */
   async ensureList(
     listTitle: string,
@@ -27,21 +31,42 @@ export class SpProvisioningService {
   ): Promise<EnsureListResult> {
     try {
       const result = await _ensureListExists(this.spFetch, listTitle, fields, options);
-      
-      trackSpEvent('sp:provision_success', {
-        listName: listTitle,
-        details: { listId: result.listId, fieldCount: fields.length }
-      });
-      
+
+      const failed = result.failedFields ?? [];
+      const requiredFailures = failed.filter(f => f.required);
+
+      if (requiredFailures.length > 0) {
+        trackSpEvent('sp:provision_partial', {
+          listName: listTitle,
+          details: {
+            listId: result.listId,
+            fieldCount: fields.length,
+            failedCount: failed.length,
+            requiredFailedCount: requiredFailures.length,
+            failedFields: failed,
+          },
+          error: `${requiredFailures.length} required field(s) failed: ${requiredFailures.map(f => f.internalName).join(', ')}`,
+        });
+      } else {
+        trackSpEvent('sp:provision_success', {
+          listName: listTitle,
+          details: {
+            listId: result.listId,
+            fieldCount: fields.length,
+            optionalFailedCount: failed.length,
+          },
+        });
+      }
+
       return result;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      
+
       trackSpEvent('sp:provision_failed', {
         listName: listTitle,
         error: message
       });
-      
+
       throw error;
     }
   }

--- a/src/lib/sp/types.ts
+++ b/src/lib/sp/types.ts
@@ -111,9 +111,25 @@ export interface ExistingFieldShape {
   Required?: boolean;
 }
 
+export type FailedFieldReason =
+  | 'row_size_limit'
+  | 'indexed_column_limit'
+  | 'http_error'
+  | 'unknown';
+
+export interface FailedFieldInfo {
+  internalName: string;
+  required: boolean;
+  reason: FailedFieldReason;
+  status?: number;
+  detail?: string;
+}
+
 export interface EnsureListResult {
   listId: string;
   title: string;
+  /** Fields that were attempted but not physically created. Present only when at least one attempt failed. */
+  failedFields?: FailedFieldInfo[];
 }
 
 export interface SharePointListMetadata {

--- a/src/lib/telemetry/spTelemetry.ts
+++ b/src/lib/telemetry/spTelemetry.ts
@@ -12,6 +12,7 @@ export type SpEventName =
   | 'sp:list_missing_optional'
   | 'sp:list_missing_required'
   | 'sp:provision_success'
+  | 'sp:provision_partial'
   | 'sp:provision_failed'
   | 'sp:guid_resolution'
   | 'sp:schema_mismatch'


### PR DESCRIPTION
## Summary

- Add structured failed-field reporting to SharePoint provisioning results
- Classify field-creation failures by `reason` (`row_size_limit` / `indexed_column_limit` / `http_error`) and HTTP status
- Emit `sp:provision_partial` when **required** fields fail during bootstrap, distinct from `sp:provision_success`
- Preserve fail-soft startup behavior while removing the silent-success bug

## Why

In production the bootstrap path was emitting `sp:provision_success` even when `Approval_Logs` / `User_Feature_Flags` / `SupportProcedure_Results` could not add required columns (`ApprovedBy`, `ApprovedAt`, `FlagKey`, `ResultDate`, etc.) due to SharePoint's 8KB row-size limit and the indexed-column-count limit. Root cause: `spFetch` raises on non-OK responses, so `addFieldToList`'s `if (!res.ok)` branch was dead code and every error fell into the `catch` block returning a flat `"error"`. `SpProvisioningService.ensureList` then trusted the no-throw completion as success.

The effect was that ops dashboards saw green while schemas were physically incomplete — the hardest class of failure to diagnose.

## Changes

- [src/lib/sp/types.ts](src/lib/sp/types.ts) — new `FailedFieldInfo` / `FailedFieldReason` types; `EnsureListResult` gains optional `failedFields`
- [src/lib/sp/spListSchema.ts](src/lib/sp/spListSchema.ts) — `classifyFieldError` / `isIndexedColumnLimitError` / `extractHttpStatus` helpers; `addFieldToList` returns structured `AddFieldResult`; classification now runs inside the `catch` block where errors actually land; `ensureListExists` collects failed fields and attaches them to the result; debug `console.error` removed
- [src/lib/telemetry/spTelemetry.ts](src/lib/telemetry/spTelemetry.ts) — new `sp:provision_partial` event name
- [src/lib/sp/spProvisioningService.ts](src/lib/sp/spProvisioningService.ts) — inspects `result.failedFields`; emits `sp:provision_partial` (with per-field `internalName`, `reason`, `httpStatus`, `detail`) when any required field failed, otherwise keeps emitting `sp:provision_success` with a new `optionalFailedCount`

## Review focus

- Does fail-soft startup behavior remain intact? (no new throws on field-creation failures)
- Is `sp:provision_partial` emitted **only** when at least one `required` / `forceCreate` field failed?
- Does the `AddFieldResult` type change break any existing callers? (verified: `governanceRepairExecutor` and `SpPersistentDriftPanel` both `await` without inspecting the return value)
- Is the row-size-limit vs indexed-column-limit classification sound? (both English and Japanese error strings covered)
- Is the fallthrough path correct when `isLimitReached` becomes true mid-loop? (required-but-skipped fields are now recorded with reason `row_size_limit`)

## Test plan

- [x] `npx vitest run src/lib/sp` — 4 files / 25 tests passing
- [x] `npx tsc --noEmit` — zero errors in the 4 changed files (pre-existing errors elsewhere are unrelated)
- [ ] Manual verification: trigger bootstrap against a tenant with a saturated `Approval_Logs` list and confirm `sp:provision_partial` fires with the expected `failedFields` payload
- [ ] Confirm dashboards that consume `sp:provision_success` still interpret the new `optionalFailedCount` detail field gracefully

## Follow-ups (separate PRs)

- **STEP 2a**: `zombie-column-purger.mjs` dry-run inventory + admin work-list generation for the 3 saturated lists (row-size path)
- **STEP 2b**: indexed-column-limit recovery for `ApprovedAt` (needs a different remediation — drop unused indexes or accept non-indexed creation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)