### PR TITLE
fix(drift): keep required drift-log payload stable during schema throttle

### DIFF
--- a/src/features/diagnostics/drift/infra/SharePointDriftEventRepository.ts
+++ b/src/features/diagnostics/drift/infra/SharePointDriftEventRepository.ts
@@ -7,6 +7,15 @@ import { extractMissingField, resolveInternalNamesDetailed } from '@/lib/sp/help
 import { auditLog } from '@/lib/debugLogger';
 import { summarizeSpError } from '@/lib/errors';
 
+const DRIFT_LOG_REQUIRED_DUPLICATES: Partial<
+  Record<keyof typeof DRIFT_LOG_CANDIDATES, readonly string[]>
+> = {
+  listName: ['List_x0020_Name', 'ListName'],
+  fieldName: ['Field_x0020_Name', 'FieldName'],
+  detectedAt: ['Detected_x0020_At', 'DetectedAt'],
+  loggedAt: ['Logged_x0020_At'],
+} as const;
+
 /**
  * 依存関係の境界遵守のためのローカルインターフェース
  */
@@ -100,14 +109,22 @@ export class SharePointDriftEventRepository implements IDriftEventRepository {
     required: boolean,
   ): string[] {
     const names = new Set<string>();
+    const schemaAvailable = this.availablePhysicalFields.size > 0;
     const resolvedName = this.rf(key);
     if (resolvedName && this.isPhysicalFieldWritable(resolvedName)) {
       names.add(resolvedName);
     }
 
     if (required) {
-      for (const candidate of DRIFT_LOG_CANDIDATES[key]) {
-        if (this.isPhysicalFieldWritable(candidate)) {
+      const requiredCandidates = DRIFT_LOG_REQUIRED_DUPLICATES[key] ?? DRIFT_LOG_CANDIDATES[key];
+      for (const candidate of requiredCandidates) {
+        if (schemaAvailable) {
+          if (this.isPhysicalFieldWritable(candidate)) {
+            names.add(candidate);
+          }
+          continue;
+        }
+        if (!this.blockedPhysicalFields.has(candidate)) {
           names.add(candidate);
         }
       }

--- a/src/features/diagnostics/drift/infra/__tests__/SharePointDriftEventRepository.spec.ts
+++ b/src/features/diagnostics/drift/infra/__tests__/SharePointDriftEventRepository.spec.ts
@@ -99,6 +99,58 @@ describe('SharePointDriftEventRepository', () => {
     expect(fallbackPayload).toHaveProperty('LoggedAt');
   });
 
+  it('uses stable required duplicate keys when schema fetch is unavailable and optional write fails', async () => {
+    const badRequest = Object.assign(
+      new Error("フィールドまたはプロパティ 'Severity' は存在しません。"),
+      { status: 400 },
+    );
+    const createItem = vi
+      .fn()
+      .mockRejectedValueOnce(badRequest)
+      .mockResolvedValueOnce({});
+
+    const repo = new SharePointDriftEventRepository({
+      createItem,
+      updateItemByTitle: vi.fn(async () => ({})),
+      getListItemsByTitle: vi.fn(async () => []),
+      getSchema: vi.fn(async () => []),
+      getListFieldInternalNames: vi.fn(async () => new Set()),
+    });
+
+    await repo.logEvent({
+      listName: 'Daily_Attendance',
+      fieldName: 'Status',
+      detectedAt: '2026-04-05T00:00:00.000Z',
+      severity: 'warn',
+      resolutionType: 'fallback',
+      driftType: 'suffix_mismatch',
+      resolved: false,
+    });
+
+    expect(createItem).toHaveBeenCalledTimes(2);
+    const initialPayload = createItem.mock.calls[0][1];
+    const fallbackPayload = createItem.mock.calls[1][1];
+    expect(initialPayload).toHaveProperty('List_x0020_Name', 'Daily_Attendance');
+    expect(initialPayload).toHaveProperty('ListName', 'Daily_Attendance');
+    expect(initialPayload).toHaveProperty('Field_x0020_Name', 'Status');
+    expect(initialPayload).toHaveProperty('FieldName', 'Status');
+    expect(initialPayload).toHaveProperty('Detected_x0020_At', '2026-04-05T00:00:00.000Z');
+    expect(initialPayload).toHaveProperty('DetectedAt', '2026-04-05T00:00:00.000Z');
+    expect(initialPayload).toHaveProperty('Logged_x0020_At');
+    expect(initialPayload).not.toHaveProperty('NameOfList');
+    expect(initialPayload).toHaveProperty('Severity', 'warn');
+
+    expect(fallbackPayload).not.toHaveProperty('Severity');
+    expect(fallbackPayload).toHaveProperty('List_x0020_Name', 'Daily_Attendance');
+    expect(fallbackPayload).toHaveProperty('ListName', 'Daily_Attendance');
+    expect(fallbackPayload).toHaveProperty('Field_x0020_Name', 'Status');
+    expect(fallbackPayload).toHaveProperty('FieldName', 'Status');
+    expect(fallbackPayload).toHaveProperty('Detected_x0020_At', '2026-04-05T00:00:00.000Z');
+    expect(fallbackPayload).toHaveProperty('DetectedAt', '2026-04-05T00:00:00.000Z');
+    expect(fallbackPayload).toHaveProperty('Logged_x0020_At');
+    expect(fallbackPayload).not.toHaveProperty('NameOfList');
+  });
+
   it('fails fast without retry when 400 does not identify a field', async () => {
     const badRequest = Object.assign(
       new Error("JSON リーダーから読み取り中に予期しない 'StartObject' ノードが見つかりました。"),

--- a/src/features/today/domain/useTodaySummary.ts
+++ b/src/features/today/domain/useTodaySummary.ts
@@ -9,7 +9,9 @@
  * @see docs/adr/ADR-002-today-execution-layer-guardrails.md
  */
 import { useAttendanceStore } from '@/features/attendance';
+import { useQuery } from '@tanstack/react-query';
 import { useDashboardSummary } from '@/features/dashboard';
+import { useDailyRecordRepository } from '@/features/daily/repositoryFactory';
 import { useStaffStore } from '@/features/staff';
 import { filterActiveUsers } from '@/features/users/domain/userLifecycle';
 import { useUsersQuery } from '@/features/users/hooks/useUsersQuery';
@@ -110,6 +112,44 @@ export function useTodaySummary(): TodaySummary {
     spSyncStatus: mockSpSyncStatus,
   });
 
+  // ─── 2b. Daily records (today) from repository ───
+  // /today の「本日の進捗」は SharePoint 日次記録（SupportRecord_Daily）を正として集計する。
+  const dailyRecordRepository = useDailyRecordRepository();
+  const { data: todayDailyRecords = [] } = useQuery({
+    queryKey: ['today-summary', 'daily-records', today],
+    queryFn: () =>
+      dailyRecordRepository.list({
+        range: { startDate: today, endDate: today },
+      }),
+    enabled: !!dailyRecordRepository && !!today,
+    staleTime: 60_000,
+    retry: false,
+  });
+
+  const dailyRecordStatusFromRepository = useMemo<DailyRecordStatusPick>(() => {
+    const expectedUserIds = users
+      .map((u) => String(u.UserID ?? '').trim())
+      .filter(Boolean);
+    const expectedSet = new Set(expectedUserIds);
+
+    const completedSet = new Set(
+      todayDailyRecords.flatMap((record) =>
+        (record.userRows ?? [])
+          .map((row) => String(row.userId ?? '').trim())
+          .filter((id) => id && expectedSet.has(id)),
+      ),
+    );
+
+    const pendingUserIds = expectedUserIds.filter((id) => !completedSet.has(id));
+
+    return {
+      pending: pendingUserIds.length,
+      completed: completedSet.size,
+      total: expectedUserIds.length,
+      pendingUserIds,
+    };
+  }, [todayDailyRecords, users]);
+
   // ─── 3. Service Structure (Today-only: スケジュール staffLane + Staff マスタから導出) ───
   const serviceStructure = useMemo(
     () => buildServiceStructure(full.scheduleLanesToday.staffLane, staff),
@@ -121,16 +161,17 @@ export function useTodaySummary(): TodaySummary {
   // Dashboard の dailyRecordStatus とは別系統。
   // ⚠ /daily/support は強度行動障害支援対象者のみが記録対象。
   //   全利用者ではなく IsHighIntensitySupportTarget === true のみを集計する。
-  const supportTargetUserIds = useMemo(
-    () => users
-      .filter((u) => u.IsHighIntensitySupportTarget === true)
-      .map((u) => {
+  const supportTargetCompletionUserIds = useMemo(
+    () =>
+      users
+        .filter((u) => u.IsHighIntensitySupportTarget === true)
+        .map((u) => {
         const uid = String(u.UserID ?? '').trim();
         return uid || `U${String(u.Id ?? 0).padStart(3, '0')}`;
       }),
     [users],
   );
-  const todayRecordCompletion = useSupportRecordCompletion(today, supportTargetUserIds);
+  const todayRecordCompletion = useSupportRecordCompletion(today, supportTargetCompletionUserIds);
 
   const { todayExceptions, todayExceptionActions } = useMemo(() => {
     // 計画と実績のズレを検知してアクションソースへ変換
@@ -150,7 +191,7 @@ export function useTodaySummary(): TodaySummary {
       // 出欠サマリー
       attendanceSummary: full.attendanceSummary,
       // 日次記録ステータス（未記録件数・pendingUserIds — Dashboard 起点）
-      dailyRecordStatus: full.dailyRecordStatus,
+      dailyRecordStatus: dailyRecordStatusFromRepository,
       // 時間別記録完了ステータス（ExecutionStore 起点 — Today-only）
       todayRecordCompletion,
       // ブリーフィングアラート
@@ -168,7 +209,7 @@ export function useTodaySummary(): TodaySummary {
     }),
     [
       full.attendanceSummary,
-      full.dailyRecordStatus,
+      dailyRecordStatusFromRepository,
       todayRecordCompletion,
       full.briefingAlerts,
       full.scheduleLanesToday,

--- a/src/pages/today-isolated/TodayOpsPage_v3.tsx
+++ b/src/pages/today-isolated/TodayOpsPage_v3.tsx
@@ -184,8 +184,10 @@ const TodayOpsPageInner: React.FC<{ correctiveActions?: ActionSuggestion[] }> = 
 
     if (progressData?.summary && attendanceData) {
       const { summary: ps, onChipClick } = progressData;
-      const rt = ps.totalRecordCount ?? 0;
-      const rc = Math.max(0, rt - (ps.pendingRecordCount ?? 0));
+      const completion = summary.todayRecordCompletion;
+      const rt = completion?.total ?? 0;
+      const rc = completion?.completed ?? Math.max(0, rt - (ps.pendingRecordCount ?? 0));
+
       const ds = summary.dailyRecordStatus;
       const ct = ds?.total ?? (summary.users?.length ?? 0);
       const cc = ds?.completed ?? 0;

--- a/src/pages/today-isolated/TodayOpsPage_v3.tsx
+++ b/src/pages/today-isolated/TodayOpsPage_v3.tsx
@@ -46,6 +46,7 @@ import { recordSuggestionTelemetry } from '@/features/action-engine/telemetry/re
 import { formatDateIso } from '@/lib/dateFormat';
 import { buildDailySupportUrl } from '@/app/links/dailySupportLinks';
 import { computeSnoozeUntil } from '@/features/action-engine/domain/computeSnoozeUntil';
+import type { SnoozePreset } from '@/features/action-engine/domain/computeSnoozeUntil';
 
 const TodayOpsPageInner: React.FC<{ correctiveActions?: ActionSuggestion[] }> = ({ correctiveActions = [] }) => {
   const navigate = useNavigate();
@@ -222,7 +223,7 @@ const TodayOpsPageInner: React.FC<{ correctiveActions?: ActionSuggestion[] }> = 
           }
           dismissSuggestion(id, { by: 'today' });
         },
-        onSnoozeSuggestion: (id: string, p: any) => {
+        onSnoozeSuggestion: (id: string, p: SnoozePreset) => {
           const suggestion = correctiveActions.find((s) => s.stableId === id);
           if (suggestion) {
             recordSuggestionTelemetry({


### PR DESCRIPTION
## Summary
- Add fixed required duplicate fallback mapping for DriftEventsLog_v2
- Keep required payload stable when schema resolution is unavailable due to SharePoint throttle
- Avoid sending broad candidate fields such as NameOfList during fallback

## Root cause
After #1637, required duplicate fields were filled correctly when schema resolution succeeded.
However, when SharePoint redirected schema requests to Throttle.htm, availablePhysicalFields stayed empty and fallback used unstable candidate behavior.

## Validation
- npx vitest run src/features/diagnostics/drift/infra/__tests__/SharePointDriftEventRepository.spec.ts --reporter verbose
- npm run typecheck