### PR TITLE
feat(telemetry): track kiosk quick link navigation by link id

### DIFF
--- a/src/app/components/KioskBackToToday.spec.tsx
+++ b/src/app/components/KioskBackToToday.spec.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { SettingsProvider } from '@/features/settings';
+import { DEFAULT_SETTINGS, SETTINGS_STORAGE_KEY } from '@/features/settings/settingsModel';
+import { KioskBackToToday } from './KioskBackToToday';
+
+function renderWithPath(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <SettingsProvider>
+        <Routes>
+          <Route path="*" element={<KioskBackToToday />} />
+        </Routes>
+      </SettingsProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('KioskBackToToday', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('shows when kiosk is enabled by URL query even if settings layoutMode is normal', () => {
+    localStorage.setItem(
+      SETTINGS_STORAGE_KEY,
+      JSON.stringify({
+        ...DEFAULT_SETTINGS,
+        layoutMode: 'normal',
+      }),
+    );
+
+    renderWithPath('/call-logs?kiosk=1');
+
+    expect(screen.getByTestId('kiosk-back-to-today')).toBeInTheDocument();
+  });
+
+  it('shows on /dashboard when kiosk mode is enabled in settings', () => {
+    localStorage.setItem(
+      SETTINGS_STORAGE_KEY,
+      JSON.stringify({
+        ...DEFAULT_SETTINGS,
+        layoutMode: 'kiosk',
+      }),
+    );
+
+    renderWithPath('/dashboard');
+
+    expect(screen.getByTestId('kiosk-back-to-today')).toBeInTheDocument();
+  });
+
+  it('hides on /today in kiosk mode', () => {
+    localStorage.setItem(
+      SETTINGS_STORAGE_KEY,
+      JSON.stringify({
+        ...DEFAULT_SETTINGS,
+        layoutMode: 'kiosk',
+      }),
+    );
+
+    renderWithPath('/today?kiosk=1');
+
+    expect(screen.queryByTestId('kiosk-back-to-today')).not.toBeInTheDocument();
+  });
+});

--- a/src/app/components/KioskBackToToday.tsx
+++ b/src/app/components/KioskBackToToday.tsx
@@ -10,23 +10,21 @@ import { Box, ButtonBase, Typography } from '@mui/material';
 import { alpha, useTheme } from '@mui/material/styles';
 import React from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { useSettingsContext } from '@/features/settings/SettingsContext';
+import { useKioskDetection } from '@/features/settings/hooks/useKioskDetection';
 
 /** Today系パス（完全一致でのみバーを非表示にする） */
