### PR TITLE
fix(dashboard): guard undefined attendance counts in summary hook

### DIFF
--- a/src/features/dashboard/useDashboardSummary.ts
+++ b/src/features/dashboard/useDashboardSummary.ts
@@ -55,6 +55,12 @@ export function useDashboardSummary(args: {
 
   // Normalize inputs: prevent Object.values(undefined) crash during initial render
   const safeVisits = visits ?? {};
+  const safeAttendanceCounts: AttendanceCounts = attendanceCounts ?? {
+    onDuty: 0,
+    out: 0,
+    absent: 0,
+    total: 0,
+  };
   
   // 1. Activity & Usage
   const activityRecords = useMemo(() => {
@@ -137,7 +143,7 @@ export function useDashboardSummary(args: {
     users,
     staff,
     safeVisits,
-    attendanceCounts,
+    safeAttendanceCounts,
   );
 
   // 4. Daily Record Status


### PR DESCRIPTION
## Summary
- guard `attendanceCounts` in `useDashboardSummary` with safe defaults (`onDuty/out/absent/total = 0`)
- pass normalized counts into `useAttendanceAnalytics` to prevent cold-load crash

## Why
CI failures were caused by `TypeError: Cannot read properties of undefined (reading 'onDuty')` in `useAttendanceAnalytics` when `attendanceCounts` was undefined in cold-load path.

## Validation
- `npx vitest run src/features/dashboard/__tests__/useDashboardSummary.spec.ts`
- `npx vitest run tests/unit/scripts/nightly-decision.reason-codes.spec.ts src/features/sp/health/hooks/__tests__/useSelfHealingResults.spec.ts tests/unit/scripts/nightly-owner-notify.spec.ts`
- `npm run typecheck`
