### PR TITLE
feat(daily): formalize planning-sheet bridge provenance for /daily/support

### DIFF
--- a/pr_body.md
+++ b/pr_body.md
@@ -1,0 +1,72 @@
+## Summary
+
+* add per-run ingest reports in JSON and Markdown under `knowledge/ingested/_reports/`
+* expand Markdown frontmatter with source traceability and review metadata
+* add incremental processing with mtime-based skip and `--force` override
+* tighten source file filtering and remove unused ingest dependency
+
+## What changed
+
+### Ingest reporting
+
+* generate a unique `run_id` for each execution
+* write machine-readable `report.json`
+* write human-readable `report.md`
+* include totals for processed / skipped / succeeded / failed and success rate
+* record per-file status, duration, error, and skipped reason
+
+### Frontmatter expansion
+
+Added metadata fields to generated Markdown:
+
+* `source_path`
+* `source_modified_at`
+* `run_id`
+* `ingest_version`
+* `review_status`
+* `tags`
+
+Existing fields such as `source_file`, `converted_at`, `converter`, `document_type`, `domain`, and `status` are preserved.
+
+### Incremental batch behavior
+
+* skip reconversion when target exists and source mtime is not newer
+* allow forced reconversion via `--force`
+* keep fail-soft behavior so one file failure does not stop the whole run
+
+### Filtering and dependency cleanup
+
+* explicitly support `.xlsx`, `.docx`, `.pptx`, `.pdf`, `.jpg`, `.jpeg`, `.png`
+* exclude temporary and system files such as `~$*`, hidden files, `.DS_Store`, and `Thumbs.db`
+* remove unused `python-dotenv` from `requirements.txt`
+
+## Validation
+
+Validated locally with real execution, not only dry-run.
+
+### Import / runtime contract
+
+* install: `pip install markitdown`
+* import: `from markitdown import MarkItDown`
+* runtime requirement: Python 3.10+
+
+### Execution checks
+
+* single-file conversion generated Markdown successfully
+* frontmatter output contains the new traceability fields
+* `_reports/<run_id>.json` and `.md` were generated successfully
+* second run skipped unchanged file as expected
+* `--force` triggered reconversion as expected
+
+## Notes
+
+* this remains a local/CLI-based Phase 2 ingest improvement
+* SharePoint-triggered automation, Power Automate integration, and ingest UI are still out of scope
+* original documents remain the source of truth
+* converted Markdown remains an AI-readable secondary asset and may still require light post-editing for complex layout files
+
+## Follow-ups
+
+* add source hash tracking for stricter change detection
+* add conversion quality scoring / review priority hints
+* evaluate SharePoint-connected ingestion in a later phase

--- a/src/domain/isp/bridge/__tests__/toDailyProcedureSteps.spec.ts
+++ b/src/domain/isp/bridge/__tests__/toDailyProcedureSteps.spec.ts
@@ -153,7 +153,7 @@ describe('toDailyProcedureSteps', () => {
 
     expect(result).toHaveLength(1);
     const step = result[0];
-    expect(step.id).toBe('ps-ps-001-1');
+    expect(step.id).toBe('ps-ps-001-1-0');
     expect(step.time).toBe('09:00');
     expect(step.activity).toBe('視線を合わせて挨拶');
     expect(step.instruction).toBe('視線を合わせて挨拶。体調チェック。');
@@ -290,5 +290,33 @@ describe('toDailyProcedureSteps', () => {
       expect(step.sourceStepOrder).toBe(i + 1);
       expect(step.source).toBe('planning_sheet');
     });
+  });
+
+  it('handles mixed valid and invalid timings gracefully', () => {
+    const design = makeDesign([
+      { order: 1, instruction: '手順A。', timing: '09:00' },
+      { order: 2, instruction: '手順B。', timing: 'invalid' },
+      { order: 3, instruction: '手順C。', timing: '10:00' },
+    ]);
+    const result = toDailyProcedureSteps(design, 'ps-009');
+
+    expect(result[0].time).toBe('09:00');
+    expect(result[1].time).toBe('09:30'); // default for order 2
+    expect(result[2].time).toBe('10:00');
+  });
+
+  it('handles duplicate orders by keeping original order but updating sourceStepOrder', () => {
+    // Note: In a real system, schema validation might prevent duplicate orders,
+    // but the bridge should handle it just in case.
+    const design = makeDesign([
+      { order: 1, instruction: '手順A。' },
+      { order: 1, instruction: '手順B。' },
+    ]);
+    const result = toDailyProcedureSteps(design, 'ps-010');
+
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe('ps-ps-010-1-0');
+    expect(result[1].id).toBe('ps-ps-010-1-1');
+    expect(result[0].id).not.toBe(result[1].id);
   });
 });

