### PR TITLE
feat(sharepoint): SpFieldName branded type (Phase 2a pilot)

### DIFF
--- a/src/sharepoint/fields/fieldUtils.ts
+++ b/src/sharepoint/fields/fieldUtils.ts
@@ -3,7 +3,47 @@
  *
  * joinSelect:              OData $select 文字列ビルダー
  * buildSelectFieldsFromMap: テナント差分に耐える動的 $select ビルダー
+ * SpFieldName / defineFieldMap / asField: Phase 2a branded 型強制（fail-open 維持）
  */
+
+// ── Phase 2a: Branded SpFieldName ────────────────────────────────────────────
+//
+// Phase 2 の目的は「既知の SSOT フィールド参照を型で保護すること」であり、
+// 「動的 drift 解決を早期に禁止すること」ではない。fail-open を維持したまま
+// 段階的に brand 化を進め、動的解決サイトの audit 完了後にのみ strict narrow を
+// 検討する（project_sp_drift_protection_completion / project_sp_query_next_steps）。
+
+declare const spFieldBrand: unique symbol;
+
+/**
+ * SSOT 由来 or audit 済みの動的解決フィールド名を表す nominal 型。
+ * ランタイムコストゼロ（型のみ）。
+ */
+export type SpFieldName = string & { readonly [spFieldBrand]: true };
+
+/**
+ * SSOT FIELD_MAP を branded 型付きで定義する helper。
+ *
+ * Before: `export const FIELD_MAP_X = { a: 'A' } as const;`
+ * After:  `export const FIELD_MAP_X = defineFieldMap({ a: 'A' });`
+ *
+ * 呼出し側は一切変更不要（`FIELD_MAP_X.a` が `'A' & SpFieldName` になるだけ）。
+ */
+export const defineFieldMap = <T extends Record<string, string>>(
+  m: T,
+): { readonly [K in keyof T]: T[K] & SpFieldName } =>
+  m as { readonly [K in keyof T]: T[K] & SpFieldName };
+
+/**
+ * 動的解決された field 名を SpFieldName として扱う escape hatch。
+ *
+ * 用途: drift tolerance のために実行時に probe した SP 内部名を
+ *       builder に渡す場合（例: `buildEq(asField(this.mf(mapping, 'key')), v)`）。
+ *
+ * 濫用警告: SSOT 化すべき箇所で使わないこと。将来的に `// drift:` 等の
+ *           コメント必須 lint ルールを検討中。
+ */
+export const asField = (s: string): SpFieldName => s as SpFieldName;
 
 /** readonly string[] を OData $select 文字列（カンマ区切り）に変換 */
 export const joinSelect = (arr: readonly string[]) => arr.join(',');

--- a/src/sharepoint/fields/handoffFields.ts
+++ b/src/sharepoint/fields/handoffFields.ts
@@ -1,12 +1,18 @@
 /**
  * SharePoint フィールド定義 — Handoff
+ *
+ * Phase 2a pilot: FIELD_MAP_HANDOFF を defineFieldMap で branded 化。
+ * 動的解決ゼロの安全な pilot として選定（project_sp_query_next_steps 参照）。
  */
-import { buildSelectFieldsFromMap } from './fieldUtils';
+import { buildSelectFieldsFromMap, defineFieldMap } from './fieldUtils';
 
 /**
  * Handoff リスト用の FIELD_MAP（HANDOFF_TIMELINE_COLUMNS から抽出）
+ *
+ * Phase 2a: defineFieldMap により各値が `SpFieldName` 型を帯びる。
+ * 呼出し側は無変更（`FIELD_MAP_HANDOFF.userCode` の利用方法は従来通り）。
  */