-const TODAY_EXACT_PATHS = new Set(['/today', '/dashboard', '/admin/dashboard']);
+const TODAY_EXACT_PATHS = new Set(['/today']);
 
 export const KioskBackToToday: React.FC = () => {
-  const { settings } = useSettingsContext();
   const location = useLocation();
   const navigate = useNavigate();
   const theme = useTheme();
-
-  const isKiosk = settings.layoutMode === 'kiosk';
+  const { isKioskMode } = useKioskDetection();
 
   // Today 画面にいるなら非表示（完全一致のみ）
   const isOnToday = TODAY_EXACT_PATHS.has(location.pathname);
 
-  if (!isKiosk || isOnToday) return null;
+  if (!isKioskMode || isOnToday) return null;
 
   return (
     <Box

--- a/src/features/today/components/KioskQuickLinks.spec.tsx
+++ b/src/features/today/components/KioskQuickLinks.spec.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { KioskQuickLinks } from './KioskQuickLinks';
+import { KIOSK_TELEMETRY_EVENTS } from '../telemetry/kioskNavigationTelemetry.types';
+
+const mockUseFeatureFlags = vi.fn();
+const mockUseUserAuthz = vi.fn();
+const mockRecordKioskTelemetry = vi.fn();
+
+vi.mock('@/config/featureFlags', () => ({
+  useFeatureFlags: () => mockUseFeatureFlags(),
+}));
+
+vi.mock('@/auth/useUserAuthz', () => ({
+  useUserAuthz: () => mockUseUserAuthz(),
+}));
+
+vi.mock('../telemetry/recordKioskTelemetry', () => ({
+  recordKioskTelemetry: (...args: unknown[]) => mockRecordKioskTelemetry(...args),
+}));
+
+describe('KioskQuickLinks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const viewerFlags = {
+    schedules: true,
+    complianceForm: false,
+    schedulesWeekV2: false,
+    icebergPdca: false,
+    staffAttendance: false,
+    todayOps: true,
+    todayLiteUi: false,
+    todayLiteNavV2: false,
+  };
+
+  it('hides schedule link when schedules feature is disabled', () => {
+    mockUseFeatureFlags.mockReturnValue({
+      ...viewerFlags,
+      schedules: false,
+    });
+    mockUseUserAuthz.mockReturnValue({ role: 'viewer', ready: true });
+
+    render(<KioskQuickLinks onNavigate={vi.fn()} />);
+
+    expect(screen.queryByTestId('kiosk-quick-link-schedule')).not.toBeInTheDocument();
+    expect(screen.getByTestId('kiosk-quick-link-handoff')).toBeInTheDocument();
+  });
+
+  it('shows renamed labels for minutes and briefing actions', () => {
+    mockUseFeatureFlags.mockReturnValue(viewerFlags);
+    mockUseUserAuthz.mockReturnValue({ role: 'viewer', ready: true });
+
+    render(<KioskQuickLinks onNavigate={vi.fn()} />);
+
+    expect(screen.getByTestId('kiosk-quick-link-minutes')).toBeInTheDocument();
+    expect(screen.getByTestId('kiosk-quick-link-briefing')).toBeInTheDocument();
+    expect(screen.getByText('議事録記録')).toBeInTheDocument();
+    expect(screen.getByText('朝夕会進行')).toBeInTheDocument();
+  });
+
+  it('records telemetry with target=link.id for schedule click and keeps navigation behavior', () => {
+    mockUseFeatureFlags.mockReturnValue(viewerFlags);
+    mockUseUserAuthz.mockReturnValue({ role: 'viewer', ready: true });
+    const onNavigate = vi.fn();
+
+    render(<KioskQuickLinks onNavigate={onNavigate} />);
+
+    fireEvent.click(screen.getByTestId('kiosk-quick-link-schedule'));
+
+    expect(mockRecordKioskTelemetry).toHaveBeenCalledWith(
+      KIOSK_TELEMETRY_EVENTS.NAVIGATE_FROM_TODAY,
+      expect.objectContaining({
+        mode: 'kiosk',
+        source: 'today',
+        target: 'schedule',
+        to: '/schedules/week',
+      }),
+    );
+    expect(onNavigate).toHaveBeenCalledWith('/schedules/week');
+  });
+
+  it('records telemetry with target=link.id for briefing click', () => {
+    mockUseFeatureFlags.mockReturnValue(viewerFlags);
+    mockUseUserAuthz.mockReturnValue({ role: 'viewer', ready: true });
+
+    render(<KioskQuickLinks onNavigate={vi.fn()} />);
+
+    fireEvent.click(screen.getByTestId('kiosk-quick-link-briefing'));
+
+    expect(mockRecordKioskTelemetry).toHaveBeenCalledWith(
+      KIOSK_TELEMETRY_EVENTS.NAVIGATE_FROM_TODAY,
+      expect.objectContaining({
+        target: 'briefing',
+        to: '/dashboard/briefing',
+      }),
+    );
+  });
+});

--- a/src/features/today/components/KioskQuickLinks.tsx
+++ b/src/features/today/components/KioskQuickLinks.tsx
@@ -15,61 +15,36 @@ import { Box, ButtonBase, Typography } from '@mui/material';
 import { alpha, useTheme } from '@mui/material/styles';
 import React from 'react';
 
+import { useUserAuthz } from '@/auth/useUserAuthz';
+import { useFeatureFlags } from '@/config/featureFlags';
+import {
+  getKioskQuickLinks,
+  type KioskQuickLinkId,
+} from '../model/getKioskQuickLinks';
 import { KIOSK_TELEMETRY_EVENTS } from '../telemetry/kioskNavigationTelemetry.types';
 import { recordKioskTelemetry } from '../telemetry/recordKioskTelemetry';
 
 // ─── Types ───────────────────────────────────────────────────
 
-export type KioskQuickLinkItem = {
-  key: string;
-  label: string;
-  icon: React.ReactNode;
-  href: string;
-};
-
 type KioskQuickLinksProps = {
   onNavigate: (href: string) => void;
 };
 
