### PR TITLE
fix(health): classify create probe failures by reason in health checks

### DIFF
--- a/src/features/diagnostics/health/__tests__/classifyCreateError.spec.ts
+++ b/src/features/diagnostics/health/__tests__/classifyCreateError.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { classifyCreateError } from '../classifyCreateError';
+
+type TestError = {
+  status?: number;
+  message: string;
+  headers?: Record<string, string>;
+};
+
+function makeErr(status: number | undefined, message: string, headers?: Record<string, string>): TestError {
+  return { status, message, headers };
+}
+
+describe('classifyCreateError', () => {
+  it.each([
+    ['401 -> auth', makeErr(401, 'Unauthorized'), 'auth'],
+    ['403 -> auth', makeErr(403, 'Forbidden'), 'auth'],
+    ['429 -> throttle', makeErr(429, 'Too many requests'), 'throttle'],
+    ['Retry-After header -> throttle', makeErr(400, 'any failure', { 'Retry-After': '30' }), 'throttle'],
+    ['duplicate text -> duplicate', makeErr(400, 'duplicate value found'), 'duplicate'],
+    ['412 + duplicate -> duplicate', makeErr(412, 'duplicate value found'), 'duplicate'],
+    ['missing field -> drift', makeErr(400, "Column 'FooBar' does not exist on list"), 'drift'],
+    ['internal name drift -> drift', makeErr(400, 'invalid internal name for field'), 'drift'],
+    ['unmatched -> unknown', makeErr(500, 'unexpected server error'), 'unknown'],
+  ])('%s', (_label, input, expected) => {
+    expect(classifyCreateError(input).reason).toBe(expected);
+  });
+
+  it('prioritizes throttle over duplicate when both match', () => {
+    const err = makeErr(429, 'duplicate value found', { 'Retry-After': '15' });
+    const classified = classifyCreateError(err);
+    expect(classified.reason).toBe('throttle');
+    expect(classified.retryAfterSeconds).toBe(15);
+  });
+
+  it('prioritizes auth over duplicate when both match', () => {
+    const err = makeErr(403, 'duplicate value found');
+    const classified = classifyCreateError(err);
+    expect(classified.reason).toBe('auth');
+  });
+});

--- a/src/features/diagnostics/health/__tests__/governanceIntegration.spec.ts
+++ b/src/features/diagnostics/health/__tests__/governanceIntegration.spec.ts
@@ -85,4 +85,35 @@ describe('Governance Integration — runHealthChecks Flow', () => {
     const ui = presentGovernanceDecision(schemaResult?.governance);
     expect(ui.badgeLabel).toBe('管理者確認推奨');
   });
+
+  it('classifies create failure and reflects classification in summary/evidence', async () => {
+    const spec: ListSpec = {
+      key: 'test_list',
+      displayName: 'テストリスト',
+      resolvedTitle: 'TestList',
+      requiredFields: [],
+      createItem: {},
+      updateItem: {},
+    };
+
+    (mockSp.getCurrentUser as any).mockResolvedValue({ id: 1 });
+    (mockSp.getWebTitle as any).mockResolvedValue('Site');
+    (mockSp.getListByTitle as any).mockResolvedValue({ id: '1', title: 'TestList' });
+    (mockSp.getItemsTop1 as any).mockResolvedValue([]);
+    (mockSp.getFields as any).mockResolvedValue([]);
+    (mockSp.createItem as any).mockRejectedValueOnce({
+      status: 412,
+      message: 'duplicate value found',
+    });
+
+    const results = await runHealthChecks({ ...baseCtx, listSpecs: () => [spec] }, mockSp);
+    const createResult = results.find(r => r.key === 'permissions.create.test_list');
+
+    expect(createResult?.status).toBe('fail');
+    expect(createResult?.summary).toBe('作成（Create）テストが一意制約で失敗しました。');
+    expect(createResult?.evidence?.classification).toMatchObject({
+      reason: 'duplicate',
+      matchedOn: ['status'],
+    });
+  });
 });

--- a/src/features/diagnostics/health/checks.ts
+++ b/src/features/diagnostics/health/checks.ts
@@ -10,6 +10,7 @@ import { SpAdapter } from "./spAdapter";
 import { getRuntimeEnv } from "@/env";
 import { emitDriftRecord, type DriftResolutionType, type DriftType } from '@/features/diagnostics/drift/domain/driftLogic';
 import { decideGovernanceAction } from '@/features/diagnostics/governance/governanceEngine';
+import { classifyCreateError } from "./classifyCreateError";
 
 // statusRank is retained for potential future worst-of aggregation.
 const _statusRank: Record<HealthStatus, number> = { pass: 0, warn: 1, fail: 2 };
