### PR TITLE
feat(observability): add threshold diagnostics for schedules and drift repositories

### DIFF
--- a/docs/runbooks/sharepoint-index-check.md
+++ b/docs/runbooks/sharepoint-index-check.md
@@ -11,12 +11,13 @@
 | リスト名 | 年間想定件数 | 必須インデックス列 | 優先度 |
 |---|---|---|---|
 | DailyActivityRecords | ~60,000 | `UserCode`, `RecordDate` | 🔴 最優先 |
+| schedule_events (Schedules) | ~30,000 | `EventDate`, `EndDate`, `cr014_dayKey` | 🔴 最優先 |
+| DriftEventsLog_v2 | ~100,000 | `Detected_At`, `listName`, `resolved` | 🔴 最優先 |
 | SupportRecord_Daily | ~7,500 | `cr013_personId`, `cr013_date` | 🟡 |
 | AttendanceDaily | ~7,500 | `UserCode`, `RecordDate`, `Key` | 🟡 |
 | ServiceProvisionRecords | ~7,500 | `EntryKey`, `UserCode`, `RecordDate` | 🟡 |
 | Transport_Log | ~15,000 | `UserCode`, `RecordDate`, `Title` | 🟡 |
 | SupportProcedureRecord_Daily | 可変 | `UserCode`, `RecordDate` | 🟡 |
-| Schedules | 可変 | `Date`, `MonthKey`, `ServiceType` | 🟢 |
 
 ---
 
