### PR TITLE
fix(ci): resolve regression test failure in planPatchToTodayActionMapper

### DIFF
--- a/src/domain/today/__tests__/planPatchToTodayActionMapper.spec.ts
+++ b/src/domain/today/__tests__/planPatchToTodayActionMapper.spec.ts
@@ -13,7 +13,7 @@ function makePatch(overrides: Partial<PlanPatchForPlan> = {}): PlanPatchForPlan 
     reason: '会議結果の反映が必要',
     evidenceIds: ['meeting-1'],
     status: 'needs_update',
-    dueAt: '2026-04-15',
+    dueAt: '2026-12-31',
     createdAt: '2026-04-12T00:00:00.000Z',
     updatedAt: '2026-04-12T00:00:00.000Z',
     ...overrides,


### PR DESCRIPTION
Fixes a unit test that fails because the default due date is in the past relative to current run time, causing unexpected 'overdue' status. Updated dueAt to 2026-12-31 to ensure stability.