### PR TITLE
fix: reduce dashboard & provider observation noise

### DIFF
--- a/src/features/dashboard/useDashboardSummary.ts
+++ b/src/features/dashboard/useDashboardSummary.ts
@@ -54,34 +54,9 @@ export function useDashboardSummary({
   attendanceCounts: AttendanceCounts;
   spSyncStatus?: HubSyncStatus;
 }) {
-  const isDevProfiling = process.env.NODE_ENV === 'development';
-
   // Normalize inputs: prevent Object.values(undefined) crash during initial render
   const safeVisits = visits ?? {};
   const safeAttendanceCounts = attendanceCounts ?? { onDuty: 0, out: 0, absent: 0, total: 0 };
-
-  const perfMark = (label: string) => {
-    if (isDevProfiling && typeof performance !== 'undefined') {
-      performance.mark(label);
-    }
-  };
-
-  const perfMeasure = (label: string) => {
-    if (isDevProfiling && typeof performance !== 'undefined' && performance.getEntriesByName(label).length > 0) {
-      try {
-        performance.measure(`${label}-duration`, label);
-        const duration = performance.getEntriesByName(`${label}-duration`)[0]?.duration || 0;
-        // eslint-disable-next-line no-console
-        console.log(`[Dashboard Perf] ${label}: ${duration.toFixed(2)}ms`);
-        performance.clearMarks(label);
-        performance.clearMeasures(`${label}-duration`);
-      } catch (e) {
-        console.error('[PERF MEASURE ERROR]', label, e);
-      }
-    }
-  };
-
-  perfMark('useDashboardSummary-start');
 
   // 1. Activity & Usage
   const attendanceOrderUserIds = Object.values(safeVisits)
@@ -138,8 +113,6 @@ export function useDashboardSummary({
 
     return calculateStaffAvailability(staff, assignments, currentTime);
   }, [staff, scheduleLanesToday.staffLane]);
-
-  perfMeasure('useDashboardSummary-start');
 
   return useMemo(
     () => ({

--- a/src/lib/data/createDataProvider.ts
+++ b/src/lib/data/createDataProvider.ts
@@ -12,11 +12,13 @@ import { isDevMode, isDemoModeEnabled, readBool, readOptionalEnv, shouldSkipShar
 export type ProviderType = 'sharepoint' | 'memory' | 'local';
 
 const providerInstances: Record<string, IDataProvider> = {};
+let lastLoggedType: string | null = null;
 
 
 /** @internal - For testing only */
 export function __clearProviderCache(): void {
   Object.keys(providerInstances).forEach(k => delete providerInstances[k]);
+  lastLoggedType = null;
 }
 
 /**
@@ -76,7 +78,11 @@ export function createDataProvider(
     providerInstances[cacheKey].setClient(spClient);
   }
 
-  console.info(`[DataProvider] Active backend: ${type}`);
+  if (type !== lastLoggedType) {
+    console.info(`[DataProvider] Active backend: ${type}`);
+    lastLoggedType = type;
+  }
+
   return { provider: providerInstances[cacheKey], type };
 }
 


### PR DESCRIPTION
## Summary

- **DataProvider**: `createDataProvider` の backend ログを状態変化時のみに限定し、provider cache 再利用時の重複出力を削減
- **DashboardSummary**: `useDashboardSummary` から render-phase の perf instrumentation（`perfMark`/`perfMeasure`）を削除し、親の再レンダー回数分出ていたノイズログを除去
- 実データ計算ロジック（useMemo セレクター群）は非侵襲
- 障害系ログ（SP 400/500, auth, threshold, sprequestguid）には影響なし

## Test plan

- [x] `createDataProvider.spec.ts` 全テスト通過
- [x] `useDashboardSummary.spec.ts` 全テスト通過
- [x] lint + typecheck（tsconfig.build.json）パス
- [ ] 実環境で `[DataProvider] Active backend:` が初回1回のみ出力されることを確認
- [ ] 実環境で `[Dashboard Perf] useDashboardSummary-start` が出なくなることを確認
- [ ] 障害系ログ（SP 400/500 等）が引き続き出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)