@@ -64,11 +65,11 @@ function pickEnvKeys(env: Record<string, unknown>, keys: string[]) {
 
 async function safe<T>(
   fn: () => Promise<T>
-): Promise<{ ok: true; v: T } | { ok: false; err: string }> {
+): Promise<{ ok: true; v: T } | { ok: false; err: string; rawErr: unknown }> {
   try {
     return { ok: true, v: await fn() };
   } catch (e) {
-    return { ok: false, err: stringifyErr(e) };
+    return { ok: false, err: stringifyErr(e), rawErr: e };
   }
 }
 
@@ -530,20 +531,55 @@ async function runListChecks(
     sp.createItem(spec.resolvedTitle, createBody)
   );
   if (!created.ok) {
+    const classified = classifyCreateError(created.rawErr);
+    const nextActionByReason = {
+      throttle: {
+        kind: "copy" as const,
+        label: "【カテゴリ: Create】数分待って再実行し、継続時は管理者に API 使用量を確認する",
+        value: `リスト「${spec.resolvedTitle}」の Create テストは一時的な制限（throttle）の可能性があります。数分後に再実行し、継続する場合は SharePoint 管理者に API 使用量の確認を依頼してください。`,
+      },
+      auth: {
+        kind: "copy" as const,
+        label: "【カテゴリ: Create】管理者に作成権限を付与するよう依頼する",
+        value: `リスト「${spec.resolvedTitle}」に対する「投稿」以上の権限を SharePoint 管理者が付与してください。`,
+      },
+      duplicate: {
+        kind: "copy" as const,
+        label: "【カテゴリ: Create】管理者に既存データ重複の有無を確認する",
+        value: `リスト「${spec.resolvedTitle}」で healthcheck 作成データの重複が発生しています。前回実行分の残存データや一意制約設定を管理者に確認してください。`,
+      },
+      drift: {
+        kind: "copy" as const,
+        label: "【カテゴリ: Create】スキーマ定義と内部名を確認する",
+        value: `リスト「${spec.resolvedTitle}」の列 internal name に不整合がある可能性があります。provision 手順と drift 候補定義を確認してください。`,
+      },
+      unknown: {
+        kind: "copy" as const,
+        label: "【カテゴリ: Create】詳細ログを確認して原因を特定する",
+        value: `リスト「${spec.resolvedTitle}」の Create テスト失敗理由を detail から確認し、必要に応じて調査 Issue を起票してください。`,
+      },
+    } as const;
+
     results.push(
       fail({
         key: `permissions.create.${spec.key}`,
         label: `権限：Create（${spec.displayName}）`,
         category: "permissions",
-        summary: "作成（Create）権限がありません。【要管理者対応】",
+        summary: classified.summaryPhrase,
         detail: created.err,
-        evidence: { listTitle: spec.resolvedTitle, payload: createBody },
-        nextActions: [
-          {
-            kind: "copy",
-            label: "【カテゴリ: Create】管理者に作成権限を付与するよう依頼する",
-            value: `リスト「${spec.resolvedTitle}」に対する「投稿」以上の権限を SharePoint 管理者が付与してください。`,
+        evidence: {
+          listTitle: spec.resolvedTitle,
+          payload: createBody,
+          classification: {
+            reason: classified.reason,
+            matchedOn: classified.matchedOn,
+            ...(typeof classified.retryAfterSeconds === "number"
+              ? { retryAfterSeconds: classified.retryAfterSeconds }
+              : {}),
           },
+        },
+        nextActions: [
+          nextActionByReason[classified.reason],
         ],
       })
     );

--- a/src/features/diagnostics/health/classifyCreateError.ts
+++ b/src/features/diagnostics/health/classifyCreateError.ts
@@ -1,0 +1,248 @@
+export type CreateErrorReason =
+  | "throttle"
+  | "auth"
+  | "duplicate"
+  | "drift"
+  | "unknown";
+
+export type ClassificationSignal = "status" | "code" | "message" | "header";
+
+export type ClassifiedCreateError = {
+  reason: CreateErrorReason;
+  summaryPhrase: string;
+  rawDetail: string;
+  matchedOn: ReadonlyArray<ClassificationSignal>;
+  retryAfterSeconds?: number;
+};
+
+type ParsedError = {
+  status?: number;
+  headers: Record<string, string>;
+  code?: string;
+  message: string;
+};
+
+const SUMMARY_BY_REASON: Record<CreateErrorReason, string> = {
+  throttle: "作成（Create）テストが一時的に制限されています。",
+  auth: "作成（Create）権限がありません。【要管理者対応】",
+  duplicate: "作成（Create）テストが一意制約で失敗しました。",
+  drift: "作成（Create）テストがスキーマ不整合で失敗しました。",
+  unknown: "作成（Create）テストに失敗しました。原因を確認してください。",
+};
+
+const AUTH_STATUS = new Set([401, 403]);
+const THROTTLE_STATUS = new Set([429]);
+const DRIFT_HINTS = [
+  "fieldnotfound",
+  "does not exist on list",
+  "column '",
+  "column \"",
+  "field not found",
+  "internal name",
+  "cannot find resource for the request",
+  "無効な列名",
+  "列が存在しません",
+  "フィールドが見つかりません",
+  "フィールドが存在しません",
+];
+const DUPLICATE_HINTS = [
+  "duplicate value",
+  "unique value",
+  "already exists",
+  "-2130575214",
+  "一意な値",
+  "重複する値",
+  "この値を持つアイテムが存在",
+];
+
+function toRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function extractMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
+}
+
+function extractStatus(err: unknown, message: string): number | undefined {
+  const rec = toRecord(err);
+  const raw = rec?.status;
+  if (typeof raw === "number" && Number.isFinite(raw)) return raw;
+
+  const match = /\((\d{3})\s/i.exec(message);
+  if (!match) return undefined;
+  const status = Number(match[1]);
+  return Number.isFinite(status) ? status : undefined;
+}
+
+function extractHeaders(err: unknown): Record<string, string> {
+  const rec = toRecord(err);
+  const raw = rec?.headers;
+  if (!raw) return {};
+
+  const out: Record<string, string> = {};
+
+  if (typeof Headers !== "undefined" && raw instanceof Headers) {
+    raw.forEach((v, k) => {
+      out[k.toLowerCase()] = String(v);
+    });
+    return out;
+  }
+
+  if (Array.isArray(raw)) {
+    for (const h of raw) {
+      if (Array.isArray(h) && h.length >= 2) {
+        out[String(h[0]).toLowerCase()] = String(h[1]);
+      }
+    }
+    return out;
+  }
+
+  const rawRecord = toRecord(raw);
+  if (!rawRecord) return {};
+  for (const [k, v] of Object.entries(rawRecord)) {
+    if (typeof v === "string" || typeof v === "number") {
+      out[k.toLowerCase()] = String(v);
+    }
+  }
+  return out;
+}
+
+function tryParseJsonPayload(message: string): Record<string, unknown> | null {
+  const trimmed = message.trim();
+  const candidates = [trimmed];
+  const start = trimmed.indexOf("{");
+  if (start > 0) candidates.push(trimmed.slice(start));
+
+  for (const c of candidates) {
+    try {
+      const parsed = JSON.parse(c);
+      const rec = toRecord(parsed);
+      if (rec) return rec;
+    } catch {
+      // noop
+    }
+  }
+  return null;
+}
+
+function extractCodeFromPayload(payload: Record<string, unknown>): string | undefined {
+  const odataError = toRecord(payload["odata.error"]);
+  const odataCode = odataError?.code;
+  if (typeof odataCode === "string" && odataCode.trim()) return odataCode;
+
+  const errorObj = toRecord(payload.error);
+  const graphCode = errorObj?.code;
+  if (typeof graphCode === "string" && graphCode.trim()) return graphCode;
+
+  return undefined;
+}
+
+function parseRetryAfterSeconds(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const sec = Number(value);
+  if (Number.isFinite(sec) && sec >= 0) return sec;
+
+  const at = Date.parse(value);
+  if (!Number.isNaN(at)) {
+    const deltaSec = Math.ceil((at - Date.now()) / 1000);
+    return deltaSec >= 0 ? deltaSec : 0;
+  }
+
+  return undefined;
+}
+
+function includesAny(text: string, patterns: string[]): boolean {
+  return patterns.some((p) => text.includes(p));
+}
+
+function parseError(err: unknown): ParsedError {
+  const message = extractMessage(err);
+  const headers = extractHeaders(err);
+  const payload = tryParseJsonPayload(message);
+  const code = payload ? extractCodeFromPayload(payload) : undefined;
+
+  return {
+    status: extractStatus(err, message),
+    headers,
+    code,
+    message,
+  };
+}
+
+export function classifyCreateError(err: unknown): ClassifiedCreateError {
+  const parsed = parseError(err);
+  const messageLower = parsed.message.toLowerCase();
+  const codeLower = parsed.code?.toLowerCase();
+  const retryAfterSeconds = parseRetryAfterSeconds(parsed.headers["retry-after"]);
+
+  const throttleByHeader = retryAfterSeconds !== undefined;
+  const throttleByStatus = parsed.status !== undefined && THROTTLE_STATUS.has(parsed.status);
+  const throttleByCode = codeLower?.includes("throttl") || false;
+  if (throttleByHeader || throttleByStatus || throttleByCode) {
+    const matchedOn: ClassificationSignal[] = [];
+    if (throttleByHeader) matchedOn.push("header");
+    if (throttleByStatus) matchedOn.push("status");
+    if (!throttleByStatus && throttleByCode) matchedOn.push("code");
+    return {
+      reason: "throttle",
+      summaryPhrase: SUMMARY_BY_REASON.throttle,
+      rawDetail: parsed.message,
+      matchedOn,
+      retryAfterSeconds,
+    };
+  }
+
+  const authByStatus = parsed.status !== undefined && AUTH_STATUS.has(parsed.status);
+  if (authByStatus) {
+    return {
+      reason: "auth",
+      summaryPhrase: SUMMARY_BY_REASON.auth,
+      rawDetail: parsed.message,
+      matchedOn: ["status"],
+    };
+  }
+
+  const duplicateByStatus = parsed.status === 412;
+  const duplicateByCode =
+    codeLower === "-2130575214" ||
+    codeLower?.includes("duplicate") ||
+    codeLower?.includes("unique");
+  const duplicateByMessage = includesAny(messageLower, DUPLICATE_HINTS);
+  if (duplicateByStatus || duplicateByCode || duplicateByMessage) {
+    const matchedOn: ClassificationSignal[] = [];
+    if (duplicateByStatus) matchedOn.push("status");
+    if (!duplicateByStatus && duplicateByCode) matchedOn.push("code");
+    if (!duplicateByStatus && !duplicateByCode && duplicateByMessage) matchedOn.push("message");
+    return {
+      reason: "duplicate",
+      summaryPhrase: SUMMARY_BY_REASON.duplicate,
+      rawDetail: parsed.message,
+      matchedOn,
+    };
+  }
+
+  const driftByCode = codeLower?.includes("fieldnotfound") || false;
+  const driftByMessage = includesAny(messageLower, DRIFT_HINTS);
+  if (driftByCode || driftByMessage) {
+    return {
+      reason: "drift",
+      summaryPhrase: SUMMARY_BY_REASON.drift,
+      rawDetail: parsed.message,
+      matchedOn: [driftByCode ? "code" : "message"],
+    };
+  }
+
+  return {
+    reason: "unknown",
+    summaryPhrase: SUMMARY_BY_REASON.unknown,
+    rawDetail: parsed.message,
+    matchedOn: [],
+  };
+}


### PR DESCRIPTION
## 概要
Health check の Create failure を一律「権限なし」で扱っていた挙動を修正し、Reason Classification（throttle/auth/duplicate/drift/unknown）を実装しました。  
対象は Create probe のみで、update/delete には未適用です。

## 背景
PR #1532 で uniqueId を run-scoped に移し、同一ページ内の再実行で同じ payload を再利用してしまう false-fail を止血しました。  
本PRではその次段として、Create failure の根本理由を分類し、誤って「権限なし」に丸めないようにします。

## 変更内容
- `src/features/diagnostics/health/classifyCreateError.ts` を新規追加
  - `classifyCreateError(err)` を実装
  - 優先順位: `throttle > auth > duplicate > drift > unknown`
  - 判定材料: HTTP status / Retry-After / SharePoint error code / message
- `src/features/diagnostics/health/checks.ts`
  - Create failure (`!created.ok`) のみ分類ベースに差し替え
  - reason ごとに `summary` / `nextActions` を切替
  - `evidence.classification` を追加
- テスト追加
  - `classifyCreateError.spec.ts`（fixtureベース + 優先順位）
  - `governanceIntegration.spec.ts` に create failure 分類反映の統合テスト1件追加

## 分類ルール
- `throttle`
  - 429 または `Retry-After` を検知
- `auth`
  - 401 / 403
- `duplicate`
  - 412 または unique / duplicate 系メッセージ
- `drift`
  - missing field / internal name drift 系メッセージ
- `unknown`
  - 上記以外

## テスト
実行:
- `npx vitest run src/features/diagnostics/health/__tests__/classifyCreateError.spec.ts src/features/diagnostics/health/__tests__/governanceIntegration.spec.ts`
- `npx vitest run src/features/diagnostics/health/__tests__/*.spec.ts`

結果:
- 2ファイル実行: 14 passed
- health配下全spec: 34 passed

## スコープ外
- Update/Delete probe への横展開
- telemetry reasonCode 連携の拡張
- unrelated な既存 TS error への対応

## 補足
- `safe()` は create failure 分類に生エラーを渡せるよう `rawErr` を返すよう拡張していますが、既存利用には非破壊です。
- 既存のローカル変更（`docs/nightly-patrol/...`, `scripts/ops/phased-purge.mjs`, `audit_temp.log`）には触れていません