### PR TITLE
Gate SharePoint bootstrap/health reads on auth readiness

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -217,13 +217,22 @@ module.exports = {
       // Use useXXXRepository() hooks instead to ensure DI (DataProvider) stability.
       files: [
         'src/pages/**',
-        'src/features/**/components/**',
-        'src/features/**/hooks/**',
+        'src/features/**',
         'src/app/**',
       ],
       excludedFiles: [
         'src/features/**/data/**',
         'src/features/**/infra/**',
+        'src/features/**/repositories/**',
+        'src/features/**/__tests__/**',
+        'src/features/**/*.spec.ts',
+        'src/features/**/*.spec.tsx',
+        'src/features/**/*.test.ts',
+        'src/features/**/*.test.tsx',
+        'src/features/**/create*Repository.ts',
+        'src/features/**/*RepositoryFactory.ts',
+        'src/features/**/*repositoryFactory.ts',
+        'src/features/**/*Repository.ts',
         'src/app/services/**',
         '**/create*Repository.ts', // Factory-defining files are allowed to call themselves for recursion/wrappers if needed
       ],

--- a/src/features/settings/pages/OperationFlowSettingsPage.tsx
+++ b/src/features/settings/pages/OperationFlowSettingsPage.tsx
@@ -34,7 +34,7 @@ import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
-import { createOperationalPhaseRepository } from '@/features/operationFlow/data/createOperationalPhaseRepository';
+import { useOperationalPhaseRepository } from '@/features/operationFlow/data/createOperationalPhaseRepository';
 import { getCurrentPhaseFromConfig } from '@/features/operationFlow/domain/getCurrentPhaseFromConfig';
 import type {
   OperationFlowPhaseConfig,
@@ -59,7 +59,7 @@ const PRIMARY_SCREEN_OPTIONS: { value: PrimaryScreen; label: string }[] = [
 // ────────────────────────────────────────
 
 const OperationFlowSettingsPage: React.FC = () => {
-  const repo = useMemo(() => createOperationalPhaseRepository(), []);
+  const repo = useOperationalPhaseRepository();
 
   // ── State ──
   const [phases, setPhases] = useState<OperationFlowPhaseConfig[]>([]);


### PR DESCRIPTION
## Summary
Gate SharePoint bootstrap and health reads on authentication readiness and suppress unauthenticated warning spam.

## Reproduction
1. Open `/admin/status?...` while not signed in (no active MSAL account)
2. Observe:
   - repeated `AUTH_REQUIRED` errors from `spFetch`
   - repeated `[auth] Rate limit exceeded` warnings
   - provisioning/health reads starting before auth is established

## Root cause
When `hasAccount=false`, multiple hooks (health checks, bootstrap, users/staff fetch, drift ingestion)
still initiated SharePoint IO.

This caused:
- repeated `AUTH_REQUIRED` failures
- token acquisition loops triggering rate-limit warnings

## Changes
- Gate `/admin/status` health execution until auth is ready
- Gate `SpInitBridge` (provision + nightly ingestion) on auth readiness
- Skip global data hooks while unauthenticated:
  - `useUsers`
  - `useStaff`
  - `useHealthChecks`
  - `useNightlySignalIngestion`
  - drift observability hooks
- Early return in `useAuth` when no active account
- De-dupe rate-limit/no-account warnings in `useAuth`
- Reduce `AUTH_REQUIRED` logging in `spFetch` to one-time warning

## Contract added
- `unauthenticated` must NOT trigger SharePoint IO

Added test:
- `unauthenticatedIoGate.spec.tsx`
  - verifies no calls to:
    - `userRepo.getAll`
    - `staffRepo.getAll`
    - `runHealthChecks`
    - `driftRepo.getEvents`
    - `spFetch`

## Verification
- `npm run -s typecheck` ✅
- `vitest` (including new contract test) ✅
- Browser reproduction:
  - `pageErrors=0`
  - no repeated `sp:provision_failed`
  - no repeated `Rate limit exceeded`
  - only one expected warning:
    `"[auth] acquireToken skipped: no active account..."`

## Notes
- Existing unrelated working tree changes are not part of this PR.
