### PR TITLE
feat(ops): add zombie column audit mode and generate dry-run inventory reports

### DIFF
--- a/artifacts/zombie-audit/Approval_Logs.csv
+++ b/artifacts/zombie-audit/Approval_Logs.csv
@@ -1,0 +1,346 @@
+ListName,InternalName,DisplayName,TypeAsString,Hidden,ReadOnly,FromBaseType,Indexed,Classification,Reason,RecommendedAction
+Approval_Logs,ContentTypeId,コンテンツ タイプの ID,ContentTypeId,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,Title,タイトル,Text,false,false,true,false,keep_system,FromBaseType=true,KEEP
+Approval_Logs,_ModerationComments,承認者のコメント,Note,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,File_x0020_Type,ファイルの種類,Text,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,_ColorHex,色,Text,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,_ColorTag,色タグ,Text,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,_Emoji,絵文字,Text,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,ComplianceAssetId,コンプライアンス資産 ID,Text,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,ParentScheduleId,親スケジュールID,Number,false,false,false,true,keep_ssot,Exact match with SSOT,KEEP
+Approval_Logs,_x627f__x8a8d__x65e5__x6642_,承認日時,DateTime,false,false,false,true,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30e1__x30e2_,承認メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x300,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x65e5__x6642_1,承認日時,DateTime,false,false,false,true,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x300,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x30,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x65e5__x6642_0,承認日時,DateTime,false,false,false,true,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x30,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x301,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x65e5__x6642_2,承認日時,DateTime,false,false,false,true,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x301,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x302,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x65e5__x6642_3,承認日時,DateTime,false,false,false,true,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x302,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x303,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x65e5__x6642_4,承認日時,DateTime,false,false,false,true,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x303,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x304,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x65e5__x6642_5,承認日時,DateTime,false,false,false,true,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x304,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x305,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x65e5__x6642_6,承認日時,DateTime,false,false,false,true,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x305,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x306,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x65e5__x6642_7,承認日時,DateTime,false,false,false,true,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x306,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x307,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x65e5__x6642_8,承認日時,DateTime,false,false,false,true,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x307,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x308,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x65e5__x6642_9,承認日時,DateTime,false,false,false,true,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x308,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x309,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x65e5__x6642_10,承認日時,DateTime,false,false,false,true,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x309,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3010,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x65e5__x6642_11,承認日時,DateTime,false,false,false,true,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3010,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3011,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x65e5__x6642_12,承認日時,DateTime,false,false,false,true,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3011,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3012,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x65e5__x6642_13,承認日時,DateTime,false,false,false,true,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3012,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3013,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x65e5__x6642_14,承認日時,DateTime,false,false,false,true,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3013,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3014,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x65e5__x6642_15,承認日時,DateTime,false,false,false,true,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3014,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3015,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x65e5__x6642_16,承認日時,DateTime,false,false,false,true,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3015,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3016,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x65e5__x6642_17,承認日時,DateTime,false,false,false,true,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3016,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3017,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3017,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3018,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3018,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3019,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3019,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3020,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3021,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3020,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3021,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3022,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3022,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3023,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3023,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3024,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3024,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3025,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3025,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3026,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3026,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3027,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3027,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3028,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3028,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3029,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3029,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3030,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3030,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3031,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3031,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3032,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3032,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3033,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3033,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3034,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3034,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3035,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3035,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3036,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3036,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3037,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3037,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3038,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3038,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3039,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3039,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3040,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3040,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3041,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3041,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3042,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3042,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3043,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3043,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3044,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3044,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3045,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3045,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3046,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3046,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3047,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3047,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3048,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3048,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3049,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3049,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3050,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3050,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3051,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3051,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3052,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3052,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3053,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3053,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3054,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3054,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3055,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3055,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3056,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3056,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3057,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3057,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3058,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3058,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3059,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3059,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3060,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3060,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3061,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3061,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3062,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3062,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3063,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3063,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3064,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3064,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3065,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3065,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3066,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3066,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3067,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3067,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3068,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3068,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3069,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3069,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3070,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3070,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3071,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3071,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3072,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3072,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3073,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3073,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3074,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3074,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3075,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3075,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3076,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3076,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3077,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3077,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3078,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3078,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3079,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3079,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3080,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3080,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3081,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3081,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3082,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3082,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3083,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3083,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3084,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3084,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3085,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3085,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3086,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3086,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3087,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3087,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3088,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3088,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3089,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3089,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3090,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3090,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3091,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3091,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3092,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3092,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3093,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3093,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3094,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3094,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3095,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3095,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3096,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3096,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3097,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3097,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3098,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3098,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x3099,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x3099,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x30100,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x30100,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x30101,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x30101,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x30102,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x30102,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x30103,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x30103,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x30104,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x30104,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x30105,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x30105,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x30106,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x30106,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x30107,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x30107,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x30108,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x30108,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x30109,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x30109,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x30110,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x30110,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x30111,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x30111,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x30112,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x30112,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x30113,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x30113,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x30114,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x30114,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x30115,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x30115,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x30116,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x30116,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x30117,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x8005__x30b3__x30117,承認者コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,_x627f__x8a8d__x30a2__x30af__x30118,承認アクション,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+Approval_Logs,ID,ID,Counter,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,ContentType,コンテンツ タイプ,Computed,false,false,true,false,keep_system,FromBaseType=true,KEEP
+Approval_Logs,Modified,更新日時,DateTime,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,Created,登録日時,DateTime,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,Author,登録者,User,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,Editor,更新者,User,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,_HasCopyDestinations,コピー先の有無,Boolean,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,_CopySource,コピー元,Text,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,owshiddenversion,owshiddenversion,Integer,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,WorkflowVersion,ワークフローのバージョン,Integer,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,_UIVersion,UI バージョン,Integer,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,_UIVersionString,バージョン,Text,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,Attachments,添付ファイル,Attachments,false,false,true,false,keep_system,FromBaseType=true,KEEP
+Approval_Logs,_ModerationStatus,承認の状況,ModStat,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,Edit,編集,Computed,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,LinkTitleNoMenu,タイトル,Computed,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,LinkTitle,タイトル,Computed,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,LinkTitle2,タイトル,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,SelectTitle,選択,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,InstanceID,インスタンス ID,Integer,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,Order,順序,Number,true,false,true,false,keep_system,"Hidden=true, FromBaseType=true",KEEP
+Approval_Logs,GUID,GUID,Guid,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,WorkflowInstanceID,ワークフロー インスタンス ID,Guid,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,FileRef,URL パス,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,FileDirRef,パス,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,Last_x0020_Modified,更新日時,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,Created_x0020_Date,登録日時,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,FSObjType,アイテムの種類,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,SortBehavior,並べ替えの種類,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,PermMask,有効な権限マスク,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,PrincipalCount,プリンシパルの数,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,FileLeafRef,名前,File,true,false,true,false,keep_system,"Hidden=true, FromBaseType=true",KEEP
+Approval_Logs,UniqueId,固有 ID,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,ParentUniqueId,ドキュメントの親 ID,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,SyncClientId,クライアント ID,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,ProgId,ProgId,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,ScopeId,ScopeId,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,HTML_x0020_File_x0020_Type,HTML ファイルの種類,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,_EditMenuTableStart,メニュー テーブルの編集の開始,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,_EditMenuTableStart2,メニュー テーブルの編集の開始,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,_EditMenuTableEnd,メニュー テーブルの編集の終了,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,LinkFilenameNoMenu,名前,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,LinkFilename,名前,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,LinkFilename2,名前,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,DocIcon,種類,Computed,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,ServerUrl,サーバーの相対 URL,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,EncodedAbsUrl,エンコードされた絶対 URL,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,BaseName,ファイル名,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,MetaInfo,プロパティ バッグ,Lookup,true,false,true,false,keep_system,"Hidden=true, FromBaseType=true",KEEP
+Approval_Logs,_Level,レベル,Integer,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,_IsCurrentVersion,現在のバージョン,Boolean,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,ItemChildCount,子アイテムの数,Lookup,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,FolderChildCount,子フォルダーの数,Lookup,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,Restricted,制限付き,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,OriginatorId,発信者 ID,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,NoExecute,NoExecute,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,ContentVersion,コンテンツのバージョン,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,_ComplianceFlags,ラベルの設定,Lookup,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,_ComplianceTag,保持ラベル,Lookup,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,_ComplianceTagWrittenTime,保持ラベルを適用済み,Lookup,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,_ComplianceTagUserId,ラベルの適用者,Lookup,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,_IsRecord,レコードとして登録されているアイテム,Computed,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,AccessPolicy,アクセス ポリシー,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,_VirusStatus,VirusStatus,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,_VirusVendorID,VirusVendorID,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,_VirusInfo,VirusInfo,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,_RansomwareAnomalyMetaInfo,RansomwareAnomalyMetaInfo,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,_DraftOwnerId,下書き所有者 ID,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,MainLinkSettings,メイン リンクの設定,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,AppAuthor,アプリの作成者,Lookup,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,AppEditor,アプリの変更者,Lookup,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,SMTotalSize,合計サイズ,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,SMLastModifiedDate,最終更新日,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,SMTotalFileStreamSize,ファイル ストリームの合計サイズ,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,SMTotalFileCount,合計ファイル数,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+Approval_Logs,_CommentFlags,コメントの設定,Lookup,true,true,false,false,keep_system,"Hidden=true, ReadOnly=true",KEEP
+Approval_Logs,_CommentCount,コメント数,Lookup,true,true,false,false,keep_system,"Hidden=true, ReadOnly=true",KEEP

