### PR TITLE
fix(sp): remove zombie user id candidate from benefit profile lists

### DIFF
--- a/src/sharepoint/spListRegistry.definitions.ts
+++ b/src/sharepoint/spListRegistry.definitions.ts
@@ -79,7 +79,7 @@ export const masterListEntries: readonly SpListEntry[] = [
       'UserID'
     ],
     provisioningFields: [
-      { internalName: 'UserID', type: 'Text', displayName: 'User ID', required: true, indexed: true, candidates: ['UserID', 'User_x0020_ID', 'Title'] },
+      { internalName: 'UserID', type: 'Text', displayName: 'User ID', required: true, indexed: true, candidates: ['UserID', 'Title'] },
       // RecipientCertNumber moved to _Ext to avoid 8KB limit
       { internalName: 'RecipientCertExpiry', type: 'DateTime', displayName: 'Recipient Cert Expiry', dateTimeFormat: 'DateOnly' },
       { internalName: 'GrantMunicipality', type: 'Text', displayName: 'Grant Municipality', candidates: ['GrantMunicipality', 'Grant_x0020_Municipality'] },
@@ -103,7 +103,7 @@ export const masterListEntries: readonly SpListEntry[] = [
       'UserID', 'RecipientCertNumber'
     ],
     provisioningFields: [
-      { internalName: 'UserID', type: 'Text', displayName: 'User ID', required: true, indexed: true, candidates: ['UserID', 'User_x0020_ID', 'Title'] },
+      { internalName: 'UserID', type: 'Text', displayName: 'User ID', required: true, indexed: true, candidates: ['UserID', 'Title'] },
       { internalName: 'RecipientCertNumber', type: 'Text', displayName: 'Recipient Cert Number', required: true, candidates: ['RecipientCertNumber', 'RecipientCertNumber0', 'Recipient_x0020_Cert_x0020_Numbe'] },
     ],
   },


### PR DESCRIPTION
## Summary
- Restore `Title` as the canonical userId candidate for `UserBenefit_Profile` and `UserBenefit_Profile_Ext`
- Keep removed zombie `User_x0020_ID` out of benefit profile field candidates (physically removed in previous step)
- Refactor `syncAccessoryList` to use the resolved `joinField` (e.g., `Title`) for all data logic
- Confirm `/admin/status` no longer reports "不達" for benefit profile lists
- Fix regression in benefit cutover tests where record creation logic was misaligned with the current data model

## Validation
- npm run typecheck: OK
- npm run lint: OK
- npm test -- src/features/users/infra/__tests__/DataProviderUserRepository.benefitCutover.spec.ts: PASSED
- npm test -- src/features/diagnostics src/sharepoint src/features/users: ALL PASSED