### PR TITLE
fix(health): prevent post-unmount side-effects in nightly signal ingestion

### DIFF
--- a/src/features/sp/health/hooks/useNightlySignalIngestion.ts
+++ b/src/features/sp/health/hooks/useNightlySignalIngestion.ts
@@ -20,23 +20,28 @@ export function useNightlySignalIngestion() {
     if (!sp || ranRef.current) return;
     ranRef.current = true;
 
+    let cancelled = false;
+
     const ingest = async () => {
       // 1. Diagnostics_Reports の取得
       try {
         const { getLatestDiagnosticsReport } = await import('@/sharepoint/diagnosticsReports');
         const report = await getLatestDiagnosticsReport(sp);
+        if (cancelled) return;
 
         if (report) {
           reportDiagnosticsReport(report);
           auditLog.debug('health:ingestion', 'Diagnostics report ingested.');
         }
       } catch (error) {
+        if (cancelled) return;
         auditLog.warn('health:ingestion', 'Failed to fetch diagnostics reports (skipping).', error);
       }
 
       // 2. DriftEventsLog の取得
       try {
         const driftLogs = await driftRepository.getEvents();
+        if (cancelled) return;
 
         for (const log of driftLogs.slice(0, 10)) {
           const event: PatrolEvent = {
@@ -53,12 +58,18 @@ export function useNightlySignalIngestion() {
         }
         auditLog.debug('health:ingestion', 'Drift logs ingested.');
       } catch (error) {
+        if (cancelled) return;
         auditLog.warn('health:ingestion', 'Failed to fetch drift logs (skipping).', error);
       }
 
+      if (cancelled) return;
       auditLog.info('health:ingestion', 'Nightly signals ingestion process completed.');
     };
 
     ingest();
+
+    return () => {
+      cancelled = true;
+    };
   }, [driftRepository, sp]);
 }


### PR DESCRIPTION
## Summary
Add cleanup to `useNightlySignalIngestion` to prevent post-unmount side-effects.

## Root cause
`useEffect` spawned a fire-and-forget `ingest()` with no cleanup and no AbortController.
Tests rendering `<App />` (e.g. `tests/smoke/router.flags.spec.tsx`) could unmount while
awaited fetches were still in flight, risking post-unmount writes to shared stores and
contributing to Vitest worker teardown instability (upstream symptom of #1506).

## Fix
- Add `cancelled` flag, set `true` in effect cleanup
- Gate every post-await side-effect (`reportDiagnosticsReport`, `reportSpHealthEvent`,
  `auditLog.*`) on `!cancelled`
- Network fetch itself is not aborted (dependencies don't accept AbortSignal), but no
  store mutations or logs fire after unmount.

## Scope
This PR fixes post-unmount side-effects in `useNightlySignalIngestion`.
It does not change SharePoint ingestion behavior during normal mounted runtime.

## Verification
- 3 candidate specs (`router.flags` / `hud.boot` / `App.notifier`): passed, no worker-exit
- `npm run test:ci:required`: 51 files / 464 tests passed, 29.54s, no worker-exit
- `npm run typecheck`: OK

## Follow-up (out of scope)
- Thread `AbortSignal` into `getLatestDiagnosticsReport` and
  `SharePointDriftEventRepository.getEvents` to cancel fetches at source

🤖 Generated with [Claude Code](https://claude.com/claude-code)