--- a/artifacts/zombie-audit/Approval_Logs.md
+++ b/artifacts/zombie-audit/Approval_Logs.md
@@ -1,0 +1,303 @@
+# Zombie Column Audit — Approval_Logs
+
+**Scan timestamp**: 2026-04-11T09:23:12.012Z
+**SSOT source**: `src/sharepoint/fields/childListSchemas.ts` @ 9c749694
+**Total fields on list**: 345
+
+## Classification summary
+
+| Tier | Count |
+|---|---|
+| `keep_ssot` | 1 |
+| `keep_system` | 85 |
+| `drift_suffix` | 0 |
+| `drift_encoded` | 259 |
+| `legacy_unknown` | 0 |
+
+## 🔴 Deletion candidates (auto-detected zombies)
+
+| InternalName | DisplayName | Type | Classification | Reason |
+|---|---|---|---|---|
+| `_x627f__x8a8d__x65e5__x6642_` | 承認日時 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30e1__x30e2_` | 承認メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x300` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x65e5__x6642_1` | 承認日時 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x300` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x30` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x65e5__x6642_0` | 承認日時 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x30` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x301` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x65e5__x6642_2` | 承認日時 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x301` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x302` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x65e5__x6642_3` | 承認日時 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x302` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x303` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x65e5__x6642_4` | 承認日時 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x303` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x304` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x65e5__x6642_5` | 承認日時 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x304` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x305` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x65e5__x6642_6` | 承認日時 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x305` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x306` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x65e5__x6642_7` | 承認日時 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x306` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x307` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x65e5__x6642_8` | 承認日時 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x307` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x308` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x65e5__x6642_9` | 承認日時 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x308` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x309` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x65e5__x6642_10` | 承認日時 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x309` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3010` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x65e5__x6642_11` | 承認日時 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3010` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3011` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x65e5__x6642_12` | 承認日時 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3011` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3012` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x65e5__x6642_13` | 承認日時 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3012` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3013` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x65e5__x6642_14` | 承認日時 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3013` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3014` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x65e5__x6642_15` | 承認日時 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3014` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3015` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x65e5__x6642_16` | 承認日時 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3015` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3016` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x65e5__x6642_17` | 承認日時 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3016` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3017` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3017` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3018` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3018` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3019` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3019` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3020` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3021` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3020` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3021` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3022` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3022` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3023` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3023` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3024` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3024` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3025` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3025` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3026` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3026` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3027` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3027` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3028` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3028` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3029` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3029` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3030` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3030` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3031` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3031` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3032` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3032` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3033` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3033` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3034` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3034` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3035` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3035` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3036` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3036` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3037` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3037` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3038` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3038` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3039` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3039` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3040` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3040` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3041` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3041` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3042` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3042` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3043` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3043` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3044` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3044` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3045` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3045` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3046` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3046` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3047` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3047` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3048` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3048` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3049` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3049` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3050` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3050` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3051` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3051` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3052` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3052` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3053` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3053` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3054` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3054` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3055` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3055` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3056` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3056` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3057` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3057` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3058` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3058` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3059` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3059` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3060` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3060` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3061` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3061` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3062` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3062` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3063` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3063` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3064` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3064` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3065` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3065` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3066` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3066` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3067` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3067` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3068` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3068` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3069` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3069` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3070` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3070` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3071` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3071` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3072` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3072` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3073` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3073` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3074` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3074` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3075` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3075` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3076` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3076` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3077` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3077` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3078` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3078` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3079` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3079` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3080` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3080` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3081` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3081` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3082` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3082` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3083` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3083` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3084` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3084` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3085` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3085` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3086` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3086` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3087` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3087` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3088` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3088` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3089` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3089` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3090` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3090` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3091` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3091` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3092` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3092` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3093` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3093` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3094` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3094` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3095` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3095` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3096` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3096` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3097` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3097` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3098` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3098` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x3099` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x3099` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x30100` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x30100` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x30101` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x30101` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x30102` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x30102` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x30103` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x30103` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x30104` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x30104` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x30105` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x30105` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x30106` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x30106` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x30107` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x30107` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x30108` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x30108` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x30109` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x30109` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x30110` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x30110` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x30111` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x30111` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x30112` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x30112` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x30113` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x30113` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x30114` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x30114` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x30115` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x30115` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x30116` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x30116` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x30117` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x8005__x30b3__x30117` | 承認者コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x627f__x8a8d__x30a2__x30af__x30118` | 承認アクション | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+
+### UI deletion path
+
+1. SharePoint サイト: https://isogokatudouhome.sharepoint.com/sites/welfare
+2. リスト設定 → "Approval_Logs" → 列
+3. 上表の InternalName と一致する列をクリック → 削除
+4. ⚠️ **削除前に必ず `Hidden=false` / `ReadOnly=false` / `FromBaseType=false` であることを UI 側でも再確認**
+
+## 🟡 Manual review required (legacy_unknown)
+
+_None._
+
+## 🟢 Keep list (do NOT delete)
+
+### SSOT canonical columns (1)
+
+| InternalName | DisplayName | Type |
+|---|---|---|
+| `ParentScheduleId` | 親スケジュールID | Number |
+
+### System / built-in columns (85)
+
+_Hidden / ReadOnly / FromBaseType = true — SharePoint が管理する列。削除禁止。_
+

