### PR TITLE
feat(health): surface operational decision signals on HealthPage

### DIFF
--- a/src/pages/HealthPage.tsx
+++ b/src/pages/HealthPage.tsx
@@ -1,7 +1,26 @@
 import React from "react";
+import {
+  Alert,
+  AlertTitle,
+  Box,
+  Button,
+  Chip,
+  Collapse,
+  Paper,
+  Stack,
+  Typography,
+} from "@mui/material";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import WarningAmberIcon from "@mui/icons-material/WarningAmber";
+import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+
 import { HealthDiagnosisPage } from "../features/diagnostics/health/HealthDiagnosisPage";
 import { HealthContext, ListSpec } from "../features/diagnostics/health/types";
 import { getRuntimeEnv } from "@/env";
+// @ts-expect-error - JSON import is handled by Vite but TSC may fail to resolve it in isolated build
+// eslint-disable-next-line import/no-unresolved
+import latestDecision from "../sharepoint/latest-decision.json";
 
 /**
  * ✅ 診断対象リスト（SSOT から自動生成）
@@ -393,6 +412,198 @@ function buildListSpecs(): ListSpec[] {
   });
 }
 
+/**
+ * 🎯 Nightly Decision Signal 型定義
+ */
+export type HealthDecisionSignal = {
+  type: 'drift' | 'index' | 'zombie'
+  severity: 'info' | 'warn' | 'critical'
+  listKey?: string
+  message: string
+  recommendation: string
+}
+
+const SEVERITY_ORDER = { critical: 0, warn: 1, info: 2 };
+
+/**
+ * 🚀 OperationalSignalCard
+ * 「5秒見れば次の一手が分かる」最小UI
+ */
+function OperationalSignalCard() {
+  const [showInfo, setShowInfo] = React.useState(false);
+  const signals = (latestDecision.interpretation?.signals as unknown as HealthDecisionSignal[]) || [];
+  
+  if (signals.length === 0) return null;
+
+  const sortedSignals = [...signals].sort(
+    (a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity]
+  );
+
+  const urgentSignals = sortedSignals.filter((s) => s.severity !== "info");
+  const infoSignals = sortedSignals.filter((s) => s.severity === "info");
+
+  const hasCritical = urgentSignals.some(s => s.severity === 'critical');
+
+  return (
+    <Paper
+      elevation={4}
+      sx={{
+        p: 2.5,
+        borderRadius: 3,
+        background: "linear-gradient(135deg, #ffffff 0%, #f0f7ff 100%)",
+        border: "1px solid",
+        borderColor: hasCritical ? "error.light" : "primary.light",
+        position: "relative",
+        overflow: "hidden",
+        boxShadow: "0 8px 32px rgba(0,0,0,0.08)",
+        "&::before": {
+          content: '""',
+          position: "absolute",
+          top: 0,
+          left: 0,
+          width: "6px",
+          height: "100%",
+          backgroundColor: hasCritical ? "error.main" : "primary.main",
+        }
+      }}
+    >
+      <Stack spacing={2.5}>
+        <Stack direction="row" justifyContent="space-between" alignItems="center">
+          <Typography variant="h6" sx={{ fontWeight: 800, color: "text.primary", display: 'flex', alignItems: 'center', gap: 1.5 }}>
+            <span style={{ fontSize: '1.2rem' }}>🎯</span> Nightly Decision Engine
+            <Chip 
+              size="small" 
+              label={`Analyzed: ${latestDecision.date ?? '---'}`} 
+              sx={{ 
+                ml: 1, 
+                height: 22, 
+                fontSize: '0.7rem', 
+                fontWeight: 600,
+                bgcolor: 'rgba(0,0,0,0.05)'
+              }} 
+            />
+          </Typography>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+             <Typography variant="caption" sx={{ fontWeight: 700, color: 'text.secondary' }}>
+               Status:
+             </Typography>
+             <Chip 
+               label={latestDecision.final?.line ?? 'Unknown'} 
+               color={hasCritical ? "error" : "warning"}
+               size="small"
+               variant="filled"
+               sx={{ fontWeight: 700, fontSize: '0.75rem' }}
+             />
+          </Box>
+        </Stack>
+
+        {/* 緊急度の高いシグナル (Critical / Warn) */}
+        <Stack spacing={1.5}>
+          {urgentSignals.map((signal, idx) => (
+            <Alert
+              key={idx}
+              severity={signal.severity === "critical" ? "error" : "warning"}
+              icon={signal.severity === "critical" ? <ErrorOutlineIcon fontSize="medium" /> : <WarningAmberIcon fontSize="medium" />}
+              sx={{ 
+                borderRadius: 2,
+                border: '1px solid',
+                borderColor: signal.severity === 'critical' ? 'error.light' : 'warning.light',
+                boxShadow: "0 2px 12px rgba(0,0,0,0.04)",
+                "& .MuiAlert-message": { width: '100%' }
+              }}
+            >
+              <AlertTitle sx={{ fontWeight: 700, mb: 0.5 }}>
+                {signal.listKey ?? signal.type.toUpperCase()} 
+                {signal.listKey && (
+                  <Typography component="span" variant="caption" sx={{ opacity: 0.8, ml: 1, fontWeight: 400 }}>
+                    [{signal.type.toUpperCase()}]
+                  </Typography>
+                )}
+              </AlertTitle>
+              <Stack spacing={1.5}>
+                <Typography variant="body2" sx={{ fontWeight: 500, lineHeight: 1.5 }}>
+                  {signal.message}
+                </Typography>
+                
+                <Box 
+                  sx={{ 
+                    p: 1.5, 
+                    borderRadius: 1.5, 
+                    bgcolor: signal.severity === 'critical' ? 'rgba(211, 47, 47, 0.05)' : 'rgba(237, 108, 2, 0.05)',
+                    borderLeft: '4px solid',
+                    borderColor: 'inherit',
+                  }}
+                >
+                  <Typography variant="caption" sx={{ display: 'flex', alignItems: 'center', gap: 0.5, fontWeight: 800, mb: 0.5, color: 'inherit' }}>
+                    💡 次のアクション (Recommendation)
+                  </Typography>
+                  <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                    {signal.recommendation}
+                  </Typography>
+                </Box>
+              </Stack>
+            </Alert>
+          ))}
+          
+          {urgentSignals.length === 0 && (
+            <Box sx={{ py: 2, textAlign: 'center', opacity: 0.6 }}>
+               <Typography variant="body2">⚠️ 緊急の対処が必要なシグナルはありません</Typography>
+            </Box>
+          )}
+        </Stack>
+
+        {/* 認容済みのシグナル (Info) - 折りたたみ表示 */}
+        {infoSignals.length > 0 && (
+          <Box>
+            <Button
+              size="small"
+              onClick={() => setShowInfo(!showInfo)}
+              startIcon={<InfoOutlinedIcon sx={{ fontSize: '1rem' }} />}
+              endIcon={<ExpandMoreIcon sx={{ transform: showInfo ? 'rotate(180deg)' : 'none', transition: 'transform 0.2s' }} />}
+              sx={{ 
+                color: "text.secondary", 
+                fontSize: '0.75rem',
+                fontWeight: 600,
+                textTransform: 'none',
+                '&:hover': { bgcolor: 'rgba(0,0,0,0.03)' }
+              }}
+            >
+              認容済みの差分を表示 ({infoSignals.length} 件)
+            </Button>
+            <Collapse in={showInfo}>
+              <Stack spacing={1} sx={{ mt: 1.5 }}>
+                {infoSignals.map((signal, idx) => (
+                  <Paper
+                    key={idx}
+                    variant="outlined"
+                    sx={{ 
+                      p: 1.25, 
+                      bgcolor: 'rgba(0,0,0,0.01)', 
+                      borderStyle: 'dashed',
+                      borderColor: 'divider',
+                      '&:hover': { bgcolor: 'rgba(0,0,0,0.03)' }
+                    }}
+                  >
+                    <Stack direction="row" spacing={1.5} alignItems="center">
+                      <Chip label={signal.type} size="small" variant="outlined" sx={{ height: 18, fontSize: '0.6rem', color: 'text.disabled' }} />
+                      <Typography variant="caption" sx={{ fontWeight: 700, minWidth: '100px' }}>
+                        {signal.listKey ?? 'General'}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        {signal.message}
+                      </Typography>
+                    </Stack>
+                  </Paper>
+                ))}
+              </Stack>
+            </Collapse>
+          </Box>
+        )}
+      </Stack>
+    </Paper>
+  );
+}
+
 export default function HealthPage() {
   const env = getRuntimeEnv() as Record<string, unknown>;
   
@@ -408,5 +619,12 @@ export default function HealthPage() {
     autonomyLevel: 'F', // デフォルトは提案ベース（Level F）
   };
 
-  return <HealthDiagnosisPage ctx={ctx} />;
+  return (
+    <Box>
+      <Box sx={{ p: 2, pb: 0 }}>
+        <OperationalSignalCard />
+      </Box>
+      <HealthDiagnosisPage ctx={ctx} />
+    </Box>
+  );
 }

