### PR TITLE
fix(app): restore FooterQuickActions in AppShell

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -20,6 +20,7 @@ import { useAppShellState } from './useAppShellState';
 import { AppShellHeader } from './AppShellHeader';
 import { AppShellSidebar, MobileNavContent } from './AppShellSidebar';
 import { ConnectionDegradedBanner } from '@/features/sp/health/components/ConnectionDegradedBanner';
+import { FooterQuickActions } from './components/FooterQuickActions';
 
 const SKIP_LOGIN = shouldSkipLogin();
 
@@ -108,7 +109,7 @@ const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) => {
           <AppShellV2
             header={headerContent}
             sidebar={sidebarContent}
-            footer={null}
+            footer={<FooterQuickActions />}
             sidebarWidth={showDesktopSidebar ? currentDrawerWidth : 0}
             contentPaddingX={isFocusMode ? 0 : 16}
             contentPaddingY={contentPaddingY}


### PR DESCRIPTION
## Summary
- Restore FooterQuickActions in AppShell after the AppShellV2 layout transition
- Fix footer/navigation RTL regressions such as handoff-footer-quicknote and daily-footer-support not rendering

## Validation
- npx vitest tests/rtl/AppShell.nav.test.tsx
- npm run typecheck
- npm run lint