### PR TITLE
fix(ops): isolate nightly-decision tests and restore baseline green

### DIFF
--- a/scripts/ops/nightly-decision.mjs
+++ b/scripts/ops/nightly-decision.mjs
@@ -712,8 +712,8 @@ function main() {
     driftJson: process.env.DRIFT_SUMMARY_PATH || '',
     adminStatusJson: process.env.ADMIN_STATUS_SUMMARY_PATH || path.join(REPORT_DIR, 'admin-status-summary-'), // will be suffixed with date
     registryAuditJson: process.env.REGISTRY_AUDIT_SUMMARY_PATH || path.join(REPORT_DIR, 'registry-audit-result.json'),
-    contractDriftJson: path.join(REPORT_DIR, 'contract-drift.json'),
-    driftLedgerJson: path.join(REPORT_DIR, 'drift-ledger.json'),
+    contractDriftJson: process.env.CONTRACT_DRIFT_SUMMARY_PATH || path.join(REPORT_DIR, 'contract-drift.json'),
+    driftLedgerJson: process.env.DRIFT_LEDGER_SUMMARY_PATH || path.join(REPORT_DIR, 'drift-ledger.json'),
     logFile: process.env.LOG_FILE || path.join(ROOT, 'logs', 'today.auto.log'),
   };
 

--- a/tests/unit/scripts/nightly-decision.reason-codes.spec.ts
+++ b/tests/unit/scripts/nightly-decision.reason-codes.spec.ts
@@ -52,9 +52,18 @@ function cleanupDateArtifacts(date: string) {
 }
 
 function runDecision(date: string, env: Record<string, string>) {
+  const tmpDir = mkTmpDir();
+  const emptyJson = path.join(tmpDir, 'empty.json');
+  writeFileSync(emptyJson, JSON.stringify({}), 'utf8');
+
   execFileSync('node', [SCRIPT, '--date', date], {
     cwd: ROOT,
-    env: { ...process.env, ...env },
+    env: {
+      ...process.env,
+      CONTRACT_DRIFT_SUMMARY_PATH: emptyJson,
+      DRIFT_LEDGER_SUMMARY_PATH: emptyJson,
+      ...env,
+    },
     stdio: 'pipe',
   });
 }


### PR DESCRIPTION
## Description
Fixes 4 test failures in `nightly-decision.reason-codes.spec.ts` by isolating the tests from global artifacts in `docs/nightly-patrol`.

## Changes
- Modified `nightly-decision.mjs` to allow overriding `contractDriftJson` and `driftLedgerJson` paths via environment variables.
- Updated `nightly-decision.reason-codes.spec.ts` to mock these paths to empty files, preventing interference from existing reports.

## Verification
- `npx vitest run tests/unit/scripts/nightly-decision.reason-codes.spec.ts` PASSED (7/7).