### PR TITLE
fix(workflow): avoid boolean splatting in provision WhatIf

### DIFF
--- a/.github/workflows/provision-sharepoint.yml
+++ b/.github/workflows/provision-sharepoint.yml
@@ -114,22 +114,15 @@ jobs:
           $forceTypeReplace = [bool]::Parse($env:FORCE_TYPE_REPLACE)
           $whatIfMode = [bool]::Parse($env:WHAT_IF)
 
-          $args = @(
-            '-SiteUrl', $siteUrl,
-            '-RecreateExisting', $recreateExisting,
-            '-ApplyFieldUpdates', $applyFieldUpdates,
-            '-ForceTypeReplace', $forceTypeReplace,
-            '-SchemaPath', $env:SCHEMA_PATH,
-            '-ChangesOutPath', 'provision/changes.json'
-          )
-
-          if ($whatIfMode) {
-            $args += '-WhatIfMode'
-          }
-
-          $args += '-EmitChanges'
-
-          & ./scripts/provision-spo.ps1 @args
+          & ./scripts/provision-spo.ps1 `
+            -SiteUrl $siteUrl `
+            -RecreateExisting:$recreateExisting `
+            -ApplyFieldUpdates:$applyFieldUpdates `
+            -ForceTypeReplace:$forceTypeReplace `
+            -WhatIfMode:$whatIfMode `
+            -SchemaPath $env:SCHEMA_PATH `
+            -ChangesOutPath 'provision/changes.json' `
+            -EmitChanges
 
           if ([bool]::Parse($env:BACKFILL_ENTRY_HASH)) {
             Write-Host "Starting entry_hash backfill..." -ForegroundColor Cyan


### PR DESCRIPTION
## Summary

`provision-sharepoint.yml` の WhatIf 実行が、SharePoint 接続前に PowerShell の引数バインドで失敗していたため修正します。

根本原因は、`scripts/provision-spo.ps1` の `[bool]` パラメータ
- `RecreateExisting`
- `ApplyFieldUpdates`
- `ForceTypeReplace`

を、workflow 側で配列 splatting (`@args`) により渡していたことです。

この経路では PowerShell が bool を string として再解釈し、
`Cannot convert value "System.String" to type "System.Boolean"` で停止していました。

本PRでは `provision-apply.yml` と同じく、named colon syntax で直接引数を渡す形に揃えます。

No production write occurred in the failed WhatIf run because execution never reached `Connect-PnPOnline`.

## Scope

- `.github/workflows/provision-sharepoint.yml` の provision step 1箇所のみ
- `@args` splatting を廃止
- `./scripts/provision-spo.ps1` への直接引数渡しに変更
- `-WhatIfMode:$whatIfMode` を明示指定
- `-EmitChanges` は switch のまま維持

## Out of scope

- `scripts/provision-spo.ps1` 本体の変更
- `provision-apply.yml` の変更
- SharePoint schema / provisioning ロジックの変更
- Lot 1b authority / runtime registry の変更
- 本番 apply 実行そのもの

## Why now

Lot 1 の効果観測を `WhatIf -> Apply` の順で安全に進める前提として、WhatIf workflow の健全化が必要なためです。

今回の不具合は Lot 1 差分とは無関係な既存 workflow バグであり、先にここを直すことで
- WhatIf first の運用ルールを維持できる
- 本番書き込み前に dry-run を再度確認できる
- 今後の provision 観測でも同じ失敗を防げる

## How it's safe

- workflow の引数渡し方法のみを修正
- `provision-spo.ps1` の契約には手を入れない
- `provision-apply.yml` で既に使われている呼び出しパターンに揃えるだけ
- 失敗していた run でも SharePoint 接続前に停止しており、本番変更は発生していない

## Test plan

- [ ] workflow YAML / PowerShell 構文に問題がないこと
- [ ] `provision-sharepoint.yml` の WhatIf 実行が parameter binding error で落ちなくなること
- [ ] run が `Connect-PnPOnline` 以降へ進むこと
- [ ] expected inputs (`SiteUrl`, `SchemaPath`, `ChangesOutPath`) が従来どおり渡ること
- [ ] WhatIf run 後も本番 apply は未実行であること

## Rollback

`provision-sharepoint.yml` の該当 step を元の `@args` splatting 方式へ戻すだけで rollback 可能です。

## Reviewer notes

- `scripts/provision-spo.ps1` 側では `RecreateExisting` / `ApplyFieldUpdates` / `ForceTypeReplace` が `[bool]`
- `WhatIfMode` / `EmitChanges` は `[switch]`
- 問題は workflow 側の splatting にあり、script 側の契約変更は不要
- `provision-apply.yml` で実績のある直接渡しパターンへの整列です
- 本修正は Lot 1 観測 unblock 用の小PRです

🤖 Generated with [Claude Code](https://claude.com/claude-code)