-// ─── Links ───────────────────────────────────────────────────
-
-const LINKS: KioskQuickLinkItem[] = [
-  {
-    key: 'schedule',
-    label: 'スケジュール',
-    icon: <CalendarMonthRoundedIcon fontSize="small" />,
-    href: '/schedules/week',
-  },
-  {
-    key: 'handoff',
-    label: '申し送り',
-    icon: <SwapHorizRoundedIcon fontSize="small" />,
-    href: '/handoff-timeline',
-  },
-  {
-    key: 'minutes',
-    label: '議事録',
-    icon: <SummarizeRoundedIcon fontSize="small" />,
-    href: '/meeting-minutes',
-  },
-  {
-    key: 'room',
-    label: 'お部屋管理',
-    icon: <MeetingRoomRoundedIcon fontSize="small" />,
-    href: '/room-management',
-  },
-  {
-    key: 'briefing',
-    label: '朝会・夕会',
-    icon: <GroupsRoundedIcon fontSize="small" />,
-    href: '/dashboard/briefing',
-  },
-];
+const LINK_ICONS: Record<KioskQuickLinkId, React.ReactNode> = {
+  schedule: <CalendarMonthRoundedIcon fontSize="small" />,
+  handoff: <SwapHorizRoundedIcon fontSize="small" />,
+  minutes: <SummarizeRoundedIcon fontSize="small" />,
+  room: <MeetingRoomRoundedIcon fontSize="small" />,
+  briefing: <GroupsRoundedIcon fontSize="small" />,
+};
 
 // ─── Component ───────────────────────────────────────────────
 
 export const KioskQuickLinks: React.FC<KioskQuickLinksProps> = ({ onNavigate }) => {
   const theme = useTheme();
+  const flags = useFeatureFlags();
+  const { role } = useUserAuthz();
+  const visibleLinks = React.useMemo(() => getKioskQuickLinks({ role, flags }), [flags, role]);
 
   return (
     <Box
@@ -84,18 +59,19 @@ export const KioskQuickLinks: React.FC<KioskQuickLinksProps> = ({ onNavigate }) 
         borderTop: `1px solid ${alpha(theme.palette.divider, 0.12)}`,
       }}
     >
