### PR TITLE
fix(home): clarify list navigation card labels

### DIFF
--- a/src/app/Home.tsx
+++ b/src/app/Home.tsx
@@ -337,7 +337,7 @@ export default function Home() {
                   <CardActions sx={{ pt: 0, pb: 2, px: 2 }}>
                     <Stack direction="row" spacing={1} alignItems="center">
                       <Typography variant="body2" color="primary" fontWeight={600}>
-                        詳細を開く
+                        一覧を表示
                       </Typography>
                       <ArrowForwardRoundedIcon fontSize="small" color="primary" />
                     </Stack>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -185,7 +185,7 @@ export default function Home() {
                       </Stack>
                       <Stack direction="row" alignItems="center" justifyContent="flex-end" mt="auto">
                         <Typography variant="body2" color="primary.main" fontWeight={500}>
-                          詳細を開く
+                          一覧を表示
                         </Typography>
                         <ArrowForwardRoundedIcon color="primary" fontSize="small" sx={{ ml: 0.5 }} />
                       </Stack>


### PR DESCRIPTION
## Summary
- Rename home card action labels from 「詳細を開く」 to 「一覧を表示」
- Clarify that these cards navigate to list pages rather than opening a specific detail panel

## Why
The previous label could be interpreted as opening an individual detail view.
For users/staff list entry points, 「一覧を表示」 better matches the actual navigation behavior.

## Scope
- `src/pages/Home.tsx`
- `src/app/Home.tsx`

## Validation
- Confirmed home cards still navigate to their existing routes
- Text-only UX copy change