### PR TITLE
fix(ops): restore patrol ledger generation for schema drift inventory

### DIFF
--- a/scripts/ops/build-drift-ledger.mjs
+++ b/scripts/ops/build-drift-ledger.mjs
@@ -16,8 +16,20 @@ import { execSync } from 'node:child_process';
 import { getAccessToken, refreshM365Token } from './auth-helper.mjs';
 
 // 1. Load SSOT (Top-level for helper visibility)
-import { SP_LIST_REGISTRY } from '../../src/sharepoint/spListRegistry.ts';
-import { SP_SYSTEM_FIELDS } from '../../src/sharepoint/spSystemFields.js';
+// NOTE:
+// `tsx` can expose TS modules as CJS-compatible namespace objects in this repo setup.
+// Resolve exports through namespace + default fallback to support both ESM and CJS shapes.
+import * as spListRegistryModule from '../../src/sharepoint/spListRegistry.ts';
+import * as spSystemFieldsModule from '../../src/sharepoint/spSystemFields.js';
+
+const SP_LIST_REGISTRY =
+  spListRegistryModule.SP_LIST_REGISTRY ??
+  spListRegistryModule.default?.SP_LIST_REGISTRY ??
+  [];
+const SP_SYSTEM_FIELDS =
+  spSystemFieldsModule.SP_SYSTEM_FIELDS ??
+  spSystemFieldsModule.default?.SP_SYSTEM_FIELDS ??
+  new Set();
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);


### PR DESCRIPTION
Refs #1632

## Summary
- Fix patrol ledger import compatibility when running build-drift-ledger.mjs via tsx
- Support both named export and default fallback for SharePoint registry modules
- Unblocks UserBenefit schema drift inventory work

## Validation
- npm run patrol:ledger
  - import error resolved
  - current stop reason is M365 auth: Logged out / missing credentials

## Notes
- No destructive SharePoint operation
- No UserBenefit mapping change
- No production behavior change