--- a/src/pages/HealthPage.tsx
+++ b/src/pages/HealthPage.tsx
@@ -18,8 +18,6 @@ import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import { HealthDiagnosisPage } from "../features/diagnostics/health/HealthDiagnosisPage";
 import { HealthContext, ListSpec } from "../features/diagnostics/health/types";
 import { getRuntimeEnv } from "@/env";
-// @ts-expect-error - JSON import is handled by Vite but TSC may fail to resolve it in isolated build
-// eslint-disable-next-line import/no-unresolved
 import latestDecision from "../sharepoint/latest-decision.json";
 
 /**

--- a/src/sharepoint/latest-decision.json
+++ b/src/sharepoint/latest-decision.json
@@ -1,0 +1,9 @@
+{
+  "date": "",
+  "final": {
+    "line": "No decision available"
+  },
+  "interpretation": {
+    "signals": []
+  }
+}


### PR DESCRIPTION
## Summary
HealthPage に Nightly Decision Engine の判定結果を表示し、
「5秒見れば次の一手が分かる」最小UIを追加しました。

## Changes
- import \src/sharepoint/latest-decision.json\
- add operational decision section to \HealthPage.tsx\
- surface \critical\ / \warn\ signals first
- collapse \info\ signals by default
- harden rendering for missing metadata such as \listKey\, analyzed date, and status

## Verification
- \
pm run typecheck:full\ ✅

## Notes
This is Phase 1 only.
Non-goals:
- filter UI
- summary cards
- major refactor of existing health diagnostics