### PR TITLE
fix(daily): restore domain SSOT in abc sync policy

### DIFF
--- a/src/features/daily/domain/abcSyncPolicy.ts
+++ b/src/features/daily/domain/abcSyncPolicy.ts
@@ -3,7 +3,7 @@ import type { ABCRecord } from '@/domain/behavior';
 export const ABC_SYNC_FAILURES_KEY = 'daily-support.abc-sync-failures.v1';
 const MAX_FAILURE_LOGS = 100;
 
-export interface AbcSyncFailureLog {
+interface AbcSyncFailureLog {
   id: string;
   userId: string;
   recordedAt: string;


### PR DESCRIPTION
## Summary
- resolve `contract.spec` Domain SSOT failure in `daily/domain`
- keep change minimal: make `AbcSyncFailureLog` internal (remove `export`)
- no behavior change, only contract alignment

## Classification
- `PR起因`: none
- `main既存`: yes (known failure group)
- `CI差分`: none detected

## Root Cause
- `src/features/daily/domain/abcSyncPolicy.ts` exported `AbcSyncFailureLog` outside `schema.ts`, violating SSOT guard

## Minimal Fix
- update `src/features/daily/domain/abcSyncPolicy.ts`
  - `export interface AbcSyncFailureLog` -> `interface AbcSyncFailureLog`

## Verification
- `npx vitest run tests/unit/contracts/contract.spec.ts --reporter=verbose --no-file-parallelism`
- result: `20 passed`
