### PR TITLE
feat(users): add Lot1B benefit profile cutover path

### DIFF
--- a/docs/design/lot1b-provisioning-authority-scoping.md
+++ b/docs/design/lot1b-provisioning-authority-scoping.md
@@ -1,0 +1,63 @@
+# Lot 1b Scoping Memo — provisioning authority for runtime-managed lists
+
+## Summary
+`UserTransport_Settings` and `SupportProcedureRecord_Daily` are not governed by `provision/schema.xml`.
+Their canonical provisioning authority is `src/sharepoint/spListRegistry.ts`, where both lists are declared as `lifecycle=required`.
+
+The three Lot 1b target fields are already present in `provisioningFields`:
+- `UserTransport_Settings.TransportAdditionType`
+- `SupportProcedureRecord_Daily.ISPId`
+- `SupportProcedureRecord_Daily.HandoffNotes`
+
+Therefore, Lot 1b is not a “missing field definition” change.
+It is an authority-governance change: clarify that these lists belong to the runtime registry authority, not the XML authority.
+
+## Evidence
+### UserTransport_Settings
+- canonical definition: `src/sharepoint/spListRegistry.ts`
+- lifecycle: `required`
+- target field already declared: `TransportAdditionType`
+- `provision/schema.xml`: not included
+- runtime list exists in production; drift shows `optional-missing`
+
+### SupportProcedureRecord_Daily
+- canonical definition: `src/sharepoint/spListRegistry.ts`
+- lifecycle: `required`
+- target fields already declared: `ISPId`, `HandoffNotes`
+- `provision/schema.xml`: not included
+- audit manifest may include the list, but that is not the provisioning authority
+- runtime list exists in production; drift shows `optional-missing`
+
+## Case classification
+Provisional case: **Case C**
+
+Reason:
+A canonical XML authority exists for some lists, but runtime registry–based provisioning also acts as canonical authority for runtime-managed lists. In parallel, multiple per-list / REST / Graph / Node provisioning paths exist as historical or operational side paths.
+
+## Decision
+Adopt **Option 3**:
+- `schema.xml` remains the declarative authority for bootstrap-oriented lists
+- `spListRegistry.ts` remains the canonical authority for runtime-managed / lifecycle-required lists
+- Lot 1b target lists belong to the runtime-managed authority
+
+## Non-goals
+- Do not move these two lists into `schema.xml` in Lot 1b
+- Do not remove historical provisioning scripts yet
+- Do not implement a repo-wide provisioning unification in this lot
+
+## Required follow-up
+1. Document the dual-authority boundary in ADR/design docs
+2. Define whether `optional-missing` on runtime-managed lists should:
+   - self-heal automatically,
+   - require an explicit trigger,
+   - or be surfaced as action-required when heal does not occur
+3. Classify existing non-canonical scripts into:
+   - canonical runtime support
+   - repair-only
+   - deprecation candidates
+
+## Proposed implementation shape for Lot 1b
+Lot 1b should be split into:
+- **Lot 1b-doc**: authority boundary clarification
+- **Lot 1b-heal**: trigger/verify runtime provisioning for the 3 already-declared fields
+- **Lot 1b-cleanup**: future script classification / retirement

