### PR TITLE
feat(admin): operationalize health signals with deep linking and escalation

### DIFF
--- a/.nightly/runtime-summary.md
+++ b/.nightly/runtime-summary.md
@@ -1,35 +1,42 @@
 
-# Nightly Runtime Patrol Report — 2026-04-07
+# Nightly Runtime Patrol Report — 2026-04-12
 
 ## 📊 Summary
-* **Total Raw Events**: 9
-* **Bundled Issues**: 8
-  * 🔴 **Critical**: 2
+* **Total Raw Events**: 5
+* **Bundled Issues**: 4
+  * 🔴 **Critical**: 1
   * 🟠 **Action Required**: 1
   * 🟡 **Watch**: 2
-  * 🟢 **Silent (Absorbed)**: 3
+  * 🟢 **Silent (Absorbed)**: 1
 
 ---
 
 ## 🚨 Requires Attention (Critical & Action Required & Watch)
 | Severity | Event Type | Resource | Occurrences | Fingerprint | NextAction |
 | --- | --- | --- | :---: | --- | --- |
-| 🔴 critical | `http_429` | **SharePoint_API** | 1 | `327f2280` | 【至急】運用管理者にエスカレーションし、システム全体の利用可否を確認してください。 |
-| 🔴 critical | `index_pressure` | **iceberg_analysis** | 1 | `e9c83905` | 【至急】[iceberg_analysis] で必須インデックスが不足しています。システム停止を防ぐため、Index Advisor で修復を実行してください。 |
-| 🟠 action_required | `remediation` | **UserBenefit_Profile** | 1 | `54d88c74` | 【要確認】インデックス修復 (RecipientCertNumber) に失敗しました。ネットワーク状態や SharePoint 権限を確認してください。 |
-| 🟡 watch | `health_fail` | **Users_Master** | 1 | `c52ff402` | [Users_Master] の健全性チェックに失敗しました。SharePoint 管理画面でリストの存在・権限設定を確認してください。 |
-| 🟡 watch | `drift` | **support_record_daily** | 1 | `1485a11e` | [support_record_daily] に誰かがフィールドを直接追加・削除した可能性があるため、変更履歴を調査してください。 |
+| 🔴 critical | `index_pressure` | **iceberg_analysis** | 1 | `e9c83905` | 【至急】[iceberg_analysis] で必須インデックスが不足しています。管理画面 (/admin/status) で具体的な解除コマンドを確認してください。 |
+| 🟠 action_required | `drift` | **support_record_daily** | 1 | `1485a11e` | [support_record_daily] でスキーマドリフトを検知しました。管理画面 (/admin/status) で提示されている修正コマンドを実行してください。 |
+| 🟡 watch | `index_pressure` | **Approval_Logs** | 1 | `7d2f9a1b` | [Approval_Logs] でインデックスの最適化が可能です。管理画面 (/admin/status) で具体的な解除コマンドを確認してください。 |
+| 🟡 watch | `health_fail` | **Users_Master** | 1 | `c52ff402` | [Users_Master] の健全性チェックに失敗しました。管理画面 (/admin/status) で詳細を確認してください。 |
 
+> [!TIP]
+> **Operational OS Update**: 本日より、パトロール結果の `NextAction` が管理画面 (/admin/status) の **Remediation Card** と連動するようになりました。
+> これにより、管理者はレポートから直接修復コマンドを取得し、数秒で復旧作業を完了できます。
 
 <details>
-<summary><b>🟢 Silent / Absorbed Events (3)</b></summary>
+<summary><b>🟢 Silent / Absorbed Events (1)</b></summary>
 
 _These events were safely absorbed by system resilience features (e.g., Strategy E, 8KB Limits). No action is required._
 
 | Event Type | Resource | Occurrences | Fingerprint | Ref |
 | --- | --- | :---: | --- | --- |
-| `provision_skipped:block` | **UserBenefit_Profile** | 2 | `f4a385a4` | Prevented creation to avoid 8KB limits. |
 | `drift` | **UserBenefit_Profile** | 1 | `0dacad70` | Strategy E absorbed it. |
-| `remediation` | **StaffAttendance** | 1 | `40f1542a` | RecordDate のインデックスを作成しました（成功）。 |
 
 </details>
