### PR TITLE
feat(infra): migrate Today feature to bridgeProxy

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -228,8 +228,6 @@ module.exports = {
         // Phase 2 targets: Existing direct bridge imports to be migrated later
         'src/features/monitoring/components/MeetingEvidenceDraftPanel.tsx',
         'src/features/monitoring/hooks/useMeetingEvidenceDraft.ts',
-        'src/features/today/hooks/useWorkflowPhases.ts',
-        'src/features/today/hooks/__tests__/useWorkflowPhases.spec.ts',
         'src/features/ibd/analysis/pdca/queries/usePdcaCycleState.ts',
         '**/create*Repository.ts', // Factory-defining files are allowed to call themselves for recursion/wrappers if needed
       ],

--- a/src/app/services/bridgeProxy.ts
+++ b/src/app/services/bridgeProxy.ts
@@ -1,4 +1,13 @@
-import { determineWorkflowPhase, type WorkflowPhase } from '@/domain/bridge/workflowPhase';
+import {
+  determineWorkflowPhase,
+  sortByWorkflowPriority,
+  toPlanningWorkflowCardItem,
+  type WorkflowPhase,
+  type PlanningSheetSnapshot,
+  type WorkflowPhaseResult,
+  type PlanningWorkflowCardItem,
+  type WorkflowSeverity,
+} from '@/domain/bridge/workflowPhase';
 import {
   resolveNextStepBanner,
   type BannerContext,
@@ -28,6 +37,18 @@ export function getPlanningWorkflowPhase(
   input: GetPlanningWorkflowPhaseInput
 ): GetPlanningWorkflowPhaseResult {
   return determineWorkflowPhase(input);
+}
+
+export function sortWorkflowItemsByPriority(
+  results: WorkflowPhaseResult[]
+): WorkflowPhaseResult[] {
+  return sortByWorkflowPriority(results);
+}
+
+export function getPlanningWorkflowCardItem(
+  result: WorkflowPhaseResult
+): PlanningWorkflowCardItem {
+  return toPlanningWorkflowCardItem(result);
 }
 
 // --- Next Step Banner ---
@@ -61,4 +82,11 @@ export function getMonitoringRecordFromMeeting(
 
 // --- Types ---
 
-export type { MonitoringToPlanningBridge, WorkflowPhase };
+export type {
+  MonitoringToPlanningBridge,
+  WorkflowPhase,
+  PlanningSheetSnapshot,
+  WorkflowPhaseResult,
+  PlanningWorkflowCardItem,
+  WorkflowSeverity,
+};

--- a/src/features/today/hooks/__tests__/useWorkflowPhases.spec.ts
+++ b/src/features/today/hooks/__tests__/useWorkflowPhases.spec.ts
@@ -10,7 +10,7 @@ import {
   countByPhase,
   toPlanningSheetSnapshot,
 } from '../useWorkflowPhases';
-import type { PlanningSheetSnapshot } from '@/domain/bridge/workflowPhase';
+import { type PlanningSheetSnapshot } from '@/app/services/bridgeProxy';
 import type { PlanningSheetListItem } from '@/domain/isp/schema';
 
 // ─────────────────────────────────────────────

--- a/src/features/today/hooks/useWorkflowPhases.ts
+++ b/src/features/today/hooks/useWorkflowPhases.ts
@@ -22,15 +22,14 @@ import type { PlanningSheetRepository } from '@/domain/isp/port';
 import type { PlanningSheetListItem } from '@/domain/isp/schema';
 import type { IUserMaster } from '@/sharepoint/fields';
 import {
-  determineWorkflowPhase,
-  sortByWorkflowPriority,
-  toPlanningWorkflowCardItem,
-  type DeterminePhaseInput,
+  getPlanningWorkflowPhase,
+  sortWorkflowItemsByPriority,
+  getPlanningWorkflowCardItem,
   type PlanningSheetSnapshot,
   type WorkflowPhaseResult,
   type PlanningWorkflowCardItem,
   type WorkflowPhase,
-} from '@/domain/bridge/workflowPhase';
+} from '@/app/services/bridgeProxy';
 
 // ─────────────────────────────────────────────
 // Output type
@@ -134,21 +133,21 @@ export function buildWorkflowItems(
 ): { results: WorkflowPhaseResult[]; items: PlanningWorkflowCardItem[] } {
   // 1. 各利用者のフェーズ判定
   const results: WorkflowPhaseResult[] = users.map((user) => {
-    const input: DeterminePhaseInput = {
+    const input = {
       userId: user.userId,
       userName: user.userName,
       planningSheets: sheetsByUser.get(user.userId) ?? [],
       reassessments: [], // 将来拡張
       referenceDate,
     };
-    return determineWorkflowPhase(input);
+    return getPlanningWorkflowPhase(input);
   });
 
   // 2. priority 順ソート
-  const sorted = sortByWorkflowPriority(results);
+  const sorted = sortWorkflowItemsByPriority(results);
 
   // 3. UI 用アイテムに変換
-  const items = sorted.map(toPlanningWorkflowCardItem);
+  const items = sorted.map(getPlanningWorkflowCardItem);
 
   return { results, items };
 }

--- a/src/features/today/widgets/PlanningWorkflowCard.tsx
+++ b/src/features/today/widgets/PlanningWorkflowCard.tsx
@@ -13,7 +13,7 @@
  * @see src/domain/bridge/workflowPhase.ts
  */
 import { motionTokens } from '@/app/theme';
-import type { PlanningWorkflowCardItem, WorkflowSeverity } from '@/domain/bridge/workflowPhase';
+import { type PlanningWorkflowCardItem, type WorkflowSeverity } from '@/app/services/bridgeProxy';
 import type { WorkflowPhaseCounts } from '@/features/today/hooks/useWorkflowPhases';
 import AssignmentLateIcon from '@mui/icons-material/AssignmentLate';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';


### PR DESCRIPTION
## Purpose
Following the successful Phase 0 infra setup, this PR migrates the Today feature (planning workflow hook and card) to `bridgeProxy`.

## Changes
- Migrated `useWorkflowPhases.ts` and its tests to use `bridgeProxy`
- - Migrated `PlanningWorkflowCard.tsx` to use `bridgeProxy`
- - Removed Today-related file exclusions from ESLint
- - Expanded `bridgeProxy.ts` with the minimum sorting and mapping logic needed for Today
## Verification
- Direct imports from `@/domain/bridge/*` in `src/features/today` are no longer needed
- - Workflow phase and card ordering logic remain intact via proxy
- - ESLint should now enforce the boundary in Today without file-level exclusions
## Review Focus
- No behavior change in the Today workflow card
- - `bridgeProxy.ts` only absorbed the minimum required bridge-facing surface
- - No unrelated migrations were included
- 