### PR TITLE
feat(sp/obs): capture httpStatus and currentUser on list read failure (isp_master, schedule_events)

### DIFF
--- a/src/data/isp/infra/DataProviderIspRepository.ts
+++ b/src/data/isp/infra/DataProviderIspRepository.ts
@@ -5,7 +5,9 @@ import {
   washRow,
   washRows
 } from '@/lib/sp/helpers';
-import { reportResourceResolution } from '@/lib/data/dataProviderObservabilityStore';
+import { reportResourceResolution, useDataProviderObservabilityStore } from '@/lib/data/dataProviderObservabilityStore';
+import { summarizeSpError } from '@/lib/errors';
+import { auditLog } from '@/lib/debugLogger';
 import type { 
   IspRepository, 
   IspCreateInput, 
@@ -77,13 +79,25 @@ export class DataProviderIspRepository implements IspRepository {
       };
       return this.resolution;
     } catch (error) {
+      const { message, httpStatus } = summarizeSpError(error);
+      const currentUser = useDataProviderObservabilityStore.getState().currentUser ?? undefined;
+
       reportResourceResolution({
         resourceName: 'ISP_Master',
         resolvedTitle: this.listTitle,
         fieldStatus: {},
         essentials: ISP_MASTER_ESSENTIALS as unknown as string[],
-        error: String(error)
+        error: message,
+        httpStatus,
       });
+
+      auditLog.warn('sp', 'list_read_failed', {
+        listKey: 'isp_master',
+        resourceName: 'ISP_Master',
+        httpStatus,
+        currentUser,
+      });
+
       throw error;
     }
   }

--- a/src/features/schedules/infra/DataProviderScheduleRepository.ts
+++ b/src/features/schedules/infra/DataProviderScheduleRepository.ts
@@ -12,7 +12,8 @@ import {
   washRow,
   washRows
 } from '@/lib/sp/helpers';
-import { reportResourceResolution } from '@/lib/data/dataProviderObservabilityStore';
+import { reportResourceResolution, useDataProviderObservabilityStore } from '@/lib/data/dataProviderObservabilityStore';
+import { summarizeSpError } from '@/lib/errors';
 import { mapSpRowToSchedule, type SpScheduleRow } from '../data/spRowSchema';
 import { getSchedulesListTitle } from '../data/spSchema';
 import type { 
@@ -114,13 +115,25 @@ export class DataProviderScheduleRepository implements ScheduleRepository {
       });
       return null;
     } catch (err) {
+      const { message, httpStatus } = summarizeSpError(err);
+      const currentUser = useDataProviderObservabilityStore.getState().currentUser ?? undefined;
+
       reportResourceResolution({
         resourceName: 'Schedule',
         resolvedTitle: this.listTitle,
         fieldStatus: {},
         essentials: [...SCHEDULE_EVENTS_ESSENTIALS] as string[],
-        error: String(err)
+        error: message,
+        httpStatus,
       });
+
+      auditLog.warn('sp', 'list_read_failed', {
+        listKey: 'schedule_events',
+        resourceName: 'Schedule',
+        httpStatus,
+        currentUser,
+      });
+
       auditLog.error('schedule:repo', 'Field resolution failed:', err);
       return null;
     }

