### PR TITLE
provision(schema): add 2 canonical optional columns to Users_Master

### DIFF
--- a/provision/schema.xml
+++ b/provision/schema.xml
@@ -24,6 +24,10 @@
             <pnp:Field ID="{C0B9C86A-9AFB-4F2C-A2BB-59D72DE0B628}" Type="Boolean" DisplayName="有効" StaticName="isActive" Name="isActive">
               <Default>1</Default>
             </pnp:Field>
+            <pnp:Field ID="{E2E0AEF6-27FA-4830-85D6-E507F71D122A}" Type="Boolean" DisplayName="支援手順記録対象" StaticName="IsSupportProcedureTarget" Name="IsSupportProcedureTarget">
+              <Default>0</Default>
+            </pnp:Field>
+            <pnp:Field ID="{395B0DEF-30AE-4F30-A37E-BFFD0F39BCFD}" Type="DateTime" DisplayName="受給資格確認日時" StaticName="EligibilityCheckedAt" Name="EligibilityCheckedAt" Format="DateTime" />
           </pnp:Fields>
         </pnp:ListInstance>
         <!-- Staff_Master: 職員マスタ（ハブ） -->


### PR DESCRIPTION
# Lot 1 PR Draft — Users_Master optional canonical provision (2 列)

## Branch
`provision/lot1-optional-canonical-columns`
（`main` から切る。現行 `fix/health-reason-classification` とは独立）

## Pre-flight (required)

This PR must be prepared from a clean `main`-based branch.

If there are any local tracked or untracked changes unrelated to Lot 1, stash them before branch creation.
Do not carry pending changes from `provision/schema.xml`, CI helper scripts, ops scripts, or local scratch files into this PR.

Example:

```bash
git stash push -u -m "pre-lot1-all-pending" \
  docs/nightly-patrol/drift-inventory-2026-04-20.csv \
  provision/schema.xml \
  scripts/ci/schemas/user-benefit-ext.mjs \
  scripts/ops/phased-purge.mjs \
  audit_temp.log
git checkout main
git pull origin main
git checkout -b provision/lot1-optional-canonical-columns
```

Acceptance for pre-flight:

- `git status` is clean before editing
- branch is created from current `main`
- diff contains only Lot 1 target changes
- no pending `UserBenefit_Profile_Ext` / `RecipientCertNumber` / CI / ops carry-over is included

---

## PR Title
`provision(schema): add 2 canonical optional columns to Users_Master`

（70 文字以内）

## PR Body

### Summary
- admin-status `/admin/status` で WARN として表面化している optional 列のうち、**Users_Master に属する 2 列** を canonical 名で SharePoint 側に追加する provision 変更。
- 当初 5 列を想定していたが、残り 3 列（`UserTransport_Settings` / `SupportProcedureRecord_Daily` 配下）は schema.xml に既存 `<pnp:ListInstance>` が無く、**新規リスト定義追加**という別種の変更になるため **Lot 1b** に分離。本 PR は既存 ListInstance への add-only に限定する。
- いずれも **add-only / non-breaking**。既存データ・参照箇所への影響なし。
- `drift-inventory-2026-04-20.csv` の `judgement=optional-missing` サブセットから 2 行を抽出。

### Scope

| listKey | listTitle | expectedField | type | 用途 |
|---|---|---|---|---|
| users_master | Users_Master | **IsSupportProcedureTarget** | per SSOT (`userFields.ts`) | ISP 三層モデル第 2/3 層の対象フラグ |
| users_master | Users_Master | **EligibilityCheckedAt** | per SSOT (`userFields.ts`) | 受給資格確認タイムスタンプ |

（各列の最終的な Type/Required/Indexed 属性は SSOT 定義に厳密一致させる。PR 本文では型を断定しない。）

Allowed in this PR:
- add new optional canonical fields to existing list definitions (Users_Master のみ)
- align XML metadata for those new fields only

Not allowed in this PR:
- add new `<pnp:ListInstance>` blocks
- rename existing fields
- delete existing fields
- backfill or mutate existing items
- change repository read/write behavior
- introduce fallback removal
- include any `UserBenefit_Profile_Ext` work

