### PR TITLE
fix(sp): resolve benefit profile user id via Title (follow-up)

### DIFF
--- a/src/features/users/infra/DataProviderUserRepository.ts
+++ b/src/features/users/infra/DataProviderUserRepository.ts
@@ -679,14 +679,14 @@ export class DataProviderUserRepository extends BaseRepository implements UserRe
     const mapping = await this.getAccessoryMapping(type);
     const request = this.toRequest(payload, mapping);
 
-    // UserID は必須で含める
-    const filteredRequest: Record<string, unknown> = { UserID: userId };
+    const joinField = mapping.userId || ACCESSORY_LIST_JOIN_FIELD;
+    const filteredRequest: Record<string, unknown> = { [joinField]: userId };
     let hasData = false;
     
     // このリストに該当する（解決済みの）物理フィールドのみを抽出
     const physicalFields = new Set(Object.values(mapping).filter((v): v is string => !!v));
     for (const [key, value] of Object.entries(request)) {
-      if (physicalFields.has(key) && key !== 'UserID') {
+      if (physicalFields.has(key) && key !== joinField) {
         filteredRequest[key] = value;
         hasData = true;
       }
@@ -698,7 +698,7 @@ export class DataProviderUserRepository extends BaseRepository implements UserRe
       const stage = this.getBenefitCutoverStage();
       finalRequest = applyBenefitCutoverWrite(filteredRequest, payload, stage);
       // cutover overlay の結果、UserID 以外にキーが増えた場合は hasData を再評価
-      if (Object.keys(finalRequest).some((k) => k !== 'UserID')) {
+      if (Object.keys(finalRequest).some((k) => k !== joinField)) {
         hasData = true;
       }
     }
@@ -713,7 +713,6 @@ export class DataProviderUserRepository extends BaseRepository implements UserRe
 
     try {
       // UserID で既存レコードを検索 (物理名 'UserID' 決め打ちだが、ACCESSORY_LIST_JOIN_FIELD も一応考慮)
-      const joinField = mapping.userId || ACCESSORY_LIST_JOIN_FIELD;
       const filter = buildEq(joinField, userId);
       const existing = await this.provider.listItems<Record<string, unknown>>(listTitle, {
         filter,

--- a/src/features/users/infra/__tests__/DataProviderUserRepository.benefitCutover.spec.ts
+++ b/src/features/users/infra/__tests__/DataProviderUserRepository.benefitCutover.spec.ts
@@ -297,7 +297,7 @@ describe('DataProviderUserRepository — benefit cutover overlay', () => {
       });
 
       const benefit = await provider.listItems<Record<string, unknown>>(BENEFIT_LIST);
-      expect(benefit[0].RecipientCertExpiry).toBeUndefined();
+      expect(benefit[0].RecipientCertExpiry).toBe('2027-03-31');
       expect(benefit[0].GrantMunicipality).toBe('Yokohama');
       expect(benefit[0].Grant_x0020_Municipality).toBe('Yokohama');
     });
@@ -309,7 +309,8 @@ describe('DataProviderUserRepository — benefit cutover overlay', () => {
       await repo.update(1, { RecipientCertExpiry: '2027-03-31' });
 
       const benefit = await provider.listItems<Record<string, unknown>>(BENEFIT_LIST);
-      expect(benefit).toHaveLength(0);
+      expect(benefit).toHaveLength(1);
+      expect(benefit[0].RecipientCertExpiry).toBe('2027-03-31');
       for (const legacyKey of [
         'Grant_x0020_Municipality',
         'Grant_x0020_Period_x0020_Start',

--- a/src/sharepoint/fields/userFields.ts
+++ b/src/sharepoint/fields/userFields.ts
@@ -356,7 +356,7 @@ export function resolveUserSelectFields(mode: UserSelectMode = 'core'): readonly
  * essentialFields (registry): ['UserID', 'RecipientCertNumber']
  */
 export const USER_BENEFIT_PROFILE_CANDIDATES = {
-  userId: CANDIDATE_USER_ID,
+  userId: [...CANDIDATE_USER_ID, 'Title'],
   recipientCertNumber: CANDIDATE_RECIPIENT_CERT_NUMBER,
   recipientCertExpiry: CANDIDATE_RECIPIENT_CERT_EXPIRY,
   grantMunicipality: CANDIDATE_GRANT_MUNICIPALITY,
@@ -399,7 +399,7 @@ export const USER_TRANSPORT_SETTINGS_ESSENTIALS: (keyof typeof USER_TRANSPORT_SE
 
 // ── User Benefit Profile EXT (user_benefit_profile_ext) ──
 export const USER_BENEFIT_PROFILE_EXT_CANDIDATES = {
-  userId: CANDIDATE_USER_ID,
+  userId: [...CANDIDATE_USER_ID, 'Title'],
   recipientCertNumber: CANDIDATE_RECIPIENT_CERT_NUMBER,
 } as const;
 


### PR DESCRIPTION
## Summary
- Restore `Title` as the canonical userId candidate for `UserBenefit_Profile` and `UserBenefit_Profile_Ext`
- Refactor `syncAccessoryList` to use the resolved `joinField`
- Fix regression in benefit cutover tests

This is a follow-up to #1616 as that PR was merged before these additional stability fixes could be included.