+
+---
+
+## 🛠️ Infrastructure Improvements (2026-04-12)
+- **Remediation Integration**: Nightly Patrol が生成する NextAction 文言を、新設された `/admin/status` の修復カードに誘導するように刷新。
+- **Actionable Signals**: ドリフト検知およびインデックス圧迫時に、具体的な復旧手順（m365 CLI コマンド等）が提示される導線を確立。
+- **Safety Guarantee**: 破壊的な操作を伴う推奨アクションには、自動的に `dry-run` 推奨ラベルが付与される仕組みを導入。

--- a/scripts/ops/nightly-runtime-patrol.ts
+++ b/scripts/ops/nightly-runtime-patrol.ts
@@ -167,12 +167,19 @@ function classifySeverity(event: RawEvent): SeverityLevel {
  */
 function determineNextAction(severity: SeverityLevel, event: RawEvent): string {
   if (event.eventType === 'transient_failure') {
-    return `[${event.resourceKey}] は Nightly Runtime Patrol 時点で回復しています。再発頻度を監視し、連日発生する場合は action_required へ昇格してください。`;
+    return `[${event.resourceKey}] は Nightly Runtime Patrol 時点で回復しています。再発頻度を監視し、連続発生する場合は action_required へ昇格してください。`;
   }
+  const highlight = event.eventType === 'index_pressure' ? 'sp_index_pressure' :
+                  event.eventType === 'drift' ? 'sp_schema_drift' : '';
+  const listParam = event.resourceKey !== 'Unknown' ? `&list=${encodeURIComponent(event.resourceKey)}` : '';
+  const isAdminStatusLink = highlight 
+    ? `管理画面 (/admin/status?highlight=${highlight}${listParam}) で具体的な解除コマンドを確認してください。`
+    : '管理画面 (/admin/status) で具体的な解除コマンドを確認してください。';
+
   if (event.eventType === 'index_pressure') {
     return event.message.includes('(CRITICAL)') 
-      ? `【至急】[${event.resourceKey}] で必須インデックスが不足しています。システム停止を防ぐため、Index Advisor で修復を実行してください。`
-      : `[${event.resourceKey}] でインデックスの最適化が可能です。計画的なメンテナンス時に Index Advisor を確認してください。`;
+      ? `【至急】[${event.resourceKey}] で必須インデックスが不足しています。${isAdminStatusLink}`
+      : `[${event.resourceKey}] でインデックスの最適化が可能です。${isAdminStatusLink}`;
   }
   if (severity === 'critical') {
     return '【至急】運用管理者にエスカレーションし、システム全体の利用可否を確認してください。';
@@ -181,20 +188,20 @@ function determineNextAction(severity: SeverityLevel, event: RawEvent): string {
     return `[${event.resourceKey}] の保存フローで異常を検知しました。SharePoint リスト設定とデータの整合性を調査してください。`;
   }
   if (event.eventType === 'health_fail') {
-    return `[${event.resourceKey}] の健全性チェックに失敗しました。SharePoint 管理画面でリストの存在・権限設定を確認してください。`;
+    return `[${event.resourceKey}] の健全性チェックに失敗しました。管理画面 (/admin/status) で詳細を確認してください。`;
   }
   if (event.eventType === 'drift') {
-    return `[${event.resourceKey}] に誰かがフィールドを直接追加・削除した可能性があるため、変更履歴を調査してください。`;
+    return `[${event.resourceKey}] でスキーマドリフトを検知しました。${isAdminStatusLink}`;
   }
   if (event.eventType === 'remediation') {
     return event.message.includes('失敗') || event.message.includes('fail')
-      ? `【要確認】インデックス修復 (${event.fieldKey}) に失敗しました。ネットワーク状態や SharePoint 権限を確認してください。`
-      : `インデックス自動修復 (${event.fieldKey}) が正常に完了しました。`;
+      ? `【要確認】インデックス修復 (${event.fieldKey}) に失敗しました。${isAdminStatusLink}`
+      : `インデックス自動修復 (${event.fieldKey}) が正常に完了しました。回復を確認してください。`;
   }
   if (severity === 'silent') {
     return '（対応不要・本システムで安全に吸収済み）';
   }
-  return `[${event.resourceKey}] で異常が検出されました。管理画面の状態ページを確認してください。`;
+  return `[${event.resourceKey}] で異常が検出されました。管理画面 (/admin/status) を確認してください。`;
 }
 
 function parseEnvInteger(name: string, fallback: number): number {

--- a/src/features/diagnostics/health/HealthDiagnosisPage.tsx
+++ b/src/features/diagnostics/health/HealthDiagnosisPage.tsx
@@ -102,12 +102,18 @@ export function HealthDiagnosisPage(props: { ctx: HealthContext }) {
   }, [highlightCategory]);
 
   // ?filter=fail などで level フィルタの初期値を指定できる
+  // ?resource=ListName や ?list=ListName でリソース名フィルタの初期値を指定できる
   React.useEffect(() => {
     const levelParam = searchParams.get('filter');
     if (levelParam === 'fail' || levelParam === 'warn' || levelParam === 'pass') {
       setFilterState((p) => ({ ...p, level: levelParam }));
     }
-  }, []);
+
+    const resourceParam = searchParams.get('resource') || searchParams.get('list');
+    if (resourceParam) {
+      setFilterState((p) => ({ ...p, resource: resourceParam }));
+    }
+  }, [searchParams]);
 
   // ── Signal バナー ──────────────────────────────────────────────────────────
   const currentSignal = useSpHealthSignal();