### Out of Scope
- `UserTransport_Settings.TransportAdditionType` → **Lot 1b**（新規 ListInstance 追加が必要）
- `SupportProcedureRecord_Daily.ISPId` → **Lot 1b**（新規 ListInstance 追加が必要）
- `SupportProcedureRecord_Daily.HandoffNotes` → **Lot 1b**（新規 ListInstance 追加が必要）
- `UserBenefit_Profile_Ext.RecipientCertNumber` → **Lot 2** で対応（essential × add-canonical、backfill を伴う）
- `user_benefit_profile.UserID` の `User_x0020_ID → UserID` → **Lot 3**（rename-migrate）
- `UserBenefit_Profile` の列サイズ上限保留 3 列 → **Lot 4 / defer**（メモリ `project_user_benefit_profile_provisioning_deferred.md`）

### Why now
- Users_Master 上の admin-status WARN を先に安全に減らす（5件 → 3件）。
- 既存 ListInstance への add-only だけに限定し、変更種別を増やさない。
- 新規 ListInstance が必要な項目は Lot 1b に分離してレビュー容易性を保つ。
- 追加のみで破壊的変更がないため、レビュー負荷・rollback コストともに最小。

### How it's safe
- `Required="FALSE"` の optional 列追加のみ。
- 既存列の削除・rename なし。既存データに触れない。
- 新規 ListInstance の追加なし。既存 `Users_Master` ブロック内への `<pnp:Field>` 追記のみ。
- 失敗時は該当 `<pnp:Field>` を XML から戻すだけで完全 rollback 可能。
- fail-open + visible drift 方針を維持（列が無かった状態でも動作済み）。

### Test Plan
- [ ] `npm run ci:schema` / drift-inventory 系バリデーションが通ること
- [ ] `provision/schema.xml` のスキーマ検証（XML 構文 / StaticName 一意性）
- [ ] preprod で provision 再実行 → 2 列が Users_Master に作成されること
- [ ] preprod admin-status で Users_Master 由来の WARN 2 件が消えること（WARN カウントが -2）
- [ ] essential 側のヘルスチェックに影響が出ないこと（FAIL 0 維持）
- [ ] SSOT 側 FieldMap と実列の drift が `optional-missing → no-action` に遷移することを再診断で確認
- [ ] diff review confirms no changes outside the 2 target fields in `provision/schema.xml`
- [ ] diff review confirms no new `<pnp:ListInstance>` blocks were introduced

### Rollback Plan
1. 対象 `<pnp:Field>` エントリ 2 行を `provision/schema.xml` の Users_Master ブロックから除去
2. preprod/prod で列を残したままにする場合は SharePoint 側で列削除（または残置して WARN 再発を許容）
3. 診断が元の WARN 2 件に戻ることを確認

### Reviewer Notes
- 2 列とも **現状 SSOT にはあるが XML に無い** パターン。実装側の drift ではなく provision 定義側の抜け。
- `Name` / `StaticName` / `DisplayName` の整合は厳密に揃える（再診断時に fuzzy_match に落ちないため）。
- 日本語 DisplayName を使う場合も、`StaticName` は ASCII / camelCase 固定。過去 drift の `_x0020_` エンコード混入を防ぐ。
- `Users_Master` への 2 列追加は ISP 三層モデル境界に触れるため、`docs/design/isp-three-layer-regulatory-mapping.md` 記載の前提と齟齬がないか軽く確認。

Selection rule for Lot 1:
- only rows classified as `optional-missing`
- only add-only changes to existing `<pnp:ListInstance>` blocks
- no new `<pnp:ListInstance>` blocks
- no essential field migration
- no rename-migrate
- no cleanup / purge

### Related
- Drift triage sheet: `docs/nightly-patrol/drift-triage-2026-04-21.md`
- Drift inventory CSV: `docs/nightly-patrol/drift-inventory-2026-04-20.csv`
- Follow-up PRs:
  - Lot 1b (new list provisioning: `UserTransport_Settings`, `SupportProcedureRecord_Daily`)
  - Lot 2 (`RecipientCertNumber` canonical)
  - Lot 3 (`UserID` rename-migrate)

---

## Post-merge Verification
1. prod に provision 再実行
2. admin-status を再取得し、Users_Master 由来の WARN 2 件が消えていることを確認
3. drift-inventory を再生成 → 対象 2 行が `judgement=no-action` に遷移しているか確認
4. 次ロット（Lot 1b = `UserTransport_Settings` / `SupportProcedureRecord_Daily` 新規 ListInstance 追加）を起票。Lot 1b では **他経路（PnP manifest / `scripts/sp-preprod/` 等）で既に provisioning されていないか** を先に調査する
