### PR TITLE
feat(infra): migrate PDCA feature to bridgeProxy and finalize guardrails

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -225,8 +225,6 @@ module.exports = {
         'src/features/**/data/**',
         'src/features/**/infra/**',
         'src/app/services/**',
-        // Phase 2 targets: Existing direct bridge imports to be migrated later
-        'src/features/ibd/analysis/pdca/queries/usePdcaCycleState.ts',
         '**/create*Repository.ts', // Factory-defining files are allowed to call themselves for recursion/wrappers if needed
       ],
       rules: {

--- a/src/app/services/bridgeProxy.ts
+++ b/src/app/services/bridgeProxy.ts
@@ -7,6 +7,7 @@ import {
   type WorkflowPhaseResult,
   type PlanningWorkflowCardItem,
   type WorkflowSeverity,
+  type ReassessmentSnapshot,
 } from '@/domain/bridge/workflowPhase';
 import {
   buildMeetingEvidenceDraft,
@@ -17,6 +18,9 @@ import {
   type ABCPatternSummary,
   type StrategyUsageSummary,
 } from '@/domain/bridge/meetingEvidenceDraft';
+import { summarizeProcedureExecution } from '@/domain/bridge/monitoringEvidence';
+import { determinePdcaCycleState } from '@/domain/bridge/pdcaCycleOrchestrator';
+import { toDailyProcedureSteps } from '@/domain/isp/bridge/toDailyProcedureSteps';
 import {
   resolveNextStepBanner,
   type BannerContext,
@@ -95,6 +99,26 @@ export function getStrategyUsageSummary(
   return summarizeStrategyUsage(...args);
 }
 
+// --- PDCA / Monitoring Analytics ---
+
+export function getProcedureExecutionSummary(
+  ...args: Parameters<typeof summarizeProcedureExecution>
+): ReturnType<typeof summarizeProcedureExecution> {
+  return summarizeProcedureExecution(...args);
+}
+
+export function getPdcaCycleState(
+  ...args: Parameters<typeof determinePdcaCycleState>
+): ReturnType<typeof determinePdcaCycleState> {
+  return determinePdcaCycleState(...args);
+}
+
+export function getDailyProcedureSteps(
+  ...args: Parameters<typeof toDailyProcedureSteps>
+): ReturnType<typeof toDailyProcedureSteps> {
+  return toDailyProcedureSteps(...args);
+}
+
 // --- Monitoring Bridge ---
 
 export function getMonitoringToPlanningBridge(
@@ -118,6 +142,7 @@ export type {
   WorkflowPhaseResult,
   PlanningWorkflowCardItem,
   WorkflowSeverity,
+  ReassessmentSnapshot,
   MeetingEvidenceDraft,
   MeetingEvidenceSection,
   ABCPatternSummary,

--- a/src/features/ibd/analysis/pdca/queries/usePdcaCycleState.ts
+++ b/src/features/ibd/analysis/pdca/queries/usePdcaCycleState.ts
@@ -1,11 +1,11 @@
-import { summarizeProcedureExecution } from '@/domain/bridge/monitoringEvidence';
-import { determinePdcaCycleState } from '@/domain/bridge/pdcaCycleOrchestrator';
 import {
-  determineWorkflowPhase,
+  getProcedureExecutionSummary,
+  getPdcaCycleState,
+  getPlanningWorkflowPhase,
+  getDailyProcedureSteps,
   type PlanningSheetSnapshot,
   type ReassessmentSnapshot,
-} from '@/domain/bridge/workflowPhase';
-import { toDailyProcedureSteps } from '@/domain/isp/bridge/toDailyProcedureSteps';
+} from '@/app/services/bridgeProxy';
 import type { BehaviorMonitoringRecord } from '@/domain/isp/behaviorMonitoring';
 import type {
   PlanningSheetRepository,
@@ -254,7 +254,7 @@ export function usePdcaCycleState(
       toWorkflowReassessmentSnapshot,
     );
 
-    const workflowResult = determineWorkflowPhase({
+    const workflowResult = getPlanningWorkflowPhase({
       userId,
       userName: userId,
       planningSheets: [toWorkflowSnapshot(planningSheet)],
@@ -284,7 +284,7 @@ export function usePdcaCycleState(
 
     const periodFrom = planAppliedAt ?? planCreatedAt ?? todayDate();
     const periodTo = referenceDate ?? todayDate();
-    const procedures = toDailyProcedureSteps(
+    const procedures = getDailyProcedureSteps(
       planningSheet.planning,
       planningSheet.id,
     );
@@ -292,7 +292,7 @@ export function usePdcaCycleState(
 
     const procedureCompletionRate =
       procedures.length > 0
-        ? summarizeProcedureExecution({
+        ? getProcedureExecutionSummary({
             userId,
             from: periodFrom,
             to: periodTo,
@@ -302,7 +302,7 @@ export function usePdcaCycleState(
           }).overallCompletionRate
         : null;
 
-    return determinePdcaCycleState({
+    return getPdcaCycleState({
       userId,
       planningSheetId: planningSheet.id,
       workflowPhase: workflowResult.phase,


### PR DESCRIPTION
## ## Purpose
This is the final PR for the specific file migration queue. It migrates the PDCA analysis feature to the bridgeProxy and removes the last specific file exclusion from ESLint.

## Changes
- Migrated usePdcaCycleState.ts to use bridgeProxy for PDCA state, workflow phase, and procedure summarization.
- - Expanded bridgeProxy.ts with PDCA and Monitoring analytics logic.
- - Removed the last PDCA-related file exclusion from ESLint.
## Verification
- Direct imports from @/domain/bridge/* and @/domain/isp/bridge/* in src/features/ibd/.../pdca are now forbidden and verified via ESLint.
- - PDCA cycle state logic remains intact via proxy.