### PR TITLE
fix(health): suppress auth placeholders and retry transient SP probes

### DIFF
--- a/src/features/diagnostics/drift/infra/SharePointDriftEventRepository.ts
+++ b/src/features/diagnostics/drift/infra/SharePointDriftEventRepository.ts
@@ -85,6 +85,11 @@ export class SharePointDriftEventRepository implements IDriftEventRepository {
     return typeof err === 'object' && err !== null && 'status' in err && (err as { status?: number }).status === 400;
   }
 
+  private extractMissingFieldFromError(err: unknown): string | null {
+    const message = err instanceof Error ? err.message : String(err ?? '');
+    return extractMissingField(message);
+  }
+
   private isListViewThresholdError(err: unknown): boolean {
     const { httpStatus, message } = summarizeSpError(err);
     if (httpStatus !== 500) return false;
@@ -497,7 +502,6 @@ export class SharePointDriftEventRepository implements IDriftEventRepository {
 
         const selectRaw = [
           'Id',
-          'ID',
           this.rf('listName'),
           this.rf('fieldName'),
           this.rf('detectedAt'),
@@ -510,22 +514,51 @@ export class SharePointDriftEventRepository implements IDriftEventRepository {
 
         // リストに実在しないフィールドを $select から完全に除外する (400エラー防止)
         const schemaKnown = this.availablePhysicalFields.size > 0;
-        const select = selectRaw.filter((f): f is string => {
+        let select = selectRaw.filter((f): f is string => {
           if (!f) return false;
-          if (f === 'Id' || f === 'ID' || f === 'Title') return true;
+          if (f === 'Id' || f === 'Title') return true;
           return !schemaKnown || this.availablePhysicalFields.has(f);
         });
 
-        // ── Threshold-Safe Query ──────────────────────────────────────────────
-        const events = await this.fetchEventsWithThresholdFallback(
-          listTitle,
-          select,
-          joinAnd(filters) || undefined,
-          'Id',
-          200, // 増やして取得
-          filter,
-          signal,
-        );
+        // ── Threshold-Safe Query (+ 400 field fallback) ───────────────────────
+        let events: DriftEvent[] = [];
+        for (let attempt = 0; attempt < 5; attempt += 1) {
+          try {
+            events = await this.fetchEventsWithThresholdFallback(
+              listTitle,
+              select,
+              joinAnd(filters) || undefined,
+              'Id',
+              200, // 増やして取得
+              filter,
+              signal,
+            );
+            break;
+          } catch (err) {
+            if (!this.isHttp400(err)) {
+              throw err;
+            }
+            const missingField = this.extractMissingFieldFromError(err);
+            if (!missingField) {
+              throw err;
+            }
+
+            const prevLength = select.length;
+            select = select.filter((f) => f !== missingField);
+            if (select.length === prevLength) {
+              throw err;
+            }
+
+            this.blockedPhysicalFields.add(missingField);
+            this.availablePhysicalFields.delete(missingField);
+
+            auditLog.warn(
+              'diagnostics:drift',
+              'DriftEventRepository removed missing field from select and retried.',
+              { listTitle, missingField, attempt: attempt + 1 },
+            );
+          }
+        }
 
         // クライアント側での日付フィルタリング (Threshold 回避のためサーバー側では行わない)
         if (filter?.since) {

--- a/src/features/diagnostics/health/checks.ts
+++ b/src/features/diagnostics/health/checks.ts
@@ -112,7 +112,8 @@ async function safeWithRetry<T>(
     maxRetries: number;
     baseDelayMs: number;
     jitterMs: number;
-  }
+  },
+  shouldRetry: (status: number | undefined) => boolean = isRetryableUpdateStatus,
 ): Promise<(SafeResult<T> & { attempts: number })> {
   const maxAttempts = options.maxRetries + 1;
   for (let attempts = 1; attempts <= maxAttempts; attempts += 1) {
@@ -120,7 +121,7 @@ async function safeWithRetry<T>(
     if (result.ok) {
       return { ...result, attempts };
     }
-    if (!isRetryableUpdateStatus(result.status) || attempts >= maxAttempts) {
+    if (!shouldRetry(result.status) || attempts >= maxAttempts) {
       return { ...result, attempts };
     }
     const jitter = options.jitterMs > 0 ? Math.floor(Math.random() * options.jitterMs) : 0;
@@ -606,18 +607,28 @@ async function runListChecks(
     createBody[physicalTitle] = `[healthcheck] ${stamp}`;
   }
 
-  const created = await safe(() =>
-    sp.createItem(spec.resolvedTitle, createBody)
+  const created = await safeWithRetry(
+    () => sp.createItem(spec.resolvedTitle, createBody),
+    {
+      maxRetries: 2,
+      baseDelayMs: 260,
+      jitterMs: 140,
+    },
+    isTransientPermissionStatus,
   );
   if (!created.ok) {
     if (isTransientPermissionStatus(created.status)) {
+      const retryCount = Math.max(0, created.attempts - 1);
       results.push(
         warn({
           key: `permissions.create.${spec.key}`,
           label: `権限：Create（${spec.displayName}）`,
           category: "permissions",
           summary: `作成（Create）確認中に一時的エラー（${summarizeHttpStatus(created.status)}）を検出しました。`,
-          detail: created.err,
+          detail:
+            retryCount > 0
+              ? `${created.err} (自動リトライ ${retryCount} 回後も解消せず)`
+              : created.err,
           evidence: { listTitle: spec.resolvedTitle, payload: createBody },
           nextActions: [
             {
@@ -726,8 +737,14 @@ async function runListChecks(
     );
   }
 
-  const deleted = await safe(() =>
-    sp.deleteItem(spec.resolvedTitle, created.v.id)
+  const deleted = await safeWithRetry(
+    () => sp.deleteItem(spec.resolvedTitle, created.v.id),
+    {
+      maxRetries: 2,
+      baseDelayMs: 260,
+      jitterMs: 140,
+    },
+    isTransientPermissionStatus,
   );
   if (!deleted.ok) {
     if (spec.isDeleteOptional) {
@@ -749,7 +766,10 @@ async function runListChecks(
           category: "permissions",
           summary:
             "削除（Delete）に失敗しました（運用上これが許容される場合もあります）。",
-          detail: deleted.err,
+          detail:
+            isTransientPermissionStatus(deleted.status) && deleted.attempts > 1
+              ? `${deleted.err} (自動リトライ ${deleted.attempts - 1} 回後も解消せず)`
+              : deleted.err,
           evidence: { id: created.v.id, listTitle: spec.resolvedTitle },
           nextActions: [
             {

--- a/src/infra/firestore/auth.ts
+++ b/src/infra/firestore/auth.ts
@@ -53,6 +53,18 @@ const allowAnonymousFallback = (): boolean => {
   return getFlag('VITE_FIREBASE_AUTH_ALLOW_ANON_FALLBACK', false);
 };
 
+const isPlaceholderFirebaseApiKey = (value: string): boolean => {
+  const normalized = value.trim().toLowerCase();
+  return (
+    normalized === '' ||
+    normalized === 'undefined' ||
+    normalized === 'null' ||
+    normalized === 'dummy-api-key' ||
+    normalized === 'your-firebase-api-key' ||
+    normalized === 'changeme'
+  );
+};
+
 const acquireMsalAccessToken = async (): Promise<string> => {
   const [{ getPcaSingleton }] = await Promise.all([
     import('@/auth/azureMsal'),
@@ -166,9 +178,9 @@ export async function initFirebaseAuth(): Promise<void> {
 
   // Skip Firebase auth when API key is not configured (graceful degradation)
   const apiKey = get('VITE_FIREBASE_API_KEY', '');
-  if (!apiKey || apiKey === 'undefined' || apiKey === 'null') {
+  if (isPlaceholderFirebaseApiKey(apiKey)) {
     if (getFlag('DEV', false)) {
-      console.info('[firebase-auth] ⏭️ skipped: VITE_FIREBASE_API_KEY is not configured');
+      console.info('[firebase-auth] ⏭️ skipped: VITE_FIREBASE_API_KEY is not configured or placeholder');
     }
     return;
   }

--- a/src/infra/firestore/auth.ts
+++ b/src/infra/firestore/auth.ts
@@ -172,7 +172,6 @@ export async function initFirebaseAuth(): Promise<void> {
   // Skip Firebase auth in E2E tests
   const isE2E = getFlag('VITE_E2E', false);
   if (isE2E) {
-    console.log('[firebase-auth] disabled:', { VITE_E2E: getFlag('VITE_E2E', false) });
     return;
   }
 


### PR DESCRIPTION
## Summary
- Skip Firebase auth initialization when placeholder API keys are configured
- Harden DriftEventsLog_v2 reads by normalizing Id selection and retrying without missing fields
- Apply transient retry handling to Create/Delete permission probes to reduce 429 noise

## Validation
- npm run -s typecheck
- npm run -s test -- src/features/diagnostics/drift/infra/__tests__/SharePointDriftEventRepository.spec.ts src/features/diagnostics/health/__tests__/permissionsTransientStatus.spec.ts

## Notes
This change preserves real schema/permission failures while reducing noise from placeholder configuration, optional field drift, and transient SharePoint throttling.