### PR TITLE
fix(health): enhance uniqueId collision resistance using crypto.randomUUID

### DIFF
--- a/src/pages/HealthPage.tsx
+++ b/src/pages/HealthPage.tsx
@@ -358,9 +358,11 @@ const listSpecs: ListSpec[] = SP_LIST_REGISTRY.map((entry) => {
     }
   }
 
-  const stamp = Date.now().toString().slice(-8); // 8 digits
-  const randomSuffix = Math.floor(Math.random() * 1000).toString().padStart(3, '0');
-  const uniqueId = `hc-${stamp}-${randomSuffix}`;
+  const stamp = Date.now().toString();
+  const uuidSuffix =
+    globalThis.crypto?.randomUUID?.().slice(0, 8) ??
+    Math.random().toString(36).slice(2, 10);
+  const uniqueId = `hc-${stamp}-${uuidSuffix}`;
 
   const createItem: Record<string, unknown> = { Title: `healthcheck-root-${uniqueId}` };
   if (entry.key === "users_master") {


### PR DESCRIPTION
## Summary
- strengthen HealthPage healthcheck ID generation to reduce Create collision risk
- use `globalThis.crypto?.randomUUID()` with a safe fallback for unsupported environments
- keep existing healthcheck payload prefixes/contracts while improving uniqueness

## Why
Users_Master Create healthcheck was failing due to duplicate `UserID` collisions. The prior `Date.now() + 3-digit random` scheme had limited entropy and could still collide. This change raises collision resistance without changing the surrounding healthcheck contract.

## Changes
- replace the `hc-<stamp>-<3digit>` style suffix generation with `Date.now() + randomUUID().slice(0, 8)`
- retain a `Math.random().toString(36)` fallback when `crypto.randomUUID` is unavailable
- keep `healthcheck-root-`, `user-`, and `staff-` prefixes unchanged

## Verification
- searched for `hc-`, `healthcheck-root-`, `user-hc-`, and `staff-hc-` dependencies
- found no test or logic depending on the old exact suffix shape
- local lint/typecheck reported green per branch notes

## Risk
- low: string format becomes more collision-resistant, but remains prefix-compatible
- no schema or runtime contract changes outside healthcheck ID generation
