### PR TITLE
test(today): align TodayOpsPage summary fixture contract

### DIFF
--- a/tests/unit/pages/TodayOpsPage.spec.tsx
+++ b/tests/unit/pages/TodayOpsPage.spec.tsx
@@ -54,7 +54,10 @@ vi.mock('../../../src/features/auth/store', () => ({
 }));
 
 vi.mock('../../../src/features/today/domain', () => ({
-  useTodaySummary: vi.fn(() => ({})),
+  useTodaySummary: vi.fn(() => ({
+    todayExceptionActions: [],
+    todayExceptions: [],
+  })),
 }));
 
 vi.mock('../../../src/features/today/hooks/useApprovalFlow', () => ({


### PR DESCRIPTION
## 背景
- `main` 既存失敗のうち、TodayOpsPage 系 (`summary.todayExceptionActions is not iterable`) を最小単位で切り出して修正します。
- `PR起因` ではなく `main既存` の失敗対応です。

## 変更内容（最小）
- `tests/unit/pages/TodayOpsPage.spec.tsx` の `useTodaySummary` モックに現行契約を追従
  - `todayExceptionActions: []`
  - `todayExceptions: []`

## 影響
- テスト fixture の契約追従のみ（実装コード変更なし）。

## 検証
- ローカルで `tests/unit/pages/TodayOpsPage.spec.tsx` を対象実行
- ただしこの環境では `vitest` worker が `ERR_WORKER_OUT_OF_MEMORY` で停止し、完走確認はCIに委譲

## 分類
- 現象: `summary.todayExceptionActions is not iterable`
- 分類: `main既存`
- 根拠: `#1464` マージ前後の `main` CI Preflight で同一失敗を確認
