### PR TITLE
refactor(infra): narrow UI-facing planning workflow types in bridgeProxy

### DIFF
--- a/src/app/services/bridgeProxy.ts
+++ b/src/app/services/bridgeProxy.ts
@@ -4,9 +4,6 @@ import {
   toPlanningWorkflowCardItem,
   type WorkflowPhase,
   type PlanningSheetSnapshot,
-  type WorkflowPhaseResult,
-  type PlanningWorkflowCardItem,
-  type WorkflowSeverity,
   type ReassessmentSnapshot,
 } from '@/domain/bridge/workflowPhase';
 import {
@@ -43,26 +40,146 @@ import {
 
 // --- 1. Workflow & Assessment ---
 // 計画策定フロー、アセスメント、進捗状態の判定
+//
+// Narrowing の原則:
+//   UI 層には「ドメインの中間表現」ではなく、画面が実際に読むプロパティだけを持つ
+//   UI 専用 interface (`PlanningWorkflowUi*`) を返す。ドメイン型 (WorkflowPhaseResult,
+//   PlanningWorkflowCardItem, WorkflowSeverity 等) はここで内部化し、UI には露出させない。
+//   これにより、ドメイン側の判定構造が変わっても UI 側は影響を受けにくくなる。
+
+/** UI 公開用の計画策定フェーズ (ドメイン WorkflowPhase の別名) */
+export type PlanningWorkflowUiPhase =
+  | 'needs_assessment'
+  | 'needs_plan'
+  | 'active_plan'
+  | 'needs_monitoring'
+  | 'monitoring_overdue'
+  | 'needs_reassessment';
+
+/** UI 公開用の深刻度 */
+export type PlanningWorkflowUiSeverity = 'info' | 'success' | 'warning' | 'danger';
+
+/**
+ * UI からフェーズ判定に渡す計画シートの最小スナップショット。
+ *
+ * ドメイン側 PlanningSheetSnapshot と structurally compatible だが、
+ * UI はこの narrow 型経由でのみ Bridge を呼ぶ。
+ */
+export interface PlanningWorkflowUiSheetSnapshot {
+  id: string;
+  status: string;
+  appliedFrom?: string | null;
+  reviewedAt?: string | null;
+  reviewCycleDays?: number;
+  procedureCount: number;
+  isCurrent?: boolean;
+}
+
+/**
+ * UI 公開用の Today カードアイテム。
+ *
+ * ドメイン PlanningWorkflowCardItem から、UI が実際に描画に使うプロパティのみに
+ * 絞っている。`priority` などの判定内部情報は含めない。
+ */
+export interface PlanningWorkflowUiCardItem {
+  userId: string;
+  userName: string;
+  phase: PlanningWorkflowUiPhase;
+  title: string;
+  subtitle: string;
+  ctaLabel: string;
+  href: string;
+  severity: PlanningWorkflowUiSeverity;
+}
+
+/** buildPlanningWorkflowUi の入力 */
+export interface PlanningWorkflowUiBuildInput {
+  users: ReadonlyArray<{ userId: string; userName: string }>;
+  sheetsByUser: ReadonlyMap<string, ReadonlyArray<PlanningWorkflowUiSheetSnapshot>>;
+  referenceDate?: string;
+}
+
+/** buildPlanningWorkflowUi の出力 */
+export interface PlanningWorkflowUiBuildResult {
+  /** priority 順にソート済みの UI 用アイテム一覧 */
+  items: PlanningWorkflowUiCardItem[];
+  /** 利用者ごとのフェーズ（集計用・未ソート） */
+  phases: ReadonlyArray<{ userId: string; phase: PlanningWorkflowUiPhase }>;
+}
+
+/**
+ * Today 用: 複数利用者のワークフローフェーズ → ソート済み UI カードアイテム一覧
+ *
+ * 内部で determineWorkflowPhase → sortByWorkflowPriority → toPlanningWorkflowCardItem
+ * を合成し、UI に渡す前に narrow 型へ射影する。UI にはドメイン中間表現が漏れない。
+ */
+export function buildPlanningWorkflowUi(
+  input: PlanningWorkflowUiBuildInput,
+): PlanningWorkflowUiBuildResult {
+  const results = input.users.map((user) =>
+    determineWorkflowPhase({
+      userId: user.userId,
+      userName: user.userName,
+      planningSheets: [...(input.sheetsByUser.get(user.userId) ?? [])],
+      reassessments: [],
+      referenceDate: input.referenceDate,
+    }),
+  );
+
+  const sorted = sortByWorkflowPriority(results);
+
+  const items: PlanningWorkflowUiCardItem[] = sorted.map((r) => {
+    const card = toPlanningWorkflowCardItem(r);
+    return {
+      userId: card.userId,
+      userName: card.userName,
+      phase: card.phase,
+      title: card.title,
+      subtitle: card.subtitle,
+      ctaLabel: card.ctaLabel,
+      href: card.href,
+      severity: card.severity,
+    };
+  });
+
+  const phases = results.map((r) => ({ userId: r.userId, phase: r.phase }));
+
+  return { items, phases };
+}
+
+/**
+ * 単一計画シートからフェーズのみを取り出す narrow 関数。
+ *
+ * SupportPlanningSheet ページの ViewModel 構築など、UI が
+ * 「今どのフェーズか」だけを知りたい場面で使う。
+ */
+export function getPlanningWorkflowPhaseForSheet(input: {
+  userId: string;
+  userName: string;
+  sheet: PlanningWorkflowUiSheetSnapshot;
+  referenceDate?: string;
+}): { phase: PlanningWorkflowUiPhase } {
+  const result = determineWorkflowPhase({
+    userId: input.userId,
+    userName: input.userName,
+    planningSheets: [input.sheet],
+    referenceDate: input.referenceDate,
+  });
+  return { phase: result.phase };
+}
+
+// --- 1b. Legacy full-shape shim (pdca 領域用) ---
+// 注意: 新規 UI コードからは buildPlanningWorkflowUi / getPlanningWorkflowPhaseForSheet
+// を使うこと。この関数は monitoring.daysRemaining など判定内部情報を必要とする
+// usePdcaCycleState 等の既存 consumer のために残している。
 
 export type GetPlanningWorkflowPhaseInput = Parameters<typeof determineWorkflowPhase>[0];
 export type GetPlanningWorkflowPhaseResult = ReturnType<typeof determineWorkflowPhase>;
 
 export function getPlanningWorkflowPhase(
-  input: GetPlanningWorkflowPhaseInput
+  input: GetPlanningWorkflowPhaseInput,
 ): GetPlanningWorkflowPhaseResult {
   return determineWorkflowPhase(input);
-}
-
-export function sortWorkflowItemsByPriority(
-  results: WorkflowPhaseResult[]
-): WorkflowPhaseResult[] {
-  return sortByWorkflowPriority(results);
-}
-
-export function getPlanningWorkflowCardItem(
-  result: WorkflowPhaseResult
-): PlanningWorkflowCardItem {
-  return toPlanningWorkflowCardItem(result);
 }
 
 // --- 2. Dashboard & Alerts ---
@@ -145,9 +262,6 @@ export type {
   MonitoringToPlanningBridge,
   WorkflowPhase,
   PlanningSheetSnapshot,
-  WorkflowPhaseResult,
-  PlanningWorkflowCardItem,
-  WorkflowSeverity,
   ReassessmentSnapshot,
   MeetingEvidenceDraft,
   MeetingEvidenceSection,

--- a/src/features/today/hooks/__tests__/useWorkflowPhases.spec.ts
+++ b/src/features/today/hooks/__tests__/useWorkflowPhases.spec.ts
@@ -10,7 +10,7 @@ import {
   countByPhase,
   toPlanningSheetSnapshot,
 } from '../useWorkflowPhases';
-import { type PlanningSheetSnapshot } from '@/app/services/bridgeProxy';
+import { type PlanningWorkflowUiSheetSnapshot } from '@/app/services/bridgeProxy';
 import type { PlanningSheetListItem } from '@/domain/isp/schema';
 
 // ─────────────────────────────────────────────
@@ -21,7 +21,7 @@ function makeUser(id: string, name: string) {
   return { userId: id, userName: name };
 }
 
-function makeSheet(overrides: Partial<PlanningSheetSnapshot> = {}): PlanningSheetSnapshot {
+function makeSheet(overrides: Partial<PlanningWorkflowUiSheetSnapshot> = {}): PlanningWorkflowUiSheetSnapshot {
   return {
     id: 'ps-1',
     status: 'active',
@@ -46,7 +46,7 @@ describe('buildWorkflowItems', () => {
       makeUser('u-3', '佐藤'),
     ];
 
-    const sheetsByUser = new Map<string, PlanningSheetSnapshot[]>([
+    const sheetsByUser = new Map<string, PlanningWorkflowUiSheetSnapshot[]>([
       // u-1: 計画シートあり → active_plan
       ['u-1', [makeSheet({ id: 'ps-1' })]],
       // u-2: 手順なし → needs_plan
@@ -54,13 +54,13 @@ describe('buildWorkflowItems', () => {
       // u-3: 計画シートなし → needs_assessment
     ]);
 
-    const { results, items } = buildWorkflowItems(users, sheetsByUser, '2026-02-15');
+    const { phases, items } = buildWorkflowItems(users, sheetsByUser, '2026-02-15');
 
-    expect(results.length).toBe(3);
+    expect(phases.length).toBe(3);
     expect(items.length).toBe(3);
 
     // 各利用者の phase が正しい
-    const phaseByUser = new Map(results.map((r) => [r.userId, r.phase]));
+    const phaseByUser = new Map(phases.map((r) => [r.userId, r.phase]));
     expect(phaseByUser.get('u-1')).toBe('active_plan');
     expect(phaseByUser.get('u-2')).toBe('needs_plan');
     expect(phaseByUser.get('u-3')).toBe('needs_assessment');
@@ -73,7 +73,7 @@ describe('buildWorkflowItems', () => {
       makeUser('u-noplan', '未実施次郎'),
     ];
 
-    const sheetsByUser = new Map<string, PlanningSheetSnapshot[]>([
+    const sheetsByUser = new Map<string, PlanningWorkflowUiSheetSnapshot[]>([
       // u-active: reviewedAt = 2026-03-20 → next due = 2026-03-20 + 90 = 2026-06-18 → safe
       ['u-active', [makeSheet({ id: 'ps-active', reviewedAt: '2026-03-20' })]],
       // u-overdue: appliedFrom = 2026-01-01 → next due = 2026-04-01 → overdue at 2026-04-10
@@ -90,17 +90,17 @@ describe('buildWorkflowItems', () => {
   });
 
   it('利用者がいない場合は空配列', () => {
-    const { results, items } = buildWorkflowItems([], new Map());
-    expect(results).toEqual([]);
+    const { phases, items } = buildWorkflowItems([], new Map());
+    expect(phases).toEqual([]);
     expect(items).toEqual([]);
   });
 
   it('計画シートがない利用者も needs_assessment として扱える', () => {
     const users = [makeUser('u-new', '新規利用者')];
-    const { results } = buildWorkflowItems(users, new Map(), '2026-03-14');
+    const { phases } = buildWorkflowItems(users, new Map(), '2026-03-14');
 
-    expect(results[0].phase).toBe('needs_assessment');
-    expect(results[0].userId).toBe('u-new');
+    expect(phases[0].phase).toBe('needs_assessment');
+    expect(phases[0].userId).toBe('u-new');
   });
 
   it('topPriorityItem が最上位になる', () => {
@@ -109,7 +109,7 @@ describe('buildWorkflowItems', () => {
       makeUser('u-2', '超過'),
     ];
 
-    const sheetsByUser = new Map<string, PlanningSheetSnapshot[]>([
+    const sheetsByUser = new Map<string, PlanningWorkflowUiSheetSnapshot[]>([
       ['u-1', [makeSheet()]],
       ['u-2', [makeSheet({ id: 'ps-2' })]],
     ]);
@@ -134,7 +134,7 @@ describe('countByPhase', () => {
       makeUser('u-5', 'E'),
     ];
 
-    const sheetsByUser = new Map<string, PlanningSheetSnapshot[]>([
+    const sheetsByUser = new Map<string, PlanningWorkflowUiSheetSnapshot[]>([
       ['u-1', [makeSheet()]],                                     // active_plan
       ['u-2', [makeSheet({ id: 'ps-2', procedureCount: 0 })]],    // needs_plan
       // u-3: なし → needs_assessment
@@ -144,8 +144,8 @@ describe('countByPhase', () => {
 
     // 2人の referenceDate を分けたいが buildWorkflowItems は全体に1つ
     // → まず overdue を確認
-    const { results } = buildWorkflowItems(users, sheetsByUser, '2026-04-10');
-    const counts = countByPhase(results);
+    const { phases } = buildWorkflowItems(users, sheetsByUser, '2026-04-10');
+    const counts = countByPhase(phases);
 
     // u-1, u-4, u-5 は全部 overdue (ref: 2026-04-10)
     // u-2 は needs_plan

--- a/src/features/today/hooks/useWorkflowPhases.ts
+++ b/src/features/today/hooks/useWorkflowPhases.ts
@@ -22,13 +22,10 @@ import type { PlanningSheetRepository } from '@/domain/isp/port';
 import type { PlanningSheetListItem } from '@/domain/isp/schema';
 import type { IUserMaster } from '@/sharepoint/fields';
 import {
-  getPlanningWorkflowPhase,
-  sortWorkflowItemsByPriority,
-  getPlanningWorkflowCardItem,
-  type PlanningSheetSnapshot,
-  type WorkflowPhaseResult,
-  type PlanningWorkflowCardItem,
-  type WorkflowPhase,
+  buildPlanningWorkflowUi,
+  type PlanningWorkflowUiSheetSnapshot,
+  type PlanningWorkflowUiCardItem,
+  type PlanningWorkflowUiPhase,
 } from '@/app/services/bridgeProxy';
 
 // ─────────────────────────────────────────────
@@ -46,23 +43,23 @@ export interface WorkflowPhaseCounts {
 
 export interface UseWorkflowPhasesResult {
   /** ソート済み UI 用アイテム一覧 */
-  items: PlanningWorkflowCardItem[];
+  items: PlanningWorkflowUiCardItem[];
   /** フェーズ別件数 */
   counts: WorkflowPhaseCounts;
   /** 最優先アイテム（優先度が最も高い） */
-  topPriorityItem?: PlanningWorkflowCardItem;
+  topPriorityItem?: PlanningWorkflowUiCardItem;
   /** 読み込み中 */
   isLoading: boolean;
-  /** 全件の生データ（テスト用） */
-  _rawResults: WorkflowPhaseResult[];
+  /** 利用者ごとのフェーズ（テスト用 — 未ソート） */
+  _phasesByUser: ReadonlyArray<{ userId: string; phase: PlanningWorkflowUiPhase }>;
 }
 
 // ─────────────────────────────────────────────
-// Adapter: PlanningSheetListItem → PlanningSheetSnapshot
+// Adapter: PlanningSheetListItem → PlanningWorkflowUiSheetSnapshot
 // ─────────────────────────────────────────────
 
 /**
- * PlanningSheetListItem を PlanningSheetSnapshot に変換する。
+ * PlanningSheetListItem を UI 向け最小スナップショットに変換する。
  *
  * repository から取得したリスト型を、workflowPhase 判定用の軽量型に変換。
  * procedureCount は PlanningSheetListItem に含まれないため、
@@ -71,7 +68,7 @@ export interface UseWorkflowPhasesResult {
 export function toPlanningSheetSnapshot(
   item: PlanningSheetListItem,
   procedureCount?: number,
-): PlanningSheetSnapshot {
+): PlanningWorkflowUiSheetSnapshot {
   return {
     id: item.id,
     status: item.status,
@@ -87,7 +84,7 @@ export function toPlanningSheetSnapshot(
 // Pure counting helper (testable)
 // ─────────────────────────────────────────────
 
-const PHASE_COUNT_KEYS: Record<WorkflowPhase, keyof WorkflowPhaseCounts> = {
+const PHASE_COUNT_KEYS: Record<PlanningWorkflowUiPhase, keyof WorkflowPhaseCounts> = {
   needs_assessment: 'needsAssessment',
   needs_plan: 'needsPlan',
   monitoring_overdue: 'monitoringOverdue',
@@ -97,9 +94,11 @@ const PHASE_COUNT_KEYS: Record<WorkflowPhase, keyof WorkflowPhaseCounts> = {
 };
 
 /**
- * WorkflowPhaseResult[] からフェーズ別件数を集計する。
+ * 利用者ごとの phase からフェーズ別件数を集計する。
  */
-export function countByPhase(results: WorkflowPhaseResult[]): WorkflowPhaseCounts {
+export function countByPhase(
+  phases: ReadonlyArray<{ phase: PlanningWorkflowUiPhase }>,
+): WorkflowPhaseCounts {
   const counts: WorkflowPhaseCounts = {
     needsAssessment: 0,
     needsPlan: 0,
@@ -109,7 +108,7 @@ export function countByPhase(results: WorkflowPhaseResult[]): WorkflowPhaseCount
     activePlan: 0,
   };
 
-  for (const r of results) {
+  for (const r of phases) {
     const key = PHASE_COUNT_KEYS[r.phase];
     if (key) counts[key]++;
   }
@@ -124,32 +123,23 @@ export function countByPhase(results: WorkflowPhaseResult[]): WorkflowPhaseCount
 /**
  * 利用者データ + 計画シートデータ → ソート済みカードアイテム一覧
  *
- * React 非依存の純関数パイプライン。テスト可能。
+ * Bridge の buildPlanningWorkflowUi を呼ぶだけの薄いラッパー。
+ * 旧 API 互換のため {phases, items} の組を返す。
  */
 export function buildWorkflowItems(
   users: Array<{ userId: string; userName: string }>,
-  sheetsByUser: Map<string, PlanningSheetSnapshot[]>,
+  sheetsByUser: Map<string, PlanningWorkflowUiSheetSnapshot[]>,
   referenceDate?: string,
-): { results: WorkflowPhaseResult[]; items: PlanningWorkflowCardItem[] } {
-  // 1. 各利用者のフェーズ判定
-  const results: WorkflowPhaseResult[] = users.map((user) => {
-    const input = {
-      userId: user.userId,
-      userName: user.userName,
-      planningSheets: sheetsByUser.get(user.userId) ?? [],
-      reassessments: [], // 将来拡張
-      referenceDate,
-    };
-    return getPlanningWorkflowPhase(input);
+): {
+  phases: ReadonlyArray<{ userId: string; phase: PlanningWorkflowUiPhase }>;
+  items: PlanningWorkflowUiCardItem[];
+} {
+  const { items, phases } = buildPlanningWorkflowUi({
+    users,
+    sheetsByUser,
+    referenceDate,
   });
-
-  // 2. priority 順ソート
-  const sorted = sortWorkflowItemsByPriority(results);
-
-  // 3. UI 用アイテムに変換
-  const items = sorted.map(getPlanningWorkflowCardItem);
-
-  return { results, items };
+  return { phases, items };
 }
 
 // ─────────────────────────────────────────────
@@ -166,7 +156,7 @@ export function useWorkflowPhases(
   users: IUserMaster[],
   repo: PlanningSheetRepository | null,
 ): UseWorkflowPhasesResult {
-  const [sheetsByUser, setSheetsByUser] = useState<Map<string, PlanningSheetSnapshot[]>>(new Map());
+  const [sheetsByUser, setSheetsByUser] = useState<Map<string, PlanningWorkflowUiSheetSnapshot[]>>(new Map());
   const [isLoading, setIsLoading] = useState(false);
 
   // 利用者の userId + userName を安定化
@@ -190,7 +180,7 @@ export function useWorkflowPhases(
     setIsLoading(true);
 
     (async () => {
-      const map = new Map<string, PlanningSheetSnapshot[]>();
+      const map = new Map<string, PlanningWorkflowUiSheetSnapshot[]>();
 
       // 並列で取得（パフォーマンス重視）
       const results = await Promise.allSettled(
@@ -221,16 +211,16 @@ export function useWorkflowPhases(
 
   // パイプライン実行 + メモ化
   return useMemo(() => {
-    const { results, items } = buildWorkflowItems(userEntries, sheetsByUser);
-    const counts = countByPhase(results);
-    const topPriorityItem = items[0]; // sortByWorkflowPriority 済み
+    const { phases, items } = buildWorkflowItems(userEntries, sheetsByUser);
+    const counts = countByPhase(phases);
+    const topPriorityItem = items[0]; // buildPlanningWorkflowUi 内でソート済み
 
     return {
       items,
       counts,
       topPriorityItem,
       isLoading,
-      _rawResults: results,
+      _phasesByUser: phases,
     };
   }, [userEntries, sheetsByUser, isLoading]);
 }

--- a/src/features/today/widgets/PlanningWorkflowCard.tsx
+++ b/src/features/today/widgets/PlanningWorkflowCard.tsx
@@ -13,7 +13,10 @@
  * @see src/domain/bridge/workflowPhase.ts
  */
 import { motionTokens } from '@/app/theme';
-import { type PlanningWorkflowCardItem, type WorkflowSeverity } from '@/app/services/bridgeProxy';
+import {
+  type PlanningWorkflowUiCardItem,
+  type PlanningWorkflowUiSeverity,
+} from '@/app/services/bridgeProxy';
 import type { WorkflowPhaseCounts } from '@/features/today/hooks/useWorkflowPhases';
 import AssignmentLateIcon from '@mui/icons-material/AssignmentLate';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
@@ -34,7 +37,7 @@ import React from 'react';
 const DEFAULT_MAX_ITEMS = 5;
 
 /** severity → 色マッピング */
-const SEVERITY_COLORS: Record<WorkflowSeverity, { bg: string; text: string; border: string }> = {
+const SEVERITY_COLORS: Record<PlanningWorkflowUiSeverity, { bg: string; text: string; border: string }> = {
   danger: { bg: 'rgba(229, 57, 53, 0.12)', text: '#e53935', border: '#e53935' },
   warning: { bg: 'rgba(245, 124, 0, 0.12)', text: '#f57c00', border: '#f57c00' },
   info: { bg: 'rgba(25, 118, 210, 0.12)', text: '#1976d2', border: '#1976d2' },
@@ -42,7 +45,7 @@ const SEVERITY_COLORS: Record<WorkflowSeverity, { bg: string; text: string; bord
 };
 
 /** severity → emoji */
-const SEVERITY_EMOJI: Record<WorkflowSeverity, string> = {
+const SEVERITY_EMOJI: Record<PlanningWorkflowUiSeverity, string> = {
   danger: '🔴',
   warning: '🟡',
   info: '🔵',
@@ -53,11 +56,11 @@ const SEVERITY_EMOJI: Record<WorkflowSeverity, string> = {
 
 export interface PlanningWorkflowCardProps {
   /** ソート済みアイテム一覧 */
-  items: PlanningWorkflowCardItem[];
+  items: PlanningWorkflowUiCardItem[];
   /** フェーズ別件数 */
   counts: WorkflowPhaseCounts;
   /** 最優先アイテム */
-  topPriorityItem?: PlanningWorkflowCardItem;
+  topPriorityItem?: PlanningWorkflowUiCardItem;
   /** 最大表示件数 */
   maxItems?: number;
   /** CTA クリック時のナビゲーション */
@@ -130,7 +133,7 @@ function WorkflowItemRow({
   item,
   onNavigate,
 }: {
-  item: PlanningWorkflowCardItem;
+  item: PlanningWorkflowUiCardItem;
   onNavigate?: (href: string) => void;
 }) {
   const colors = SEVERITY_COLORS[item.severity];

--- a/src/pages/support-planning-sheet/hooks/supportPlanningSheetViewModelMapper.ts
+++ b/src/pages/support-planning-sheet/hooks/supportPlanningSheetViewModelMapper.ts
@@ -1,4 +1,7 @@
-import { getPlanningWorkflowPhase, type MonitoringToPlanningBridge } from '@/app/services/bridgeProxy';
+import {
+  getPlanningWorkflowPhaseForSheet,
+  type MonitoringToPlanningBridge,
+} from '@/app/services/bridgeProxy';
 import type { SupportPlanningSheet } from '@/domain/isp/schema';
 import type { SupportPlanningSheetViewModel } from '../types';
 import type { SupportPlanningSheetUiState } from './useSupportPlanningSheetUiState';
@@ -97,10 +100,10 @@ export function mapToSupportPlanningSheetViewModel(input: MapperInput): SupportP
   const allProvenanceEntries = [...persistedProvenance, ...uiState.sessionProvenance];
 
   // 2. ワークフローフェーズの判定（派生データ）
-  const workflowResult = getPlanningWorkflowPhase({
+  const workflowResult = getPlanningWorkflowPhaseForSheet({
     userId: sheet.userId,
-    userName: sheet.title, 
-    planningSheets: [{
+    userName: sheet.title,
+    sheet: {
       id: sheet.id,
       status: sheet.status,
       appliedFrom: sheet.supportStartDate ?? null,
@@ -108,7 +111,7 @@ export function mapToSupportPlanningSheetViewModel(input: MapperInput): SupportP
       reviewCycleDays: sheet.monitoringCycleDays ?? 90,
       procedureCount: sheet.planning?.procedureSteps?.length ?? 0,
       isCurrent: true,
-    }],
+    },
   });
 
   return {


### PR DESCRIPTION
## Summary
Bridge デカップリング (#1478–#1482) に続く「型境界の硬化」第一弾。Planning workflow 系のみを対象に、UI が受け取るデータ契約を最小化する。

- `bridgeProxy.ts` に UI 専用 narrow 型 `PlanningWorkflowUi*` を追加
- 合成関数 `buildPlanningWorkflowUi` / `getPlanningWorkflowPhaseForSheet` を追加 (determine → sort → cardMap を内部化し、UI には narrow 型だけを返す)
- Today の `useWorkflowPhases` / `PlanningWorkflowCard`、Support Planning Sheet の ViewModel mapper を narrow 型に追随
- ドメイン中間型 (`WorkflowPhaseResult`, `PlanningWorkflowCardItem`, `WorkflowSeverity`) の UI への漏洩を停止

## Background
#1482 まででUI → Bridge の**物理的な依存**は `bridgeProxy.ts` に集約済みだが、`ReturnType<typeof ...>` 経由でドメイン型がそのまま UI に流れており、`priority` / `monitoring.daysRemaining` / `details.*` など UI が読まないフィールドまで到達していた。本 PR は UI が実際に描画に使うプロパティだけを公開するよう narrowing する。

## Scope
- 対象: Planning workflow 系のみ
- 含める consumer:
  - `features/today/hooks/useWorkflowPhases.ts`
  - `features/today/widgets/PlanningWorkflowCard.tsx`
  - `pages/support-planning-sheet/hooks/supportPlanningSheetViewModelMapper.ts`
- **out of scope**:
  - Monitoring / PDCA / Today 他領域
  - `bridgeProxy.ts` の物理分割
  - ドメインロジック変更、UI 挙動変更
- `usePdcaCycleState.ts` は `monitoring.daysRemaining` 等の判定内部情報を必要とするため、`getPlanningWorkflowPhase` + `WorkflowPhase` / `PlanningSheetSnapshot` / `ReassessmentSnapshot` の再 export は **Legacy full-shape shim** として明示コメント付きで残す。

## Non-functional
- ロジック値の変更なし (既存ドメイン関数 `determineWorkflowPhase` → `sortByWorkflowPriority` → `toPlanningWorkflowCardItem` を同順で呼ぶ薄い合成関数)
- UI 描画・テキスト・遷移先に変更なし
- 型境界の縮退のみ
- 公開 API の削除は unused シンボルのみ (`sortWorkflowItemsByPriority`, `getPlanningWorkflowCardItem`, `WorkflowPhaseResult` / `PlanningWorkflowCardItem` / `WorkflowSeverity` の re-export)

## Test plan
- [x] `useWorkflowPhases.spec.ts` 9/9 passed
- [x] `features/today` + `pages/support-planning-sheet` 606/606 passed
- [x] touched files の `tsc --noEmit` clean
- [x] touched files の ESLint clean
- [ ] CI 全体 green
- [ ] Today ページで支援計画管理カードの表示・ソート・CTA 動作確認
- [ ] Support Planning Sheet ページで `currentPhase` が従来通り表示される

## Review Focus
1. **UI 実消費プロパティだけに narrow できているか** — `PlanningWorkflowUiCardItem` の 8 プロパティが UI 側で全て使われ、かつそれ以上含まれていないか
2. **合成関数が既存ロジックを保っているか** — `buildPlanningWorkflowUi` 内の determine → sort → cardMap の順序・引数が変わっていないこと
3. **PDCA shim の残置理由が妥当か** — `usePdcaCycleState` が `monitoring.daysRemaining` 等を参照しているため、今回の narrow 化対象から外したことの妥当性
4. **narrow 化パターンが今後横展開可能か** — 同じ pattern (narrow 型 + 合成関数) を Monitoring / PDCA / Today 他領域に再利用できる形か
5. **consumer の追随漏れ** — 4 ファイル以外に `PlanningWorkflowCardItem` / `WorkflowPhaseResult` / `WorkflowSeverity` を直接参照する UI コードが残っていないか

## Risk / Rollback
- 単一コミットで `git revert` 可能
- 1 ファイル (`bridgeProxy.ts`) + 4 consumer の範囲に閉じており、部分ロールバックも容易
- DB / 永続化 / 外部 I/F への影響なし (型レイヤーのみ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)