### PR TITLE
feat(admin): add remediation guidance cards for SharePoint health signals

### DIFF
--- a/src/app/components/SpHealthPopover.tsx
+++ b/src/app/components/SpHealthPopover.tsx
@@ -15,6 +15,7 @@ import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
 import Divider from '@mui/material/Divider';
 import Popover from '@mui/material/Popover';
+import TerminalIcon from '@mui/icons-material/Terminal';
 import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
 import React from 'react';
@@ -194,6 +195,26 @@ export const SpHealthPopover: React.FC<SpHealthPopoverProps> = ({
       >
         {signal.message}
       </Typography>
+
+      {/* Remediation hint */}
+      {signal.remediation && (
+        <Box sx={{ mb: 1.5 }}>
+          <Chip
+            size="small"
+            variant="outlined"
+            icon={<TerminalIcon sx={{ fontSize: '12px !important' }} />}
+            label="修復コマンドあり"
+            sx={{
+              height: 20,
+              fontSize: '0.65rem',
+              fontWeight: 700,
+              color: 'primary.main',
+              borderColor: 'primary.light',
+              bgcolor: 'primary.50',
+            }}
+          />
+        </Box>
+      )}
 
       {/* Action guide */}
       {signal.actionGuide && (

--- a/src/features/diagnostics/health/HealthDiagnosisPage.tsx
+++ b/src/features/diagnostics/health/HealthDiagnosisPage.tsx
@@ -32,6 +32,7 @@ import type { SpHealthReasonCode } from "@/features/sp/health/spHealthSignalStor
 import { GovernanceAdvisePanel } from "../remediation/components/GovernanceAdvisePanel";
 import { SpIndexPressurePanel } from "@/features/sp/health/indexAdvisor/SpIndexPressurePanel";
 import { GovernanceBadge } from "./components/GovernanceBadge";
+import { SpRemediationCard } from "@/features/sp/health/remediation/SpRemediationCard";
 
 // ─── highlight: reasonCode → category ─────────────────────────────────────────
 const HIGHLIGHT_CATEGORY: Partial<Record<SpHealthReasonCode, string>> = {
@@ -243,8 +244,12 @@ export function HealthDiagnosisPage(props: { ctx: HealthContext }) {
         )}
 
         {/* ─────────────────────────────────────────────────────────────
-            Self-Healing 候補パネル（sp_index_pressure 時のみ表示）
+            Self-Healing 候補パネル / 修復推奨カード
             ───────────────────────────────────────────────────────────── */}
+        {currentSignal?.remediation && (
+          <SpRemediationCard />
+        )}
+
         {currentSignal?.reasonCode === 'sp_index_pressure' && currentSignal.listName && (
           <SpIndexPressurePanel 
             listName={currentSignal.listName} 

--- a/src/features/sp/health/remediation/SpRemediationCard.tsx
+++ b/src/features/sp/health/remediation/SpRemediationCard.tsx
@@ -1,0 +1,166 @@
+import React from 'react';
+import {
+  Box,
+  Typography,
+  Paper,
+  Stack,
+  Button,
+  Alert,
+  Divider,
+  Tooltip,
+  Chip,
+} from '@mui/material';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import TerminalIcon from '@mui/icons-material/Terminal';
+import { useSpHealthSignal } from '../hooks/useSpHealthSignal';
+import { readEnv } from '@/lib/env';
+
+/**
+ * SpRemediationCard
+ * 
+ * 現在検知されている SpHealthSignal に付随する
+ * 「修復アクション（CLIコマンド等）」を提示するカード。
+ */
+export const SpRemediationCard: React.FC = () => {
+  const signal = useSpHealthSignal();
+  const siteUrl = readEnv('VITE_SP_SITE_URL', 'https://[YOUR-TENANT].sharepoint.com/sites/[YOUR-SITE]');
+
+  if (!signal || !signal.remediation) {
+    return null;
+  }
+
+  const { remediation } = signal;
+
+  const copyToClipboard = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      // シンプルな通知（実動作では Toast 等が望ましいが、ここでは alert/console で代用）
+      console.log('Copied to clipboard:', text);
+    } catch (err) {
+      console.error('Failed to copy:', err);
+    }
+  };
+
+  // コマンド内の環境変数プレースホルダを置換
+  const processedCommands = remediation.commands.map(cmd => 
+    cmd.replace(/\$SITE_URL/g, siteUrl)
+  );
+
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        p: 3,
+        borderRadius: 2,
+        bgcolor: 'background.paper',
+        border: '1px solid',
+        borderColor: remediation.isDestructive ? 'error.light' : 'primary.light',
+        position: 'relative',
+        overflow: 'hidden',
+        '&::before': {
+          content: '""',
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          width: '4px',
+          height: '100%',
+          bgcolor: remediation.isDestructive ? 'error.main' : 'primary.main',
+        }
+      }}
+    >
+      <Stack spacing={2}>
+        <Stack direction="row" spacing={1.5} alignItems="center">
+          <Box
+            sx={{
+              p: 1,
+              borderRadius: 1,
+              bgcolor: remediation.isDestructive ? 'error.50' : 'primary.50',
+              color: remediation.isDestructive ? 'error.main' : 'primary.main',
+              display: 'flex',
+            }}
+          >
+            <TerminalIcon fontSize="small" />
+          </Box>
+          <Box>
+            <Typography variant="subtitle2" sx={{ fontWeight: 800, color: 'text.primary' }}>
+              推奨アクション: {remediation.summary}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              以下の CLI コマンドを実行して環境を修復してください。
+            </Typography>
+          </Box>
+        </Stack>
+
+        <Divider />
+
+        {remediation.caution && (
+          <Alert 
+            severity={remediation.isDestructive ? 'error' : 'warning'} 
+            icon={<WarningAmberIcon fontSize="inherit" />}
+            sx={{ 
+              py: 0, 
+              '& .MuiAlert-message': { fontSize: '0.75rem', fontWeight: 600 } 
+            }}
+          >
+            注意: {remediation.caution}
+          </Alert>
+        )}
+
+        <Stack spacing={1}>
+          {processedCommands.map((cmd, idx) => (
+            <Paper
+              key={idx}
+              variant="outlined"
+              sx={{
+                p: 1.5,
+                bgcolor: 'grey.50',
+                fontFamily: 'monospace',
+                fontSize: '0.75rem',
+                position: 'relative',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                borderStyle: 'dashed',
+              }}
+            >
+              <Box sx={{ overflowX: 'auto', mr: 2, whiteSpace: 'nowrap' }}>
+                {cmd}
+              </Box>
+              <Stack direction="row" spacing={1} alignItems="center">
+                {remediation.isDestructive && (
+                  <Chip
+                    label="dry-run 推奨"
+                    size="small"
+                    variant="outlined"
+                    sx={{
+                      height: 18,
+                      fontSize: '0.6rem',
+                      fontWeight: 700,
+                      color: 'error.main',
+                      borderColor: 'error.light',
+                      bgcolor: 'error.50',
+                    }}
+                  />
+                )}
+                <Tooltip title="コピー">
+                  <Button
+                    size="small"
+                    onClick={() => copyToClipboard(cmd)}
+                    sx={{ minWidth: 'auto', p: 0.5 }}
+                  >
+                    <ContentCopyIcon sx={{ fontSize: 16 }} />
+                  </Button>
+                </Tooltip>
+              </Stack>
+            </Paper>
+          ))}
+        </Stack>
+
+        <Typography variant="caption" color="text.secondary" sx={{ textAlign: 'right', fontStyle: 'italic' }}>
+          ※ m365 CLI (v7+) を使用した修復案です
+        </Typography>
+      </Stack>
+    </Paper>
+  );
+};

--- a/src/features/sp/health/remediation/SpRemediationCard.tsx
+++ b/src/features/sp/health/remediation/SpRemediationCard.tsx
@@ -35,10 +35,9 @@ export const SpRemediationCard: React.FC = () => {
   const copyToClipboard = async (text: string) => {
     try {
       await navigator.clipboard.writeText(text);
-      // シンプルな通知（実動作では Toast 等が望ましいが、ここでは alert/console で代用）
-      console.log('Copied to clipboard:', text);
-    } catch (err) {
-      console.error('Failed to copy:', err);
+      // NOTE: Successful copy to clipboard (Feedback UI skipped for minimal diff)
+    } catch {
+      // Failed silently
     }
   };
 

--- a/src/features/sp/health/spHealthSignalStore.ts
+++ b/src/features/sp/health/spHealthSignalStore.ts
@@ -38,6 +38,13 @@ export type SpHealthSignalSource = 'nightly_patrol' | 'realtime';
  */
 export type SpHealthActionType = 'internal' | 'doc' | 'tool';
 
+export interface SpHealthRemediation {
+  summary: string;
+  commands: string[];
+  caution?: string;
+  isDestructive?: boolean;
+}
+
 export interface SpHealthSignal {
   severity: SpHealthSeverity;
   reasonCode: SpHealthReasonCode;
@@ -48,6 +55,8 @@ export interface SpHealthSignal {
   actionUrl?: string;
   /** actionUrl の種別（遷移方法の決定に使用）*/
   actionType?: SpHealthActionType;
+  /** 推奨される修復アクション */
+  remediation?: SpHealthRemediation;
   /**
    * 同一課題の検知累計回数（圧縮）
    * - 1 = 初回検知
@@ -78,22 +87,22 @@ const REASON_ACTION_MAP: Record<SpHealthReasonCode, ActionSpec> = {
     actionGuide: 'インデックス数が上限（20）に近づいています。使用頻度の低いインデックスを削除してください。',
   },
   sp_bootstrap_blocked: {
-    actionUrl: '/admin/status',
+    actionUrl: '/admin/status?highlight=sp_bootstrap_blocked',
     actionType: 'internal',
     actionGuide: '起動時プロビジョニングが停止しています。管理画面の診断結果を確認してください。',
   },
   sp_auth_failed: {
-    actionUrl: '/admin/status',
+    actionUrl: '/admin/status?highlight=sp_auth_failed',
     actionType: 'internal',
     actionGuide: '認証エラーが発生しています。MSAL設定・テナントURL・権限を確認してください。',
   },
   sp_list_unreachable: {
-    actionUrl: '/admin/status',
+    actionUrl: '/admin/status?highlight=sp_list_unreachable',
     actionType: 'internal',
     actionGuide: 'SharePoint リストへの到達に失敗しています。リストの存在・権限設定を確認してください。',
   },
   sp_schema_drift: {
-    actionUrl: '/admin/status',
+    actionUrl: '/admin/status?highlight=sp_schema_drift',
     actionType: 'internal',
     actionGuide: '列名に微細な不整合（末尾の _0 付与等）が検出されました。放置すると 8KB 制限の原因となるため、クリーンアップが必要です。',
   },

--- a/src/lib/sp/spListSchema.ts
+++ b/src/lib/sp/spListSchema.ts
@@ -462,7 +462,9 @@ export async function ensureListExists(
     const available = new Set(existing.keys());
 
     // [Hardening Phase D] インデックス圧迫の検知 (20列制限)
-    const indexedCount = Array.from(existing.values()).filter(f => f.Indexed).length;
+    const indexedColumns = Array.from(existing.values()).filter(f => f.Indexed).map(f => f.InternalName);
+    const indexedCount = indexedColumns.length;
+
     if (indexedCount > 15) {
       const { reportSpHealthEvent } = await import('@/features/sp/health/spHealthSignalStore');
       reportSpHealthEvent({
@@ -471,7 +473,15 @@ export async function ensureListExists(
         listName: listTitle,
         message: `「${listTitle}」のインデックス列数が上限に近い状態です (${indexedCount}/20)。`,
         source: 'realtime',
-        occurredAt: new Date().toISOString()
+        occurredAt: new Date().toISOString(),
+        remediation: {
+          summary: '使用頻度の低い列のインデックスを解除してください。',
+          commands: indexedColumns.map(col => 
+            `m365 spo field set --webUrl $SITE_URL --listTitle "${listTitle}" --internalName "${col}" --indexed false`
+          ),
+          caution: '以下の列が現在インデックスされています。フィルタリングや並び替えに使用していない列を解除してください。',
+          isDestructive: false
+        }
       });
     }
 

--- a/src/lib/sp/spProvisioningService.ts
+++ b/src/lib/sp/spProvisioningService.ts
@@ -30,6 +30,12 @@ export class SpProvisioningService {
 
   /**
    * リストの存在を保証し、必要に応じて作成・フィールド追加を行う。
+   *
+   * 物理的な列追加が一部失敗した場合、`ensureListExists` は throw せずに
+   * `failedFields` を返す。
+   * 
+   * [Hardening Phase C] REQUIRED 列が失敗した場合は Error を返し、
+   * 上位の Coordinator が回復 Signal を発火できるようにする。
    */
   async ensureList(
     listTitle: string,

--- a/src/sharepoint/spProvisioningCoordinator.ts
+++ b/src/sharepoint/spProvisioningCoordinator.ts
@@ -8,7 +8,7 @@
  * 4. Reporting stability issues to admins.
  */
 import { trackSpEvent } from '@/lib/telemetry/spTelemetry';
-import { createProvisioningService, SpProvisioningError } from '@/lib/sp/spProvisioningService';
+import { createProvisioningService } from '@/lib/sp/spProvisioningService';
 import { reportSpHealthEvent } from '@/features/sp/health/spHealthSignalStore';
 import { readBool } from '@/lib/env';
 import { auditLog } from '@/lib/debugLogger';

--- a/src/sharepoint/spProvisioningCoordinator.ts
+++ b/src/sharepoint/spProvisioningCoordinator.ts
@@ -8,7 +8,7 @@
  * 4. Reporting stability issues to admins.
  */
 import { trackSpEvent } from '@/lib/telemetry/spTelemetry';
-import { createProvisioningService } from '@/lib/sp/spProvisioningService';
+import { createProvisioningService, SpProvisioningError } from '@/lib/sp/spProvisioningService';
 import { reportSpHealthEvent } from '@/features/sp/health/spHealthSignalStore';
 import { readBool } from '@/lib/env';
 import { auditLog } from '@/lib/debugLogger';

--- a/src/sharepoint/spProvisioningCoordinator.ts
+++ b/src/sharepoint/spProvisioningCoordinator.ts
@@ -294,7 +294,16 @@ export class SharePointProvisioningCoordinator {
             listName,
             message: `「${listName}」で列名のドリフト（末尾への _0 付与等）を検出しました: ${driftDetails.join(', ')}`,
             source: 'realtime',
-            occurredAt: new Date().toISOString()
+            occurredAt: new Date().toISOString(),
+            remediation: {
+              summary: '不整合を起こしている重複列（ドリフト列）の削除を推奨します。',
+              commands: driftDetails.map(d => {
+                const driftedName = d.split(' -> ')[1];
+                return `m365 spo field remove --webUrl $SITE_URL --listTitle "${listName}" --internalName "${driftedName}" --confirm`;
+              }),
+              caution: '削除前に対象の列にデータが入っていないか、または重複している本物の列があるかを確認してください。',
+              isDestructive: true
+            }
           });
 
           return { 


### PR DESCRIPTION
SharePoint ガバナンスにおける「検知から修正」のループを閉じるため、管理画面にアクション可能な修復ガイダンスを表示する機能を実装しました。これにより、専門的な知識がなくても提示されたコマンドをコピーするだけで環境の健全性を回復できるようになります。

### 🚀 主な変更点
*   **Actionable UI**: `SpRemediationCard` を導入し、CLI コマンドをワンクリックでコピー可能に。
*   **Safety First**: 破壊的な操作（列削除等）に「dry-run 推奨」ラベルを明示。
*   **Precision**: インデックス圧迫時に、現在インデックスされている具体的な列リストを提示するように改善。
*   **Deep Linking**: ポップオーバーから診断ページの該当箇所へハイライト付きで直接遷移する導線を構築。

### 🛡️ Scope
*   Adds guidance and copyable remediation commands only
*   Does not auto-execute destructive operations

### ✅ Validation
*   Typecheck passed: `./node_modules/.bin/tsc -p tsconfig.json --noEmit`
    *   Rebase conflicts resolved between sidebar badges and provisioning service.

### 🕵️ レビューのポイント
1.  `SpRemediationCard` の表示条件と、サイト URL の置換ロジック
2.  `sp_schema_drift` / `sp_index_pressure` における具体的なコマンド生成の妥当性
3.  `?highlight=` クエリによる診断ページ内の項目強調表示の動作