### PR TITLE
fix(drift): detect list view threshold errors in Japanese locale

### DIFF
--- a/src/features/diagnostics/drift/infra/SharePointDriftEventRepository.ts
+++ b/src/features/diagnostics/drift/infra/SharePointDriftEventRepository.ts
@@ -72,7 +72,12 @@ export class SharePointDriftEventRepository implements IDriftEventRepository {
     if (typeof err !== 'object' || err === null) return false;
     const status = 'status' in err ? (err as { status?: number }).status : undefined;
     const message = 'message' in err ? String((err as { message?: unknown }).message ?? '') : '';
-    return status === 500 && /list view threshold/i.test(message);
+    if (status !== 500) return false;
+    return (
+      /list view threshold/i.test(message) ||
+      /リストビュー.*しきい値/.test(message) ||
+      /しきい値を超えている/.test(message)
+    );
   }
 
   private isRequiredFieldKey(key: keyof typeof DRIFT_LOG_CANDIDATES): boolean {

--- a/src/features/diagnostics/drift/infra/__tests__/SharePointDriftEventRepository.spec.ts
+++ b/src/features/diagnostics/drift/infra/__tests__/SharePointDriftEventRepository.spec.ts
@@ -272,6 +272,53 @@ describe('SharePointDriftEventRepository', () => {
     ]);
   });
 
+  it('falls back to Id-desc scan when threshold error is reported in Japanese locale', async () => {
+    const thresholdError = Object.assign(
+      new Error('この操作は、リストビューのしきい値を超えているため実行できません。'),
+      { status: 500 },
+    );
+    const getListItemsByTitle = vi
+      .fn()
+      .mockRejectedValueOnce(thresholdError)
+      .mockResolvedValueOnce([
+        {
+          ID: 31,
+          NameOfList: 'Daily_Attendance',
+          InternalName: 'Status0',
+          OccurredAt: '2026-04-12T10:00:00.000Z',
+          Resolution: 'fallback',
+          Category: 'suffix_mismatch',
+          IsResolved: false,
+          Level: 'warn',
+        },
+      ]);
+
+    const repo = new SharePointDriftEventRepository({
+      createItem: vi.fn(async () => ({})),
+      updateItemByTitle: vi.fn(async () => ({})),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      getListItemsByTitle: getListItemsByTitle as any,
+      getSchema: vi.fn(async () => [
+        'NameOfList',
+        'InternalName',
+        'OccurredAt',
+        'Level',
+        'Resolution',
+        'Category',
+        'IsResolved',
+      ]),
+    });
+
+    const events = await repo.getEvents({ listName: 'Daily_Attendance' });
+
+    expect(getListItemsByTitle).toHaveBeenCalledTimes(2);
+    expect(getListItemsByTitle.mock.calls[1][2]).toBeUndefined();
+    expect(getListItemsByTitle.mock.calls[1][3]).toBe('Id desc');
+    expect(getListItemsByTitle.mock.calls[1][4]).toBe(200);
+    expect(events).toHaveLength(1);
+    expect(events[0].id).toBe('31');
+  });
+
   it('uses resolved physical field when marking resolved', async () => {
     const updateItemByTitle = vi.fn(async () => ({}));
 


### PR DESCRIPTION
## Summary

`SharePointDriftEventRepository` には既に threshold fallback が実装されていましたが、判定が英語メッセージ `/list view threshold/i` のみに依存していたため、**日本語環境では fallback が発火せず 500 がそのまま user-facing になっていました**。本PRでは threshold エラー判定を多言語化し、既存 fallback を日本語メッセージでも有効化します。

### 根拠（現地ログ + コード突き合わせ）

キオスク端末のログに次が出ていました:

```
spFetch ... DriftEventsLog ... 500
この操作は、リストビューのしきい値を超えているため実行できません
```

一方、[SharePointDriftEventRepository.ts:71-76](src/features/diagnostics/drift/infra/SharePointDriftEventRepository.ts#L71-L76) の threshold 判定は:

```ts
return status === 500 && /list view threshold/i.test(message);
```

→ 日本語メッセージはこの regex にマッチしないため、[SharePointDriftEventRepository.ts:157-206](src/features/diagnostics/drift/infra/SharePointDriftEventRepository.ts#L157-L206) の `Id desc` フォールバックが**発火せず 500 が rethrow されていました**。

### なぜ \`$top\` 削減ではなくこの fix なのか

SharePoint の list view threshold は **scan 件数** で発動するため、`$top` を小さくしても primary クエリが non-indexed 列で sort する限り threshold は回避できません。今回の症状は「threshold 対策が無い」のではなく「**threshold 対策が locale 差で起動していない**」ものなので、発火条件の多言語化が正しい最小修正です。

### 変更点

- [SharePointDriftEventRepository.ts](src/features/diagnostics/drift/infra/SharePointDriftEventRepository.ts) `isListViewThresholdError` の regex を多言語化
  - 既存: `/list view threshold/i`
  - 追加: `/リストビュー.*しきい値/`, `/しきい値を超えている/`
- [SharePointDriftEventRepository.spec.ts](src/features/diagnostics/drift/infra/__tests__/SharePointDriftEventRepository.spec.ts) に日本語メッセージでの fallback 発火テストを 1 本追加（既存英語テストと同構造）

### このPRで触らないこと

- `$top` / `$filter` / `$orderby` の値・戦略
- `fetchEventsWithThresholdFallback` の fallback ロジック本体
- Schedules 本線の調査（別 issue で `sp:list_read_failed` 1 行待ち）
- Signal semantics / severity 判定

## Test plan

- [x] `vitest run SharePointDriftEventRepository.spec.ts` — 8 passed (7 既存 + 1 新規日本語ケース)
- [x] pre-commit hooks (lint / typecheck / guard:tz) 全 green
- [x] audit log で「threshold fallback: retrying with Id-desc scan」が日本語エラーでも出ることをテスト内で確認
- [ ] マージ後、キオスク端末で `DriftEventsLog` の 500 が user-facing に出なくなることを確認

## Scope 明記

Schedules 本線 (`sp:list_read_failed` httpStatus 待ち) とは独立した hotfix です。本 PR は DriftEventsLog の観測安定化のみを目的とし、Schedules 側の調査結果には影響しません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)