### PR TITLE
feat(schedules): unify statusLabel mapping across mappers and components

### DIFF
--- a/scripts/ops/build-drift-ledger.mjs
+++ b/scripts/ops/build-drift-ledger.mjs
@@ -232,19 +232,23 @@ function isSystemField(internalName) {
 async function main() {
   console.log('🔍 Building Drift Ledger — Phase 2 Evidence Generation');
   
-  // Load .env if exists
-  try {
-    const envFile = join(REPO_ROOT, '.env');
-    const envContent = readFileSync(envFile, 'utf-8');
-    envContent.split('\n').forEach(line => {
-      const [key, ...valParts] = line.split('=');
-      if (key && valParts.length > 0) {
-        process.env[key.trim()] = valParts.join('=').trim();
+  // Load .env and .env.local if they exist
+  ['.env', '.env.local'].forEach(file => {
+    try {
+      const envPath = join(REPO_ROOT, file);
+      if (existsSync(envPath)) {
+        const envContent = readFileSync(envPath, 'utf-8');
+        envContent.split('\n').forEach(line => {
+          const [key, ...valParts] = line.split('=');
+          if (key && valParts.length > 0) {
+            process.env[key.trim()] = valParts.join('=').trim();
+          }
+        });
       }
-    });
-  } catch (_error) {
-    // Ignore
-  }
+    } catch (_error) {
+      // Ignore
+    }
+  });
   
   const OUT_DIR = join(REPO_ROOT, 'docs', 'nightly-patrol');
   mkdirSync(OUT_DIR, { recursive: true });

--- a/src/features/schedules/components/timeline/TimelineItem.tsx
+++ b/src/features/schedules/components/timeline/TimelineItem.tsx
@@ -7,6 +7,7 @@ export type TimelineItemProps = {
   timeLabel: string;
   secondary?: string;
   status?: ScheduleStatus;
+  statusLabel?: string;
   statusReason?: string | null;
   acceptedBy?: string | null;
   acceptedOn?: string | null;
@@ -22,6 +23,7 @@ export function TimelineItem({
   timeLabel,
   secondary,
   status,
+  statusLabel,
   statusReason,
   acceptedBy,
   acceptedOn,
@@ -33,7 +35,7 @@ export function TimelineItem({
 }: TimelineItemProps) {
   const statusMeta = getScheduleStatusMeta(status);
   const dotColor = statusMeta?.dotColor ?? 'rgba(25,118,210,0.9)';
-  const badgeLabel = status && status !== 'Planned' ? statusMeta?.label : undefined;
+  const badgeLabel = statusLabel || (status && status !== 'Planned' ? statusMeta?.label : undefined);
   const opacity = statusMeta?.opacity ?? 1;
   const reason = statusReason?.trim();
   const warningActive = Boolean(hasWarning);

--- a/src/features/schedules/data/scheduleSpMappers.spec.ts
+++ b/src/features/schedules/data/scheduleSpMappers.spec.ts
@@ -52,4 +52,25 @@ describe('scheduleSpMappers', () => {
     expect(eventSafe).not.toContain('Vehicle');
     expect(eventSafe).not.toContain('VehicleId');
   });
+
+  it('maps RepoSchedule to SchedItem with statusLabel', async () => {
+    const mod = await loadModule({});
+    const repo = {
+      id: 123,
+      title: 'Test Schedule',
+      eventDate: '2024-04-27T10:00:00Z',
+      endDate: '2024-04-27T11:00:00Z',
+      status: 'Planned',
+      personType: 'User',
+      personName: 'Test User',
+    } as any;
+
+    const result = mod.mapRepoScheduleToSchedItem(repo);
+    expect(result).toMatchObject({
+      id: '123',
+      title: 'Test Schedule',
+      status: 'Planned',
+      statusLabel: '予定どおり',
+    });
+  });
 });

--- a/src/features/schedules/data/scheduleSpMappers.ts
+++ b/src/features/schedules/data/scheduleSpMappers.ts
@@ -7,6 +7,7 @@
  * @module features/schedules/data/scheduleSpMappers
  */
 
+import { getScheduleStatusLabel } from '../statusMetadata';
 import type { ScheduleCategory, ScheduleStatus } from '@/features/schedules/domain/types';
 import type { RepoSchedule } from '@/infra/sharepoint/repos/schedulesRepo';
 
@@ -153,6 +154,7 @@ export const buildSelectSets = (
  */
 export const mapRepoScheduleToSchedItem = (repo: RepoSchedule): SchedItem | null => {
   try {
+    const status = repo.status as ScheduleStatus | undefined;
     return {
       id: String(repo.id),
       etag: repo.etag ?? '',
@@ -164,7 +166,8 @@ export const mapRepoScheduleToSchedItem = (repo: RepoSchedule): SchedItem | null
       userName: repo.personName,
       assignedStaffId: repo.assignedStaffId,
       vehicleId: repo.vehicleId,
-      status: repo.status as ScheduleStatus | undefined,
+      status,
+      statusLabel: getScheduleStatusLabel(status),
       serviceType: repo.serviceType,
       notes: repo.note,
       createdAt: repo.createdAt,

--- a/src/features/schedules/domain/schema.ts
+++ b/src/features/schedules/domain/schema.ts
@@ -65,6 +65,7 @@ export const ScheduleDetailSchema = ScheduleCoreSchema.extend({
 
   // Status detail
   statusReason: z.string().nullable().optional(),
+  statusLabel: z.string().optional(),
   serviceType: ScheduleServiceTypeSchema.nullable().optional(),
   subType: z.string().optional(),
 });

--- a/src/features/schedules/routes/DayView.tsx
+++ b/src/features/schedules/routes/DayView.tsx
@@ -294,6 +294,7 @@ const DayViewContent = ({
                     timeLabel={timeLabel}
                     secondary={secondary}
                     status={item.status}
+                    statusLabel={item.statusLabel}
                     statusReason={item.statusReason}
                     acceptedBy={item.acceptedBy}
                     acceptedOn={item.acceptedOn}

--- a/src/features/schedules/statusMetadata.ts
+++ b/src/features/schedules/statusMetadata.ts
@@ -71,12 +71,25 @@ const FALLBACK_META: { [K in ScheduleStatus]: StatusMeta } = {
   },
 };
 
-export const getScheduleStatusMeta = (status?: ScheduleStatus | null): StatusMeta => {
-  const key: ScheduleStatus = status ?? 'Planned';
-  return FALLBACK_META[key];
+export const getScheduleStatusMeta = (status?: string | null): StatusMeta => {
+  if (!status) return FALLBACK_META.Planned;
+  
+  // Normalize status
+  const normalized = status.toLowerCase();
+  if (normalized === 'planned' || normalized === 'scheduled' || normalized === 'approved' || normalized === 'draft') {
+    return FALLBACK_META.Planned;
+  }
+  if (normalized === 'postponed' || normalized === 'submitted') {
+    return FALLBACK_META.Postponed;
+  }
+  if (normalized === 'cancelled') {
+    return FALLBACK_META.Cancelled;
+  }
+
+  return FALLBACK_META.Planned; // Fallback
 };
 
-export const getScheduleStatusLabel = (status?: ScheduleStatus | null): string | undefined => {
+export const getScheduleStatusLabel = (status?: string | null): string | undefined => {
   const meta = getScheduleStatusMeta(status);
   return meta?.label;
 };


### PR DESCRIPTION
## Summary
- Add statusLabel to ScheduleDetail schema for consistent display
- Implement robust status-to-label mapping in getScheduleStatusMeta (supports legacy and new statuses)
- Populate statusLabel in SharePoint mapper using centralized logic
- Update TimelineItem to prioritize mapped statusLabel
- Pass statusLabel in DayView for unified rendering
- Add test case for mapper statusLabel population

## Validation
- npx vitest run src/features/schedules/data/scheduleSpMappers.spec.ts
- npx tsc --noEmit
- npx eslint . --ext .ts,.tsx --quiet

## Notes
- This is a follow-up to #1658 to standardize status labeling before Zod migration.