--- a/artifacts/zombie-audit/SupportProcedure_Results.csv
+++ b/artifacts/zombie-audit/SupportProcedure_Results.csv
@@ -1,0 +1,399 @@
+ListName,InternalName,DisplayName,TypeAsString,Hidden,ReadOnly,FromBaseType,Indexed,Classification,Reason,RecommendedAction
+SupportProcedure_Results,ContentTypeId,コンテンツ タイプの ID,ContentTypeId,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,Title,タイトル,Text,false,false,true,false,keep_system,FromBaseType=true,KEEP
+SupportProcedure_Results,_ModerationComments,承認者のコメント,Note,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,File_x0020_Type,ファイルの種類,Text,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,_ColorHex,色,Text,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,_ColorTag,色タグ,Text,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,_Emoji,絵文字,Text,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,ComplianceAssetId,コンプライアンス資産 ID,Text,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,ParentScheduleId,親スケジュールID,Number,false,false,false,true,keep_ssot,Exact match with SSOT,KEEP
+SupportProcedure_Results,_x7d50__x679c__x65e5_,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x30,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x30,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_0,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x300,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_0,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x300,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_1,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x301,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_1,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x301,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_2,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x302,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_2,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x302,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_3,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x303,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_3,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x303,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_4,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x304,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_4,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x304,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_5,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x305,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_5,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x305,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_6,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x306,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_6,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x306,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_7,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x307,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_7,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x307,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_8,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x308,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_8,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x308,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_9,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x309,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_9,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x309,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_10,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3010,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_10,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3010,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_11,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3011,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_11,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3011,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_12,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3012,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_12,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3012,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_13,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3013,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_13,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3013,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_14,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3014,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_14,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3014,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_15,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3015,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_15,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3015,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_16,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3016,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_16,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3016,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_17,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3017,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_17,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3017,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_18,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3018,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_18,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3018,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_19,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3019,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_19,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3019,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_20,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3020,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_20,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3020,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_21,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3021,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_21,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3021,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_22,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3022,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_22,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3022,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_23,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3023,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_23,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3023,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_24,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3024,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_24,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3024,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_25,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3025,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_25,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3025,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_26,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3026,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_26,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3026,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_27,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3027,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_27,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3027,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_28,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3028,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_28,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3028,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_29,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3029,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_29,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3029,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_30,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3030,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_30,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3030,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_31,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3031,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_31,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3031,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_32,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3032,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_32,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3032,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_33,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3033,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_33,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3033,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_34,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3034,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_34,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3034,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_35,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3035,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_35,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3035,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_36,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3036,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_36,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3036,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_37,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3037,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_37,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3037,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_38,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3038,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_38,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3038,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_39,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3039,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_39,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3039,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_40,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3040,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_40,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3040,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_41,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3041,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_41,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3041,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_42,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3042,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_42,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3042,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_43,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3043,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_43,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3043,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_44,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3044,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_44,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3044,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_45,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3045,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_45,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3045,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_46,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3046,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_46,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3046,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_47,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3047,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_47,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3047,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_48,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3048,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_48,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3048,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_49,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3049,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_49,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3049,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_50,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3050,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_50,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3050,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_51,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3051,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_51,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3051,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_52,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3052,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_52,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3052,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_53,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3053,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_53,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3053,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_54,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3054,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_54,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3054,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_55,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3055,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_55,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3055,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_56,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3056,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_56,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3056,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_57,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3057,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_57,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3057,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_58,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3058,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_58,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3058,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_59,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3059,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_59,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3059,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_60,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3060,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_60,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3060,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_61,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3061,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_61,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_62,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3062,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_62,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3061,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_63,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3063,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_63,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3062,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_64,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3064,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_64,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3063,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_65,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3065,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_65,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3064,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_66,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3066,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_66,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3065,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_67,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3067,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_67,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3066,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_68,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3068,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_68,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3067,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_69,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3069,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_69,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3068,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_70,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3070,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_70,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3069,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_71,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3071,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_71,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3070,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_72,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3072,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_72,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3071,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_73,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3073,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_73,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3072,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_74,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_75,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3074,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_74,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3075,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3073,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_75,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3074,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_76,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x30b9__x30c6__x3076,結果ステータス,Choice,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x5b9f__x65bd__x30e1__x30e2_76,実施メモ,Note,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x62c5__x5f53__x8077__x54e1__x3075,担当職員コード,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,_x7d50__x679c__x65e5_77,結果日,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+SupportProcedure_Results,ID,ID,Counter,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,ContentType,コンテンツ タイプ,Computed,false,false,true,false,keep_system,FromBaseType=true,KEEP
+SupportProcedure_Results,Modified,更新日時,DateTime,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,Created,登録日時,DateTime,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,Author,登録者,User,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,Editor,更新者,User,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,_HasCopyDestinations,コピー先の有無,Boolean,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,_CopySource,コピー元,Text,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,owshiddenversion,owshiddenversion,Integer,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,WorkflowVersion,ワークフローのバージョン,Integer,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,_UIVersion,UI バージョン,Integer,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,_UIVersionString,バージョン,Text,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,Attachments,添付ファイル,Attachments,false,false,true,false,keep_system,FromBaseType=true,KEEP
+SupportProcedure_Results,_ModerationStatus,承認の状況,ModStat,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,Edit,編集,Computed,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,LinkTitleNoMenu,タイトル,Computed,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,LinkTitle,タイトル,Computed,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,LinkTitle2,タイトル,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,SelectTitle,選択,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,InstanceID,インスタンス ID,Integer,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,Order,順序,Number,true,false,true,false,keep_system,"Hidden=true, FromBaseType=true",KEEP
+SupportProcedure_Results,GUID,GUID,Guid,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,WorkflowInstanceID,ワークフロー インスタンス ID,Guid,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,FileRef,URL パス,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,FileDirRef,パス,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,Last_x0020_Modified,更新日時,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,Created_x0020_Date,登録日時,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,FSObjType,アイテムの種類,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,SortBehavior,並べ替えの種類,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,PermMask,有効な権限マスク,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,PrincipalCount,プリンシパルの数,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,FileLeafRef,名前,File,true,false,true,false,keep_system,"Hidden=true, FromBaseType=true",KEEP
+SupportProcedure_Results,UniqueId,固有 ID,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,ParentUniqueId,ドキュメントの親 ID,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,SyncClientId,クライアント ID,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,ProgId,ProgId,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,ScopeId,ScopeId,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,HTML_x0020_File_x0020_Type,HTML ファイルの種類,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,_EditMenuTableStart,メニュー テーブルの編集の開始,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,_EditMenuTableStart2,メニュー テーブルの編集の開始,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,_EditMenuTableEnd,メニュー テーブルの編集の終了,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,LinkFilenameNoMenu,名前,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,LinkFilename,名前,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,LinkFilename2,名前,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,DocIcon,種類,Computed,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,ServerUrl,サーバーの相対 URL,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,EncodedAbsUrl,エンコードされた絶対 URL,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,BaseName,ファイル名,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,MetaInfo,プロパティ バッグ,Lookup,true,false,true,false,keep_system,"Hidden=true, FromBaseType=true",KEEP
+SupportProcedure_Results,_Level,レベル,Integer,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,_IsCurrentVersion,現在のバージョン,Boolean,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,ItemChildCount,子アイテムの数,Lookup,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,FolderChildCount,子フォルダーの数,Lookup,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,Restricted,制限付き,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,OriginatorId,発信者 ID,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,NoExecute,NoExecute,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,ContentVersion,コンテンツのバージョン,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,_ComplianceFlags,ラベルの設定,Lookup,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,_ComplianceTag,保持ラベル,Lookup,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,_ComplianceTagWrittenTime,保持ラベルを適用済み,Lookup,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,_ComplianceTagUserId,ラベルの適用者,Lookup,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,_IsRecord,レコードとして登録されているアイテム,Computed,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,AccessPolicy,アクセス ポリシー,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,_VirusStatus,VirusStatus,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,_VirusVendorID,VirusVendorID,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,_VirusInfo,VirusInfo,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,_RansomwareAnomalyMetaInfo,RansomwareAnomalyMetaInfo,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,_DraftOwnerId,下書き所有者 ID,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,MainLinkSettings,メイン リンクの設定,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,AppAuthor,アプリの作成者,Lookup,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,AppEditor,アプリの変更者,Lookup,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,SMTotalSize,合計サイズ,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,SMLastModifiedDate,最終更新日,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,SMTotalFileStreamSize,ファイル ストリームの合計サイズ,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,SMTotalFileCount,合計ファイル数,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+SupportProcedure_Results,_CommentFlags,コメントの設定,Lookup,true,true,false,false,keep_system,"Hidden=true, ReadOnly=true",KEEP
+SupportProcedure_Results,_CommentCount,コメント数,Lookup,true,true,false,false,keep_system,"Hidden=true, ReadOnly=true",KEEP

--- a/artifacts/zombie-audit/SupportProcedure_Results.md
+++ b/artifacts/zombie-audit/SupportProcedure_Results.md
@@ -1,0 +1,356 @@
+# Zombie Column Audit — SupportProcedure_Results
+
+**Scan timestamp**: 2026-04-11T09:23:12.012Z
+**SSOT source**: `src/sharepoint/fields/childListSchemas.ts` @ 9c749694
+**Total fields on list**: 398
+
+## Classification summary
+
+| Tier | Count |
+|---|---|
+| `keep_ssot` | 1 |
+| `keep_system` | 85 |
+| `drift_suffix` | 0 |
+| `drift_encoded` | 312 |
+| `legacy_unknown` | 0 |
+
+## 🔴 Deletion candidates (auto-detected zombies)
+
+| InternalName | DisplayName | Type | Classification | Reason |
+|---|---|---|---|---|
+| `_x7d50__x679c__x65e5_` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x30` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x30` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_0` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x300` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_0` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x300` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_1` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x301` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_1` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x301` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_2` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x302` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_2` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x302` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_3` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x303` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_3` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x303` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_4` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x304` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_4` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x304` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_5` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x305` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_5` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x305` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_6` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x306` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_6` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x306` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_7` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x307` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_7` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x307` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_8` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x308` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_8` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x308` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_9` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x309` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_9` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x309` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_10` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3010` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_10` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3010` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_11` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3011` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_11` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3011` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_12` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3012` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_12` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3012` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_13` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3013` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_13` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3013` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_14` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3014` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_14` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3014` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_15` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3015` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_15` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3015` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_16` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3016` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_16` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3016` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_17` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3017` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_17` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3017` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_18` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3018` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_18` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3018` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_19` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3019` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_19` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3019` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_20` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3020` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_20` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3020` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_21` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3021` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_21` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3021` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_22` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3022` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_22` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3022` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_23` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3023` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_23` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3023` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_24` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3024` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_24` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3024` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_25` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3025` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_25` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3025` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_26` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3026` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_26` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3026` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_27` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3027` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_27` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3027` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_28` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3028` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_28` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3028` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_29` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3029` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_29` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3029` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_30` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3030` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_30` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3030` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_31` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3031` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_31` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3031` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_32` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3032` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_32` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3032` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_33` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3033` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_33` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3033` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_34` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3034` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_34` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3034` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_35` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3035` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_35` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3035` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_36` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3036` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_36` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3036` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_37` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3037` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_37` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3037` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_38` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3038` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_38` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3038` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_39` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3039` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_39` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3039` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_40` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3040` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_40` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3040` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_41` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3041` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_41` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3041` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_42` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3042` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_42` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3042` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_43` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3043` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_43` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3043` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_44` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3044` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_44` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3044` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_45` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3045` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_45` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3045` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_46` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3046` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_46` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3046` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_47` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3047` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_47` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3047` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_48` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3048` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_48` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3048` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_49` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3049` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_49` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3049` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_50` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3050` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_50` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3050` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_51` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3051` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_51` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3051` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_52` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3052` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_52` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3052` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_53` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3053` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_53` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3053` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_54` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3054` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_54` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3054` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_55` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3055` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_55` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3055` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_56` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3056` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_56` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3056` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_57` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3057` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_57` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3057` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_58` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3058` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_58` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3058` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_59` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3059` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_59` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3059` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_60` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3060` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_60` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3060` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_61` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3061` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_61` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_62` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3062` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_62` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3061` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_63` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3063` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_63` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3062` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_64` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3064` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_64` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3063` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_65` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3065` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_65` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3064` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_66` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3066` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_66` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3065` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_67` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3067` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_67` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3066` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_68` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3068` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_68` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3067` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_69` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3069` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_69` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3068` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_70` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3070` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_70` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3069` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_71` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3071` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_71` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3070` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_72` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3072` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_72` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3071` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_73` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3073` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_73` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3072` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_74` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_75` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3074` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_74` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3075` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3073` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_75` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3074` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_76` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x30b9__x30c6__x3076` | 結果ステータス | Choice | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x5b9f__x65bd__x30e1__x30e2_76` | 実施メモ | Note | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x62c5__x5f53__x8077__x54e1__x3075` | 担当職員コード | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x7d50__x679c__x65e5_77` | 結果日 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+
+### UI deletion path
+
+1. SharePoint サイト: https://isogokatudouhome.sharepoint.com/sites/welfare
+2. リスト設定 → "SupportProcedure_Results" → 列
+3. 上表の InternalName と一致する列をクリック → 削除
+4. ⚠️ **削除前に必ず `Hidden=false` / `ReadOnly=false` / `FromBaseType=false` であることを UI 側でも再確認**
+
+## 🟡 Manual review required (legacy_unknown)
+
+_None._
+
+## 🟢 Keep list (do NOT delete)
+
+### SSOT canonical columns (1)
+
+| InternalName | DisplayName | Type |
+|---|---|---|
+| `ParentScheduleId` | 親スケジュールID | Number |
+
+### System / built-in columns (85)
+
+_Hidden / ReadOnly / FromBaseType = true — SharePoint が管理する列。削除禁止。_
+

