### PR TITLE
fix(schedules): suppress repository and legacy hook abort noise

### DIFF
--- a/src/features/diagnostics/drift/infra/SharePointDriftEventRepository.ts
+++ b/src/features/diagnostics/drift/infra/SharePointDriftEventRepository.ts
@@ -403,6 +403,12 @@ export class SharePointDriftEventRepository implements IDriftEventRepository {
       return events;
 
     } catch (err) {
+      // Abortエラー時は静かに終了（ログノイズ抑制）
+      const isAbort = (err as Error)?.name === 'AbortError' || 
+                      (err as { code?: number | string })?.code === 20 ||
+                      (err as { code?: number | string })?.code === 'ABORT_ERR';
+      if (isAbort) return [];
+
       auditLog.warn('diagnostics:drift', 'DriftEventRepository failed to fetch events (fail-open).', err);
       return [];
     }

--- a/src/features/schedules/hooks/legacy/useSchedules.ts
+++ b/src/features/schedules/hooks/legacy/useSchedules.ts
@@ -114,7 +114,16 @@ export function useSchedules(range: DateRange): UseSchedulesResult {
         setItems(data);
       } catch (err) {
         // Handle errors gracefully without throwing
-        if (!alive || abortController.signal.aborted) return;
+        if (!alive) return;
+        
+        // Abortエラー時は静かに終了（ログノイズ抑制）
+        const isAbort = (err as Error)?.name === 'AbortError' || 
+                        (err as { code?: number | string })?.code === 20 ||
+                        (err as { code?: number | string })?.code === 'ABORT_ERR';
+        if (isAbort) {
+          return;
+        }
+
         const error = err instanceof Error ? err.message : 'Failed to fetch schedules';
         // eslint-disable-next-line no-console
         console.error('[useSchedules] Failed to load schedule items', {

--- a/src/features/schedules/infra/DataProviderScheduleRepository.ts
+++ b/src/features/schedules/infra/DataProviderScheduleRepository.ts
@@ -318,9 +318,16 @@ export class DataProviderScheduleRepository implements ScheduleRepository {
   private handleError(err: unknown, userMessage: string): never {
     const error = toSafeError(err);
     const { httpStatus, message: spMessage, sprequestguid } = summarizeSpError(err);
+
+    // Silently throw AbortError to avoid noise in logs during navigation/unmount
+    const isAbort = error.name === 'AbortError' || 
+                   (err as { code?: number | string })?.code === 20 || 
+                   (err as { code?: number | string })?.code === 'ABORT_ERR';
+    if (isAbort) {
+      throw error;
+    }
     
     // Detect Threshold error (SharePoint view limit 5000 items)
-    // 500 Internal Server Error with specific message is the standard for threshold failures
     const isThreshold = httpStatus === 500 && (
       spMessage.includes('しきい値') || 
       spMessage.toLowerCase().includes('threshold') ||


### PR DESCRIPTION
## Summary
This PR eliminates the remaining `signal is aborted without reason` logs by silencing AbortError logging at both the repository and hook layers.

## Key Changes
- **`DataProviderScheduleRepository.ts`**: Updated `handleError` to catch `AbortError` and re-throw it silently without triggering an `auditLog.error`.
- **`legacy/useSchedules.ts`**: Refined the `catch` block in the main fetch effect to ignore `AbortError` silently, preventing unnecessary console errors during UI navigation or unmounting.
- **`SharePointDriftEventRepository.ts`**: Added defensive `AbortError` handling to `getEvents` to ensure consistency across SharePoint repositories.

## Verification
- Monitor production-like logs for the disappearance of `signal is aborted without reason` messages during rapid navigation between schedule views.
- Verify that standard HTTP errors (400, 500) and SharePoint threshold errors are still correctly logged and reported.