### PR TITLE
fix(health): silence non-critical optional schema drift

### DIFF
--- a/scripts/ops/nightly-runtime-patrol.ts
+++ b/scripts/ops/nightly-runtime-patrol.ts
@@ -260,7 +260,7 @@ function classifySeverity(event: RawEvent): SeverityLevel {
   if (event.eventType === 'provision_skipped:block') return 'silent';
   // Done (Remediation Success)
   if (event.eventType === 'remediation' && (event.message.includes('成功') || event.message.includes('success'))) return 'silent';
-  if (event.eventType === 'drift' && event.reasonCode === 'absorbed_strategy_e')
+  if (event.eventType === 'drift' && (event.reasonCode === 'absorbed_strategy_e' || event.message.includes('Severity: silent')))
     return 'silent';
 
   // 4. Watch

--- a/src/features/diagnostics/drift/domain/driftLogic.ts
+++ b/src/features/diagnostics/drift/domain/driftLogic.ts
@@ -28,8 +28,8 @@ export type DriftEvent = {
   fieldName: string;
   /** 検知日時 (ISOString) */
   detectedAt: string;
-  /** 緊急度 (ドリフトは原則 warn / info) */
-  severity: 'warn' | 'info';
+  /** 緊急度 (ドリフトは原則 warn / info / silent) */
+  severity: 'warn' | 'info' | 'silent';
   /** 解決方法 */
   resolutionType: DriftResolutionType;
   /** ドリフトの詳細型 */
@@ -56,13 +56,14 @@ export const emitDriftRecord = (
   fieldName: string, 
   resolution: DriftResolutionType = 'fuzzy_match',
   driftType: DriftType = 'unknown',
-  description?: string
+  description?: string,
+  severity?: 'warn' | 'info' | 'silent'
 ) => {
   driftEventBus.emit({
     listName,
     fieldName,
     detectedAt: new Date().toISOString(),
-    severity: resolution === 'action_required' ? 'warn' : 'info',
+    severity: severity || (resolution === 'action_required' ? 'warn' : 'info'),
     resolutionType: resolution,
     driftType,
     resolved: false,

--- a/src/features/diagnostics/health/checks.ts
+++ b/src/features/diagnostics/health/checks.ts
@@ -412,7 +412,9 @@ async function runListChecks(
     const resolution = resolveInternalNamesDetailed(available, candidates, {
       onDrift: (fieldName, resolutionType, driftType) => {
         // 診断ツール実行時も、ドリフトを正規のイベントとして記録する
-        emitDriftRecord(spec.resolvedTitle, fieldName, resolutionType as DriftResolutionType, driftType as DriftType);
+        const fieldSpec = spec.requiredFields.find(f => f.internalName === fieldName);
+        const severity = fieldSpec?.isSilent ? 'silent' : undefined;
+        emitDriftRecord(spec.resolvedTitle, fieldName, resolutionType as DriftResolutionType, driftType as DriftType, undefined, severity);
       }
     });
     fieldStatus = resolution.fieldStatus;
@@ -423,7 +425,7 @@ async function runListChecks(
       (f) => f.isEssential && missing.includes(f.internalName)
     );
     const missingOptional = spec.requiredFields.filter(
-      (f) => !f.isEssential && missing.includes(f.internalName)
+      (f) => !f.isEssential && !f.isSilent && missing.includes(f.internalName)
     );
 
     // 3. Detect Drift

--- a/src/features/diagnostics/health/types.ts
+++ b/src/features/diagnostics/health/types.ts
@@ -52,6 +52,8 @@ export type SpFieldSpec = {
   typeHint?: string; // "Text" | "DateTime" | "Number" | "Choice" | "Lookup" など（表示用）
   /** drift 吸収用の候補名リスト。未指定時は [internalName] のみで解決 */
   candidates?: string[];
+  /** 欠落していても WARN を出さない（isSilent） */
+  isSilent?: boolean;
 };
 
 export type ListSpec = {

--- a/src/lib/sp/types.ts
+++ b/src/lib/sp/types.ts
@@ -94,6 +94,10 @@ export interface SpFieldDef {
    * 指定されている場合、既存フィールドのチェック時にこれらも含めて検索し、二重作成を防止する。
    */
   candidates?: readonly string[];
+  /**
+   * 健全性診断において、この列が欠落していても警告を発報しない（FAIL:0 / WARN 抑制方針）。
+   */
+  isSilent?: boolean;
 }
 
 export interface EnsureListOptions {

--- a/src/pages/HealthPage.tsx
+++ b/src/pages/HealthPage.tsx
@@ -338,18 +338,20 @@ const DRIFT_ESSENTIALS_BY_KEY: Record<string, readonly string[]> = {
 function buildListSpecs(): ListSpec[] {
   return SP_LIST_REGISTRY.map((entry) => {
   const effectiveEssentials = DRIFT_ESSENTIALS_BY_KEY[entry.key] ?? (entry.essentialFields || []);
+  const essentialSet = new Set(DRIFT_ESSENTIALS_BY_KEY[entry.key] ?? (entry.essentialFields || []));
 
   // 1. All fields from provisioning (default: optional)
   const driftOverride = DRIFT_CANDIDATES_BY_KEY[entry.key];
   const provisionFields: SpFieldSpec[] = (entry.provisioningFields || []).map((f) => ({
     internalName: f.internalName,
-    isEssential: effectiveEssentials.includes(f.internalName),
+    isEssential: essentialSet.has(f.internalName),
     typeHint: f.type,
-    candidates: driftOverride?.[f.internalName],
+    candidates: driftOverride?.[f.internalName] ?? (f.candidates ? [...f.candidates] : undefined),
+    isSilent: f.isSilent,
   }));
 
   // 2. Ensure essentials (ID, etc.) are present
-  const essentials = ["Id", "Title", ...effectiveEssentials];
+  const essentials = ["Id", "Title", ...essentialSet];
   const combined: SpFieldSpec[] = [...provisionFields];
 
   for (const name of essentials) {

--- a/src/sharepoint/fields/__tests__/dailyFields.drift.spec.ts
+++ b/src/sharepoint/fields/__tests__/dailyFields.drift.spec.ts
@@ -101,7 +101,7 @@ describe('DAILY_RECORD_CANONICAL_CANDIDATES drift', () => {
 describe('DAILY_RECORD_ROW_AGGREGATE_CANDIDATES drift', () => {
   it('標準名がそのまま解決される（drift なし）', () => {
     const available = new Set([
-      'Title', 'ParentID', 'UserCode', 'RecordDate', 'Status', 'ReporterName', 'Payload', 'Kind', 'Group', 'SpecialNote',
+      'Title', 'ParentID', 'UserCode', 'RecordDate', 'Status', 'ReporterName', 'Payload', 'Kind', 'Group', 'SpecialNote', 'Version',
     ]);
     const { resolved, missing } = resolveInternalNamesDetailed(
       available,

--- a/src/sharepoint/fields/dailyFields.ts
+++ b/src/sharepoint/fields/dailyFields.ts
@@ -143,6 +143,7 @@ export const DAILY_RECORD_ROW_AGGREGATE_CANDIDATES = {
   kind: ['Kind', 'kind', 'cr013_kind'],
   group: ['Group', 'group', 'cr013_group'],
   specialNote: ['SpecialNote', 'specialNote', 'cr013_specialnote'],
+  version: ['Version', 'VersionNo', 'cr013_version'],
 } as const;
 
 export const DAILY_RECORD_ROW_AGGREGATE_ESSENTIALS: (keyof typeof DAILY_RECORD_ROW_AGGREGATE_CANDIDATES)[] = [

--- a/src/sharepoint/fields/ispThreeLayerFields.ts
+++ b/src/sharepoint/fields/ispThreeLayerFields.ts
@@ -441,6 +441,8 @@ export const PROCEDURE_RECORD_CANDIDATES = {
   executionStatus: ['ExecutionStatus', 'Status', 'cr013_executionStatus'],
   performedBy: ['PerformedBy', 'Staff', 'cr013_performedBy'],
   performedAt: ['PerformedAt', 'Time', 'cr013_performedAt'],
+  ispId: ['ISPId', 'ISPLookupId', 'cr013_ispId'],
+  handoffNotes: ['HandoffNotes', 'Handoff_x0020_Notes', 'cr013_handoffNotes'],
 } as const;
 
 export const PROCEDURE_RECORD_ESSENTIALS: (keyof typeof PROCEDURE_RECORD_CANDIDATES)[] = [

--- a/src/sharepoint/spListRegistry.definitions.ts
+++ b/src/sharepoint/spListRegistry.definitions.ts
@@ -203,7 +203,7 @@ export const dailyListEntries: readonly SpListEntry[] = [
     provisioningFields: [
       { internalName: 'UserCode', type: 'Text', displayName: 'User Code', required: true, indexed: true },
       { internalName: 'RecordDate', type: 'DateTime', displayName: 'Record Date', required: true, dateTimeFormat: 'DateOnly', indexed: true },
-      { internalName: 'ISPId', type: 'Text', displayName: 'ISP ID' },
+      { internalName: 'ISPId', type: 'Text', displayName: 'ISP ID', isSilent: true, candidates: ['ISPId', 'ISPLookupId', 'cr013_ispId'] },
       { internalName: 'PlanningSheetId', type: 'Text', displayName: 'Planning Sheet ID', required: true },
       { internalName: 'ProcedureText', type: 'Note', displayName: 'Procedure Text', richText: false, candidates: ['ProcedureText', 'Procedure_x0020_Text'] },
       { internalName: 'ExecutionStatus', type: 'Text', displayName: 'Execution Status', candidates: ['ExecutionStatus', 'Execution_x0020_Status'] },
@@ -213,7 +213,7 @@ export const dailyListEntries: readonly SpListEntry[] = [
       { internalName: 'PerformedAt', type: 'DateTime', displayName: 'Performed At', candidates: ['PerformedAt', 'Performed_x0020_At'] },
       { internalName: 'UserResponse', type: 'Note', displayName: 'User Response', richText: false, candidates: ['UserResponse', 'User_x0020_Response'] },
       { internalName: 'SpecialNotes', type: 'Note', displayName: 'Special Notes', richText: false, candidates: ['SpecialNotes', 'Special_x0020_Notes'] },
-      { internalName: 'HandoffNotes', type: 'Note', displayName: 'Handoff Notes', richText: false },
+      { internalName: 'HandoffNotes', type: 'Note', displayName: 'Handoff Notes', richText: false, isSilent: true, candidates: ['HandoffNotes', 'Handoff_x0020_Notes', 'cr013_handoffNotes'] },
     ],
   },
   {
@@ -229,9 +229,9 @@ export const dailyListEntries: readonly SpListEntry[] = [
     provisioningFields: [
       { internalName: 'ParentID', type: 'Number', displayName: 'Parent ID', required: true, indexed: true, candidates: ['ParentID', 'Parent_x0020_ID'] },
       { internalName: 'UserID', type: 'Text', displayName: 'User ID', required: true, indexed: true, candidates: ['UserID', 'User_x0020_ID', 'Title'] },
-      { internalName: 'Version', type: 'Number', displayName: 'Version', default: 1, candidates: ['Version', 'VersionNo'] },
+      { internalName: 'Version', type: 'Number', displayName: 'Version', default: 1, isSilent: true, candidates: ['Version', 'VersionNo', 'cr013_version'] },
       { internalName: 'Status', type: 'Text', displayName: 'Status' },
-      { internalName: 'Payload', type: 'Note', displayName: 'Row Data JSON', richText: false, candidates: ['Payload', 'PayloadJSON'] },
+      { internalName: 'Payload', type: 'Note', displayName: 'Row Data JSON', richText: false, isSilent: true, candidates: ['Payload', 'PayloadJSON', 'cr013_payload'] },
       { internalName: 'RecordedAt', type: 'DateTime', displayName: 'Recorded At', candidates: ['RecordedAt', 'Recorded_x0020_At'] },
     ],
   },
@@ -302,7 +302,7 @@ export const dailyListEntries: readonly SpListEntry[] = [
       { internalName: 'LunchAmount', type: 'Choice', displayName: 'Lunch Amount', choices: ['完食', '8割', '半分', '少量', 'なし'] },
       { internalName: 'ProblemBehavior', type: 'Boolean', displayName: 'Problem Behavior' },
       { internalName: 'Seizure', type: 'Boolean', displayName: 'Seizure' },
-      { internalName: 'Goals', type: 'Note', displayName: 'Goals JSON', richText: false },
+      { internalName: 'Goals', type: 'Note', displayName: 'Goals JSON', richText: false, isSilent: true, candidates: ['Goals', 'goals', 'GoalIds', 'cr013_goals'] },
       { internalName: 'Notes', type: 'Note', displayName: 'Notes', richText: false },
     ],
   },


### PR DESCRIPTION
## Summary
- Add `isSilent` support for optional SharePoint field diagnostics
- Classify non-critical optional drift as `silent`
- Exclude absorbed/silent drift from actionable Nightly Patrol warnings
- Add candidate mappings for known physical-name drift

## Intent
This PR reduces operational noise while preserving drift observability.
Optional fields that do not affect runtime continuity are no longer surfaced as actionable WARNs.
This preserves drift observability while reducing actionable warning noise for known non-critical optional fields.

## Validation
- typecheck: Pass
- lint: Pass
- diagnostics tests: Pass (src/features/diagnostics)
- sharepoint tests: Pass (src/sharepoint)

### Follow-up fix after rebase

After rebasing onto the latest `main`, this PR restores `FooterQuickActions` in `AppShell`.
This resolves navigation/footer RTL regressions caused by the AppShellV2 layout transition.

Validation:
- `npx vitest tests/rtl/AppShell.nav.test.tsx` ✅
- lint/typecheck ✅