### PR TITLE
fix(provision): add PlanGoal required fields

### DIFF
--- a/provision/schema.xml
+++ b/provision/schema.xml
@@ -220,6 +220,15 @@
             </pnp:Field>
           </pnp:Fields>
         </pnp:ListInstance>
+        <!-- PlanGoal: 支援計画目標（ISP） -->
+        <pnp:ListInstance Title="PlanGoal" Description="支援計画目標（ISP）" TemplateType="100" Url="Lists/PlanGoal">
+          <pnp:Fields>
+            <pnp:Field Type="Text" DisplayName="利用者コード" Required="TRUE" Indexed="TRUE" StaticName="UserCode" Name="UserCode" />
+            <pnp:Field Type="Text" DisplayName="目標種別" Required="TRUE" StaticName="GoalType" Name="GoalType" />
+            <pnp:Field Type="Note" DisplayName="目標内容" StaticName="GoalText" Name="GoalText" NumLines="6" RichText="FALSE" />
+            <pnp:Field Type="Text" DisplayName="計画状態" StaticName="PlanStatus" Name="PlanStatus" />
+          </pnp:Fields>
+        </pnp:ListInstance>
         <!-- Behavior_Support_Plans: 行動支援計画（計画版への参照） -->
         <pnp:ListInstance Title="Behavior_Support_Plans" Description="行動支援計画" TemplateType="100" Url="Lists/Behavior_Support_Plans">
           <pnp:Fields>

--- a/scripts/sp-preprod/lists.manifest.json
+++ b/scripts/sp-preprod/lists.manifest.json
@@ -272,10 +272,16 @@
       "description": "支援計画目標（ISP旧モデル）",
       "category": "plan",
       "requiredFields": [
-        { "internalName": "Id",    "type": "Number", "required": true },
-        { "internalName": "Title", "type": "Text",   "required": true }
+        { "internalName": "Id",         "type": "Number", "required": true  },
+        { "internalName": "Title",      "type": "Text",   "required": true  },
+        { "internalName": "UserCode",   "type": "Text",   "required": true  },
+        { "internalName": "GoalType",   "type": "Text",   "required": true  },
+        { "internalName": "GoalText",   "type": "Note",   "required": false },
+        { "internalName": "PlanStatus", "type": "Text",   "required": false }
       ],
-      "indexes": []
+      "indexes": [
+        { "field": "UserCode", "unique": false }
+      ]
     },
 
     {


### PR DESCRIPTION
## Summary
This follow-up to #1578 adds the missing PlanGoal provisioning contract so new or repaired SharePoint environments create the required fields used by Iceberg-PDCA diagnosis.

## Changes
- Adds PlanGoal to `provision/schema.xml`
- Adds `UserCode`, `GoalType`, `GoalText`, and `PlanStatus` to `scripts/sp-preprod/lists.manifest.json`
- Marks `UserCode` as required and indexed
- Keeps the runtime PlanGoal naming introduced by #1578

## Validation
- `npm run sp:audit` ✅ PASS
- `npm run typecheck` ✅ PASS

## Follow-up
After merge, run provisioning or Health remediation and re-run Iceberg-PDCA environment diagnosis.

Expected:
- `schema.fields.plan_goals`: pass
- `FAIL: 0`
- WARN may remain for drift/optional fields