@@ -37,12 +38,13 @@ Connect-PnPOnline -Url "https://<tenant>.sharepoint.com/sites/<site>" -Interacti
 ```powershell
 $targetLists = @(
   @{ Name = 'DailyActivityRecords'; RequiredIndexes = @('UserCode', 'RecordDate') },
+  @{ Name = 'schedule_events';      RequiredIndexes = @('EventDate', 'EndDate', 'cr014_dayKey') },
+  @{ Name = 'DriftEventsLog_v2';    RequiredIndexes = @('Detected_At', 'listName', 'resolved') },
   @{ Name = 'SupportRecord_Daily';  RequiredIndexes = @('cr013_personId', 'cr013_date') },
   @{ Name = 'AttendanceDaily';      RequiredIndexes = @('UserCode', 'RecordDate', 'Key') },
   @{ Name = 'ServiceProvisionRecords'; RequiredIndexes = @('EntryKey', 'UserCode', 'RecordDate') },
   @{ Name = 'Transport_Log';        RequiredIndexes = @('UserCode', 'RecordDate', 'Title') },
-  @{ Name = 'SupportProcedureRecord_Daily'; RequiredIndexes = @('UserCode', 'RecordDate') },
-  @{ Name = 'Schedules';            RequiredIndexes = @('Date', 'MonthKey', 'ServiceType') }
+  @{ Name = 'SupportProcedureRecord_Daily'; RequiredIndexes = @('UserCode', 'RecordDate') }
 )
 
 foreach ($list in $targetLists) {
@@ -152,6 +154,11 @@ if ($duplicates) {
 
 - [ ] DailyActivityRecords: `UserCode` indexed
 - [ ] DailyActivityRecords: `RecordDate` indexed
+- [ ] schedule_events: `EventDate` indexed
+- [ ] schedule_events: `EndDate` indexed
+- [ ] schedule_events: `cr014_dayKey` indexed
+- [ ] DriftEventsLog_v2: `Detected_At` indexed
+- [ ] DriftEventsLog_v2: `listName` indexed
 - [ ] SupportRecord_Daily: `cr013_personId` indexed
 - [ ] SupportRecord_Daily: `cr013_date` indexed
 - [ ] AttendanceDaily: `UserCode` indexed

--- a/src/features/diagnostics/drift/infra/SharePointDriftEventRepository.ts
+++ b/src/features/diagnostics/drift/infra/SharePointDriftEventRepository.ts
@@ -5,6 +5,7 @@ import { buildDateTime, buildEq, buildGe, joinAnd } from '@/sharepoint/query/bui
 import { DRIFT_LOG_CANDIDATES } from '@/sharepoint/fields/diagnosticsFields';
 import { extractMissingField, resolveInternalNamesDetailed } from '@/lib/sp/helpers';
 import { auditLog } from '@/lib/debugLogger';
+import { summarizeSpError } from '@/lib/errors';
 
 /**
  * 依存関係の境界遵守のためのローカルインターフェース
@@ -69,14 +70,14 @@ export class SharePointDriftEventRepository implements IDriftEventRepository {
   }
 
   private isListViewThresholdError(err: unknown): boolean {
-    if (typeof err !== 'object' || err === null) return false;
-    const status = 'status' in err ? (err as { status?: number }).status : undefined;
-    const message = 'message' in err ? String((err as { message?: unknown }).message ?? '') : '';
-    if (status !== 500) return false;
+    const { httpStatus, message } = summarizeSpError(err);
+    if (httpStatus !== 500) return false;
+    
     return (
       /list view threshold/i.test(message) ||
       /リストビュー.*しきい値/.test(message) ||
-      /しきい値を超えている/.test(message)
+      /しきい値を超えている/.test(message) ||
+      message.includes('5000')
     );
   }
 
@@ -184,6 +185,7 @@ export class SharePointDriftEventRepository implements IDriftEventRepository {
         throw err;
       }
 
+      const { sprequestguid } = summarizeSpError(err);
       auditLog.warn(
         'diagnostics:drift',
         'DriftEventRepository threshold fallback: retrying with Id-desc scan.',
@@ -191,6 +193,7 @@ export class SharePointDriftEventRepository implements IDriftEventRepository {
           listTitle,
           filterQuery,
           orderBy: `${detectedAtField} desc`,
+          sprequestguid
         },
       );
 

--- a/src/features/schedules/infra/DataProviderScheduleRepository.ts
+++ b/src/features/schedules/infra/DataProviderScheduleRepository.ts
@@ -320,17 +320,24 @@ export class DataProviderScheduleRepository implements ScheduleRepository {
     const { httpStatus, message: spMessage, sprequestguid } = summarizeSpError(err);
     
     // Detect Threshold error (SharePoint view limit 5000 items)
-    const isThreshold = spMessage.includes('しきい値') || spMessage.toLowerCase().includes('threshold');
+    // 500 Internal Server Error with specific message is the standard for threshold failures
+    const isThreshold = httpStatus === 500 && (
+      spMessage.includes('しきい値') || 
+      spMessage.toLowerCase().includes('threshold') ||
+      spMessage.includes('5000')
+    );
     
+    const guid = sprequestguid ? ` [Request ID: ${sprequestguid}]` : '';
     const enrichedMessage = isThreshold 
-      ? `${userMessage} (SharePoint リストのしきい値制限 [5000件] に抵触した可能性があります。EventDate 等の列のインデックス化が必要です)`
-      : `${userMessage} (${error.message})`;
+      ? `${userMessage} (SharePoint リストのしきい値制限 [5000件] に抵触しました。EventDate, EndDate, cr014_dayKey 等の列を SharePoint 設定からインデックス化する必要があります)${guid}`
+      : `${userMessage} (${error.message})${guid}`;
 
     auditLog.error('schedule:repo', enrichedMessage, { 
       error,
       status: httpStatus,
       sprequestguid,
-      originalMessage: spMessage
+      originalMessage: spMessage,
+      listTitle: this.listTitle
     });
 
     const finalError = new Error(enrichedMessage) as Error & { status?: number; sprequestguid?: string };

--- a/tests/integration/diagnose.threshold_risks.spec.ts
+++ b/tests/integration/diagnose.threshold_risks.spec.ts
@@ -1,0 +1,110 @@
+import { test } from '@playwright/test';
+import { resolveSharePointSiteUrl } from './_shared/resolveSiteUrl';
+
+/**
+ * Diagnostic: Check critical column indexing to prevent SharePoint Threshold errors (500)
+ * 
+ * Target Lists:
+ * - schedule_events (Schedules)
+ * - DriftEventsLog_v2 (Drift Logging)
+ * 
+ * Target Columns:
+ * - EventDate, EndDate, cr014_dayKey (Schedules)
+ * - Detected_At (DriftEventsLog)
+ * 
+ * Run: SHAREPOINT_SITE=https://... npm test tests/integration/diagnose.threshold_risks.spec.ts
+ */
+test.describe('SharePoint Threshold Risk Diagnosis', () => {
+  test.use({
+    storageState: 'tests/.auth/storageState.json',
+  });
+  const siteUrl = resolveSharePointSiteUrl();
+
+  const TARGET_LISTS = [
+    {
+      title: 'schedule_events',
+      criticalFields: ['EventDate', 'EndDate', 'cr014_dayKey']
+    },
+    {
+      title: 'DriftEventsLog_v2',
+      criticalFields: ['Detected_At', 'DetectedAt', 'Detected_x0020_At'] // Try common variants
+    }
+  ];
+
+  for (const listInfo of TARGET_LISTS) {
+    test(`Check indexing for list: ${listInfo.title}`, async ({ context }) => {
+      const request = context.request;
+      
+      console.log(`\n[Threshold Check] List: ${listInfo.title}`);
+      
+      // 1. Get List Entry (to see item count)
+      const listUrl = `${siteUrl}/_api/web/lists/GetByTitle('${listInfo.title}')?$select=Title,ItemCount,Id`;
+      const listRes = await request.get(listUrl);
+      
+      if (!listRes.ok()) {
+        console.warn(`⚠️ List '${listInfo.title}' not found or not accessible. Skipping.`);
+        return;
+      }
+      
+      const listJson = await listRes.json();
+      const list = listJson?.d || listJson;
+      const itemCount = list.ItemCount;
+      
+      console.log(`   ItemCount: ${itemCount}`);
+      if (itemCount >= 5000) {
+        console.log(`   🚨 CRITICAL: List has reached the 5000 item threshold!`);
+      } else if (itemCount >= 4000) {
+        console.log(`   ⚠️ WARNING: List is approaching the 5000 item threshold.`);
+      }
+
+      // 2. Check each critical field's Indexed property
+      for (const fieldName of listInfo.criticalFields) {
+        const fieldUrl = `${siteUrl}/_api/web/lists/GetByTitle('${listInfo.title}')/fields/GetByInternalNameOrTitle('${fieldName}')?$select=InternalName,Indexed,Title`;
+        const fieldRes = await request.get(fieldUrl);
+        
+        if (!fieldRes.ok()) {
+          // If not found, skip variant
+          continue;
+        }
+        
+        const field = (await fieldRes.json())?.d || (await fieldRes.json());
+        const isIndexed = field.Indexed;
+        
+        if (isIndexed) {
+          console.log(`   ✅ [${field.InternalName}] is INDEXED.`);
+        } else {
+          console.log(`   ❌ [${field.InternalName}] is NOT INDEXED.`);
+          if (itemCount >= 5000) {
+            console.log(`      🔥 RISK: This column will cause 500 Threshold Errors when used in $filter or $orderby!`);
+          }
+        }
+      }
+    });
+  }
+
+  test('Check DriftEventsLog_v2 specifically for Detected_At indexing', async ({ context }) => {
+    const request = context.request;
+    const listTitle = 'DriftEventsLog_v2';
+    
+    // Attempt to find ANY of the detectedAt variants
+    const fieldProbes = ['Detected_At', 'DetectedAt', 'Detected_x0020_At'];
+    let foundAny = false;
+
+    for (const fieldName of fieldProbes) {
+      const url = `${siteUrl}/_api/web/lists/GetByTitle('${listTitle}')/fields/GetByInternalNameOrTitle('${fieldName}')?$select=InternalName,Indexed`;
+      const res = await request.get(url);
+      if (res.ok()) {
+        const field = (await res.json())?.d || (await res.json());
+        console.log(`\n[DriftLog] Found field: ${field.InternalName}, Indexed: ${field.Indexed}`);
+        foundAny = true;
+        if (!field.Indexed) {
+          console.log(`   🚨 RECOMMENDATION: Index '${field.InternalName}' in '${listTitle}' immediately.`);
+        }
+      }
+    }
+
+    if (!foundAny) {
+      console.warn(`\n[DriftLog] Could not find any DetectedAt variants in '${listTitle}'.`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Improve SharePoint threshold observability for schedules and drift repositories, and add a diagnostic path to verify index risk before applying admin-side fixes.

## Why

We need to separate:

* threshold failures originating from `schedule_events`
* threshold failures originating from `DriftEventsLog_v2`
* other SharePoint 500-class failures

This PR strengthens request-level diagnostics so operators can capture HTTP status, `sprequestguid`, and threshold-specific hints, then verify index readiness with a dedicated diagnostic spec.

## Changes

* add threshold-aware error hints to `DataProviderScheduleRepository`
* capture `sprequestguid` and improved SharePoint error summaries in `SharePointDriftEventRepository`
* add `tests/integration/diagnose.threshold_risks.spec.ts` for index-risk inspection
* update `docs/runbooks/sharepoint-index-check.md` with priority index targets and admin guidance

## Out of scope

* applying SharePoint indexes automatically
* proving that index changes alone fully resolve all schedule failures
* changing the auth flow

## Reviewer checks

* schedule-side threshold failures include request id and index hints
* drift-side threshold fallbacks retain enough correlation info for admin follow-up
* the new diagnostic spec is clearly operator-facing and safe to run
* runbook guidance matches the actual fields queried in production