### PR TITLE
fix(drift): align DriftEventsLog_v2 field mapping

### DIFF
--- a/src/features/diagnostics/drift/infra/SharePointDriftEventRepository.ts
+++ b/src/features/diagnostics/drift/infra/SharePointDriftEventRepository.ts
@@ -28,6 +28,7 @@ export class SharePointDriftEventRepository implements IDriftEventRepository {
 
   /** 本番リストで使用されている物理内部名のキャッシュ */
   private resolvedFields: Record<string, string | undefined> = {};
+  private availablePhysicalFields = new Set<string>();
   private missingLogicalFields = new Set<keyof typeof DRIFT_LOG_CANDIDATES>();
   private blockedPhysicalFields = new Set<string>();
   private writeDisabled = false;
@@ -41,10 +42,6 @@ export class SharePointDriftEventRepository implements IDriftEventRepository {
 
   private rf(key: keyof typeof DRIFT_LOG_CANDIDATES): string | undefined {
     return this.resolvedFields[key];
-  }
-
-  private rfWithFallback(key: keyof typeof DRIFT_LOG_CANDIDATES): string {
-    return this.resolvedFields[key] || DRIFT_LOG_CANDIDATES[key][0];
   }
 
   private readRowValue<T = unknown>(
@@ -89,15 +86,42 @@ export class SharePointDriftEventRepository implements IDriftEventRepository {
   }
 
   private isRequiredFieldKey(key: keyof typeof DRIFT_LOG_CANDIDATES): boolean {
-    return key === 'listName' || key === 'fieldName' || key === 'detectedAt';
+    return key === 'listName' || key === 'fieldName' || key === 'detectedAt' || key === 'loggedAt';
   }
 
-  private isRequiredPhysicalField(fieldName: string): boolean {
-    return [
-      this.rfWithFallback('listName'),
-      this.rfWithFallback('fieldName'),
-      this.rfWithFallback('detectedAt'),
-    ].includes(fieldName);
+  private isPhysicalFieldWritable(fieldName: string): boolean {
+    if (this.blockedPhysicalFields.has(fieldName)) return false;
+    if (this.availablePhysicalFields.size > 0 && !this.availablePhysicalFields.has(fieldName)) return false;
+    return true;
+  }
+
+  private getWritablePhysicalNames(
+    key: keyof typeof DRIFT_LOG_CANDIDATES,
+    required: boolean,
+  ): string[] {
+    const names = new Set<string>();
+    const resolvedName = this.rf(key);
+    if (resolvedName && this.isPhysicalFieldWritable(resolvedName)) {
+      names.add(resolvedName);
+    }
+
+    if (required) {
+      for (const candidate of DRIFT_LOG_CANDIDATES[key]) {
+        if (this.isPhysicalFieldWritable(candidate)) {
+          names.add(candidate);
+        }
+      }
+    }
+
+    // スキーマ未取得時は fail-open 優先で最小候補を使う。
+    if (names.size === 0 && this.availablePhysicalFields.size === 0) {
+      const fallback = DRIFT_LOG_CANDIDATES[key][0];
+      if (fallback && !this.blockedPhysicalFields.has(fallback)) {
+        names.add(fallback);
+      }
+    }
+
+    return Array.from(names);
   }
 
   private buildCreatePayload(event: DriftEvent, includeOptional: boolean): Record<string, unknown> | null {
@@ -109,27 +133,29 @@ export class SharePointDriftEventRepository implements IDriftEventRepository {
       key: keyof typeof DRIFT_LOG_CANDIDATES,
       value: unknown,
     ): boolean => {
-      const resolvedName = this.rf(key);
       const isRequired = this.isRequiredFieldKey(key);
+      const physicalNames = this.getWritablePhysicalNames(key, isRequired);
 
-      // 1. 必須フィールドは読み込めなければフォールバック（Title等は確実に存在する想定）
-      // 2. 任意フィールドは解決されていない場合は書き込まない（HTTP 400 回避）
-      const physicalName = resolvedName || (isRequired ? DRIFT_LOG_CANDIDATES[key][0] : undefined);
-
-      if (!physicalName || this.blockedPhysicalFields.has(physicalName)) {
+      if (physicalNames.length === 0) {
         return !isRequired;
       }
-      if (this.missingLogicalFields.has(key)) {
-        return !this.isRequiredFieldKey(key);
+
+      if (!isRequired && this.missingLogicalFields.has(key)) {
+        return true;
       }
-      payload[physicalName] = value;
+
+      for (const physicalName of physicalNames) {
+        payload[physicalName] = value;
+      }
       return true;
     };
 
+    const now = new Date().toISOString();
     const requiredOk =
       pushField('listName', String(event.listName)) &&
       pushField('fieldName', String(event.fieldName)) &&
-      pushField('detectedAt', String(event.detectedAt));
+      pushField('detectedAt', String(event.detectedAt)) &&
+      pushField('loggedAt', now);
 
     if (!requiredOk) {
       return null;
@@ -263,6 +289,7 @@ export class SharePointDriftEventRepository implements IDriftEventRepository {
             }
 
             if (availableFields.length === 0) return;
+            this.availablePhysicalFields = new Set(availableFields);
 
             const res = resolveInternalNamesDetailed(
               new Set(availableFields),
@@ -286,6 +313,7 @@ export class SharePointDriftEventRepository implements IDriftEventRepository {
         auditLog.warn('diagnostics:drift', 'DriftEventRepository initialization error or timeout.', err);
         // Fallback: use default candidates
         this.resolvedFields = {};
+        this.availablePhysicalFields = new Set();
       }
     })();
 

--- a/src/features/diagnostics/drift/infra/__tests__/SharePointDriftEventRepository.spec.ts
+++ b/src/features/diagnostics/drift/infra/__tests__/SharePointDriftEventRepository.spec.ts
@@ -23,6 +23,7 @@ describe('SharePointDriftEventRepository', () => {
         'ListName',
         'FieldName',
         'DetectedAt',
+        'LoggedAt',
         'Severity',
         'ResolutionType',
         'Resolved',
@@ -46,6 +47,7 @@ describe('SharePointDriftEventRepository', () => {
       ListName: 'Daily_Attendance',
       FieldName: 'Status',
       DetectedAt: '2026-04-05T00:00:00.000Z',
+      LoggedAt: expect.any(String),
       Severity: 'warn',
       ResolutionType: 'fallback',
       Resolved: false,
@@ -53,12 +55,15 @@ describe('SharePointDriftEventRepository', () => {
     expect(payload).not.toHaveProperty('DriftType');
   });
 
-  it('records field as blocked but does not retry immediately on 400 error', async () => {
+  it('records field as blocked and retries once with required-only payload on 400 error', async () => {
     const badRequest = Object.assign(
       new Error("フィールドまたはプロパティ 'DriftType' は存在しません。"),
       { status: 400 },
     );
-    const createItem = vi.fn().mockRejectedValueOnce(badRequest);
+    const createItem = vi
+      .fn()
+      .mockRejectedValueOnce(badRequest)
+      .mockResolvedValueOnce({});
 
     const repo = new SharePointDriftEventRepository({
       createItem,
@@ -68,6 +73,7 @@ describe('SharePointDriftEventRepository', () => {
         'ListName',
         'FieldName',
         'DetectedAt',
+        'LoggedAt',
         'Severity',
         'ResolutionType',
         'DriftType',
@@ -85,10 +91,12 @@ describe('SharePointDriftEventRepository', () => {
       resolved: false,
     });
 
-    // Ensure we only tried once (fail-fast)
-    expect(createItem).toHaveBeenCalledTimes(1);
-    const payload = createItem.mock.calls[0][1];
-    expect(payload).toHaveProperty('DriftType', 'suffix_mismatch');
+    expect(createItem).toHaveBeenCalledTimes(2);
+    const initialPayload = createItem.mock.calls[0][1];
+    const fallbackPayload = createItem.mock.calls[1][1];
+    expect(initialPayload).toHaveProperty('DriftType', 'suffix_mismatch');
+    expect(fallbackPayload).not.toHaveProperty('DriftType');
+    expect(fallbackPayload).toHaveProperty('LoggedAt');
   });
 
   it('fails fast without retry when 400 does not identify a field', async () => {
@@ -115,6 +123,48 @@ describe('SharePointDriftEventRepository', () => {
     });
 
     expect(createItem).toHaveBeenCalledTimes(1);
+  });
+
+  it('writes duplicate required encoded/plain fields when both exist in list schema', async () => {
+    const createItem = vi.fn(async (_listTitle: string, _payload: Record<string, unknown>) => ({}));
+    const repo = new SharePointDriftEventRepository({
+      createItem,
+      updateItemByTitle: vi.fn(async () => ({})),
+      getListItemsByTitle: vi.fn(async () => []),
+      getSchema: vi.fn(async () => [
+        'List_x0020_Name',
+        'ListName',
+        'Field_x0020_Name',
+        'FieldName',
+        'Detected_x0020_At',
+        'DetectedAt',
+        'Logged_x0020_At',
+      ]),
+    });
+
+    await repo.logEvent({
+      listName: 'Daily_Attendance',
+      fieldName: 'Status',
+      detectedAt: '2026-04-05T00:00:00.000Z',
+      severity: 'warn',
+      resolutionType: 'fallback',
+      driftType: 'suffix_mismatch',
+      resolved: false,
+    });
+
+    expect(createItem).toHaveBeenCalledTimes(1);
+    const [, payload] = createItem.mock.calls[0];
+    expect(payload).toMatchObject({
+      Title: 'Daily_Attendance:Status',
+      List_x0020_Name: 'Daily_Attendance',
+      ListName: 'Daily_Attendance',
+      Field_x0020_Name: 'Status',
+      FieldName: 'Status',
+      Detected_x0020_At: '2026-04-05T00:00:00.000Z',
+      DetectedAt: '2026-04-05T00:00:00.000Z',
+      Logged_x0020_At: expect.any(String),
+    });
+    expect(payload).not.toHaveProperty('Severity');
   });
 
   it('applies since/resolved/list filters and maps drifted physical names', async () => {

--- a/src/lib/sp/helpers.ts
+++ b/src/lib/sp/helpers.ts
@@ -495,9 +495,9 @@ export function resolveInternalNamesDetailed<T extends string>(
         for (const base of candidates[key]) {
           const lowerBase = base.toLowerCase();
 
-          // Strategy A: Suffix check (v2: handles multi-digit suffixes 0-99 and encoded spaces)
+          // Strategy A: Suffix check (v2: handles multi-digit suffixes 0-99, _Zombie, and encoded spaces)
           const encodedBase = lowerBase.replace(/ /g, '_x0020_');
-          const suffixRegex = new RegExp(`^${encodedBase}(\\d+)$`);
+          const suffixRegex = new RegExp(`^${encodedBase}(\\d+|_zombie)$`);
           
           for (const [availableLow, actual] of availableMap.entries()) {
             if (suffixRegex.test(availableLow)) {


### PR DESCRIPTION
## Summary
- Add `loggedAt` to required DriftEventsLog_v2 write payload
- Write all existing required duplicate physical fields for `listName` / `fieldName` / `detectedAt` / `loggedAt`
- Keep optional drift-log fields write-safe by sending them only when resolved

## Root cause
DriftEventsLog_v2 has required duplicate columns such as encoded/plain pairs:
- `List_x0020_Name` and `ListName`
- `Field_x0020_Name` and `FieldName`
- `Detected_x0020_At` and `DetectedAt`
- `Logged_x0020_At`

The repository previously wrote only one physical field per logical key and did not send `loggedAt`, causing SharePoint item creation to fail with 400.

## Validation
- `npm run test -- src/features/diagnostics/drift/infra/__tests__/SharePointDriftEventRepository.spec.ts`
- `npm run typecheck`
- `m365 spo field list --webUrl "https://isogokatudouhome.sharepoint.com/sites/welfare" --listTitle "DriftEventsLog_v2" --output json`

## Notes
- Stacked PR on top of #1636 (`fix/drift-log-write-failopen`)
- This PR focuses on field-mapping alignment; no destructive operation
