### PR TITLE
feat(infra): migrate Monitoring feature to bridgeProxy

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -226,8 +226,6 @@ module.exports = {
         'src/features/**/infra/**',
         'src/app/services/**',
         // Phase 2 targets: Existing direct bridge imports to be migrated later
-        'src/features/monitoring/components/MeetingEvidenceDraftPanel.tsx',
-        'src/features/monitoring/hooks/useMeetingEvidenceDraft.ts',
         'src/features/ibd/analysis/pdca/queries/usePdcaCycleState.ts',
         '**/create*Repository.ts', // Factory-defining files are allowed to call themselves for recursion/wrappers if needed
       ],

--- a/src/app/services/bridgeProxy.ts
+++ b/src/app/services/bridgeProxy.ts
@@ -9,6 +9,15 @@ import {
   type WorkflowSeverity,
 } from '@/domain/bridge/workflowPhase';
 import {
+  buildMeetingEvidenceDraft,
+  summarizeABCPatterns,
+  summarizeStrategyUsage,
+  type MeetingEvidenceDraft,
+  type MeetingEvidenceSection,
+  type ABCPatternSummary,
+  type StrategyUsageSummary,
+} from '@/domain/bridge/meetingEvidenceDraft';
+import {
   resolveNextStepBanner,
   type BannerContext,
   type BannerTone,
@@ -66,6 +75,26 @@ export function getNextStepBanner(
   return resolveNextStepBanner(input);
 }
 
+// --- Meeting Evidence Draft ---
+
+export function getMeetingEvidenceDraft(
+  ...args: Parameters<typeof buildMeetingEvidenceDraft>
+): ReturnType<typeof buildMeetingEvidenceDraft> {
+  return buildMeetingEvidenceDraft(...args);
+}
+
+export function getABCPatternSummary(
+  ...args: Parameters<typeof summarizeABCPatterns>
+): ReturnType<typeof summarizeABCPatterns> {
+  return summarizeABCPatterns(...args);
+}
+
+export function getStrategyUsageSummary(
+  ...args: Parameters<typeof summarizeStrategyUsage>
+): ReturnType<typeof summarizeStrategyUsage> {
+  return summarizeStrategyUsage(...args);
+}
+
 // --- Monitoring Bridge ---
 
 export function getMonitoringToPlanningBridge(
@@ -89,4 +118,8 @@ export type {
   WorkflowPhaseResult,
   PlanningWorkflowCardItem,
   WorkflowSeverity,
+  MeetingEvidenceDraft,
+  MeetingEvidenceSection,
+  ABCPatternSummary,
+  StrategyUsageSummary,
 };

--- a/src/features/monitoring/components/MeetingEvidenceDraftPanel.tsx
+++ b/src/features/monitoring/components/MeetingEvidenceDraftPanel.tsx
@@ -33,7 +33,7 @@ import Typography from '@mui/material/Typography';
 import React from 'react';
 
 import type { UseMeetingEvidenceDraftResult } from '../hooks/useMeetingEvidenceDraft';
-import type { MeetingEvidenceSection } from '@/domain/bridge/meetingEvidenceDraft';
+import { type MeetingEvidenceSection } from '@/app/services/bridgeProxy';
 
 // ── Types ───────────────────────────────────────────────
 

--- a/src/features/monitoring/hooks/useMeetingEvidenceDraft.ts
+++ b/src/features/monitoring/hooks/useMeetingEvidenceDraft.ts
@@ -27,13 +27,13 @@ import {
 import { getABCRecordsForUser } from '@/features/ibd/core/ibdStore';
 import { buildUserAlerts, type UserAlert } from '@/features/today/domain/buildUserAlerts';
 import {
-  buildMeetingEvidenceDraft,
-  summarizeABCPatterns,
-  summarizeStrategyUsage,
+  getMeetingEvidenceDraft,
+  getABCPatternSummary,
+  getStrategyUsageSummary,
   type MeetingEvidenceDraft,
   type ABCPatternSummary,
   type StrategyUsageSummary,
-} from '@/domain/bridge/meetingEvidenceDraft';
+} from '@/app/services/bridgeProxy';
 
 // ─────────────────────────────────────────────────────────
 // Constants
@@ -146,18 +146,18 @@ export function useMeetingEvidenceDraft(
 
     // 3. ABC パターン
     const abcPatterns = safeCall<ABCPatternSummary | null>(
-      () => summarizeABCPatterns(abcRecords),
+      () => getABCPatternSummary(abcRecords),
       null,
     );
 
     // 4. 戦略実績
     const strategyUsage = safeCall<StrategyUsageSummary | null>(
-      () => summarizeStrategyUsage(abcRecords),
+      () => getStrategyUsageSummary(abcRecords),
       null,
     );
 
     // ── 統合 ──
-    const draft = buildMeetingEvidenceDraft({
+    const draft = getMeetingEvidenceDraft({
       userName,
       from: range.from,
       to: range.to,


### PR DESCRIPTION
### Purpose
Resolve direct references to the domain layer (Bridge) in the Monitoring domain and centralize access through `bridgeProxy.ts` to promote loose coupling and enforce architectural guardrails.

### Changes
- **bridgeProxy.ts**: Added meeting evidence draft generation and summarization logic for monitoring (`getMeetingEvidenceDraft`, `getABCPatternSummary`, `getStrategyUsageSummary`).
- - **useMeetingEvidenceDraft.ts**: Changed direct imports from the domain layer to use `bridgeProxy`.
- - **MeetingEvidenceDraftPanel.tsx**: Changed the import source for `MeetingEvidenceSection` type to `bridgeProxy`.
- - **.eslintrc.cjs**: Removed ESLint exclusions for `monitoring` related files.
### Verification
- Confirmed that CI (Lint / Quality Gates) passes successfully.
- - Verified that there are no direct references to the domain layer under `features/monitoring`.
### Review Focus
- Does the added functions in `bridgeProxy.ts` encapsulate Monitoring domain requirements minimally and appropriately?
- - Are there any new warnings in related files after removing ESLint exclusions?