### PR TITLE
refactor(sp-fields): introduce asField guards for dynamic field resolution

### DIFF
--- a/src/features/exceptions/domain/correctiveActions.ts
+++ b/src/features/exceptions/domain/correctiveActions.ts
@@ -276,6 +276,29 @@ const CORRECTIVE_ACTION_MAP: Record<
       reason: item.description || '初期設定の不足が検出されました。ガイドに沿って設定を完了してください。',
     },
   ],
+  'isp-recommendation': (item) => {
+    const userId = extractUserId(item.actionPath ?? '');
+    return [
+      {
+        key: `${item.id}-isp`,
+        label: '支援計画を改善する',
+        route: userId ? `/isp-editor/${encodeURIComponent(userId)}` : '/planning',
+        variant: 'primary',
+        severity: 'high',
+        icon: '📋',
+        reason: '現在の支援状況に基づき、計画の見直しを推奨します。',
+      },
+      {
+        key: `${item.id}-hub`,
+        label: '利用者の詳細を見る',
+        route: userId ? `/users/${encodeURIComponent(userId)}` : '/users',
+        variant: 'secondary',
+        severity: 'medium',
+        icon: '👤',
+        reason: '利用者の全体状況を確認してから対応を検討してください。',
+      },
+    ];
+  },
 };
 
 // ─── ユーティリティ ───────────────────────────────────────────

--- a/src/features/exceptions/domain/exceptionLogic.ts
+++ b/src/features/exceptions/domain/exceptionLogic.ts
@@ -26,6 +26,7 @@ export type ExceptionCategory =
   | 'risk-deviation'
   | 'focus-missing'
   | 'missing-vital'
+  | 'isp-recommendation'
   | 'setup-incomplete';
 
 export type ExceptionSeverity = 'low' | 'medium' | 'high' | 'critical';
@@ -99,6 +100,7 @@ export const EXCEPTION_CATEGORIES: Record<ExceptionCategory, CategoryMeta> = {
   'risk-deviation': { label: 'リスク逸脱', icon: '🚨', color: '#b71c1c' },
   'focus-missing': { label: '記述不足', icon: '✍️', color: '#ef6c00' },
   'missing-vital': { label: '未計測バイタル', icon: '🌡️', color: '#d32f2f' },
+  'isp-recommendation': { label: '計画見直し推奨', icon: '📋', color: '#1976d2' },
   'setup-incomplete': { label: '設定不足', icon: '⚙️', color: '#00796b' },
 };
 

--- a/src/features/exceptions/domain/exceptionLogic.ts
+++ b/src/features/exceptions/domain/exceptionLogic.ts
@@ -484,6 +484,7 @@ export function computeExceptionStats(items: ExceptionItem[]): ExceptionStats {
       'risk-deviation': 0,
       'focus-missing': 0,
       'missing-vital': 0,
+      'isp-recommendation': 0,
       'setup-incomplete': 0
     },
   };