--- a/src/lib/__tests__/dataProviderObservabilityStore.spec.ts
+++ b/src/lib/__tests__/dataProviderObservabilityStore.spec.ts
@@ -4,7 +4,7 @@ import { useDataProviderObservabilityStore, reportResourceResolution } from '../
 describe('DataProviderObservabilityStore Idempotency', () => {
   beforeEach(() => {
     useDataProviderObservabilityStore.getState().clearResolutions();
-    useDataProviderObservabilityStore.setState({ currentProvider: null });
+    useDataProviderObservabilityStore.setState({ currentProvider: null, currentUser: null });
   });
 
   it('setProvider should not trigger update if values are identical', () => {
@@ -84,5 +84,37 @@ describe('DataProviderObservabilityStore Idempotency', () => {
 
     const storeAfterSecond = useDataProviderObservabilityStore.getState().resolutions['Users_Master'];
     expect(storeAfterSecond?.status).toBe('missing_required');
+  });
+
+  it('reportResourceResolution should persist httpStatus on failures', async () => {
+    reportResourceResolution({
+      resourceName: 'ISP_Master',
+      resolvedTitle: 'ISP_Master',
+      fieldStatus: {},
+      essentials: ['Title'],
+      error: 'Forbidden',
+      httpStatus: 403,
+    });
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    const state = useDataProviderObservabilityStore.getState().resolutions['ISP_Master'];
+    expect(state?.status).toBe('missing_required');
+    expect(state?.httpStatus).toBe(403);
+    expect(state?.error).toBe('Forbidden');
+  });
+
+  it('setCurrentUser should update currentUser and skip redundant updates', () => {
+    const store = useDataProviderObservabilityStore.getState();
+    const subscribeMock = vi.fn();
+    const unsubscribe = useDataProviderObservabilityStore.subscribe(subscribeMock);
+
+    store.setCurrentUser('kiosk@tenant.onmicrosoft.com');
+    expect(useDataProviderObservabilityStore.getState().currentUser).toBe('kiosk@tenant.onmicrosoft.com');
+    expect(subscribeMock).toHaveBeenCalledTimes(1);
+
+    store.setCurrentUser('kiosk@tenant.onmicrosoft.com');
+    expect(subscribeMock).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
   });
 });

--- a/src/lib/__tests__/errors.summarizeSpError.spec.ts
+++ b/src/lib/__tests__/errors.summarizeSpError.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { summarizeSpError } from '../errors';
+
+describe('summarizeSpError', () => {
+  it('extracts status and message from raiseHttpError-style errors', () => {
+    const err: Error & { status?: number } = new Error('Forbidden');
+    err.status = 403;
+
+    const summary = summarizeSpError(err);
+    expect(summary.httpStatus).toBe(403);
+    expect(summary.message).toBe('Forbidden');
+  });
+
+  it('returns undefined httpStatus for plain Error', () => {
+    const summary = summarizeSpError(new Error('boom'));
+    expect(summary.httpStatus).toBeUndefined();
+    expect(summary.message).toBe('boom');
+  });
+
+  it('extracts nested response.status', () => {
+    const err = { response: { status: 401 }, message: 'Unauthorized' };
+    const summary = summarizeSpError(err);
+    expect(summary.httpStatus).toBe(401);
+    expect(summary.message).toBe('Unauthorized');
+  });
+
+  it('falls back to String(error) for non-object inputs', () => {
+    expect(summarizeSpError('oops').message).toBe('oops');
+    expect(summarizeSpError(null).message).toBe('null');
+  });
+});

--- a/src/lib/data/dataProviderObservabilityStore.ts
+++ b/src/lib/data/dataProviderObservabilityStore.ts
@@ -34,18 +34,21 @@ export interface ResourceResolutionState {
   lastAccessedAt: string;
   error?: string;
   fallbackFrom?: string;
+  httpStatus?: number;
 }
 
 interface ObservabilityState {
   currentProvider: ProviderType | null;
+  currentUser: string | null;
   resolutions: Record<string, ResourceResolutionState>;
-  
+
   isPanelOpen: boolean;
   activeTab: string;
   focusResourceName?: string;
 
   // Actions
   setProvider: (type: ProviderType) => void;
+  setCurrentUser: (user: string | null) => void;
   reportResolution: (state: ResourceResolutionState) => void;
   clearResolutions: () => void;
   openPanel: (options?: { tab?: string; resourceName?: string }) => void;
@@ -58,6 +61,7 @@ interface ObservabilityState {
  */
 export const useDataProviderObservabilityStore = create<ObservabilityState>((set) => ({
   currentProvider: null,
+  currentUser: null,
   resolutions: {},
   isPanelOpen: false,
   activeTab: 'obs',
@@ -66,6 +70,11 @@ export const useDataProviderObservabilityStore = create<ObservabilityState>((set
   setProvider: (type) => set((state) => {
     if (state.currentProvider === type) return state;
     return { currentProvider: type };
+  }),
+
+  setCurrentUser: (user) => set((state) => {
+    if (state.currentUser === user) return state;
+    return { currentUser: user };
   }),
 
   reportResolution: (state) => set((prev) => {
@@ -120,6 +129,7 @@ export interface ResourceResolutionReport {
   essentials: string[];
   error?: string;
   fallbackFrom?: string;
+  httpStatus?: number;
 }
 
 /**
@@ -137,6 +147,7 @@ export function reportResourceResolution(report: ResourceResolutionReport): void
     essentials,
     error,
     fallbackFrom,
+    httpStatus,
   } = report;
 
   const fields: FieldResolutionInfo[] = Object.entries(fieldStatus).map(([key, info]) => ({
@@ -187,7 +198,8 @@ export function reportResourceResolution(report: ResourceResolutionReport): void
       fields,
       lastAccessedAt: new Date().toISOString(),
       error,
-      fallbackFrom
+      fallbackFrom,
+      httpStatus,
     });
   }, 0);
 }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -204,3 +204,31 @@ export function classifyErrorWithHint(error: SafeError | null | undefined): Erro
   const kind = classifyError(error);
   return { kind, hint: ERROR_HINTS[kind] };
 }
+
+export interface SpErrorSummary {
+  message: string;
+  httpStatus?: number;
+}
+
+export function summarizeSpError(error: unknown): SpErrorSummary {
+  if (!error || typeof error !== 'object') {
+    return { message: String(error) };
+  }
+
+  const obj = error as Record<string, unknown>;
+  let httpStatus: number | undefined;
+
+  if (typeof obj.status === 'number') {
+    httpStatus = obj.status;
+  } else if (obj.response && typeof obj.response === 'object') {
+    const resp = obj.response as Record<string, unknown>;
+    if (typeof resp.status === 'number') httpStatus = resp.status;
+    else if (typeof resp.statusCode === 'number') httpStatus = resp.statusCode;
+  } else if (obj.cause && typeof obj.cause === 'object') {
+    const cause = obj.cause as Record<string, unknown>;
+    if (typeof cause.status === 'number') httpStatus = cause.status;
+  }
+
+  const message = typeof obj.message === 'string' ? obj.message : String(error);
+  return { message, httpStatus };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -230,6 +230,12 @@ const run = async (): Promise<void> => {
           ?? (activeAccount as { homeAccountId?: string })?.homeAccountId
           ?? '(unknown)';
         console.info('[msal] ✅ redirect success:', username);
+        try {
+          const { useDataProviderObservabilityStore } = await import('@/lib/data/dataProviderObservabilityStore');
+          useDataProviderObservabilityStore.getState().setCurrentUser(username);
+        } catch {
+          // observability store is optional at bootstrap; ignore failures
+        }
         const msalKeys = Object.keys(sessionStorage).filter(k => k.toLowerCase().includes('msal'));
         console.info('[msal] sessionStorage MSAL keys:', msalKeys);
 


### PR DESCRIPTION
## Summary

- SharePoint リスト読み取り失敗時の観測性を拡張する先行対応(Phase 1)
- `ISP_Master` / `Schedule` の2リポジトリのみ対象。残り14リポジトリは効果確認後に追従PRで横展開
- 現在キオスク端末で発生中の `ISP_Master` / `Schedule` 欠損事象(#1490 と同様の診断ニーズ)で 401/403/404 を即判定できるようにする

## What's included

- **新規**: `summarizeSpError()` ヘルパーを `@/lib/errors` に追加。`raiseHttpError` が付与する `.status` を透過的に抽出
- **拡張**: `ResourceResolutionReport` / `ResourceResolutionState` に optional な `httpStatus` を追加
- **拡張**: observability store に `currentUser` フィールド + `setCurrentUser` action を追加
- **配線**: `main.tsx` の MSAL redirect 成功時に `setCurrentUser(username)` を呼ぶ(動的 import で bootstrap 段階の失敗を防護)
- **ログ**: `DataProviderIspRepository` / `DataProviderScheduleRepository` の catch ブロックで `sp:list_read_failed` 構造化ログを出力(`listKey` / `resourceName` / `httpStatus` / `currentUser`)

## Non-goals (intentionally out of scope)

- 残り14 repository への展開(追従PR)
- `spFetch.ts` / `helpers.ts` の既存テレメトリ変更
- UI / バナー表示ロジック変更
- ロジック・例外再送制御の変更

**observability のみの PR です。** 機能挙動は変わりません。

## Test plan

- [x] `summarizeSpError` ユニットテスト追加(4ケース、`@/lib/errors` 配下)
- [x] observability store の `httpStatus` 永続化 & `setCurrentUser` idempotency テスト追加(計2ケース)
- [x] 既存テスト(`dataProviderObservabilityStore`, `scheduleSpUtils`, `DataProviderPlanningSheetRepository`)green 維持
- [x] `tsc` 型チェック(触れたファイルでエラーなし)
- [x] `eslint` pass(pre-commit hook 経由)
- [ ] 実機確認: キオスク端末で再現時に `sp:list_read_failed` が `listKey` / `httpStatus` / `currentUser` 付きで出ること

## Expected log output

権限問題の場合:
```
[sp] warn list_read_failed {
  listKey: 'isp_master',
  resourceName: 'ISP_Master',
  httpStatus: 403,
  currentUser: 'kiosk@tenant.onmicrosoft.com'
}
```

Observability store state:
```ts
state.resolutions['ISP_Master'] = {
  status: 'missing_required',
  error: 'Forbidden',
  httpStatus: 403,
  ...
}
```

## Follow-up

- 実機で 401/403/404 のどれかが拾えた時点で、残り14 repository へ横展開する追従PRを作成

🤖 Generated with [Claude Code](https://claude.com/claude-code)