--- a/src/domain/isp/bridge/toDailyProcedureSteps.ts
+++ b/src/domain/isp/bridge/toDailyProcedureSteps.ts
@@ -88,7 +88,7 @@ export function toDailyProcedureSteps(
     const activityLabel = options?.activityLabels?.[ispStep.order];
 
     return {
-      id: `ps-${planningSheetId}-${ispStep.order}`,
+      id: `ps-${planningSheetId}-${ispStep.order}-${index}`,
       time,
       activity: extractActivityLabel(ispStep.instruction, activityLabel),
       instruction: ispStep.instruction,

--- a/src/domain/metrics/adapters/pdcaCycleBuilder.ts
+++ b/src/domain/metrics/adapters/pdcaCycleBuilder.ts
@@ -43,13 +43,17 @@ export interface CycleBuilderInput {
 
 function addDaysToDate(isoDate: string, days: number): string {
   const d = new Date(isoDate);
+  if (isNaN(d.getTime())) return isoDate;
   d.setDate(d.getDate() + days);
-  return d.toISOString();
+  return isNaN(d.getTime()) ? isoDate : d.toISOString();
 }
 
 function isWithinRange(isoDate: string, rangeStart: string, rangeEnd: string): boolean {
   const t = new Date(isoDate).getTime();
-  return t >= new Date(rangeStart).getTime() && t < new Date(rangeEnd).getTime();
+  const s = new Date(rangeStart).getTime();
+  const e = new Date(rangeEnd).getTime();
+  if (isNaN(t) || isNaN(s) || isNaN(e)) return false;
+  return t >= s && t < e;
 }
 
 // ─── メイン構築関数 ──────────────────────────────────────
@@ -73,17 +77,26 @@ export function buildPdcaCycleRecords(input: CycleBuilderInput): PdcaCycleRecord
     today = new Date().toISOString(),
   } = input;
 
+  const startDate = new Date(supportStartDate);
+  const todayDate = new Date(today);
+
+  if (isNaN(startDate.getTime()) || isNaN(todayDate.getTime())) {
+    return [];
+  }
+
   // 最大ラウンド数を算出
   const elapsedDays = Math.max(0,
-    (new Date(today).getTime() - new Date(supportStartDate).getTime()) / (1000 * 60 * 60 * 24),
+    (todayDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24),
   );
-  const maxRounds = input.maxRounds ?? Math.max(1, Math.ceil(elapsedDays / cycleDays));
+  
+  const safeCycleDays = cycleDays || DEFAULT_CYCLE_DAYS;
+  const maxRounds = input.maxRounds ?? Math.max(1, Math.ceil(elapsedDays / safeCycleDays));
 
   const records: PdcaCycleRecord[] = [];
 
   for (let round = 1; round <= maxRounds; round++) {
-    const startedAt = addDaysToDate(supportStartDate, (round - 1) * cycleDays);
-    const dueAt = addDaysToDate(supportStartDate, round * cycleDays);
+    const startedAt = addDaysToDate(supportStartDate, (round - 1) * safeCycleDays);
+    const dueAt = addDaysToDate(supportStartDate, round * safeCycleDays);
 
     // proposalAcceptedAt: サイクル期間内の最初の accept
     const proposalAcceptedAt = findFirstAcceptInRange(

--- a/src/features/planning-sheet/__tests__/monitoringSchedule.spec.ts
+++ b/src/features/planning-sheet/__tests__/monitoringSchedule.spec.ts
@@ -13,35 +13,35 @@ describe('calculateMonitoringSchedule', () => {
 
   it('支援初日は第1期・残り90日', () => {
     const info = calculateMonitoringSchedule('2026-01-01', 90, '2026-01-01');
-    expect(info.currentCycleNumber).toBe(1);
-    expect(info.elapsedDays).toBe(0);
-    expect(info.nextMonitoringDate).toBe('2026-04-01');
-    expect(info.remainingDays).toBe(90);
-    expect(info.isOverdue).toBe(false);
-    expect(info.overdueDays).toBe(0);
-    expect(info.progressPercent).toBe(0);
+    expect(info?.currentCycleNumber).toBe(1);
+    expect(info?.elapsedDays).toBe(0);
+    expect(info?.nextMonitoringDate).toBe('2026-04-01');
+    expect(info?.remainingDays).toBe(90);
+    expect(info?.isOverdue).toBe(false);
+    expect(info?.overdueDays).toBe(0);
+    expect(info?.progressPercent).toBe(0);
   });
 
   it('45日経過で残り45日・進捗50%', () => {
     const info = calculateMonitoringSchedule('2026-01-01', 90, '2026-02-15');
-    expect(info.elapsedDays).toBe(45);
-    expect(info.remainingDays).toBe(45);
-    expect(info.isOverdue).toBe(false);
-    expect(info.progressPercent).toBe(50);
+    expect(info?.elapsedDays).toBe(45);
+    expect(info?.remainingDays).toBe(45);
+    expect(info?.isOverdue).toBe(false);
+    expect(info?.progressPercent).toBe(50);
   });
 
   it('89日経過で残り1日・進捗99%', () => {
     const info = calculateMonitoringSchedule('2026-01-01', 90, '2026-03-31');
-    expect(info.elapsedDays).toBe(89);
-    expect(info.remainingDays).toBe(1);
-    expect(info.progressPercent).toBe(99);
+    expect(info?.elapsedDays).toBe(89);
+    expect(info?.remainingDays).toBe(1);
+    expect(info?.progressPercent).toBe(99);
   });
 
   it('ちょうど 90日で第2期に入る', () => {
     const info = calculateMonitoringSchedule('2026-01-01', 90, '2026-04-01');
-    expect(info.currentCycleNumber).toBe(2);
-    expect(info.nextMonitoringDate).toBe('2026-06-30'); // 1/1 + 180日
-    expect(info.remainingDays).toBe(90); // 4/1 → 6/30
+    expect(info?.currentCycleNumber).toBe(2);
+    expect(info?.nextMonitoringDate).toBe('2026-06-30'); // 1/1 + 180日
+    expect(info?.remainingDays).toBe(90); // 4/1 → 6/30
   });
 
   // ── 期限超過 ──
@@ -49,24 +49,24 @@ describe('calculateMonitoringSchedule', () => {
   it('期限超過時は isOverdue=true, overdueDays が正', () => {
     // 第1期の期限(4/1)を10日超過
     const info = calculateMonitoringSchedule('2026-01-01', 90, '2026-04-11');
-    expect(info.currentCycleNumber).toBe(2);
-    expect(info.isOverdue).toBe(false); // 第2期に入っているので第2期の期限まで猶予あり
+    expect(info?.currentCycleNumber).toBe(2);
+    expect(info?.isOverdue).toBe(false); // 第2期に入っているので第2期の期限まで猶予あり
   });
 
   // ── カスタム周期 ──
 
   it('30日周期で計算できる', () => {
     const info = calculateMonitoringSchedule('2026-01-01', 30, '2026-01-16');
-    expect(info.currentCycleNumber).toBe(1);
-    expect(info.remainingDays).toBe(15);
-    expect(info.progressPercent).toBe(50);
+    expect(info?.currentCycleNumber).toBe(1);
+    expect(info?.remainingDays).toBe(15);
+    expect(info?.progressPercent).toBe(50);
   });
 
   it('180日周期（6ヶ月）で計算できる', () => {
     const info = calculateMonitoringSchedule('2026-01-01', 180, '2026-04-01');
-    expect(info.currentCycleNumber).toBe(1);
-    expect(info.elapsedDays).toBe(90);
-    expect(info.progressPercent).toBe(50);
+    expect(info?.currentCycleNumber).toBe(1);
+    expect(info?.elapsedDays).toBe(90);
+    expect(info?.progressPercent).toBe(50);
   });
 
   // ── デフォルト ──
@@ -80,9 +80,29 @@ describe('calculateMonitoringSchedule', () => {
   it('第3期（180日〜270日）に正しく入る', () => {
     const info = calculateMonitoringSchedule('2026-01-01', 90, '2026-07-15');
     // 1/1 + 195日 = 7/15
-    expect(info.elapsedDays).toBe(195);
-    expect(info.currentCycleNumber).toBe(3);
-    expect(info.nextMonitoringDate).toBe('2026-09-28'); // 1/1 + 270日
+    expect(info?.elapsedDays).toBe(195);
+    expect(info?.currentCycleNumber).toBe(3);
+    expect(info?.nextMonitoringDate).toBe('2026-09-28'); // 1/1 + 270日
+  });
+
+  // ── 異常系 ──
+
+  it('スラッシュ区切りの日付も処理できる', () => {
+    const info = calculateMonitoringSchedule('2026/01/01', 90, '2026/02/15');
+    expect(info?.elapsedDays).toBe(45);
+    expect(info?.remainingDays).toBe(45);
+    expect(info?.nextMonitoringDate).toBe('2026-04-01');
+  });
+
+  it('不正な日付文字列の場合は null を返す', () => {
+    expect(calculateMonitoringSchedule('invalid', 90)).toBeNull();
+    expect(calculateMonitoringSchedule('', 90)).toBeNull();
+  });
+
+  it('周期が 0 や負数の場合にクラッシュしない', () => {
+    const info = calculateMonitoringSchedule('2026-01-01', 0);
+    expect(info).not.toBeNull();
+    expect(info?.cycleDays).toBe(0);
   });
 });
 

--- a/src/features/planning-sheet/__tests__/planningToDailyBridge.spec.ts
+++ b/src/features/planning-sheet/__tests__/planningToDailyBridge.spec.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+import type { SupportPlanningSheet } from '@/domain/isp/schema';
+import { bridgePlanningSheetToDailyProcedures, type BridgeSource } from '../planningToRecordBridge';
+
+// ─── Mock Data Helpers ───
+
+function makeSheet(overrides: Partial<SupportPlanningSheet> = {}): SupportPlanningSheet {
+  return {
+    id: 'sheet-001',
+    userId: 'user-001',
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    status: 'active',
+    version: 1,
+    isCurrent: true,
+    title: 'テスト計画書',
+    supportPolicy: '',
+    concreteApproaches: '',
+    environmentalAdjustments: '',
+    intake: {
+      userId: 'user-001',
+      medicalFlags: [],
+      sensoryTriggers: [],
+      riskBehaviors: [],
+      strengths: '',
+      weaknesses: '',
+      history: '',
+      remarks: '',
+    },
+    assessment: {
+      behaviorSummary: '',
+      environmentalFactors: '',
+      hypothesis: '',
+    },
+    planning: {
+      supportPriorities: [],
+      antecedentStrategies: [],
+      teachingStrategies: [],
+      consequenceStrategies: [],
+      procedureSteps: [],
+      crisisThresholds: null,
+      restraintPolicy: 'prohibited_except_emergency',
+      reviewCycleDays: 180,
+    },
+    ...overrides,
+  };
+}
+
+// ─── Tests ───
+
+describe('bridgePlanningSheetToDailyProcedures', () => {
+  it('prioritizes structured procedureSteps when available', () => {
+    const sheet = makeSheet({
+      supportPolicy: 'テキストの方針',
+      planning: {
+        procedureSteps: [
+          { order: 1, instruction: '構造化手順1', timing: '09:00', staff: '' },
+          { order: 2, instruction: '構造化手順2', timing: '10:00', staff: '' },
+        ],
+      } as any,
+    });
+
+    const { steps, source } = bridgePlanningSheetToDailyProcedures(sheet);
+
+    expect(source).toBe('sheet_structured' as BridgeSource);
+    expect(steps).toHaveLength(2);
+    expect(steps[0].activity).toBe('構造化手順1');
+    expect(steps[0].time).toBe('09:00');
+    expect(steps[0].instruction).toBe('構造化手順1');
+    expect(steps[1].activity).toBe('構造化手順2');
+  });
+
+  it('falls back to supportPolicy and concreteApproaches when procedureSteps is empty', () => {
+    const sheet = makeSheet({
+      supportPolicy: '朝の挨拶をする\n持ち物を整理する',
+      concreteApproaches: '笑顔で接する',
+      planning: {
+        procedureSteps: [],
+      } as any,
+    });
+
+    const { steps, source } = bridgePlanningSheetToDailyProcedures(sheet);
+
+    expect(source).toBe('sheet_fallback_text' as BridgeSource);
+    // policyItems (2) + approachItems (1) = 3 steps
+    expect(steps).toHaveLength(3);
+    expect(steps[0].activity).toBe('支援方針');
+    expect(steps[0].instruction).toBe('朝の挨拶をする');
+    expect(steps[1].instruction).toBe('持ち物を整理する');
+    expect(steps[2].activity).toBe('具体的対応');
+    expect(steps[2].instruction).toBe('笑顔で接する');
+  });
+
+  it('sets source as empty if both structured and text data are missing', () => {
+    const sheet = makeSheet({
+      supportPolicy: '',
+      concreteApproaches: '',
+      planning: {
+        procedureSteps: [],
+      } as any,
+    });
+
+    const { steps, source } = bridgePlanningSheetToDailyProcedures(sheet);
+    expect(source).toBe('empty');
+    expect(steps).toEqual([]);
+  });
+
+  it('handles environmentalAdjustments in fallback mode', () => {
+    const sheet = makeSheet({
+      supportPolicy: '方針のみ',
+      environmentalAdjustments: '静かな環境を整える',
+      planning: {
+        procedureSteps: [],
+      } as any,
+    });
+
+    const { steps, source } = bridgePlanningSheetToDailyProcedures(sheet);
+
+    expect(source).toBe('sheet_fallback_text');
+    expect(steps).toHaveLength(2);
+    expect(steps[1].activity).toBe('環境調整（留意点）');
+    expect(steps[1].instruction).toContain('静かな環境を整える');
+  });
+
+  it('assigns planningSheetId correctly in both modes', () => {
+    // Mode 1: Structured
+    const structuredSheet = makeSheet({
+      id: 'structured-id',
+      planning: {
+        procedureSteps: [{ order: 1, instruction: 'A', timing: '', staff: '' }],
+      } as any,
+    });
+    const result1 = bridgePlanningSheetToDailyProcedures(structuredSheet);
+    expect(result1.steps[0].planningSheetId).toBe('structured-id');
+    expect(result1.source).toBe('sheet_structured');
+
+    // Mode 2: Fallback
+    const fallbackSheet = makeSheet({
+      id: 'fallback-id',
+      supportPolicy: 'B',
+      planning: { procedureSteps: [] } as any,
+    });
+    const result2 = bridgePlanningSheetToDailyProcedures(fallbackSheet);
+    expect(result2.steps[0].planningSheetId).toBe('fallback-id');
+    expect(result2.source).toBe('sheet_fallback_text');
+  });
+});

--- a/src/features/planning-sheet/hooks/usePlanningSheetData.ts
+++ b/src/features/planning-sheet/hooks/usePlanningSheetData.ts
@@ -55,6 +55,8 @@ export function usePlanningSheetData(
     }
 
     let cancelled = false;
+    // 新しい ID の取得を開始する前に、以前のデータをクリアして stale 表示を防ぐ
+    setData(null);
     setIsLoading(true);
     setError(null);
 

--- a/src/features/planning-sheet/hooks/usePlanningSheetToProcedureBridge.ts
+++ b/src/features/planning-sheet/hooks/usePlanningSheetToProcedureBridge.ts
@@ -1,0 +1,41 @@
+import { useMemo } from 'react';
+import { usePlanningSheetRepositories } from './usePlanningSheetRepositories';
+import { usePlanningSheetData } from './usePlanningSheetData';
+import { bridgePlanningSheetToDailyProcedures, type BridgeSource } from '../planningToRecordBridge';
+import type { ScheduleItem } from '@/features/daily/components/split-stream/ProcedurePanel';
+
+/**
+ * 支援計画シートを取得し、Daily サポート用の手順リスト（ScheduleItem[]）に変換する hook。
+ * 
+ * 戦略:
+ * 1. URL 等から渡された planningSheetId がある場合、その実体を取得。
+ * 2. 取得中 (isLoading) またはエラー (error) の状態を管理。
+ * 3. 取得成功時、計画書の内容を実施手順へ変換して返す。
+ * 4. ID 切替時は直ちにデータをクリアし、stale な手順が表示されないことを保証する。
+ * 
+ * @param planningSheetId 取得対象の支援計画シートID
+ * @returns { schedule, isLoading, error, bridgeSource } 変換後の手順と状態
+ */
+export function usePlanningSheetToProcedureBridge(planningSheetId?: string) {
+  const planningRepo = usePlanningSheetRepositories();
+  const { data: sheetData, isLoading, error } = usePlanningSheetData(planningSheetId, planningRepo);
+
+  const bridgeResult = useMemo(() => {
+    if (!sheetData || !planningSheetId) {
+      return { schedule: undefined, source: 'repository_default' as BridgeSource };
+    }
+    
+    const result = bridgePlanningSheetToDailyProcedures(sheetData);
+    return {
+      schedule: result.steps as ScheduleItem[],
+      source: result.source,
+    };
+  }, [sheetData, planningSheetId]);
+
+  return {
+    schedule: bridgeResult.schedule,
+    bridgeSource: bridgeResult.source,
+    isLoading,
+    error,
+  };
+}

--- a/src/features/planning-sheet/monitoringSchedule.ts
+++ b/src/features/planning-sheet/monitoringSchedule.ts
@@ -50,14 +50,19 @@ export interface MonitoringScheduleInfo {
  * 日付文字列を UTC 0:00 の Date に変換する（ローカル TZ ずれ防止）
  */
 function parseDate(isoDate: string): Date {
-  const [y, m, d] = isoDate.split('-').map(Number);
-  return new Date(Date.UTC(y, m - 1, d));
+  if (!isoDate) return new Date(NaN);
+  // '-' または '/' を区切り文字としてサポート
+  const parts = isoDate.includes('-') ? isoDate.split('-') : isoDate.split('/');
+  const [y, m, d] = parts.map(Number);
+  const date = new Date(Date.UTC(y, m - 1, d));
+  return date;
 }
 
 /**
  * 2つの日付の差を日数で返す
  */
 function diffDays(from: Date, to: Date): number {
+  if (isNaN(from.getTime()) || isNaN(to.getTime())) return 0;
   const ms = to.getTime() - from.getTime();
   return Math.floor(ms / (24 * 60 * 60 * 1000));
 }
@@ -66,7 +71,9 @@ function diffDays(from: Date, to: Date): number {
  * Date に日数を加算して ISO date 文字列を返す
  */
 function addDays(date: Date, days: number): string {
+  if (isNaN(date.getTime())) return 'Invalid Date';
   const result = new Date(date.getTime() + days * 24 * 60 * 60 * 1000);
+  if (isNaN(result.getTime())) return 'Invalid Date';
   return result.toISOString().slice(0, 10);
 }
 
@@ -76,45 +83,56 @@ function addDays(date: Date, days: number): string {
  * @param supportStartDate - 支援開始日 (ISO 8601 date, e.g. '2026-01-15')
  * @param cycleDays - モニタリング周期（日数、デフォルト 90）
  * @param today - 基準日（テスト用にオーバーライド可能）
- * @returns モニタリングスケジュール情報
+ * @returns モニタリングスケジュール情報。日付が不正な場合は null。
  */
 export function calculateMonitoringSchedule(
   supportStartDate: string,
   cycleDays: number = DEFAULT_MONITORING_CYCLE_DAYS,
   today: string = new Date().toISOString().slice(0, 10),
-): MonitoringScheduleInfo {
-  const start = parseDate(supportStartDate);
-  const now = parseDate(today);
+): MonitoringScheduleInfo | null {
+  try {
+    const start = parseDate(supportStartDate);
+    const now = parseDate(today);
 
-  const elapsedDays = diffDays(start, now);
+    if (isNaN(start.getTime()) || isNaN(now.getTime())) {
+      return null;
+    }
 
-  // 現在の周期番号: 開始日〜cycleDays は第1期、cycleDays+1〜2*cycleDays は第2期...
-  const currentCycleNumber = Math.max(1, Math.ceil((elapsedDays + 1) / cycleDays));
+    const elapsedDays = diffDays(start, now);
 
-  // 次回モニタリング予定日（現在の周期の終了日）
-  const nextMonitoringDate = addDays(start, currentCycleNumber * cycleDays);
+    // 現在の周期番号: 開始日〜cycleDays は第1期、cycleDays+1〜2*cycleDays は第2期...
+    const currentCycleNumber = Math.max(1, Math.ceil((elapsedDays + 1) / (cycleDays || DEFAULT_MONITORING_CYCLE_DAYS)));
 
-  const nextDate = parseDate(nextMonitoringDate);
-  const remainingDays = diffDays(now, nextDate);
-  const isOverdue = remainingDays < 0;
-  const overdueDays = isOverdue ? Math.abs(remainingDays) : 0;
+    // 次回モニタリング予定日（現在の周期の終了日）
+    const nextMonitoringDate = addDays(start, currentCycleNumber * cycleDays);
 
-  // 進捗率: 現在の周期内での経過割合
-  const cycleStartDay = (currentCycleNumber - 1) * cycleDays;
-  const daysIntoCycle = elapsedDays - cycleStartDay;
-  const progressPercent = Math.round((daysIntoCycle / cycleDays) * 100);
+    if (nextMonitoringDate === 'Invalid Date') return null;
 
-  return {
-    supportStartDate,
-    cycleDays,
-    nextMonitoringDate,
-    elapsedDays,
-    currentCycleNumber,
-    isOverdue,
-    overdueDays,
-    remainingDays,
-    progressPercent,
-  };
+    const nextDate = parseDate(nextMonitoringDate);
+    const remainingDays = diffDays(now, nextDate);
+    const isOverdue = remainingDays < 0;
+    const overdueDays = isOverdue ? Math.abs(remainingDays) : 0;
+
+    // 進捗率: 現在の周期内での経過割合
+    const cycleStartDay = (currentCycleNumber - 1) * cycleDays;
+    const daysIntoCycle = elapsedDays - cycleStartDay;
+    const progressPercent = cycleDays > 0 ? Math.round((daysIntoCycle / cycleDays) * 100) : 0;
+
+    return {
+      supportStartDate,
+      cycleDays,
+      nextMonitoringDate,
+      elapsedDays,
+      currentCycleNumber,
+      isOverdue,
+      overdueDays,
+      remainingDays,
+      progressPercent,
+    };
+  } catch (e) {
+    console.error('calculateMonitoringSchedule failed:', e);
+    return null;
+  }
 }
 
 /**

--- a/src/features/planning-sheet/planningToRecordBridge.ts
+++ b/src/features/planning-sheet/planningToRecordBridge.ts
@@ -19,6 +19,7 @@
  * @see assessmentBridge.ts — 同一パターンの先行実装
  */
 import type { PlanningIntake, PlanningSheetFormValues, SupportPlanningSheet } from '@/domain/isp/schema';
+import { toDailyProcedureSteps } from '@/domain/isp/bridge/toDailyProcedureSteps';
 import type { ProcedureStep } from '@/features/daily/domain/legacy/ProcedureRepository';
 import type { ProvenanceEntry } from '@/features/planning-sheet/assessmentBridge';
 
@@ -249,4 +250,48 @@ export function bridgeSheetToRecord(
     existingSteps,
     sheet.id,
   );
+}
+
+export type BridgeSource = 'sheet_structured' | 'sheet_fallback_text' | 'empty' | 'repository_default';
+
+export interface BridgeProceduresResult {
+  steps: ProcedureStep[];
+  source: BridgeSource;
+}
+
+/**
+ * 支援計画シートを手順記録（Daily スケジュール）へ変換する。
+ *
+ * 戦略:
+ * 1. 構造化された手順リスト (L2 Planning) があればそれを優先する。
+ * 2. 構造化データがない場合は、テキスト項目（対応方針・具体策）から抽出生成する。
+ *
+ * @param sheet 支援計画シート
+ * @returns 変換後の手順ステップ配列とソース情報
+ */
+export function bridgePlanningSheetToDailyProcedures(
+  sheet: SupportPlanningSheet,
+): BridgeProceduresResult {
+  // 1. 構造化手順リストの変換を試行
+  const structuredSteps = toDailyProcedureSteps(sheet.planning, sheet.id);
+  if (structuredSteps.length > 0) {
+    return {
+      steps: structuredSteps,
+      source: 'sheet_structured',
+    };
+  }
+
+  // 2. 構造化データがない場合はテキスト項目からのブリッジを試行
+  const bridgedResult = bridgeSheetToRecord(sheet, []);
+  if (bridgedResult.steps.length > 0) {
+    return {
+      steps: bridgedResult.steps,
+      source: 'sheet_fallback_text',
+    };
+  }
+
+  return {
+    steps: [],
+    source: 'empty',
+  };
 }

--- a/src/pages/TimeBasedSupportRecordPage.tsx
+++ b/src/pages/TimeBasedSupportRecordPage.tsx
@@ -19,7 +19,6 @@ import { useIbdPageGuard } from '@/features/daily/hooks/useIbdPageGuard';
 import { useSupportRecordSubmit } from '@/pages/hooks/useSupportRecordSubmit';
 import { useTimeBasedSupportRecordPage } from '@/pages/hooks/useTimeBasedSupportRecordPage';
 import { usePlanningSheetToProcedureBridge } from '@/features/planning-sheet/hooks/usePlanningSheetToProcedureBridge';
-import type { ScheduleItem } from '@/features/daily/components/split-stream/ProcedurePanel';
 import { CircularProgress } from '@mui/material';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';

--- a/src/pages/TimeBasedSupportRecordPage.tsx
+++ b/src/pages/TimeBasedSupportRecordPage.tsx
@@ -18,6 +18,9 @@ import { useUsers } from '@/features/users/useUsers';
 import { useIbdPageGuard } from '@/features/daily/hooks/useIbdPageGuard';
 import { useSupportRecordSubmit } from '@/pages/hooks/useSupportRecordSubmit';
 import { useTimeBasedSupportRecordPage } from '@/pages/hooks/useTimeBasedSupportRecordPage';
+import { usePlanningSheetToProcedureBridge } from '@/features/planning-sheet/hooks/usePlanningSheetToProcedureBridge';
+import type { ScheduleItem } from '@/features/daily/components/split-stream/ProcedurePanel';
+import { CircularProgress } from '@mui/material';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -71,6 +74,14 @@ const TimeBasedSupportRecordPage: React.FC = () => {
   // ── Wizard state ──
   const wizard = useSupportWizard(initialParams.userId, initialParams.stepKey);
 
+  // ── Phase E: 支援計画シートからの手順取得 ──
+  const { 
+    schedule: overrideSchedule, 
+    isLoading: isSheetLoading,
+    error: sheetError,
+    bridgeSource
+  } = usePlanningSheetToProcedureBridge(initialParams.planningSheetId);
+
   // ── Core record page hook (uses wizard's userId) ──
   const {
     targetUserId,
@@ -96,6 +107,7 @@ const TimeBasedSupportRecordPage: React.FC = () => {
     initialUserId: wizard.wizardUserId || initialParams.userId,
     initialStepKey: wizard.wizardSlotId || initialParams.stepKey,
     initialUnfilledOnly: initialParams.unfilledOnly,
+    overrideSchedule,
   });
 
   // ── Submit logic ──
@@ -253,6 +265,45 @@ const TimeBasedSupportRecordPage: React.FC = () => {
   // IBDガード: リダイレクト中はレンダリングしない
   if (ibdGuard === 'redirecting') return null;
 
+  // シート情報読み込み待ち（Phase E 導線時のみ）
+  if (initialParams.planningSheetId && isSheetLoading) {
+    return (
+      <FullScreenDailyDialogPage title="支援手順の読み込み中..." backTo="/today">
+        <Box sx={{ display: 'flex', flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+          <CircularProgress />
+        </Box>
+      </FullScreenDailyDialogPage>
+    );
+  }
+
+  const renderPlanningError = () => {
+    // 1. 取得エラー時
+    if (sheetError) {
+      return (
+        <Box sx={{ px: 2, pt: 2 }}>
+          <Alert severity="warning" sx={{ mb: 0 }}>
+            支援計画シート「{initialParams.planningSheetId}」の取得に失敗しました。
+            既定の手順を表示します。（エラー: {sheetError}）
+          </Alert>
+        </Box>
+      );
+    }
+
+    // 2. 計画書は取得できたが、手順が空の場合（未設計など）
+    if (initialParams.planningSheetId && bridgeSource === 'empty') {
+      return (
+        <Box sx={{ px: 2, pt: 2 }}>
+          <Alert severity="info" sx={{ mb: 0 }}>
+            指定された支援計画シートに実施手順が設定されていません。
+            既定の手順（リポジトリ）を表示します。
+          </Alert>
+        </Box>
+      );
+    }
+
+    return null;
+  };
+
   return (
     <FullScreenDailyDialogPage
       title="支援手順の実施（行動観察）"
@@ -323,6 +374,7 @@ const TimeBasedSupportRecordPage: React.FC = () => {
 
         {/* ── Step Content ── */}
         <Box sx={{ flex: 1, minHeight: 0, overflow: 'hidden' }}>
+          {renderPlanningError()}
           {wizard.step === 'user' && (
             <UserSelectionStep
               filteredUsers={filteredUsers}

--- a/src/pages/hooks/useTimeBasedSupportRecordPage.ts
+++ b/src/pages/hooks/useTimeBasedSupportRecordPage.ts
@@ -13,6 +13,8 @@ type UseTimeBasedSupportRecordPageArgs = {
   initialStepKey?: string;
   initialUnfilledOnly?: boolean;
   storageKey?: string;
+  /** 手順（TimeBasedSupportRecordPage から渡される優先スケジュール） */
+  overrideSchedule?: ScheduleItem[];
 };
 
 const DEFAULT_UNFILLED_STORAGE_KEY = 'daily-support-unfilled-only';
@@ -25,6 +27,7 @@ export function useTimeBasedSupportRecordPage({
   initialStepKey,
   initialUnfilledOnly,
   storageKey = DEFAULT_UNFILLED_STORAGE_KEY,
+  overrideSchedule,
 }: UseTimeBasedSupportRecordPageArgs) {
   const [targetUserId, setTargetUserId] = useState(initialUserId);
   const [isAcknowledged, setIsAcknowledged] = useState(false);
@@ -39,9 +42,10 @@ export function useTimeBasedSupportRecordPage({
   const skipAutoSelectRef = useRef(false);
 
   const schedule = useMemo(() => {
+    if (overrideSchedule && overrideSchedule.length > 0) return overrideSchedule;
     if (!targetUserId) return [];
     return procedureRepo.getByUser(targetUserId) as ScheduleItem[];
-  }, [procedureRepo, targetUserId]);
+  }, [overrideSchedule, procedureRepo, targetUserId]);
   const recentObservations = useMemo(
     () => behaviorRecords.filter((behavior) => behavior.userId === targetUserId),
     [behaviorRecords, targetUserId],

--- a/src/pages/support-planning-sheet/SheetHeader.tsx
+++ b/src/pages/support-planning-sheet/SheetHeader.tsx
@@ -223,6 +223,7 @@ const SheetHeader: React.FC<SheetHeaderProps> = ({
           startDate,
           ((sheet as Record<string, unknown>).monitoringCycleDays as number) ?? 90,
         );
+        if (!schedule) return null;
         return (
           <Paper
             variant="outlined"

--- a/src/pages/support-planning-sheet/SupportPlanningSheetView.tsx
+++ b/src/pages/support-planning-sheet/SupportPlanningSheetView.tsx
@@ -49,6 +49,28 @@ export const SupportPlanningSheetView: React.FC<SupportPlanningSheetViewProps> =
     [pendingPatches],
   );
 
+  const planningSheetId = viewModel?.planningSheetId;
+
+  React.useEffect(() => {
+    if (!planningSheetId || planningSheetId === 'new') {
+      setPendingPatchCount(0);
+      setPendingPatches([]);
+      return;
+    }
+
+    let active = true;
+
+    void planPatchRepository.findPending(planningSheetId).then((patches) => {
+      if (!active) return;
+      setPendingPatchCount(patches.length);
+      setPendingPatches(patches);
+    });
+
+    return () => {
+      active = false;
+    };
+  }, [planPatchRepository, planningSheetId]);
+
   if (!viewModel) {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: 300 }}>
@@ -58,7 +80,7 @@ export const SupportPlanningSheetView: React.FC<SupportPlanningSheetViewProps> =
   }
 
   const {
-    planningSheetId,
+    // planningSheetId, // Already extracted above
     sheet,
     isLoading,
     error,
@@ -94,26 +116,6 @@ export const SupportPlanningSheetView: React.FC<SupportPlanningSheetViewProps> =
     source,
     diffSummary,
   } = viewModel;
-
-  React.useEffect(() => {
-    if (!planningSheetId || planningSheetId === 'new') {
-      setPendingPatchCount(0);
-      setPendingPatches([]);
-      return;
-    }
-
-    let active = true;
-
-    void planPatchRepository.findPending(planningSheetId).then((patches) => {
-      if (!active) return;
-      setPendingPatchCount(patches.length);
-      setPendingPatches(patches);
-    });
-
-    return () => {
-      active = false;
-    };
-  }, [planPatchRepository, planningSheetId]);
 
   if (isLoading) {
     return (


### PR DESCRIPTION
## Summary
* formalize the planning-sheet -> daily/support bridge as a provenance-aware contract
* * add strict bridge source typing (`sheet_structured` / `sheet_fallback_text` / `repository_default` / `empty`)
* * harden loading, fallback, and race-condition handling in the planning sheet bridge hook
* * refine UI guidance so fetch failures are warnings and empty planning content is shown as informational fallback
## Why
Previously, `/daily/support` could render the correct procedures, but it could not always explain why those procedures were being shown. This change upgrades the flow from simple data passing to a strict entry contract with provenance, safe fallback behavior, and deterministic async handling.

## Result
* stale procedures are cleared immediately on planningSheetId changes
* * invalid IDs and fetch failures fail safely to repository defaults
* * empty planning sheets are distinguished from fetch failures
* * the UI can now explain the active input source with compile-time-safe provenance values