### PR TITLE
fix(nav): move tokusei survey to severe support group

### DIFF
--- a/src/app/config/navigationConfig.ts
+++ b/src/app/config/navigationConfig.ts
@@ -234,7 +234,7 @@ export function createNavItems(config: CreateNavItemsConfig): NavItem[] {
       isActive: (pathname) => pathname.startsWith('/survey/tokusei'),
       icon: undefined,
       audience: NAV_AUDIENCE.admin,
-      group: 'planning' as NavGroupKey,
+      group: 'severe' as NavGroupKey,
       tier: 'more',
       featureFlag: 'todayLiteNavV2',
     },


### PR DESCRIPTION
## Summary
- 特性アンケート（/survey/tokusei）のサイドナビ配置を **標準支援 (planning)** から **強度行動障害支援 (severe)** グループに変更
- アセスメント / 行動分析と同じグループに揃え、業務フロー上の兄弟ツールとして自然な位置に配置

## Problem
`特性アンケート` は ISP 三層モデルにおける第2・3層（IBD 対象者向け）の入力ツールですが、現状のサイドナビでは `planning`（標準支援）グループに配置されており、同じ IBD 系ツールである `アセスメント` / `行動分析` から孤立していました。

そのため、サイドナビを開くと「特性アンケート」が標準支援ブロックに、「アセスメント」「行動分析」は強度行動障害支援ブロックに分散し、実際の業務導線とナビの構造が一致していませんでした。

## Decision
`navigationConfig.ts` 上の `特性アンケート` の `group` を `'planning'` から `'severe'` に変更します。

これにより、サイドナビの「強度行動障害支援」グループには
- 支援計画シート
- アセスメント
- **特性アンケート**（new）
- 行動分析

が同居し、三層モデルの「第2・3層は IBD 対象者のみ」という前提と視覚的にも整合します。

## Scope
- `src/app/config/navigationConfig.ts` のみ（1 行変更）
- audience / tier / featureFlag は従来どおり（admin 専用、more tier、`todayLiteNavV2` フラグ配下）
- ルーティング・コンポーネント・権限ロジックには一切変更なし

## Reviewer focus
- グループ移動後もサイドナビの順序・見え方に違和感がないか
- `todayLiteNavV2` フラグ OFF 時に従前通り非表示のままであること
- 三層モデル前提との整合

## Test plan
- [x] `tests/unit/app/config/navigationConfig.spec.ts` (44 tests) passed
- [x] typecheck / lint pass
- [ ] 手元で admin ロール + `todayLiteNavV2` ON のサイドナビを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)