### PR TITLE
fix(test): resolve act warnings in TransportAssignmentPage.test.tsx

### DIFF
--- a/src/pages/__tests__/TransportAssignmentPage.test.tsx
+++ b/src/pages/__tests__/TransportAssignmentPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import TransportAssignmentPage from '@/pages/TransportAssignmentPage';
@@ -76,14 +76,19 @@ describe('TransportAssignmentPage', () => {
     localStorage.clear();
   });
 
-  it('renders transport assignment board and controls', () => {
-    render(
-      <MemoryRouter>
-        <TransportAssignmentPage />
-      </MemoryRouter>,
-    );
+  it('renders transport assignment board and controls', async () => {
+    await act(async () => {
+      render(
+        <MemoryRouter>
+          <TransportAssignmentPage />
+        </MemoryRouter>,
+      );
+    });
 
-    expect(screen.getByRole('heading', { level: 1, name: '送迎配車表' })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { level: 1, name: '送迎配車表' })).toBeInTheDocument();
+    });
+
     expect(screen.getByTestId('transport-assignment-date')).toBeInTheDocument();
     expect(screen.getByTestId('transport-assignment-week-prev')).toBeInTheDocument();
     expect(screen.getByTestId('transport-assignment-week-next')).toBeInTheDocument();
@@ -119,12 +124,18 @@ describe('TransportAssignmentPage', () => {
     expect(backLink).toHaveAttribute('href', '/today');
 
     const vehicleNameInput = screen.getByTestId('transport-assignment-vehicle-name-input-1');
-    fireEvent.change(vehicleNameInput, { target: { value: '青1号' } });
-    fireEvent.blur(vehicleNameInput);
+    await act(async () => {
+      fireEvent.change(vehicleNameInput, { target: { value: '青1号' } });
+      fireEvent.blur(vehicleNameInput);
+    });
+
     expect(screen.getByTestId('transport-assignment-vehicle-name-input-1')).toHaveValue('青1号');
     expect(localStorage.getItem('transport.vehicle-name-overrides.v1')).toContain('青1号');
 
-    fireEvent.click(screen.getByTestId('transport-assignment-apply-week-bulk-default'));
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('transport-assignment-apply-week-bulk-default'));
+    });
+
     expect(screen.getByTestId('transport-assignment-week-bulk-summary')).toBeInTheDocument();
     expect(screen.getByTestId('transport-assignment-save-button')).toBeEnabled();
   });


### PR DESCRIPTION
## Description
Resolves `act(...)` warnings in `TransportAssignmentPage.test.tsx` by wrapping the initial render and interactions in `act`.

## Changes
- Wrapped `render` in `act`.
- Wrapped `fireEvent.change`, `fireEvent.blur`, and `fireEvent.click` in `act`.
- Added `waitFor` to ensure async effects settle.

## Verification
- `npx vitest run src/pages/__tests__/TransportAssignmentPage.test.tsx` PASSED with no warnings.