### PR TITLE
docs(pr): add security check review gate to pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,6 +20,38 @@
 
 ---
 
+## 🔒 Security Check（プロジェクト固有ルール確認 / 全PR必須）
+
+> 違反は原則マージブロック。静的解析で捕捉できない設計判断をレビュー入口で止めるためのゲート。
+
+### データアクセス層
+- [ ] **Repository経由**: UI / Hook から Repository Factory を直呼びしていない（`useXXXRepository()` 経由）
+- [ ] **通信経路限定**: `spFetch` / `graphFetch` / `resilientFetch` 以外の生 `fetch()` を新規追加していない
+- [ ] **SharePoint直参照なし**: Repository層から `@/lib/sp/*`（helpers除く）を直接 import していない
+
+### スキーマ / SSOT
+- [ ] **`fields/*.ts` 準拠**: 新規参照するフィールドは `src/sharepoint/fields/*.ts` に定義済み
+- [ ] **OData手組みなし**: `eq` / `ne` / `substringof(` 等のフィルタ文字列を手動組立していない（`builders.ts` 使用）
+- [ ] **drift fail-open**: 欠損フィールドで処理停止させず、観測（telemetry / log）に逃がしている
+
+### UI / 状態管理
+- [ ] **`window.confirm` 不使用**: 確認ダイアログは `useConfirmDialog` + `ConfirmDialog` を使用
+- [ ] **Zustand selector 安定性**: selector で新規 object / array リテラルを返していない（個別購読 or memo）
+- [ ] **pure / IO 分離**: ビジネスロジックから副作用（fetch / storage / telemetry）を分離
+
+### 認証 / 認可 / セキュリティ
+- [ ] **認可チェック**: データアクセスに対象リソースの権限確認がある（ID指定のみで他人データ取得不可）
+- [ ] **サーバー側検証**: バリデーションをクライアント側のみに依存していない
+- [ ] **シークレット直書きなし**: APIキー / トークン / 接続文字列を直書きしていない（env / Secrets のみ）
+- [ ] **エラー露出なし**: ユーザー向け文言と内部ログが分離、スタックトレース / 内部ID / SQL を露出していない
+- [ ] **入力検証**: 外部入力を無検証で DOM / query / storage に流していない（XSS / Injection対策）
+
+### 該当なし宣言（該当チェックのスキップ理由）
+<!-- 例: "UI変更なしのため Zustand / confirm 項目は N/A" / "認可は親Page側で実施済み" -->
+- N/A 項目と理由:
+
+---
+
 ## 🧭 AI Skills（[Protocol](docs/ai-skills-protocol.md)）
 
 <!-- 使ったスキル名を 2-3 個まで列挙。未使用なら N/A -->


### PR DESCRIPTION
## Summary
- `.github/pull_request_template.md` の Verification ブロック直後に `## 🔒 Security Check` セクションを追加
- 既存セクションは変更なし（追記のみ、+32行）
- 新規依存なし、ドキュメント変更のみ

## Why
静的解析（ESLint / tsc）で捕捉できない**設計判断レベルのガード**をレビュー入口で補完するため。既存の `no-restricted-globals`（`fetch` / `confirm`）や OData builder ルールは強力だが、以下は人間レビューでしか拾えない:

- 認可チェックの有無（ID指定のみで他人データ取得可能か）
- サーバー側バリデーションの存在
- drift fail-open 方針の遵守
- pure / IO 分離
- 内部情報（スタックトレース / 内部ID）露出禁止

## Changes
- [x] Verification 直後に `## 🔒 Security Check（プロジェクト固有ルール確認 / 全PR必須）` を追加
- [x] 4カテゴリ構成: データアクセス層 / スキーマ・SSOT / UI・状態管理 / 認証・認可・セキュリティ
- [x] `該当なし宣言` 欄を設け、形骸化を抑制

## Test plan
- [x] ESLint / typecheck / lint:cookies（pre-commit hook）PASS
- [ ] GitHub UI で PR テンプレが正しくレンダリングされることを確認（このPR自体で確認可能）
- [ ] 既存セクション（AI Skills / Design Review / Pre-Merge Checklist 等）が壊れていないことを目視確認

## Rollback Plan
- [ ] Revert this PR（ドキュメント変更のみのため即時ロールバック可能）

## Notes
- 次の一手候補:
  1. **Danger 連携**（軽量・即効）: `.github/workflows/danger.yml` に「Security Check 未記入警告」を追加
  2. **SSOT fields 型強制 Phase2**（本命・面積広）: `project_sp_query_next_steps.md` 参照
- 今回はテンプレ追記のみに絞り、機械化は別PRで分離

🤖 Generated with [Claude Code](https://claude.com/claude-code)