-      {LINKS.map((link) => (
+      {visibleLinks.map((link) => (
         <ButtonBase
-          key={link.key}
+          key={link.id}
           onClick={() => {
             recordKioskTelemetry(KIOSK_TELEMETRY_EVENTS.NAVIGATE_FROM_TODAY, {
               mode: 'kiosk',
-              target: link.key as Parameters<typeof recordKioskTelemetry>[1]['target'],
+              target: link.id,
               source: 'today',
+              to: link.href,
             });
             onNavigate(link.href);
           }}
-          data-testid={`kiosk-quick-link-${link.key}`}
+          data-testid={`kiosk-quick-link-${link.id}`}
           sx={{
             display: 'flex',
             alignItems: 'center',
@@ -114,7 +90,7 @@ export const KioskQuickLinks: React.FC<KioskQuickLinksProps> = ({ onNavigate }) 
           }}
         >
           <Box sx={{ color: 'primary.main', display: 'flex' }}>
-            {link.icon}
+            {LINK_ICONS[link.id]}
           </Box>
           <Typography
             variant="caption"

--- a/src/features/today/model/getKioskQuickLinks.spec.ts
+++ b/src/features/today/model/getKioskQuickLinks.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { getKioskQuickLinks } from './getKioskQuickLinks';
+
+const baseFlags = {
+  schedules: true,
+  complianceForm: false,
+  schedulesWeekV2: false,
+  icebergPdca: false,
+  staffAttendance: false,
+  todayOps: true,
+  todayLiteUi: false,
+  todayLiteNavV2: false,
+} as const;
+
+describe('getKioskQuickLinks', () => {
+  it('returns all default links when schedules is enabled', () => {
+    const links = getKioskQuickLinks({
+      role: 'viewer',
+      flags: { ...baseFlags },
+    });
+
+    expect(links.map((link) => link.id)).toEqual([
+      'schedule',
+      'handoff',
+      'minutes',
+      'room',
+      'briefing',
+    ]);
+  });
+
+  it('hides schedule link when schedules flag is disabled', () => {
+    const links = getKioskQuickLinks({
+      role: 'viewer',
+      flags: { ...baseFlags, schedules: false },
+    });
+
+    expect(links.map((link) => link.id)).toEqual([
+      'handoff',
+      'minutes',
+      'room',
+      'briefing',
+    ]);
+  });
+});
+

--- a/src/features/today/model/getKioskQuickLinks.ts
+++ b/src/features/today/model/getKioskQuickLinks.ts
@@ -1,0 +1,73 @@
+import type { Role } from '@/auth/roles';
+import type { FeatureFlagSnapshot } from '@/config/featureFlags';
+
+export type KioskQuickLinkId = 'schedule' | 'handoff' | 'minutes' | 'room' | 'briefing';
+
+export type KioskQuickLink = {
+  id: KioskQuickLinkId;
+  label: string;
+  href: string;
+};
+
+type KioskQuickLinkRule = KioskQuickLink & {
+  requiredRole?: Role;
+  requiredFlag?: keyof FeatureFlagSnapshot;
+};
+
+export type GetKioskQuickLinksInput = {
+  role: Role;
+  flags: FeatureFlagSnapshot;
+};
+
+const ALL_KIOSK_QUICK_LINKS: KioskQuickLinkRule[] = [
+  {
+    id: 'schedule',
+    label: 'スケジュール',
+    href: '/schedules/week',
+    requiredRole: 'viewer',
+    requiredFlag: 'schedules',
+  },
+  {
+    id: 'handoff',
+    label: '申し送り',
+    href: '/handoff-timeline',
+    requiredRole: 'viewer',
+  },
+  {
+    id: 'minutes',
+    label: '議事録記録',
+    href: '/meeting-minutes',
+    requiredRole: 'viewer',
+  },
+  {
+    id: 'room',
+    label: 'お部屋管理',
+    href: '/room-management',
+    requiredRole: 'viewer',
+  },
+  {
+    id: 'briefing',
+    label: '朝夕会進行',
+    href: '/dashboard/briefing',
+    requiredRole: 'viewer',
+  },
+];
+
+const ROLE_LEVEL: Record<Role, number> = {
+  viewer: 1,
+  reception: 2,
+  admin: 3,
+};
+
+const canAccess = (role: Role, requiredRole: Role): boolean => ROLE_LEVEL[role] >= ROLE_LEVEL[requiredRole];
+
+export function getKioskQuickLinks(input: GetKioskQuickLinksInput): KioskQuickLink[] {
+  const { role, flags } = input;
+
+  return ALL_KIOSK_QUICK_LINKS.filter((link) => {
+    if (link.requiredFlag && !flags[link.requiredFlag]) return false;
+    if (link.requiredRole && !canAccess(role, link.requiredRole)) return false;
+    return true;
+  }).map(({ id, label, href }) => ({ id, label, href }));
+}
+

--- a/src/features/today/telemetry/kioskNavigationTelemetry.types.ts
+++ b/src/features/today/telemetry/kioskNavigationTelemetry.types.ts
@@ -1,3 +1,5 @@
+import type { KioskQuickLinkId } from '../model/getKioskQuickLinks';
+
 /**
  * Kiosk UX Regression Tracking Events
  *
@@ -51,7 +53,10 @@ export interface KioskNavigationPayload {
    * ナビゲーションの「遷移先（目的地）」
    * ※`ux_navigate_from_today` などの場合にセット
    */
-  target?: 'schedules' | 'handoff' | 'minutes' | 'rooms' | 'records';
+  target?: KioskQuickLinkId;
+
+  /** 遷移先パス（UI側との突合せ用） */
+  to?: string;
 
   /**
    * ナビゲーションの「起点（トリガー箇所）」

--- a/tests/e2e/kiosk-ux-regression.smoke.spec.ts
+++ b/tests/e2e/kiosk-ux-regression.smoke.spec.ts
@@ -123,5 +123,33 @@ test.describe('Kiosk UX Regression (Smoke)', () => {
     const progressRing = page.locator('svg').filter({ has: page.locator('circle') });
     await expect(progressRing.first()).toBeVisible();
   });
-});
 
+  test('kiosk mode: hides schedule quick link when schedules feature is disabled', async ({ page }) => {
+    await page.addInitScript(() => {
+      const w = window as typeof window & { __ENV__?: Record<string, string> };
+      w.__ENV__ = {
+        ...(w.__ENV__ ?? {}),
+        VITE_FEATURE_SCHEDULES: '0',
+      };
+      window.localStorage.setItem(
+        'audit:settings:v1',
+        JSON.stringify({
+          colorMode: 'system',
+          density: 'comfortable',
+          fontSize: 'medium',
+          colorPreset: 'default',
+          layoutMode: 'kiosk',
+          hiddenNavGroups: [],
+          hiddenNavItems: [],
+          lastModified: Date.now(),
+        }),
+      );
+    });
+
+    await page.goto('/today?kiosk=1');
+    await page.waitForLoadState('domcontentloaded');
+
+    await expect(page.getByTestId('kiosk-quick-link-schedule')).toHaveCount(0);
+    await expect(page.getByTestId('kiosk-quick-link-handoff')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

This PR hardens kiosk navigation UX by aligning quick-link visibility, telemetry, and regression coverage around the same `link.id` SSOT.

### What changed

- Extracted kiosk quick-link visibility rules into a pure `getKioskQuickLinks(...)` helper
- Updated `KioskQuickLinks` telemetry to send `target = link.id`
- Added regression coverage for `kiosk + schedules=false` so the schedule quick link is hidden when unavailable

### Why

This removes the “clickable but unusable” kiosk path, keeps metrics aligned with the visibility contract, and makes future label changes safer because tracking no longer depends on display text.