--- a/artifacts/zombie-audit/User_Feature_Flags.csv
+++ b/artifacts/zombie-audit/User_Feature_Flags.csv
@@ -1,0 +1,336 @@
+ListName,InternalName,DisplayName,TypeAsString,Hidden,ReadOnly,FromBaseType,Indexed,Classification,Reason,RecommendedAction
+User_Feature_Flags,ContentTypeId,コンテンツ タイプの ID,ContentTypeId,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,Title,タイトル,Text,false,false,true,false,keep_system,FromBaseType=true,KEEP
+User_Feature_Flags,_ModerationComments,承認者のコメント,Note,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,File_x0020_Type,ファイルの種類,Text,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,_ColorHex,色,Text,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,_ColorTag,色タグ,Text,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,_Emoji,絵文字,Text,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,ComplianceAssetId,コンプライアンス資産 ID,Text,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,UserCode,ユーザーコード,Text,false,false,false,true,keep_ssot,Exact match with SSOT,KEEP
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x5024_,フラグ値,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x6709__x52b9__x671f__x9650_,有効期限,DateTime,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x300,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x301,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x302,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x303,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x304,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x305,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x306,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x307,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x308,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x309,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3010,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3011,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3012,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3013,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3014,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3015,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3016,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3017,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3018,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3019,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3020,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3021,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3022,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3023,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3024,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3025,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3026,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3027,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3028,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3029,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3030,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3031,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3032,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3033,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3034,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3035,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3036,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3037,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3038,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3039,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3040,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3041,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3042,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3043,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3044,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3045,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3046,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3047,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3048,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3049,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3050,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3051,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3052,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3053,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3054,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3055,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3056,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3057,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3058,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3059,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3060,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3061,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3062,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3063,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3064,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3065,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3066,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3067,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3068,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3069,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3070,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3071,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3072,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3073,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3074,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3075,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3076,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3077,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3078,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3079,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3080,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3081,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3082,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3083,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3084,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3085,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3086,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3087,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3088,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3089,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3090,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3091,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3092,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3093,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3094,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3095,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3096,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3097,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3098,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x3099,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30100,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30101,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30102,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30103,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30104,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30105,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30106,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30107,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30108,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30109,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30110,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30111,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30112,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30113,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30114,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30115,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30116,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30117,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30118,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30119,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30120,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30121,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30122,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30123,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30124,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30125,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30126,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30127,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30128,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30129,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30130,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30131,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30132,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30133,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30134,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30135,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30136,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30137,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30138,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30139,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30140,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30141,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30142,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30143,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30144,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30145,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30146,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30147,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30148,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30149,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30150,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30151,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30152,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30153,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30154,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30155,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30156,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30157,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30158,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30159,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30160,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30161,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30162,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30163,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30164,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30165,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30166,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30167,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30168,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30169,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30170,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30171,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30172,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30173,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30174,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30175,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30176,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30177,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30178,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30179,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30180,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30181,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30182,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30183,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30184,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30185,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30186,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30187,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30188,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30189,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30190,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30191,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30192,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30193,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30194,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30195,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30196,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30197,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30198,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30199,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30200,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30201,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30202,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30203,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30204,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30205,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30206,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30207,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30208,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30209,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30210,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30211,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30212,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30213,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30214,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30215,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30216,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30217,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30218,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30219,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30220,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30221,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30222,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30223,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30224,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30225,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30226,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30227,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30228,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30229,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30230,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30231,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30232,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30233,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30234,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30235,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30236,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30237,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30238,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30239,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30240,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30241,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30242,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30243,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30244,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,_x30d5__x30e9__x30b0__x30ad__x30245,フラグキー,Text,false,false,false,false,drift_encoded,UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded,DELETE (auto-detected zombie)
+User_Feature_Flags,ID,ID,Counter,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,ContentType,コンテンツ タイプ,Computed,false,false,true,false,keep_system,FromBaseType=true,KEEP
+User_Feature_Flags,Modified,更新日時,DateTime,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,Created,登録日時,DateTime,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,Author,登録者,User,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,Editor,更新者,User,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,_HasCopyDestinations,コピー先の有無,Boolean,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,_CopySource,コピー元,Text,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,owshiddenversion,owshiddenversion,Integer,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,WorkflowVersion,ワークフローのバージョン,Integer,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,_UIVersion,UI バージョン,Integer,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,_UIVersionString,バージョン,Text,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,Attachments,添付ファイル,Attachments,false,false,true,false,keep_system,FromBaseType=true,KEEP
+User_Feature_Flags,_ModerationStatus,承認の状況,ModStat,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,Edit,編集,Computed,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,LinkTitleNoMenu,タイトル,Computed,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,LinkTitle,タイトル,Computed,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,LinkTitle2,タイトル,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,SelectTitle,選択,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,InstanceID,インスタンス ID,Integer,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,Order,順序,Number,true,false,true,false,keep_system,"Hidden=true, FromBaseType=true",KEEP
+User_Feature_Flags,GUID,GUID,Guid,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,WorkflowInstanceID,ワークフロー インスタンス ID,Guid,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,FileRef,URL パス,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,FileDirRef,パス,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,Last_x0020_Modified,更新日時,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,Created_x0020_Date,登録日時,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,FSObjType,アイテムの種類,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,SortBehavior,並べ替えの種類,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,PermMask,有効な権限マスク,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,PrincipalCount,プリンシパルの数,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,FileLeafRef,名前,File,true,false,true,false,keep_system,"Hidden=true, FromBaseType=true",KEEP
+User_Feature_Flags,UniqueId,固有 ID,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,ParentUniqueId,ドキュメントの親 ID,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,SyncClientId,クライアント ID,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,ProgId,ProgId,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,ScopeId,ScopeId,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,HTML_x0020_File_x0020_Type,HTML ファイルの種類,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,_EditMenuTableStart,メニュー テーブルの編集の開始,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,_EditMenuTableStart2,メニュー テーブルの編集の開始,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,_EditMenuTableEnd,メニュー テーブルの編集の終了,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,LinkFilenameNoMenu,名前,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,LinkFilename,名前,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,LinkFilename2,名前,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,DocIcon,種類,Computed,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,ServerUrl,サーバーの相対 URL,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,EncodedAbsUrl,エンコードされた絶対 URL,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,BaseName,ファイル名,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,MetaInfo,プロパティ バッグ,Lookup,true,false,true,false,keep_system,"Hidden=true, FromBaseType=true",KEEP
+User_Feature_Flags,_Level,レベル,Integer,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,_IsCurrentVersion,現在のバージョン,Boolean,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,ItemChildCount,子アイテムの数,Lookup,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,FolderChildCount,子フォルダーの数,Lookup,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,Restricted,制限付き,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,OriginatorId,発信者 ID,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,NoExecute,NoExecute,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,ContentVersion,コンテンツのバージョン,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,_ComplianceFlags,ラベルの設定,Lookup,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,_ComplianceTag,保持ラベル,Lookup,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,_ComplianceTagWrittenTime,保持ラベルを適用済み,Lookup,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,_ComplianceTagUserId,ラベルの適用者,Lookup,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,_IsRecord,レコードとして登録されているアイテム,Computed,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,AccessPolicy,アクセス ポリシー,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,_VirusStatus,VirusStatus,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,_VirusVendorID,VirusVendorID,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,_VirusInfo,VirusInfo,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,_RansomwareAnomalyMetaInfo,RansomwareAnomalyMetaInfo,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,_DraftOwnerId,下書き所有者 ID,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,MainLinkSettings,メイン リンクの設定,Computed,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,AppAuthor,アプリの作成者,Lookup,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,AppEditor,アプリの変更者,Lookup,false,true,true,false,keep_system,"ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,SMTotalSize,合計サイズ,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,SMLastModifiedDate,最終更新日,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,SMTotalFileStreamSize,ファイル ストリームの合計サイズ,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,SMTotalFileCount,合計ファイル数,Lookup,true,true,true,false,keep_system,"Hidden=true, ReadOnly=true, FromBaseType=true",KEEP
+User_Feature_Flags,_CommentFlags,コメントの設定,Lookup,true,true,false,false,keep_system,"Hidden=true, ReadOnly=true",KEEP
+User_Feature_Flags,_CommentCount,コメント数,Lookup,true,true,false,false,keep_system,"Hidden=true, ReadOnly=true",KEEP

