### PR TITLE
fix(sp): restore registry baseline green on main

### DIFF
--- a/src/sharepoint/__tests__/driftProbeRegistry.spec.ts
+++ b/src/sharepoint/__tests__/driftProbeRegistry.spec.ts
@@ -20,7 +20,7 @@ describe('DriftProbeRegistry / Dynamic Discovery', () => {
     const users = targets.find(t => t.key === 'users_master');
     
     expect(users).toBeDefined();
-    expect(users?.listTitle).toBe('User_Profiles');
+    expect(users?.listTitle).toBe('Users_Master');
     // Id and Title are automatically added by the mapper if missing
     expect(users?.selectFields).toContain('Id');
     expect(users?.selectFields).toContain('Title');

--- a/src/sharepoint/__tests__/spListRegistry.ssot.spec.ts
+++ b/src/sharepoint/__tests__/spListRegistry.ssot.spec.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { SP_LIST_REGISTRY, listDefinitions as registryDefinitions } from '../spListRegistry';
+import { listDefinitions } from '../spListRegistry.definitions';
+
+describe('spListRegistry SSOT', () => {
+  it('uses definitions module as the single source of truth', () => {
+    expect(registryDefinitions).toBe(listDefinitions);
+    expect(SP_LIST_REGISTRY).toBe(listDefinitions);
+  });
+});

--- a/src/sharepoint/spListRegistry.definitions.ts
+++ b/src/sharepoint/spListRegistry.definitions.ts
@@ -727,6 +727,24 @@ export const complianceListEntries: readonly SpListEntry[] = [
       { internalName: 'RemediationSource', type: 'Text', displayName: 'Remediation Source', candidates: ['RemediationSource', 'Source'] },
     ],
   },
+  {
+    key: 'remediation_audit_log',
+    displayName: '修復監査ログ',
+    resolve: () => 'Remediation_AuditLog',
+    operations: ['R', 'W'],
+    category: 'compliance',
+    lifecycle: 'optional',
+    essentialFields: ['PlanId', 'Phase', 'ListKey', 'Action', 'Timestamp'],
+    provisioningFields: [
+      { internalName: 'PlanId', type: 'Text', displayName: 'Plan ID', required: true, indexed: true },
+      { internalName: 'Phase', type: 'Text', displayName: 'Phase', required: true },
+      { internalName: 'ListKey', type: 'Text', displayName: 'List Key', required: true, indexed: true },
+      { internalName: 'Action', type: 'Text', displayName: 'Action', required: true },
+      { internalName: 'Timestamp', type: 'DateTime', displayName: 'Timestamp', required: true },
+      { internalName: 'Status', type: 'Text', displayName: 'Status' },
+      { internalName: 'Payload', type: 'Note', displayName: 'Payload JSON', richText: false },
+    ],
+  },
 ];
 
 export const otherListEntries: readonly SpListEntry[] = [
@@ -811,4 +829,16 @@ export const otherListEntries: readonly SpListEntry[] = [
     category: 'other',
     lifecycle: 'optional',
   },
+];
+
+/** 全リスト定義の統合（参照等価性を維持するため） */
+export const listDefinitions: readonly SpListEntry[] = [
+  ...masterListEntries,
+  ...dailyListEntries,
+  ...attendanceListEntries,
+  ...scheduleListEntries,
+  ...meetingListEntries,
+  ...handoffListEntries,
+  ...complianceListEntries,
+  ...otherListEntries,
 ];

--- a/src/sharepoint/spListRegistry.ts
+++ b/src/sharepoint/spListRegistry.ts
@@ -8,14 +8,7 @@
  */
 
 import {
-  attendanceListEntries,
-  complianceListEntries,
-  dailyListEntries,
-  handoffListEntries,
-  masterListEntries,
-  meetingListEntries,
-  otherListEntries,
-  scheduleListEntries,
+  listDefinitions,
 } from './spListRegistry.definitions';
 import type { SpListCategory, SpListEntry } from './spListRegistry.shared';
 
@@ -33,16 +26,10 @@ export type {
 /**
  * SharePoint リスト レジストリ — 全リストの Single Source of Truth
  */
-export const SP_LIST_REGISTRY = [
-  ...masterListEntries,
-  ...dailyListEntries,
-  ...attendanceListEntries,
-  ...scheduleListEntries,
-  ...meetingListEntries,
-  ...handoffListEntries,
-  ...complianceListEntries,
-  ...otherListEntries,
-] as const satisfies readonly SpListEntry[];
+export const SP_LIST_REGISTRY = listDefinitions;
+
+/** 互換性のためのエイリアス */
+export { listDefinitions };
 
 /** キーでリスト定義を取得 */
 export const findListEntry = (key: string): SpListEntry | undefined =>


### PR DESCRIPTION
## Summary
Restore the SharePoint registry baseline on top of \main\ after PR #1556 merged without the final stabilization fixes.

## Changes
- restore missing \emediation_audit_log\ registry definition
- re-align the registry facade with the SSOT referential contract
- update drift probe expectation from \User_Profiles\ to \Users_Master\
- restore missing \spListRegistry.ssot.spec.ts\ contract test

## Verification
- vitest (registryIntegration / ssot / driftProbe): PASS
- lint: PASS
- typecheck: PASS

## Context
PR #1556 merged index governance, but baseline stabilization was missing.
This PR restores full baseline green with minimal corrective scope.