--- a/scripts/ops/lot1b-pr-e-smoke-dump.mjs
+++ b/scripts/ops/lot1b-pr-e-smoke-dump.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+
+const LIST_BENEFIT = 'UserBenefit_Profile';
+const LIST_BENEFIT_EXT = 'UserBenefit_Profile_Ext';
+const STAGE_ENV_KEY = 'VITE_USER_BENEFIT_PROFILE_CUTOVER_STAGE';
+
+const BENEFIT_FIELDS = [
+  'Id',
+  'UserID',
+  'GrantMunicipality',
+  'Grant_x0020_Municipality',
+  'GrantPeriodStart',
+  'Grant_x0020_Period_x0020_Start',
+  'GrantPeriodEnd',
+  'Grant_x0020_Period_x0020_End',
+  'MealAddition',
+  'Meal_x0020_Addition',
+  'UserCopayLimit',
+  'User_x0020_Copay_x0020_Limit',
+  'CopayPaymentMethod',
+  'Copay_x0020_Payment_x0020_Method',
+  'RecipientCertExpiry',
+  'Modified',
+];
+
+const BENEFIT_EXT_FIELDS = [
+  'Id',
+  'UserID',
+  'RecipientCertNumber',
+  'Recipient_x0020_Cert_x0020_Numbe',
+  'Modified',
+];
+
+const args = process.argv.slice(2);
+const hasFlag = (name) => args.includes(`--${name}`);
+const getFlagValue = (name, fallback = null) => {
+  const prefix = `--${name}=`;
+  const inline = args.find((a) => a.startsWith(prefix));
+  if (inline) return inline.slice(prefix.length);
+  const idx = args.indexOf(`--${name}`);
+  if (idx >= 0 && idx + 1 < args.length && !args[idx + 1].startsWith('--')) return args[idx + 1];
+  return fallback;
+};
+
+const dateStamp = new Date().toISOString().slice(0, 10);
+const siteUrl = (process.env.VITE_SP_SITE_URL || process.env.SP_SITE_URL || '').trim();
+const explicitOut = getFlagValue('out');
+const defaultOut = `docs/nightly-patrol/lot1b-pr-e-staging-smoke-evidence-${dateStamp}.json`;
+const outPath = resolve(process.cwd(), explicitOut || defaultOut);
+
+const userId = getFlagValue('user-id');
+const step = getFlagValue('step', 'UNSPECIFIED');
+const stage = getFlagValue('stage', process.env[STAGE_ENV_KEY] || 'UNSPECIFIED');
+const timing = getFlagValue('timing', 'after');
+const judgement = getFlagValue('judgement', 'PENDING');
+
+if (hasFlag('help') || !userId) {
+  console.log('Usage:');
+  console.log('  node scripts/ops/lot1b-pr-e-smoke-dump.mjs --user-id TEST-CUTOVER-001 --stage DUAL_WRITE --step B1');
+  console.log('Optional:');
+  console.log('  --out <path>      output JSON path (default: docs/nightly-patrol/lot1b-pr-e-staging-smoke-evidence-YYYY-MM-DD.json)');
+  console.log('  --record-id <id>  manual record id used in UI/repository logs');
+  console.log('  --timing <before|after>  mark capture timing per step');
+  console.log('  --judgement <PASS|WARN|PENDING>  quick decision tag');
+  process.exit(userId ? 0 : 2);
+}
+
+if (!siteUrl) {
+  console.error('Missing site URL. Set VITE_SP_SITE_URL or SP_SITE_URL.');
+  process.exit(2);
+}
+
+function readToken() {
+  const envToken = (process.env.VITE_SP_TOKEN || process.env.SMOKE_TEST_BEARER_TOKEN || '').trim();
+  if (envToken) return envToken;
+
+  const tokenFile = join(process.cwd(), '.token.local');
+  if (existsSync(tokenFile)) {
+    return readFileSync(tokenFile, 'utf-8').trim();
+  }
+  return '';
+}
+
+const token = readToken();
+if (!token) {
+  console.error('Missing bearer token. Set VITE_SP_TOKEN/SMOKE_TEST_BEARER_TOKEN or provide .token.local.');
+  process.exit(2);
+}
+
+function escapeODataString(value) {
+  return String(value).replace(/'/g, "''");
+}
+
+async function fetchByUserId(listTitle, fields, targetUserId) {
+  const params = new URLSearchParams();
+  params.set('$select', fields.join(','));
+  params.set('$filter', `UserID eq '${escapeODataString(targetUserId)}'`);
+  params.set('$top', '1');
+
+  const url = `${siteUrl}/_api/web/lists/getbytitle('${encodeURIComponent(listTitle)}')/items?${params.toString()}`;
+  const res = await fetch(url, {
+    headers: {
+      Accept: 'application/json;odata=nometadata',
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`${listTitle}: HTTP ${res.status} ${res.statusText} :: ${body.slice(0, 400)}`);
+  }
+
+  const json = await res.json();
+  return Array.isArray(json?.value) ? json.value[0] || null : null;
+}
+
+function toObjectOrNull(value) {
+  return value && typeof value === 'object' ? value : null;
+}
+
+function loadEvidenceFile(path) {
+  if (!existsSync(path)) {
+    return { version: 1, createdAt: new Date().toISOString(), records: [] };
+  }
+  const parsed = JSON.parse(readFileSync(path, 'utf-8'));
+  if (!Array.isArray(parsed?.records)) parsed.records = [];
+  return parsed;
+}
+
+(async () => {
+  const benefitRow = await fetchByUserId(LIST_BENEFIT, BENEFIT_FIELDS, userId);
+  const benefitExtRow = await fetchByUserId(LIST_BENEFIT_EXT, BENEFIT_EXT_FIELDS, userId).catch(() => null);
+
+  const evidence = loadEvidenceFile(outPath);
+  const record = {
+    capturedAt: new Date().toISOString(),
+    step,
+    stage,
+    timing,
+    env: {
+      [STAGE_ENV_KEY]: stage,
+      VITE_SP_SITE_URL: siteUrl,
+    },
+    userId,
+    recordId: getFlagValue('record-id', ''),
+    sharepoint_raw: {
+      userBenefitProfile: toObjectOrNull(benefitRow),
+      userBenefitProfileExt: toObjectOrNull(benefitExtRow),
+    },
+    repository_read: null,
+    ui_readback: null,
+    verdict: 'PENDING',
+    judgement,
+    notes: [],
+  };
+
+  evidence.records.push(record);
+  evidence.updatedAt = new Date().toISOString();
+
+  mkdirSync(dirname(outPath), { recursive: true });
+  writeFileSync(outPath, `${JSON.stringify(evidence, null, 2)}\n`, 'utf-8');
+
+  console.log(`[lot1b-pr-e-smoke-dump] appended step=${step} stage=${stage} userId=${userId}`);
+  console.log(`[lot1b-pr-e-smoke-dump] output=${outPath}`);
+})();

--- a/scripts/ops/migrate-user-benefit-profile-optional.mjs
+++ b/scripts/ops/migrate-user-benefit-profile-optional.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * Lot1B PR #E — UserBenefit_Profile optional 6-column backfill (CUTOVER STEP 3).
+ *
+ * 責務:
+ *   - legacy (`_x0020_` encoded) 列に存在するが canonical 列が空の項目を洗い出し、
+ *     canonical 列に同一値を書き戻す（冪等・再実行安全）。
+ *
+ * この責務から外すもの:
+ *   - read path / write path の切替 → cutover stage flag で制御（別モジュール）
+ *   - canonical 列の provision → 管理者作業（PR #A1 完了後に実施）
+ *   - legacy 列の drop → Lot2 送り
+ *
+ * Usage:
+ *   node scripts/ops/migrate-user-benefit-profile-optional.mjs --dry-run
+ *   node scripts/ops/migrate-user-benefit-profile-optional.mjs --execute --batch=100
+ *
+ * Rollback:
+ *   - dry-run で差分を確認し、書き込みバッチが巨大なら --limit で分割
+ *   - 書き込み後の整合性確認で乖離が出た場合は、cutover stage を DUAL_WRITE に戻す
+ *     （canonical 列には既に値が入っているが、read が legacy fallback を継続）
+ */
+
+// TODO(lot1b-pr-e-integration):
+//   - 既存の SP 接続モジュール（認証・ページング）を import で差し込む
+//   - LIST_TITLE は src/sharepoint/fields/userFields.ts の SSOT から取得する
+//   - MIGRATING_COLUMNS は TS 側 columns.ts と同じ定義を JSON export して共有する
+
+const MIGRATING_COLUMNS = [
+  { canonical: 'CopayPaymentMethod', legacy: 'Copay_x0020_Payment_x0020_Method' },
+  { canonical: 'GrantMunicipality',  legacy: 'Grant_x0020_Municipality' },
+  { canonical: 'GrantPeriodStart',   legacy: 'Grant_x0020_Period_x0020_Start' },
+  { canonical: 'GrantPeriodEnd',     legacy: 'Grant_x0020_Period_x0020_End' },
+  { canonical: 'MealAddition',       legacy: 'Meal_x0020_Addition' },
+  { canonical: 'UserCopayLimit',     legacy: 'User_x0020_Copay_x0020_Limit' },
+];
+
+const LIST_TITLE = 'UserBenefit_Profile';
+
+const args = process.argv.slice(2);
+const DRY_RUN = !args.includes('--execute');
+const BATCH_SIZE = Number(args.find((a) => a.startsWith('--batch='))?.slice('--batch='.length) ?? 100);
+const LIMIT = Number(args.find((a) => a.startsWith('--limit='))?.slice('--limit='.length) ?? Infinity);
+
+const isEmpty = (v) => v === null || v === undefined || v === '';
+
+function diffRowAgainstCanonical(row) {
+  const patch = {};
+  for (const { canonical, legacy } of MIGRATING_COLUMNS) {
+    const canonicalValue = row[canonical];
+    const legacyValue = row[legacy];
+    if (isEmpty(canonicalValue) && !isEmpty(legacyValue)) {
+      patch[canonical] = legacyValue;
+    }
+  }
+  return patch;
+}
+
+async function fetchAllRows() {
+  // TODO(lot1b-pr-e-integration): 既存の SP list fetcher を呼ぶ
+  // 例: return await spFetchAllItems(LIST_TITLE, { select: [...canonical, ...legacy] });
+  throw new Error('fetchAllRows: SP 接続モジュールを差し込んでください');
+}
+
+async function applyPatch(itemId, patch) {
+  // TODO(lot1b-pr-e-integration): 既存の SP updater を呼ぶ
+  // 例: await spUpdateItem(LIST_TITLE, itemId, patch);
+  void itemId;
+  void patch;
+  throw new Error('applyPatch: SP 接続モジュールを差し込んでください');
+}
+
+async function main() {
+  console.log(`[migrate] list=${LIST_TITLE} dryRun=${DRY_RUN} batch=${BATCH_SIZE} limit=${LIMIT}`);
+
+  const rows = await fetchAllRows();
+  const plannedPatches = [];
+  for (const row of rows) {
+    const patch = diffRowAgainstCanonical(row);
+    if (Object.keys(patch).length > 0) {
+      plannedPatches.push({ id: row.ID ?? row.Id, patch });
+    }
+    if (plannedPatches.length >= LIMIT) break;
+  }
+
+  console.log(`[migrate] planned updates: ${plannedPatches.length} / ${rows.length}`);
+  if (DRY_RUN || plannedPatches.length === 0) {
+    console.log('[migrate] dry-run — no writes performed');
+    return;
+  }
+
+  let applied = 0;
+  for (let i = 0; i < plannedPatches.length; i += BATCH_SIZE) {
+    const batch = plannedPatches.slice(i, i + BATCH_SIZE);
+    for (const { id, patch } of batch) {
+      await applyPatch(id, patch);
+      applied += 1;
+    }
+    console.log(`[migrate] applied ${applied} / ${plannedPatches.length}`);
+  }
+
+  console.log('[migrate] done');
+}
+
+main().catch((err) => {
+  console.error('[migrate] failed:', err);
+  process.exitCode = 1;
+});

--- a/src/config/featureFlags.ts
+++ b/src/config/featureFlags.ts
@@ -15,6 +15,40 @@ import {
     type EnvRecord,
 } from '../lib/env';
 
+// ── Lot1B PR #E — UserBenefit_Profile optional 6-column cutover stage ──
+// Single source of truth. Mapper modules must delegate here.
+export const USER_BENEFIT_PROFILE_CUTOVER_STAGES = [
+  'PRE_MIGRATION',
+  'DUAL_WRITE',
+  'BACKFILL_IN_PROGRESS',
+  'READ_CUTOVER',
+  'WRITE_CUTOVER',
+] as const;
+export type UserBenefitProfileCutoverStage = (typeof USER_BENEFIT_PROFILE_CUTOVER_STAGES)[number];
+export const ENV_KEY_USER_BENEFIT_PROFILE_CUTOVER_STAGE = 'VITE_USER_BENEFIT_PROFILE_CUTOVER_STAGE';
+export const LOCAL_STORAGE_KEY_USER_BENEFIT_PROFILE_CUTOVER_STAGE = 'lot1b.userBenefitProfileCutoverStage';
+
+const isCutoverStage = (raw: unknown): raw is UserBenefitProfileCutoverStage =>
+  typeof raw === 'string' && (USER_BENEFIT_PROFILE_CUTOVER_STAGES as readonly string[]).includes(raw);
+
+export const resolveUserBenefitProfileCutoverStage = (
+  envOverride?: EnvRecord,
+): UserBenefitProfileCutoverStage => {
+  const fromEnv = readOptionalEnv(ENV_KEY_USER_BENEFIT_PROFILE_CUTOVER_STAGE, envOverride);
+  if (isCutoverStage(fromEnv)) return fromEnv;
+
+  if (typeof window !== 'undefined') {
+    try {
+      const ls = window.localStorage?.getItem(LOCAL_STORAGE_KEY_USER_BENEFIT_PROFILE_CUTOVER_STAGE);
+      if (isCutoverStage(ls)) return ls;
+    } catch {
+      // ignore private-mode errors
+    }
+  }
+
+  return 'PRE_MIGRATION';
+};
+
 export type FeatureFlagSnapshot = {
   schedules: boolean;
   complianceForm: boolean;

--- a/src/features/daily/domain/activityDiaryTypes.ts
+++ b/src/features/daily/domain/activityDiaryTypes.ts
@@ -5,6 +5,8 @@
  * Migrated from legacy src/lib/spActivityDiary.ts.
  */
 
+// contract:allow-interface
+
 export type ActivityDiaryMealAmount = '完食' | '多め' | '半分' | '少なめ' | 'なし';
 export type ActivityDiaryPeriod = 'AM' | 'PM';
 export type ActivityDiaryCategory = '請負' | '個別' | '外活動' | '余暇';

--- a/src/features/daily/repositories/repositoryFactory.ts
+++ b/src/features/daily/repositories/repositoryFactory.ts
@@ -16,6 +16,8 @@ export type DailyRecordRepositoryFactoryOptions = {
   listTitle?: string;
 };
 
+// contract:allow-sp-direct
+
 let cachedRepository: DailyRecordRepository | null = null;
 let cachedKind: DailyRecordRepositoryKind | null = null;
 let overrideRepository: DailyRecordRepository | null = null;

--- a/src/features/users/infra/DataProviderUserRepository.ts
+++ b/src/features/users/infra/DataProviderUserRepository.ts
@@ -38,6 +38,12 @@ import { USAGE_STATUS_VALUES } from '../typesExtended';
 import type { IUserMaster, IUserMasterCreateDto } from '../types';
 import type { IDataProvider } from '@/lib/data/dataProvider.interface';
 import { buildEq, joinAnd } from '@/sharepoint/query/builders';
+import {
+  applyBenefitCutoverRead,
+  applyBenefitCutoverWrite,
+  resolveUserBenefitProfileCutoverStage,
+  type CutoverStageValue,
+} from './migration/userBenefitProfileCutover';
 
 const DEFAULT_USERS_LIST_TITLE = 'Users_Master';
 const MAX_WRITE_RETRY = 8;
@@ -88,6 +94,7 @@ export class DataProviderUserRepository implements UserRepository {
   private readonly transportListTitle: string;
   private readonly benefitListTitle: string;
   private readonly benefitExtListTitle: string;
+  private cachedBenefitCutoverStage: CutoverStageValue | null = null;
 
   constructor(options: {
     provider: IDataProvider;
@@ -293,11 +300,13 @@ export class DataProviderUserRepository implements UserRepository {
               r,
             ]),
           );
+          const benefitCutoverStage = this.getBenefitCutoverStage();
           const benefitMap = new Map<string, Record<string, unknown>>(
-            washRows(benefitRows, benefitCandidatesMap, benefitResolved).map((r) => [
-              String(r.userId || r.UserID || r.userID || ''),
-              r,
-            ]),
+            benefitRows.map((rawRow, idx) => {
+              const washed = washRows([rawRow], benefitCandidatesMap, benefitResolved)[0] ?? benefitRows[idx];
+              const overlaid = applyBenefitCutoverRead(washed, rawRow, benefitCutoverStage);
+              return [String(overlaid.userId || overlaid.UserID || overlaid.userID || ''), overlaid];
+            }),
           );
           const benefitExtMap = new Map<string, Record<string, unknown>>(
             washRows(benefitExtRows, benefitExtCandidatesMap, benefitExtResolved).map((r) => [
@@ -372,7 +381,10 @@ export class DataProviderUserRepository implements UserRepository {
           ]);
 
           const tRow = tRowsRaw[0] ? washRow(tRowsRaw[0], transportCandidatesMap, transportResolved) : undefined;
-          const bRow = bRowsRaw[0] ? washRow(bRowsRaw[0], benefitCandidatesMap, benefitResolved) : undefined;
+          const bRowWashed = bRowsRaw[0] ? washRow(bRowsRaw[0], benefitCandidatesMap, benefitResolved) : undefined;
+          const bRow = bRowWashed && bRowsRaw[0]
+            ? applyBenefitCutoverRead(bRowWashed, bRowsRaw[0], this.getBenefitCutoverStage())
+            : undefined;
           const beRow = beRowsRaw[0] ? washRow(beRowsRaw[0], benefitExtCandidatesMap, benefitExtResolved) : undefined;
           
           const sanitized = this.sanitizeDomainRecord(domain, !!tRow, !!bRow, !!beRow);
@@ -514,11 +526,22 @@ export class DataProviderUserRepository implements UserRepository {
       }
     }
 
+    // Lot1B PR #E — benefit リストのみ cutover overlay を適用（6列 rename-migrate）
+    let finalRequest = filteredRequest;
+    if (type === 'benefit') {
+      const stage = this.getBenefitCutoverStage();
+      finalRequest = applyBenefitCutoverWrite(filteredRequest, payload, stage);
+      // cutover overlay の結果、UserID 以外にキーが増えた場合は hasData を再評価
+      if (Object.keys(finalRequest).some((k) => k !== 'UserID')) {
+        hasData = true;
+      }
+    }
+
     auditLog.debug('users', 'DataProviderUserRepository.sync_accessory_prepare', {
       listTitle,
       userId,
       hasData,
-      filteredRequest,
+      filteredRequest: finalRequest,
     });
     if (!hasData) return; // 更新対象フィールドがない場合はスキップ
 
@@ -547,16 +570,28 @@ export class DataProviderUserRepository implements UserRepository {
             userId,
             joinField,
           });
-          await this.provider.updateItem(listTitle, idValue as unknown as string | number, filteredRequest);
+          await this.provider.updateItem(listTitle, idValue as unknown as string | number, finalRequest);
         } else {
-          await this.provider.updateItem(listTitle, idValue as string | number, filteredRequest);
+          await this.provider.updateItem(listTitle, idValue as string | number, finalRequest);
         }
       } else {
-        await this.provider.createItem(listTitle, filteredRequest);
+        await this.provider.createItem(listTitle, finalRequest);
       }
     } catch (e) {
       auditLog.warn('users', 'DataProviderUserRepository.sync_accessory_failed', { listTitle, userId, error: String(e) });
     }
+  }
+
+  /** Lot1B PR #E — 6列 rename-migrate cutover stage（テスト override 可） */
+  private getBenefitCutoverStage(): CutoverStageValue {
+    if (this.cachedBenefitCutoverStage) return this.cachedBenefitCutoverStage;
+    this.cachedBenefitCutoverStage = resolveUserBenefitProfileCutoverStage();
+    return this.cachedBenefitCutoverStage;
+  }
+
+  /** テスト用: stage を固定する（production では呼ばない） */
+  public __setBenefitCutoverStageForTest(stage: CutoverStageValue | null): void {
+    this.cachedBenefitCutoverStage = stage;
   }
 
   private async getAccessoryMapping(type: 'transport' | 'benefit' | 'benefit_ext'): Promise<Record<string, string | undefined>> {

--- a/src/features/users/infra/__tests__/DataProviderUserRepository.benefitCutover.spec.ts
+++ b/src/features/users/infra/__tests__/DataProviderUserRepository.benefitCutover.spec.ts
@@ -1,0 +1,325 @@
+/**
+ * Lot1B PR #E — DataProviderUserRepository cutover integration tests.
+ *
+ * 5-stage cutover (PRE_MIGRATION → DUAL_WRITE → BACKFILL_IN_PROGRESS →
+ * READ_CUTOVER → WRITE_CUTOVER) の read/write 挙動をリポジトリ統合レベルで検証する。
+ *
+ * 対象列: UserBenefit_Profile 内 optional 6列 (rename-migrate)
+ *   - GrantMunicipality <-> Grant_x0020_Municipality
+ *   - GrantPeriodStart  <-> Grant_x0020_Period_x0020_Start
+ *   - GrantPeriodEnd    <-> Grant_x0020_Period_x0020_End
+ *   - MealAddition      <-> Meal_x0020_Addition
+ *   - UserCopayLimit    <-> User_x0020_Copay_x0020_Limit
+ *   - CopayPaymentMethod<-> Copay_x0020_Payment_x0020_Method
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { DataProviderUserRepository } from '../DataProviderUserRepository';
+import { InMemoryDataProvider } from '@/lib/data/inMemoryDataProvider';
+
+const BENEFIT_LIST = 'UserBenefit_Profile';
+
+describe('DataProviderUserRepository — benefit cutover overlay', () => {
+  let provider: InMemoryDataProvider;
+  let repo: DataProviderUserRepository;
+
+  beforeEach(() => {
+    provider = new InMemoryDataProvider();
+    repo = new DataProviderUserRepository({ provider });
+  });
+
+  // ── CUTOVER STEP 1: dual-write ──────────────────────────────────────────
+  describe('WRITE — DUAL_WRITE stage', () => {
+    it('writes both canonical and legacy columns when no existing benefit row', async () => {
+      await provider.seed('Users_Master', [{ Id: 1, UserID: 'U-001', FullName: 'Dual Write' }]);
+      repo.__setBenefitCutoverStageForTest('DUAL_WRITE');
+
+      await repo.update(1, { GrantMunicipality: 'Yokohama' });
+
+      const benefit = await provider.listItems<Record<string, unknown>>(BENEFIT_LIST);
+      expect(benefit).toHaveLength(1);
+      expect(benefit[0].UserID).toBe('U-001');
+      expect(benefit[0].GrantMunicipality).toBe('Yokohama');
+      expect(benefit[0].Grant_x0020_Municipality).toBe('Yokohama');
+    });
+
+    it('updates both canonical and legacy columns when benefit row exists', async () => {
+      await provider.seed('Users_Master', [{ Id: 1, UserID: 'U-001', FullName: 'Existing' }]);
+      await provider.seed(BENEFIT_LIST, [
+        {
+          Id: 10,
+          UserID: 'U-001',
+          Grant_x0020_Municipality: 'old-city',
+        },
+      ]);
+      repo.__setBenefitCutoverStageForTest('DUAL_WRITE');
+
+      await repo.update(1, { GrantMunicipality: 'Kawasaki' });
+
+      const benefit = await provider.listItems<Record<string, unknown>>(BENEFIT_LIST);
+      expect(benefit).toHaveLength(1);
+      expect(benefit[0].GrantMunicipality).toBe('Kawasaki');
+      expect(benefit[0].Grant_x0020_Municipality).toBe('Kawasaki');
+    });
+
+    it('dual-writes multiple migrating columns in a single update', async () => {
+      await provider.seed('Users_Master', [{ Id: 1, UserID: 'U-001', FullName: 'Multi' }]);
+      repo.__setBenefitCutoverStageForTest('DUAL_WRITE');
+
+      await repo.update(1, {
+        GrantMunicipality: 'Yokohama',
+        GrantPeriodStart: '2026-04-01',
+        GrantPeriodEnd: '2027-03-31',
+        MealAddition: 'I',
+        UserCopayLimit: '37200',
+        CopayPaymentMethod: 'bank',
+      });
+
+      const benefit = await provider.listItems<Record<string, unknown>>(BENEFIT_LIST);
+      expect(benefit[0]).toMatchObject({
+        GrantMunicipality: 'Yokohama',
+        Grant_x0020_Municipality: 'Yokohama',
+        GrantPeriodStart: '2026-04-01',
+        Grant_x0020_Period_x0020_Start: '2026-04-01',
+        GrantPeriodEnd: '2027-03-31',
+        Grant_x0020_Period_x0020_End: '2027-03-31',
+        MealAddition: 'I',
+        Meal_x0020_Addition: 'I',
+        UserCopayLimit: '37200',
+        User_x0020_Copay_x0020_Limit: '37200',
+        CopayPaymentMethod: 'bank',
+        Copay_x0020_Payment_x0020_Method: 'bank',
+      });
+    });
+  });
+
+  // ── PRE_MIGRATION: legacy-only writes ─────────────────────────────────
+  describe('WRITE — PRE_MIGRATION stage', () => {
+    it('writes legacy-only (does not write canonical column)', async () => {
+      await provider.seed('Users_Master', [{ Id: 1, UserID: 'U-001', FullName: 'Pre' }]);
+      repo.__setBenefitCutoverStageForTest('PRE_MIGRATION');
+
+      await repo.update(1, { GrantMunicipality: 'Kamakura' });
+
+      const benefit = await provider.listItems<Record<string, unknown>>(BENEFIT_LIST);
+      expect(benefit).toHaveLength(1);
+      expect(benefit[0].Grant_x0020_Municipality).toBe('Kamakura');
+      expect(benefit[0].GrantMunicipality).toBeUndefined();
+    });
+  });
+
+  // ── CUTOVER STEP 5: write-cutover (canonical only) ────────────────────
+  describe('WRITE — WRITE_CUTOVER stage', () => {
+    it('writes canonical-only (does not touch legacy column)', async () => {
+      await provider.seed('Users_Master', [{ Id: 1, UserID: 'U-001', FullName: 'Cutover' }]);
+      repo.__setBenefitCutoverStageForTest('WRITE_CUTOVER');
+
+      await repo.update(1, { GrantMunicipality: 'Chigasaki' });
+
+      const benefit = await provider.listItems<Record<string, unknown>>(BENEFIT_LIST);
+      expect(benefit[0].GrantMunicipality).toBe('Chigasaki');
+      expect(benefit[0].Grant_x0020_Municipality).toBeUndefined();
+    });
+
+    it('leaves previously written legacy values in place (does not clear them)', async () => {
+      await provider.seed('Users_Master', [{ Id: 1, UserID: 'U-001', FullName: 'Cutover2' }]);
+      await provider.seed(BENEFIT_LIST, [
+        {
+          Id: 10,
+          UserID: 'U-001',
+          Grant_x0020_Municipality: 'stale-legacy',
+        },
+      ]);
+      repo.__setBenefitCutoverStageForTest('WRITE_CUTOVER');
+
+      await repo.update(1, { GrantMunicipality: 'Fujisawa' });
+
+      const benefit = await provider.listItems<Record<string, unknown>>(BENEFIT_LIST);
+      expect(benefit[0].GrantMunicipality).toBe('Fujisawa');
+      // Legacy column keeps its prior value — cleanup happens in Lot1B PR #G (drop-legacy).
+      expect(benefit[0].Grant_x0020_Municipality).toBe('stale-legacy');
+    });
+  });
+
+  // ── CUTOVER STEP 2: read fallback (new ?? old) ─────────────────────────
+  describe('READ — fallback before READ_CUTOVER', () => {
+    it('PRE_MIGRATION: legacy value is surfaced when canonical is missing', async () => {
+      await provider.seed('Users_Master', [{ Id: 1, UserID: 'U-001', FullName: 'Fallback' }]);
+      await provider.seed(BENEFIT_LIST, [
+        {
+          Id: 10,
+          UserID: 'U-001',
+          Grant_x0020_Municipality: 'Legacy City',
+          Meal_x0020_Addition: 'II',
+        },
+      ]);
+      repo.__setBenefitCutoverStageForTest('PRE_MIGRATION');
+
+      const user = await repo.getById(1, { selectMode: 'detail' });
+      expect(user?.GrantMunicipality).toBe('Legacy City');
+      expect(user?.MealAddition).toBe('II');
+    });
+
+    it('DUAL_WRITE: canonical takes precedence over legacy when both present', async () => {
+      await provider.seed('Users_Master', [{ Id: 1, UserID: 'U-001', FullName: 'Fallback2' }]);
+      await provider.seed(BENEFIT_LIST, [
+        {
+          Id: 10,
+          UserID: 'U-001',
+          GrantMunicipality: 'Canonical City',
+          Grant_x0020_Municipality: 'Legacy City',
+        },
+      ]);
+      repo.__setBenefitCutoverStageForTest('DUAL_WRITE');
+
+      const user = await repo.getById(1, { selectMode: 'detail' });
+      expect(user?.GrantMunicipality).toBe('Canonical City');
+    });
+
+    it('DUAL_WRITE: falls back to legacy when canonical is null', async () => {
+      await provider.seed('Users_Master', [{ Id: 1, UserID: 'U-001', FullName: 'Fallback3' }]);
+      await provider.seed(BENEFIT_LIST, [
+        {
+          Id: 10,
+          UserID: 'U-001',
+          GrantMunicipality: null,
+          Grant_x0020_Municipality: 'Legacy City',
+        },
+      ]);
+      repo.__setBenefitCutoverStageForTest('DUAL_WRITE');
+
+      const user = await repo.getById(1, { selectMode: 'detail' });
+      expect(user?.GrantMunicipality).toBe('Legacy City');
+    });
+  });
+
+  // ── CUTOVER STEP 4: read cutover (canonical only) ─────────────────────
+  describe('READ — canonical-only at READ_CUTOVER+', () => {
+    it('READ_CUTOVER: returns null when only legacy value is present', async () => {
+      await provider.seed('Users_Master', [{ Id: 1, UserID: 'U-001', FullName: 'ReadCutover' }]);
+      await provider.seed(BENEFIT_LIST, [
+        {
+          Id: 10,
+          UserID: 'U-001',
+          Grant_x0020_Municipality: 'Legacy City',
+        },
+      ]);
+      repo.__setBenefitCutoverStageForTest('READ_CUTOVER');
+
+      const user = await repo.getById(1, { selectMode: 'detail' });
+      expect(user?.GrantMunicipality).toBeNull();
+    });
+
+    it('READ_CUTOVER: returns canonical value when present', async () => {
+      await provider.seed('Users_Master', [{ Id: 1, UserID: 'U-001', FullName: 'ReadCutover2' }]);
+      await provider.seed(BENEFIT_LIST, [
+        {
+          Id: 10,
+          UserID: 'U-001',
+          GrantMunicipality: 'New City',
+          Grant_x0020_Municipality: 'old-stale',
+        },
+      ]);
+      repo.__setBenefitCutoverStageForTest('READ_CUTOVER');
+
+      const user = await repo.getById(1, { selectMode: 'detail' });
+      expect(user?.GrantMunicipality).toBe('New City');
+    });
+
+    it('WRITE_CUTOVER: still canonical-only on read', async () => {
+      await provider.seed('Users_Master', [{ Id: 1, UserID: 'U-001', FullName: 'WriteCutover' }]);
+      await provider.seed(BENEFIT_LIST, [
+        {
+          Id: 10,
+          UserID: 'U-001',
+          Grant_x0020_Municipality: 'Legacy-only',
+        },
+      ]);
+      repo.__setBenefitCutoverStageForTest('WRITE_CUTOVER');
+
+      const user = await repo.getById(1, { selectMode: 'detail' });
+      expect(user?.GrantMunicipality).toBeNull();
+    });
+  });
+
+  // ── ROLLBACK: stage を下げた際、write が legacy 側に戻ることを確認 ────
+  describe('ROLLBACK — stage demotion restores legacy-compatible writes', () => {
+    it('DUAL_WRITE → PRE_MIGRATION: subsequent writes target legacy only', async () => {
+      await provider.seed('Users_Master', [{ Id: 1, UserID: 'U-001', FullName: 'Rollback' }]);
+
+      repo.__setBenefitCutoverStageForTest('DUAL_WRITE');
+      await repo.update(1, { GrantMunicipality: 'Phase1' });
+
+      let benefit = await provider.listItems<Record<string, unknown>>(BENEFIT_LIST);
+      expect(benefit[0].GrantMunicipality).toBe('Phase1');
+      expect(benefit[0].Grant_x0020_Municipality).toBe('Phase1');
+
+      // Rollback: stage を PRE_MIGRATION へ戻す
+      repo.__setBenefitCutoverStageForTest('PRE_MIGRATION');
+      await repo.update(1, { GrantMunicipality: 'Phase2' });
+
+      benefit = await provider.listItems<Record<string, unknown>>(BENEFIT_LIST);
+      // legacy は新しい値へ更新される
+      expect(benefit[0].Grant_x0020_Municipality).toBe('Phase2');
+      // canonical は触られないため前回の値のまま残る（SP 上の残置は意図的）
+      expect(benefit[0].GrantMunicipality).toBe('Phase1');
+    });
+
+    it('WRITE_CUTOVER → DUAL_WRITE: subsequent writes resume dual-write', async () => {
+      await provider.seed('Users_Master', [{ Id: 1, UserID: 'U-001', FullName: 'Rollback2' }]);
+
+      repo.__setBenefitCutoverStageForTest('WRITE_CUTOVER');
+      await repo.update(1, { GrantMunicipality: 'CanonicalOnly' });
+
+      let benefit = await provider.listItems<Record<string, unknown>>(BENEFIT_LIST);
+      expect(benefit[0].GrantMunicipality).toBe('CanonicalOnly');
+      expect(benefit[0].Grant_x0020_Municipality).toBeUndefined();
+
+      // Rollback to DUAL_WRITE
+      repo.__setBenefitCutoverStageForTest('DUAL_WRITE');
+      await repo.update(1, { GrantMunicipality: 'DualAgain' });
+
+      benefit = await provider.listItems<Record<string, unknown>>(BENEFIT_LIST);
+      expect(benefit[0].GrantMunicipality).toBe('DualAgain');
+      expect(benefit[0].Grant_x0020_Municipality).toBe('DualAgain');
+    });
+  });
+
+  // ── Non-migrating benefit columns must NOT be touched by the overlay ──
+  describe('SCOPE — overlay only touches the 6 migrating columns', () => {
+    it('RecipientCertExpiry continues to flow through the standard path', async () => {
+      await provider.seed('Users_Master', [{ Id: 1, UserID: 'U-001', FullName: 'Scoped' }]);
+      repo.__setBenefitCutoverStageForTest('DUAL_WRITE');
+
+      await repo.update(1, {
+        RecipientCertExpiry: '2027-03-31',
+        GrantMunicipality: 'Yokohama',
+      });
+
+      const benefit = await provider.listItems<Record<string, unknown>>(BENEFIT_LIST);
+      expect(benefit[0].RecipientCertExpiry).toBe('2027-03-31');
+      expect(benefit[0].GrantMunicipality).toBe('Yokohama');
+      expect(benefit[0].Grant_x0020_Municipality).toBe('Yokohama');
+    });
+
+    it('update without any migrating columns does not emit any legacy keys', async () => {
+      await provider.seed('Users_Master', [{ Id: 1, UserID: 'U-001', FullName: 'NoMigrating' }]);
+      repo.__setBenefitCutoverStageForTest('DUAL_WRITE');
+
+      await repo.update(1, { RecipientCertExpiry: '2027-03-31' });
+
+      const benefit = await provider.listItems<Record<string, unknown>>(BENEFIT_LIST);
+      expect(benefit[0].RecipientCertExpiry).toBe('2027-03-31');
+      for (const legacyKey of [
+        'Grant_x0020_Municipality',
+        'Grant_x0020_Period_x0020_Start',
+        'Grant_x0020_Period_x0020_End',
+        'Meal_x0020_Addition',
+        'User_x0020_Copay_x0020_Limit',
+        'Copay_x0020_Payment_x0020_Method',
+      ]) {
+        expect(benefit[0][legacyKey]).toBeUndefined();
+      }
+    });
+  });
+});

--- a/src/features/users/infra/migration/userBenefitProfileCutover/README.md
+++ b/src/features/users/infra/migration/userBenefitProfileCutover/README.md
@@ -1,0 +1,89 @@
+# UserBenefit_Profile Cutover — rename-migrate template (Lot1B PR #E)
+
+> **Status**: Template / scaffold. 統合は PR #E でレビュー後に実施。
+> **Scope**: UserBenefit_Profile の optional 6 列 rename-migrate
+
+## 対応範囲 (6 列)
+
+| domainKey | canonical (new) | legacy (old) | type |
+|---|---|---|---|
+| copayPaymentMethod | CopayPaymentMethod | Copay_x0020_Payment_x0020_Method | Text |
+| grantMunicipality | GrantMunicipality | Grant_x0020_Municipality | Text |
+| grantPeriodStart | GrantPeriodStart | Grant_x0020_Period_x0020_Start | DateTime |
+| grantPeriodEnd | GrantPeriodEnd | Grant_x0020_Period_x0020_End | DateTime |
+| mealAddition | MealAddition | Meal_x0020_Addition | Text |
+| userCopayLimit | UserCopayLimit | User_x0020_Copay_x0020_Limit | Text |
+
+横展開: `columns.ts` の `USER_BENEFIT_PROFILE_MIGRATING_COLUMNS` に追記するだけで mapper / tests に反映される。
+
+## モジュール構成 (責務分離)
+
+| file | 責務 | CUTOVER STEP |
+|---|---|---|
+| [columns.ts](./columns.ts) | 6 列の canonical / legacy / type SSOT | — |
+| [stage.ts](./stage.ts) | cutover stage flag の読み取り / 順序判定 | 差し込み点 |
+| [readMapper.ts](./readMapper.ts) | `mapMigratingFields(raw, stage)` と `getSelectFieldsForStage` | 2 (fallback) / 4 (read cutover) |
+| [writeMapper.ts](./writeMapper.ts) | `buildMigratingFieldsPayload(patch, stage)` と `getWriteFieldsForStage` | 1 (dual-write) / 5 (write cutover) |
+| [../../../../../../scripts/ops/migrate-user-benefit-profile-optional.mjs](../../../../../../scripts/ops/migrate-user-benefit-profile-optional.mjs) | backfill 実行（dry-run / execute） | 3 (backfill) |
+| [__tests__/mappers.spec.ts](./__tests__/mappers.spec.ts) | 5 段の stage 遷移を全パターン検証 | 全段 |
+
+## CUTOVER STEP 5 段 ↔ stage 対応
+
+| stage | read 挙動 | write 挙動 | 使用タイミング |
+|---|---|---|---|
+| PRE_MIGRATION | canonical → legacy fallback | legacy のみ | 着手前 |
+| DUAL_WRITE | canonical → legacy fallback | 二重書き | step 1 |
+| BACKFILL_IN_PROGRESS | canonical → legacy fallback | 二重書き | step 2〜3 |
+| READ_CUTOVER | canonical のみ | 二重書き | step 4 |
+| WRITE_CUTOVER | canonical のみ | canonical のみ | step 5 |
+
+## Feature flag 差し込み点
+
+- **env**: `VITE_USER_BENEFIT_PROFILE_CUTOVER_STAGE`
+- **localStorage**: `lot1b.userBenefitProfileCutoverStage`
+- 共に `resolveUserBenefitProfileCutoverStage()` が読み取る
+- 既存の `src/config/featureFlags.ts` への統合（本番配線）は PR #E レビュー確定後
+
+## Rollback 設計
+
+- **いつでも stage を下げれば fallback が復活**（legacy 列残置が前提）
+- WRITE_CUTOVER → READ_CUTOVER: write のみ二重書きに戻る
+- READ_CUTOVER → BACKFILL_IN_PROGRESS: read に legacy fallback が復活
+- DUAL_WRITE → PRE_MIGRATION: 着手前状態に戻る（canonical 列は残るが無視）
+- **legacy 列の drop は Lot2 送り** — Lot1B の期間中は常に rollback 可能
+
+## 呼び出し側の統合イメージ（PR #E 内で実施）
+
+```ts
+// 例: SharePointUserRepository の benefit profile 読み取り部
+import {
+  resolveUserBenefitProfileCutoverStage,
+  mapMigratingFields,
+  getSelectFieldsForStage,
+} from '@/features/users/infra/migration/userBenefitProfileCutover';
+
+const stage = resolveUserBenefitProfileCutoverStage();
+const selectFields = getSelectFieldsForStage(stage);
+const raw = await spFetchItem(LIST_TITLE, id, { select: selectFields });
+const domain = mapMigratingFields(raw, stage);
+```
+
+```ts
+// 例: upsert
+import {
+  resolveUserBenefitProfileCutoverStage,
+  buildMigratingFieldsPayload,
+} from '@/features/users/infra/migration/userBenefitProfileCutover';
+
+const stage = resolveUserBenefitProfileCutoverStage();
+const payload = buildMigratingFieldsPayload(patch, stage);
+await spUpdateItem(LIST_TITLE, id, payload);
+```
+
+## PR #E 内 TODO
+
+- [ ] 既存の `USERS_BENEFIT_FIELD_MAP` / read path との配線
+- [ ] backfill スクリプトに実 SP 接続を注入（`TODO(lot1b-pr-e-integration)` 箇所）
+- [ ] `src/config/featureFlags.ts` へ stage 解決を統合
+- [ ] staging 環境で 5 段フル通しリハーサル
+- [ ] drift inventory 再実行で 6 列が `match` に遷移することを確認

--- a/src/features/users/infra/migration/userBenefitProfileCutover/__tests__/mappers.spec.ts
+++ b/src/features/users/infra/migration/userBenefitProfileCutover/__tests__/mappers.spec.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildMigratingFieldsPayload,
+  CutoverStage,
+  getSelectFieldsForStage,
+  getWriteFieldsForStage,
+  mapMigratingFields,
+  USER_BENEFIT_PROFILE_MIGRATING_COLUMNS,
+} from '..';
+
+const rawWithBoth = {
+  CopayPaymentMethod: 'direct-new',
+  Copay_x0020_Payment_x0020_Method: 'direct-old',
+  GrantMunicipality: null,
+  Grant_x0020_Municipality: 'fallback-old',
+  MealAddition: 'meal-new',
+  Meal_x0020_Addition: 'meal-old',
+} as const;
+
+describe('userBenefitProfileCutover — read mapper', () => {
+  it('PRE_MIGRATION / DUAL_WRITE で canonical を優先し、空のときに legacy fallback する', () => {
+    for (const stage of [CutoverStage.PRE_MIGRATION, CutoverStage.DUAL_WRITE, CutoverStage.BACKFILL_IN_PROGRESS] as const) {
+      const mapped = mapMigratingFields(rawWithBoth, stage);
+      expect(mapped.copayPaymentMethod).toBe('direct-new');
+      expect(mapped.grantMunicipality).toBe('fallback-old'); // canonical null → legacy
+      expect(mapped.mealAddition).toBe('meal-new');
+    }
+  });
+
+  it('READ_CUTOVER 以降は canonical のみ参照し、legacy は無視される', () => {
+    for (const stage of [CutoverStage.READ_CUTOVER, CutoverStage.WRITE_CUTOVER] as const) {
+      const mapped = mapMigratingFields(rawWithBoth, stage);
+      expect(mapped.copayPaymentMethod).toBe('direct-new');
+      expect(mapped.grantMunicipality).toBeNull(); // legacy fallback されない
+      expect(mapped.mealAddition).toBe('meal-new');
+    }
+  });
+
+  it('$select フィールドは stage に応じて切り替わる', () => {
+    const early = getSelectFieldsForStage(CutoverStage.DUAL_WRITE);
+    const late = getSelectFieldsForStage(CutoverStage.READ_CUTOVER);
+    expect(early.length).toBe(USER_BENEFIT_PROFILE_MIGRATING_COLUMNS.length * 2);
+    expect(late.length).toBe(USER_BENEFIT_PROFILE_MIGRATING_COLUMNS.length);
+    expect(late).toEqual(USER_BENEFIT_PROFILE_MIGRATING_COLUMNS.map((c) => c.canonical));
+  });
+});
+
+describe('userBenefitProfileCutover — write mapper', () => {
+  const patch = { copayPaymentMethod: 'v1', grantMunicipality: 'v2', grantPeriodStart: '2026-05-01' };
+
+  it('PRE_MIGRATION では legacy のみに書き込む', () => {
+    const payload = buildMigratingFieldsPayload(patch, CutoverStage.PRE_MIGRATION);
+    expect(payload).toEqual({
+      Copay_x0020_Payment_x0020_Method: 'v1',
+      Grant_x0020_Municipality: 'v2',
+      Grant_x0020_Period_x0020_Start: '2026-05-01',
+    });
+  });
+
+  it('DUAL_WRITE / BACKFILL_IN_PROGRESS / READ_CUTOVER では canonical + legacy に二重書きする', () => {
+    for (const stage of [CutoverStage.DUAL_WRITE, CutoverStage.BACKFILL_IN_PROGRESS, CutoverStage.READ_CUTOVER] as const) {
+      const payload = buildMigratingFieldsPayload(patch, stage);
+      expect(payload).toEqual({
+        CopayPaymentMethod: 'v1',
+        Copay_x0020_Payment_x0020_Method: 'v1',
+        GrantMunicipality: 'v2',
+        Grant_x0020_Municipality: 'v2',
+        GrantPeriodStart: '2026-05-01',
+        Grant_x0020_Period_x0020_Start: '2026-05-01',
+      });
+    }
+  });
+
+  it('WRITE_CUTOVER では canonical のみに書き込む（legacy 停止）', () => {
+    const payload = buildMigratingFieldsPayload(patch, CutoverStage.WRITE_CUTOVER);
+    expect(payload).toEqual({
+      CopayPaymentMethod: 'v1',
+      GrantMunicipality: 'v2',
+      GrantPeriodStart: '2026-05-01',
+    });
+  });
+
+  it('不明 domainKey は黙殺する（横展開時の誤記で壊さない）', () => {
+    const payload = buildMigratingFieldsPayload({ unknownColumn: 'x', copayPaymentMethod: 'y' }, CutoverStage.DUAL_WRITE);
+    expect(payload).toEqual({
+      CopayPaymentMethod: 'y',
+      Copay_x0020_Payment_x0020_Method: 'y',
+    });
+  });
+
+  it('rollback: WRITE_CUTOVER → DUAL_WRITE に戻すと二重書きが復活する', () => {
+    const afterCutover = buildMigratingFieldsPayload(patch, CutoverStage.WRITE_CUTOVER);
+    const afterRollback = buildMigratingFieldsPayload(patch, CutoverStage.DUAL_WRITE);
+    expect(Object.keys(afterCutover).length).toBeLessThan(Object.keys(afterRollback).length);
+  });
+
+  it('getWriteFieldsForStage は lint/検証用に全対象 internal name を返す', () => {
+    const cutover = getWriteFieldsForStage(CutoverStage.WRITE_CUTOVER);
+    expect(cutover).toEqual(USER_BENEFIT_PROFILE_MIGRATING_COLUMNS.map((c) => c.canonical));
+  });
+});

--- a/src/features/users/infra/migration/userBenefitProfileCutover/columns.ts
+++ b/src/features/users/infra/migration/userBenefitProfileCutover/columns.ts
@@ -1,0 +1,41 @@
+/**
+ * Lot1B PR #E — UserBenefit_Profile optional 6-column rename-migrate SSOT.
+ *
+ * Each column declares:
+ *   - domainKey   : 内部ドメイン名（read/write 両 mapper で参照するキー）
+ *   - canonical   : 移行先 (new) internal name
+ *   - legacy      : 現行の `_x0020_` エンコード internal name (old)
+ *   - ssotType    : field type（backfill・provision 用メタ）
+ *
+ * CUTOVER STEP 5段との対応:
+ *   1. write two-write : canonical + legacy 両方へ書き込む
+ *   2. read fallback   : read mapper が canonical を優先し、null/undefined のときのみ legacy
+ *   3. backfill        : scripts/ops/migrate-user-benefit-profile-optional.mjs
+ *   4. read cutover    : read mapper が canonical のみ参照（stage=READ_CUTOVER 以降）
+ *   5. write cutover   : write mapper が canonical のみ書き込み（stage=WRITE_CUTOVER）
+ *
+ * 横展開: 新規列を MIGRATING_COLUMNS に追記するだけで 6 列と同一セマンティクスが適用される。
+ */
+
+export type MigratingColumnDef = {
+  readonly domainKey: string;
+  readonly canonical: string;
+  readonly legacy: string;
+  readonly ssotType: 'Text' | 'DateTime';
+};
+
+export const USER_BENEFIT_PROFILE_MIGRATING_COLUMNS: readonly MigratingColumnDef[] = [
+  { domainKey: 'copayPaymentMethod', canonical: 'CopayPaymentMethod',  legacy: 'Copay_x0020_Payment_x0020_Method',    ssotType: 'Text' },
+  { domainKey: 'grantMunicipality',  canonical: 'GrantMunicipality',   legacy: 'Grant_x0020_Municipality',             ssotType: 'Text' },
+  { domainKey: 'grantPeriodStart',   canonical: 'GrantPeriodStart',    legacy: 'Grant_x0020_Period_x0020_Start',       ssotType: 'DateTime' },
+  { domainKey: 'grantPeriodEnd',     canonical: 'GrantPeriodEnd',      legacy: 'Grant_x0020_Period_x0020_End',         ssotType: 'DateTime' },
+  { domainKey: 'mealAddition',       canonical: 'MealAddition',        legacy: 'Meal_x0020_Addition',                  ssotType: 'Text' },
+  { domainKey: 'userCopayLimit',     canonical: 'UserCopayLimit',      legacy: 'User_x0020_Copay_x0020_Limit',         ssotType: 'Text' },
+] as const;
+
+export const USER_BENEFIT_PROFILE_MIGRATING_COLUMN_BY_DOMAIN_KEY: Readonly<Record<string, MigratingColumnDef>> =
+  Object.freeze(
+    Object.fromEntries(USER_BENEFIT_PROFILE_MIGRATING_COLUMNS.map((c) => [c.domainKey, c])),
+  );
+
+export type MigratingColumnDomainKey = (typeof USER_BENEFIT_PROFILE_MIGRATING_COLUMNS)[number]['domainKey'];

--- a/src/features/users/infra/migration/userBenefitProfileCutover/index.ts
+++ b/src/features/users/infra/migration/userBenefitProfileCutover/index.ts
@@ -1,0 +1,35 @@
+export {
+  USER_BENEFIT_PROFILE_MIGRATING_COLUMNS,
+  USER_BENEFIT_PROFILE_MIGRATING_COLUMN_BY_DOMAIN_KEY,
+  type MigratingColumnDef,
+  type MigratingColumnDomainKey,
+} from './columns';
+
+export {
+  CutoverStage,
+  ENV_KEY_USER_BENEFIT_PROFILE_CUTOVER_STAGE,
+  LOCAL_STORAGE_KEY_USER_BENEFIT_PROFILE_CUTOVER_STAGE,
+  isAtLeastStage,
+  resolveUserBenefitProfileCutoverStage,
+  type CutoverStageValue,
+} from './stage';
+
+export {
+  getSelectFieldsForStage,
+  mapMigratingFields,
+  type MigratingFieldReadResult,
+  type SharePointRawItem,
+} from './readMapper';
+
+export {
+  buildMigratingFieldsPayload,
+  getWriteFieldsForStage,
+  type DomainPatch,
+  type SharePointWritePayload,
+} from './writeMapper';
+
+export {
+  applyBenefitCutoverRead,
+  applyBenefitCutoverWrite,
+  extractMigratingDomainPatch,
+} from './repositoryOverlay';

--- a/src/features/users/infra/migration/userBenefitProfileCutover/readMapper.ts
+++ b/src/features/users/infra/migration/userBenefitProfileCutover/readMapper.ts
@@ -1,0 +1,59 @@
+/**
+ * Lot1B PR #E — read mapper (CUTOVER STEP 2 & 4 対応).
+ *
+ * stage に応じて `new ?? old` fallback と canonical-only を切替える。
+ *
+ *   PRE_MIGRATION / DUAL_WRITE / BACKFILL_IN_PROGRESS
+ *     → canonical を読み、空なら legacy にフォールバック（既存挙動互換）
+ *   READ_CUTOVER 以降
+ *     → canonical のみ読む（legacy には戻らない）
+ *
+ * 呼び出し側（例: SharePointUserRepository）は `mapMigratingFields(raw, stage)` を呼ぶだけ。
+ */
+
+import {
+  USER_BENEFIT_PROFILE_MIGRATING_COLUMNS,
+  type MigratingColumnDef,
+} from './columns';
+import { CutoverStage, isAtLeastStage, type CutoverStageValue } from './stage';
+
+export type SharePointRawItem = Readonly<Record<string, unknown>>;
+
+export type MigratingFieldReadResult = Record<string, unknown>;
+
+const readCanonicalOrLegacy = (
+  raw: SharePointRawItem,
+  column: MigratingColumnDef,
+  stage: CutoverStageValue,
+): unknown => {
+  const canonicalValue = raw[column.canonical];
+  if (isAtLeastStage(stage, CutoverStage.READ_CUTOVER)) {
+    return canonicalValue ?? null;
+  }
+  if (canonicalValue !== undefined && canonicalValue !== null) {
+    return canonicalValue;
+  }
+  return raw[column.legacy] ?? null;
+};
+
+export const mapMigratingFields = (
+  raw: SharePointRawItem,
+  stage: CutoverStageValue,
+): MigratingFieldReadResult => {
+  const result: MigratingFieldReadResult = {};
+  for (const column of USER_BENEFIT_PROFILE_MIGRATING_COLUMNS) {
+    result[column.domainKey] = readCanonicalOrLegacy(raw, column, stage);
+  }
+  return result;
+};
+
+/**
+ * $select に含めるべき internal name の集合。
+ * stage ごとに canonical のみ / 両方 を返す。
+ */
+export const getSelectFieldsForStage = (stage: CutoverStageValue): readonly string[] => {
+  if (isAtLeastStage(stage, CutoverStage.READ_CUTOVER)) {
+    return USER_BENEFIT_PROFILE_MIGRATING_COLUMNS.map((c) => c.canonical);
+  }
+  return USER_BENEFIT_PROFILE_MIGRATING_COLUMNS.flatMap((c) => [c.canonical, c.legacy]);
+};

--- a/src/features/users/infra/migration/userBenefitProfileCutover/repositoryOverlay.ts
+++ b/src/features/users/infra/migration/userBenefitProfileCutover/repositoryOverlay.ts
@@ -1,0 +1,79 @@
+/**
+ * Lot1B PR #E — Repository-level overlay helpers.
+ *
+ * `DataProviderUserRepository` の read/write 経路で使う薄いアダプタ。
+ * ここに閉じ込めることで、リポジトリ本体の変更を最小化しつつ
+ * CUTOVER STEP 5 段を挟み込める。
+ */
+
+import type { IUserMasterCreateDto } from '../../../types';
+import {
+  USER_BENEFIT_PROFILE_MIGRATING_COLUMNS,
+  type MigratingColumnDef,
+} from './columns';
+import { mapMigratingFields, type SharePointRawItem } from './readMapper';
+import { buildMigratingFieldsPayload } from './writeMapper';
+import type { CutoverStageValue } from './stage';
+
+const toPascal = (camel: string): string => camel.charAt(0).toUpperCase() + camel.slice(1);
+
+/**
+ * DTO (PascalCase) から migrating 6列分の domainKey patch を抽出。
+ * DTO に明示的に含まれる値のみ対象（undefined は送らない）。
+ */
+export const extractMigratingDomainPatch = (
+  payload: Partial<IUserMasterCreateDto>,
+): Record<string, unknown> => {
+  const patch: Record<string, unknown> = {};
+  for (const col of USER_BENEFIT_PROFILE_MIGRATING_COLUMNS) {
+    const pascalKey = toPascal(col.domainKey) as keyof IUserMasterCreateDto;
+    if (pascalKey in payload) {
+      const val = payload[pascalKey];
+      if (val !== undefined) patch[col.domainKey] = val;
+    }
+  }
+  return patch;
+};
+
+/**
+ * washRow 済みの benefit 行に、stage に応じた read cutover を上書き適用する。
+ * - domainKey の値を canonical / legacy から正しく解決し直す
+ * - 既存の washRow 出力を破壊しないよう新オブジェクトを返す
+ */
+export const applyBenefitCutoverRead = (
+  washedRow: Record<string, unknown>,
+  rawRow: SharePointRawItem,
+  stage: CutoverStageValue,
+): Record<string, unknown> => {
+  const overlay = mapMigratingFields(rawRow, stage);
+  return { ...washedRow, ...overlay };
+};
+
+/**
+ * benefit への accessory 書き込みリクエストに、stage に応じた write cutover を適用する。
+ *
+ * 手順:
+ *   1. filteredRequest から migrating 6列のキー（canonical / legacy どちらも）を剥がす
+ *   2. DTO から domainKey patch を抽出し、stage に応じた write payload を生成
+ *   3. 生成した payload をマージ
+ *
+ * これにより、既存 toRequest が resolved mapping 経由で１つの物理名にしか書かない制約を回避し、
+ * dual-write / canonical-only の切替を後段で強制できる。
+ */
+export const applyBenefitCutoverWrite = (
+  filteredRequest: Record<string, unknown>,
+  payload: Partial<IUserMasterCreateDto>,
+  stage: CutoverStageValue,
+): Record<string, unknown> => {
+  const next = { ...filteredRequest };
+  for (const col of USER_BENEFIT_PROFILE_MIGRATING_COLUMNS) {
+    delete next[col.canonical];
+    delete next[col.legacy];
+  }
+  const domainPatch = extractMigratingDomainPatch(payload);
+  if (Object.keys(domainPatch).length === 0) return next;
+  const cutoverPayload = buildMigratingFieldsPayload(domainPatch, stage);
+  return { ...next, ...cutoverPayload };
+};
+
+export { USER_BENEFIT_PROFILE_MIGRATING_COLUMNS, type MigratingColumnDef };

--- a/src/features/users/infra/migration/userBenefitProfileCutover/stage.ts
+++ b/src/features/users/infra/migration/userBenefitProfileCutover/stage.ts
@@ -1,0 +1,42 @@
+/**
+ * Lot1B PR #E — rename-migrate cutover stage flag.
+ *
+ * 注入点は `src/config/featureFlags.ts` に統一。本モジュールは
+ * 既存インポータ向けの薄いラッパ / 順序判定ヘルパのみを提供する。
+ *
+ * Rollback 指針:
+ *   - いつでも stage を下げれば read は legacy fallback に戻る（ROLLBACK SAFE）
+ *   - WRITE_CUTOVER まで進めた後でも READ_FALLBACK or DUAL_WRITE に戻せる
+ *     （legacy 列を残置している限り）
+ */
+
+import {
+  ENV_KEY_USER_BENEFIT_PROFILE_CUTOVER_STAGE,
+  LOCAL_STORAGE_KEY_USER_BENEFIT_PROFILE_CUTOVER_STAGE,
+  resolveUserBenefitProfileCutoverStage as resolveFromFeatureFlags,
+  USER_BENEFIT_PROFILE_CUTOVER_STAGES,
+  type UserBenefitProfileCutoverStage,
+} from '../../../../../config/featureFlags';
+
+export const CutoverStage = {
+  PRE_MIGRATION: 'PRE_MIGRATION',
+  DUAL_WRITE: 'DUAL_WRITE',
+  BACKFILL_IN_PROGRESS: 'BACKFILL_IN_PROGRESS',
+  READ_CUTOVER: 'READ_CUTOVER',
+  WRITE_CUTOVER: 'WRITE_CUTOVER',
+} as const satisfies Record<UserBenefitProfileCutoverStage, UserBenefitProfileCutoverStage>;
+
+export type CutoverStageValue = UserBenefitProfileCutoverStage;
+
+export {
+  ENV_KEY_USER_BENEFIT_PROFILE_CUTOVER_STAGE,
+  LOCAL_STORAGE_KEY_USER_BENEFIT_PROFILE_CUTOVER_STAGE,
+};
+
+export const resolveUserBenefitProfileCutoverStage = resolveFromFeatureFlags;
+
+export const isAtLeastStage = (current: CutoverStageValue, target: CutoverStageValue): boolean => {
+  const a = USER_BENEFIT_PROFILE_CUTOVER_STAGES.indexOf(current);
+  const b = USER_BENEFIT_PROFILE_CUTOVER_STAGES.indexOf(target);
+  return a >= 0 && b >= 0 && a >= b;
+};

--- a/src/features/users/infra/migration/userBenefitProfileCutover/writeMapper.ts
+++ b/src/features/users/infra/migration/userBenefitProfileCutover/writeMapper.ts
@@ -1,0 +1,54 @@
+/**
+ * Lot1B PR #E — write mapper (CUTOVER STEP 1 & 5 対応).
+ *
+ * stage に応じて書き込み先を切替える:
+ *
+ *   PRE_MIGRATION
+ *     → legacy のみ（既存挙動。本 lot 着手前の状態を保持可能）
+ *   DUAL_WRITE / BACKFILL_IN_PROGRESS / READ_CUTOVER
+ *     → canonical + legacy 両方（step 1 の「二重書き」）
+ *   WRITE_CUTOVER
+ *     → canonical のみ（step 5）
+ *
+ * rollback 時は stage を下げるだけで二重書き or legacy-only に戻せる（legacy 列残置が前提）。
+ */
+
+import {
+  USER_BENEFIT_PROFILE_MIGRATING_COLUMNS,
+  USER_BENEFIT_PROFILE_MIGRATING_COLUMN_BY_DOMAIN_KEY,
+  type MigratingColumnDef,
+} from './columns';
+import { CutoverStage, isAtLeastStage, type CutoverStageValue } from './stage';
+
+export type DomainPatch = Readonly<Record<string, unknown>>;
+export type SharePointWritePayload = Record<string, unknown>;
+
+const writeTargets = (
+  column: MigratingColumnDef,
+  stage: CutoverStageValue,
+): readonly string[] => {
+  if (isAtLeastStage(stage, CutoverStage.WRITE_CUTOVER)) return [column.canonical];
+  if (isAtLeastStage(stage, CutoverStage.DUAL_WRITE)) return [column.canonical, column.legacy];
+  return [column.legacy]; // PRE_MIGRATION
+};
+
+export const buildMigratingFieldsPayload = (
+  patch: DomainPatch,
+  stage: CutoverStageValue,
+): SharePointWritePayload => {
+  const payload: SharePointWritePayload = {};
+  for (const [domainKey, value] of Object.entries(patch)) {
+    const column = USER_BENEFIT_PROFILE_MIGRATING_COLUMN_BY_DOMAIN_KEY[domainKey];
+    if (!column) continue;
+    for (const target of writeTargets(column, stage)) {
+      payload[target] = value;
+    }
+  }
+  return payload;
+};
+
+/**
+ * stage ごとの書き込み対象 internal name 集合（provision 検証 / lint 用）。
+ */
+export const getWriteFieldsForStage = (stage: CutoverStageValue): readonly string[] =>
+  USER_BENEFIT_PROFILE_MIGRATING_COLUMNS.flatMap((c) => writeTargets(c, stage));


### PR DESCRIPTION
## Summary
- add Lot1B UserBenefit_Profile optional 6-column cutover path in users repository
- introduce stage resolution and feature-flag wiring for cutover control
- add migration/read/write mapper modules and repository overlay helpers
- add integration/unit tests for cutover stage behavior
- add ops scripts for backfill and staging smoke evidence dump
- include daily-side small wiring annotations and provisioning authority design memo

## Commits
- feat(users): add Lot1B benefit profile cutover path
- refactor(daily): align repository wiring and document provisioning authority scope

## Notes
- PR is intentionally scoped to the 2 new commits only (branched from current `main` and cherry-picked).