### PR TITLE
test(settings): align SettingsDialog planning switch selector label

### DIFF
--- a/src/features/settings/__tests__/SettingsDialog.spec.tsx
+++ b/src/features/settings/__tests__/SettingsDialog.spec.tsx
@@ -78,7 +78,7 @@ describe('SettingsDialog planning visibility behavior', () => {
 
   it('updates explicit planning preference to hide when user toggles planning off', () => {
     renderDialog();
-    fireEvent.click(screen.getByRole('switch', { name: 'Planning' }));
+    fireEvent.click(screen.getByRole('switch', { name: '標準支援' }));
 
     expect(mockUpdateSettings).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -105,7 +105,7 @@ describe('SettingsDialog planning visibility behavior', () => {
       navGroupVisibilityPrefs: { planning: 'hide' },
     };
     renderDialog();
-    fireEvent.click(screen.getByRole('switch', { name: 'Planning' }));
+    fireEvent.click(screen.getByRole('switch', { name: '標準支援' }));
 
     expect(mockUpdateSettings).toHaveBeenCalledWith(
       expect.objectContaining({


### PR DESCRIPTION
## Summary
- align `SettingsDialog` test switch selector with current UI label
- replace stale selector name `Planning` -> `標準支援`
- keep implementation unchanged (test-only minimal fix)

## Classification
- `main既存`
- `PR起因`: none
- `CI差分`: none

## Verification
- `npx vitest run src/features/settings/__tests__/SettingsDialog.spec.tsx --reporter=verbose --no-file-parallelism`
  - 2 passed
