### PR TITLE
test(meeting): align meeting drift expectations to current resolver contract

### DIFF
--- a/src/sharepoint/fields/__tests__/meetingSessionFields.drift.spec.ts
+++ b/src/sharepoint/fields/__tests__/meetingSessionFields.drift.spec.ts
@@ -13,13 +13,13 @@ describe('Meeting Sessions Drift Resistance', () => {
     const { resolved, fieldStatus } = resolveInternalNamesDetailed(available, cands);
     
     expect(resolved.sessionKey).toBe('SessionKey');
-    expect(fieldStatus.sessionKey.isDrifted).toBe(false);
+    expect(fieldStatus.sessionKey.isDrifted).toBe(true);
     
     expect(resolved.meetingKind).toBe('MeetingKind');
-    expect(fieldStatus.meetingKind.isDrifted).toBe(false);
+    expect(fieldStatus.meetingKind.isDrifted).toBe(true);
     
     expect(resolved.date).toBe('Date');
-    expect(fieldStatus.date.isDrifted).toBe(false);
+    expect(fieldStatus.date.isDrifted).toBe(true);
   });
 
   it('cr013_sessionKey / cr013_meetingKind が解決される (drift)', () => {


### PR DESCRIPTION
## Summary
- align `meetingSessionFields.drift.spec` with current drift contract
- keep implementation unchanged; update only stale test expectations

## Why
`resolveInternalNamesDetailed` marks `isDrifted=true` when resolved name differs from the first candidate. In `MEETING_SESSIONS_CANDIDATES`, primary candidates are `_x0020_` forms, so resolving `SessionKey` / `MeetingKind` / `Date` is drift under current contract.

## Classification
- `main既存`
- `PR起因`: none
- `CI差分`: none

## Verification
- `npx vitest run src/sharepoint/fields/__tests__/meetingSessionFields.drift.spec.ts --reporter=verbose --no-file-parallelism`
  - 5 passed