-export const FIELD_MAP_HANDOFF = {
+export const FIELD_MAP_HANDOFF = defineFieldMap({
   id: 'Id',
   title: 'Title',
   message: 'Message',
@@ -28,7 +34,7 @@ export const FIELD_MAP_HANDOFF = {
   modifiedAt: 'ModifiedAt',
   created: 'Created',
   modified: 'Modified',
-} as const;
+});
 
 /**
  * 0. Handoff リストのフィールド候補

--- a/src/sharepoint/query/builders.ts
+++ b/src/sharepoint/query/builders.ts
@@ -11,8 +11,16 @@
  */
 
 import { escapeODataString } from '@/lib/odata';
+import type { SpFieldName } from '@/sharepoint/fields/fieldUtils';
 
 type ODataPrimitive = string | number | boolean | null;
+
+/**
+ * Phase 2a: field 引数は SSOT 由来（defineFieldMap 経由）か、
+ * 動的解決された string を受け入れる transitional union。
+ * Phase 2d で `SpFieldName` のみに narrow 予定。
+ */
+type SpField = SpFieldName | string;
 
 // eslint-disable-next-line no-restricted-syntax
 const fmt = (v: ODataPrimitive): string => {
@@ -27,39 +35,39 @@ const fmt = (v: ODataPrimitive): string => {
 // ── Comparison operators ─────────────────────────────────────────────────────
 
 // eslint-disable-next-line no-restricted-syntax
-export const buildEq = (field: string, value: ODataPrimitive): string =>
+export const buildEq = (field: SpField, value: ODataPrimitive): string =>
   `${field} eq ${fmt(value)}`;
 
 // eslint-disable-next-line no-restricted-syntax
-export const buildNe = (field: string, value: ODataPrimitive): string =>
+export const buildNe = (field: SpField, value: ODataPrimitive): string =>
   `${field} ne ${fmt(value)}`;
 
 // eslint-disable-next-line no-restricted-syntax
-export const buildGe = (field: string, value: string | number): string =>
+export const buildGe = (field: SpField, value: string | number): string =>
   `${field} ge ${fmt(value)}`;
 
 // eslint-disable-next-line no-restricted-syntax
-export const buildLe = (field: string, value: string | number): string =>
+export const buildLe = (field: SpField, value: string | number): string =>
   `${field} le ${fmt(value)}`;
 
 // eslint-disable-next-line no-restricted-syntax
-export const buildGt = (field: string, value: string | number): string =>
+export const buildGt = (field: SpField, value: string | number): string =>
   `${field} gt ${fmt(value)}`;
 
 // eslint-disable-next-line no-restricted-syntax
-export const buildLt = (field: string, value: string | number): string =>
+export const buildLt = (field: SpField, value: string | number): string =>
   `${field} lt ${fmt(value)}`;
 
 // ── Search & Functions ───────────────────────────────────────────────────────
 
 /** substringof('value', field) */
 // eslint-disable-next-line no-restricted-syntax
-export const buildSubstringOf = (field: string, value: string): string =>
+export const buildSubstringOf = (field: SpField, value: string): string =>
   `substringof('${escapeODataString(value)}', ${field})`;
 
 /** startswith(field, 'value') */
 // eslint-disable-next-line no-restricted-syntax
-export const buildStartsWith = (field: string, value: string): string =>
+export const buildStartsWith = (field: SpField, value: string): string =>
   `startswith(${field}, '${escapeODataString(value)}')`;
 
 /** OData datetime literal: datetime'YYYY-MM-DDTHH:mm:ssZ' */


### PR DESCRIPTION
## Summary
- Phase 2a of SSOT field type enforcement: introduce `SpFieldName` branded type + `defineFieldMap` / `asField` helpers
- Pilot migration: `handoffFields.ts` only（動的解決ゼロの安全な baseline）
- `builders.ts` の field 引数を `SpFieldName | string` transitional union に緩和
- **既存 call site は一切変更なし**（41ファイル / 218箇所すべて無変更で通過）

## Why
SSOT `fields/*.ts` への参照を**型で保護**したい。しかし単純な union narrow（`buildEq(field: KnownSpField, ...)`）は drift tolerance を破壊する:

- **Type A（静的 SSOT）**: `buildEq(FIELD_MAP_HANDOFF.userCode, ...)` — 大多数、型強制の恩恵を素直に受ける
- **Type B（動的 drift 解決）**: `buildEq(this.mf(mapping, 'recordId'), ...)` — 約20%、`project_sp_drift_protection_completion` で確立した fail-open 設計の中核

→ Phase 2 の目的は「既知の SSOT フィールド参照を型で保護すること」であり、「動的 drift 解決を早期に禁止すること」ではない。fail-open を維持したまま段階的に brand 化を進め、動的解決サイトの audit 完了後にのみ strict narrow を検討する。

## Changes
- [x] `src/sharepoint/fields/fieldUtils.ts`:
  - `SpFieldName = string & { readonly [unique symbol]: true }` branded 型
  - `defineFieldMap<T>(m: T)` — SSOT map の branded 定義 helper
  - `asField(s: string): SpFieldName` — 動的解決の escape hatch
- [x] `src/sharepoint/fields/handoffFields.ts`: `FIELD_MAP_HANDOFF` を `defineFieldMap(...)` に置換（pilot）
- [x] `src/sharepoint/query/builders.ts`:
  - `SpField = SpFieldName | string` transitional union を定義
  - `buildEq` / `buildNe` / `buildGe` / `buildLe` / `buildGt` / `buildLt` / `buildSubstringOf` / `buildStartsWith` の第1引数を `SpField` に変更

## Test plan
- [x] `npm run typecheck` PASS
- [x] `npm run lint` PASS
- [x] `npx vitest run src/sharepoint/query/__tests__/builders.spec.ts src/sharepoint/fields/__tests__ src/features/handoff` — 57 files / 978 tests PASS
- [x] Pre-commit hooks (lint-staged) PASS
- [x] Pre-push hook (eslint vs origin/main) PASS

## 🔒 Security Check
- **Repository経由**: N/A（型定義のみ）
- **通信経路**: 変更なし
- **fields/\*.ts 準拠**: 本PR自体が SSOT 保護を強化
- **drift fail-open**: `SpFieldName | string` union と `asField()` escape hatch で完全維持
- **pure/IO 分離**: 型レイヤのみ、副作用ゼロ
- **シークレット直書きなし**: 該当なし
- **エラー露出なし**: 該当なし
- N/A 項目と理由: UI変更 / 認可 / バリデーション関連はスコープ外（型のみ変更）

## Rollback Plan
- [ ] Revert this PR — call site無変更のため影響ゼロで戻せる
- [ ] 型拡張のみのため、ランタイム挙動に変化なし

## Notes / 次フェーズ
- **Phase 2b/2c**: 動的解決サイトの audit issue を別PRで起票予定
  - 対象候補: `DataProviderAttendanceRepository` / `DataProviderMonitoringMeetingRepository` / `DataProviderUserRepository` / `ispRepo` / `transportRepo` / `RestApiUserRepository`
- **Phase 2d**: 全 map の brand 化 + audit 完了後に `buildEq(field: SpFieldName, ...)` へ narrow（compile error で未 brand の raw string を拒否）
- **負例テスト**: Phase 2d で `@ts-expect-error` による保護テスト追加予定
- ESLint `// drift:` コメント必須ルールは Phase 2c/2d で検討

### 設計メモ
> Phase 2 の目的は「既知の SSOT フィールド参照を型で保護すること」であり、「動的 drift 解決を早期に禁止すること」ではない。
> fail-open を維持したまま段階的に brand 化を進め、動的解決サイトの audit 完了後にのみ strict narrow を検討する。

## 関連
- Depends on: N/A（独立）
- Related: PR #1473 (PR template security check gate)
- Roadmap: `project_sp_query_next_steps` Phase 2a

🤖 Generated with [Claude Code](https://claude.com/claude-code)