### PR TITLE
fix(ops): align ActivityDiary index governance with Date candidates

### DIFF
--- a/src/features/sp/health/indexAdvisor/spIndexKnownConfig.ts
+++ b/src/features/sp/health/indexAdvisor/spIndexKnownConfig.ts
@@ -51,6 +51,13 @@ export const KNOWN_REQUIRED_INDEXED_FIELDS: Record<string, IndexFieldSpec[]> = {
     },
   ],
   // 高頻度フィルタを使うリストは随時追加
+  ActivityDiary: [
+    {
+      internalName: 'Date',
+      displayName: '記録日',
+      reason: '日次・期間取得の主キー（$filter 利用）',
+    },
+  ],
   DailyActivityRecords: [
     {
       internalName: 'RecordDate',
@@ -58,11 +65,40 @@ export const KNOWN_REQUIRED_INDEXED_FIELDS: Record<string, IndexFieldSpec[]> = {
       reason: '$filter=RecordDate eq X（日次取得）',
     },
   ],
+  DailyRecordRows: [
+    {
+      internalName: 'ParentID',
+      displayName: '親レコードID',
+      reason: '結合取得のキー',
+    },
+    {
+      internalName: 'UserID',
+      displayName: '利用者ID',
+      reason: '利用者別履歴取得のキー',
+    },
+  ],
+  SupportRecord_Daily: [
+    {
+      internalName: 'UserCode',
+      displayName: '利用者コード',
+      reason: '利用者別履歴取得のキー',
+    },
+    {
+      internalName: 'RecordDate',
+      displayName: '記録日',
+      reason: '日次・期間取得のフィルタ用',
+    },
+  ],
   Schedules: [
     {
       internalName: 'AssignedStaffId',
       displayName: '職員コード',
       reason: '$filter=AssignedStaffId eq X（職員別スケジュール取得）',
+    },
+    {
+      internalName: 'EventDate',
+      displayName: 'イベント日',
+      reason: '期間フィルタ・重複チェック用',
     },
   ],
   UserBenefit_Profile_Ext: [
@@ -109,6 +145,13 @@ export const KNOWN_REQUIRED_INDEXED_FIELDS: Record<string, IndexFieldSpec[]> = {
       internalName: 'SessionId',
       displayName: 'セッションID',
       reason: '特定分析セッションの識別用',
+    },
+  ],
+  Users_Master: [
+    {
+      internalName: 'UserID',
+      displayName: '利用者ID',
+      reason: '利用者情報の主キー（マスタ参照用）',
     },
   ],
 };

--- a/src/sharepoint/fields/activityDiaryFields.ts
+++ b/src/sharepoint/fields/activityDiaryFields.ts
@@ -14,7 +14,7 @@ export const ACTIVITY_DIARY_CANDIDATES = {
   /** ユーザー識別子。Text 型の UserID と Lookup 型 UserId/UserIdId の両方を吸収 */
   userId:          ['UserID', 'UserId', 'UserIdId', 'user_id', 'cr013_userId'],
   /** 記録日 */
-  date:            ['Date', 'date', 'RecordDate', 'EntryDate', 'cr013_date'],
+  date:            ['Date', 'date', 'ServiceDate', 'RecordDate', 'EntryDate', 'cr013_date'],
   /** 時間帯 (AM / PM / 1日) */
   shift:           ['Shift', 'shift', 'Period', 'TimeSlot', 'cr013_shift'],
   /** 活動カテゴリ */

--- a/src/sharepoint/spListRegistry.definitions.ts
+++ b/src/sharepoint/spListRegistry.definitions.ts
@@ -296,7 +296,7 @@ export const dailyListEntries: readonly SpListEntry[] = [
     essentialFields: ['UserID', 'Date', 'Shift', 'Category'],
     provisioningFields: [
       { internalName: 'UserID', type: 'Text', displayName: 'User ID', required: true },
-      { internalName: 'Date', type: 'DateTime', displayName: 'Date', required: true, dateTimeFormat: 'DateOnly', indexed: true },
+      { internalName: 'Date', type: 'DateTime', displayName: 'Date', required: true, dateTimeFormat: 'DateOnly', indexed: true, candidates: ['Date', 'ServiceDate', 'RecordDate', 'EntryDate', 'cr013_date'] },
       { internalName: 'Shift', type: 'Choice', displayName: 'Shift', choices: ['AM', 'PM', '1日'], required: true },
       { internalName: 'Category', type: 'Choice', displayName: 'Category', choices: ['請負', '個別', '外活動', '余暇'], required: true },
       { internalName: 'LunchAmount', type: 'Choice', displayName: 'Lunch Amount', choices: ['完食', '8割', '半分', '少量', 'なし'] },


### PR DESCRIPTION
## Summary
- Harden index governance for high-volume SharePoint lists
- Add required index governance for:
  - ActivityDiary: Date
  - DailyRecordRows: ParentID, UserID
  - SupportRecord_Daily: UserCode, RecordDate
  - Schedules: EventDate / AssignedStaffId
- Treat legacy `ServiceDate` as a valid physical candidate for canonical `ActivityDiary.Date`
- Confirm `UserBenefit_Profile` / `UserBenefit_Profile_Ext` no longer contain zombie `User_x0020_ID`

## Rationale
`ActivityDiary` was reporting index pressure against stale `ServiceDate`.
The canonical field is `Date`, but the governance layer should tolerate the legacy physical candidate where present.

This PR aligns the index advisor, field candidates, and list registry so Nightly Patrol evaluates the current schema correctly.

## Validation
- npm run typecheck
- npm run lint
- npm test -- src/features/sp/health/indexAdvisor
- npm run patrol:ledger
