### PR TITLE
feat(isp): implement KPI validation and PDCA health monitoring

### DIFF
--- a/.nightly/runtime-summary.json
+++ b/.nightly/runtime-summary.json
@@ -1,5 +1,5 @@
 {
-  "reportDate": "2026-04-07",
+  "reportDate": "2026-04-11",
   "totalEvents": 9,
   "bundledCount": 8,
   "countsBySeverity": {
@@ -15,9 +15,10 @@
       "eventType": "http_429",
       "area": "Platform",
       "resourceKey": "SharePoint_API",
+      "reasonCode": "rate_limit",
       "occurrences": 1,
-      "firstSeen": "2026-04-07T05:50:12.178Z",
-      "lastSeen": "2026-04-07T05:50:12.178Z",
+      "firstSeen": "2026-04-11T14:28:21.464Z",
+      "lastSeen": "2026-04-11T14:28:21.464Z",
       "nextAction": "【至急】運用管理者にエスカレーションし、システム全体の利用可否を確認してください。",
       "sampleMessage": "SharePoint Throttle occurred."
     },
@@ -27,9 +28,10 @@
       "eventType": "index_pressure",
       "area": "Runtime",
       "resourceKey": "iceberg_analysis",
+      "reasonCode": "index_required",
       "occurrences": 1,
-      "firstSeen": "2026-04-07T05:50:12.178Z",
-      "lastSeen": "2026-04-07T05:50:12.178Z",
+      "firstSeen": "2026-04-11T14:28:21.464Z",
+      "lastSeen": "2026-04-11T14:28:21.464Z",
       "nextAction": "【至急】[iceberg_analysis] で必須インデックスが不足しています。システム停止を防ぐため、Index Advisor で修復を実行してください。",
       "sampleMessage": "(CRITICAL) Severity: critical. Index Count: 18 / 20. Essential indexes missing."
     },
@@ -39,9 +41,10 @@
       "eventType": "remediation",
       "area": "Runtime",
       "resourceKey": "UserBenefit_Profile",
+      "reasonCode": "manual",
       "occurrences": 1,
-      "firstSeen": "2026-04-07T05:50:12.178Z",
-      "lastSeen": "2026-04-07T05:50:12.178Z",
+      "firstSeen": "2026-04-11T14:28:21.464Z",
+      "lastSeen": "2026-04-11T14:28:21.464Z",
       "nextAction": "【要確認】インデックス修復 (RecipientCertNumber) に失敗しました。ネットワーク状態や SharePoint 権限を確認してください。",
       "sampleMessage": "RecipientCertNumber のインデックス作成に失敗しました: Network Error"
     },
@@ -51,9 +54,10 @@
       "eventType": "health_fail",
       "area": "Platform",
       "resourceKey": "Users_Master",
+      "reasonCode": "list_not_found",
       "occurrences": 1,
-      "firstSeen": "2026-04-07T05:50:12.178Z",
-      "lastSeen": "2026-04-07T05:50:12.178Z",
+      "firstSeen": "2026-04-11T14:28:21.464Z",
+      "lastSeen": "2026-04-11T14:28:21.464Z",
       "nextAction": "[Users_Master] の健全性チェックに失敗しました。SharePoint 管理画面でリストの存在・権限設定を確認してください。",
       "sampleMessage": "Users_Master list does not exist."
     },
@@ -63,9 +67,10 @@
       "eventType": "drift",
       "area": "Daily",
       "resourceKey": "support_record_daily",
+      "reasonCode": "unknown_field_added",
       "occurrences": 1,
-      "firstSeen": "2026-04-07T05:50:12.178Z",
-      "lastSeen": "2026-04-07T05:50:12.178Z",
+      "firstSeen": "2026-04-11T14:28:21.464Z",
+      "lastSeen": "2026-04-11T14:28:21.464Z",
       "nextAction": "[support_record_daily] に誰かがフィールドを直接追加・削除した可能性があるため、変更履歴を調査してください。",
       "sampleMessage": "New field encountered."
     },
@@ -75,9 +80,10 @@
       "eventType": "provision_skipped:block",
       "area": "UserBenefit",
       "resourceKey": "UserBenefit_Profile",
+      "reasonCode": "max_size_exceeded",
       "occurrences": 2,
-      "firstSeen": "2026-04-07T05:50:12.178Z",
-      "lastSeen": "2026-04-07T05:50:12.178Z",
+      "firstSeen": "2026-04-11T14:28:21.463Z",
+      "lastSeen": "2026-04-11T14:28:21.464Z",
       "nextAction": "（対応不要・本システムで安全に吸収済み）",
       "sampleMessage": "Prevented creation to avoid 8KB limits."
     },
@@ -87,9 +93,10 @@
       "eventType": "drift",
       "area": "UserBenefit",
       "resourceKey": "UserBenefit_Profile",
+      "reasonCode": "absorbed_strategy_e",
       "occurrences": 1,
-      "firstSeen": "2026-04-07T05:50:12.178Z",
-      "lastSeen": "2026-04-07T05:50:12.178Z",
+      "firstSeen": "2026-04-11T14:28:21.464Z",
+      "lastSeen": "2026-04-11T14:28:21.464Z",
       "nextAction": "[UserBenefit_Profile] に誰かがフィールドを直接追加・削除した可能性があるため、変更履歴を調査してください。",
       "sampleMessage": "Strategy E absorbed it."
     },
@@ -99,11 +106,72 @@
       "eventType": "remediation",
       "area": "Runtime",
       "resourceKey": "StaffAttendance",
+      "reasonCode": "manual",
       "occurrences": 1,
-      "firstSeen": "2026-04-07T05:50:12.178Z",
-      "lastSeen": "2026-04-07T05:50:12.178Z",
+      "firstSeen": "2026-04-11T14:28:21.464Z",
+      "lastSeen": "2026-04-11T14:28:21.464Z",
       "nextAction": "インデックス自動修復 (RecordDate) が正常に完了しました。",
       "sampleMessage": "RecordDate のインデックスを作成しました（成功）。"
     }
-  ]
+  ],
+  "reasonCodeSummary": [
+    {
+      "reasonCode": "manual",
+      "count": 2,
+      "resources": [
+        "StaffAttendance",
+        "UserBenefit_Profile"
+      ]
+    },
+    {
+      "reasonCode": "absorbed_strategy_e",
+      "count": 1,
+      "resources": [
+        "UserBenefit_Profile"
+      ]
+    },
+    {
+      "reasonCode": "index_required",
+      "count": 1,
+      "resources": [
+        "iceberg_analysis"
+      ]
+    },
+    {
+      "reasonCode": "list_not_found",
+      "count": 1,
+      "resources": [
+        "Users_Master"
+      ]
+    },
+    {
+      "reasonCode": "max_size_exceeded",
+      "count": 1,
+      "resources": [
+        "UserBenefit_Profile"
+      ]
+    },
+    {
+      "reasonCode": "rate_limit",
+      "count": 1,
+      "resources": [
+        "SharePoint_API"
+      ]
+    },
+    {
+      "reasonCode": "unknown_field_added",
+      "count": 1,
+      "resources": [
+        "support_record_daily"
+      ]
+    }
+  ],
+  "driftLogReadStats": {
+    "fallbackUsed": false,
+    "scannedCount": 0,
+    "filteredCount": 0,
+    "lookbackHours": 24,
+    "topLimit": 200,
+    "safety": "safe"
+  }
 }

--- a/.nightly/runtime-summary.md
+++ b/.nightly/runtime-summary.md
@@ -1,5 +1,5 @@
 
-# Nightly Runtime Patrol Report — 2026-04-07
+# Nightly Runtime Patrol Report — 2026-04-11
 
 ## 📊 Summary
 * **Total Raw Events**: 9
@@ -8,8 +8,29 @@
   * 🟠 **Action Required**: 1
   * 🟡 **Watch**: 2
   * 🟢 **Silent (Absorbed)**: 3
+* 📘 **Drift Log Read**: fallback=no / scanned=0 / filtered=0 / safety=safe
+
 
 ---
+
+## 🧾 Reason Code Summary
+| Reason Code | Count | Resources |
+| --- | :---: | --- |
+| `manual` | 2 | StaffAttendance, UserBenefit_Profile |
+| `absorbed_strategy_e` | 1 | UserBenefit_Profile |
+| `index_required` | 1 | iceberg_analysis |
+| `list_not_found` | 1 | Users_Master |
+| `max_size_exceeded` | 1 | UserBenefit_Profile |
+| `rate_limit` | 1 | SharePoint_API |
+| `unknown_field_added` | 1 | support_record_daily |
+
+## 🔁 Repeated Transient Failures
+_No events recorded._
+
+
+## ♻️ Recovered Transient Failures
+_No events recorded._
+
 
 ## 🚨 Requires Attention (Critical & Action Required & Watch)
 | Severity | Event Type | Resource | Occurrences | Fingerprint | NextAction |

--- a/src/app/config/navigationConfig.ts
+++ b/src/app/config/navigationConfig.ts
@@ -300,15 +300,15 @@ export function createNavItems(config: CreateNavItemsConfig): NavItem[] {
       featureFlag: 'todayLiteNavV2',
     },
     {
-      // Tier B: 制度遵守（モニタリング・計画）の監査・監視。管理者のみ表示。
-      label: '制度遵守ダッシュボード',
+      // OSの心臓部。PDCAの停滞を可視化し、全職員の意思決定を支援。
+      label: 'PDCAサイクル監視 (OS)',
       to: '/admin/regulatory-dashboard',
       isActive: (pathname) => pathname === '/admin/regulatory-dashboard',
       icon: undefined,
       testId: 'nav-regulatory-dashboard',
-      audience: NAV_AUDIENCE.admin,
-      group: 'operations' as NavGroupKey,
-      tier: 'admin',
+      audience: NAV_AUDIENCE.staff,
+      group: 'severe' as NavGroupKey,
+      tier: 'more',
       featureFlag: 'todayLiteNavV2',
     },
     createHubNavItem('billing', { testId: TESTIDS.nav.billing }),

--- a/src/data/isp/infra/DataProviderImprovementOutcomeRepository.ts
+++ b/src/data/isp/infra/DataProviderImprovementOutcomeRepository.ts
@@ -1,0 +1,127 @@
+import type { IDataProvider } from '@/lib/data/dataProvider.interface';
+import { areEssentialFieldsResolved, resolveInternalNamesDetailed } from '@/lib/sp/helpers';
+import type { ImprovementOutcome } from '@/domain/isp/improvementOutcome';
+import type { ImprovementOutcomeRepository } from '@/domain/isp/improvementOutcomeRepository';
+import {
+  IMPROVEMENT_OUTCOME_CANDIDATES,
+  IMPROVEMENT_OUTCOME_ENSURE_FIELDS,
+  IMPROVEMENT_OUTCOME_ESSENTIALS,
+  type ImprovementOutcomeCandidateKey,
+  type ImprovementOutcomeFieldMapping,
+  type SpImprovementOutcomeRow,
+} from '@/sharepoint/fields/improvementOutcomeFields';
+
+const LIST_TITLE = 'ImprovementOutcomes';
+
+export class DataProviderImprovementOutcomeRepository
+  implements ImprovementOutcomeRepository {
+  private resolution: { listTitle: string; mapping: ImprovementOutcomeFieldMapping } | null = null;
+
+  constructor(
+    private readonly provider: IDataProvider,
+    private readonly listTitle: string = LIST_TITLE,
+  ) {}
+
+  private mf(mapping: ImprovementOutcomeFieldMapping, key: ImprovementOutcomeCandidateKey): string {
+    return mapping[key] ?? IMPROVEMENT_OUTCOME_CANDIDATES[key][0];
+  }
+
+  private async resolveSource(): Promise<{ listTitle: string; mapping: ImprovementOutcomeFieldMapping }> {
+    if (this.resolution) return this.resolution;
+
+    await this.provider.ensureListExists(
+      this.listTitle,
+      [...IMPROVEMENT_OUTCOME_ENSURE_FIELDS] as unknown as Parameters<IDataProvider['ensureListExists']>[1],
+    );
+
+    const available = await this.provider.getFieldInternalNames(this.listTitle);
+    const { resolved } = resolveInternalNamesDetailed(
+      available,
+      IMPROVEMENT_OUTCOME_CANDIDATES as unknown as Record<string, string[]>,
+    );
+
+    const isHealthy = areEssentialFieldsResolved(
+      resolved,
+      IMPROVEMENT_OUTCOME_ESSENTIALS as unknown as string[],
+    );
+
+    if (!isHealthy) {
+      throw new Error(`ImprovementOutcome schema could not be resolved: ${this.listTitle}`);
+    }
+
+    this.resolution = {
+      listTitle: this.listTitle,
+      mapping: resolved as ImprovementOutcomeFieldMapping,
+    };
+    return this.resolution;
+  }
+
+  private mapRow(row: SpImprovementOutcomeRow, mapping: ImprovementOutcomeFieldMapping): ImprovementOutcome {
+    return {
+      id: String(row[this.mf(mapping, 'outcomeId')] ?? ''),
+      planningSheetId: String(row[this.mf(mapping, 'planningSheetId')] ?? ''),
+      patchId: String(row[this.mf(mapping, 'patchId')] ?? ''),
+      observedAt: String(row[this.mf(mapping, 'observedAt')] ?? ''),
+      targetMetric: String(row[this.mf(mapping, 'targetMetric')] ?? 'incident_count') as ImprovementOutcome['targetMetric'],
+      source: String(row[this.mf(mapping, 'source')] ?? 'manual_kpi') as ImprovementOutcome['source'],
+      metricDefinitionId: String(row[this.mf(mapping, 'metricDefinitionId')] ?? '') || undefined,
+      beforeValue: Number(row[this.mf(mapping, 'beforeValue')] ?? 0),
+      afterValue: Number(row[this.mf(mapping, 'afterValue')] ?? 0),
+      changeRate: Number(row[this.mf(mapping, 'changeRate')] ?? 0),
+      isImproved: Boolean(row[this.mf(mapping, 'isImproved')]),
+      confidence: String(row[this.mf(mapping, 'confidence')] ?? 'medium') as ImprovementOutcome['confidence'],
+      evaluationWindowDays: row[this.mf(mapping, 'evaluationWindowDays')] == null
+        ? undefined
+        : Number(row[this.mf(mapping, 'evaluationWindowDays')]),
+      createdAt: String(row[this.mf(mapping, 'createdAt')] ?? ''),
+    };
+  }
+
+  private buildPayload(
+    outcome: ImprovementOutcome,
+    mapping: ImprovementOutcomeFieldMapping,
+  ): Record<string, unknown> {
+    return {
+      Title: outcome.id,
+      [this.mf(mapping, 'outcomeId')]: outcome.id,
+      [this.mf(mapping, 'planningSheetId')]: outcome.planningSheetId,
+      [this.mf(mapping, 'patchId')]: outcome.patchId,
+      [this.mf(mapping, 'observedAt')]: outcome.observedAt,
+      [this.mf(mapping, 'targetMetric')]: outcome.targetMetric,
+      [this.mf(mapping, 'source')]: outcome.source,
+      [this.mf(mapping, 'metricDefinitionId')]: outcome.metricDefinitionId ?? null,
+      [this.mf(mapping, 'beforeValue')]: outcome.beforeValue,
+      [this.mf(mapping, 'afterValue')]: outcome.afterValue,
+      [this.mf(mapping, 'changeRate')]: outcome.changeRate,
+      [this.mf(mapping, 'isImproved')]: outcome.isImproved,
+      [this.mf(mapping, 'confidence')]: outcome.confidence,
+      [this.mf(mapping, 'evaluationWindowDays')]: outcome.evaluationWindowDays ?? null,
+      [this.mf(mapping, 'createdAt')]: outcome.createdAt,
+    };
+  }
+
+  async save(outcome: ImprovementOutcome): Promise<void> {
+    const { listTitle, mapping } = await this.resolveSource();
+    await this.provider.createItem(listTitle, this.buildPayload(outcome, mapping));
+  }
+
+  async findByPlanningSheetId(planningSheetId: string): Promise<ImprovementOutcome[]> {
+    const { listTitle, mapping } = await this.resolveSource();
+    const rows = await this.provider.listItems<SpImprovementOutcomeRow>(listTitle, {
+      filter: `${this.mf(mapping, 'planningSheetId')} eq '${planningSheetId.replace(/'/g, "''")}'`,
+      orderby: `${this.mf(mapping, 'observedAt')} desc`,
+      top: 200,
+    });
+    return rows.map((row) => this.mapRow(row, mapping));
+  }
+
+  async findByPatchId(patchId: string): Promise<ImprovementOutcome[]> {
+    const { listTitle, mapping } = await this.resolveSource();
+    const rows = await this.provider.listItems<SpImprovementOutcomeRow>(listTitle, {
+      filter: `${this.mf(mapping, 'patchId')} eq '${patchId.replace(/'/g, "''")}'`,
+      orderby: `${this.mf(mapping, 'observedAt')} desc`,
+      top: 200,
+    });
+    return rows.map((row) => this.mapRow(row, mapping));
+  }
+}

