### PR TITLE
fix(ci): restore green quality gates after diagnostics hardening

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -120,6 +120,27 @@ module.exports = {
       rules: {
         'import/no-unresolved': 'off'
       }
+    },
+    {
+      files: [
+        '**/*.spec.ts',
+        '**/*.spec.tsx',
+        '**/*.test.ts',
+        '**/*.test.tsx',
+        'tests/setupTests.ts',
+        'tests/**/*.ts',
+        'tests/**/*.tsx'
+      ],
+      rules: {
+        'no-restricted-globals': [
+          'error',
+          {
+            name: 'confirm',
+            message: 'window.confirm は禁止です。useConfirmDialog + ConfirmDialog を使用してください。',
+          },
+          // 'fetch' is intentionally omitted: test files legitimately use global.fetch for spy/mock.
+        ]
+      }
     }
   ]
 };

--- a/src/features/diagnostics/drift/infra/__tests__/SharePointDriftEventRepository.spec.ts
+++ b/src/features/diagnostics/drift/infra/__tests__/SharePointDriftEventRepository.spec.ts
@@ -114,7 +114,7 @@ describe('SharePointDriftEventRepository', () => {
       updateItemByTitle: vi.fn(async () => ({})),
       getListItemsByTitle: vi.fn(async () => []),
       getSchema: vi.fn(async () => []),
-      getListFieldInternalNames: vi.fn(async () => new Set()),
+      getListFieldInternalNames: vi.fn(async () => new Set<string>()),
     });
 
     await repo.logEvent({

--- a/src/features/transport-assignments/application/__tests__/transportAssignmentApplication.spec.ts
+++ b/src/features/transport-assignments/application/__tests__/transportAssignmentApplication.spec.ts
@@ -142,7 +142,8 @@ describe('transportAssignmentApplication contract tests', () => {
       
       expect(mockRepo.saveBulk).toHaveBeenCalled();
       const calledAssignments = vi.mocked(mockRepo.saveBulk).mock.calls[0][0];
-      expect(calledAssignments[0].vehicleId).toBe('車両1');
+      expect(calledAssignments[0].type).toBe('transport');
+      expect((calledAssignments[0] as TransportAssignment).vehicleId).toBe('車両1');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Restore CI quality gates after recent diagnostics/runtime hardening work
- Fix TypeScript inference issues in drift repository and transport assignment tests
- Allow test-only global.fetch mocks through ESLint override while keeping production fetch restrictions
- Confirm focused SharePoint ensureList contract test passes

## Validation
- npx vitest run tests/unit/spClient.ensureList.spec.ts
- npx tsc --noEmit
- npx eslint . --ext .ts,.tsx --quiet

## Notes
- Production fetch restrictions remain enforced.
- The ESLint override is limited to test/setup files.
- No runtime behavior change.