### PR TITLE
fix(health): generate healthcheck unique ids per run

### DIFF
--- a/src/features/diagnostics/health/__tests__/governanceIntegration.spec.ts
+++ b/src/features/diagnostics/health/__tests__/governanceIntegration.spec.ts
@@ -19,7 +19,7 @@ describe('Governance Integration — runHealthChecks Flow', () => {
   const baseCtx: HealthContext = {
     env: { VITE_SP_RESOURCE: 'https://test', VITE_MSAL_CLIENT_ID: 'cid', VITE_MSAL_TENANT_ID: 'tid' },
     siteUrl: 'https://test',
-    listSpecs: [],
+    listSpecs: () => [],
     isProductionLike: true,
     autonomyLevel: 'G',
   };
@@ -43,7 +43,7 @@ describe('Governance Integration — runHealthChecks Flow', () => {
     // actual fields has "fullname" (case mismatch)
     (mockSp.getFields as any).mockResolvedValue([{ internalName: 'fullname', staticName: 'fullname' }]);
 
-    const results = await runHealthChecks({ ...baseCtx, listSpecs: [spec] }, mockSp);
+    const results = await runHealthChecks({ ...baseCtx, listSpecs: () => [spec] }, mockSp);
 
     const schemaResult = results.find(r => r.key === 'schema.fields.test_list');
     expect(schemaResult).toBeDefined();
@@ -77,7 +77,7 @@ describe('Governance Integration — runHealthChecks Flow', () => {
     // suffix mismatch
     (mockSp.getFields as any).mockResolvedValue([{ internalName: 'Status0', staticName: 'Status0' }]);
 
-    const results = await runHealthChecks({ ...baseCtx, listSpecs: [spec] }, mockSp);
+    const results = await runHealthChecks({ ...baseCtx, listSpecs: () => [spec] }, mockSp);
 
     const schemaResult = results.find(r => r.key === 'schema.fields.test_list');
     expect(schemaResult?.governance?.action).toBe('propose');

--- a/src/features/diagnostics/health/__tests__/optionalLists.spec.ts
+++ b/src/features/diagnostics/health/__tests__/optionalLists.spec.ts
@@ -22,7 +22,7 @@ describe('Health Checks — Optional List Contract', () => {
       VITE_MSAL_TENANT_ID: 'tenant-id',
     },
     siteUrl: 'https://tenant.sharepoint.com/sites/test',
-    listSpecs: [],
+    listSpecs: () => [],
     isProductionLike: true,
     autonomyLevel: 'F',
   };
@@ -40,7 +40,7 @@ describe('Health Checks — Optional List Contract', () => {
 
     (mockSp.getListByTitle as any).mockRejectedValueOnce(new Error('404 Not Found'));
 
-    const ctx = { ...baseCtx, listSpecs: [spec] };
+    const ctx = { ...baseCtx, listSpecs: () => [spec] };
     const results = await runHealthChecks(ctx, mockSp);
 
     const existenceCheck = results.find(r => r.key === 'lists.exists.required_list');
@@ -61,7 +61,7 @@ describe('Health Checks — Optional List Contract', () => {
 
     (mockSp.getListByTitle as any).mockRejectedValueOnce(new Error('404 Not Found'));
 
-    const ctx = { ...baseCtx, listSpecs: [spec] };
+    const ctx = { ...baseCtx, listSpecs: () => [spec] };
     const results = await runHealthChecks(ctx, mockSp);
 
     const existenceCheck = results.find(r => r.key === 'lists.exists.optional_list');
@@ -83,7 +83,7 @@ describe('Health Checks — Optional List Contract', () => {
     (mockSp.getListByTitle as any).mockResolvedValueOnce({ id: 'guid', title: 'OptionalList' });
     (mockSp.getFields as any).mockResolvedValueOnce([]);
 
-    const ctx = { ...baseCtx, listSpecs: [spec] };
+    const ctx = { ...baseCtx, listSpecs: () => [spec] };
     const results = await runHealthChecks(ctx, mockSp);
 
     const existenceCheck = results.find(r => r.key === 'lists.exists.optional_list');

--- a/src/features/diagnostics/health/checks.ts
+++ b/src/features/diagnostics/health/checks.ts
@@ -263,7 +263,7 @@ export async function runHealthChecks(
   }
 
   // --- D/E) Lists, Schema, Permissions (CRUD) ---
-  for (const spec of ctx.listSpecs) {
+  for (const spec of ctx.listSpecs()) {
     await runListChecks(results, sp, spec, ctx);
   }
 

--- a/src/features/diagnostics/health/types.ts
+++ b/src/features/diagnostics/health/types.ts
@@ -72,7 +72,7 @@ export type HealthContext = {
   env: Record<string, unknown>;
   // 診断対象の SharePoint 情報
   siteUrl: string;
-  listSpecs: ListSpec[];
+  listSpecs: () => ListSpec[];
 
   // UI向け
   isProductionLike: boolean;

--- a/src/pages/HealthPage.tsx
+++ b/src/pages/HealthPage.tsx
@@ -318,7 +318,8 @@ const DRIFT_ESSENTIALS_BY_KEY: Record<string, readonly string[]> = {
 
 
 
-const listSpecs: ListSpec[] = SP_LIST_REGISTRY.map((entry) => {
+function buildListSpecs(): ListSpec[] {
+  return SP_LIST_REGISTRY.map((entry) => {
   const effectiveEssentials = DRIFT_ESSENTIALS_BY_KEY[entry.key] ?? (entry.essentialFields || []);
 
   // 1. All fields from provisioning (default: optional)
@@ -389,7 +390,8 @@ const listSpecs: ListSpec[] = SP_LIST_REGISTRY.map((entry) => {
     updateItem: { Title: `healthcheck-updated-${uniqueId}` },
     isReadOnly: !entry.operations.includes("W"),
   };
-});
+  });
+}
 
 export default function HealthPage() {
   const env = getRuntimeEnv() as Record<string, unknown>;
@@ -399,7 +401,7 @@ export default function HealthPage() {
     siteUrl:
       String(env.VITE_SP_RESOURCE ?? "") +
       String(env.VITE_SP_SITE_RELATIVE ?? ""),
-    listSpecs,
+    listSpecs: buildListSpecs,
     isProductionLike:
       String(env.MODE ?? "").toLowerCase() === "production" ||
       String(env.VITE_APP_ENV ?? "").toLowerCase() === "production",


### PR DESCRIPTION
## Summary
- move healthcheck list spec generation from module scope to run scope
- call `ctx.listSpecs()` inside `runHealthChecks()` so each diagnostic run gets fresh create/update payloads
- prevent duplicate `UserID` reuse when the health page is executed multiple times without a full page reload

## Root cause
`listSpecs` was previously created at module load time in `HealthPage.tsx`.
That meant the `uniqueId` used by create probes was generated only once per page load.

As a result, the 2nd and later healthcheck runs on the same page reused the same payload and could falsely fail with duplicate-value errors on unique columns such as `UserID`.

Commit `34eeb481` (PR #1527) previously strengthened the entropy source (`Math.random` → `crypto.randomUUID`) but did not change the generation timing, so the same-session collision path remained.

## Changes
- `src/features/diagnostics/health/types.ts`
  - `listSpecs: ListSpec[]` → `listSpecs: () => ListSpec[]`
- `src/features/diagnostics/health/checks.ts`
  - `ctx.listSpecs` → `ctx.listSpecs()`
- `src/pages/HealthPage.tsx`
  - replace module-scoped `const listSpecs = ...` with `buildListSpecs()`
  - pass `listSpecs: buildListSpecs`
- tests
  - update test contexts from `listSpecs: []` to `listSpecs: () => []`

## Verification
- health check tests: 22/22 passing (`vitest run src/features/diagnostics/health/__tests__/`)
- touched files: TypeScript errors = 0

## Test plan
- [ ] open `/admin/status`, run the diagnostic twice in the same page load, confirm the 2nd run does not FAIL `Users_Master` with a duplicate `UserID`
- [ ] confirm other lists (Staff_Master, Monitoring_Meetings) also re-run cleanly

## Follow-up
- implement Reason Classification for create failures so that `duplicate`, `drift`, `throttle`, and `auth` failures are labeled distinctly instead of all being reported as "作成（Create）権限がありません"
  - target classes: `auth` (401/403) / `duplicate` (unique constraint) / `drift` (internal-name mismatch) / `throttle` (429 / Retry-After) / `unknown`

🤖 Generated with [Claude Code](https://claude.com/claude-code)