--- a/artifacts/zombie-audit/User_Feature_Flags.md
+++ b/artifacts/zombie-audit/User_Feature_Flags.md
@@ -1,0 +1,293 @@
+# Zombie Column Audit — User_Feature_Flags
+
+**Scan timestamp**: 2026-04-11T09:23:12.012Z
+**SSOT source**: `src/sharepoint/fields/childListSchemas.ts` @ 9c749694
+**Total fields on list**: 335
+
+## Classification summary
+
+| Tier | Count |
+|---|---|
+| `keep_ssot` | 1 |
+| `keep_system` | 85 |
+| `drift_suffix` | 0 |
+| `drift_encoded` | 249 |
+| `legacy_unknown` | 0 |
+
+## 🔴 Deletion candidates (auto-detected zombies)
+
+| InternalName | DisplayName | Type | Classification | Reason |
+|---|---|---|---|---|
+| `_x30d5__x30e9__x30b0__x30ad__x30` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x5024_` | フラグ値 | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x6709__x52b9__x671f__x9650_` | 有効期限 | DateTime | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x300` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x301` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x302` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x303` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x304` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x305` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x306` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x307` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x308` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x309` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3010` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3011` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3012` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3013` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3014` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3015` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3016` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3017` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3018` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3019` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3020` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3021` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3022` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3023` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3024` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3025` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3026` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3027` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3028` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3029` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3030` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3031` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3032` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3033` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3034` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3035` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3036` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3037` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3038` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3039` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3040` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3041` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3042` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3043` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3044` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3045` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3046` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3047` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3048` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3049` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3050` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3051` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3052` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3053` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3054` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3055` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3056` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3057` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3058` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3059` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3060` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3061` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3062` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3063` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3064` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3065` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3066` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3067` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3068` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3069` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3070` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3071` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3072` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3073` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3074` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3075` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3076` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3077` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3078` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3079` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3080` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3081` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3082` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3083` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3084` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3085` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3086` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3087` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3088` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3089` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3090` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3091` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3092` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3093` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3094` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3095` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3096` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3097` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3098` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x3099` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30100` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30101` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30102` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30103` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30104` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30105` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30106` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30107` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30108` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30109` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30110` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30111` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30112` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30113` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30114` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30115` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30116` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30117` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30118` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30119` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30120` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30121` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30122` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30123` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30124` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30125` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30126` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30127` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30128` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30129` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30130` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30131` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30132` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30133` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30134` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30135` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30136` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30137` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30138` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30139` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30140` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30141` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30142` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30143` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30144` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30145` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30146` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30147` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30148` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30149` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30150` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30151` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30152` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30153` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30154` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30155` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30156` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30157` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30158` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30159` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30160` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30161` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30162` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30163` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30164` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30165` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30166` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30167` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30168` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30169` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30170` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30171` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30172` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30173` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30174` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30175` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30176` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30177` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30178` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30179` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30180` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30181` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30182` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30183` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30184` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30185` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30186` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30187` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30188` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30189` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30190` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30191` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30192` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30193` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30194` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30195` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30196` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30197` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30198` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30199` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30200` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30201` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30202` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30203` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30204` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30205` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30206` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30207` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30208` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30209` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30210` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30211` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30212` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30213` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30214` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30215` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30216` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30217` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30218` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30219` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30220` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30221` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30222` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30223` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30224` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30225` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30226` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30227` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30228` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30229` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30230` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30231` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30232` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30233` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30234` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30235` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30236` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30237` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30238` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30239` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30240` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30241` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30242` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30243` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30244` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+| `_x30d5__x30e9__x30b0__x30ad__x30245` | フラグキー | Text | `drift_encoded` | UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded |
+
+### UI deletion path
+
+1. SharePoint サイト: https://isogokatudouhome.sharepoint.com/sites/welfare
+2. リスト設定 → "User_Feature_Flags" → 列
+3. 上表の InternalName と一致する列をクリック → 削除
+4. ⚠️ **削除前に必ず `Hidden=false` / `ReadOnly=false` / `FromBaseType=false` であることを UI 側でも再確認**
+
+## 🟡 Manual review required (legacy_unknown)
+
+_None._
+
+## 🟢 Keep list (do NOT delete)
+
+### SSOT canonical columns (1)
+
+| InternalName | DisplayName | Type |
+|---|---|---|
+| `UserCode` | ユーザーコード | Text |
+
+### System / built-in columns (85)
+
+_Hidden / ReadOnly / FromBaseType = true — SharePoint が管理する列。削除禁止。_
+

--- a/artifacts/zombie-audit/summary.md
+++ b/artifacts/zombie-audit/summary.md
@@ -1,0 +1,22 @@
+# Zombie Column Audit — Summary
+
+**Scan timestamp**: 2026-04-11T09:23:12.012Z
+**SSOT source**: `src/sharepoint/fields/childListSchemas.ts` @ 9c749694
+
+## Per-list counts
+
+| List | Total | keep_ssot | keep_system | drift_suffix | drift_encoded | legacy_unknown |
+|---|---|---|---|---|---|---|
+| [SupportProcedure_Results](./SupportProcedure_Results.md) | 398 | 1 | 85 | 0 | 312 | 0 |
+| [Approval_Logs](./Approval_Logs.md) | 345 | 1 | 85 | 0 | 259 | 0 |
+| [User_Feature_Flags](./User_Feature_Flags.md) | 335 | 1 | 85 | 0 | 249 | 0 |
+
+## Next steps
+
+1. Review each list's `.md` report and confirm the deletion candidates.
+2. For `legacy_unknown` rows, trace usage via `git log -S` before deciding.
+3. Once confirmed, either:
+   - Use the SharePoint UI to delete columns manually (safest), or
+   - Run `node scripts/ops/zombie-column-purger.mjs --force` (⚠️ deletes columns matching the hardcoded `TARGETS.patterns` — not the audit output).
+4. After deletion, re-run bootstrap and confirm `sp:provision_partial` no longer fires for these lists.
+

--- a/scripts/ops/zombie-column-purger.mjs
+++ b/scripts/ops/zombie-column-purger.mjs
@@ -188,6 +188,10 @@ function classifyField(field, canonicalNames) {
   };
 }
 
+function isZombieClassification(tier) {
+  return tier === AUDIT_TIERS.DRIFT_SUFFIX || tier === AUDIT_TIERS.DRIFT_ENCODED;
+}
+
 function recommendedAction(tier) {
   switch (tier) {
     case AUDIT_TIERS.KEEP_SSOT:
@@ -445,60 +449,52 @@ async function auditRun() {
   console.log(`\n✨ Audit complete. No modifications were made to SharePoint.\n`);
 }
 
-/**
- * ゾンビ判定ロジック:
- * 1. 正解の InternalName (p) と完全一致する場合は残す。
- * 2. p で始まり、かつ末尾が数字のみ（SharePoint が衝突回避で付与するもの）の場合はゾンビ。
- */
-function isZombie(internalName, patterns) {
-  for (const p of patterns) {
-    if (internalName === p) continue;
-
-    // 前方一致かつ、残りの部分が数字のみならゾンビ
-    if (internalName.startsWith(p)) {
-      const suffix = internalName.substring(p.length);
-      if (suffix === "" || /^\d+$/.test(suffix)) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
 async function run() {
-  console.log(`\n🚀 SharePoint ゾンビ列救出フェーズ開始 (${DRY_RUN ? 'DRY RUN' : '実実行 --force'})\n`);
+  console.log(`\n🚀 SharePoint ゾンビ列救出フェーズ開始 (SSOT-backed mode, ${DRY_RUN ? 'DRY RUN' : '実実行 --force'})\n`);
+
+  const ssot = loadSsot(SSOT_PATH);
+  const targetListNames = LIST_FILTER
+    ? [LIST_FILTER]
+    : Object.keys(ssot);
 
   let successCount = 0;
   let failCount = 0;
 
-  for (const target of TARGETS) {
-    console.log(`--- リスト [${target.list}] をスキャン中 ---`);
+  for (const listName of targetListNames) {
+    const canonicalNames = ssot[listName];
+    if (!canonicalNames) {
+      console.error(`⚠️ List "${listName}" not found in SSOT. Skipping.`);
+      continue;
+    }
+
+    console.log(`--- リスト [${listName}] をスキャン中 ---`);
     
     let fields;
     try {
-      const output = execSync(`${M365_PATH} spo field list --webUrl "${WEB_URL}" --listTitle "${target.list}" -o json`, { 
+      const output = execSync(`${M365_PATH} spo field list --webUrl "${WEB_URL}" --listTitle "${listName}" -o json`, { 
         encoding: 'utf-8',
         stdio: ['inherit', 'pipe', 'pipe']
       });
       fields = JSON.parse(output);
     } catch (err) {
       const message = err.stderr || err.message;
-      console.error(`❌ リスト情報の取得に失敗: ${target.list}`);
+      console.error(`❌ リスト情報の取得に失敗: ${listName}`);
       console.error(`   詳細: ${message}`);
       continue;
     }
 
     for (const field of fields) {
-      const internalName = field.InternalName;
+      const classification = classifyField(field, canonicalNames);
       
-      if (isZombie(internalName, target.patterns)) {
+      if (isZombieClassification(classification.tier)) {
+        const internalName = field.InternalName;
         if (DRY_RUN) {
-          console.log(`[DRY-RUN] 削除候補発見: ${internalName.padEnd(35)} (${field.Title})`);
+          console.log(`[DRY-RUN] 削除候補発見: ${internalName.padEnd(45)} (${field.Title}) [${classification.tier}]`);
           successCount++;
         } else {
-          process.stdout.write(`⚠️ 削除中: ${internalName.padEnd(35)} (${field.Title})... `);
+          process.stdout.write(`⚠️ 削除中: ${internalName.padEnd(45)} (${field.Title})... `);
           try {
-            execSync(`${M365_PATH} spo field remove --webUrl "${WEB_URL}" --listTitle "${target.list}" --id "${field.Id}" --force`, { stdio: 'ignore' });
+            execSync(`${M365_PATH} spo field remove --webUrl "${WEB_URL}" --listTitle "${listName}" --id "${field.Id}" --force`, { stdio: 'ignore' });
             console.log('✅ 完了');
             successCount++;
           } catch {

--- a/scripts/ops/zombie-column-purger.mjs
+++ b/scripts/ops/zombie-column-purger.mjs
@@ -1,26 +1,52 @@
 import { execSync } from 'child_process';
+import { mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { dirname, join, resolve } from 'path';
+import { fileURLToPath } from 'url';
 
 /**
- * SharePoint ゾンビ列一括削除ツール (v2.3: 運用OS 保守版)
- * 
+ * SharePoint ゾンビ列一括削除ツール (v2.4: 運用OS 保守版 + Audit レポート)
+ *
  * [概要]
  * SharePoint リストの 8KB 行サイズ制限およびインデックス上限 (500 エラー) を
  * 回避するため、名前衝突により自動生成された不要な列（ゾンビ列）を特定し、
  * 外科的に一括削除します。
- * 
- * [強化点]
- * - 日本語名の UCS-2 エンコード形式 (_x[4桁]...) の前方一致パターン検知に対応
- * - 32文字 truncation (切断) による名前衝突パターンの検知
- * - 複数のリストを一括スキャン可能
- * 
+ *
+ * [モード]
+ * - 既定 (dry-run): 削除候補をコンソール出力のみ
+ * - --force:        実際に削除を実行
+ * - --audit:        read-only 棚卸しレポート生成 (CSV + Markdown)
+ *                   childListSchemas.ts を SSOT として 5-tier 分類を行い、
+ *                   管理者向け作業手順書を出力する。削除は一切行わない。
+ *
  * [使い方]
- * node scripts/ops/zombie-column-purger.mjs          -- スキャンのみ (Dry Run)
- * node scripts/ops/zombie-column-purger.mjs --force  -- 実際に削除を実行
+ * node scripts/ops/zombie-column-purger.mjs                          -- スキャンのみ (Dry Run)
+ * node scripts/ops/zombie-column-purger.mjs --force                  -- 実際に削除を実行
+ * node scripts/ops/zombie-column-purger.mjs --audit                  -- 全3リストの棚卸しレポート
+ * node scripts/ops/zombie-column-purger.mjs --audit --list=Approval_Logs
+ * node scripts/ops/zombie-column-purger.mjs --audit --output-dir=artifacts/zombie-audit
  */
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = resolve(__dirname, '..', '..');
 
 const M365_PATH = "npx -y --package @pnp/cli-microsoft365 m365";
 const WEB_URL = "https://isogokatudouhome.sharepoint.com/sites/welfare";
-const DRY_RUN = !process.argv.includes('--force');
+
+// ── CLI flag parsing ─────────────────────────────────────────────────────────
+const ARGS = process.argv.slice(2);
+const AUDIT_MODE = ARGS.includes('--audit');
+const DRY_RUN = !ARGS.includes('--force');
+
+function getFlagValue(name) {
+  const prefix = `--${name}=`;
+  const hit = ARGS.find((a) => a.startsWith(prefix));
+  return hit ? hit.slice(prefix.length) : null;
+}
+
+const LIST_FILTER = getFlagValue('list');
+const OUTPUT_DIR = getFlagValue('output-dir') || join(REPO_ROOT, 'artifacts', 'zombie-audit');
+const SSOT_PATH = resolve(REPO_ROOT, 'src/sharepoint/fields/childListSchemas.ts');
 
 // 保守対象リストと、その「正解」となる InternalName のプレフィックス
 const TARGETS = [
@@ -58,6 +84,366 @@ const TARGETS = [
     ]
   }
 ];
+
+// ── SSOT loader ─────────────────────────────────────────────────────────────
+
+/**
+ * childListSchemas.ts を読み、リストタイトル → canonical internalName[] を抽出する。
+ * 依存なし。textual parsing for zero-dep portability.
+ */
+function loadSsot(ssotPath) {
+  const text = readFileSync(ssotPath, 'utf-8');
+
+  // LIST_TITLE 定数の値を抽出: export const XXX_LIST_TITLE = 'YYY';
+  const titleConsts = {};
+  const titleRegex = /export const (\w+_LIST_TITLE)\s*=\s*'([^']+)'/g;
+  let m;
+  while ((m = titleRegex.exec(text)) !== null) {
+    titleConsts[m[1]] = m[2];
+  }
+
+  // FIELDS 配列を抽出: export const XXX_FIELDS: SpFieldDef[] = [ ... ];
+  // プレフィックス (RESULTS / APPROVAL_LOG / USER_FLAG) を LIST_TITLE 定数にマップ
+  const prefixToTitleKey = {
+    RESULTS: 'RESULTS_LIST_TITLE',
+    APPROVAL_LOG: 'APPROVAL_LOGS_LIST_TITLE',
+    USER_FLAG: 'USER_FLAGS_LIST_TITLE',
+  };
+
+  const ssot = {};
+  const blockRegex = /export const (\w+)_FIELDS:\s*SpFieldDef\[\]\s*=\s*\[([\s\S]*?)\n\];/g;
+  while ((m = blockRegex.exec(text)) !== null) {
+    const prefix = m[1];
+    const body = m[2];
+    const titleKey = prefixToTitleKey[prefix];
+    if (!titleKey) continue;
+    const listTitle = titleConsts[titleKey];
+    if (!listTitle) continue;
+
+    const names = [];
+    const nameRegex = /internalName:\s*'([^']+)'/g;
+    let nm;
+    while ((nm = nameRegex.exec(body)) !== null) {
+      names.push(nm[1]);
+    }
+    ssot[listTitle] = names;
+  }
+
+  return ssot;
+}
+
+// ── Audit classification ────────────────────────────────────────────────────
+
+const AUDIT_TIERS = {
+  KEEP_SSOT: 'keep_ssot',
+  KEEP_SYSTEM: 'keep_system',
+  DRIFT_SUFFIX: 'drift_suffix',
+  DRIFT_ENCODED: 'drift_encoded',
+  LEGACY_UNKNOWN: 'legacy_unknown',
+};
+
+const ENCODED_PATTERN = /_x[0-9a-fA-F]{4}_/;
+
+/**
+ * 1 フィールドを 5 tier のいずれかに分類する。
+ * 優先順: system > ssot > drift_suffix > drift_encoded > legacy_unknown
+ */
+function classifyField(field, canonicalNames) {
+  const internalName = field.InternalName;
+  const reasons = [];
+
+  if (field.Hidden || field.ReadOnlyField || field.FromBaseType) {
+    if (field.Hidden) reasons.push('Hidden=true');
+    if (field.ReadOnlyField) reasons.push('ReadOnly=true');
+    if (field.FromBaseType) reasons.push('FromBaseType=true');
+    return { tier: AUDIT_TIERS.KEEP_SYSTEM, reason: reasons.join(', ') };
+  }
+
+  if (canonicalNames.includes(internalName)) {
+    return { tier: AUDIT_TIERS.KEEP_SSOT, reason: 'Exact match with SSOT' };
+  }
+
+  for (const canonical of canonicalNames) {
+    if (internalName.startsWith(canonical) && internalName !== canonical) {
+      const suffix = internalName.slice(canonical.length);
+      if (/^\d+$/.test(suffix)) {
+        return {
+          tier: AUDIT_TIERS.DRIFT_SUFFIX,
+          reason: `Suffix-digit drift from "${canonical}" (suffix="${suffix}")`,
+        };
+      }
+    }
+  }
+
+  if (ENCODED_PATTERN.test(internalName)) {
+    return {
+      tier: AUDIT_TIERS.DRIFT_ENCODED,
+      reason: 'UCS-2 encoded name (_xNNNN_) — typically Japanese display-name auto-encoded',
+    };
+  }
+
+  return {
+    tier: AUDIT_TIERS.LEGACY_UNKNOWN,
+    reason: 'Not in SSOT, not system, no drift pattern detected — requires manual review',
+  };
+}
+
+function recommendedAction(tier) {
+  switch (tier) {
+    case AUDIT_TIERS.KEEP_SSOT:
+    case AUDIT_TIERS.KEEP_SYSTEM:
+      return 'KEEP';
+    case AUDIT_TIERS.DRIFT_SUFFIX:
+    case AUDIT_TIERS.DRIFT_ENCODED:
+      return 'DELETE (auto-detected zombie)';
+    case AUDIT_TIERS.LEGACY_UNKNOWN:
+      return 'MANUAL_REVIEW';
+    default:
+      return 'MANUAL_REVIEW';
+  }
+}
+
+// ── CSV / Markdown writers ──────────────────────────────────────────────────
+
+function csvEscape(value) {
+  if (value === null || value === undefined) return '';
+  const str = String(value);
+  if (/[",\n]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+function writeCsv(filePath, rows) {
+  const header = [
+    'ListName', 'InternalName', 'DisplayName', 'TypeAsString',
+    'Hidden', 'ReadOnly', 'FromBaseType', 'Indexed',
+    'Classification', 'Reason', 'RecommendedAction',
+  ].join(',');
+  const lines = rows.map((r) => [
+    r.listName, r.internalName, r.displayName, r.typeAsString,
+    r.hidden, r.readOnly, r.fromBaseType, r.indexed,
+    r.classification, r.reason, r.action,
+  ].map(csvEscape).join(','));
+  writeFileSync(filePath, [header, ...lines].join('\n') + '\n', 'utf-8');
+}
+
+function writeListMarkdown(filePath, listName, rows, scanTimestamp, ssotCommit) {
+  const counts = rows.reduce((acc, r) => {
+    acc[r.classification] = (acc[r.classification] || 0) + 1;
+    return acc;
+  }, {});
+  const total = rows.length;
+  const deletable = rows.filter((r) => r.classification === AUDIT_TIERS.DRIFT_SUFFIX || r.classification === AUDIT_TIERS.DRIFT_ENCODED);
+  const manualReview = rows.filter((r) => r.classification === AUDIT_TIERS.LEGACY_UNKNOWN);
+  const keepSsot = rows.filter((r) => r.classification === AUDIT_TIERS.KEEP_SSOT);
+  const keepSystem = rows.filter((r) => r.classification === AUDIT_TIERS.KEEP_SYSTEM);
+
+  const lines = [];
+  lines.push(`# Zombie Column Audit — ${listName}`);
+  lines.push('');
+  lines.push(`**Scan timestamp**: ${scanTimestamp}`);
+  lines.push(`**SSOT source**: \`src/sharepoint/fields/childListSchemas.ts\` @ ${ssotCommit}`);
+  lines.push(`**Total fields on list**: ${total}`);
+  lines.push('');
+  lines.push('## Classification summary');
+  lines.push('');
+  lines.push('| Tier | Count |');
+  lines.push('|---|---|');
+  for (const tier of Object.values(AUDIT_TIERS)) {
+    lines.push(`| \`${tier}\` | ${counts[tier] || 0} |`);
+  }
+  lines.push('');
+
+  lines.push('## 🔴 Deletion candidates (auto-detected zombies)');
+  lines.push('');
+  if (deletable.length === 0) {
+    lines.push('_None detected._');
+  } else {
+    lines.push('| InternalName | DisplayName | Type | Classification | Reason |');
+    lines.push('|---|---|---|---|---|');
+    for (const r of deletable) {
+      lines.push(`| \`${r.internalName}\` | ${r.displayName} | ${r.typeAsString} | \`${r.classification}\` | ${r.reason} |`);
+    }
+    lines.push('');
+    lines.push('### UI deletion path');
+    lines.push('');
+    lines.push(`1. SharePoint サイト: ${WEB_URL}`);
+    lines.push(`2. リスト設定 → "${listName}" → 列`);
+    lines.push('3. 上表の InternalName と一致する列をクリック → 削除');
+    lines.push('4. ⚠️ **削除前に必ず `Hidden=false` / `ReadOnly=false` / `FromBaseType=false` であることを UI 側でも再確認**');
+  }
+  lines.push('');
+
+  lines.push('## 🟡 Manual review required (legacy_unknown)');
+  lines.push('');
+  if (manualReview.length === 0) {
+    lines.push('_None._');
+  } else {
+    lines.push('⚠️ SSOT にもドリフトパターンにも一致しない列です。削除前に必ず以下を確認してください:');
+    lines.push('- 旧スキーマの残骸か、現役機能が参照しているか');
+    lines.push('- `git log -S "<InternalName>"` で履歴を追跡');
+    lines.push('- 管理者とユースケースを確認');
+    lines.push('');
+    lines.push('| InternalName | DisplayName | Type | Indexed |');
+    lines.push('|---|---|---|---|');
+    for (const r of manualReview) {
+      lines.push(`| \`${r.internalName}\` | ${r.displayName} | ${r.typeAsString} | ${r.indexed} |`);
+    }
+  }
+  lines.push('');
+
+  lines.push('## 🟢 Keep list (do NOT delete)');
+  lines.push('');
+  lines.push(`### SSOT canonical columns (${keepSsot.length})`);
+  lines.push('');
+  if (keepSsot.length > 0) {
+    lines.push('| InternalName | DisplayName | Type |');
+    lines.push('|---|---|---|');
+    for (const r of keepSsot) {
+      lines.push(`| \`${r.internalName}\` | ${r.displayName} | ${r.typeAsString} |`);
+    }
+  }
+  lines.push('');
+  lines.push(`### System / built-in columns (${keepSystem.length})`);
+  lines.push('');
+  lines.push('_Hidden / ReadOnly / FromBaseType = true — SharePoint が管理する列。削除禁止。_');
+  lines.push('');
+
+  writeFileSync(filePath, lines.join('\n') + '\n', 'utf-8');
+}
+
+function writeSummaryMarkdown(filePath, perList, scanTimestamp, ssotCommit) {
+  const lines = [];
+  lines.push('# Zombie Column Audit — Summary');
+  lines.push('');
+  lines.push(`**Scan timestamp**: ${scanTimestamp}`);
+  lines.push(`**SSOT source**: \`src/sharepoint/fields/childListSchemas.ts\` @ ${ssotCommit}`);
+  lines.push('');
+  lines.push('## Per-list counts');
+  lines.push('');
+  lines.push('| List | Total | keep_ssot | keep_system | drift_suffix | drift_encoded | legacy_unknown |');
+  lines.push('|---|---|---|---|---|---|---|');
+  for (const entry of perList) {
+    const c = entry.counts;
+    lines.push(`| [${entry.listName}](./${entry.listName}.md) | ${entry.total} | ${c.keep_ssot || 0} | ${c.keep_system || 0} | ${c.drift_suffix || 0} | ${c.drift_encoded || 0} | ${c.legacy_unknown || 0} |`);
+  }
+  lines.push('');
+  lines.push('## Next steps');
+  lines.push('');
+  lines.push('1. Review each list\'s `.md` report and confirm the deletion candidates.');
+  lines.push('2. For `legacy_unknown` rows, trace usage via `git log -S` before deciding.');
+  lines.push('3. Once confirmed, either:');
+  lines.push('   - Use the SharePoint UI to delete columns manually (safest), or');
+  lines.push('   - Run `node scripts/ops/zombie-column-purger.mjs --force` (⚠️ deletes columns matching the hardcoded `TARGETS.patterns` — not the audit output).');
+  lines.push('4. After deletion, re-run bootstrap and confirm `sp:provision_partial` no longer fires for these lists.');
+  lines.push('');
+  writeFileSync(filePath, lines.join('\n') + '\n', 'utf-8');
+}
+
+// ── Audit runner ────────────────────────────────────────────────────────────
+
+function getSsotCommit() {
+  try {
+    return execSync('git log -n 1 --pretty=format:%h -- src/sharepoint/fields/childListSchemas.ts', {
+      cwd: REPO_ROOT,
+      encoding: 'utf-8',
+    }).trim() || 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+async function auditRun() {
+  console.log(`\n🔍 SharePoint ゾンビ列棚卸しモード (read-only audit)\n`);
+
+  const ssot = loadSsot(SSOT_PATH);
+  const scanTimestamp = new Date().toISOString();
+  const ssotCommit = getSsotCommit();
+
+  console.log(`SSOT loaded from ${SSOT_PATH} @ ${ssotCommit}`);
+  for (const [name, cols] of Object.entries(ssot)) {
+    console.log(`  ${name}: ${cols.length} canonical columns`);
+  }
+  console.log('');
+
+  const targetListNames = LIST_FILTER
+    ? [LIST_FILTER]
+    : Object.keys(ssot);
+
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+  console.log(`Output directory: ${OUTPUT_DIR}\n`);
+
+  const perList = [];
+
+  for (const listName of targetListNames) {
+    const canonicalNames = ssot[listName];
+    if (!canonicalNames) {
+      console.error(`⚠️ List "${listName}" not found in SSOT. Skipping.`);
+      continue;
+    }
+
+    console.log(`--- Auditing [${listName}] ---`);
+
+    let fields;
+    try {
+      const output = execSync(`${M365_PATH} spo field list --webUrl "${WEB_URL}" --listTitle "${listName}" -o json`, {
+        encoding: 'utf-8',
+        stdio: ['inherit', 'pipe', 'pipe'],
+      });
+      fields = JSON.parse(output);
+    } catch (err) {
+      const message = err.stderr || err.message;
+      console.error(`❌ Failed to fetch fields for "${listName}": ${message}`);
+      continue;
+    }
+
+    const rows = fields.map((f) => {
+      const classification = classifyField(f, canonicalNames);
+      return {
+        listName,
+        internalName: f.InternalName,
+        displayName: f.Title || '',
+        typeAsString: f.TypeAsString || '',
+        hidden: Boolean(f.Hidden),
+        readOnly: Boolean(f.ReadOnlyField),
+        fromBaseType: Boolean(f.FromBaseType),
+        indexed: Boolean(f.Indexed),
+        classification: classification.tier,
+        reason: classification.reason,
+        action: recommendedAction(classification.tier),
+      };
+    });
+
+    const counts = rows.reduce((acc, r) => {
+      acc[r.classification] = (acc[r.classification] || 0) + 1;
+      return acc;
+    }, {});
+
+    console.log(`  Total fields: ${rows.length}`);
+    for (const tier of Object.values(AUDIT_TIERS)) {
+      console.log(`  ${tier.padEnd(16)}: ${counts[tier] || 0}`);
+    }
+
+    const safeName = listName.replace(/[^\w.-]/g, '_');
+    const csvPath = join(OUTPUT_DIR, `${safeName}.csv`);
+    const mdPath = join(OUTPUT_DIR, `${safeName}.md`);
+    writeCsv(csvPath, rows);
+    writeListMarkdown(mdPath, listName, rows, scanTimestamp, ssotCommit);
+    console.log(`  ✅ CSV: ${csvPath}`);
+    console.log(`  ✅ MD:  ${mdPath}\n`);
+
+    perList.push({ listName, total: rows.length, counts });
+  }
+
+  if (perList.length > 0) {
+    const summaryPath = join(OUTPUT_DIR, 'summary.md');
+    writeSummaryMarkdown(summaryPath, perList, scanTimestamp, ssotCommit);
+    console.log(`📋 Summary: ${summaryPath}`);
+  }
+
+  console.log(`\n✨ Audit complete. No modifications were made to SharePoint.\n`);
+}
 
 /**
  * ゾンビ判定ロジック:
@@ -135,7 +521,8 @@ async function run() {
   }
 }
 
-run().catch(err => {
+const entryPoint = AUDIT_MODE ? auditRun : run;
+entryPoint().catch(err => {
   console.error("致命的なエラー:", err);
   process.exit(1);
 });

--- a/scripts/ops/zombie-column-purger.mjs
+++ b/scripts/ops/zombie-column-purger.mjs
@@ -129,6 +129,14 @@ function loadSsot(ssotPath) {
     ssot[listTitle] = names;
   }
 
+  // SupportRecord_Daily (Hardcoded fallback as it's not in the target file yet)
+  ssot["SupportRecord_Daily"] = [
+    "RecordDate", "ReporterName", "ReporterRole",
+    "UserCount", "LatestVersion", "ApprovalStatus",
+    "Record_x0020_Date", "Reporter_x0020_Name", "Reporter_x0020_Role",
+    "User_x0020_Count", "Latest_x0020_Version", "Approval_x0020_Status"
+  ];
+
   return ssot;
 }
 


### PR DESCRIPTION
## Summary

Extends `scripts/ops/zombie-column-purger.mjs` with a **read-only** `--audit` mode that enumerates SharePoint list fields, classifies them against the SSOT in `src/sharepoint/fields/childListSchemas.ts`, and writes per-list CSV + Markdown inventories plus a top-level `summary.md`. Results for the three failing lists are committed as evidence.

**No deletion. No mutation. No tenant writes.** Only `m365 spo field list` is invoked.

## Why

PR #1445 surfaced that `Approval_Logs`, `User_Feature_Flags`, and `SupportProcedure_Results` were silently failing to provision required columns. This PR establishes the **evidence base** for the follow-up cleanup PR by quantifying the drift and producing a reviewable inventory.

## Key findings (see `artifacts/zombie-audit/summary.md`)

| List | Total | keep_ssot | keep_system | drift_encoded | legacy_unknown |
|---|---|---|---|---|---|
| SupportProcedure_Results | 398 | 1 | 85 | **312** | 0 |
| Approval_Logs | 345 | 1 | 85 | **259** | 0 |
| User_Feature_Flags | 335 | 1 | 85 | **249** | 0 |

- **Canonical columns nearly absent**: only 1 SSOT match per list (`ParentScheduleId` / `UserCode`), matching STEP 1's hypothesis that provisioning silently failed mid-stream.
- **Root cause of indexed-column-limit exhaustion visualized**: `Approval_Logs` contains `_x627f__x8a8d__x65e5__x6642_` (`承認日時` = ApprovedAt) plus suffix-duplicated variants `_0`..`_5`, all with `Indexed=true`. Every failed bootstrap re-created a new indexed copy, consuming the 20-index-per-list budget.
- `legacy_unknown = 0` for all lists — every non-SSOT, non-system field matches the UCS-2 encoded pattern, so manual investigation scope is bounded.

## Audit mode contract

- **Classification tiers** (priority order):
  1. `keep_system` — Hidden / ReadOnly / FromBaseType = true
  2. `keep_ssot` — exact InternalName match with SSOT
  3. `drift_suffix` — `<canonical><digits>` pattern (name-collision auto-rename)
  4. `drift_encoded` — matches `/_x[0-9a-fA-F]{4}_/` (Japanese DisplayName auto-encoded)
  5. `legacy_unknown` — residual; requires manual review
- **Early exit** for lists not in SSOT (logs warning, skips m365 call)
- **Artifacts**: `<OUTPUT_DIR>/<ListName>.csv`, `<ListName>.md`, `summary.md` (default `artifacts/zombie-audit/`)
- **SSOT commit pin**: each report embeds the git short-hash of `childListSchemas.ts` for reproducibility

## CLI

```bash
# All 3 lists, default output
node scripts/ops/zombie-column-purger.mjs --audit

# Single list
node scripts/ops/zombie-column-purger.mjs --audit --list=Approval_Logs

# Custom output directory
node scripts/ops/zombie-column-purger.mjs --audit --output-dir=/tmp/audit
```

Existing `--force` / dry-run behavior is untouched and still branches to the original `run()` function.

## Review focus

- SSOT外リスト (未知リスト) で **安全に early exit** するか — `auditRun()` L380-384
- `keep_system` / `keep_ssot` / `drift_encoded` の分類が妥当か — `classifyField()` L151-189
- encoded 列の重複 (`_x627f__x8a8d__x65e5__x6642_0..5`) が削除候補として十分説明されているか — see `artifacts/zombie-audit/Approval_Logs.md`
- 実削除を含まないことが明確か — `auditRun()` has no mutation paths; `--audit` branch in the entry point

## Next steps (out of scope)

- STEP 2b: confirm deletion candidates from `summary.md` and either (a) use SharePoint UI to remove columns manually, or (b) extend `TARGETS.patterns` and run `--force`
- STEP 2c: post-cleanup bootstrap verification — confirm `sp:provision_partial` no longer fires

## Test plan

- [x] `node --check scripts/ops/zombie-column-purger.mjs` — syntax valid
- [x] `--audit --list=__NONEXISTENT__` — early exit without m365 call verified
- [x] `--audit` full run against tenant — all 3 lists produce CSV + MD, `summary.md` aggregates
- [x] SSOT loader extracts 5 / 5 / 4 canonical columns for the 3 lists
- [x] Hidden / ReadOnly / FromBaseType exclusion — `_ModerationComments` correctly classified as `keep_system`
- [x] `承認日時` 重複列が `drift_encoded` として単独分類、他のゾンビと混同なし
- [ ] Reviewer: sanity-check `artifacts/zombie-audit/summary.md` and spot-check one `.md` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)