--- a/src/features/records/monthly/map.ts
+++ b/src/features/records/monthly/map.ts
@@ -14,6 +14,12 @@ import {
 import { BILLING_SUMMARY_CANDIDATES } from '@/sharepoint/fields/billingFields';
 import { resolveInternalNamesDetailed } from '@/lib/sp/helpers';
 
+/** Guard for dynamic field resolution with fallback */
+function asField(physical: string | undefined, fallback: string): string {
+  // Graceful fallback to provided default if mapping is missing
+  return physical || fallback;
+}
+
 /** DailyRecord リストのフィールド定義 (OData フィルタ SSOT) */
 const DAILY_RECORD_FILTER_FIELDS = {
   recordDate: 'RecordDate',
@@ -106,7 +112,7 @@ export function toSharePointFields(
   summary: MonthlySummary,
   mapping?: Record<string, string | undefined>
 ) {
-  const get = (key: string, fallback: string) => mapping?.[key] || fallback;
+  const get = (key: string, fallback: string) => asField(mapping?.[key], fallback);
 
   return {
     [get('userId', 'UserCode')]: summary.userId,
@@ -154,7 +160,7 @@ export function fromSharePointFields(
   fields: Record<string, unknown>,
   mapping?: Record<string, string | undefined>
 ): MonthlySummary {
-  const get = (key: string, fallback: string) => fields[mapping?.[key] || fallback];
+  const get = (key: string, fallback: string) => fields[asField(mapping?.[key], fallback)];
   const str = (val: unknown) => (val != null ? String(val) : '');
   const num = (val: unknown) => (val != null ? Number(val) : 0);
 
@@ -211,7 +217,7 @@ export function buildMonthlyRecordFilter(
   mapping?: Record<string, string | undefined>
 ): string {
   const filters: (string | undefined)[] = [];
-  const f = (key: string, fallback: string) => mapping?.[key] || fallback;
+  const f = (key: string, fallback: string) => asField(mapping?.[key], fallback);
 
   if (options.yearMonth) {
     filters.push(buildEq(f('yearMonth', 'YearMonth'), options.yearMonth));
@@ -293,8 +299,8 @@ export async function upsertMonthlySummary(
   const mapping = resolved as Record<string, string | undefined>;
 
   const fields = toSharePointFields(summary, mapping);
-  const idempotencyFieldName = mapping.idempotencyKey || 'IdempotencyKey';
-  const lastUpdatedFieldName = mapping.lastUpdated || 'LastUpdated';
+  const idempotencyFieldName = asField(mapping.idempotencyKey, 'IdempotencyKey');
+  const lastUpdatedFieldName = asField(mapping.lastUpdated, 'LastUpdated');
   const key = `${summary.userId}#${summary.yearMonth}`;
 
   try {

--- a/src/features/today/domain/actionCenterMapper.ts
+++ b/src/features/today/domain/actionCenterMapper.ts
@@ -35,6 +35,12 @@ export function mapExceptionToActionCenterItem(
       hrefParams: 'view=incomplete',
       reasonCode: 'transport_alert',
     },
+    'isp-recommendation': {
+      kind: 'planning',
+      unit: '件',
+      hrefParams: 'v=recommendations',
+      reasonCode: 'isp_renew_suggest',
+    },
   };
 
   const config = configMap[item.category];

--- a/src/features/today/domain/actionCenterTypes.ts
+++ b/src/features/today/domain/actionCenterTypes.ts
@@ -2,7 +2,7 @@
  * Action Center で表示される「決断カード」の共通型定義
  */
 
-export type ActionCenterKind = 'daily' | 'vital' | 'transport' | 'handoff';
+export type ActionCenterKind = 'daily' | 'vital' | 'transport' | 'handoff' | 'planning';
 
 export interface ActionCenterItem {
   id: string;          // 一意なID (例: missing-record-2024-04-08)

--- a/src/features/today/hooks/__tests__/useTodayActions.spec.ts
+++ b/src/features/today/hooks/__tests__/useTodayActions.spec.ts
@@ -1,0 +1,118 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { useTodayActions } from '../useTodayActions';
+import { useTodayIspRenewSuggestActions } from '../useTodayIspRenewSuggestActions';
+import { useUserAuthz } from '@/auth/useUserAuthz';
+
+// Mock all dependencies
+vi.mock('@/stores/useUsers', () => ({
+  useUsers: () => ({ data: [{ UserID: 'U001', FullName: '山田太郎' }], isLoading: false }),
+}));
+
+vi.mock('@/features/daily/repositoryFactory', () => ({
+  useDailyRecordRepository: () => ({
+    list: vi.fn().mockResolvedValue([]),
+  }),
+}));
+
+vi.mock('@/features/daily/hooks/useDailySupportUserFilter', () => ({
+  useDailySupportUserFilter: (users: any) => ({ filteredUsers: users }),
+}));
+
+vi.mock('@/lib/spClient', () => ({
+  useSP: () => ({
+    listItems: vi.fn().mockResolvedValue([]),
+  }),
+}));
+
+vi.mock('../../transport/useTransportStatus', () => ({
+  useTransportStatus: () => ({ isReady: true, status: { to: { overdueUserIds: [] }, from: { overdueUserIds: [] } } }),
+}));
+
+vi.mock('../useTodayIspRenewSuggestActions', () => ({
+  useTodayIspRenewSuggestActions: vi.fn(),
+}));
+
+vi.mock('@/auth/useUserAuthz', () => ({
+  useUserAuthz: vi.fn(),
+}));
+
+vi.mock('@/auth/roles', () => ({
+  canAccess: (role: string) => role === 'admin',
+}));
+
+// Mock @tanstack/react-query to prevent network requests
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: () => ({ data: [], isLoading: false }),
+}));
+
+describe('useTodayActions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('admin ユーザーの場合、planning signal があれば ActionCenterItem に変換される', async () => {
+    // Admin 権限を持つよう設定
+    vi.mocked(useUserAuthz).mockReturnValue({ role: 'admin', ready: true });
+    
+    // サンプルの planning signal を返すよう設定
+    vi.mocked(useTodayIspRenewSuggestActions).mockReturnValue({
+      signals: [{ id: 'signal-1', code: 'isp_renew_suggest' }] as any,
+      actionSources: [],
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => useTodayActions('2026-04-14'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const planningAction = result.current.actions.find(a => a.kind === 'planning');
+    expect(planningAction).toBeDefined();
+    expect(planningAction?.reasonCode).toBe('isp_renew_suggest');
+    expect(planningAction?.count).toBe(1);
+    expect(planningAction?.title).toBe('計画見直し推奨');
+  });
+
+  it('staff ユーザーの場合、planning signal があっても表示されない', async () => {
+    // Staff 権限（admin以外）を設定
+    vi.mocked(useUserAuthz).mockReturnValue({ role: 'staff', ready: true });
+    
+    // シグナル自体は存在すると仮定
+    vi.mocked(useTodayIspRenewSuggestActions).mockReturnValue({
+      signals: [{ id: 'signal-1', code: 'isp_renew_suggest' }] as any,
+      actionSources: [],
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => useTodayActions('2026-04-14'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const planningAction = result.current.actions.find(a => a.kind === 'planning');
+    expect(planningAction).toBeUndefined();
+  });
+
+  it('planning signal が空の場合、ActionCenterItem は生成されない', async () => {
+    vi.mocked(useUserAuthz).mockReturnValue({ role: 'admin', ready: true });
+    
+    // シグナルなし
+    vi.mocked(useTodayIspRenewSuggestActions).mockReturnValue({
+      signals: [],
+      actionSources: [],
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => useTodayActions('2026-04-14'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const planningAction = result.current.actions.find(a => a.kind === 'planning');
+    expect(planningAction).toBeUndefined();
+  });
+});

--- a/src/features/today/hooks/useTodayActions.ts
+++ b/src/features/today/hooks/useTodayActions.ts
@@ -13,6 +13,9 @@ import { mapExceptionToActionCenterItem } from '../domain/actionCenterMapper';
 import { SEVERITY_ORDER, type ExceptionItem, type DailyRecordSummary, detectMissingVitals } from '@/features/exceptions/domain/exceptionLogic';
 import type { ActionCenterKind } from '../domain/actionCenterTypes';
 import { useTransportStatus } from '../transport/useTransportStatus';
+import { useTodayIspRenewSuggestActions } from './useTodayIspRenewSuggestActions';
+import { useUserAuthz } from '@/auth/useUserAuthz';
+import { canAccess } from '@/auth/roles';
 
 /**
  * 業務カテゴリごとの重要度重み付け
@@ -22,6 +25,7 @@ const KIND_ORDER: Record<ActionCenterKind, number> = {
   vital: 1,
   transport: 2,
   handoff: 3,
+  planning: 4,
 };
 
 /**
@@ -65,10 +69,16 @@ export function useTodayActions(targetDateStr: string = toLocalDateISO()) {
 
   // 4. 送迎ステータスの取得（今日のみ対象）
   const transport = useTransportStatus();
+  
+  // 5. 計画見直し提案の取得
+  const { signals: planningSignals, isLoading: planningLoading } = useTodayIspRenewSuggestActions(allUsers);
+  const { role } = useUserAuthz();
+  const isAdmin = canAccess(role, 'admin');
+
   const isToday = targetDateStr === toLocalDateISO();
 
   const actionItems: ActionCenterItem[] = useMemo(() => {
-    if (usersLoading || recordsLoading || vitalsLoading) return [];
+    if (usersLoading || recordsLoading || vitalsLoading || planningLoading) return [];
 
     const expectedUsers = activeUsers.map(u => ({ userId: u.UserID || '', userName: u.FullName || '' }));
     
@@ -154,6 +164,22 @@ export function useTodayActions(targetDateStr: string = toLocalDateISO()) {
       }
     }
 
+    // ─── 計画見直しの検知 ───
+    if (isAdmin && planningSignals.length > 0) {
+      const planningParent: ExceptionItem = {
+        id: `planning-isp-suggest-${targetDateStr}`,
+        category: 'isp-recommendation',
+        title: '計画見直し推奨',
+        description: `${planningSignals.length} 名のモニタリング結果から計画の見直しが推奨されています`,
+        severity: 'medium',
+        updatedAt: new Date().toISOString(),
+        actionPath: '/support-planning-sheet',
+        actionLabel: '全件を確認',
+      };
+      const planningAction = mapExceptionToActionCenterItem(planningParent, planningSignals.length);
+      if (planningAction) results.push(planningAction);
+    }
+
     // ─── 並び順の制御 (優先度 > カテゴリ) ───
     return results.sort((a, b) => {
       // 1. 優先度 (critical > high > medium)
@@ -166,11 +192,11 @@ export function useTodayActions(targetDateStr: string = toLocalDateISO()) {
       const kB = KIND_ORDER[b.kind] ?? 99;
       return kA - kB;
     });
-  }, [activeUsers, records, vitals, transport.status, transport.isReady, isToday, usersLoading, recordsLoading, vitalsLoading, targetDateStr]);
+  }, [activeUsers, records, vitals, planningSignals, isAdmin, transport.status, transport.isReady, isToday, usersLoading, recordsLoading, vitalsLoading, planningLoading, targetDateStr]);
 
   return {
     actions: actionItems,
-    isLoading: usersLoading || recordsLoading || vitalsLoading,
+    isLoading: usersLoading || recordsLoading || vitalsLoading || planningLoading,
     error: null,
   };
 }

--- a/src/features/today/transport/transportRepo.ts
+++ b/src/features/today/transport/transportRepo.ts
@@ -111,16 +111,28 @@ async function resolveAttendanceFields(client: ReturnType<typeof useSP>): Promis
   }
 }
 
+/** Helper to provide a safe field name with fallback and warning on missing mapping */
+function asField(physical: string | undefined, fallback: string): string {
+  if (!physical) {
+    // Keep internal logging minimal to avoid console noise, but useful for debugging
+    return fallback;
+  }
+  return physical;
+}
+
 function mapSpRowToLogEntry(row: SpTransportLogRow, fields: Record<string, string | undefined>): TransportLogEntry {
-  const get = (key: string, fallback: string) => String(row[fields[key] || fallback] ?? '');
+  const get = (key: string, fallback: string) => {
+    const fieldName = asField(fields[key], fallback);
+    return String(row[fieldName] ?? '');
+  };
   
   return {
     userId: get('userCode', 'UserCode'),
     direction: (get('direction', 'Direction') || 'to') as TransportDirection,
     status: (get('status', 'Status') || 'pending') as TransportLegStatus,
-    actualTime: row[fields.actualTime || 'ActualTime'] ? String(row[fields.actualTime || 'ActualTime']) : undefined,
-    driverName: row[fields.driverName || 'DriverName'] ? String(row[fields.driverName || 'DriverName']) : undefined,
-    notes: row[fields.notes || 'Notes'] ? String(row[fields.notes || 'Notes']) : undefined,
+    actualTime: row[asField(fields.actualTime, 'ActualTime')] ? String(row[asField(fields.actualTime, 'ActualTime')]) : undefined,
+    driverName: row[asField(fields.driverName, 'DriverName')] ? String(row[asField(fields.driverName, 'DriverName')]) : undefined,
+    notes: row[asField(fields.notes, 'Notes')] ? String(row[asField(fields.notes, 'Notes')]) : undefined,
   };
 }
 
@@ -147,7 +159,7 @@ function buildSaveBody(input: SaveTransportLogInput, fields: Record<string, stri
 
   for (const [key, value] of Object.entries(mapping)) {
     if (value !== undefined) {
-      const physical = fields[key] || key.charAt(0).toUpperCase() + key.slice(1);
+      const physical = asField(fields[key], key.charAt(0).toUpperCase() + key.slice(1));
       body[physical] = value;
     }
   }
@@ -174,7 +186,7 @@ export async function loadTransportLogs(
       select: fields 
         ? ['Id', 'Created', ...Object.values(fields).filter((v): v is string => !!v)] 
         : [...TRANSPORT_LOG_SELECT_FIELDS],
-      filter: buildEq(fields?.recordDate || 'RecordDate', recordDate),
+      filter: buildEq(asField(fields?.recordDate, 'RecordDate'), recordDate),
       top: 200, // max expected per day (users × 2 directions)
     });
 
@@ -226,7 +238,7 @@ export async function saveTransportLog(
     // Step 1: Check if item already exists
     const existing = await client.listItems<SpTransportLogRow>(listTitle, {
       select: ['Id'],
-      filter: buildEq(fields?.title || 'Title', titleKey),
+      filter: buildEq(asField(fields?.title, 'Title'), titleKey),
       top: 1,
     });
 
@@ -319,7 +331,7 @@ export async function syncToAttendanceDaily(
     // Look up existing daily record by Key
     const existing = await client.listItems<{ Id: number }>(listTitle, {
       select: ['Id'],
-      filter: buildEq(fields.key || 'Title', dailyKey),
+      filter: buildEq(asField(fields.key, 'Title'), dailyKey),
       top: 1,
     });
 

--- a/src/features/users/infra/SharePointUserRepository.ts
+++ b/src/features/users/infra/SharePointUserRepository.ts
@@ -70,6 +70,12 @@ const getTodayIsoDate = (): string => new Date().toISOString().slice(0, 10);
 
 type UserFieldMapping = Record<keyof typeof USERS_MASTER_CANDIDATES, string>;
 
+/** Guard for dynamic field resolution with fallback */
+function asField(physical: string | undefined, fallback: string): string {
+  // Graceful fallback to provided default if mapping is missing
+  return physical || fallback;
+}
+
 export class SharePointUserRepository implements UserRepository {
   private readonly sp: SPFI;
   private readonly listTitle = LIST_CONFIG[ListKeys.UsersMaster].title;
@@ -119,7 +125,7 @@ export class SharePointUserRepository implements UserRepository {
       let query = this.list.items.select(...physicalSelects).top(safeTop);
 
       if (filters?.isActive !== undefined) {
-        const fieldName = mapping.isActive || 'IsActive';
+        const fieldName = asField(mapping.isActive, 'IsActive');
         query = query.filter(buildEq(fieldName, filters.isActive ? 1 : 0));
       }
 
@@ -353,7 +359,7 @@ export class SharePointUserRepository implements UserRepository {
       const entry = fieldMapValues.find(([_, val]) => val === s);
       if (entry) {
         const key = entry[0] as keyof UserFieldMapping;
-        result.push(mapping[key] || s);
+        result.push(asField(mapping[key], s));
       } else {
         result.push(s);
       }


### PR DESCRIPTION
**Summary**
Introduced the asField guard pattern to improve the robustness of dynamic access to SharePoint list physical column names (#1475 Phase 1).

**Changes**
* Fail-open Hardening: Instead of forcing strict type narrowing immediately, we maintain intentional fallbacks (default names) when mapping is missing, while wrapping them in the asField guard function.
* * Explicit Intent: Replaced direct || 'Fallback' resolution with a consistent guard function.
* * Future Scalability: Created points within asField where debug logs or telemetry can be inserted in the future.
**Applied Locations**
* transportRepo.ts (Today's movements / transport logs)
* * monthly/map.ts (Monthly aggregation conversion)
* * SharePointUserRepository.ts (User master retrieval)