### PR TITLE
[codex] stabilize drift log threshold fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,8 @@ nightly-report.md
 
 # Nightly Patrol artifacts
 .nightly/
+docs/nightly-patrol/*.json
+docs/nightly-patrol/*.md
+sp-telemetry*.json
+sp-telemetry*.backup.json
+lane-assertion-result.json

--- a/docs/operations/sp-health-admin-runbook.md
+++ b/docs/operations/sp-health-admin-runbook.md
@@ -2,7 +2,7 @@
 
 **対象ページ**: `/admin/status`（管理者専用）  
 **診断実装**: `src/features/diagnostics/health/checks.ts`  
-**最終更新**: 2026-04-02
+**最終更新**: 2026-04-11
 
 ---
 
@@ -110,6 +110,36 @@ Provision を実行してリストを作成する
 ### WARN (optional missing) — オプション列の欠落
 
 アプリの基本機能には影響しません。必要に応じて Provision を再実行してオプション列を追加できます。
+
+### WARN / 500 (DriftEventsLog threshold) — 監視ログ読み取りの退避動作
+
+```
+DriftEventsLog の期間フィルタ付き読み取りが list view threshold で失敗した
+```
+
+**現在のアプリ動作:**
+1. まず通常クエリで取得を試みます
+   - `DetectedAt desc`
+   - `since / resolved / listName` フィルタ付き
+2. これが SharePoint の `list view threshold` で 500 失敗した場合、アプリは自動的に退避クエリへ切り替えます
+   - `Id desc`
+   - フィルタなしで直近の一部件数を取得
+3. 取得後、アプリ側で `since / resolved / listName` を再適用します
+
+**重要な意味合い:**
+- これは **根本解決ではなく可用性確保のための退避動作** です
+- `/admin/status` や Drift observability は継続利用できる場合があります
+- ただし SharePoint 側の件数増加やインデックス未整備は解消されません
+
+**管理者・運用者が理解しておくこと:**
+- 画面が表示できても、`DriftEventsLog` の健全性が回復したわけではありません
+- 退避クエリは `Id desc` ベースのため、取得件数上限を超える古いイベントは観測対象外になります
+- 観測窓が不足すると、古い drift 事象や低頻度イベントを取りこぼす可能性があります
+
+**推奨対応:**
+1. `DriftEventsLog` の `DetectedAt` または運用で使用する日時列にインデックスが作成されているか確認する
+2. リスト件数が増えすぎている場合は、古いログのアーカイブまたはパージを検討する
+3. threshold 500 が継続する場合は、取得件数上限で必要観測期間を満たせているか開発者と確認する
 
 ---
 

--- a/scripts/ops/nightly-runtime-patrol.ts
+++ b/scripts/ops/nightly-runtime-patrol.ts
@@ -76,7 +76,22 @@ export interface NightlySummary {
   }>;
   /** Phase B+: sp:field_skipped streak results. Top entries by streak, window-filtered. */
   fieldSkipStreaks?: FieldSkipRankEntry[];
+  driftLogReadStats?: {
+    fallbackUsed: boolean;
+    scannedCount: number;
+    filteredCount: number;
+    lookbackHours: number;
+    topLimit: number;
+    safety: 'safe' | 'watch' | 'near_limit';
+  };
 }
