### PR TITLE
feat(schedules): enable WeekPage create and edit flows

### DIFF
--- a/src/features/schedules/components/pages/ScheduleViewContainer.tsx
+++ b/src/features/schedules/components/pages/ScheduleViewContainer.tsx
@@ -90,6 +90,7 @@ export function ScheduleViewContainer(props: ScheduleViewContainerProps) {
         categoryFilter={categoryFilter}
         emptyCtaLabel={categoryFilter === 'Org' ? '施設予定を追加' : '予定を追加'}
         compact={compact}
+        onItemClick={onItemSelect}
       />
     );
   }

--- a/src/features/schedules/components/timeline/TimelineItem.tsx
+++ b/src/features/schedules/components/timeline/TimelineItem.tsx
@@ -14,6 +14,7 @@ export type TimelineItemProps = {
   hasWarning?: boolean;
   warningLabel?: string;
   compact?: boolean;
+  onClick?: () => void;
 };
 
 export function TimelineItem({
@@ -28,6 +29,7 @@ export function TimelineItem({
   hasWarning,
   warningLabel,
   compact,
+  onClick,
 }: TimelineItemProps) {
   const statusMeta = getScheduleStatusMeta(status);
   const dotColor = statusMeta?.dotColor ?? 'rgba(25,118,210,0.9)';
@@ -65,12 +67,31 @@ export function TimelineItem({
 
   return (
     <div
+      role={onClick ? 'button' : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      onClick={onClick}
+      onKeyDown={(e) => {
+        if (onClick && (e.key === 'Enter' || e.key === ' ')) {
+          e.preventDefault();
+          onClick();
+        }
+      }}
       style={{
         display: 'grid',
         gridTemplateColumns: isCompact ? '68px minmax(0, 1fr)' : '80px minmax(0, 1fr)',
         columnGap: isCompact ? SCHEDULE_TIMELINE_SPACING.itemGridGapCompact : SCHEDULE_TIMELINE_SPACING.itemGridGapNormal,
         alignItems: 'flex-start',
         opacity,
+        cursor: onClick ? 'pointer' : 'default',
+        padding: '4px 0',
+        borderRadius: 8,
+        transition: 'background-color 0.2s',
+      }}
+      onMouseEnter={(e) => {
+        if (onClick) e.currentTarget.style.backgroundColor = 'rgba(0,0,0,0.03)';
+      }}
+      onMouseLeave={(e) => {
+        if (onClick) e.currentTarget.style.backgroundColor = 'transparent';
       }}
     >
       <div

--- a/src/features/schedules/hooks/legacy/useSchedulesCrud.ts
+++ b/src/features/schedules/hooks/legacy/useSchedulesCrud.ts
@@ -310,15 +310,8 @@ export function useSchedulesCrud(deps: CrudDeps): CrudReturn {
           await update(payload);
         } else {
           // --- ORCHESTRATOR DELEGATION ---
-          const { nextGap } = await (orchestrator as any).handleCreateSchedule(input);
-          
-          if (nextGap) {
-            const startDate = new Date(`${nextGap.date}T${nextGap.startTime}:00`);
-            const endDate = new Date(`${nextGap.date}T${nextGap.endTime}:00`);
-            const createCategory = categoryFilter === 'All' ? 'User' : categoryFilter;
-            setDialogParams(buildCreateDialogIntent(createCategory, startDate, endDate));
-            showSnack('info', `次の未入力枠を開きました（${nextGap.startTime}〜${nextGap.endTime}）`);
-          }
+          await (orchestrator as any).handleCreateSchedule(input);
+          onCreateSuccess?.(input.startLocal);
         }
         handleCreateDialogClose();
       } catch (error) {

--- a/src/features/schedules/routes/DayView.tsx
+++ b/src/features/schedules/routes/DayView.tsx
@@ -26,6 +26,7 @@ type DayViewProps = {
   categoryFilter?: 'All' | ScheduleCategory;
   emptyCtaLabel?: string;
   compact?: boolean;
+  onItemClick?: (item: SchedItem) => void;
 };
 
 export default function DayView(props: DayViewProps = {}) {
@@ -39,6 +40,7 @@ export default function DayView(props: DayViewProps = {}) {
         range={props.range!}
         categoryFilter={props.categoryFilter}
         compact={props.compact}
+        onItemClick={props.onItemClick}
       />
     );
   }
@@ -62,6 +64,7 @@ const DayViewWithData = (props: DayViewProps) => {
       range={resolvedRange}
       categoryFilter={props.categoryFilter}
       compact={props.compact}
+      onItemClick={props.onItemClick}
     />
   );
 };
@@ -72,12 +75,14 @@ const DayViewContent = ({
   range,
   categoryFilter,
   compact,
+  onItemClick,
 }: {
   items: SchedItem[];
   loading: boolean;
   range: DateRange;
   categoryFilter?: 'All' | ScheduleCategory;
   compact?: boolean;
+  onItemClick?: (item: SchedItem) => void;
 }) => {
   const headingId = useId();
   const listLabelId = useId();
@@ -296,6 +301,7 @@ const DayViewContent = ({
                     hasWarning={hasWarning}
                     warningLabel={warningLabel}
                     compact={isCompact}
+                    onClick={onItemClick ? () => onItemClick(item) : undefined}
                   />
                 </li>
               );


### PR DESCRIPTION
## Summary
- Enable create-success callback flow so WeekPage can continue to the next available gap
- Add clickable schedule items in DayView
- Wire DayView item selection into existing view/edit dialog flow
- Preserve existing schedules domain, mapper, repository, and dialog responsibilities

## Validation
- npm run typecheck
- npm run lint

## Notes
- This PR focuses on WeekPage/DayView create-edit flow only.
- Zod validation migration and statusLabel mapper cleanup are intentionally left for follow-up PRs.