### PR TITLE
fix(nav): stabilize navigation integrity on main

### DIFF
--- a/src/app/config/routeGroups/planningRoutes.ts
+++ b/src/app/config/routeGroups/planningRoutes.ts
@@ -10,8 +10,8 @@ import { TESTIDS } from '@/testids';
 export const PLANNING_ROUTES = {
   SUPPORT_PLAN_GUIDE: (_isFieldStaffShell: boolean) => ({
     label: '支援計画ガイド',
-    to: '/planning/guide',
-    isActive: (pathname: string) => pathname.startsWith('/planning/guide'),
+    to: '/support-plan-guide',
+    isActive: (pathname: string) => pathname.startsWith('/support-plan-guide'),
     icon: undefined,
     audience: NAV_AUDIENCE.staff as NavAudience,
     group: 'planning' as NavGroupKey,

--- a/src/app/routes/appRoutePaths.ts
+++ b/src/app/routes/appRoutePaths.ts
@@ -20,6 +20,7 @@ export const APP_ROUTE_PATHS = [
   'master',
   'platform',
   'transport/assignments',
+  'transport/execution',
   'room-management',
   'meeting-guide',
   'compliance',


### PR DESCRIPTION
## Summary
Fixes navigation/router integrity drift left after PR #1573.

## Changes
- Add /transport/execution to APP_ROUTE_PATHS so the route registry matches the router.
- Update planning guide navigation from /planning/guide to /support-plan-guide.

## Validation
- Passed: npx vitest run tests/unit/app/navigation/nav-router-consistency.spec.ts --reporter=verbose

## Notes
This is a narrow follow-up to restore nav-integrity CI on main after #1573.