### PR TITLE
fix(ops): recover nightly runtime patrol artifact upload

### DIFF
--- a/.github/workflows/nightly-runtime-patrol.yml
+++ b/.github/workflows/nightly-runtime-patrol.yml
@@ -92,12 +92,25 @@ jobs:
           GITHUB_API_URL: ${{ github.api_url }}
         run: npx tsx scripts/ops/nightly-runtime-patrol.ts
 
+      - name: Diagnose artifact path
+        if: always()
+        run: |
+          echo "## cwd"
+          pwd
+          echo "## top-level"
+          ls -la
+          echo "## .nightly/ contents"
+          ls -la .nightly || echo "(.nightly not present)"
+          echo "## recursive find"
+          find . -maxdepth 3 -name 'runtime-summary*' 2>/dev/null || true
+
       - name: Upload Patrol Artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: nightly-runtime-summary-${{ github.run_number }}
           path: .nightly/
+          include-hidden-files: true
           if-no-files-found: warn
 
       - name: Commit report to docs


### PR DESCRIPTION
## 症状

`nightly-runtime-patrol.yml` の `Upload Patrol Artifacts` が
`Warning: No files were found with the provided path: .nightly/.` で空振り。
script ログでは `.nightly/runtime-summary.{json,md}` への write は成功している。

## 原因

`actions/upload-artifact@v4` はデフォルトで **dot-prefixed (hidden) ディレクトリを除外**する。
出力先が `.nightly/` のため、生成物があっても拾われずに WARN になっていた。

## 変更

- `include-hidden-files: true` を追加し、`.nightly/` 配下を upload 対象に含める
- 併せて直前に `Diagnose artifact path` step を追加し、cwd / `.nightly/` 実在 / `runtime-summary*` の有無を各 run のログで恒常確認できるようにした

## 期待効果

- nightly runtime patrol の summary artifact が安定して回収される
- run ごとの生成有無を workflow ログから即座に切り分けできる

## 変更対象外（別 PR で追う）

- SharePoint REST の 401（`DriftEventsLog` / `DiagnosticsReports` fetch 失敗）
  → AAD app-only の SharePoint permission (`Sites.Read.All` / `Sites.FullControl.All`) と admin consent、および証明書有効期限の確認が次タスク

## Test plan

- [ ] `workflow_dispatch` で `Nightly Runtime Patrol` を手動実行
- [ ] `Diagnose artifact path` step のログで `.nightly/runtime-summary.{json,md}` が存在することを確認
- [ ] `Upload Patrol Artifacts` step が WARN なく成功し、`nightly-runtime-summary-<run>` artifact がダウンロード可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)