+
+type DriftLogReadStats = NonNullable<NightlySummary['driftLogReadStats']>;
+
+type FetchRealEventsResult = {
+  events: RawEvent[];
+  driftLogReadStats: DriftLogReadStats;
+};
 
 const TRANSIENT_FAILURE_WORKFLOW_TARGETS: Record<string, string> = {
   'integration (users)': 'Users_Master',
@@ -86,6 +101,14 @@ const TRANSIENT_FAILURE_WORKFLOW_TARGETS: Record<string, string> = {
 
 const DEFAULT_TRANSIENT_FAILURE_WINDOW_HOURS = 6;
 const REPEATED_TRANSIENT_FAILURE_THRESHOLD = 3;
+const DRIFT_LOG_FALLBACK_TOP = 200;
+const DRIFT_LOG_LOOKBACK_HOURS = 24;
+
+function classifyDriftLogSafety(scannedCount: number): DriftLogReadStats['safety'] {
+  if (scannedCount >= 180) return 'near_limit';
+  if (scannedCount >= 100) return 'watch';
+  return 'safe';
+}
 
 // --- Engine Logic ---
 
@@ -382,6 +405,9 @@ export function aggregateEvents(rawEvents: RawEvent[]): NightlySummary {
 // --- Output Formatters ---
 
 export function formatMarkdown(summary: NightlySummary): string {
+  const driftLogLine = summary.driftLogReadStats
+    ? `* 📘 **Drift Log Read**: fallback=${summary.driftLogReadStats.fallbackUsed ? 'yes' : 'no'} / scanned=${summary.driftLogReadStats.scannedCount} / filtered=${summary.driftLogReadStats.filteredCount} / safety=${summary.driftLogReadStats.safety}\n`
+    : '';
   const header = `
 # Nightly Runtime Patrol Report — ${summary.reportDate}
 
@@ -392,6 +418,7 @@ export function formatMarkdown(summary: NightlySummary): string {
   * 🟠 **Action Required**: ${summary.countsBySeverity.action_required}
   * 🟡 **Watch**: ${summary.countsBySeverity.watch}
   * 🟢 **Silent (Absorbed)**: ${summary.countsBySeverity.silent}
+${driftLogLine}
 
 ---
 `;
@@ -540,13 +567,21 @@ async function writeStepSummary(summary: NightlySummary): Promise<void> {
 
 // --- Data Ingestion ---
 
-async function fetchRealEvents(fallbackMock: RawEvent[]): Promise<RawEvent[]> {
+async function fetchRealEvents(fallbackMock: RawEvent[]): Promise<FetchRealEventsResult> {
   const token = process.env.VITE_SP_TOKEN;
   const siteUrl = process.env.VITE_SP_SITE_URL;
+  const driftLogReadStats: DriftLogReadStats = {
+    fallbackUsed: false,
+    scannedCount: 0,
+    filteredCount: 0,
+    lookbackHours: DRIFT_LOG_LOOKBACK_HOURS,
+    topLimit: DRIFT_LOG_FALLBACK_TOP,
+    safety: 'safe',
+  };
 
   if (!token || !siteUrl) {
     console.warn('⚠️ VITE_SP_TOKEN or VITE_SP_SITE_URL is not set. Falling back to mock data.');
-    return fallbackMock;
+    return { events: fallbackMock, driftLogReadStats };
   }
 
   const events: RawEvent[] = [];
@@ -561,38 +596,84 @@ async function fetchRealEvents(fallbackMock: RawEvent[]): Promise<RawEvent[]> {
     'Accept': 'application/json;odata=nometadata' 
   };
 
+  const fetchJson = async (url: string) => {
+    const res = await globalThis.fetch(url, { headers });
+    const text = await res.text();
+    let data: any = {};
+    try {
+      data = text ? JSON.parse(text) : {};
+    } catch {
+      data = {};
+    }
+    return { res, data, text };
+  };
+
+  const isListViewThresholdResponse = (res: Response, text: string): boolean =>
+    res.status === 500 && /list view threshold/i.test(text);
+
+  const mapDriftItemToEvent = (item: any): RawEvent => {
+    let eType: RawEvent['eventType'] = 'drift';
+
+    const msg = item.Title || '';
+    const field = item.FieldName || item.Field_x0020_Name || 'None';
+    if (field === 'INDEX_PRESSURE') eType = 'index_pressure';
+    else if (field.startsWith('INDEX_')) eType = 'remediation';
+    else if (msg.includes('provision_failed')) eType = 'provision_failed';
+    else if (msg.includes('provision_skipped:block')) eType = 'provision_skipped:block';
+
+    return {
+      id: `drift-${item.Id}`,
+      timestamp: item.DetectedAt || item.Detected_x0020_At || item.Created,
+      eventType: eType,
+      area: 'Runtime',
+      resourceKey: item.ListName || item.List_x0020_Name || 'Unknown',
+      fieldKey: field,
+      reasonCode: item.ResolutionType || 'unknown',
+      message: `${item.Severity === 'critical' ? '(CRITICAL) ' : ''}Severity: ${item.Severity}. ${item.ErrorMessage || msg}`,
+    };
+  };
+
   try {
     // 1. DriftEventsLog fetches
     const driftUrl = `${siteUrl}/_api/web/lists/getbytitle('DriftEventsLog')/items?$filter=Created ge datetime'${filterDate}'`;
-    // Bypass ESLint rule against raw fetch in this CLI script
-    const driftRes = await globalThis.fetch(driftUrl, { headers });
-    
-    if (driftRes.ok) {
-      const data = await driftRes.json();
-      data.value.forEach((item: any) => {
-         let eType: RawEvent['eventType'] = 'drift';
-         
-         const msg = item.Title || '';
-         const field = item.FieldName || '';
-         if (field === 'INDEX_PRESSURE') eType = 'index_pressure';
-         else if (field.startsWith('INDEX_')) eType = 'remediation';
-         else if (msg.includes('provision_failed')) eType = 'provision_failed';
-         else if (msg.includes('provision_skipped:block')) eType = 'provision_skipped:block';
-         
-         events.push({
-            id: `drift-${item.Id}`,
-            timestamp: item.DetectedAt || item.Created,
-            eventType: eType,
-            area: 'Runtime',
-            resourceKey: item.ListName || 'Unknown',
-            fieldKey: item.FieldName || 'None',
-            reasonCode: item.ResolutionType || 'unknown',
-            message: `${item.Severity === 'critical' ? '(CRITICAL) ' : ''}Severity: ${item.Severity}. ${item.ErrorMessage || msg}`
-         });
+    const driftAttempt = await fetchJson(driftUrl);
+
+    if (driftAttempt.res.ok) {
+      driftAttempt.data.value.forEach((item: any) => {
+        events.push(mapDriftItemToEvent(item));
       });
-      console.log(`  └ Fetched ${data.value.length} DriftEventsLog events.`);
+      driftLogReadStats.scannedCount = driftAttempt.data.value.length;
+      driftLogReadStats.filteredCount = driftAttempt.data.value.length;
+      driftLogReadStats.safety = classifyDriftLogSafety(driftLogReadStats.scannedCount);
+      console.log(`  └ Fetched ${driftAttempt.data.value.length} DriftEventsLog events.`);
+    } else if (isListViewThresholdResponse(driftAttempt.res, driftAttempt.text)) {
+      console.warn(`⚠️ DriftEventsLog threshold detected. Falling back to Id desc top ${DRIFT_LOG_FALLBACK_TOP}.`);
+      driftLogReadStats.fallbackUsed = true;
+      const fallbackUrl =
+        `${siteUrl}/_api/web/lists/getbytitle('DriftEventsLog')/items` +
+        `?$select=Id,Title,Created,DetectedAt,Detected_x0020_At,ListName,List_x0020_Name,FieldName,Field_x0020_Name,Severity,ResolutionType,ErrorMessage` +
+        `&$orderby=Id desc&$top=${DRIFT_LOG_FALLBACK_TOP}`;
+      const fallbackAttempt = await fetchJson(fallbackUrl);
+      if (fallbackAttempt.res.ok) {
+        const filtered = (fallbackAttempt.data.value as any[])
+          .filter((item: any) => {
+            const timestamp = item.DetectedAt || item.Detected_x0020_At || item.Created;
+            const time = Date.parse(timestamp);
+            const since = Date.parse(filterDate);
+            return Number.isNaN(time) || Number.isNaN(since) ? true : time >= since;
+          });
+        filtered.forEach((item: any) => {
+          events.push(mapDriftItemToEvent(item));
+        });
+        driftLogReadStats.scannedCount = fallbackAttempt.data.value.length;
+        driftLogReadStats.filteredCount = filtered.length;
+        driftLogReadStats.safety = classifyDriftLogSafety(driftLogReadStats.scannedCount);
+        console.log(`  └ Fetched ${filtered.length} DriftEventsLog events via fallback (${fallbackAttempt.data.value.length} scanned).`);
+      } else {
+        console.warn(`⚠️ Failed to fetch DriftEventsLog fallback: ${fallbackAttempt.res.status} ${fallbackAttempt.res.statusText}`);
+      }
     } else {
-      console.warn(`⚠️ Failed to fetch DriftEventsLog: ${driftRes.status} ${driftRes.statusText}`);
+      console.warn(`⚠️ Failed to fetch DriftEventsLog: ${driftAttempt.res.status} ${driftAttempt.res.statusText}`);
     }
 
     // 2. DiagnosticsReports fetches
@@ -622,10 +703,10 @@ async function fetchRealEvents(fallbackMock: RawEvent[]): Promise<RawEvent[]> {
   } catch (err) {
     console.error('Network Error during SharePoint fetch:', err);
     console.warn('Falling back to mock data due to network error.');
-    return fallbackMock;
+    return { events: fallbackMock, driftLogReadStats };
   }
 
-  return events;
+  return { events, driftLogReadStats };
 }
 
 // --- Remediation Result → RawEvent conversion ---
@@ -804,7 +885,7 @@ async function run() {
   ];
 
   // 実データの取得（失敗時や設定がない場合はモックへフォールバック）
-  const rawEvents = await fetchRealEvents(mockRawEvents);
+  const { events: rawEvents, driftLogReadStats } = await fetchRealEvents(mockRawEvents);
 
   const transientFailureEvents = await fetchTransientFailureEvents(rawEvents);
   if (transientFailureEvents.length > 0) {
@@ -837,6 +918,7 @@ async function run() {
   // ─────────────────────────────────────────────────────────────────────────
 
   const summary = aggregateEvents(rawEvents);
+  summary.driftLogReadStats = driftLogReadStats;
 
   // ── Phase B: sp:field_skipped streak集計 ─────────────────────────────────
   if (token && siteUrl) {

--- a/src/features/diagnostics/drift/infra/SharePointDriftEventRepository.ts
+++ b/src/features/diagnostics/drift/infra/SharePointDriftEventRepository.ts
@@ -68,6 +68,13 @@ export class SharePointDriftEventRepository implements IDriftEventRepository {
     return typeof err === 'object' && err !== null && 'status' in err && (err as { status?: number }).status === 400;
   }
 
+  private isListViewThresholdError(err: unknown): boolean {
+    if (typeof err !== 'object' || err === null) return false;
+    const status = 'status' in err ? (err as { status?: number }).status : undefined;
+    const message = 'message' in err ? String((err as { message?: unknown }).message ?? '') : '';
+    return status === 500 && /list view threshold/i.test(message);
+  }
+
   private isRequiredFieldKey(key: keyof typeof DRIFT_LOG_CANDIDATES): boolean {
     return key === 'listName' || key === 'fieldName' || key === 'detectedAt';
   }
@@ -113,6 +120,89 @@ export class SharePointDriftEventRepository implements IDriftEventRepository {
     }
 
     return payload;
+  }
+
+  private mapItemToEvent(item: Record<string, unknown>): DriftEvent {
+    return {
+      id: String(item.Id ?? item.ID ?? ''),
+      listName: String(this.readRowValue(item, 'listName') ?? ''),
+      fieldName: String(this.readRowValue(item, 'fieldName') ?? ''),
+      detectedAt: String(this.readRowValue(item, 'detectedAt') ?? ''),
+      severity: (this.readRowValue(item, 'severity') as 'warn' | 'info') || 'info',
+      resolutionType: (this.readRowValue(item, 'resolutionType') as DriftResolutionType) || 'fuzzy_match',
+      driftType: (this.readRowValue(item, 'driftType') as DriftType) || 'unknown',
+      resolved: this.parseResolved(this.readRowValue(item, 'resolved')),
+    };
+  }
+
+  private matchesFilter(
+    event: DriftEvent,
+    filter?: {
+      listName?: string;
+      resolved?: boolean;
+      since?: string;
+    },
+  ): boolean {
+    if (!filter) return true;
+    if (filter.listName && event.listName !== filter.listName) return false;
+    if (filter.resolved !== undefined && event.resolved !== filter.resolved) return false;
+    if (filter.since) {
+      const eventTime = Date.parse(event.detectedAt);
+      const sinceTime = Date.parse(filter.since);
+      if (!Number.isNaN(eventTime) && !Number.isNaN(sinceTime) && eventTime < sinceTime) return false;
+    }
+    return true;
+  }
+
+  private async fetchEventsWithThresholdFallback(
+    listTitle: string,
+    select: string[],
+    filterQuery: string | undefined,
+    detectedAtField: string,
+    filter?: {
+      listName?: string;
+      resolved?: boolean;
+      since?: string;
+    },
+  ): Promise<DriftEvent[]> {
+    try {
+      const items = await this.spClient.getListItemsByTitle<Record<string, unknown>>(
+        listTitle,
+        select,
+        filterQuery,
+        `${detectedAtField} desc`,
+        100,
+      );
+      return items.map((item) => this.mapItemToEvent(item));
+    } catch (err) {
+      if (!this.isListViewThresholdError(err)) {
+        throw err;
+      }
+
+      auditLog.warn(
+        'diagnostics:drift',
+        'DriftEventRepository threshold fallback: retrying with Id-desc scan.',
+        {
+          listTitle,
+          filterQuery,
+          orderBy: `${detectedAtField} desc`,
+        },
+      );
+
+      const fallbackItems = await this.spClient.getListItemsByTitle<Record<string, unknown>>(
+        listTitle,
+        select,
+        undefined,
+        'Id desc',
+        200,
+      );
+
+      return fallbackItems
+        .map((item) => this.mapItemToEvent(item))
+        .filter((event) => this.matchesFilter(event, filter))
+        .sort((a, b) => Date.parse(b.detectedAt) - Date.parse(a.detectedAt))
+        .slice(0, 100);
+    }
   }
 
   private async initializeResolvedFields(listTitle: string): Promise<void> {
@@ -277,24 +367,15 @@ export class SharePointDriftEventRepository implements IDriftEventRepository {
         ]),
       );
 
-      const items = await this.spClient.getListItemsByTitle<Record<string, unknown>>(
+      const events = await this.fetchEventsWithThresholdFallback(
         listTitle,
         select,
         joinAnd(filters) || undefined,
-        `${detectedAtField} desc`,
-        100,
+        detectedAtField,
+        filter,
       );
 
-      return items.map(item => ({
-        id: String(item.Id ?? item.ID ?? ''),
-        listName: String(this.readRowValue(item, 'listName') ?? ''),
-        fieldName: String(this.readRowValue(item, 'fieldName') ?? ''),
-        detectedAt: String(this.readRowValue(item, 'detectedAt') ?? ''),
-        severity: (this.readRowValue(item, 'severity') as 'warn' | 'info') || 'info',
-        resolutionType: (this.readRowValue(item, 'resolutionType') as DriftResolutionType) || 'fuzzy_match',
-        driftType: (this.readRowValue(item, 'driftType') as DriftType) || 'unknown',
-        resolved: this.parseResolved(this.readRowValue(item, 'resolved')),
-      }));
+      return events;
 
     } catch (err) {
       auditLog.warn('diagnostics:drift', 'DriftEventRepository failed to fetch events (fail-open).', err);

--- a/src/features/diagnostics/drift/infra/__tests__/SharePointDriftEventRepository.spec.ts
+++ b/src/features/diagnostics/drift/infra/__tests__/SharePointDriftEventRepository.spec.ts
@@ -116,9 +116,9 @@ describe('SharePointDriftEventRepository', () => {
     const secondPayload = createItem.mock.calls[1][1];
     expect(secondPayload).toEqual({
       Title: 'Daily_Attendance:Status',
-      ListName: 'Daily_Attendance',
-      FieldName: 'Status',
-      DetectedAt: '2026-04-05T00:00:00.000Z',
+      List_x0020_Name: 'Daily_Attendance',
+      Field_x0020_Name: 'Status',
+      Detected_x0020_At: '2026-04-05T00:00:00.000Z',
     });
   });
 
@@ -196,6 +196,80 @@ describe('SharePointDriftEventRepository', () => {
     });
 
     await expect(repo.getEvents()).resolves.toEqual([]);
+  });
+
+  it('falls back to Id-desc scan when filtered query hits list view threshold', async () => {
+    const thresholdError = Object.assign(
+      new Error('The attempted operation is prohibited because it exceeds the list view threshold.'),
+      { status: 500 },
+    );
+    const getListItemsByTitle = vi
+      .fn()
+      .mockRejectedValueOnce(thresholdError)
+      .mockResolvedValueOnce([
+        {
+          ID: 21,
+          NameOfList: 'Daily_Attendance',
+          InternalName: 'Status0',
+          OccurredAt: '2026-04-10T10:00:00.000Z',
+          Resolution: 'fallback',
+          Category: 'suffix_mismatch',
+          IsResolved: false,
+          Level: 'warn',
+        },
+        {
+          ID: 20,
+          NameOfList: 'Other_List',
+          InternalName: 'Unused',
+          OccurredAt: '2026-04-01T10:00:00.000Z',
+          Resolution: 'fallback',
+          Category: 'suffix_mismatch',
+          IsResolved: false,
+          Level: 'warn',
+        },
+      ]);
+
+    const repo = new SharePointDriftEventRepository({
+      createItem: vi.fn(async () => ({})),
+      updateItemByTitle: vi.fn(async () => ({})),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      getListItemsByTitle: getListItemsByTitle as any,
+      getSchema: vi.fn(async () => [
+        'NameOfList',
+        'InternalName',
+        'OccurredAt',
+        'Level',
+        'Resolution',
+        'Category',
+        'IsResolved',
+      ]),
+    });
+
+    const since = '2026-04-03T00:00:00.000Z';
+    const events = await repo.getEvents({
+      listName: 'Daily_Attendance',
+      resolved: false,
+      since,
+    });
+
+    expect(getListItemsByTitle).toHaveBeenCalledTimes(2);
+    expect(getListItemsByTitle.mock.calls[0][2]).toContain(`OccurredAt ge datetime'${since}'`);
+    expect(getListItemsByTitle.mock.calls[0][3]).toBe('OccurredAt desc');
+    expect(getListItemsByTitle.mock.calls[1][2]).toBeUndefined();
+    expect(getListItemsByTitle.mock.calls[1][3]).toBe('Id desc');
+    expect(getListItemsByTitle.mock.calls[1][4]).toBe(200);
+    expect(events).toEqual([
+      {
+        id: '21',
+        listName: 'Daily_Attendance',
+        fieldName: 'Status0',
+        detectedAt: '2026-04-10T10:00:00.000Z',
+        severity: 'warn',
+        resolutionType: 'fallback',
+        driftType: 'suffix_mismatch',
+        resolved: false,
+      },
+    ]);
   });
 
   it('uses resolved physical field when marking resolved', async () => {

--- a/src/features/sp/health/hooks/useNightlySignalIngestion.ts
+++ b/src/features/sp/health/hooks/useNightlySignalIngestion.ts
@@ -4,11 +4,11 @@ import { auditLog } from '@/lib/debugLogger';
 import {
   DIAGNOSTICS_REPORTS_LIST_TITLE,
   DIAGNOSTICS_REPORTS_SELECT_FIELDS,
-  DRIFT_LOG_LIST_TITLE,
 } from '@/sharepoint/fields';
 import { reportDiagnosticsReport, mapPatrolEventToSignal, type PatrolEvent } from '../mapping';
 import { reportSpHealthEvent } from '../spHealthSignalStore';
 import type { DiagnosticsReportItem } from '@/sharepoint/diagnosticsReports';
+import { SharePointDriftEventRepository } from '@/features/diagnostics/drift/infra/SharePointDriftEventRepository';
 
 /**
  * useNightlySignalIngestion — Nightly Patrol 結果を UI に取り込む Hook
@@ -19,6 +19,7 @@ import type { DiagnosticsReportItem } from '@/sharepoint/diagnosticsReports';
 export function useNightlySignalIngestion() {
   const sp = useSP();
   const ranRef = React.useRef(false);
+  const driftRepository = React.useMemo(() => new SharePointDriftEventRepository(sp), [sp]);
 
   React.useEffect(() => {
     if (!sp || ranRef.current) return;
@@ -45,37 +46,15 @@ export function useNightlySignalIngestion() {
 
       // 2. DriftEventsLog の取得
       try {
-        const driftLogs = await sp.getListItemsByTitle(
-          DRIFT_LOG_LIST_TITLE,
-          ['Id', 'ListName', 'FieldName', 'DetectedAt', 'Severity', 'ResolutionType', 'ErrorMessage'],
-          undefined,
-          'Created desc',
-          10
-        );
+        const driftLogs = await driftRepository.getEvents();
 
-        interface DriftLogItem {
-          Severity?: { Value: string } | string;
-          ResolutionType?: string;
-          ListName?: string;
-          FieldName?: string;
-          DetectedAt?: string;
-          ErrorMessage?: string;
-          Created?: string;
-        }
-
-        const driftLogsTyped = driftLogs as unknown as DriftLogItem[];
-        for (const log of driftLogsTyped) {
-          const sev = log.Severity;
-          const severity = (typeof sev === 'object' && sev !== null && 'Value' in sev)
-            ? (sev as { Value: string }).Value
-            : (typeof sev === 'string' ? sev : 'watch');
-
+        for (const log of driftLogs.slice(0, 10)) {
           const event: PatrolEvent = {
-            severity: severity,
-            code: log.ResolutionType || 'unknown',
-            listName: log.ListName,
-            message: log.ErrorMessage || `Drift detected in ${log.FieldName || 'unknown field'}`,
-            occurredAt: log.DetectedAt || log.Created || new Date().toISOString(),
+            severity: log.severity || 'watch',
+            code: log.resolutionType || 'unknown',
+            listName: log.listName,
+            message: `Drift detected in ${log.fieldName || 'unknown field'}`,
+            occurredAt: log.detectedAt || new Date().toISOString(),
           };
           const signal = mapPatrolEventToSignal(event);
           if (signal) {
@@ -91,5 +70,5 @@ export function useNightlySignalIngestion() {
     };
 
     ingest();
-  }, [sp]);
+  }, [driftRepository, sp]);
 }


### PR DESCRIPTION
## What changed
- added threshold fallback for DriftEventsLog reads in the shared drift repository
- routed nightly signal ingestion through the shared repository path
- added the same Id-desc fallback path to nightly-runtime-patrol
- recorded drift log fallback/scanned/filtered stats in nightly summary output
- documented the fallback behavior and its operational limits in the admin runbook

## Why
DriftEventsLog queries could fail with SharePoint list view threshold errors, which made observability paths brittle. This change keeps diagnostics and nightly patrol usable even when the filtered query path fails, while also adding telemetry so we can verify whether the current fallback limit is sufficient in production.

## Impact
- /admin/status and drift observability can fail open instead of dropping out on threshold-triggered 500s
- nightly patrol now uses the same fallback strategy and emits concrete safety signals for the fallback window
- operations documentation now explains that this is a resilience improvement, not a root-cause fix

## Root cause
Filtered reads against DriftEventsLog could exceed SharePoint list view threshold constraints. The code previously had multiple read paths with inconsistent behavior, including a direct nightly fetch path that did not share the fallback logic.

## Validation
- `npx vitest run src/features/diagnostics/drift/infra/__tests__/SharePointDriftEventRepository.spec.ts`
- `npx eslint scripts/ops/nightly-runtime-patrol.ts src/features/diagnostics/drift/infra/SharePointDriftEventRepository.ts src/features/diagnostics/drift/infra/__tests__/SharePointDriftEventRepository.spec.ts src/features/sp/health/hooks/useNightlySignalIngestion.ts`
- commit hooks also ran `npm run lint` and `npm run typecheck`