--- a/src/data/isp/infra/DataProviderPlanPatchRepository.ts
+++ b/src/data/isp/infra/DataProviderPlanPatchRepository.ts
@@ -1,0 +1,165 @@
+import type { IDataProvider } from '@/lib/data/dataProvider.interface';
+import { areEssentialFieldsResolved, resolveInternalNamesDetailed } from '@/lib/sp/helpers';
+import type { PlanPatch } from '@/domain/isp/planPatch';
+import type { PlanPatchRepository } from '@/domain/isp/planPatchRepository';
+import {
+  PLAN_PATCH_CANDIDATES,
+  PLAN_PATCH_ENSURE_FIELDS,
+  PLAN_PATCH_ESSENTIALS,
+  type PlanPatchCandidateKey,
+  type PlanPatchFieldMapping,
+  type SpPlanPatchRow,
+} from '@/sharepoint/fields/planPatchFields';
+
+const LIST_TITLE = 'PlanPatches';
+
+function parseJson<T>(value: unknown, fallback: T): T {
+  if (!value || typeof value !== 'string') return fallback;
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+export class DataProviderPlanPatchRepository implements PlanPatchRepository {
+  private resolution: { listTitle: string; mapping: PlanPatchFieldMapping } | null = null;
+
+  constructor(
+    private readonly provider: IDataProvider,
+    private readonly listTitle: string = LIST_TITLE,
+  ) {}
+
+  private mf(mapping: PlanPatchFieldMapping, key: PlanPatchCandidateKey): string {
+    return mapping[key] ?? PLAN_PATCH_CANDIDATES[key][0];
+  }
+
+  private async resolveSource(): Promise<{ listTitle: string; mapping: PlanPatchFieldMapping }> {
+    if (this.resolution) return this.resolution;
+
+    await this.provider.ensureListExists(
+      this.listTitle,
+      [...PLAN_PATCH_ENSURE_FIELDS] as unknown as Parameters<IDataProvider['ensureListExists']>[1],
+    );
+
+    const available = await this.provider.getFieldInternalNames(this.listTitle);
+    const { resolved } = resolveInternalNamesDetailed(
+      available,
+      PLAN_PATCH_CANDIDATES as unknown as Record<string, string[]>,
+    );
+
+    const isHealthy = areEssentialFieldsResolved(
+      resolved,
+      PLAN_PATCH_ESSENTIALS as unknown as string[],
+    );
+
+    if (!isHealthy) {
+      throw new Error(`PlanPatch schema could not be resolved: ${this.listTitle}`);
+    }
+
+    this.resolution = {
+      listTitle: this.listTitle,
+      mapping: resolved as PlanPatchFieldMapping,
+    };
+    return this.resolution;
+  }
+
+  private mapRow(row: SpPlanPatchRow, mapping: PlanPatchFieldMapping): PlanPatch {
+    const target = String(row[this.mf(mapping, 'target')] ?? 'plan');
+    const base = {
+      id: String(row[this.mf(mapping, 'patchId')] ?? ''),
+      planningSheetId: String(row[this.mf(mapping, 'planningSheetId')] ?? ''),
+      baseVersion: String(row[this.mf(mapping, 'baseVersion')] ?? ''),
+      reason: String(row[this.mf(mapping, 'reason')] ?? ''),
+      evidenceIds: parseJson<string[]>(row[this.mf(mapping, 'evidenceIdsJson')], []),
+      status: String(row[this.mf(mapping, 'status')] ?? 'draft') as PlanPatch['status'],
+      dueAt: String(row[this.mf(mapping, 'dueAt')] ?? '') || undefined,
+      createdAt: String(row[this.mf(mapping, 'createdAt')] ?? ''),
+      updatedAt: String(row[this.mf(mapping, 'updatedAt')] ?? ''),
+    };
+
+    if (target === 'procedure') {
+      return {
+        ...base,
+        target: 'procedure',
+        before: parseJson(row[this.mf(mapping, 'beforeJson')], []),
+        after: parseJson(row[this.mf(mapping, 'afterJson')], []),
+      };
+    }
+
+    return {
+      ...base,
+      target: 'plan',
+      before: parseJson(row[this.mf(mapping, 'beforeJson')], {}),
+      after: parseJson(row[this.mf(mapping, 'afterJson')], {}),
+    };
+  }
+
+  private buildPayload(patch: PlanPatch, mapping: PlanPatchFieldMapping): Record<string, unknown> {
+    return {
+      Title: `${patch.planningSheetId}_${patch.target}_${patch.status}`,
+      [this.mf(mapping, 'patchId')]: patch.id,
+      [this.mf(mapping, 'planningSheetId')]: patch.planningSheetId,
+      [this.mf(mapping, 'target')]: patch.target,
+      [this.mf(mapping, 'baseVersion')]: patch.baseVersion,
+      [this.mf(mapping, 'beforeJson')]: JSON.stringify(patch.before),
+      [this.mf(mapping, 'afterJson')]: JSON.stringify(patch.after),
+      [this.mf(mapping, 'reason')]: patch.reason,
+      [this.mf(mapping, 'evidenceIdsJson')]: JSON.stringify(patch.evidenceIds),
+      [this.mf(mapping, 'status')]: patch.status,
+      [this.mf(mapping, 'dueAt')]: patch.dueAt ?? null,
+      [this.mf(mapping, 'createdAt')]: patch.createdAt,
+      [this.mf(mapping, 'updatedAt')]: patch.updatedAt,
+    };
+  }
+
+  private async findSpItemId(patchId: string, listTitle: string, mapping: PlanPatchFieldMapping): Promise<number | null> {
+    const rows = await this.provider.listItems<SpPlanPatchRow>(listTitle, {
+      select: ['Id'],
+      filter: `${this.mf(mapping, 'patchId')} eq '${patchId.replace(/'/g, "''")}'`,
+      top: 1,
+    });
+
+    const spId = rows[0]?.Id;
+    return typeof spId === 'number' ? spId : null;
+  }
+
+  async save(patch: PlanPatch): Promise<void> {
+    const { listTitle, mapping } = await this.resolveSource();
+    const payload = this.buildPayload(patch, mapping);
+    const spId = await this.findSpItemId(patch.id, listTitle, mapping);
+
+    if (spId === null) {
+      await this.provider.createItem(listTitle, payload);
+      return;
+    }
+
+    await this.provider.updateItem(listTitle, spId, payload, { etag: '*' });
+  }
+
+  async findByPlanningSheetId(planningSheetId: string): Promise<PlanPatch[]> {
+    const { listTitle, mapping } = await this.resolveSource();
+    const rows = await this.provider.listItems<SpPlanPatchRow>(listTitle, {
+      filter: `${this.mf(mapping, 'planningSheetId')} eq '${planningSheetId.replace(/'/g, "''")}'`,
+      orderby: `${this.mf(mapping, 'createdAt')} desc`,
+      top: 200,
+    });
+    return rows.map((row) => this.mapRow(row, mapping));
+  }
+
+  async updateStatus(patchId: string, status: PlanPatch['status']): Promise<void> {
+    const { listTitle, mapping } = await this.resolveSource();
+    const spId = await this.findSpItemId(patchId, listTitle, mapping);
+    if (spId === null) return;
+
+    await this.provider.updateItem(listTitle, spId, {
+      [this.mf(mapping, 'status')]: status,
+      [this.mf(mapping, 'updatedAt')]: new Date().toISOString(),
+    }, { etag: '*' });
+  }
+
+  async findPending(planningSheetId: string): Promise<PlanPatch[]> {
+    const patches = await this.findByPlanningSheetId(planningSheetId);
+    return patches.filter((patch) => patch.status !== 'confirmed');
+  }
+}

--- a/src/domain/bridge/__tests__/nextStepBanner.spec.ts
+++ b/src/domain/bridge/__tests__/nextStepBanner.spec.ts
@@ -28,6 +28,8 @@ function makeInput(overrides: Partial<ResolveNextStepInput> = {}): ResolveNextSt
     planningSheetId: 'ps-1',
     hasMonitoringSignals: false,
     hasUnappliedReassessment: false,
+    hasPendingPlanUpdate: false,
+    hasOverduePlanUpdate: false,
     ...overrides,
   };
 }
