### PR TITLE
fix(debug): unify VITE_AUDIT_DEBUG truthy parsing via isDebugFlag

### DIFF
--- a/src/auth/useAuth.ts
+++ b/src/auth/useAuth.ts
@@ -1,6 +1,8 @@
 
 import type { IPublicClientApplication } from '@azure/msal-browser';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { isDebugFlag } from '../lib/debugFlag';
+import { auditLog } from '../lib/debugLogger';
 import { getAppConfig, isE2eMsalMockEnabled, shouldSkipLogin } from '../lib/env';
 import { clearRuntimeListReady } from '../lib/listReadyRuntime';
 import { createE2EMsalAccount, persistMsalToken } from '../lib/msal';
@@ -30,9 +32,9 @@ const NOOP_SIGN_OUT = () => Promise.resolve();
 const NOOP_ACQUIRE_TOKEN = () => Promise.resolve(null as string | null);
 
 const authConfig = getAppConfig();
-const debugEnabled = authConfig.VITE_AUDIT_DEBUG === '1' || authConfig.VITE_AUDIT_DEBUG === 'true';
+const debugEnabled = isDebugFlag(authConfig.VITE_AUDIT_DEBUG);
 function debugLog(...args: unknown[]) {
-  if (debugEnabled) console.debug('[auth]', ...args);
+  auditLog.debug('auth', '[auth]', ...args);
 }
 
 type BasicAccountInfo = {
@@ -52,7 +54,7 @@ const ensureActiveAccount = (instance: IPublicClientApplication) => {
       account = firstAccount;
       if (authConfig.isDev) {
         const accountLabel = firstAccount.username ?? firstAccount.homeAccountId ?? '(unknown account)';
-        console.info('[MSAL] Active account auto-set:', accountLabel);
+        auditLog.debug('auth', '[MSAL] Active account auto-set:', accountLabel);
       }
     }
   }
