### PR TITLE
fix(ops): add missing telemetry materialization scripts for nightly patrol

### DIFF
--- a/scripts/ops/materialize-sp-telemetry.mjs
+++ b/scripts/ops/materialize-sp-telemetry.mjs
@@ -1,0 +1,59 @@
+/* eslint-disable no-console -- CLI ops script */
+import fs from 'node:fs';
+import path from 'node:path';
+import { resolveSpTelemetryInput } from './resolve-sp-telemetry-input.mjs';
+
+const ROOT = process.cwd();
+const REPORT_DIR = path.join(ROOT, 'docs', 'nightly-patrol');
+
+function utcTodayStamp() {
+  const now = new Date();
+  const y = now.getUTCFullYear();
+  const m = String(now.getUTCMonth() + 1).padStart(2, '0');
+  const d = String(now.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+function sameFilePath(a, b) {
+  return path.resolve(a) === path.resolve(b);
+}
+
+async function main() {
+  const date = utcTodayStamp();
+  const resolved = resolveSpTelemetryInput({
+    root: ROOT,
+    reportDir: REPORT_DIR,
+    date,
+    preferRootDump: true,
+  });
+  const sourcePath = resolved.resolvedPath;
+  const datedOutputPath = path.join(REPORT_DIR, `sp-telemetry-${date}.json`);
+  const latestOutputPath = path.join(REPORT_DIR, 'sp-telemetry.json');
+
+  console.log('📦 Materializing SP telemetry artifact...');
+
+  if (!sourcePath) {
+    const checked = Array.isArray(resolved.candidates) && resolved.candidates.length > 0
+      ? ` Checked: ${resolved.candidates.join(', ')}`
+      : '';
+    console.log(`   ℹ️ no telemetry source found.${checked}`);
+    return;
+  }
+
+  fs.mkdirSync(REPORT_DIR, { recursive: true });
+
+  const payload = fs.readFileSync(sourcePath, 'utf8');
+
+  if (!sameFilePath(sourcePath, datedOutputPath)) {
+    fs.writeFileSync(datedOutputPath, payload, 'utf8');
+  }
+  if (!sameFilePath(sourcePath, latestOutputPath)) {
+    fs.writeFileSync(latestOutputPath, payload, 'utf8');
+  }
+
+  console.log(`   ✅ source: ${path.relative(ROOT, sourcePath)}`);
+  console.log(`   ✅ dated:  ${path.relative(ROOT, datedOutputPath)}`);
+  console.log(`   ✅ latest: ${path.relative(ROOT, latestOutputPath)}`);
+}
+
+await main();

--- a/scripts/ops/resolve-sp-telemetry-input.mjs
+++ b/scripts/ops/resolve-sp-telemetry-input.mjs
@@ -1,0 +1,65 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+function isDateStamp(value) {
+  return typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value);
+}
+
+function utcTodayStamp() {
+  const now = new Date();
+  const y = now.getUTCFullYear();
+  const m = String(now.getUTCMonth() + 1).padStart(2, '0');
+  const d = String(now.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+function normalizeCandidate(root, candidate) {
+  if (!candidate || typeof candidate !== 'string') return null;
+  const trimmed = candidate.trim();
+  if (!trimmed) return null;
+  return path.isAbsolute(trimmed) ? trimmed : path.join(root, trimmed);
+}
+
+export function resolveSpTelemetryInput(options = {}) {
+  const root = options.root || process.cwd();
+  const reportDir = options.reportDir || path.join(root, 'docs', 'nightly-patrol');
+  const date = isDateStamp(options.date) ? options.date : utcTodayStamp();
+  const envPath = typeof options.envPath === 'string' ? options.envPath : process.env.SP_TELEMETRY_PATH || '';
+  const preferRootDump = options.preferRootDump === true;
+
+  const implicitCandidates = preferRootDump
+    ? [
+        path.join(root, `sp-telemetry-${date}.json`),
+        path.join(root, 'sp-telemetry.json'),
+        path.join(reportDir, `sp-telemetry-${date}.json`),
+        path.join(reportDir, 'sp-telemetry.json'),
+      ]
+    : [
+        path.join(reportDir, `sp-telemetry-${date}.json`),
+        path.join(reportDir, 'sp-telemetry.json'),
+        path.join(root, `sp-telemetry-${date}.json`),
+        path.join(root, 'sp-telemetry.json'),
+      ];
+
+  const candidates = [
+    envPath,
+    ...implicitCandidates,
+  ]
+    .map((candidate) => normalizeCandidate(root, candidate))
+    .filter(Boolean);
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return {
+        resolvedPath: candidate,
+        usedEnvPath: Boolean(envPath && path.resolve(candidate) === path.resolve(normalizeCandidate(root, envPath))),
+      };
+    }
+  }
+
+  return {
+    resolvedPath: null,
+    usedEnvPath: false,
+    candidates: candidates.map((candidate) => path.relative(root, candidate).replace(/\\/g, '/')),
+  };
+}


### PR DESCRIPTION
## 概要
package.json の patrol:telemetry コマンドが依存している、テレメトリ集計・マテリアライズ用スクリプトの欠落を補完します。

## 変更点
- scripts/ops/materialize-sp-telemetry.mjs 追加
- scripts/ops/resolve-sp-telemetry-input.mjs 追加 (上記スクリプトの依存先)