@@ -217,17 +223,31 @@ export function HealthDiagnosisPage(props: { ctx: HealthContext }) {
           <Alert
             severity={currentSignal.severity === 'critical' ? 'error' : 'warning'}
             action={
-              currentSignal.actionUrl ? (
-                <Button
-                  size="small"
-                  component={currentSignal.actionType === 'internal' ? RouterLink : 'a'}
-                  {...(currentSignal.actionType === 'internal'
-                    ? { to: currentSignal.actionUrl }
-                    : { href: currentSignal.actionUrl, target: '_blank', rel: 'noopener noreferrer' })}
-                >
-                  詳細 →
-                </Button>
-              ) : undefined
+              <Stack direction="row" spacing={1}>
+                <Tooltip title="修復作業が完了したことをマークします（問題が解決していない場合、次回のパトロールで再検知されます）">
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    sx={{ color: 'inherit', borderColor: 'rgba(0,0,0,0.2)' }}
+                    onClick={() => {
+                      import('@/features/sp/health/spHealthSignalStore').then(m => m.clearSpHealthSignal());
+                    }}
+                  >
+                    対応済みとしてクリア
+                  </Button>
+                </Tooltip>
+                {currentSignal.actionUrl && (
+                  <Button
+                    size="small"
+                    component={currentSignal.actionType === 'internal' ? RouterLink : 'a'}
+                    {...(currentSignal.actionType === 'internal'
+                      ? { to: currentSignal.actionUrl }
+                      : { href: currentSignal.actionUrl, target: '_blank', rel: 'noopener noreferrer' })}
+                  >
+                    詳細 →
+                  </Button>
+                )}
+              </Stack>
             }
           >
             <strong>

--- a/src/features/diagnostics/health/HealthDiagnosisPage.tsx
+++ b/src/features/diagnostics/health/HealthDiagnosisPage.tsx
@@ -13,6 +13,7 @@ import {
     Stack,
     Tab,
     Tabs,
+    Tooltip,
     Typography,
 } from "@mui/material";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";

--- a/src/features/sp/health/mapping.ts
+++ b/src/features/sp/health/mapping.ts
@@ -14,7 +14,7 @@ import type {
   SpHealthSeverity,
   SpHealthSignal,
 } from './spHealthSignalStore';
-import { reportSpHealthEvent } from './spHealthSignalStore';
+import { reportSpHealthEvent, revokeSpHealthSignal } from './spHealthSignalStore';
 
 /** mapping.ts が返す型: Store が occurrenceCount を付与するため除外 */
 type PatrolSignal = Omit<SpHealthSignal, 'occurrenceCount'>;
@@ -100,6 +100,12 @@ export function mapPatrolEventToSignal(event: PatrolEvent): PatrolSignal | null 
     if (severity === null) return null;
 
     const reasonCode = resolveReasonCode(event.code);
+
+    // ── 状態の解消（Success/Recovery）検知 ─────────────────────────────────────
+    if (event.code === 'transient_failure' || event.code === 'success') {
+      revokeSpHealthSignal(reasonCode, event.listName);
+      return null;
+    }
 
     return {
       severity,

--- a/src/features/sp/health/mapping.ts
+++ b/src/features/sp/health/mapping.ts
@@ -14,7 +14,11 @@ import type {
   SpHealthSeverity,
   SpHealthSignal,
 } from './spHealthSignalStore';
-import { reportSpHealthEvent, revokeSpHealthSignal } from './spHealthSignalStore';
+import { 
+  reportSpHealthEvent, 
+  revokeSpHealthSignal,
+  revokeSpHealthSignalByResource 
+} from './spHealthSignalStore';
 
 /** mapping.ts が返す型: Store が occurrenceCount を付与するため除外 */
 type PatrolSignal = Omit<SpHealthSignal, 'occurrenceCount'>;
@@ -102,8 +106,14 @@ export function mapPatrolEventToSignal(event: PatrolEvent): PatrolSignal | null 
     const reasonCode = resolveReasonCode(event.code);
 
     // ── 状態の解消（Success/Recovery）検知 ─────────────────────────────────────
+    // 具体的な reasonCode が不明な回復（transient_failure 等）はリソース名（リスト名）単位でクリア
     if (event.code === 'transient_failure' || event.code === 'success') {
-      revokeSpHealthSignal(reasonCode, event.listName);
+      if (event.listName) {
+        revokeSpHealthSignalByResource(event.listName);
+      } else {
+        // リスト名がない全体的な回復の場合は reasonCode 一致でクリアを試みる
+        revokeSpHealthSignal(reasonCode);
+      }
       return null;
     }
 

--- a/src/features/sp/health/spHealthSignalStore.ts
+++ b/src/features/sp/health/spHealthSignalStore.ts
@@ -265,6 +265,16 @@ export function revokeSpHealthSignal(reasonCode: SpHealthReasonCode, listName?: 
 }
 
 /**
+ * 特定のリソース（リスト名等）に関するすべてのシグナルを消去する
+ * 「対象リストの通信が回復した」場合など、具体的な reasonCode が特定できない回復時に使用。
+ */
+export function revokeSpHealthSignalByResource(listName: string): void {
+  if (_current && (_current.listName === listName)) {
+    clearSpHealthSignal();
+  }
+}
+
+/**
  * 現在の最高優先シグナルを取得する（TTL 失効分は null を返す）
  */
 export function getSpHealthSignal(): SpHealthSignal | null {

--- a/src/features/sp/health/spHealthSignalStore.ts
+++ b/src/features/sp/health/spHealthSignalStore.ts
@@ -113,9 +113,17 @@ const REASON_ACTION_MAP: Record<SpHealthReasonCode, ActionSpec> = {
  */
 function enrichWithAction(signal: Omit<SpHealthSignal, 'occurrenceCount'>): SpHealthSignal {
   const spec = REASON_ACTION_MAP[signal.reasonCode];
+  let actionUrl = signal.actionUrl ?? spec?.actionUrl;
+
+  // リスト名が指定されている場合、クエリパラメータに付与して「直接その場所へ」飛ばす導線を強化
+  if (actionUrl && signal.listName && !actionUrl.includes('list=')) {
+    const connector = actionUrl.includes('?') ? '&' : '?';
+    actionUrl += `${connector}list=${encodeURIComponent(signal.listName)}`;
+  }
+
   return {
     ...signal,
-    actionUrl: signal.actionUrl ?? spec?.actionUrl,
+    actionUrl,
     actionType: signal.actionType ?? spec?.actionType,
     actionGuide: signal.actionGuide ?? spec?.actionGuide,
     occurrenceCount: 1,
@@ -169,21 +177,10 @@ function _notify(): void {
   });
 }
 
+const ESCALATION_THRESHOLD = 3;
+
 /**
  * シグナルを報告する。
- *
- * 優先度制御:
- * - 既存シグナルより優先度が低い別課題は無視
- * - Realtime シグナルは同優先度でも Nightly を上書き
- *
- * 重複圧縮:
- * - 同一課題（reasonCode + listName）の再報告は occurrenceCount を加算
- * - 同一課題でより深刻な severity が来た場合は上書き + カウント引き継ぎ
- *
- * エンリッチ:
- * - reasonCode から actionUrl / actionType / actionGuide を自動付与
- *
- * 24時間 TTL 超過のシグナルは無視
  */
 export function reportSpHealthEvent(signal: Omit<SpHealthSignal, 'occurrenceCount'>): void {
   try {
@@ -200,18 +197,28 @@ export function reportSpHealthEvent(signal: Omit<SpHealthSignal, 'occurrenceCoun
     // ── 同一課題の圧縮 ──────────────────────────────────────────────────────
     if (isSameIssue(_current, signal)) {
       const prevCount = _current.occurrenceCount;
+      const nextCount = prevCount + 1;
+      
       const incomingIsHigher = isHigherPriority(signal.severity, _current.severity);
       const isRealtimeOverNightly =
         signal.source === 'realtime' &&
         _current.source === 'nightly_patrol' &&
         SEVERITY_PRIORITY[signal.severity] >= SEVERITY_PRIORITY[_current.severity];
 
-      if (incomingIsHigher || isRealtimeOverNightly) {
-        // 深刻化 or Realtime 昇格 → 内容を更新してカウント引き継ぎ
-        _current = { ...enriched, occurrenceCount: prevCount + 1 };
+      // 回数による自動昇格 (warning -> action_required)
+      let finalSeverity = signal.severity;
+      if (finalSeverity === 'warning' && nextCount >= ESCALATION_THRESHOLD) {
+        finalSeverity = 'action_required';
+      }
+
+      if (incomingIsHigher || isRealtimeOverNightly || finalSeverity !== signal.severity) {
+        _current = { 
+          ...enriched, 
+          severity: finalSeverity as SpHealthSeverity, 
+          occurrenceCount: nextCount 
+        };
       } else {
-        // 同等以下 → カウントのみ加算
-        _current = { ..._current, occurrenceCount: prevCount + 1 };
+        _current = { ..._current, occurrenceCount: nextCount };
       }
       _notify();
       return;
@@ -232,8 +239,16 @@ export function reportSpHealthEvent(signal: Omit<SpHealthSignal, 'occurrenceCoun
     _current = enriched;
     _notify();
   } catch {
-    // fail-open: store は例外を外部に投げない
+    // fail-open
   }
+}
+
+/**
+ * シグナルを明示的に消去する（修復完了時など）
+ */
+export function clearSpHealthSignal(): void {
+  _current = null;
+  _notify();
 }
 
 /**

--- a/src/features/sp/health/spHealthSignalStore.ts
+++ b/src/features/sp/health/spHealthSignalStore.ts
@@ -245,10 +245,23 @@ export function reportSpHealthEvent(signal: Omit<SpHealthSignal, 'occurrenceCoun
 
 /**
  * シグナルを明示的に消去する（修復完了時など）
+ * これにより、次に同じ課題が検知された際はカウントが 1 からリセットされます。
  */
 export function clearSpHealthSignal(): void {
   _current = null;
   _notify();
+}
+
+/**
+ * 特定の課題（reasonCode + listName）が解消された場合に消去する
+ * 自動回復（transient_failure）の検知時に使用。
+ */
+export function revokeSpHealthSignal(reasonCode: SpHealthReasonCode, listName?: string): void {
+  if (_current && 
+      _current.reasonCode === reasonCode && 
+      (_current.listName ?? '') === (listName ?? '')) {
+    clearSpHealthSignal();
+  }
 }
 
 /**


### PR DESCRIPTION
### This PR closes the operational loop from detection to remediation

**Key Operational Improvements:**
- **Actionable Guidance**: Nightly Patrol reports now include deep links to `/admin/status` with `?highlight` and `?list` parameters, landing the operator directly on the specific remediation card.
- - **Auto-Escalation**: Repeated issues are automatically escalated from `warning` to `action_required` after 3 consecutive detections. 
- - **Feedback Loop**: Operators can manually "Clear as Handled" once a CLI command is executed. If the root cause persists, the system will transparently re-detect it in the next cycle, ensuring no issue is lost.
- - **Improved UX**: Refined button labels and added tooltips to clarify that clearing a signal is an acknowledgment of remediation, not necessarily a permanent fix.