### PR TITLE
fix(transport): add retry-with-merge for assignment conflicts

### DIFF
--- a/src/features/schedules/domain/ScheduleRepository.ts
+++ b/src/features/schedules/domain/ScheduleRepository.ts
@@ -44,6 +44,20 @@ export type CreateScheduleEventInput = CreateScheduleInput;
 export type UpdateScheduleEventInput = UpdateScheduleInput;
 
 /**
+ * Thrown when an update fails because the stored item's ETag no longer matches
+ * (HTTP 412 Precondition Failed). Carries `status = 412` so `getHttpStatus`
+ * utilities can recognize it after the underlying provider error is rewrapped.
+ */
+export class ScheduleConflictError extends Error {
+  readonly status = 412;
+  readonly code = 'SCHEDULE_CONFLICT';
+  constructor(message = '予定が別のユーザーによって更新されました (conflict)。最新の情報に更新してから再度お試しください。') {
+    super(message);
+    this.name = 'ScheduleConflictError';
+  }
+}
+
+/**
  * Parameters for listing schedules
  */
 export type ScheduleRepositoryListParams = {

--- a/src/features/schedules/infra/DataProviderScheduleRepository.ts
+++ b/src/features/schedules/infra/DataProviderScheduleRepository.ts
@@ -16,13 +16,14 @@ import { reportResourceResolution, useDataProviderObservabilityStore } from '@/l
 import { summarizeSpError } from '@/lib/errors';
 import { mapSpRowToSchedule, type SpScheduleRow } from '../data/spRowSchema';
 import { getSchedulesListTitle } from '../data/spSchema';
-import type { 
-  CreateScheduleInput, 
-  ScheduleItem, 
-  ScheduleRepository, 
-  ScheduleRepositoryListParams, 
-  ScheduleRepositoryMutationParams, 
-  UpdateScheduleInput 
+import {
+  ScheduleConflictError,
+  type CreateScheduleInput,
+  type ScheduleItem,
+  type ScheduleRepository,
+  type ScheduleRepositoryListParams,
+  type ScheduleRepositoryMutationParams,
+  type UpdateScheduleInput,
 } from '../domain/ScheduleRepository';
 
 import { BaseRepository } from '@/lib/data/BaseRepository';
@@ -284,7 +285,7 @@ export class DataProviderScheduleRepository extends BaseRepository implements Sc
     } catch (err) {
       const status = getHttpStatus(err);
       if (status === 412) {
-        throw new Error('予定が別のユーザーによって更新されました (conflict)。最新の情報に更新してから再度お試しください。');
+        throw new ScheduleConflictError();
       }
       return this.handleError(err, '予定の更新に失敗しました。', fields);
     }

--- a/src/features/schedules/infra/SharePointAssignmentRepository.ts
+++ b/src/features/schedules/infra/SharePointAssignmentRepository.ts
@@ -1,12 +1,16 @@
 import type { Assignment, AssignmentListFilter, AssignmentRepository, TransportAssignment } from '../domain/assignment';
-import type { ScheduleRepository } from '../domain/ScheduleRepository';
+import type { ScheduleItem, ScheduleRepository, UpdateScheduleInput } from '../domain/ScheduleRepository';
 import { isTransportScheduleRow, inferTransportDirections } from '@/features/today/transport/transportAssignments';
-import { 
-  normalizeText, 
+import {
+  normalizeText,
   extractTransportAttendantStaffId,
   extractTransportCourseId,
   buildTransportNotes
 } from '@/features/transport-assignments/domain/transportAssignmentDraft';
+import { emitTelemetry } from '@/lib/telemetry';
+import { getHttpStatus } from './scheduleSpUtils';
+
+type UserAssignmentTarget = { vehicleId: string; driverId: string; attendantId: string };
 
 /**
  * SharePoint-backed implementation of AssignmentRepository.
@@ -74,17 +78,14 @@ export class SharePointAssignmentRepository implements AssignmentRepository {
     // Assumes bulk save is for a single date/direction context for now
     const first = transportAssignments[0];
     const date = first.id.split('-')[1];
+    const range = {
+      from: `${date}T00:00:00+09:00`,
+      to: `${date}T23:59:59+09:00`,
+    };
 
-    // 1. Fetch all items for this date to determine current state
-    const allItems = await this.scheduleRepo.list({ 
-      range: { 
-        from: `${date}T00:00:00+09:00`, 
-        to: `${date}T23:59:59+09:00` 
-      } 
-    });
+    const allItems = await this.scheduleRepo.list({ range });
 
-    // 2. Build a mapping of user -> target assignment details
-    const userMapping = new Map<string, { vehicleId: string, driverId: string, attendantId: string }>();
+    const userMapping = new Map<string, UserAssignmentTarget>();
     for (const a of transportAssignments) {
       for (const uId of a.userIds) {
         userMapping.set(uId, {
@@ -95,8 +96,6 @@ export class SharePointAssignmentRepository implements AssignmentRepository {
       }
     }
 
-    // 3. Identify items to update
-    const patches: any[] = [];
     for (const item of allItems) {
       const rawRow = item as unknown as Record<string, unknown>;
       if (!isTransportScheduleRow(rawRow)) continue;
@@ -107,44 +106,115 @@ export class SharePointAssignmentRepository implements AssignmentRepository {
       const mapping = userMapping.get(uId);
       if (!mapping) continue;
 
-      // Note: We only update if the item direction matches the assignment direction
-      // However, our current Assignment.id includes direction, but Assignment object doesn't have it explicitly as a top-level field.
-      // We'll rely on the mapping being correct for the bulk context.
+      const patch = this.buildPatch(item as ScheduleItem, mapping);
+      if (!patch) continue;
 
-      // currentAttendant removed (unused)
-      const currentCourse = extractTransportCourseId(item.notes);
-      const nextNotes = buildTransportNotes(item.notes, mapping.attendantId, currentCourse) || '';
-
-      const isChanged = 
-        item.vehicleId !== mapping.vehicleId ||
-        item.assignedStaffId !== mapping.driverId ||
-        (item.notes || '') !== nextNotes;
-
-      if (isChanged) {
-        patches.push({
-          ...item,
-          vehicleId: mapping.vehicleId,
-          assignedStaffId: mapping.driverId,
-          notes: nextNotes,
-          // Map domain-agnostic fields to what ScheduleRepository.update expects
-          startLocal: item.start,
-          endLocal: item.end,
-        });
-      }
+      await this.updateWithRetry(patch, mapping, range);
     }
+  }
 
-    // 4. Perform updates
-    // In production, this should use a batch operation if available.
-    for (const patch of patches) {
+  private buildPatch(item: ScheduleItem, mapping: UserAssignmentTarget): UpdateScheduleInput | null {
+    const currentCourse = extractTransportCourseId(item.notes);
+    const nextNotes = buildTransportNotes(item.notes, mapping.attendantId, currentCourse) || '';
+
+    const isChanged =
+      item.vehicleId !== mapping.vehicleId ||
+      item.assignedStaffId !== mapping.driverId ||
+      (item.notes || '') !== nextNotes;
+
+    if (!isChanged) return null;
+
+    return {
+      ...(item as unknown as UpdateScheduleInput),
+      vehicleId: mapping.vehicleId,
+      assignedStaffId: mapping.driverId,
+      notes: nextNotes,
+      startLocal: item.start,
+      endLocal: item.end,
+    };
+  }
+
+  /**
+   * Update a schedule item with one-shot retry-with-merge on 412 conflicts.
+   * On ETag conflict: refetch the latest row, overlay the caller's intended
+   * assignment fields onto the server's latest snapshot, and retry once.
+   * Telemetry:
+   *  - assignment:conflict_resolved  — retry succeeded after a 412
+   *  - assignment:conflict_unresolved — retry exhausted, row vanished, or non-conflict error
+   */
+  private async updateWithRetry(
+    patch: UpdateScheduleInput,
+    mapping: UserAssignmentTarget,
+    range: { from: string; to: string },
+  ): Promise<void> {
+    try {
       await this.scheduleRepo.update(patch);
+    } catch (err) {
+      const status = getHttpStatus(err);
+      if (status !== 412) {
+        emitTelemetry('assignment:conflict_unresolved', {
+          itemId: patch.id,
+          reason: 'non_conflict_error',
+          status,
+          retryCount: 0,
+        });
+        throw err;
+      }
+
+      // 412: refetch, merge, retry once.
+      const fresh = await this.scheduleRepo.list({ range });
+      const latest = fresh.find(i => i.id === patch.id);
+      if (!latest) {
+        emitTelemetry('assignment:conflict_unresolved', {
+          itemId: patch.id,
+          reason: 'item_gone',
+          retryCount: 1,
+        });
+        throw err;
+      }
+
+      const mergedPatch = this.buildPatch(latest, mapping);
+      if (!mergedPatch) {
+        // Server already reflects our intended state — treat as resolved.
+        emitTelemetry('assignment:conflict_resolved', {
+          itemId: patch.id,
+          reason: 'already_consistent',
+          retryCount: 1,
+        });
+        return;
+      }
+
+      try {
+        await this.scheduleRepo.update(mergedPatch);
+        emitTelemetry('assignment:conflict_resolved', {
+          itemId: patch.id,
+          retryCount: 1,
+        });
+      } catch (retryErr) {
+        emitTelemetry('assignment:conflict_unresolved', {
+          itemId: patch.id,
+          reason: getHttpStatus(retryErr) === 412 ? 'retry_exhausted' : 'retry_failed',
+          status: getHttpStatus(retryErr),
+          retryCount: 1,
+        });
+        throw retryErr;
+      }
     }
   }
 
   /**
    * Internal helper to map schedule items to grouped TransportAssignment models.
    */
-  private mapToTransportAssignments(items: any[], filter: AssignmentListFilter): TransportAssignment[] {
-    const dateGroups = new Map<string, Map<string, Map<string, any>>>(); // Date -> Direction -> VehicleId -> Data
+  private mapToTransportAssignments(items: ScheduleItem[], filter: AssignmentListFilter): TransportAssignment[] {
+    type VehicleAccumulator = {
+      userIds: string[];
+      assistantStaffIds: string[];
+      start: string;
+      end: string;
+      etag?: string;
+      driverId?: string;
+    };
+    const dateGroups = new Map<string, Map<string, Map<string, VehicleAccumulator>>>(); // Date -> Direction -> VehicleId -> Data
 
     for (const item of items) {
       const rawRow = item as unknown as Record<string, unknown>;

--- a/src/features/schedules/infra/__tests__/SharePointAssignmentRepository.spec.ts
+++ b/src/features/schedules/infra/__tests__/SharePointAssignmentRepository.spec.ts
@@ -1,7 +1,12 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SharePointAssignmentRepository } from '../SharePointAssignmentRepository';
-import type { ScheduleRepository } from '../../domain/ScheduleRepository';
+import { ScheduleConflictError, type ScheduleRepository } from '../../domain/ScheduleRepository';
 import type { TransportAssignment } from '../../domain/assignment';
+import { emitTelemetry } from '@/lib/telemetry';
+
+vi.mock('@/lib/telemetry', () => ({
+  emitTelemetry: vi.fn(),
+}));
 
 describe('SharePointAssignmentRepository', () => {
   const mockScheduleRepo = {
@@ -49,11 +54,11 @@ describe('SharePointAssignmentRepository', () => {
       }
     ];
 
-    (mockScheduleRepo.list as any).mockResolvedValue(mockItems);
+    vi.mocked(mockScheduleRepo.list).mockResolvedValue(mockItems as never);
 
-    const results = await repo.list({ 
-      type: 'transport', 
-      range: { from: '2026-04-23T00:00:00Z', to: '2026-04-23T23:59:59Z' } 
+    const results = await repo.list({
+      type: 'transport',
+      range: { from: '2026-04-23T00:00:00Z', to: '2026-04-23T23:59:59Z' }
     });
 
     expect(results).toHaveLength(2);
@@ -69,6 +74,139 @@ describe('SharePointAssignmentRepository', () => {
     expect(vehicleB).toBeDefined();
     expect(vehicleB?.userIds).toEqual(['user3']);
     expect(vehicleB?.driverId).toBe('staff3');
+  });
+
+  describe('saveBulk: retry-with-merge on 412 conflicts', () => {
+    const baseItem = {
+      id: 'sched-1',
+      title: '送迎',
+      userId: 'user1',
+      vehicleId: 'VehicleA',
+      assignedStaffId: 'staffOld',
+      serviceType: 'transport',
+      start: '2026-04-25T08:00:00+09:00',
+      end: '2026-04-25T09:00:00+09:00',
+      notes: '',
+      etag: '"v1"',
+    };
+
+    const targetAssignment: TransportAssignment = {
+      id: 'transport-2026-04-25-to-VehicleA',
+      type: 'transport',
+      start: '2026-04-25T08:00:00+09:00',
+      end: '2026-04-25T09:00:00+09:00',
+      title: '送迎: VehicleA',
+      status: 'planned',
+      vehicleId: 'VehicleA',
+      driverId: 'staffNew',
+      assistantStaffIds: [],
+      userIds: ['user1'],
+      direction: 'to',
+    };
+
+    let scheduleRepo: ScheduleRepository;
+    let repo: SharePointAssignmentRepository;
+
+    beforeEach(() => {
+      vi.mocked(emitTelemetry).mockClear();
+      scheduleRepo = {
+        list: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+        remove: vi.fn(),
+      } as unknown as ScheduleRepository;
+      repo = new SharePointAssignmentRepository(scheduleRepo);
+    });
+
+    it('updates normally when no conflict occurs (no retry telemetry)', async () => {
+      vi.mocked(scheduleRepo.list).mockResolvedValue([baseItem] as never);
+      vi.mocked(scheduleRepo.update).mockResolvedValue(baseItem as never);
+
+      await repo.saveBulk([targetAssignment]);
+
+      expect(scheduleRepo.update).toHaveBeenCalledTimes(1);
+      expect(emitTelemetry).not.toHaveBeenCalled();
+    });
+
+    it('refetches, merges, and retries once on 412 — emits conflict_resolved', async () => {
+      const freshItem = { ...baseItem, etag: '"v2"', notes: 'touched-by-other-user' };
+      vi.mocked(scheduleRepo.list)
+        .mockResolvedValueOnce([baseItem] as never)   // initial fetch
+        .mockResolvedValueOnce([freshItem] as never); // refetch after 412
+      vi.mocked(scheduleRepo.update)
+        .mockRejectedValueOnce(new ScheduleConflictError())
+        .mockResolvedValueOnce(freshItem as never);
+
+      await repo.saveBulk([targetAssignment]);
+
+      expect(scheduleRepo.update).toHaveBeenCalledTimes(2);
+
+      // The retry payload must carry the refetched etag and the caller's intended fields.
+      const retryPayload = vi.mocked(scheduleRepo.update).mock.calls[1][0];
+      expect(retryPayload.etag).toBe('"v2"');
+      expect(retryPayload.assignedStaffId).toBe('staffNew');
+
+      expect(emitTelemetry).toHaveBeenCalledWith(
+        'assignment:conflict_resolved',
+        expect.objectContaining({ itemId: 'sched-1', retryCount: 1 }),
+      );
+    });
+
+    it('emits conflict_unresolved when retry also fails with 412', async () => {
+      vi.mocked(scheduleRepo.list)
+        .mockResolvedValueOnce([baseItem] as never)
+        .mockResolvedValueOnce([{ ...baseItem, etag: '"v2"' }] as never);
+      vi.mocked(scheduleRepo.update)
+        .mockRejectedValueOnce(new ScheduleConflictError())
+        .mockRejectedValueOnce(new ScheduleConflictError());
+
+      await expect(repo.saveBulk([targetAssignment])).rejects.toBeInstanceOf(ScheduleConflictError);
+
+      expect(emitTelemetry).toHaveBeenCalledWith(
+        'assignment:conflict_unresolved',
+        expect.objectContaining({
+          itemId: 'sched-1',
+          reason: 'retry_exhausted',
+          retryCount: 1,
+        }),
+      );
+    });
+
+    it('emits conflict_unresolved on a non-conflict error without retrying', async () => {
+      vi.mocked(scheduleRepo.list).mockResolvedValueOnce([baseItem] as never);
+      vi.mocked(scheduleRepo.update).mockRejectedValueOnce(new Error('boom'));
+
+      await expect(repo.saveBulk([targetAssignment])).rejects.toThrow('boom');
+
+      expect(scheduleRepo.update).toHaveBeenCalledTimes(1);
+      expect(emitTelemetry).toHaveBeenCalledWith(
+        'assignment:conflict_unresolved',
+        expect.objectContaining({
+          itemId: 'sched-1',
+          reason: 'non_conflict_error',
+          retryCount: 0,
+        }),
+      );
+    });
+
+    it('emits conflict_unresolved with reason=item_gone if the row vanished on refetch', async () => {
+      vi.mocked(scheduleRepo.list)
+        .mockResolvedValueOnce([baseItem] as never)
+        .mockResolvedValueOnce([] as never);
+      vi.mocked(scheduleRepo.update).mockRejectedValueOnce(new ScheduleConflictError());
+
+      await expect(repo.saveBulk([targetAssignment])).rejects.toBeInstanceOf(ScheduleConflictError);
+
+      expect(scheduleRepo.update).toHaveBeenCalledTimes(1);
+      expect(emitTelemetry).toHaveBeenCalledWith(
+        'assignment:conflict_unresolved',
+        expect.objectContaining({
+          itemId: 'sched-1',
+          reason: 'item_gone',
+          retryCount: 1,
+        }),
+      );
+    });
   });
 
   it('should filter by resourceId', async () => {
@@ -89,10 +227,10 @@ describe('SharePointAssignmentRepository', () => {
       }
     ];
 
-    (mockScheduleRepo.list as any).mockResolvedValue(mockItems);
+    vi.mocked(mockScheduleRepo.list).mockResolvedValue(mockItems as never);
 
-    const results = await repo.list({ 
-      type: 'transport', 
+    const results = await repo.list({
+      type: 'transport',
       range: { from: '2026-04-23T00:00:00Z', to: '2026-04-23T23:59:59Z' },
       resourceId: 'VehicleA'
     });

--- a/src/lib/telemetry/index.ts
+++ b/src/lib/telemetry/index.ts
@@ -10,7 +10,9 @@ export type CommonTelemetryEvent =
   | 'remediation:triggered'
   | 'remediation:completed'
   | 'remediation:failed'
-  | 'assignment:concurrency_conflict';
+  | 'assignment:concurrency_conflict'
+  | 'assignment:conflict_resolved'
+  | 'assignment:conflict_unresolved';
 
 export type TelemetryPayload = Record<string, unknown>;
 
@@ -34,12 +36,17 @@ export const emitTelemetry = (event: CommonTelemetryEvent | string, payload: Tel
   
   if (typeof window !== 'undefined') {
     // Robust E2E diagnostic hook (Persistent log)
-    const log = (window as any).__TELEMETRY_LOG__ || [];
+    type TelemetryLogEntry = { event: string; payload: TelemetryPayload; timestamp: number };
+    const diag = window as Window & {
+      __TELEMETRY_LOG__?: TelemetryLogEntry[];
+      __LAST_TELEMETRY__?: TelemetryLogEntry;
+    };
+    const log = diag.__TELEMETRY_LOG__ ?? [];
     log.push({ event, payload, timestamp: Date.now() });
-    (window as any).__TELEMETRY_LOG__ = log;
-    (window as any).__LAST_TELEMETRY__ = { event, payload, timestamp: Date.now() };
-    
-    window.dispatchEvent(new CustomEvent('app:telemetry', { 
+    diag.__TELEMETRY_LOG__ = log;
+    diag.__LAST_TELEMETRY__ = { event, payload, timestamp: Date.now() };
+
+    window.dispatchEvent(new CustomEvent('app:telemetry', {
       detail: { event, payload, timestamp: new Date().toISOString() } 
     }));
 
@@ -51,6 +58,26 @@ export const emitTelemetry = (event: CommonTelemetryEvent | string, payload: Tel
         code: 'CONCURRENCY_CONFLICT',
         message: Array.isArray(payload.vehicles) ? payload.vehicles.join(', ') : String(payload.vehicles || ''),
         count: Number(payload.conflictCount || 1),
+      });
+    }
+
+    if (event === 'assignment:conflict_resolved') {
+      spTelemetryStore.record({
+        type: 'config_warning',
+        scope: 'TransportAssignment',
+        code: 'CONFLICT_RESOLVED',
+        message: String(payload.itemId ?? ''),
+        count: Number(payload.retryCount ?? 1),
+      });
+    }
+
+    if (event === 'assignment:conflict_unresolved') {
+      spTelemetryStore.record({
+        type: 'config_warning',
+        scope: 'TransportAssignment',
+        code: 'CONFLICT_UNRESOLVED',
+        message: String(payload.reason ?? payload.itemId ?? ''),
+        count: Number(payload.retryCount ?? 1),
       });
     }
   }

--- a/src/lib/telemetry/spTelemetryStore.ts
+++ b/src/lib/telemetry/spTelemetryStore.ts
@@ -106,6 +106,9 @@ export const spTelemetryStore = {
 
     let assignmentConcurrencyConflicts = 0;
     const assignmentConflictVehicles: string[] = [];
+    let assignmentConflictResolved = 0;
+    let assignmentConflictUnresolved = 0;
+    let assignmentRetryTotal = 0;
 
     for (const e of events) {
       if (e.event === 'config_warning' && e.code === 'CONCURRENCY_CONFLICT') {
@@ -114,6 +117,18 @@ export const spTelemetryStore = {
           const vehicles = e.message.split(',').map(v => v.trim());
           assignmentConflictVehicles.push(...vehicles);
         }
+        continue;
+      }
+
+      if (e.event === 'config_warning' && e.code === 'CONFLICT_RESOLVED') {
+        assignmentConflictResolved++;
+        assignmentRetryTotal += Number(e.count ?? 1);
+        continue;
+      }
+
+      if (e.event === 'config_warning' && e.code === 'CONFLICT_UNRESOLVED') {
+        assignmentConflictUnresolved++;
+        assignmentRetryTotal += Number(e.count ?? 1);
         continue;
       }
 
@@ -180,6 +195,9 @@ export const spTelemetryStore = {
       lanes: laneMetrics,
       assignmentConcurrencyConflicts,
       assignmentConflictVehicles: [...new Set(assignmentConflictVehicles)], // Unique list
+      assignmentConflictResolved,
+      assignmentConflictUnresolved,
+      assignmentRetryTotal,
     };
   },
 


### PR DESCRIPTION
## Summary
- Add one-shot retry-with-merge handling for SharePoint 412 assignment conflicts
- Refetch latest assignment state and merge safe mutable fields before retry
- Emit resolved/unresolved assignment conflict telemetry for Nightly Patrol

## Validation
- 7 assignment repository tests passed
- src/features/schedules: 370 passed

## Design notes
- Retry is bounded to a single attempt by construction (straight-line code path, no recursion)
- Merge preserves server-side `start`/`end`/`etag` and overlays only caller intent (`vehicleId`, `driverId`, attendant notes)
- Non-412 failures escalate immediately as `conflict_unresolved` with reason `non_conflict_error`
- `unresolved` reasons are classified (`retry_exhausted` / `non_conflict_error` / `item_gone` / `retry_failed`) so the upcoming Exception Center (PR-2) can filter to genuine user-intervention cases

## Telemetry contract (consumed by Nightly Patrol)
- `assignment:conflict_resolved` → `spTelemetryStore` code `CONFLICT_RESOLVED`
- `assignment:conflict_unresolved` → `spTelemetryStore` code `CONFLICT_UNRESOLVED`
- New summary fields: `assignmentConflictResolved`, `assignmentConflictUnresolved`, `assignmentRetryTotal`

## Test plan
- [x] Unit: normal (no retry, no telemetry)
- [x] Unit: 412 → refetch → retry success (asserts refreshed etag + resolved telemetry)
- [x] Unit: 412 → 412 (retry_exhausted + throws)
- [x] Unit: non-412 error (non_conflict_error, no retry)
- [x] Unit: item_gone on refetch (unresolved, retryCount=1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)