### PR TITLE
fix(drift): stabilize default nowProvider to prevent effect loop

### DIFF
--- a/src/features/diagnostics/drift/observability/__tests__/useDriftObservability.spec.tsx
+++ b/src/features/diagnostics/drift/observability/__tests__/useDriftObservability.spec.tsx
@@ -1,0 +1,57 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { IDriftEventRepository } from '../../domain/DriftEventRepository';
+import { useDriftObservability } from '../useDriftObservability';
+
+vi.mock('@/lib/spClient', () => ({
+  useSP: () => null,
+}));
+
+vi.mock('../../infra/driftEventRepositoryFactory', () => ({
+  useDriftEventRepository: () => null,
+}));
+
+const createRepository = (): IDriftEventRepository => ({
+  logEvent: vi.fn(async () => {}),
+  getEvents: vi.fn(async () => []),
+  markResolved: vi.fn(async () => {}),
+});
+
+describe('useDriftObservability — effect stability', () => {
+  it('calls repository.getEvents exactly once when nowProvider is omitted, even across re-renders', async () => {
+    const repository = createRepository();
+
+    const { rerender } = renderHook(() => useDriftObservability({ repository }));
+
+    await waitFor(() => {
+      expect(repository.getEvents).toHaveBeenCalledTimes(1);
+    });
+
+    rerender();
+    rerender();
+    rerender();
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(repository.getEvents).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not refetch when the caller passes a stable nowProvider reference', async () => {
+    const repository = createRepository();
+    const nowProvider = () => new Date('2026-04-20T00:00:00.000Z');
+
+    const { rerender } = renderHook(() => useDriftObservability({ repository, nowProvider }));
+
+    await waitFor(() => {
+      expect(repository.getEvents).toHaveBeenCalledTimes(1);
+    });
+
+    rerender();
+    rerender();
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(repository.getEvents).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/diagnostics/drift/observability/useDriftObservability.ts
+++ b/src/features/diagnostics/drift/observability/useDriftObservability.ts
@@ -30,6 +30,8 @@ const EMPTY_SNAPSHOT: DriftObservabilitySnapshot = {
   lastUpdatedAt: null,
 };
 
+const DEFAULT_NOW_PROVIDER = (): Date => new Date();
+
 export const getPeriodStart = (
   period: DriftObservabilityPeriod,
   now: Date = new Date(),
@@ -60,7 +62,7 @@ const safeCompute = <T,>(label: string, compute: () => T, fallback: T): T => {
 export const useDriftObservability = (options: UseDriftObservabilityOptions = {}) => {
   const driftRepository = useDriftEventRepository();
   const repository = options.repository ?? driftRepository;
-  const nowProvider = options.nowProvider ?? (() => new Date());
+  const nowProvider = options.nowProvider ?? DEFAULT_NOW_PROVIDER;
   const [period, setPeriod] = React.useState<DriftObservabilityPeriod>('weekly');
   const [loading, setLoading] = React.useState(false);
   const [snapshot, setSnapshot] = React.useState<DriftObservabilitySnapshot>(EMPTY_SNAPSHOT);


### PR DESCRIPTION
## Summary
- hoist `DEFAULT_NOW_PROVIDER` to module scope in `useDriftObservability`
- add regression test ensuring `getEvents` is not called repeatedly
  when `nowProvider` is omitted (or when caller passes a stable one)

## Why
- inline `() => new Date()` default caused the effect dep array to
  invalidate on every render
- combined with `setSnapshot({ lastUpdatedAt: new Date().toISOString() })`
  inside the effect, this produced a render → effect → setState → render
  loop, spamming `DriftEventsLog_v2` queries
- at ~10k items the list hits the SharePoint View Threshold (5000),
  returning 500 on every retry — matching the production symptom

## Scope
- `src/features/diagnostics/drift/observability/useDriftObservability.ts`
- `src/features/diagnostics/drift/observability/__tests__/useDriftObservability.spec.tsx` (new)

## Notes
- repository reference is already stable via memoized `useRepository` + `useAuth`; no change needed there
- pre-existing `DriftObservabilityPanel.spec.tsx` failures (`ensureConfig` mock missing) are unrelated to this PR and reproducible on `main`
- proactive threshold fallback (skip initial 5000-scan when known-large) is a separate improvement; the existing reactive fallback in `SharePointDriftEventRepository.fetchEventsWithThresholdFallback` already handles single-shot threshold hits