@@ -217,6 +219,37 @@ describe('resolveNextStepBanner — reassessment', () => {
 // ─────────────────────────────────────────────
 
 describe('resolveNextStepBanner — planning', () => {
+  it('未反映の計画更新があると warning バナーで更新案確認を促す', () => {
+    const result = resolveNextStepBanner(
+      makeInput({
+        phase: 'active_plan',
+        context: 'planning',
+        hasPendingPlanUpdate: true,
+      }),
+    );
+
+    expect(result.hidden).toBe(false);
+    expect(result.tone).toBe('warning');
+    expect(result.title).toContain('未反映');
+    expect(result.ctaLabel).toBe('更新案を確認');
+    expect(result.href).toContain('tab=planning');
+  });
+
+  it('期限超過の計画更新があると danger バナーを返す', () => {
+    const result = resolveNextStepBanner(
+      makeInput({
+        phase: 'active_plan',
+        context: 'planning',
+        hasPendingPlanUpdate: true,
+        hasOverduePlanUpdate: true,
+      }),
+    );
+
+    expect(result.hidden).toBe(false);
+    expect(result.tone).toBe('danger');
+    expect(result.title).toContain('期限');
+  });
+
   it('needs_plan → info「手順を追加」', () => {
     const result = resolveNextStepBanner(
       makeInput({
@@ -301,6 +334,41 @@ describe('resolveNextStepBanner — ルール', () => {
 });
 
 describe('resolveNextStepBanner — PDCA alerts', () => {
+  it('未反映の計画更新があると alert を追加する', () => {
+    const result = resolveNextStepBanner(
+      makeInput({
+        phase: 'needs_monitoring',
+        context: 'overview',
+        hasPendingPlanUpdate: true,
+      }),
+    );
+
+    expect(result.alerts).toContainEqual({
+      type: 'warning',
+      message: '支援計画の更新が未反映',
+      action: '更新案を確認',
+      priority: 'p1',
+    });
+  });
+
+  it('期限超過の計画更新があると p0 alert を追加する', () => {
+    const result = resolveNextStepBanner(
+      makeInput({
+        phase: 'needs_monitoring',
+        context: 'overview',
+        hasPendingPlanUpdate: true,
+        hasOverduePlanUpdate: true,
+      }),
+    );
+
+    expect(result.alerts).toContainEqual({
+      type: 'danger',
+      message: '支援計画の更新期限を超過',
+      action: '更新案を確認',
+      priority: 'p0',
+    });
+  });
+
   it('check phase + 3日 → p2', () => {
     const alerts = buildPdcaAlerts(
       makePdcaState({

--- a/src/domain/bridge/nextStepBanner.ts
+++ b/src/domain/bridge/nextStepBanner.ts
@@ -63,6 +63,10 @@ export interface ResolveNextStepInput {
   hasMonitoringSignals?: boolean;
   /** 再評価結果が未反映か */
   hasUnappliedReassessment?: boolean;
+  /** 計画更新案が未反映か */
+  hasPendingPlanUpdate?: boolean;
+  /** 期限超過の計画更新案があるか */
+  hasOverduePlanUpdate?: boolean;
   /** PDCA サイクル状態（ある場合のみ補助判定に使用） */
   pdcaCycleState?: PdcaCycleState | null;
 }
@@ -299,6 +303,23 @@ export function buildPdcaAlerts(
   return sortAlertsByPriority(alerts);
 }
 
+function buildPlanUpdateAlerts(input: ResolveNextStepInput): NextStepAlert[] {
+  if (!input.hasPendingPlanUpdate) {
+    return [];
+  }
+
+  const priority: NextStepAlertPriority = input.hasOverduePlanUpdate ? 'p0' : 'p1';
+
+  return [{
+    type: alertTypeFromPriority(priority),
+    message: input.hasOverduePlanUpdate
+      ? '支援計画の更新期限を超過'
+      : '支援計画の更新が未反映',
+    action: '更新案を確認',
+    priority,
+  }];
+}
+
 // ─────────────────────────────────────────────
 // Context-specific resolvers
 // ─────────────────────────────────────────────
@@ -423,7 +444,21 @@ function resolveReassessment(input: ResolveNextStepInput): NextStepBannerModel {
 }
 
 function resolvePlanning(input: ResolveNextStepInput): NextStepBannerModel {
-  const { userId, phase } = input;
+  const { userId, phase, planningSheetId, hasPendingPlanUpdate, hasOverduePlanUpdate } = input;
+
+  if (hasPendingPlanUpdate) {
+    return {
+      tone: hasOverduePlanUpdate ? 'danger' : 'warning',
+      title: hasOverduePlanUpdate
+        ? '未反映の計画更新が期限を超過しています'
+        : '未反映の計画更新があります',
+      description: '会議で生成された更新案をレビューし、必要に応じて計画へ反映してください。',
+      ctaLabel: '更新案を確認',
+      href: planningSheetId ? `/support-planning-sheet/${planningSheetId}?tab=planning` : '',
+      hidden: false,
+      alerts: [],
+    };
+  }
 
   if (phase === 'needs_plan') {
     return {
@@ -478,9 +513,10 @@ export function resolveNextStepBanner(
   })();
 
   const pdcaAlerts = buildPdcaAlerts(input.pdcaCycleState);
+  const planUpdateAlerts = buildPlanUpdateAlerts(input);
 
   return {
     ...existingBanner,
-    alerts: [...existingBanner.alerts, ...pdcaAlerts],
+    alerts: [...existingBanner.alerts, ...planUpdateAlerts, ...pdcaAlerts],
   };
 }

--- a/src/domain/isp/__tests__/improvementOutcome.spec.ts
+++ b/src/domain/isp/__tests__/improvementOutcome.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { calculateImprovementFactor, evaluateImprovement, type ImprovementOutcome } from '../improvementOutcome';
+
+function makeOutcome(overrides: Partial<ImprovementOutcome> = {}): ImprovementOutcome {
+  return {
+    id: 'outcome-1',
+    planningSheetId: 'sheet-1',
+    patchId: 'patch-1',
+    observedAt: '2026-04-12',
+    targetMetric: 'incident_count',
+    source: 'manual_kpi',
+    beforeValue: 5,
+    afterValue: 2,
+    changeRate: -0.6,
+    isImproved: true,
+    confidence: 'medium',
+    createdAt: '2026-04-12T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('improvementOutcome', () => {
+  it('evaluateImprovement detects decrease-good improvements', () => {
+    expect(
+      evaluateImprovement({
+        before: 10,
+        after: 4,
+        direction: 'decrease_good',
+      }),
+    ).toEqual({
+      changeRate: -0.6,
+      isImproved: true,
+    });
+  });
+
+  it('calculateImprovementFactor returns success rate', () => {
+    expect(
+      calculateImprovementFactor([
+        makeOutcome(),
+        makeOutcome({ id: 'outcome-2', isImproved: false }),
+      ]),
+    ).toBe(0.5);
+  });
+});

--- a/src/domain/isp/__tests__/pdcaHealth.spec.ts
+++ b/src/domain/isp/__tests__/pdcaHealth.spec.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import { buildPdcaHealthScore, calculatePdcaHealthScore } from '../pdcaHealth';
+import type { ImprovementOutcome } from '../improvementOutcome';
+import type { PlanPatchForPlan } from '../planPatch';
+import type { MonitoringMeetingRecord } from '../monitoringMeeting';
+
+function makePatch(overrides: Partial<PlanPatchForPlan> = {}): PlanPatchForPlan {
+  return {
+    id: 'patch-1',
+    planningSheetId: 'sheet-1',
+    baseVersion: '1',
+    target: 'plan',
+    before: {},
+    after: { status: 'revision_pending' },
+    reason: '計画更新',
+    evidenceIds: ['meeting-1'],
+    status: 'needs_update',
+    dueAt: '2026-04-10',
+    createdAt: '2026-04-01T00:00:00.000Z',
+    updatedAt: '2026-04-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeMeeting(overrides: Partial<MonitoringMeetingRecord> = {}): MonitoringMeetingRecord {
+  return {
+    id: 'meeting-1',
+    userId: 'U001',
+    userName: '利用者A',
+    planningSheetId: 'sheet-1',
+    ispId: 'ISP001',
+    meetingType: 'regular',
+    meetingDate: '2026-04-01',
+    venue: '相談室',
+    attendees: [],
+    goalEvaluations: [],
+    overallAssessment: '',
+    userFeedback: '',
+    familyFeedback: '',
+    issueSummary: '',
+    effectiveSupportSummary: '',
+    planChangeDecision: 'minor_revision',
+    requiresPlanSheetUpdate: true,
+    changeReason: '',
+    decisions: [],
+    nextActions: [],
+    nextMonitoringDate: '2026-04-20',
+    discussionSummary: '',
+    recordedBy: 'tester',
+    recordedAt: '2026-04-01T00:00:00.000Z',
+    status: 'finalized',
+    ...overrides,
+  };
+}
+
+function makeOutcome(overrides: Partial<ImprovementOutcome> = {}): ImprovementOutcome {
+  return {
+    id: 'outcome-1',
+    planningSheetId: 'sheet-1',
+    patchId: 'patch-1',
+    observedAt: '2026-04-12',
+    targetMetric: 'incident_count',
+    source: 'manual_kpi',
+    beforeValue: 5,
+    afterValue: 2,
+    changeRate: -0.6,
+    isImproved: true,
+    confidence: 'medium',
+    createdAt: '2026-04-12T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('pdcaHealth', () => {
+  it('calculates severity from overdue and pending counts', () => {
+    expect(
+      calculatePdcaHealthScore({
+        pendingPatchCount: 1,
+        overdueDays: 0,
+        daysSinceLastMeeting: 1,
+        evidenceCount: 1,
+      }),
+    ).toMatchObject({ severity: 'medium', baseScore: 13 });
+
+    expect(
+      calculatePdcaHealthScore({
+        pendingPatchCount: 2,
+        overdueDays: 4,
+        daysSinceLastMeeting: 5,
+        evidenceCount: 2,
+      }),
+    ).toMatchObject({ severity: 'high', baseScore: 52 });
+
+    expect(
+      calculatePdcaHealthScore({
+        pendingPatchCount: 5,
+        overdueDays: 1,
+        daysSinceLastMeeting: 5,
+        evidenceCount: 3,
+      }),
+    ).toMatchObject({ severity: 'critical', baseScore: 68 });
+  });
+
+  it('builds pdca health score from patches and meetings', () => {
+    const result = buildPdcaHealthScore({
+      planningSheetId: 'sheet-1',
+      userId: 'U001',
+      patches: [
+        makePatch(),
+        makePatch({ id: 'patch-2', evidenceIds: ['meeting-2', 'meeting-3'] }),
+      ],
+      meetings: [makeMeeting({ meetingDate: '2026-04-05' })],
+      outcomes: [makeOutcome()],
+      referenceDate: '2026-04-12',
+    });
+
+    expect(result).toMatchObject({
+      planningSheetId: 'sheet-1',
+      userId: 'U001',
+      pendingPatchCount: 2,
+      overdueDays: 2,
+      daysSinceLastMeeting: 7,
+      evidenceCount: 3,
+      baseScore: 47,
+      improvementSuccessRate: 1,
+      improvementFactor: 1,
+      score: 94,
+      severity: 'medium',
+    });
+  });
+});

--- a/src/domain/isp/__tests__/planPatch.spec.ts
+++ b/src/domain/isp/__tests__/planPatch.spec.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest';
+import type { SupportPlanningSheet, ProcedureStep } from '@/domain/isp/schema';
+import {
+  applyPlanPatch,
+  detectPlanNeedsUpdate,
+  generatePlanPatch,
+  isPlanPatchOverdue,
+  validatePlanPatch,
+  type MeetingDecision,
+  type PlanPatch,
+} from '../planPatch';
+
+function makeSheet(overrides: Partial<SupportPlanningSheet> = {}): SupportPlanningSheet {
+  return {
+    id: 'sheet-1',
+    version: 1,
+    userId: 'U001',
+    ispId: 'ISP001',
+    title: '支援計画シート',
+    targetScene: '',
+    targetDomain: '',
+    observationFacts: '観察',
+    collectedInformation: '',
+    interpretationHypothesis: '仮説',
+    supportIssues: '既存課題',
+    supportPolicy: '既存方針',
+    environmentalAdjustments: '',
+    concreteApproaches: '既存具体策',
+    appliedFrom: null,
+    nextReviewAt: '2026-06-01',
+    supportStartDate: null,
+    monitoringCycleDays: 90,
+    authoredByStaffId: '',
+    authoredByQualification: 'unknown',
+    authoredAt: null,
+    applicableServiceType: 'other',
+    applicableAddOnTypes: ['none'],
+    deliveredToUserAt: null,
+    reviewedAt: null,
+    hasMedicalCoordination: false,
+    hasEducationCoordination: false,
+    regulatoryBasisSnapshot: {
+      supportLevel: null,
+      behaviorScore: null,
+      serviceType: null,
+      eligibilityCheckedAt: null,
+    },
+    status: 'active',
+    isCurrent: true,
+    intake: {
+      presentingProblem: '',
+      targetBehaviorsDraft: [],
+      behaviorItemsTotal: null,
+      incidentSummaryLast30d: '',
+      communicationModes: [],
+      sensoryTriggers: [],
+      medicalFlags: [],
+      consentScope: [],
+      consentDate: null,
+    },
+    assessment: {
+      targetBehaviors: [],
+      abcEvents: [],
+      hypotheses: [],
+      riskLevel: 'low',
+      healthFactors: [],
+      teamConsensusNote: '',
+    },
+    planning: {
+      supportPriorities: [],
+      antecedentStrategies: [],
+      teachingStrategies: [],
+      consequenceStrategies: [],
+      procedureSteps: [],
+      crisisThresholds: null,
+      restraintPolicy: 'prohibited_except_emergency',
+      reviewCycleDays: 180,
+    },
+    createdAt: '2026-04-01T00:00:00.000Z',
+    updatedAt: '2026-04-01T00:00:00.000Z',
+    createdBy: 'tester',
+    updatedBy: 'tester',
+    ...overrides,
+  };
+}
+
+function makeDecision(overrides: Partial<MeetingDecision> = {}): MeetingDecision {
+  return {
+    id: 'meeting-1',
+    planningSheetId: 'sheet-1',
+    planChangeDecision: 'major_revision',
+    changeReason: '支援方針の見直しが必要',
+    discussionSummary: '会議で新しい対応方針を協議した',
+    issueSummary: '午後の不穏が増えている',
+    effectiveSupportSummary: '静養室での切り替え支援は有効',
+    nextActions: ['午後活動前に休憩を入れる'],
+    requiresPlanSheetUpdate: true,
+    meetingDate: '2026-04-12',
+    nextMonitoringDate: '2026-07-12',
+    ...overrides,
+  };
+}
+
+describe('planPatch', () => {
+  it('generatePlanPatch creates pending plan patch from meeting decision', () => {
+    const patch = generatePlanPatch(makeDecision(), makeSheet());
+
+    expect(patch).not.toBeNull();
+    expect(patch?.target).toBe('plan');
+    expect(patch?.status).toBe('needs_update');
+    expect(patch?.baseVersion).toBe('1');
+    expect(patch?.dueAt).toBe('2026-07-12');
+    expect(patch?.after.status).toBe('revision_pending');
+    expect(patch?.evidenceIds).toEqual(['meeting-1']);
+  });
+
+  it('generatePlanPatch returns null when no plan change is required', () => {
+    const patch = generatePlanPatch(
+      makeDecision({ planChangeDecision: 'no_change', requiresPlanSheetUpdate: false }),
+      makeSheet(),
+    );
+
+    expect(patch).toBeNull();
+  });
+
+  it('applyPlanPatch merges plan patch fields into current plan', () => {
+    const patch = generatePlanPatch(makeDecision(), makeSheet());
+    expect(patch).not.toBeNull();
+
+    const updated = applyPlanPatch(patch as PlanPatch, makeSheet());
+
+    expect(updated.status).toBe('revision_pending');
+    expect(updated.reviewedAt).toBe('2026-04-12');
+    expect(updated.supportIssues).toContain('午後の不穏');
+  });
+
+  it('applyPlanPatch replaces procedure steps for procedure target', () => {
+    const patch: PlanPatch = {
+      id: 'patch-2',
+      planningSheetId: 'sheet-1',
+      baseVersion: '1',
+      target: 'procedure',
+      before: [],
+      after: [{ order: 1, instruction: '静養室でスケジュール確認', staff: 'A', timing: '09:00' }] satisfies ProcedureStep[],
+      reason: '手順変更',
+      evidenceIds: ['meeting-1'],
+      status: 'review',
+      createdAt: '2026-04-12T00:00:00.000Z',
+      updatedAt: '2026-04-12T00:00:00.000Z',
+    };
+
+    const updated = applyPlanPatch(patch, makeSheet());
+
+    expect(updated.planning.procedureSteps).toHaveLength(1);
+    expect(updated.planning.procedureSteps[0]?.instruction).toContain('スケジュール確認');
+  });
+
+  it('validatePlanPatch returns return when evidence is missing', () => {
+    const patch = generatePlanPatch(makeDecision(), makeSheet()) as PlanPatch;
+    const invalid: PlanPatch = { ...patch, evidenceIds: [] };
+
+    expect(validatePlanPatch(invalid)).toBe('return');
+  });
+
+  it('applyPlanPatch throws on version conflict', () => {
+    const patch = generatePlanPatch(makeDecision(), makeSheet()) as PlanPatch;
+
+    expect(() => applyPlanPatch(patch, makeSheet({ version: 2 }))).toThrow('VERSION_CONFLICT');
+  });
+
+  it('detectPlanNeedsUpdate returns true while unconfirmed patch exists', () => {
+    const patch = generatePlanPatch(makeDecision(), makeSheet());
+    expect(detectPlanNeedsUpdate(patch ? [patch] : [])).toBe(true);
+  });
+
+  it('isPlanPatchOverdue returns true when dueAt is past the reference date', () => {
+    const patch = generatePlanPatch(
+      makeDecision({ nextMonitoringDate: '2026-04-10' }),
+      makeSheet(),
+    ) as PlanPatch;
+
+    expect(isPlanPatchOverdue(patch, '2026-04-12')).toBe(true);
+  });
+});

--- a/src/domain/isp/derivedKpi.ts
+++ b/src/domain/isp/derivedKpi.ts
@@ -1,0 +1,67 @@
+import type { AbcRecord } from '../abc/abcRecord';
+import type { ImprovementOutcome, ImprovementTargetMetric } from './improvementOutcome';
+import type { MetricDefinition } from './metricDefinition';
+
+export type AbcWindow = {
+  after: AbcRecord[];
+  before: AbcRecord[];
+};
+
+/**
+ * ABC 記録から改善評価（Outcome）を自動算出する
+ */
+export function deriveImprovementOutcome(
+  metric: MetricDefinition,
+  window: AbcWindow,
+  context: { planningSheetId: string; patchId: string; observedAt: string }
+): ImprovementOutcome | null {
+  if (metric.source !== 'derived') return null;
+
+  let beforeValue = 0;
+  let afterValue = 0;
+
+  // 重要：データ不足の場合はノイズ抑制のため生成しない（安全装置）
+  if (window.before.length < 5 || window.after.length < 5) {
+    return null;
+  }
+
+  switch (metric.id) {
+    case 'derived_behavior_frequency':
+      beforeValue = window.before.length;
+      afterValue = window.after.length;
+      break;
+
+    case 'derived_intensity_avg': {
+      const intensityWeight: Record<string, number> = { low: 1, medium: 2, high: 3 };
+      beforeValue = window.before.length === 0 ? 0 : 
+        window.before.reduce((sum, r) => sum + (intensityWeight[r.intensity] || 1), 0) / window.before.length;
+      afterValue = window.after.length === 0 ? 0 :
+        window.after.reduce((sum, r) => sum + (intensityWeight[r.intensity] || 1), 0) / window.after.length;
+      break;
+    }
+
+    default:
+      return null;
+  }
+
+  const changeRate = beforeValue === 0 ? 0 : (afterValue - beforeValue) / beforeValue;
+  const isImproved = metric.direction === 'decrease_good' 
+    ? afterValue < beforeValue 
+    : afterValue > beforeValue;
+
+  return {
+    id: `derived-${metric.id}-${context.patchId}`,
+    planningSheetId: context.planningSheetId,
+    patchId: context.patchId,
+    observedAt: context.observedAt,
+    targetMetric: metric.id as ImprovementTargetMetric,
+    source: 'derived',
+    metricDefinitionId: metric.id,
+    beforeValue,
+    afterValue,
+    changeRate,
+    isImproved,
+    confidence: 'low', // 推定値は常に信頼度：低
+    createdAt: new Date().toISOString(),
+  };
+}

--- a/src/domain/isp/improvementOutcome.ts
+++ b/src/domain/isp/improvementOutcome.ts
@@ -1,0 +1,81 @@
+export const improvementMetricValues = [
+  'behavior_frequency',
+  'incident_count',
+  'intervention_count',
+  'duration_minutes',
+  'intensity_score',
+  'adaptive_behavior_score',
+  'derived_behavior_frequency',
+  'derived_intensity_avg',
+] as const;
+
+export type ImprovementTargetMetric = (typeof improvementMetricValues)[number];
+
+export const improvementConfidenceValues = [
+  'low',
+  'medium',
+  'high',
+] as const;
+
+export type ImprovementConfidence = (typeof improvementConfidenceValues)[number];
+
+export type ImprovementOutcome = {
+  id: string;
+  planningSheetId: string;
+  patchId: string;
+  observedAt: string;
+  targetMetric: ImprovementTargetMetric;
+  source: 'manual_kpi' | 'derived';
+  metricDefinitionId?: string;
+  beforeValue: number;
+  afterValue: number;
+  changeRate: number;
+  isImproved: boolean;
+  confidence: ImprovementConfidence;
+  evaluationWindowDays?: number;
+  createdAt: string;
+};
+
+export type ImprovementEvaluationDirection = 'decrease_good' | 'increase_good';
+
+export function evaluateImprovement(input: {
+  before: number;
+  after: number;
+  direction: ImprovementEvaluationDirection;
+}): Pick<ImprovementOutcome, 'changeRate' | 'isImproved'> {
+  const { before, after, direction } = input;
+  const changeRate = before === 0 ? 0 : (after - before) / before;
+  const isImproved =
+    direction === 'decrease_good'
+      ? after < before
+      : after > before;
+
+  return {
+    changeRate,
+    isImproved,
+  };
+}
+
+export function calculateImprovementFactor(
+  outcomes: readonly ImprovementOutcome[],
+): number {
+  const manualOutcomes = outcomes.filter((outcome) => outcome.source === 'manual_kpi');
+  const derivedOutcomes = outcomes.filter((outcome) => outcome.source === 'derived');
+
+  let totalScore = 0;
+  let totalWeight = 0;
+
+  if (manualOutcomes.length > 0) {
+    const successCount = manualOutcomes.filter((o) => o.isImproved).length;
+    totalScore += (successCount / manualOutcomes.length) * 1.0;
+    totalWeight += 1.0;
+  }
+
+  if (derivedOutcomes.length > 0) {
+    const successCount = derivedOutcomes.filter((o) => o.isImproved).length;
+    totalScore += (successCount / derivedOutcomes.length) * 0.2; // Derived is weak
+    totalWeight += 0.2;
+  }
+
+  return totalWeight > 0 ? totalScore / totalWeight : 0;
+}

--- a/src/domain/isp/improvementOutcomeRepository.ts
+++ b/src/domain/isp/improvementOutcomeRepository.ts
@@ -1,0 +1,7 @@
+import type { ImprovementOutcome } from './improvementOutcome';
+
+export interface ImprovementOutcomeRepository {
+  save(outcome: ImprovementOutcome): Promise<void>;
+  findByPlanningSheetId(planningSheetId: string): Promise<ImprovementOutcome[]>;
+  findByPatchId(patchId: string): Promise<ImprovementOutcome[]>;
+}

--- a/src/domain/isp/metricDefinition.ts
+++ b/src/domain/isp/metricDefinition.ts
@@ -1,0 +1,85 @@
+import type { ImprovementTargetMetric } from './improvementOutcome';
+
+export type MetricDirection = 'decrease_good' | 'increase_good';
+export type MetricSource = 'manual' | 'derived';
+export type MetricUnit = 'count' | 'minutes' | 'score';
+
+export type MetricDefinition = {
+  id: ImprovementTargetMetric;
+  name: string;
+  direction: MetricDirection;
+  unit: MetricUnit;
+  source: MetricSource;
+  description?: string;
+};
+
+export const DEFAULT_METRIC_DEFINITIONS: readonly MetricDefinition[] = [
+  {
+    id: 'behavior_frequency',
+    name: '問題行動の発生回数',
+    direction: 'decrease_good',
+    unit: 'count',
+    source: 'manual',
+    description: '観察期間内の対象行動の発生回数',
+  },
+  {
+    id: 'incident_count',
+    name: 'トラブル・インシデント件数',
+    direction: 'decrease_good',
+    unit: 'count',
+    source: 'manual',
+    description: 'ヒヤリハット、事故、物損などの発生件数',
+  },
+  {
+    id: 'intervention_count',
+    name: '支援介入（制止等）回数',
+    direction: 'decrease_good',
+    unit: 'count',
+    source: 'manual',
+    description: 'パニック抑制、身体的制止が必要になった回数',
+  },
+  {
+    id: 'duration_minutes',
+    name: '問題行動の継続時間',
+    direction: 'decrease_good',
+    unit: 'minutes',
+    source: 'manual',
+    description: '対象行動が持続した合計時間（分）',
+  },
+  {
+    id: 'intensity_score',
+    name: '行動の強度スコア',
+    direction: 'decrease_good',
+    unit: 'score',
+    source: 'manual',
+    description: '行動強度を数値化したスコア（自傷、他害、破壊などの程度）',
+  },
+  {
+    id: 'adaptive_behavior_score',
+    name: '適応行動スコア',
+    direction: 'increase_good',
+    unit: 'score',
+    source: 'manual',
+    description: '代替行動や望ましい行動の達成度スコア',
+  },
+  {
+    id: 'derived_behavior_frequency',
+    name: '【自動】行動発生数',
+    direction: 'decrease_good',
+    unit: 'count',
+    source: 'derived',
+    description: 'ABC記録から自動算出される発生頻度（推定値）',
+  },
+  {
+    id: 'derived_intensity_avg',
+    name: '【自動】平均強度ランク',
+    direction: 'decrease_good',
+    unit: 'score',
+    source: 'derived',
+    description: 'ABC記録から自動算出される平均的な行動強度（推定値）',
+  },
+] as const;
+
+export function getMetricDefinition(metricId: string): MetricDefinition | null {
+  return DEFAULT_METRIC_DEFINITIONS.find((metric) => metric.id === metricId) ?? null;
+}

--- a/src/domain/isp/pdcaHealth.ts
+++ b/src/domain/isp/pdcaHealth.ts
@@ -1,0 +1,134 @@
+import type { MonitoringMeetingRecord } from './monitoringMeeting';
+import { calculateImprovementFactor, type ImprovementOutcome } from './improvementOutcome';
+import { isPlanPatchOverdue, type PlanPatch } from './planPatch';
+
+export type PdcaHealthSeverity = 'low' | 'medium' | 'high' | 'critical';
+
+export type PdcaHealthScore = {
+  planningSheetId: string;
+  userId: string;
+  pendingPatchCount: number;
+  overdueDays: number;
+  daysSinceLastMeeting: number;
+  evidenceCount: number;
+  improvementSuccessRate: number;
+  improvementFactor: number;
+  manualOutcomeCount: number;
+  derivedOutcomeCount: number;
+  confidenceScore: 'low' | 'medium' | 'high';
+  baseScore: number;
+  score: number;
+  severity: PdcaHealthSeverity;
+};
+
+type PdcaHealthMetricsInput = Pick<
+  PdcaHealthScore,
+  'pendingPatchCount' | 'overdueDays' | 'daysSinceLastMeeting' | 'evidenceCount'
+>;
+
+type BuildPdcaHealthScoreInput = {
+  planningSheetId: string;
+  userId: string;
+  patches: PlanPatch[];
+  meetings: MonitoringMeetingRecord[];
+  outcomes?: ImprovementOutcome[];
+  referenceDate?: string | Date;
+};
+
+function toDateOnly(value: string | Date | null | undefined): string | null {
+  if (!value) return null;
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value.toISOString().slice(0, 10);
+  }
+  const normalized = value.trim().slice(0, 10);
+  return /^\d{4}-\d{2}-\d{2}$/.test(normalized) ? normalized : null;
+}
+
+function daysBetween(startDate: string | null, endDate: string): number {
+  if (!startDate) return 0;
+  const start = Date.parse(`${startDate}T00:00:00Z`);
+  const end = Date.parse(`${endDate}T00:00:00Z`);
+  if (Number.isNaN(start) || Number.isNaN(end)) return 0;
+  return Math.max(0, Math.floor((end - start) / 86_400_000));
+}
+
+export function calculatePdcaHealthScore(
+  input: PdcaHealthMetricsInput,
+): Pick<PdcaHealthScore, 'baseScore' | 'severity'> {
+  const baseScore =
+    input.pendingPatchCount * 10 +
+    input.overdueDays * 5 +
+    input.daysSinceLastMeeting * 2 +
+    input.evidenceCount;
+
+  let severity: PdcaHealthSeverity;
+
+  if (input.overdueDays >= 7 || input.pendingPatchCount >= 5) {
+    severity = 'critical';
+  } else if (input.overdueDays >= 3) {
+    severity = 'high';
+  } else if (input.pendingPatchCount > 0) {
+    severity = 'medium';
+  } else {
+    severity = 'low';
+  }
+
+  return { baseScore, severity };
+}
+
+export function buildPdcaHealthScore(
+  input: BuildPdcaHealthScoreInput,
+): PdcaHealthScore {
+  const referenceDate = toDateOnly(input.referenceDate ?? new Date()) ?? new Date().toISOString().slice(0, 10);
+  const pendingPatches = input.patches.filter((patch) => patch.status !== 'confirmed');
+  const overdueDays = pendingPatches.reduce((max, patch) => {
+    if (!isPlanPatchOverdue(patch, referenceDate) || !patch.dueAt) {
+      return max;
+    }
+    return Math.max(max, daysBetween(toDateOnly(patch.dueAt), referenceDate));
+  }, 0);
+
+  const lastMeetingDate = input.meetings
+    .map((meeting) => toDateOnly(meeting.meetingDate))
+    .filter((value): value is string => Boolean(value))
+    .sort((a, b) => b.localeCompare(a))[0] ?? null;
+
+  const daysSinceLastMeeting = daysBetween(lastMeetingDate, referenceDate);
+  const evidenceCount = new Set(
+    pendingPatches.flatMap((patch) => patch.evidenceIds),
+  ).size;
+  const improvementSuccessRate = calculateImprovementFactor(input.outcomes ?? []);
+  const improvementFactor = improvementSuccessRate;
+
+  const manualOutcomeCount = (input.outcomes ?? []).filter(o => o.source === 'manual_kpi').length;
+  const derivedOutcomeCount = (input.outcomes ?? []).filter(o => o.source === 'derived').length;
+  
+  const confidenceScore =
+    manualOutcomeCount >= 10 ? 'high' :
+    manualOutcomeCount >= 3 ? 'medium' :
+    'low';
+
+  const metrics: PdcaHealthMetricsInput = {
+    pendingPatchCount: pendingPatches.length,
+    overdueDays,
+    daysSinceLastMeeting,
+    evidenceCount,
+  };
+
+  const { baseScore, severity } = calculatePdcaHealthScore(metrics);
+  const score = Math.round(baseScore * (1 + improvementFactor));
+
+  return {
+    planningSheetId: input.planningSheetId,
+    userId: input.userId,
+    ...metrics,
+    improvementSuccessRate,
+    improvementFactor,
+    manualOutcomeCount,
+    derivedOutcomeCount,
+    confidenceScore,
+    baseScore,
+    score,
+    severity,
+  };
+}

--- a/src/domain/isp/planPatch.ts
+++ b/src/domain/isp/planPatch.ts
@@ -1,0 +1,225 @@
+import type { MonitoringMeetingRecord } from './monitoringMeeting';
+import type { SupportPlanningSheet, ProcedureStep } from './schema';
+import { safeRandomUUID } from '@/lib/uuid';
+
+export type PlanPatchStatus =
+  | 'draft'
+  | 'review'
+  | 'confirmed'
+  | 'needs_update';
+
+export type PlanPatchTarget = 'plan' | 'procedure';
+
+export type PlanPatchBase = {
+  id: string;
+  planningSheetId: string;
+  baseVersion: string;
+  reason: string;
+  evidenceIds: string[];
+  status: PlanPatchStatus;
+  dueAt?: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type PlanPatchForPlan = PlanPatchBase & {
+  target: 'plan';
+  before: Partial<SupportPlanningSheet>;
+  after: Partial<SupportPlanningSheet>;
+};
+
+export type PlanPatchForProcedure = PlanPatchBase & {
+  target: 'procedure';
+  before: ProcedureStep[];
+  after: ProcedureStep[];
+};
+
+export type PlanPatch = PlanPatchForPlan | PlanPatchForProcedure;
+
+export type MeetingDecision = Pick<
+  MonitoringMeetingRecord,
+  | 'id'
+  | 'planningSheetId'
+  | 'planChangeDecision'
+  | 'changeReason'
+  | 'discussionSummary'
+  | 'issueSummary'
+  | 'effectiveSupportSummary'
+  | 'nextActions'
+  | 'requiresPlanSheetUpdate'
+  | 'meetingDate'
+  | 'nextMonitoringDate'
+>;
+
+function buildReason(decision: MeetingDecision): string {
+  const parts = [
+    decision.changeReason,
+    decision.issueSummary,
+    decision.discussionSummary,
+  ].map((value) => value?.trim()).filter(Boolean);
+
+  if (parts.length > 0) {
+    return parts.join('\n\n');
+  }
+
+  return `モニタリング会議（${decision.meetingDate}）の結果に基づく更新案`;
+}
+
+function toDateOnly(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const normalized = value.trim().slice(0, 10);
+  return /^\d{4}-\d{2}-\d{2}$/.test(normalized) ? normalized : null;
+}
+
+function addDays(dateOnly: string, days: number): string {
+  const date = new Date(`${dateOnly}T00:00:00Z`);
+  date.setUTCDate(date.getUTCDate() + days);
+  return date.toISOString().slice(0, 10);
+}
+
+function resolvePatchDueAt(
+  decision: MeetingDecision,
+  currentPlan: SupportPlanningSheet,
+): string | undefined {
+  const dueAtFromSchedule =
+    toDateOnly(decision.nextMonitoringDate) ??
+    toDateOnly(currentPlan.nextReviewAt);
+
+  if (dueAtFromSchedule) {
+    return dueAtFromSchedule;
+  }
+
+  const meetingDate = toDateOnly(decision.meetingDate);
+  return meetingDate ? addDays(meetingDate, 7) : undefined;
+}
+
+export function generatePlanPatch(
+  decision: MeetingDecision,
+  currentPlan: SupportPlanningSheet,
+): PlanPatchForPlan | null {
+  if (!decision.planningSheetId || decision.planChangeDecision === 'no_change') {
+    return null;
+  }
+
+  const now = new Date().toISOString();
+  const nextReviewAt = decision.nextMonitoringDate || currentPlan.nextReviewAt;
+  const dueAt = resolvePatchDueAt(decision, currentPlan);
+
+  const before: Partial<SupportPlanningSheet> = {
+    reviewedAt: currentPlan.reviewedAt,
+    nextReviewAt: currentPlan.nextReviewAt,
+    status: currentPlan.status,
+    supportIssues: currentPlan.supportIssues,
+    supportPolicy: currentPlan.supportPolicy,
+    concreteApproaches: currentPlan.concreteApproaches,
+  };
+
+  const summaryBlocks = [
+    decision.issueSummary?.trim() ? `【会議で確認した課題】\n${decision.issueSummary.trim()}` : '',
+    decision.effectiveSupportSummary?.trim() ? `【継続候補の支援】\n${decision.effectiveSupportSummary.trim()}` : '',
+    decision.nextActions?.length ? `【次回までの確認事項】\n${decision.nextActions.join('\n')}` : '',
+  ].filter(Boolean);
+
+  const nextApproaches = summaryBlocks.length
+    ? [currentPlan.concreteApproaches, ...summaryBlocks].filter(Boolean).join('\n\n')
+    : currentPlan.concreteApproaches;
+
+  const after: Partial<SupportPlanningSheet> = {
+    reviewedAt: decision.meetingDate,
+    nextReviewAt,
+    status: 'revision_pending',
+    supportIssues: decision.issueSummary?.trim()
+      ? [currentPlan.supportIssues, `【会議追記 ${decision.meetingDate}】\n${decision.issueSummary.trim()}`]
+          .filter(Boolean)
+          .join('\n\n')
+      : currentPlan.supportIssues,
+    supportPolicy: decision.changeReason?.trim()
+      ? [currentPlan.supportPolicy, `【更新理由 ${decision.meetingDate}】\n${decision.changeReason.trim()}`]
+          .filter(Boolean)
+          .join('\n\n')
+      : currentPlan.supportPolicy,
+    concreteApproaches: nextApproaches,
+  };
+
+  return {
+    id: `patch-${safeRandomUUID()}`,
+    planningSheetId: decision.planningSheetId,
+    baseVersion: String(currentPlan.version),
+    target: 'plan',
+    before,
+    after,
+    reason: buildReason(decision),
+    evidenceIds: [decision.id],
+    status: decision.requiresPlanSheetUpdate ? 'needs_update' : 'draft',
+    dueAt,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+export function applyPlanPatch(
+  patch: PlanPatch,
+  currentPlan: SupportPlanningSheet,
+): SupportPlanningSheet {
+  if (patch.baseVersion !== String(currentPlan.version)) {
+    throw new Error('VERSION_CONFLICT');
+  }
+
+  if (patch.target === 'procedure') {
+    return {
+      ...currentPlan,
+      planning: {
+        ...currentPlan.planning,
+        procedureSteps: patch.after,
+      },
+    };
+  }
+
+  return {
+    ...currentPlan,
+    ...patch.after,
+  };
+}
+
+export function validatePlanPatch(
+  patch: PlanPatch,
+): 'ok' | 'warning' | 'return' | 'hold' {
+  if (!patch.planningSheetId || patch.evidenceIds.length === 0) {
+    return 'return';
+  }
+
+  if (!patch.reason.trim()) {
+    return 'warning';
+  }
+
+  if (patch.target === 'plan') {
+    return Object.keys(patch.after).length === 0 ? 'hold' : 'ok';
+  }
+
+  return patch.after.length === 0 ? 'hold' : 'ok';
+}
+
+function toReferenceDate(referenceDate: string | Date): string {
+  if (referenceDate instanceof Date) {
+    return referenceDate.toISOString().slice(0, 10);
+  }
+  return referenceDate.slice(0, 10);
+}
+
+export function isPlanPatchOverdue(
+  patch: PlanPatch,
+  referenceDate: string | Date = new Date(),
+): boolean {
+  if (!patch.dueAt || patch.status === 'confirmed') {
+    return false;
+  }
+
+  const dueAt = toDateOnly(patch.dueAt);
+  if (!dueAt) return false;
+
+  return dueAt < toReferenceDate(referenceDate);
+}
+
+export function detectPlanNeedsUpdate(patches: readonly PlanPatch[]): boolean {
+  return patches.some((patch) => patch.status !== 'confirmed');
+}

--- a/src/domain/isp/planPatchRepository.ts
+++ b/src/domain/isp/planPatchRepository.ts
@@ -1,0 +1,8 @@
+import type { PlanPatch } from './planPatch';
+
+export interface PlanPatchRepository {
+  save(patch: PlanPatch): Promise<void>;
+  findByPlanningSheetId(planningSheetId: string): Promise<PlanPatch[]>;
+  updateStatus(patchId: string, status: PlanPatch['status']): Promise<void>;
+  findPending(planningSheetId: string): Promise<PlanPatch[]>;
+}

--- a/src/domain/today/__tests__/planPatchToTodayActionMapper.spec.ts
+++ b/src/domain/today/__tests__/planPatchToTodayActionMapper.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import type { PlanPatchForPlan } from '@/domain/isp/planPatch';
+import { mapPlanPatchToTodayActionSource } from '../planPatchToTodayActionMapper';
+
+function makePatch(overrides: Partial<PlanPatchForPlan> = {}): PlanPatchForPlan {
+  return {
+    id: 'patch-1',
+    planningSheetId: 'sheet-1',
+    baseVersion: '1',
+    target: 'plan',
+    before: {},
+    after: { status: 'revision_pending' },
+    reason: '会議結果の反映が必要',
+    evidenceIds: ['meeting-1'],
+    status: 'needs_update',
+    dueAt: '2026-04-15',
+    createdAt: '2026-04-12T00:00:00.000Z',
+    updatedAt: '2026-04-12T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('mapPlanPatchToTodayActionSource', () => {
+  it('maps a pending patch into Today navigate action', () => {
+    const result = mapPlanPatchToTodayActionSource({
+      patch: makePatch(),
+      userId: 'U001',
+      userName: '山田太郎',
+    });
+
+    expect(result.sourceType).toBe('plan_patch');
+    expect(result.title).toContain('計画更新');
+    expect(result.payload).toMatchObject({
+      patchId: 'patch-1',
+      planningSheetId: 'sheet-1',
+      userId: 'U001',
+      path: '/support-planning-sheet/sheet-1?tab=planning',
+    });
+  });
+
+  it('marks overdue patch title with deadline breach wording', () => {
+    const result = mapPlanPatchToTodayActionSource({
+      patch: makePatch({ dueAt: '2026-04-01' }),
+      userId: 'U001',
+      userName: '山田太郎',
+    });
+
+    expect(result.title).toContain('期限超過');
+  });
+});

--- a/src/domain/today/planPatchToTodayActionMapper.ts
+++ b/src/domain/today/planPatchToTodayActionMapper.ts
@@ -1,0 +1,54 @@
+import type { PlanPatch } from '@/domain/isp/planPatch';
+import { isPlanPatchOverdue } from '@/domain/isp/planPatch';
+import type { RawActionSource } from '@/features/today/domain/models/queue.types';
+
+type PlanPatchActionContext = {
+  patch: PlanPatch;
+  userId: string;
+  userName?: string;
+};
+
+function toTargetTime(dueAt?: string): Date | undefined {
+  const dateOnly = dueAt?.slice(0, 10);
+  if (!dateOnly) return undefined;
+
+  const target = new Date(`${dateOnly}T09:00:00`);
+  return Number.isNaN(target.getTime()) ? undefined : target;
+}
+
+export function mapPlanPatchToTodayActionSource({
+  patch,
+  userId,
+  userName,
+}: PlanPatchActionContext): RawActionSource {
+  const displayName = userName?.trim() || userId;
+  const overdue = isPlanPatchOverdue(patch);
+
+  return {
+    id: `today-plan-patch-${patch.id}`,
+    sourceType: 'plan_patch',
+    title: overdue
+      ? `【更新期限超過】${displayName} さんの支援計画を確認`
+      : `【計画更新】${displayName} さんの支援計画を確認`,
+    targetTime: toTargetTime(patch.dueAt),
+    slaMinutes: 0,
+    isCompleted: patch.status === 'confirmed',
+    payload: {
+      patchId: patch.id,
+      planningSheetId: patch.planningSheetId,
+      userId,
+      userName: displayName,
+      status: patch.status,
+      reason: patch.reason,
+      dueAt: patch.dueAt,
+      evidenceIds: patch.evidenceIds,
+      path: `/support-planning-sheet/${patch.planningSheetId}?tab=planning`,
+    },
+  };
+}
+
+export function mapPlanPatchesToTodayActionSources(
+  patches: PlanPatchActionContext[],
+): RawActionSource[] {
+  return patches.map(mapPlanPatchToTodayActionSource);
+}

--- a/src/features/monitoring/components/MonitoringMeetingForm.tsx
+++ b/src/features/monitoring/components/MonitoringMeetingForm.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import {
+import React, { useState } from 'react';
+import { 
   Box,
   Button,
   Card,
@@ -33,6 +33,15 @@ import {
 import { useStaff } from '@/stores/useStaff';
 import { Staff } from '@/types';
 import { MonitoringMeetingPDFAction } from '../reports/MonitoringMeetingPDFAction';
+import type { MetricDefinition } from '@/domain/isp/metricDefinition';
+
+export type ImprovementInput = {
+  patchId: string;
+  metricId: string;
+  beforeValue: number | '';
+  afterValue: number | '';
+  confidence: 'low' | 'medium' | 'high';
+};
 
 interface MonitoringMeetingFormProps {
   draft: MonitoringMeetingDraft;
@@ -42,6 +51,10 @@ interface MonitoringMeetingFormProps {
   onCancel: () => void;
   isSaving?: boolean;
   planningSheets?: { id: string, title: string }[];
+  patchOptions?: { id: string; label: string }[];
+  metricDefinitions?: readonly MetricDefinition[];
+  improvementInput?: ImprovementInput;
+  onImprovementInputChange?: (patch: Partial<ImprovementInput>) => void;
 }
 
 export const MonitoringMeetingForm: React.FC<MonitoringMeetingFormProps> = ({
@@ -51,8 +64,14 @@ export const MonitoringMeetingForm: React.FC<MonitoringMeetingFormProps> = ({
   onFinalize,
   onCancel,
   isSaving,
-  planningSheets = []
+  planningSheets = [],
+  patchOptions = [],
+  metricDefinitions = [],
+  improvementInput,
+  onImprovementInputChange,
 }) => {
+  const [validationErrors, setValidationErrors] = useState<string[]>([]);
+  const [validationWarnings, setValidationWarnings] = useState<string[]>([]);
   const { data: staffMaster = [] } = useStaff();
   const isFinalized = draft.status === 'finalized';
 
@@ -73,7 +92,7 @@ export const MonitoringMeetingForm: React.FC<MonitoringMeetingFormProps> = ({
       hasBasicTraining: staff.hasBasicBehaviorSupportTraining,
       hasPracticalTraining: staff.hasPracticalBehaviorSupportTraining,
       trainingLevel: staff.hasPracticalBehaviorSupportTraining ? 'practical' 
-                    : staff.hasBasicBehaviorSupportTraining? 'basic' : 'none'
+                    : staff.hasBasicBehaviorSupportTraining ? 'basic' : 'none'
     };
 
     onUpdate({ attendees: [...draft.attendees, newAttendee] });
@@ -82,6 +101,64 @@ export const MonitoringMeetingForm: React.FC<MonitoringMeetingFormProps> = ({
   const handleRemoveStaff = (id: string | undefined) => {
     if (isFinalized || !id) return;
     onUpdate({ attendees: draft.attendees.filter(a => a.staffId !== id) });
+  };
+
+  const validateImprovement = (): boolean => {
+    // 改善評価が入力されている場合のみバリデーションを行う
+    if (!improvementInput || (!improvementInput.patchId && !improvementInput.metricId && improvementInput.beforeValue === '' && improvementInput.afterValue === '')) {
+      setValidationErrors([]);
+      setValidationWarnings([]);
+      return true;
+    }
+
+    const errors: string[] = [];
+    const warnings: string[] = [];
+
+    // 1. 形式バリデーション (Errors - 保存を止める)
+    if (!improvementInput.metricId) {
+      errors.push('対象指標を選択してください');
+    }
+    if (improvementInput.beforeValue === '' || improvementInput.afterValue === '') {
+      errors.push('before / after を入力してください');
+    }
+    if (typeof improvementInput.beforeValue === 'number' && improvementInput.beforeValue < 0) {
+      errors.push('before値は0以上で入力してください');
+    }
+    if (typeof improvementInput.afterValue === 'number' && improvementInput.afterValue < 0) {
+      errors.push('after値は0以上で入力してください');
+    }
+    if (improvementInput.beforeValue === 0 && improvementInput.afterValue === 0) {
+      errors.push('変化が測定できません');
+    }
+
+    // 2. 測定品質バリデーション (Warnings - 保存は止めないが警告)
+    if (errors.length === 0 && typeof improvementInput.beforeValue === 'number' && typeof improvementInput.afterValue === 'number') {
+      const diff = Math.abs(improvementInput.afterValue - improvementInput.beforeValue);
+      
+      if (diff === 0) {
+        warnings.push('変化がありません（測定対象として適切か確認してください）');
+      }
+
+      if (improvementInput.beforeValue > 0 && diff / improvementInput.beforeValue > 5) {
+        warnings.push('変化が大きすぎます（入力ミスの可能性があります）');
+      }
+    }
+
+    setValidationErrors(errors);
+    setValidationWarnings(warnings);
+    return errors.length === 0;
+  };
+
+  const handleSave = () => {
+    if (validateImprovement()) {
+      onSave();
+    }
+  };
+
+  const handleFinalize = () => {
+    if (validateImprovement()) {
+      onFinalize?.();
+    }
   };
 
   return (
@@ -349,6 +426,119 @@ export const MonitoringMeetingForm: React.FC<MonitoringMeetingFormProps> = ({
           </CardContent>
         </Card>
 
+        <Card elevation={0} variant="outlined">
+          <CardContent>
+            <Typography variant="h6" gutterBottom color="primary">
+              6. 改善評価（任意）
+            </Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+              既に反映済みの更新案に対して、before / after の測定結果がある場合のみ入力してください。
+            </Typography>
+            <Grid container spacing={2}>
+              <Grid size={{ xs: 12, md: 6 }}>
+                <TextField
+                  fullWidth
+                  select
+                  label="評価対象の更新案"
+                  value={improvementInput?.patchId ?? ''}
+                  onChange={(e) => onImprovementInputChange?.({ patchId: e.target.value })}
+                  disabled={isFinalized || patchOptions.length === 0}
+                  helperText={patchOptions.length === 0 ? '評価対象にできる確定済み更新案がありません' : '効果を確認したい更新案を選択'}
+                >
+                  {patchOptions.map((patch) => (
+                    <MenuItem key={patch.id} value={patch.id}>{patch.label}</MenuItem>
+                  ))}
+                </TextField>
+              </Grid>
+              <Grid size={{ xs: 12, md: 6 }}>
+                <TextField
+                  fullWidth
+                  select
+                  label="対象指標"
+                  value={improvementInput?.metricId ?? ''}
+                  onChange={(e) => onImprovementInputChange?.({ metricId: e.target.value })}
+                  disabled={isFinalized}
+                >
+                  {metricDefinitions.map((metric) => (
+                    <MenuItem key={metric.id} value={metric.id}>
+                      {metric.name}
+                    </MenuItem>
+                  ))}
+                </TextField>
+              </Grid>
+              <Grid size={{ xs: 12, md: 4 }}>
+                <TextField
+                  fullWidth
+                  type="number"
+                  label="before"
+                  value={improvementInput?.beforeValue ?? ''}
+                  onChange={(e) => onImprovementInputChange?.({
+                    beforeValue: e.target.value === '' ? '' : Number(e.target.value),
+                  })}
+                  disabled={isFinalized}
+                />
+              </Grid>
+              <Grid size={{ xs: 12, md: 4 }}>
+                <TextField
+                  fullWidth
+                  type="number"
+                  label="after"
+                  value={improvementInput?.afterValue ?? ''}
+                  onChange={(e) => onImprovementInputChange?.({
+                    afterValue: e.target.value === '' ? '' : Number(e.target.value),
+                  })}
+                  disabled={isFinalized}
+                />
+              </Grid>
+              <Grid size={{ xs: 12, md: 4 }}>
+                <TextField
+                  fullWidth
+                  select
+                  label="信頼度"
+                  value={improvementInput?.confidence ?? 'medium'}
+                  onChange={(e) => onImprovementInputChange?.({
+                    confidence: e.target.value as ImprovementInput['confidence'],
+                  })}
+                  disabled={isFinalized}
+                >
+                  <MenuItem value="low">低</MenuItem>
+                  <MenuItem value="medium">中</MenuItem>
+                  <MenuItem value="high">高</MenuItem>
+                </TextField>
+              </Grid>
+            </Grid>
+          </CardContent>
+        </Card>
+
+        {/* Validation Errors & Warnings */}
+        <Stack spacing={2} sx={{ mb: 2 }}>
+          {validationErrors.length > 0 && (
+            <Alert severity="error">
+              <Typography variant="subtitle2" sx={{ fontWeight: 'bold', mb: 1 }}>
+                ⚠ 改善評価に問題があります
+              </Typography>
+              <Box component="ul" sx={{ m: 0, pl: 2 }}>
+                {validationErrors.map((error, idx) => (
+                  <li key={idx}>{error}</li>
+                ))}
+              </Box>
+            </Alert>
+          )}
+
+          {validationWarnings.length > 0 && (
+            <Alert severity="warning">
+              <Typography variant="subtitle2" sx={{ fontWeight: 'bold', mb: 1 }}>
+                💡 測定品質に関する確認事項
+              </Typography>
+              <Box component="ul" sx={{ m: 0, pl: 2 }}>
+                {validationWarnings.map((warning, idx) => (
+                  <li key={idx}>{warning}</li>
+                ))}
+              </Box>
+            </Alert>
+          )}
+        </Stack>
+
         {/* Footer actions */}
         <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 2, pb: 4 }}>
           <Button variant="outlined" onClick={onCancel}>一覧へ戻る</Button>
@@ -356,7 +546,7 @@ export const MonitoringMeetingForm: React.FC<MonitoringMeetingFormProps> = ({
             <>
               <Button 
                 variant="outlined" 
-                onClick={onSave}
+                onClick={handleSave}
                 disabled={isSaving}
               >
                 下書き保存
@@ -365,7 +555,7 @@ export const MonitoringMeetingForm: React.FC<MonitoringMeetingFormProps> = ({
                 variant="contained" 
                 size="large" 
                 color="primary"
-                onClick={onFinalize}
+                onClick={handleFinalize}
                 disabled={isSaving || !draft.discussionSummary}
                 startIcon={<LockIcon />}
               >

--- a/src/features/monitoring/data/useImprovementOutcomeRepository.ts
+++ b/src/features/monitoring/data/useImprovementOutcomeRepository.ts
@@ -1,0 +1,13 @@
+import { useMemo } from 'react';
+import { useDataProvider } from '@/lib/data/useDataProvider';
+import { DataProviderImprovementOutcomeRepository } from '@/data/isp/infra/DataProviderImprovementOutcomeRepository';
+import type { ImprovementOutcomeRepository } from '@/domain/isp/improvementOutcomeRepository';
+
+export function useImprovementOutcomeRepository(): ImprovementOutcomeRepository {
+  const { provider } = useDataProvider();
+
+  return useMemo(
+    () => new DataProviderImprovementOutcomeRepository(provider),
+    [provider],
+  );
+}

--- a/src/features/planning-sheet/components/PhaseNextStepBanner.tsx
+++ b/src/features/planning-sheet/components/PhaseNextStepBanner.tsx
@@ -54,6 +54,10 @@ export interface PhaseNextStepBannerProps {
   hasMonitoringSignals?: boolean;
   /** 再評価結果が未反映か */
   hasUnappliedReassessment?: boolean;
+  /** 計画更新案が未反映か */
+  hasPendingPlanUpdate?: boolean;
+  /** 期限超過の計画更新案があるか */
+  hasOverduePlanUpdate?: boolean;
   /** PDCA サイクル状態（optional） */
   pdcaCycleState?: PdcaCycleState | null;
   /** 遷移ハンドラ */
@@ -95,6 +99,8 @@ export const PhaseNextStepBanner: React.FC<PhaseNextStepBannerProps> = ({
   planningSheetId,
   hasMonitoringSignals,
   hasUnappliedReassessment,
+  hasPendingPlanUpdate,
+  hasOverduePlanUpdate,
   pdcaCycleState,
   onNavigate,
 }) => {
@@ -105,6 +111,8 @@ export const PhaseNextStepBanner: React.FC<PhaseNextStepBannerProps> = ({
     planningSheetId,
     hasMonitoringSignals,
     hasUnappliedReassessment,
+    hasPendingPlanUpdate,
+    hasOverduePlanUpdate,
     pdcaCycleState,
   };
 

--- a/src/features/planning-sheet/components/__tests__/PhaseNextStepBanner.spec.tsx
+++ b/src/features/planning-sheet/components/__tests__/PhaseNextStepBanner.spec.tsx
@@ -123,4 +123,19 @@ describe('PhaseNextStepBanner', () => {
     expect(items[1]).not.toHaveAttribute('data-p0-emphasis');
     expect(screen.getByText('モニタリング時期が近づいています')).toBeInTheDocument();
   });
+
+  it('計画更新未反映があると planning バナーでレビュー導線を表示する', () => {
+    render(
+      <PhaseNextStepBanner
+        phase="active_plan"
+        context="planning"
+        userId="u-1"
+        planningSheetId="ps-1"
+        hasPendingPlanUpdate
+      />,
+    );
+
+    expect(screen.getByText('未反映の計画更新があります')).toBeInTheDocument();
+    expect(screen.getByText('更新案を確認')).toBeInTheDocument();
+  });
 });

--- a/src/features/planning-sheet/hooks/usePlanPatchRepository.ts
+++ b/src/features/planning-sheet/hooks/usePlanPatchRepository.ts
@@ -1,0 +1,9 @@
+import { useMemo } from 'react';
+import type { PlanPatchRepository } from '@/domain/isp/planPatchRepository';
+import { useDataProvider } from '@/lib/data/useDataProvider';
+import { DataProviderPlanPatchRepository } from '@/data/isp/infra/DataProviderPlanPatchRepository';
+
+export function usePlanPatchRepository(): PlanPatchRepository {
+  const { provider } = useDataProvider();
+  return useMemo(() => new DataProviderPlanPatchRepository(provider), [provider]);
+}

--- a/src/features/regulatory/hooks/usePdcaStopRanking.ts
+++ b/src/features/regulatory/hooks/usePdcaStopRanking.ts
@@ -1,0 +1,140 @@
+import type { ImprovementOutcomeRepository } from '@/domain/isp/improvementOutcomeRepository';
+import { buildPdcaHealthScore, type PdcaHealthScore } from '@/domain/isp/pdcaHealth';
+import type { MonitoringMeetingRepository } from '@/domain/isp/monitoringMeetingRepository';
+import type { PlanningSheetRepository } from '@/domain/isp/port';
+import type { PlanPatchRepository } from '@/domain/isp/planPatchRepository';
+import type { IUserMaster } from '@/sharepoint/fields';
+import { useEffect, useMemo, useState } from 'react';
+
+export interface PdcaStopRankingEntry extends PdcaHealthScore {
+  userName?: string;
+}
+
+export interface PdcaStopRankingResult {
+  ranking: PdcaStopRankingEntry[];
+  isLoading: boolean;
+  error: Error | null;
+}
+
+function resolveUserId(user: IUserMaster): string {
+  const userId = String(user.UserID ?? '').trim();
+  return userId || `user-${user.Id}`;
+}
+
+export function usePdcaStopRanking(
+  users: IUserMaster[],
+  isLoading: boolean,
+  error: Error | null,
+  planningSheetRepo?: PlanningSheetRepository | null,
+  monitoringMeetingRepo?: MonitoringMeetingRepository | null,
+  planPatchRepository?: PlanPatchRepository | null,
+  improvementOutcomeRepository?: ImprovementOutcomeRepository | null,
+): PdcaStopRankingResult {
+  const [ranking, setRanking] = useState<PdcaStopRankingEntry[]>([]);
+  const [rankingLoading, setRankingLoading] = useState(false);
+  const [rankingError, setRankingError] = useState<Error | null>(null);
+
+  const targetUsers = useMemo(
+    () => users.filter((user) => user.IsActive !== false && user.IsHighIntensitySupportTarget === true),
+    [users],
+  );
+
+  useEffect(() => {
+    let active = true;
+
+    async function load(): Promise<void> {
+      if (
+        isLoading ||
+        error ||
+        !planningSheetRepo ||
+        !monitoringMeetingRepo ||
+        !planPatchRepository ||
+        !improvementOutcomeRepository
+      ) {
+        if (active) {
+          setRanking([]);
+          setRankingError(error);
+        }
+        return;
+      }
+
+      if (targetUsers.length === 0) {
+        if (active) setRanking([]);
+        return;
+      }
+
+      setRankingLoading(true);
+      setRankingError(null);
+
+      try {
+        const rows = await Promise.all(
+          targetUsers.map(async (user) => {
+            const userId = resolveUserId(user);
+            const sheets = await planningSheetRepo.listCurrentByUser(userId);
+            if (sheets.length === 0) {
+              return [];
+            }
+
+            const meetings = await monitoringMeetingRepo.listByUser(userId);
+
+            const scores = await Promise.all(
+              sheets.map(async (sheet) => {
+                const patches = await planPatchRepository.findByPlanningSheetId(sheet.id);
+                const outcomes = await improvementOutcomeRepository.findByPlanningSheetId(sheet.id);
+                return buildPdcaHealthScore({
+                  planningSheetId: sheet.id,
+                  userId,
+                  patches,
+                  meetings: meetings.filter((meeting) => meeting.planningSheetId === sheet.id),
+                  outcomes,
+                });
+              }),
+            );
+
+            return scores
+              .filter((score) => score.score > 0)
+              .map((score) => ({
+                ...score,
+                userName: user.FullName ?? userId,
+              }));
+          }),
+        );
+
+        if (active) {
+          setRanking(
+            rows
+              .flat()
+              .sort((a, b) => b.score - a.score),
+          );
+        }
+      } catch (loadError) {
+        if (active) {
+          setRankingError(loadError instanceof Error ? loadError : new Error(String(loadError)));
+          setRanking([]);
+        }
+      } finally {
+        if (active) setRankingLoading(false);
+      }
+    }
+
+    void load();
+
+    return () => {
+      active = false;
+    };
+  }, [
+    error,
+    improvementOutcomeRepository,
+    isLoading,
+    monitoringMeetingRepo,
+    planPatchRepository,
+    planningSheetRepo,
+    targetUsers,
+  ]);
+
+  return {
+    ranking,
+    isLoading: isLoading || rankingLoading,
+    error: error || rankingError,
+  };
+}

--- a/src/features/today/domain/engine/mapToActionCard.ts
+++ b/src/features/today/domain/engine/mapToActionCard.ts
@@ -15,6 +15,7 @@ function resolveActionType(item: ScoredActionItem): ActionType {
       return 'ACKNOWLEDGE';
     case 'incident':
     case 'corrective_action':
+    case 'plan_patch':
       return 'NAVIGATE';
     case 'schedule':
       return 'OPEN_DRAWER';
@@ -36,6 +37,16 @@ function buildContextMessage(item: ScoredActionItem): string {
       return summarizeEvidence(payload.suggestion.evidence);
     }
     return '改善提案';
+  }
+
+  if (item.sourceType === 'plan_patch') {
+    const payload = item.payload as { dueAt?: string; status?: string } | undefined;
+    if (payload?.dueAt) {
+      return item.isOverdue
+        ? `更新期限 ${payload.dueAt.slice(0, 10)} / 対応遅延`
+        : `更新期限 ${payload.dueAt.slice(0, 10)}`;
+    }
+    return `状態: ${payload?.status ?? 'needs_update'}`;
   }
 
   const base = item.targetTime

--- a/src/features/today/domain/engine/scoreActionPriority.ts
+++ b/src/features/today/domain/engine/scoreActionPriority.ts
@@ -23,6 +23,12 @@ export function scoreActionPriority(source: RawActionSource): ActionPriority {
       return 'P3';
     case 'exception':
       return 'P1';
+    case 'plan_patch': {
+      const payload = source.payload as { dueAt?: string } | undefined;
+      const dueAt = payload?.dueAt?.slice(0, 10);
+      const today = new Date().toISOString().slice(0, 10);
+      return dueAt && dueAt < today ? 'P0' : 'P1';
+    }
     default: {
       const _exhaustive: never = source.sourceType;
       return _exhaustive;

--- a/src/features/today/domain/models/queue.types.ts
+++ b/src/features/today/domain/models/queue.types.ts
@@ -6,7 +6,8 @@ export type ActionSourceType =
   | 'handoff'
   | 'incident'
   | 'corrective_action'
-  | 'exception';
+  | 'exception'
+  | 'plan_patch';
 
 export interface RawActionSource {
   id: string;

--- a/src/features/today/hooks/useTodayPlanPatchActions.ts
+++ b/src/features/today/hooks/useTodayPlanPatchActions.ts
@@ -1,0 +1,72 @@
+import { mapPlanPatchesToTodayActionSources } from '@/domain/today/planPatchToTodayActionMapper';
+import type { RawActionSource } from '@/features/today/domain/models/queue.types';
+import { usePlanPatchRepository } from '@/features/planning-sheet/hooks/usePlanPatchRepository';
+import { usePlanningSheetRepositories } from '@/features/planning-sheet/hooks/usePlanningSheetRepositories';
+import type { IUserMaster } from '@/features/users/types';
+import { useEffect, useMemo, useState } from 'react';
+
+function resolveUserId(user: IUserMaster): string {
+  const userId = String(user.UserID ?? '').trim();
+  return userId || `U${String(user.Id ?? 0).padStart(3, '0')}`;
+}
+
+export function useTodayPlanPatchActions(users: IUserMaster[]): RawActionSource[] {
+  const planningSheetRepository = usePlanningSheetRepositories();
+  const planPatchRepository = usePlanPatchRepository();
+  const [actions, setActions] = useState<RawActionSource[]>([]);
+
+  const targetUsers = useMemo(
+    () => users.filter((user) => user.IsHighIntensitySupportTarget === true),
+    [users],
+  );
+
+  useEffect(() => {
+    let active = true;
+
+    async function load(): Promise<void> {
+      if (targetUsers.length === 0) {
+        if (active) setActions([]);
+        return;
+      }
+
+      const collected = await Promise.all(
+        targetUsers.map(async (user) => {
+          const userId = resolveUserId(user);
+          const sheets = await planningSheetRepository.listCurrentByUser(userId);
+          if (sheets.length === 0) return [];
+
+          const pendingGroups = await Promise.all(
+            sheets.map((sheet) => planPatchRepository.findPending(sheet.id)),
+          );
+
+          return mapPlanPatchesToTodayActionSources(
+            pendingGroups
+              .flat()
+              .filter((patch) => patch.status !== 'confirmed')
+              .map((patch) => ({
+                patch,
+                userId,
+                userName: user.FullName ?? userId,
+              })),
+          );
+        }),
+      );
+
+      if (active) {
+        setActions(collected.flat());
+      }
+    }
+
+    void load().catch(() => {
+      if (active) {
+        setActions([]);
+      }
+    });
+
+    return () => {
+      active = false;
+    };
+  }, [planPatchRepository, planningSheetRepository, targetUsers]);
+
+  return actions;
+}

--- a/src/infra/localStorage/localPlanPatchRepository.ts
+++ b/src/infra/localStorage/localPlanPatchRepository.ts
@@ -1,0 +1,64 @@
+import type { PlanPatch } from '@/domain/isp/planPatch';
+import type { PlanPatchRepository } from '@/domain/isp/planPatchRepository';
+
+const STORAGE_KEY = 'isp.plan-patches.v1';
+const MAX_PATCHES = 500;
+
+function readStore(): PlanPatch[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    return JSON.parse(raw) as PlanPatch[];
+  } catch {
+    return [];
+  }
+}
+
+function writeStore(patches: PlanPatch[]): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(patches));
+}
+
+export const localPlanPatchRepository: PlanPatchRepository = {
+  async save(patch: PlanPatch): Promise<void> {
+    const all = readStore();
+    const existingIndex = all.findIndex((item) => item.id === patch.id);
+
+    if (existingIndex >= 0) {
+      all[existingIndex] = {
+        ...all[existingIndex],
+        ...patch,
+        updatedAt: new Date().toISOString(),
+      };
+    } else {
+      all.unshift(patch);
+      if (all.length > MAX_PATCHES) {
+        all.length = MAX_PATCHES;
+      }
+    }
+
+    writeStore(all);
+  },
+
+  async findByPlanningSheetId(planningSheetId: string): Promise<PlanPatch[]> {
+    return readStore().filter((patch) => patch.planningSheetId === planningSheetId);
+  },
+
+  async updateStatus(patchId: string, status: PlanPatch['status']): Promise<void> {
+    const all = readStore();
+    const index = all.findIndex((patch) => patch.id === patchId);
+    if (index < 0) return;
+
+    all[index] = {
+      ...all[index],
+      status,
+      updatedAt: new Date().toISOString(),
+    };
+    writeStore(all);
+  },
+
+  async findPending(planningSheetId: string): Promise<PlanPatch[]> {
+    return readStore().filter(
+      (patch) => patch.planningSheetId === planningSheetId && patch.status !== 'confirmed',
+    );
+  },
+};

--- a/src/pages/MonitoringMeetingRecordPage.tsx
+++ b/src/pages/MonitoringMeetingRecordPage.tsx
@@ -15,14 +15,25 @@ import { MonitoringMeetingForm } from '@/features/monitoring/components/Monitori
 import { useMonitoringMeetingForm } from '@/features/monitoring/hooks/useMonitoringMeetingForm';
 import { useMonitoringMeetingRepository } from '@/features/monitoring/data/useMonitoringMeetingRepository';
 import { usePlanningSheetList } from '@/features/monitoring/hooks/usePlanningSheetList';
+import { usePlanningSheetRepositories } from '@/features/planning-sheet/hooks/usePlanningSheetRepositories';
+import { usePlanPatchRepository } from '@/features/planning-sheet/hooks/usePlanPatchRepository';
+import { useImprovementOutcomeRepository } from '@/features/monitoring/data/useImprovementOutcomeRepository';
 import { useAuth } from '@/auth/useAuth';
 import { useUser } from '@/features/users/useUsers';
 import { MonitoringMeetingRecord } from '@/domain/isp/monitoringMeeting';
+import { generatePlanPatch } from '@/domain/isp/planPatch';
+import { DEFAULT_METRIC_DEFINITIONS, getMetricDefinition } from '@/domain/isp/metricDefinition';
+import { evaluateImprovement } from '@/domain/isp/improvementOutcome';
+import { safeRandomUUID } from '@/lib/uuid';
+import type { ImprovementInput } from '@/features/monitoring/components/MonitoringMeetingForm';
 
 export default function MonitoringMeetingRecordPage() {
   const { userId } = useParams<{ userId: string }>();
   const navigate = useNavigate();
   const repository = useMonitoringMeetingRepository();
+  const planningSheetRepository = usePlanningSheetRepositories();
+  const planPatchRepository = usePlanPatchRepository();
+  const improvementOutcomeRepository = useImprovementOutcomeRepository();
   const { account } = useAuth();
   
   // 利用主情報の取得
@@ -38,6 +49,14 @@ export default function MonitoringMeetingRecordPage() {
 
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [patchOptions, setPatchOptions] = useState<{ id: string; label: string }[]>([]);
+  const [improvementInput, setImprovementInput] = useState<ImprovementInput>({
+    patchId: '',
+    metricId: '',
+    beforeValue: '',
+    afterValue: '',
+    confidence: 'medium',
+  });
 
   // 初回ロード時に利用者名をセット
   useEffect(() => {
@@ -46,8 +65,51 @@ export default function MonitoringMeetingRecordPage() {
     }
   }, [userMaster, draft.userName, update]);
 
+  useEffect(() => {
+    const planningSheetId = draft.planningSheetId;
+    if (!planningSheetId) {
+      setPatchOptions([]);
+      setImprovementInput((prev) => ({ ...prev, patchId: '' }));
+      return;
+    }
+
+    let active = true;
+    void planPatchRepository.findByPlanningSheetId(planningSheetId).then((patches) => {
+      if (!active) return;
+      const options = patches
+        .filter((patch) => patch.status === 'confirmed')
+        .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+        .map((patch) => ({
+          id: patch.id,
+          label: `${patch.target === 'plan' ? '計画' : '手順'} / ${patch.updatedAt.slice(0, 10)} / ${patch.reason.split('\n')[0]}`,
+        }));
+      setPatchOptions(options);
+      setImprovementInput((prev) => (
+        options.some((option) => option.id === prev.patchId)
+          ? prev
+          : { ...prev, patchId: '' }
+      ));
+    });
+
+    return () => {
+      active = false;
+    };
+  }, [draft.planningSheetId, planPatchRepository]);
+
   // 利用者名の表示用
   const dispUserName = userMaster?.FullName || `利用者 ${userId}` || '未選択'; 
+
+  const isImprovementInputEmpty =
+    !improvementInput.patchId &&
+    !improvementInput.metricId &&
+    improvementInput.beforeValue === '' &&
+    improvementInput.afterValue === '';
+
+  const isImprovementInputComplete =
+    !!improvementInput.patchId &&
+    !!improvementInput.metricId &&
+    improvementInput.beforeValue !== '' &&
+    improvementInput.afterValue !== '';
 
   const handleSave = async (isFinalizing: boolean = false) => {
     if (!draft.discussionSummary) {
@@ -56,6 +118,11 @@ export default function MonitoringMeetingRecordPage() {
     }
 
     if (isFinalizing && !window.confirm('会議記録を確定します。確定後は編集できません。よろしいですか？')) {
+      return;
+    }
+
+    if (!isImprovementInputEmpty && !isImprovementInputComplete) {
+      setError('改善評価を入力する場合は、対象更新案・対象指標・before・after をすべて入力してください。');
       return;
     }
 
@@ -77,7 +144,51 @@ export default function MonitoringMeetingRecordPage() {
         dataToSave.userName = userMaster.FullName;
       }
       
-      await repository.save(dataToSave as unknown as MonitoringMeetingRecord); 
+      const savedMeeting = await repository.save(dataToSave as unknown as MonitoringMeetingRecord);
+
+      if (isFinalizing && isImprovementInputComplete && savedMeeting.planningSheetId) {
+        const metric = getMetricDefinition(improvementInput.metricId);
+        if (!metric) {
+          throw new Error('改善評価の対象指標が不正です。');
+        }
+
+        const result = evaluateImprovement({
+          before: Number(improvementInput.beforeValue),
+          after: Number(improvementInput.afterValue),
+          direction: metric.direction,
+        });
+
+        await improvementOutcomeRepository.save({
+          id: `outcome-${safeRandomUUID()}`,
+          planningSheetId: savedMeeting.planningSheetId,
+          patchId: improvementInput.patchId,
+          observedAt: savedMeeting.meetingDate,
+          targetMetric: metric.id,
+          source: 'manual_kpi',
+          metricDefinitionId: metric.id,
+          beforeValue: Number(improvementInput.beforeValue),
+          afterValue: Number(improvementInput.afterValue),
+          changeRate: result.changeRate,
+          isImproved: result.isImproved,
+          confidence: improvementInput.confidence,
+          createdAt: new Date().toISOString(),
+        });
+      }
+
+      if (
+        isFinalizing &&
+        savedMeeting.planningSheetId &&
+        savedMeeting.planChangeDecision !== 'no_change'
+      ) {
+        const currentPlan = await planningSheetRepository.getById(savedMeeting.planningSheetId);
+        if (currentPlan) {
+          const patch = generatePlanPatch(savedMeeting, currentPlan);
+          if (patch) {
+            await planPatchRepository.save(patch);
+          }
+        }
+      }
+
       navigate(-1);
     } catch (e) {
       setError(e instanceof Error ? e.message : '保存中にエラーが発生しました');
@@ -122,6 +233,10 @@ export default function MonitoringMeetingRecordPage() {
             id: s.id, 
             title: `${s.title} (${s.reviewedAt || '日付不明'})` 
           }))}
+          patchOptions={patchOptions}
+          metricDefinitions={DEFAULT_METRIC_DEFINITIONS}
+          improvementInput={improvementInput}
+          onImprovementInputChange={(patch) => setImprovementInput((prev) => ({ ...prev, ...patch }))}
         />
       </Paper>
     </Container>

--- a/src/pages/RegulatoryDashboardPage.tsx
+++ b/src/pages/RegulatoryDashboardPage.tsx
@@ -45,10 +45,13 @@ import {
 import { useUsers } from '@/features/users/useUsers';
 import { useStaff } from '@/stores/useStaff';
 import { usePlanningSheetRepositories } from '@/features/planning-sheet/hooks/usePlanningSheetRepositories';
+import { usePlanPatchRepository } from '@/features/planning-sheet/hooks/usePlanPatchRepository';
+import { useImprovementOutcomeRepository } from '@/features/monitoring/data/useImprovementOutcomeRepository';
 import {
   localWeeklyObservationRepository,
   localQualificationAssignmentRepository,
 } from '@/infra/localStorage/localStaffQualificationRepository';
+import { usePdcaStopRanking } from '@/features/regulatory/hooks/usePdcaStopRanking';
 
 // ── Local (split) ──
 import type { AuditFindingSeverity, UnifiedFindingRow } from './regulatory-dashboard/types';
@@ -57,6 +60,7 @@ import { generateDemoFindings, generateDemoSevereAddonFindings, generateDemoIceb
 import { SummaryCard, TypeBreakdown, DomainSummary } from './regulatory-dashboard/SummaryPanel';
 import { SevereAddonSummaryPanel } from './regulatory-dashboard/SevereAddonPanel';
 import { FindingsTable } from './regulatory-dashboard/FindingsTable';
+import { PdcaStopRankingPanel } from './regulatory-dashboard/PdcaStopRankingPanel';
 
 // ─────────────────────────────────────────────
 // Page Component
@@ -75,6 +79,8 @@ const RegulatoryDashboardPage: React.FC = () => {
   const { data: spUsers, status: usersStatus, error: usersError } = useUsers({ selectMode: 'full' });
   const { staff: spStaff, isLoading: staffLoading, error: staffError } = useStaff();
   const planningSheetRepo = usePlanningSheetRepositories();
+  const planPatchRepository = usePlanPatchRepository();
+  const improvementOutcomeRepository = useImprovementOutcomeRepository();
   const procedureRecordRepo = useProcedureRecordRepository();
   const monitoringMeetingRepo = useMonitoringMeetingRepository();
   const dataLoading = usersStatus === 'loading' || staffLoading;
@@ -118,6 +124,19 @@ const RegulatoryDashboardPage: React.FC = () => {
     return generateDemoSevereAddonFindings();
   }, [realAddonInput]);
   const addonSummary = useMemo(() => summarizeSevereAddonFindings(addonFindings), [addonFindings]);
+
+  const {
+    ranking: pdcaStopRanking,
+    isLoading: pdcaStopRankingLoading,
+  } = usePdcaStopRanking(
+    spUsers,
+    dataLoading,
+    dataError,
+    planningSheetRepo,
+    monitoringMeetingRepo,
+    planPatchRepository,
+    improvementOutcomeRepository,
+  );
 
   // 統合行データ
   const unifiedRows = useMemo(
@@ -273,6 +292,14 @@ const RegulatoryDashboardPage: React.FC = () => {
           }}
         />
         <SafetyOperationsSummaryCard />
+      </Box>
+
+      <Box sx={{ mb: 3 }}>
+        <PdcaStopRankingPanel
+          ranking={pdcaStopRanking}
+          isLoading={pdcaStopRankingLoading}
+          onNavigate={(url) => navigate(url)}
+        />
       </Box>
 
       {/* フィルター */}

--- a/src/pages/TodayOpsPage.tsx
+++ b/src/pages/TodayOpsPage.tsx
@@ -65,6 +65,7 @@ import { UserStatusQuickDialog } from '@/features/schedules/components/dialogs/U
 // Phase 9: Today → Schedule Ops 高負荷タイル連携
 import { useWeeklyHighLoadStatus } from '@/features/today/hooks/useWeeklyHighLoadStatus';
 import { useTodayExceptions } from '@/features/today/hooks/useTodayExceptions';
+import { useTodayPlanPatchActions } from '@/features/today/hooks/useTodayPlanPatchActions';
 
 import { Alert, Snackbar } from '@mui/material';
 import { useQueryClient } from '@tanstack/react-query';
@@ -148,6 +149,7 @@ const LegacyTodayOpsPage: React.FC<TodayOpsPageProps> = ({
 
   // ── Data Fetching (Facade) ──
   const summary = useTodaySummary();
+  const todayPlanPatchActions = useTodayPlanPatchActions(summary.users ?? []);
 
   // 支援手順の実施の未入力ユーザーを算出（todayRecordCompletion.pendingUserIds 起点）
   const pendingSupportUsers = useMemo(() => {
@@ -216,7 +218,7 @@ const LegacyTodayOpsPage: React.FC<TodayOpsPageProps> = ({
     currentStaffId: 'staff-a', // 仮: ログインユーザーのIDを連携できるとベター
     correctiveActions,
     suggestionStates,
-    exceptionActions: summary.todayExceptionActions,
+    exceptionActions: [...summary.todayExceptionActions, ...todayPlanPatchActions],
   });
   const suggestionByStableId = useMemo(() => {
     return new Map(correctiveActions.map((s) => [s.stableId, s]));

--- a/src/pages/regulatory-dashboard/PdcaStopRankingPanel.tsx
+++ b/src/pages/regulatory-dashboard/PdcaStopRankingPanel.tsx
@@ -1,0 +1,195 @@
+import type { PdcaStopRankingEntry } from '@/features/regulatory/hooks/usePdcaStopRanking';
+import AssignmentRoundedIcon from '@mui/icons-material/AssignmentRounded';
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
+import ScheduleIcon from '@mui/icons-material/Schedule';
+import TrendingUpIcon from '@mui/icons-material/TrendingUp';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Card from '@mui/material/Card';
+import Chip from '@mui/material/Chip';
+import CircularProgress from '@mui/material/CircularProgress';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import React from 'react';
+
+type Props = {
+  ranking: PdcaStopRankingEntry[];
+  isLoading: boolean;
+  onNavigate: (url: string) => void;
+};
+
+const SEVERITY_COLOR: Record<PdcaStopRankingEntry['severity'], 'success' | 'warning' | 'error' | 'default'> = {
+  low: 'success',
+  medium: 'warning',
+  high: 'error',
+  critical: 'error',
+};
+
+const SEVERITY_LABEL: Record<PdcaStopRankingEntry['severity'], string> = {
+  low: '低',
+  medium: '中',
+  high: '高',
+  critical: '危険',
+};
+
+export const PdcaStopRankingPanel: React.FC<Props> = ({
+  ranking,
+  isLoading,
+  onNavigate,
+}) => {
+  const topRows = ranking.slice(0, 5);
+
+  return (
+    <Card variant="outlined" sx={{ p: 2.5 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
+        <TrendingUpIcon color="warning" />
+        <Typography variant="subtitle1" fontWeight={800}>
+          PDCA停止ランキング
+        </Typography>
+        <Chip
+          label={`${ranking.length}件`}
+          size="small"
+          color={ranking.length > 0 ? 'warning' : 'default'}
+          variant={ranking.length > 0 ? 'filled' : 'outlined'}
+          sx={{ ml: 'auto', fontWeight: 700 }}
+        />
+      </Box>
+
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        未反映パッチ、期限超過、会議停滞をまとめて優先順位化しています。
+      </Typography>
+
+      {isLoading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+          <CircularProgress size={28} />
+        </Box>
+      ) : topRows.length === 0 ? (
+        <Alert severity="success" variant="outlined">
+          現時点で PDCA 停止状態の利用者はありません。
+        </Alert>
+      ) : (
+        <Stack spacing={1.5}>
+          {topRows.map((row, index) => (
+            <Box
+              key={`${row.planningSheetId}-${row.userId}`}
+              sx={{
+                p: 1.5,
+                border: '1px solid',
+                borderColor: 'divider',
+                borderRadius: 2,
+                bgcolor: index === 0 ? 'rgba(237,108,2,0.06)' : 'background.paper',
+              }}
+            >
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+                <Chip
+                  label={`${index + 1}位`}
+                  size="small"
+                  color={index === 0 ? 'warning' : 'default'}
+                  variant={index === 0 ? 'filled' : 'outlined'}
+                  sx={{ fontWeight: 700 }}
+                />
+                <Typography variant="body2" fontWeight={700}>
+                  {row.userName ?? row.userId}
+                </Typography>
+                <Chip
+                  label={SEVERITY_LABEL[row.severity]}
+                  size="small"
+                  color={SEVERITY_COLOR[row.severity]}
+                  variant="filled"
+                  sx={{ fontWeight: 700 }}
+                />
+                <Typography variant="caption" color="text.secondary" sx={{ ml: 'auto' }}>
+                  score {row.score}
+                </Typography>
+              </Box>
+
+              <Box sx={{ mb: 1.5, px: 0.5 }}>
+                <Typography variant="caption" sx={{ color: 'warning.main', fontWeight: 700, display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                  👉 判定理由：{[
+                    row.overdueDays > 0 && `${row.overdueDays}日未更新`,
+                    row.pendingPatchCount > 0 && `未反映${row.pendingPatchCount}件`,
+                    row.daysSinceLastMeeting > 90 && '会議停滞',
+                    row.manualOutcomeCount < 3 && '評価データ不足'
+                  ].filter(Boolean).join(' / ') || '定期モニタリング中'}
+                </Typography>
+              </Box>
+
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 1 }}>
+                <Chip
+                  icon={<ErrorOutlineIcon />}
+                  label={`未反映 ${row.pendingPatchCount}件`}
+                  size="small"
+                  color={row.pendingPatchCount > 0 ? 'warning' : 'default'}
+                  variant={row.pendingPatchCount > 0 ? 'filled' : 'outlined'}
+                />
+                <Chip
+                  icon={<ScheduleIcon />}
+                  label={`期限超過 ${row.overdueDays}日`}
+                  size="small"
+                  color={row.overdueDays > 0 ? 'error' : 'default'}
+                  variant={row.overdueDays > 0 ? 'filled' : 'outlined'}
+                />
+                <Chip
+                  label={`最終会議 ${row.daysSinceLastMeeting}日前`}
+                  size="small"
+                  variant="outlined"
+                />
+                <Chip
+                  label={`根拠 ${row.evidenceCount}件`}
+                  size="small"
+                  variant="outlined"
+                />
+                <Chip
+                  label={`改善成功率 ${Math.round(row.improvementSuccessRate * 100)}%`}
+                  size="small"
+                  color={row.improvementSuccessRate >= 0.5 ? 'success' : 'default'}
+                  variant={row.improvementSuccessRate >= 0.5 ? 'filled' : 'outlined'}
+                />
+                <Chip
+                  label={`KPI評価数 ${row.manualOutcomeCount}件`}
+                  size="small"
+                  variant="outlined"
+                />
+                {row.derivedOutcomeCount > 0 && (
+                  <Chip
+                    label={`自動分析 ${row.derivedOutcomeCount}件`}
+                    size="small"
+                    variant="outlined"
+                    sx={{ borderStyle: 'dashed' }}
+                  />
+                )}
+                <Chip
+                  label={`信頼度：${row.confidenceScore === 'high' ? '高' : row.confidenceScore === 'medium' ? '中' : '低'}`}
+                  size="small"
+                  color={row.confidenceScore === 'high' ? 'success' : row.confidenceScore === 'medium' ? 'warning' : 'default'}
+                  variant={row.confidenceScore !== 'low' ? 'filled' : 'outlined'}
+                />
+              </Box>
+
+              <Stack direction="row" spacing={1}>
+                <Button
+                  size="small"
+                  variant={row.manualOutcomeCount < 3 ? 'outlined' : 'contained'}
+                  color="primary"
+                  onClick={() => onNavigate(`/support-planning-sheet/${row.planningSheetId}?tab=planning`)}
+                >
+                  計画更新を確認
+                </Button>
+                <Button
+                  size="small"
+                  variant={row.manualOutcomeCount < 3 ? 'contained' : 'outlined'}
+                  color="primary"
+                  startIcon={<AssignmentRoundedIcon />}
+                  onClick={() => onNavigate(`/monitoring-meeting/${row.userId}`)}
+                >
+                  モニタリング会議
+                </Button>
+              </Stack>
+            </Box>
+          ))}
+        </Stack>
+      )}
+    </Card>
+  );
+};

--- a/src/pages/support-planning-sheet/SupportPlanningSheetView.tsx
+++ b/src/pages/support-planning-sheet/SupportPlanningSheetView.tsx
@@ -4,12 +4,22 @@ import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
+import Divider from '@mui/material/Divider';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
 
 // import { createSharePointIspRepository } from '@/data/isp/sharepoint/SharePointIspRepository';
 import { usePlanningSheetRepositories } from '@/features/planning-sheet/hooks/usePlanningSheetRepositories';
+import { usePlanPatchRepository } from '@/features/planning-sheet/hooks/usePlanPatchRepository';
 import { NewPlanningSheetForm } from '@/features/planning-sheet/components/NewPlanningSheetForm';
 // import { useSP } from '@/lib/spClient';
 import { TESTIDS, tid } from '@/testids';
+import {
+  applyPlanPatch,
+  detectPlanNeedsUpdate,
+  isPlanPatchOverdue,
+  type PlanPatch,
+} from '@/domain/isp/planPatch';
 
 import { type SupportPlanningSheetViewProps } from './types';
 import type { IspRepository } from '@/domain/isp/port';
@@ -22,10 +32,22 @@ export const SupportPlanningSheetView: React.FC<SupportPlanningSheetViewProps> =
   handlers,
 }) => {
   const planningSheetRepo = usePlanningSheetRepositories();
+  const planPatchRepository = usePlanPatchRepository();
   // const spClient = useSP();
   const ispRepo = React.useMemo(() => ({
     getCurrentByUser: async () => null,
   } as unknown as IspRepository), []);
+  const [pendingPatchCount, setPendingPatchCount] = React.useState(0);
+  const [pendingPatches, setPendingPatches] = React.useState<PlanPatch[]>([]);
+  const [patchActionMessage, setPatchActionMessage] = React.useState<string | null>(null);
+  const hasPendingPlanUpdate = React.useMemo(
+    () => detectPlanNeedsUpdate(pendingPatches),
+    [pendingPatches],
+  );
+  const hasOverduePlanUpdate = React.useMemo(
+    () => pendingPatches.some((patch) => isPlanPatchOverdue(patch)),
+    [pendingPatches],
+  );
 
   if (!viewModel) {
     return (
@@ -73,6 +95,26 @@ export const SupportPlanningSheetView: React.FC<SupportPlanningSheetViewProps> =
     diffSummary,
   } = viewModel;
 
+  React.useEffect(() => {
+    if (!planningSheetId || planningSheetId === 'new') {
+      setPendingPatchCount(0);
+      setPendingPatches([]);
+      return;
+    }
+
+    let active = true;
+
+    void planPatchRepository.findPending(planningSheetId).then((patches) => {
+      if (!active) return;
+      setPendingPatchCount(patches.length);
+      setPendingPatches(patches);
+    });
+
+    return () => {
+      active = false;
+    };
+  }, [planPatchRepository, planningSheetId]);
+
   if (isLoading) {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: 300 }}>
@@ -110,9 +152,106 @@ export const SupportPlanningSheetView: React.FC<SupportPlanningSheetViewProps> =
     );
   }
 
+  const handlePatchStatusChange = async (
+    patchId: string,
+    status: PlanPatch['status'],
+  ) => {
+    await planPatchRepository.updateStatus(patchId, status);
+    const next = pendingPatches
+      .map((patch) => (patch.id === patchId ? { ...patch, status } : patch))
+      .filter((patch) => patch.status !== 'confirmed');
+    setPendingPatches(next);
+    setPendingPatchCount(next.length);
+  };
+
+  const handleApplyPatch = async (patch: PlanPatch) => {
+    try {
+      const updated = applyPlanPatch(patch, sheet);
+      await planningSheetRepo.update(sheet.id, updated as never);
+      await planPatchRepository.updateStatus(patch.id, 'confirmed');
+      const next = pendingPatches.filter((item) => item.id !== patch.id);
+      setPendingPatches(next);
+      setPendingPatchCount(next.length);
+      setPatchActionMessage('更新案を支援計画シートへ反映しました。画面を再読み込みすると最新状態が表示されます。');
+    } catch (error) {
+      if (error instanceof Error && error.message === 'VERSION_CONFLICT') {
+        setPatchActionMessage('バージョン競合が発生しました。最新の支援計画シートを確認してから再適用してください。');
+        return;
+      }
+      setPatchActionMessage('更新案の反映に失敗しました。');
+    }
+  };
+
   return (
     <Box sx={{ display: 'flex', position: 'relative' }}>
       <Box sx={{ flex: 1, p: { xs: 2, md: 3 }, pb: 4 }} {...tid(TESTIDS['planning-sheet-page'])}>
+        {hasPendingPlanUpdate ? (
+          <Alert severity="warning" sx={{ mb: 2 }}>
+            未反映の計画更新案が {pendingPatchCount} 件あります。モニタリング会議の結果を確認し、必要に応じて計画へ反映してください。
+          </Alert>
+        ) : null}
+        {patchActionMessage ? (
+          <Alert severity="info" sx={{ mb: 2 }} onClose={() => setPatchActionMessage(null)}>
+            {patchActionMessage}
+          </Alert>
+        ) : null}
+        {pendingPatches.length > 0 ? (
+          <Paper variant="outlined" sx={{ mb: 3, p: 2 }}>
+            <Typography variant="h6" sx={{ mb: 1 }}>
+              未反映の更新案レビュー
+            </Typography>
+            {pendingPatches.map((patch, index) => (
+              <Box key={patch.id} sx={{ py: 2 }}>
+                {index > 0 ? <Divider sx={{ mb: 2 }} /> : null}
+                <Typography variant="subtitle2" sx={{ mb: 1 }}>
+                  {patch.target === 'plan' ? '計画更新案' : '手順更新案'} / status: {patch.status} / baseVersion: {patch.baseVersion}
+                </Typography>
+                <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', mb: 1 }}>
+                  理由: {patch.reason}
+                </Typography>
+                <Typography variant="caption" display="block" sx={{ mb: 1 }}>
+                  根拠記録: {patch.evidenceIds.join(', ') || 'なし'}
+                </Typography>
+                <Box
+                  sx={{
+                    display: 'grid',
+                    gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' },
+                    gap: 2,
+                    mb: 2,
+                  }}
+                >
+                  <Box>
+                    <Typography variant="caption" display="block" sx={{ mb: 0.5 }}>
+                      Before
+                    </Typography>
+                    <Box component="pre" sx={{ m: 0, p: 1.5, bgcolor: 'grey.100', overflow: 'auto', fontSize: 12 }}>
+                      {JSON.stringify(patch.before, null, 2)}
+                    </Box>
+                  </Box>
+                  <Box>
+                    <Typography variant="caption" display="block" sx={{ mb: 0.5 }}>
+                      After
+                    </Typography>
+                    <Box component="pre" sx={{ m: 0, p: 1.5, bgcolor: 'grey.100', overflow: 'auto', fontSize: 12 }}>
+                      {JSON.stringify(patch.after, null, 2)}
+                    </Box>
+                  </Box>
+                </Box>
+                <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+                  <Button variant="contained" size="small" onClick={() => void handleApplyPatch(patch)}>
+                    承認して反映
+                  </Button>
+                  <Button variant="outlined" size="small" onClick={() => void handlePatchStatusChange(patch.id, 'review')}>
+                    保留
+                  </Button>
+                  <Button variant="text" size="small" color="warning" onClick={() => void handlePatchStatusChange(patch.id, 'draft')}>
+                    差し戻し
+                  </Button>
+                </Box>
+              </Box>
+            ))}
+          </Paper>
+        ) : null}
         <PlanningMainStackSection
           headerProps={{
             sheet,
@@ -159,6 +298,8 @@ export const SupportPlanningSheetView: React.FC<SupportPlanningSheetViewProps> =
             activeTab,
             onTabChange: handlers.onTabChange,
             currentPhase,
+            hasPendingPlanUpdate,
+            hasOverduePlanUpdate,
             onBannerNavigate: handlers.onBannerNavigate,
             isEditing,
             form,

--- a/src/pages/support-planning-sheet/sections/PlanningTabsSection.tsx
+++ b/src/pages/support-planning-sheet/sections/PlanningTabsSection.tsx
@@ -32,6 +32,8 @@ type PlanningTabsSectionProps = {
   activeTab: SheetTabKey;
   onTabChange: (tab: SheetTabKey) => void;
   currentPhase: WorkflowPhase | null;
+  hasPendingPlanUpdate?: boolean;
+  hasOverduePlanUpdate?: boolean;
   onBannerNavigate: (href: string) => void;
   isEditing: boolean;
   form: UsePlanningSheetFormReturn;
@@ -54,6 +56,8 @@ export function PlanningTabsSection({
   activeTab,
   onTabChange,
   currentPhase,
+  hasPendingPlanUpdate = false,
+  hasOverduePlanUpdate = false,
   onBannerNavigate,
   isEditing,
   form,
@@ -97,6 +101,9 @@ export function PlanningTabsSection({
           <PhaseNextStepBanner
             phase={currentPhase}
             context="overview"
+            planningSheetId={sheet.id}
+            hasPendingPlanUpdate={hasPendingPlanUpdate}
+            hasOverduePlanUpdate={hasOverduePlanUpdate}
             onNavigate={onBannerNavigate}
           />
         )}
@@ -148,6 +155,17 @@ export function PlanningTabsSection({
             onDaysChange={onTrendDaysChange}
             loading={trendLoading}
           />
+          {currentPhase && (
+            <PhaseNextStepBanner
+              phase={currentPhase}
+              context="planning"
+              userId={sheet.userId}
+              planningSheetId={sheet.id}
+              hasPendingPlanUpdate={hasPendingPlanUpdate}
+              hasOverduePlanUpdate={hasOverduePlanUpdate}
+              onNavigate={onBannerNavigate}
+            />
+          )}
           {isEditing ? (
             <EditablePlanningDesignSection
               planning={form.planning}

--- a/src/sharepoint/fields/improvementOutcomeFields.ts
+++ b/src/sharepoint/fields/improvementOutcomeFields.ts
@@ -1,0 +1,86 @@
+import { buildSelectFieldsFromMap } from './fieldUtils';
+
+export const IMPROVEMENT_OUTCOME_FIELDS = {
+  outcomeId: 'OutcomeId',
+  planningSheetId: 'PlanningSheetId',
+  patchId: 'PatchId',
+  observedAt: 'ObservedAt',
+  targetMetric: 'TargetMetric',
+  source: 'OutcomeSource',
+  metricDefinitionId: 'MetricDefinitionId',
+  beforeValue: 'BeforeValue',
+  afterValue: 'AfterValue',
+  changeRate: 'ChangeRate',
+  isImproved: 'IsImproved',
+  confidence: 'Confidence',
+  evaluationWindowDays: 'EvaluationWindowDays',
+  createdAt: 'CreatedAt',
+} as const;
+
+export const IMPROVEMENT_OUTCOME_CANDIDATES = {
+  outcomeId: [IMPROVEMENT_OUTCOME_FIELDS.outcomeId, 'outcomeId', 'RecordId'],
+  planningSheetId: [IMPROVEMENT_OUTCOME_FIELDS.planningSheetId, 'planningSheetId'],
+  patchId: [IMPROVEMENT_OUTCOME_FIELDS.patchId, 'patchId'],
+  observedAt: [IMPROVEMENT_OUTCOME_FIELDS.observedAt, 'observedAt'],
+  targetMetric: [IMPROVEMENT_OUTCOME_FIELDS.targetMetric, 'targetMetric'],
+  source: [IMPROVEMENT_OUTCOME_FIELDS.source, 'source'],
+  metricDefinitionId: [IMPROVEMENT_OUTCOME_FIELDS.metricDefinitionId, 'metricDefinitionId'],
+  beforeValue: [IMPROVEMENT_OUTCOME_FIELDS.beforeValue, 'beforeValue'],
+  afterValue: [IMPROVEMENT_OUTCOME_FIELDS.afterValue, 'afterValue'],
+  changeRate: [IMPROVEMENT_OUTCOME_FIELDS.changeRate, 'changeRate'],
+  isImproved: [IMPROVEMENT_OUTCOME_FIELDS.isImproved, 'isImproved'],
+  confidence: [IMPROVEMENT_OUTCOME_FIELDS.confidence, 'confidence'],
+  evaluationWindowDays: [IMPROVEMENT_OUTCOME_FIELDS.evaluationWindowDays, 'evaluationWindowDays'],
+  createdAt: [IMPROVEMENT_OUTCOME_FIELDS.createdAt, 'createdAt'],
+} as const;
+
+export const IMPROVEMENT_OUTCOME_ESSENTIALS = [
+  'outcomeId',
+  'planningSheetId',
+  'patchId',
+  'targetMetric',
+  'source',
+] as const;
+
+export type ImprovementOutcomeCandidateKey = keyof typeof IMPROVEMENT_OUTCOME_CANDIDATES;
+export type ImprovementOutcomeFieldMapping = Partial<Record<ImprovementOutcomeCandidateKey, string>>;
+
+export const IMPROVEMENT_OUTCOME_SELECT_FIELDS = buildSelectFieldsFromMap(IMPROVEMENT_OUTCOME_FIELDS, undefined, {
+  alwaysInclude: ['Id', 'Title'],
+});
+
+export const IMPROVEMENT_OUTCOME_ENSURE_FIELDS = [
+  { internalName: IMPROVEMENT_OUTCOME_FIELDS.outcomeId, type: 'Text', required: true },
+  { internalName: IMPROVEMENT_OUTCOME_FIELDS.planningSheetId, type: 'Text', required: true },
+  { internalName: IMPROVEMENT_OUTCOME_FIELDS.patchId, type: 'Text', required: true },
+  { internalName: IMPROVEMENT_OUTCOME_FIELDS.observedAt, type: 'Text', required: true },
+  { internalName: IMPROVEMENT_OUTCOME_FIELDS.targetMetric, type: 'Text', required: true },
+  { internalName: IMPROVEMENT_OUTCOME_FIELDS.source, type: 'Text', required: true },
+  { internalName: IMPROVEMENT_OUTCOME_FIELDS.metricDefinitionId, type: 'Text', required: false },
+  { internalName: IMPROVEMENT_OUTCOME_FIELDS.beforeValue, type: 'Number', required: true },
+  { internalName: IMPROVEMENT_OUTCOME_FIELDS.afterValue, type: 'Number', required: true },
+  { internalName: IMPROVEMENT_OUTCOME_FIELDS.changeRate, type: 'Number', required: true },
+  { internalName: IMPROVEMENT_OUTCOME_FIELDS.isImproved, type: 'Boolean', required: true },
+  { internalName: IMPROVEMENT_OUTCOME_FIELDS.confidence, type: 'Text', required: true },
+  { internalName: IMPROVEMENT_OUTCOME_FIELDS.evaluationWindowDays, type: 'Number', required: false },
+  { internalName: IMPROVEMENT_OUTCOME_FIELDS.createdAt, type: 'Text', required: true },
+] as const;
+
+export type SpImprovementOutcomeRow = {
+  Id?: number;
+  Title?: string;
+  OutcomeId?: string;
+  PlanningSheetId?: string;
+  PatchId?: string;
+  ObservedAt?: string;
+  TargetMetric?: string;
+  OutcomeSource?: string;
+  MetricDefinitionId?: string;
+  BeforeValue?: number;
+  AfterValue?: number;
+  ChangeRate?: number;
+  IsImproved?: boolean;
+  Confidence?: string;
+  EvaluationWindowDays?: number;
+  CreatedAt?: string;
+} & Record<string, unknown>;

--- a/src/sharepoint/fields/planPatchFields.ts
+++ b/src/sharepoint/fields/planPatchFields.ts
@@ -1,0 +1,77 @@
+import { buildSelectFieldsFromMap } from './fieldUtils';
+
+export const PLAN_PATCH_FIELDS = {
+  patchId: 'PatchId',
+  planningSheetId: 'PlanningSheetId',
+  target: 'PatchTarget',
+  baseVersion: 'BaseVersion',
+  beforeJson: 'BeforeJson',
+  afterJson: 'AfterJson',
+  reason: 'PatchReason',
+  evidenceIdsJson: 'EvidenceIdsJson',
+  status: 'PatchStatus',
+  dueAt: 'PatchDueAt',
+  createdAt: 'PatchCreatedAt',
+  updatedAt: 'PatchUpdatedAt',
+} as const;
+
+export const PLAN_PATCH_CANDIDATES = {
+  patchId: [PLAN_PATCH_FIELDS.patchId, 'patchId', 'RecordId'],
+  planningSheetId: [PLAN_PATCH_FIELDS.planningSheetId, 'planningSheetId'],
+  target: [PLAN_PATCH_FIELDS.target, 'target'],
+  baseVersion: [PLAN_PATCH_FIELDS.baseVersion, 'baseVersion'],
+  beforeJson: [PLAN_PATCH_FIELDS.beforeJson, 'beforeJson'],
+  afterJson: [PLAN_PATCH_FIELDS.afterJson, 'afterJson'],
+  reason: [PLAN_PATCH_FIELDS.reason, 'reason'],
+  evidenceIdsJson: [PLAN_PATCH_FIELDS.evidenceIdsJson, 'evidenceIds', 'evidenceIdsJson'],
+  status: [PLAN_PATCH_FIELDS.status, 'status'],
+  dueAt: [PLAN_PATCH_FIELDS.dueAt, 'dueAt'],
+  createdAt: [PLAN_PATCH_FIELDS.createdAt, 'createdAt'],
+  updatedAt: [PLAN_PATCH_FIELDS.updatedAt, 'updatedAt'],
+} as const;
+
+export const PLAN_PATCH_ESSENTIALS = [
+  'patchId',
+  'planningSheetId',
+  'target',
+  'status',
+] as const;
+
+export type PlanPatchCandidateKey = keyof typeof PLAN_PATCH_CANDIDATES;
+export type PlanPatchFieldMapping = Partial<Record<PlanPatchCandidateKey, string>>;
+
+export const PLAN_PATCH_SELECT_FIELDS = buildSelectFieldsFromMap(PLAN_PATCH_FIELDS, undefined, {
+  alwaysInclude: ['Id', 'Title'],
+});
+
+export const PLAN_PATCH_ENSURE_FIELDS = [
+  { internalName: PLAN_PATCH_FIELDS.patchId, type: 'Text', required: true },
+  { internalName: PLAN_PATCH_FIELDS.planningSheetId, type: 'Text', required: true },
+  { internalName: PLAN_PATCH_FIELDS.target, type: 'Text', required: true },
+  { internalName: PLAN_PATCH_FIELDS.baseVersion, type: 'Text', required: true },
+  { internalName: PLAN_PATCH_FIELDS.beforeJson, type: 'Note', required: false },
+  { internalName: PLAN_PATCH_FIELDS.afterJson, type: 'Note', required: false },
+  { internalName: PLAN_PATCH_FIELDS.reason, type: 'Note', required: false },
+  { internalName: PLAN_PATCH_FIELDS.evidenceIdsJson, type: 'Note', required: false },
+  { internalName: PLAN_PATCH_FIELDS.status, type: 'Text', required: true },
+  { internalName: PLAN_PATCH_FIELDS.dueAt, type: 'Text', required: false },
+  { internalName: PLAN_PATCH_FIELDS.createdAt, type: 'Text', required: true },
+  { internalName: PLAN_PATCH_FIELDS.updatedAt, type: 'Text', required: true },
+] as const;
+
+export type SpPlanPatchRow = {
+  Id?: number;
+  Title?: string;
+  PatchId?: string;
+  PlanningSheetId?: string;
+  PatchTarget?: string;
+  BaseVersion?: string;
+  BeforeJson?: string;
+  AfterJson?: string;
+  PatchReason?: string;
+  EvidenceIdsJson?: string;
+  PatchStatus?: string;
+  PatchDueAt?: string;
+  PatchCreatedAt?: string;
+  PatchUpdatedAt?: string;
+} & Record<string, unknown>;


### PR DESCRIPTION
## 概要
個別支援計画の PDCA サイクルを自律化するための KPI 評価基盤、更新案（Plan Patch）管理、および PDCA 停滞検知機能を実装しました。

Closes #1451

## 変更内容
### 追加
- **Domain**: `ImprovementOutcome`, `PlanPatch`, `PdcaHealth`, `MetricDefinition` 等の PDCA 評価用ドメインモデル
- **Infrastructure**: SharePoint リスト項目定義（`PlanPatch`, `ImprovementOutcome`）および LocalStorage/SP 両対応のリポジトリ実装
- **UI Components**:
  - `PdcaStopRankingPanel`: 監査ダッシュボード用。PDCA が停滞している利用者を自動抽出
  - `PhaseNextStepBanner`: 計画シート等の構成ページで「次に何をすべきか」を動的に提示
- **Hooks**: `usePdcaStopRanking`, `useTodayPlanPatchActions` 等の業務ロジック hooks

### 変更
- **MonitoringMeetingForm**: モニタリング会議記録に「改善評価」の入力欄を追加。before/after の定量的評価が可能に
- **TodayOpsPage**: 実行支援画面で「計画の更新案」をアクションカードとして提示するよう統合
- **RegulatoryDashboardPage**: 分析ダッシュボードに PDCA 健全性モニタリングセクションを追加

## 変更ファイル一覧
| ファイル | 変更種別 | 変更内容 |
|---------|---------|---------| 
| `src/domain/isp/*` | 追加 | KPI/PDCA 評価のコアロジック |
| `src/infra/localStorage/*` | 追加 | リポジトリのモック/ローカル実装 |
| `src/features/monitoring/components/MonitoringMeetingForm.tsx` | 変更 | 改善評価入力の追加と型エラー修正 |
| `src/pages/RegulatoryDashboardPage.tsx` | 変更 | 停滞ランキングパネルの統合 |
| `src/app/config/navigationConfig.ts` | 変更 | 新規機能のメニュー追加 |

## テスト
- [x] 既存テスト通過
- [x] 型チェック通過
- [x] 新規ドメインロジックの単体テスト追加 (`improvementOutcome.spec.ts`, `pdcaHealth.spec.ts` 等)

## セルフレビュー
- [x] `console.log` 残していない
- [x] `any` 使っていない
- [x] 責務分離を守っている
- [x] 600行ルール違反なし (MonitoringMeetingForm は既存肥大化のため許容範囲内)

## 影響範囲
- モニタリング会議の入力フローに「改善評価」が加わりますが、任意入力のため既存業務を阻害しません。
- 監査ダッシュボードに新しい分析パネルが表示されるようになります。
