### PR TITLE
fix(users): clarify navigation labels in user detail views

### DIFF
--- a/src/features/users/UserDetailSections/UserDetailHeader.tsx
+++ b/src/features/users/UserDetailSections/UserDetailHeader.tsx
@@ -164,7 +164,7 @@ export const UserDetailHeader: React.FC<UserDetailHeaderProps> = ({
                 to={`/users/${encodeURIComponent(user.UserID || String(user.Id))}`}
                 sx={{ textTransform: 'none', flex: 1 }}
               >
-                詳細を表示
+                利用者ハブを開く
               </Button>
             </Stack>
           </>

--- a/src/features/users/UserDetailSections/UserDetailHeader.tsx
+++ b/src/features/users/UserDetailSections/UserDetailHeader.tsx
@@ -164,7 +164,7 @@ export const UserDetailHeader: React.FC<UserDetailHeaderProps> = ({
                 to={`/users/${encodeURIComponent(user.UserID || String(user.Id))}`}
                 sx={{ textTransform: 'none', flex: 1 }}
               >
-                詳細を開く
+                詳細を表示
               </Button>
             </Stack>
           </>

--- a/src/pages/UserDetailPage.tsx
+++ b/src/pages/UserDetailPage.tsx
@@ -250,7 +250,7 @@ const UserDetailPage: React.FC = () => {
               onClick={() => navigate(`/users?tab=list&selected=${encodeURIComponent(userCode)}`)}
               data-testid="user-detail-open-full"
             >
-              詳細を開く
+              一覧を表示
             </Button>
           </Stack>
           {/* Attendance info */}


### PR DESCRIPTION
## 概要
- 利用者詳細ハブ（UserDetailPage.tsx）およびヘッダーコンポーネントにおけるナビゲーションボタンのラベルを「詳細を開く」から「一覧を表示」および「詳細を表示」に変更しました。
- UIのラベルを標準化し、利用者のリストや詳細画面への遷移であることが直感的に伝わるように改善しました。