### PR TITLE
chore(ci): align user benefit/users schema essentials to canonical fields

### DIFF
--- a/docs/ops/column-cleanup-checklist-v2.md
+++ b/docs/ops/column-cleanup-checklist-v2.md
@@ -10,6 +10,26 @@
 
 ---
 
+### 🆕 今期対象 (2026-04-19 追加)
+
+#### `UserBenefit_Profile_Ext` — `User_x0020_ID` 重複解消
+
+- [ ] **削除対象内部名:** `User_x0020_ID`
+- [ ] **canonical（残す列）:** `UserID`
+- [ ] **判定根拠:**
+  1. Registry SSOT: `spListRegistry.definitions.ts` の `user_benefit_profile_ext.provisioningFields.UserID` が primary、`User_x0020_ID` は candidates fallback
+  2. Read path: `DataProviderUserRepository.ts` に `User_x0020_ID` 直参照なし（FieldMap/candidates resolver 経由）
+  3. Migration: `scripts/migrate-user-benefit-userid.ps1` が canonical `UserID` を前提として backfill 済み
+- [ ] **削除前提条件（2026-04-19 時点で解消済み）:**
+  1. CI schema 更新済み: `scripts/ci/schemas/user-benefit-ext.mjs` の `ESSENTIAL_FIELDS` を `['UserID']` に矯正
+  2. 参考: `scripts/ci/schemas/users.mjs` も同時に canonical essential 化済み（`Users_Master` 実テナントは canonical のみ存在を確認）
+- [ ] **推奨事前確認:**
+  - `pwsh ./scripts/migrate-user-benefit-userid.ps1 -DryRun` で `UserID` 列にデータが入っていることを確認
+- [ ] **削除後確認:**
+  - `/admin/status` で `schema.fields.user_benefit_profile_ext` の drift `UserID -> User_x0020_ID` が消えて `pass` もしくは `warn`（他 drift 残）に遷移
+
+---
+
 ### 🛠️ 推奨ツール
 *   [zombie-column-purger.mjs](../../scripts/ops/zombie-column-purger.mjs)
     *   使い方: `node scripts/ops/zombie-column-purger.mjs --force`

--- a/scripts/ci/schemas/user-benefit-ext.mjs
+++ b/scripts/ci/schemas/user-benefit-ext.mjs
@@ -6,7 +6,7 @@
 export const LIST_TITLE = 'UserBenefit_Profile_Ext';
 
 export const ESSENTIAL_FIELDS = [
-  'User_x0020_ID',
+  'UserID',
 ];
 
 export const OPTIONAL_FIELDS = [

--- a/scripts/ci/schemas/users.mjs
+++ b/scripts/ci/schemas/users.mjs
@@ -6,13 +6,11 @@
 export const LIST_TITLE = 'Users_Master';
 
 export const ESSENTIAL_FIELDS = [
-  'User_x0020_ID',
-  'Full_x0020_Name',
+  'UserID',
+  'FullName',
 ];
 
 export const OPTIONAL_FIELDS = [
-  'UserID',
-  'FullName',
   'IsActive',
   'Title',
   'Furigana',


### PR DESCRIPTION
## Summary
- update CI schema essentials for `user-benefit-ext` to canonical `UserID`
- update CI schema essentials for `users` to canonical `UserID` / `FullName`
- remove duplicated canonical fields from `users` optional list
- append cleanup lane notes for `UserBenefit_Profile_Ext.UserID` in column cleanup checklist

## Why
- aligns CI drift validation with registry SSOT primary candidates
- unblocks `UserBenefit_Profile_Ext.User_x0020_ID` legacy deletion lane

## Scope
- `scripts/ci/schemas/user-benefit-ext.mjs`
- `scripts/ci/schemas/users.mjs`
- `docs/ops/column-cleanup-checklist-v2.md`

## Notes
- only the 3 files above are included
- unrelated local changes remain on the original working branch/worktree