### PR TITLE
fix(health): propagate AbortSignal through nightly ingestion dependencies

### DIFF
--- a/src/features/diagnostics/drift/infra/SharePointDriftEventRepository.ts
+++ b/src/features/diagnostics/drift/infra/SharePointDriftEventRepository.ts
@@ -13,7 +13,7 @@ import { summarizeSpError } from '@/lib/errors';
 export interface ISpOperations {
   createItem: (listTitle: string, payload: Record<string, unknown>) => Promise<unknown>;
   updateItemByTitle: (listTitle: string, id: number, payload: Record<string, unknown>) => Promise<unknown>;
-  getListItemsByTitle: <T>(listTitle: string, select?: string[], filter?: string, orderby?: string, top?: number) => Promise<T[]>;
+  getListItemsByTitle: <T>(listTitle: string, select?: string[], filter?: string, orderby?: string, top?: number, signal?: AbortSignal) => Promise<T[]>;
   getListFieldInternalNames?: (listTitle: string) => Promise<Set<string>>;
 }
 
@@ -179,6 +179,7 @@ export class SharePointDriftEventRepository implements IDriftEventRepository {
       resolved?: boolean;
       since?: string;
     },
+    signal?: AbortSignal,
   ): Promise<DriftEvent[]> {
     try {
       const items = await this.spClient.getListItemsByTitle<Record<string, unknown>>(
@@ -187,6 +188,7 @@ export class SharePointDriftEventRepository implements IDriftEventRepository {
         filterQuery,
         `${detectedAtField} desc`,
         100,
+        signal,
       );
       return items.map((item) => this.mapItemToEvent(item));
     } catch (err) {
@@ -212,6 +214,7 @@ export class SharePointDriftEventRepository implements IDriftEventRepository {
         undefined,
         'Id desc',
         200,
+        signal,
       );
 
       return fallbackItems
@@ -353,7 +356,7 @@ export class SharePointDriftEventRepository implements IDriftEventRepository {
     listName?: string;
     resolved?: boolean;
     since?: string;
-  }): Promise<DriftEvent[]> {
+  }, signal?: AbortSignal): Promise<DriftEvent[]> {
     try {
       const entry = findListEntry('drift_events_log');
       if (!entry) return [];
@@ -398,6 +401,7 @@ export class SharePointDriftEventRepository implements IDriftEventRepository {
         joinAnd(filters) || undefined,
         detectedAtField || 'Detected_x0020_At', // OrderBy fallback
         filter,
+        signal,
       );
 
       return events;

--- a/src/features/sp/health/hooks/useNightlySignalIngestion.ts
+++ b/src/features/sp/health/hooks/useNightlySignalIngestion.ts
@@ -21,12 +21,17 @@ export function useNightlySignalIngestion() {
     ranRef.current = true;
 
     let cancelled = false;
+    const controller = new AbortController();
+    const isAbortError = (err: unknown) =>
+      (err as Error)?.name === 'AbortError' ||
+      (err as { code?: number | string })?.code === 20 ||
+      (err as { code?: number | string })?.code === 'ABORT_ERR';
 
     const ingest = async () => {
       // 1. Diagnostics_Reports の取得
       try {
         const { getLatestDiagnosticsReport } = await import('@/sharepoint/diagnosticsReports');
-        const report = await getLatestDiagnosticsReport(sp);
+        const report = await getLatestDiagnosticsReport(sp, controller.signal);
         if (cancelled) return;
 
         if (report) {
@@ -34,13 +39,13 @@ export function useNightlySignalIngestion() {
           auditLog.debug('health:ingestion', 'Diagnostics report ingested.');
         }
       } catch (error) {
-        if (cancelled) return;
+        if (cancelled || isAbortError(error)) return;
         auditLog.warn('health:ingestion', 'Failed to fetch diagnostics reports (skipping).', error);
       }
 
       // 2. DriftEventsLog の取得
       try {
-        const driftLogs = await driftRepository.getEvents();
+        const driftLogs = await driftRepository.getEvents(undefined, controller.signal);
         if (cancelled) return;
 
         for (const log of driftLogs.slice(0, 10)) {
@@ -58,7 +63,7 @@ export function useNightlySignalIngestion() {
         }
         auditLog.debug('health:ingestion', 'Drift logs ingested.');
       } catch (error) {
-        if (cancelled) return;
+        if (cancelled || isAbortError(error)) return;
         auditLog.warn('health:ingestion', 'Failed to fetch drift logs (skipping).', error);
       }
 
@@ -70,6 +75,7 @@ export function useNightlySignalIngestion() {
 
     return () => {
       cancelled = true;
+      controller.abort();
     };
   }, [driftRepository, sp]);
 }

--- a/src/sharepoint/diagnosticsReports.ts
+++ b/src/sharepoint/diagnosticsReports.ts
@@ -481,7 +481,10 @@ export async function resetNotificationFlag(sp: UseSP, reportId: number): Promis
 /**
  * 最新の診断レポートを取得する
  */
-export async function getLatestDiagnosticsReport(sp: UseSP): Promise<DiagnosticsReportItem | null> {
+export async function getLatestDiagnosticsReport(
+  sp: UseSP,
+  signal?: AbortSignal,
+): Promise<DiagnosticsReportItem | null> {
   const listTitle = DIAGNOSTICS_REPORTS_LIST_TITLE;
   const resolvedFields = await resolveDiagnosticsFields(sp);
   const selectFields = buildDiagnosticsSelectFields(resolvedFields);
@@ -491,7 +494,8 @@ export async function getLatestDiagnosticsReport(sp: UseSP): Promise<Diagnostics
     selectFields,
     undefined,
     `${resolvedFields.modified ?? FIELD_MAP_DIAGNOSTICS_REPORTS.modified} desc`,
-    1
+    1,
+    signal,
   );
 
   return reports.length > 0 ? normalizeDiagnosticsReportItem(reports[0], resolvedFields) : null;


### PR DESCRIPTION
## Summary
Propagate `AbortSignal` through nightly ingestion dependencies so in-flight requests are
cancelled on unmount, completing the async leak hardening started in #1507.

## Context
#1507 guarded post-unmount side-effects with a `cancelled` flag, but the underlying
network requests kept running to completion. This PR closes that remaining gap by
threading an `AbortSignal` through the ingestion path down to `sp.getListItemsByTitle`
(which is already signal-aware).

## Changes
- `getLatestDiagnosticsReport(sp, signal?)` — forwards signal to `sp.getListItemsByTitle`
- `SharePointDriftEventRepository.getEvents(filter?, signal?)` — forwards signal through
  `fetchEventsWithThresholdFallback` to both `spClient.getListItemsByTitle` invocations;
  local `ISpOperations` interface extended to expose the signal parameter
- `useNightlySignalIngestion`:
  - Creates an `AbortController` in the effect
  - Passes `controller.signal` to both fetches
  - Calls `controller.abort()` in cleanup
  - Silently swallows `AbortError` in catch blocks (avoids noisy warn on expected cancel)
  - Existing `cancelled` guard retained as defense-in-depth

## Scope
This PR adds signal threading to the two ingestion-path entry points.
Other callers of `SharePointDriftEventRepository.getEvents` (e.g. `useDriftObservability`,
`DriftEventTable`) and `getLatestDiagnosticsReport` (none) are unaffected — signal is
optional.
Production mounted-runtime behavior is unchanged.

## Verification
- `npm run typecheck`: OK
- 4 affected specs (router.flags / hud.boot / App.notifier / SharePointDriftEventRepository): 11/11 passed
- `npm run test:ci:required`: 51 files / 464 tests passed, 29.55s, no worker-exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)