### PR TITLE
fix(users): prevent Title fallback for user id resolution

### DIFF
--- a/src/debug/SpDevPanel.tsx
+++ b/src/debug/SpDevPanel.tsx
@@ -17,7 +17,7 @@ import { useConfirmDialog } from '@/components/ui/useConfirmDialog';
 import { useSP } from '../lib/spClient';
 import { useDataProvider } from '@/lib/data/useDataProvider';
 import { migrateUserSplitData } from '../features/users/utils/migrateUserSplitData';
-import { useDataProviderObservabilityStore, type ResourceStatus } from '@/lib/data/dataProviderObservabilityStore';
+import { useDataProviderObservabilityStore } from '@/lib/data/dataProviderObservabilityStore';
 import { DATA_OS_RESOURCE_REGISTRY } from '@/lib/data/dataOSResourceRegistry';
 
 // ── Types ──────────────────────────────────────────────────────────────────
@@ -166,14 +166,10 @@ function CopyButton({ text }: { text: string }) {
   );
 }
 
-const STATUS_COLORS: Record<ResourceStatus, string> = {
-  resolved: '#4caf50',
-  missing_optional: '#ffc107',
-  missing_required: '#ff6b6b',
-  fallback_triggered: '#00bcd4',
-  schema_mismatch: '#ff9800',
-  schema_warning: '#ff9800',
-  pending: '#888',
+const SEVERITY_COLORS: Record<string, string> = {
+  critical: '#ff1744', // Red A400
+  warn: '#ff9100',     // Orange A400
+  info: '#4caf50',     // Green 500
 };
 
 export default function SpDevPanel() {
@@ -197,8 +193,8 @@ export default function SpDevPanel() {
   if (!isPanelOpen) return null;
 
   const resolutionList = Object.values(resolutions);
-  const errorCount = resolutionList.filter(r => r.status === 'missing_required').length;
-  const warnCount = resolutionList.filter(r => r.status === 'fallback_triggered' || r.status === 'schema_mismatch').length;
+  const errorCount = resolutionList.filter(r => r.severity === 'critical').length;
+  const warnCount = resolutionList.filter(r => r.severity === 'warn').length;
 
   return (
     <div style={PANEL} data-testid="sp-dev-panel">
@@ -371,8 +367,16 @@ function ObservabilityTab({ confirmDialog }: { confirmDialog: ReturnType<typeof 
                 <div style={{ fontWeight: 600 }}>{r.resourceName}</div>
                 {r.fallbackFrom && <div style={{ fontSize: '9px', color: '#00bcd4' }}>from {r.fallbackFrom}</div>}
               </td>
-              <td style={{ ...TD, color: STATUS_COLORS[r.status], fontWeight: 700 }}>
-                {r.status.toUpperCase()}
+              <td style={{ ...TD, color: SEVERITY_COLORS[r.severity], fontWeight: 700 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                  {r.status.toUpperCase()}
+                  {r.fields.some(f => (f.key === 'userId' || f.key === 'id') && !f.isResolved) && (
+                    <span style={{ 
+                      fontSize: '8px', background: SEVERITY_COLORS.critical, color: '#fff', 
+                      padding: '1px 4px', borderRadius: '2px' 
+                    }}>ID MISSING</span>
+                  )}
+                </div>
               </td>
               <td style={TD}>
                 <div style={{ fontSize: '10px' }}>{r.resolvedTitle}</div>

--- a/src/features/attendance/infra/DataProviderAttendanceRepository.ts
+++ b/src/features/attendance/infra/DataProviderAttendanceRepository.ts
@@ -263,7 +263,7 @@ export class DataProviderAttendanceRepository implements AttendanceRepository {
       reportResourceResolution({
         resourceName: `Attendance:${schema.listTitle}`,
         resolvedTitle: schema.listTitle,
-        fieldStatus: schema.fieldStatus as Record<string, { resolvedName?: string; candidates: string[]; isDrifted: boolean }>,
+        fieldStatus: schema.fieldStatus as Record<string, { resolvedName?: string; candidates: string[]; isSilent: boolean }>,
         essentials: [...ATTENDANCE_USERS_ESSENTIALS],
         lifecycle: 'required',
       });
@@ -280,7 +280,7 @@ export class DataProviderAttendanceRepository implements AttendanceRepository {
       reportResourceResolution({
         resourceName: `Attendance:${schema.listTitle}`,
         resolvedTitle: schema.listTitle,
-        fieldStatus: schema.fieldStatus as Record<string, { resolvedName?: string; candidates: string[]; isDrifted: boolean }>,
+        fieldStatus: schema.fieldStatus as Record<string, { resolvedName?: string; candidates: string[]; isSilent: boolean }>,
         essentials: [...ATTENDANCE_DAILY_ESSENTIALS],
         lifecycle: 'required',
       });

--- a/src/features/attendance/infra/modules/AttendanceSchemaResolver.ts
+++ b/src/features/attendance/infra/modules/AttendanceSchemaResolver.ts
@@ -6,6 +6,7 @@ type FieldStatus = {
   resolvedName?: string;
   candidates: string[];
   isDrifted: boolean;
+  isSilent: boolean;
 };
 
 export type AttendanceResolvedSchema<TKey extends string> = {
@@ -229,6 +230,7 @@ export class AttendanceSchemaResolver<TKey extends string> {
       status[key] = {
         candidates: [...fieldCandidates],
         isDrifted: false,
+        isSilent: !this.essentials.includes(key),
       };
     }
     return status;
@@ -261,7 +263,15 @@ export class AttendanceSchemaResolver<TKey extends string> {
       resolved as Record<TKey, string | undefined>,
       [...this.essentials],
     );
-    const typedFieldStatus = fieldStatus as Record<TKey, FieldStatus>;
+    const typedFieldStatus = Object.fromEntries(
+      Object.entries(fieldStatus).map(([key, status]) => [
+        key,
+        {
+          ...(status as any),
+          isSilent: !this.essentials.includes(key as TKey),
+        },
+      ]),
+    ) as Record<TKey, FieldStatus>;
     if (!isHealthy) {
       return { mapping: null, missingFields: missing, select: [], fieldStatus: typedFieldStatus };
     }

--- a/src/features/attendance/infra/modules/AttendanceSchemaResolver.ts
+++ b/src/features/attendance/infra/modules/AttendanceSchemaResolver.ts
@@ -267,7 +267,7 @@ export class AttendanceSchemaResolver<TKey extends string> {
       Object.entries(fieldStatus).map(([key, status]) => [
         key,
         {
-          ...(status as any),
+          ...(status as { resolvedName?: string; candidates: string[]; isDrifted: boolean }),
           isSilent: !this.essentials.includes(key as TKey),
         },
       ]),

--- a/src/features/daily/infra/DataProviderDailyRecordRepository.ts
+++ b/src/features/daily/infra/DataProviderDailyRecordRepository.ts
@@ -321,7 +321,7 @@ export class DataProviderDailyRecordRepository extends BaseRepository implements
         Object.entries(fieldStatus).map(([key, status]) => [
           key,
           {
-            ...(status as any),
+            ...(status as { resolvedName?: string; candidates: string[] }),
             isSilent: !essentialsSet.has(key),
           },
         ])
@@ -360,7 +360,7 @@ export class DataProviderDailyRecordRepository extends BaseRepository implements
         Object.entries(fieldStatus).map(([key, status]) => [
           key,
           {
-            ...(status as any),
+            ...(status as { resolvedName?: string; candidates: string[] }),
             isSilent: !essentialsSet.has(key),
           },
         ])

--- a/src/features/daily/infra/DataProviderDailyRecordRepository.ts
+++ b/src/features/daily/infra/DataProviderDailyRecordRepository.ts
@@ -316,10 +316,21 @@ export class DataProviderDailyRecordRepository extends BaseRepository implements
       const essentials = DAILY_RECORD_CANONICAL_ESSENTIALS as unknown as string[];
       const isHealthy = areEssentialFieldsResolved(resolved as Record<string, string | undefined>, essentials);
 
+      const essentialsSet = new Set(essentials);
+      const fieldStatusWithSilent = Object.fromEntries(
+        Object.entries(fieldStatus).map(([key, status]) => [
+          key,
+          {
+            ...(status as any),
+            isSilent: !essentialsSet.has(key),
+          },
+        ])
+      );
+
       reportResourceResolution({
         resourceName: title,
         resolvedTitle: title,
-        fieldStatus: fieldStatus as Record<string, { resolvedName?: string; candidates: string[] }>,
+        fieldStatus: fieldStatusWithSilent,
         essentials,
       });
 
@@ -344,10 +355,21 @@ export class DataProviderDailyRecordRepository extends BaseRepository implements
       const essentials = DAILY_RECORD_ROW_AGGREGATE_ESSENTIALS as unknown as string[];
       const isHealthy = areEssentialFieldsResolved(resolved as Record<string, string | undefined>, essentials);
 
+      const essentialsSet = new Set(essentials);
+      const fieldStatusWithSilent = Object.fromEntries(
+        Object.entries(fieldStatus).map(([key, status]) => [
+          key,
+          {
+            ...(status as any),
+            isSilent: !essentialsSet.has(key),
+          },
+        ])
+      );
+
       reportResourceResolution({
         resourceName: title,
         resolvedTitle: title,
-        fieldStatus: fieldStatus as Record<string, { resolvedName?: string; candidates: string[] }>,
+        fieldStatus: fieldStatusWithSilent,
         essentials,
       });
 

--- a/src/features/schedules/infra/DataProviderScheduleRepository.ts
+++ b/src/features/schedules/infra/DataProviderScheduleRepository.ts
@@ -312,7 +312,7 @@ export class DataProviderScheduleRepository extends BaseRepository implements Sc
     // buildMappedPayload は内部で getCaseInsensitiveValue と normalizeClearableValue を使用する
     const payload = this.buildMappedPayload({ 
       input: input as unknown as Record<string, unknown>, 
-      mapping: fields as any 
+      mapping: fields as unknown as Record<string, string | undefined> 
     });
     
     // 2. 特殊ロジックが必要なフィールドの個別処理

--- a/src/features/schedules/infra/DataProviderScheduleRepository.ts
+++ b/src/features/schedules/infra/DataProviderScheduleRepository.ts
@@ -90,14 +90,21 @@ export class DataProviderScheduleRepository extends BaseRepository implements Sc
       const isHealthy = areEssentialFieldsResolved(resolved, [...SCHEDULE_EVENTS_ESSENTIALS] as string[]);
       
       // Observability への報告（バナーのトリガー）から拡張分を除去し、バナーをクリアする
+      const essentialsSet = new Set(SCHEDULE_EVENTS_ESSENTIALS as string[]);
       const stableFieldStatus = Object.fromEntries(
-        (Object.keys(SCHEDULE_EVENTS_CANDIDATES) as ScheduleCandidateKeys[]).map(k => [k, fieldStatus[k]])
+        (Object.keys(SCHEDULE_EVENTS_CANDIDATES) as ScheduleCandidateKeys[]).map(k => [
+          k, 
+          { 
+            ...fieldStatus[k], 
+            isSilent: !essentialsSet.has(k) 
+          }
+        ])
       );
 
       reportResourceResolution({
         resourceName: 'Schedule',
         resolvedTitle: this.listTitle,
-        fieldStatus: stableFieldStatus as Record<string, { resolvedName?: string; candidates: string[] }>,
+        fieldStatus: stableFieldStatus as Record<string, { resolvedName?: string; candidates: string[]; isSilent: boolean }>,
         essentials: [...SCHEDULE_EVENTS_ESSENTIALS] as string[],
       });
 

--- a/src/features/users/infra/DataProviderUserRepository.ts
+++ b/src/features/users/infra/DataProviderUserRepository.ts
@@ -267,7 +267,7 @@ export class DataProviderUserRepository extends BaseRepository implements UserRe
   ): Promise<{ resolvedFields: Record<string, string | undefined>, resolvedKeys: Set<string> }> {
     try {
       const available = await this.provider.getFieldInternalNames(listTitle);
-      const { resolved } = resolveInternalNamesDetailed(available, candidates);
+      const { resolved, fieldStatus } = resolveInternalNamesDetailed(available, candidates);
       
       const bestEffort: Record<string, string | undefined> = {};
       const resolvedKeys = new Set<string>();
@@ -284,6 +284,20 @@ export class DataProviderUserRepository extends BaseRepository implements UserRe
           bestEffort[key] = undefined;
         }
       }
+
+      // 可視化ストアへの報告
+      reportResourceResolution({
+        resourceName: listTitle, // リスト名をリソース名として使用
+        resolvedTitle: listTitle,
+        fieldStatus: Object.fromEntries(
+          Object.entries(fieldStatus).map(([key, info]) => [
+            key,
+            { ...info, isSilent: !essentials.includes(key) }
+          ])
+        ),
+        essentials,
+      });
+
       return { resolvedFields: bestEffort, resolvedKeys };
     } catch {
       // 解決不能な場合は必須フィールドのみフォールバック使用

--- a/src/lib/data/dataProviderObservabilityStore.ts
+++ b/src/lib/data/dataProviderObservabilityStore.ts
@@ -17,6 +17,8 @@ export type ResourceStatus =
   | 'schema_warning'    // 一部非必須列（optional）の名前解決ができていない
   | 'pending';          // 未解決（初期状態）
 
+export type ResourceSeverity = 'info' | 'warn' | 'critical';
+
 export interface FieldResolutionInfo {
   key: string;
   resolvedName?: string;
@@ -29,6 +31,7 @@ export interface FieldResolutionInfo {
 export interface ResourceResolutionState {
   resourceName: string;
   status: ResourceStatus;
+  severity: ResourceSeverity;
   resolvedTitle: string;
   fields: FieldResolutionInfo[];
   lastAccessedAt: string;
@@ -170,7 +173,17 @@ export function reportResourceResolution(report: ResourceResolutionReport): void
     status = 'schema_warning';
   }
 
-  // 1. 同一性の判定用シグネチャ生成
+  // 1. Severity の判定
+  let severity: ResourceSeverity = 'info';
+  const isJoinKeyMissing = fields.some(f => (f.key === 'userId' || f.key === 'id') && !f.isResolved);
+  
+  if (status === 'missing_required' || isJoinKeyMissing) {
+    severity = 'critical';
+  } else if (status === 'schema_mismatch' || status === 'fallback_triggered' || status === 'schema_warning') {
+    severity = 'warn';
+  }
+
+  // 2. 同一性の判定用シグネチャ生成
   // key, resolvedName, isResolved, isSilent, isEssential すべてを網羅
   const getFieldsSig = (fs: FieldResolutionInfo[]) => 
     fs.map(f => `${f.key}:${f.resolvedName}:${f.isResolved}:${f.isSilent}:${f.isEssential}`).sort().join('|');
@@ -194,6 +207,7 @@ export function reportResourceResolution(report: ResourceResolutionReport): void
     useDataProviderObservabilityStore.getState().reportResolution({
       resourceName,
       status,
+      severity,
       resolvedTitle,
       fields,
       lastAccessedAt: new Date().toISOString(),

--- a/src/lib/sp/helpers.ts
+++ b/src/lib/sp/helpers.ts
@@ -475,7 +475,6 @@ export function resolveInternalNamesDetailed<T extends string>(
 
   for (const key in candidates) {
     if (Object.prototype.hasOwnProperty.call(candidates, key)) {
-      console.log(`[DIAGNOSTIC:helpers] Resolving ${key}. Candidates:`, candidates[key]);
       let driftType: string | undefined = undefined;
 
       // 1. First Pass: Exact match (case-insensitive)

--- a/src/sharepoint/fields/userFields.ts
+++ b/src/sharepoint/fields/userFields.ts
@@ -145,7 +145,7 @@ export const USERS_MASTER_COMPLIANCE_FIELD_MAP = {
 } as const;
 
 // ── Common Candidates (SSOT) ──
-const CANDIDATE_USER_ID = ['UserID', 'User ID', 'UserCode', 'userId', 'cr013_userId', 'PersonID', 'Title'];
+const CANDIDATE_USER_ID = ['UserID', 'User ID', 'UserCode', 'userId', 'cr013_userId', 'PersonID'];
 const CANDIDATE_FULL_NAME = ['FullName', 'Name', 'DisplayName', 'FullName0', 'cr013_fullName'];
 const CANDIDATE_FURIGANA = ['Furigana', 'Kana', 'FullNameFurigana', 'cr013_furigana'];
 const CANDIDATE_FULL_NAME_KANA = ['FullNameKana', 'FullName_Kana', 'cr013_fullNameKana'];


### PR DESCRIPTION
## Summary
- Remove `Title` from shared UserID candidate resolution
- Prevent UserBenefit_Profile from incorrectly resolving `UserID` to SharePoint Title
- Remove leftover debug logging from resolveInternalNamesDetailed
- Report accessory/split-list schema resolution to the observability store
- Surface `ID MISSING` in SpDevPanel when `id` / `userId` cannot be resolved

## Verification
- npm run typecheck
- npm run lint
- npm test src/features/users/infra/__tests__/DataProviderUserRepository.spec.ts

## Notes
This PR intentionally combines data integrity hardening with observability improvements:

- ID resolution now fails safely instead of falling back to `Title`
- split profile lists such as `UserBenefit_Profile` are visible in diagnostics
- administrators can detect missing join keys from the Dev Panel instead of discovering the issue through data mismatch later