@@ -217,9 +219,7 @@ export const useAuth = () => {
     const allAccounts = current.instance.getAllAccounts() as BasicAccountInfo[];
     const activeAccount = ensureActiveAccount(current.instance) ?? (allAccounts[0] as BasicAccountInfo | undefined) ?? null;
     if (!activeAccount) {
-      if (debugEnabled) {
-        console.log('[auth-skip] acquireToken skipped: no active account (user likely not logged in)');
-      }
+      auditLog.debug('auth', '[auth-skip] acquireToken skipped: no active account (user likely not logged in)');
       reportSpHealthEvent({
         severity: 'watch',
         reasonCode: 'sp_auth_failed',
@@ -238,15 +238,13 @@ export const useAuth = () => {
     }
     totalRequestsInWindow += 1;
 
-    // 🔍 Debug logging
-    if (totalRequestsInWindow <= 5 || debugEnabled) {
-      console.log('[auth-debug] acquireToken MSAL call', {
-        callNumber: totalRequestsInWindow,
-        resource: targetResource.slice(-30),
-        inProgress: msalStateRef.current.inProgress,
-        hasAccount: true,
-      });
-    }
+    // 🔍 Debug logging — gated by VITE_AUDIT_DEBUG via auditLog.debug
+    auditLog.debug('auth', '[auth-debug] acquireToken MSAL call', {
+      callNumber: totalRequestsInWindow,
+      resource: targetResource.slice(-30),
+      inProgress: msalStateRef.current.inProgress,
+      hasAccount: true,
+    });
 
     if (totalRequestsInWindow > MAX_REQUESTS_PER_WINDOW) {
       console.warn('[auth] Rate limit exceeded! Throttling token acquisition to break infinite loop.');

--- a/src/components/DataIntegrityAlert.tsx
+++ b/src/components/DataIntegrityAlert.tsx
@@ -1,4 +1,5 @@
 import { motionTokens } from '@/app/theme';
+import { isDebugFlag } from '@/lib/debugFlag';
 import { env } from '@/lib/env';
 import { translateZodIssue } from '@/lib/zodErrorUtils';
 import CloseIcon from '@mui/icons-material/Close';
@@ -42,7 +43,7 @@ const DataIntegrityAlert: React.FC<DataIntegrityAlertProps> = ({
 }) => {
   const [expanded, setExpanded] = useState(false);
   const [copied, setCopied] = useState(false);
-  const isDebugMode = env.VITE_AUDIT_DEBUG;
+  const isDebugMode = isDebugFlag(env.VITE_AUDIT_DEBUG);
   const issueCount = error.issues.length;
 
   const handleCopy = useCallback(async () => {

--- a/src/features/ibd/analysis/iceberg/SharePointIcebergRepository.ts
+++ b/src/features/ibd/analysis/iceberg/SharePointIcebergRepository.ts
@@ -1,3 +1,4 @@
+import { isDebugFlag } from '@/lib/debugFlag';
 import { getAppConfig } from '@/lib/env';
 import { createSpClient } from '@/lib/spClient';
 import { FIELD_MAP_ICEBERG_ANALYSIS, LIST_CONFIG, ListKeys } from '@/sharepoint/fields';
@@ -84,7 +85,7 @@ async function raiseHttpError(response: Response, _context: { url: string; metho
 
 export async function createIcebergRepository(acquireToken: () => Promise<string | null>, baseUrl: string) {
   const config = getAppConfig();
-  const debugEnabled = config.VITE_AUDIT_DEBUG === '1' || config.VITE_AUDIT_DEBUG === 'true';
+  const debugEnabled = isDebugFlag(config.VITE_AUDIT_DEBUG);
   const dbg = (...args: unknown[]) => {
     if (debugEnabled) console.debug('[IcebergRepository]', ...args);
   };

--- a/src/features/ibd/analysis/pdca/IcebergPdcaPage.tsx
+++ b/src/features/ibd/analysis/pdca/IcebergPdcaPage.tsx
@@ -16,6 +16,7 @@ import { buildSupportPlanMonitoringUrl } from '@/app/links/navigationLinks';
 import { useFeatureFlag } from '@/config/featureFlags';
 import { canAccessDashboardAudience, isDashboardAudience, useAuthStore } from '@/features/auth/store';
 import { useUsersStore } from '@/features/users/store';
+import { isDebugFlag } from '@/lib/debugFlag';
 import { getMsalInstance } from '@/lib/msal';
 import { getEnv } from '@/lib/runtimeEnv';
 import { TESTIDS } from '@/testids';
@@ -252,7 +253,7 @@ export const IcebergPdcaPage: React.FC<IcebergPdcaPageProps> = ({ writeEnabled: 
   const [deleteTarget, setDeleteTarget] = React.useState<IcebergPdcaItem | null>(null);
   const [snackbar, setSnackbar] = React.useState<string | null>(null);
 
-  const debugEnabled = getEnv('VITE_AUDIT_DEBUG') === '1';
+  const debugEnabled = isDebugFlag(getEnv('VITE_AUDIT_DEBUG'));
   if (import.meta.env.DEV && debugEnabled) {
     // eslint-disable-next-line no-console
     console.log('[iceberg-pdca]', {

--- a/src/lib/__tests__/debugFlag.spec.ts
+++ b/src/lib/__tests__/debugFlag.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { isDebugFlag } from '../debugFlag';
+
+describe('isDebugFlag', () => {
+  it.each(['1', 'true', 'yes', 'on'])('returns true for canonical truthy string %s', (value) => {
+    expect(isDebugFlag(value)).toBe(true);
+  });
+
+  it.each(['TRUE', 'True', 'YES', 'On', 'ON'])('is case-insensitive (%s)', (value) => {
+    expect(isDebugFlag(value)).toBe(true);
+  });
+
+  it.each(['  true  ', '\t1\n', ' yes', 'on '])('trims surrounding whitespace (%s)', (value) => {
+    expect(isDebugFlag(value)).toBe(true);
+  });
+
+  it.each(['0', 'false', 'no', 'off', 'enabled', '2', 'banana', ''])(
+    'returns false for non-truthy strings (%s)',
+    (value) => {
+      expect(isDebugFlag(value)).toBe(false);
+    },
+  );
+
+  it('returns false for whitespace-only strings', () => {
+    expect(isDebugFlag('   ')).toBe(false);
+  });
+
+  it('returns false for undefined and null', () => {
+    expect(isDebugFlag(undefined)).toBe(false);
+    expect(isDebugFlag(null)).toBe(false);
+  });
+
+  it('preserves boolean primitives', () => {
+    expect(isDebugFlag(true)).toBe(true);
+    expect(isDebugFlag(false)).toBe(false);
+  });
+
+  it('treats numeric 1 as true and other numbers as false', () => {
+    expect(isDebugFlag(1)).toBe(true);
+    expect(isDebugFlag(0)).toBe(false);
+    expect(isDebugFlag(2)).toBe(false);
+    expect(isDebugFlag(Number.NaN)).toBe(false);
+  });
+
+  it('returns false for objects and arrays', () => {
+    expect(isDebugFlag({})).toBe(false);
+    expect(isDebugFlag([])).toBe(false);
+    expect(isDebugFlag({ value: '1' })).toBe(false);
+  });
+});

--- a/src/lib/debugFlag.ts
+++ b/src/lib/debugFlag.ts
@@ -1,0 +1,16 @@
+const TRUTHY = new Set(['1', 'true', 'yes', 'on']);
+
+/**
+ * Normalize debug-flag-style values across env strings, runtime overrides, and
+ * raw boolean/number primitives. Treats '1' / 'true' / 'yes' / 'on' (case- and
+ * whitespace-insensitive) as enabled. Everything else — including undefined,
+ * empty strings, '0', 'false', and unrelated numbers — is disabled.
+ */
+export const isDebugFlag = (value: unknown): boolean => {
+  if (value === true) return true;
+  if (typeof value === 'number') return value === 1;
+  if (typeof value !== 'string') return false;
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return false;
+  return TRUTHY.has(normalized);
+};

--- a/src/lib/debugLogger.ts
+++ b/src/lib/debugLogger.ts
@@ -1,10 +1,11 @@
+import { isDebugFlag } from '@/lib/debugFlag';
 import { env } from '@/lib/env';
 import { getRuntimeEnv } from '@/lib/env.schema';
 
 type Level = 'debug' | 'info' | 'warn' | 'error';
 
 function log(level: Level, ns: string, ...args: unknown[]) {
-  const isDebugEnabled = String(env.VITE_AUDIT_DEBUG) === 'true';
+  const isDebugEnabled = isDebugFlag(env.VITE_AUDIT_DEBUG);
   const mode = getRuntimeEnv()?.MODE;
   // Allow all levels if VITE_AUDIT_DEBUG is enabled, regardless of mode.
   // Otherwise, only show errors in production.
@@ -18,5 +19,5 @@ export const auditLog = {
   info: (ns: string, ...a: unknown[]) => log('info', ns, ...a),
   warn: (ns: string, ...a: unknown[]) => log('warn', ns, ...a),
   error: (ns: string, ...a: unknown[]) => log('error', ns, ...a),
-  get enabled() { return env.VITE_AUDIT_DEBUG; }
+  get enabled() { return isDebugFlag(env.VITE_AUDIT_DEBUG); }
 };

--- a/src/lib/sp/helpers.ts
+++ b/src/lib/sp/helpers.ts
@@ -4,6 +4,7 @@
  * Consolidated from former helpers.ts + spHelpers.ts.
  * Pure functions for path building, error handling, cache management, etc.
  */
+import { isDebugFlag } from '@/lib/debugFlag';
 import { auditLog } from '@/lib/debugLogger';
 import { getAppConfig } from '@/lib/env';
 export type ResolutionResult<T extends string> = {
@@ -362,7 +363,7 @@ export const raiseHttpError = async (
   } = {},
 ): Promise<never> => {
   const detail = await readErrorPayload(res);
-  const AUDIT_DEBUG = getAppConfig().VITE_AUDIT_DEBUG;
+  const AUDIT_DEBUG = isDebugFlag(getAppConfig().VITE_AUDIT_DEBUG);
   const { quietStatuses, silent } = options.spOptions || {};
 
   // 1. Report to Global Health Store (Realtime Signal)

--- a/src/lib/sp/spFetch.ts
+++ b/src/lib/sp/spFetch.ts
@@ -5,6 +5,7 @@
  * This module exports a factory `createSpFetch` that returns an `spFetch` function.
  */
 
+import { isDebugFlag } from '@/lib/debugFlag';
 import { auditLog } from '@/lib/debugLogger';
 import type { EnvRecord } from '@/lib/env';
 import { isE2eMsalMockEnabled, shouldSkipLogin, skipSharePoint } from '@/lib/env';
@@ -259,7 +260,7 @@ export function createSpFetch(deps: SpFetchDeps) {
     const isE2EWithMsalMock = isE2eMsalMockEnabled(config);
     // VITE_SKIP_SHAREPOINT=1 (skipSharePoint) should always trigger mock, even in E2E
     const shouldMock = skipSharePoint(config) || (!isE2EWithMsalMock && (!baseUrl || baseUrl === '' || shouldSkipLogin(config)));
-    const AUDIT_DEBUG = config.VITE_AUDIT_DEBUG;
+    const AUDIT_DEBUG = isDebugFlag(config.VITE_AUDIT_DEBUG);
 
     if (AUDIT_DEBUG || isE2EWithMsalMock) {
       auditLog.debug('sp:fetch', 'request', {

--- a/src/lib/sp/spListRead.ts
+++ b/src/lib/sp/spListRead.ts
@@ -5,6 +5,7 @@
  * All functions accept `SpFetchFn` + `NormalizePathFn` via closure injection.
  */
 
+import { isDebugFlag } from '@/lib/debugFlag';
 import { auditLog } from '@/lib/debugLogger';
 import { readEnv } from '@/lib/env';
 
@@ -124,7 +125,7 @@ export async function listItems<TRow = JsonRecord>(
   const query = params.toString();
   const initialPath = query ? `${basePath}/items?${query}` : `${basePath}/items`;
 
-  const AUDIT_DEBUG = String(readEnv('VITE_AUDIT_DEBUG', '')) === '1';
+  const AUDIT_DEBUG = isDebugFlag(readEnv('VITE_AUDIT_DEBUG', ''));
   if (AUDIT_DEBUG) {
     auditLog.debug('sp:read', 'list_items_start', { path: initialPath });
   }

--- a/src/lib/sp/spListSchema.ts
+++ b/src/lib/sp/spListSchema.ts
@@ -5,6 +5,7 @@
  * All functions accept `SpFetchFn` via explicit parameter injection.
  */
 
+import { isDebugFlag } from '@/lib/debugFlag';
 import { auditLog } from '@/lib/debugLogger';
 import { readEnv } from '@/lib/env';
 
@@ -141,7 +142,7 @@ export async function getListFieldInternalNames(
   baseUrl: string,
   listTitle: string,
 ): Promise<Set<string>> {
-  const debug = String(readEnv('VITE_AUDIT_DEBUG', '')) === '1';
+  const debug = isDebugFlag(readEnv('VITE_AUDIT_DEBUG', ''));
   const siteUrl = baseUrl;
   const cacheKey = makeFieldsCacheKey(siteUrl, listTitle);
 

--- a/src/lib/spClient.ts
+++ b/src/lib/spClient.ts
@@ -12,6 +12,7 @@
 
 import { useAuth } from '@/auth/useAuth';
 import type { UnifiedResourceEvent } from '@/features/resources/types';
+import { isDebugFlag } from '@/lib/debugFlag';
 import { getAppConfig, readEnv, type EnvRecord } from '@/lib/env';
 import { useMemo } from 'react';
 
@@ -68,7 +69,7 @@ export function createSpClient(
     baseDelay: Number(config.VITE_SP_RETRY_BASE_MS) || 400,
     capDelay: Number(config.VITE_SP_RETRY_MAX_DELAY_MS) || 5000,
   } as const;
-  const debugEnabled = !!config.VITE_AUDIT_DEBUG;
+  const debugEnabled = isDebugFlag(config.VITE_AUDIT_DEBUG);
 
   // ── Path normalizer ──
   const normalizePath = createNormalizePath(envRecord, spSiteLegacy, baseUrl);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,5 @@
 import { clearEnvCache, getRuntimeEnv, isDev } from '@/env';
+import { isDebugFlag } from '@/lib/debugFlag';
 import { guardProdMisconfig } from '@/lib/envGuards';
 import '@/styles/kiosk.css';
 import '@/styles/print.css';
@@ -288,7 +289,7 @@ const run = async (): Promise<void> => {
     finalizeHydrationSpan(completeFirebaseAuth);
   }
 
-  if (hasWindow && window.__ENV__?.VITE_AUDIT_DEBUG === '1') {
+  if (hasWindow && isDebugFlag(window.__ENV__?.VITE_AUDIT_DEBUG)) {
     void Promise.all([import('./lib/spClient'), import('./lib/msal')])
       .then(([{ createSpClient, ensureConfig }, { acquireSpAccessToken }]) => {
         const helper = async ({ path, method = 'GET' }: { path: string; method?: string }) => {

--- a/src/pages/IcebergPdcaPage.tsx
+++ b/src/pages/IcebergPdcaPage.tsx
@@ -1,9 +1,10 @@
 import { IcebergPdcaPage } from '@/features/ibd/analysis/pdca/IcebergPdcaPage';
+import { isDebugFlag } from '@/lib/debugFlag';
 import { getEnv } from '@/lib/runtimeEnv';
 
 const Page = (): JSX.Element => {
   const writeEnabled = getEnv('VITE_WRITE_ENABLED') === '1';
-  const debugEnabled = getEnv('VITE_AUDIT_DEBUG') === '1';
+  const debugEnabled = isDebugFlag(getEnv('VITE_AUDIT_DEBUG'));
   if (debugEnabled) {
     // eslint-disable-next-line no-console
     console.log('[iceberg-pdca/pages] mounted', {


### PR DESCRIPTION
## Summary

Normalizes all `VITE_AUDIT_DEBUG` flag checks across the codebase to use the shared `isDebugFlag()` utility, replacing inconsistent string-based truthy checks (`=== "true"`, `=== "1"`, `!!value`, etc.).

## Changes

- **New module**: `src/lib/debugFlag.ts` — canonical `isDebugFlag(value)` parser accepting `"true"`, `"1"`, `"yes"`, `"on"`, `true`, `1` (case- and whitespace-insensitive)
- **New tests**: `src/lib/__tests__/debugFlag.spec.ts` — full matrix of truthy/falsy inputs
- **Unified consumers**: All modules that previously did ad-hoc `VITE_AUDIT_DEBUG` parsing now delegate to `isDebugFlag()`:
  - `src/lib/debugLogger.ts`
  - `src/lib/sp/helpers.ts`
  - `src/lib/sp/spFetch.ts`
  - `src/lib/sp/spListRead.ts`
  - `src/lib/sp/spListSchema.ts`
  - `src/lib/spClient.ts`
  - `src/main.tsx`
  - `src/auth/useAuth.ts`
  - `src/components/DataIntegrityAlert.tsx`
  - `src/features/ibd/analysis/iceberg/SharePointIcebergRepository.ts`
  - `src/features/ibd/analysis/pdca/IcebergPdcaPage.tsx`
  - `src/pages/IcebergPdcaPage.tsx`

## Scope note

This PR also replaces two pre-existing `console.log` debug statements and one `console.info` / `console.debug` in `src/auth/useAuth.ts` with `auditLog.debug`.

Reason:
- `useAuth.ts` is touched by this PR for `VITE_AUDIT_DEBUG` normalization.
- The pre-push hook enforces `--max-warnings=0` on touched files.
- The cleanup keeps the touched-file lint baseline green and aligns auth debug logging with the shared debug-flag behavior.

## Verification

- [x] `npx eslint --max-warnings=0` passes on all changed files
- [x] `tsc --noEmit` passes
- [x] `debugFlag.spec.ts` covers all edge cases
- [x] Pre-push hook passes without `--no-verify`