### PR TITLE
ci: trim duplicated PR tests and scope deep chromium lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,13 @@ jobs:
         run: |
           set -o pipefail
           echo "Running unit tests..."
-          npm run test:ci 2>&1 | tee /tmp/vitest-ci.log
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "PR lane: running required unit subset (test:ci:required)"
+            npm run test:ci:required 2>&1 | tee /tmp/vitest-ci.log
+          else
+            echo "Push lane: running full unit suite (test:ci)"
+            npm run test:ci 2>&1 | tee /tmp/vitest-ci.log
+          fi
           node scripts/ci/check-act-warnings.mjs /tmp/vitest-ci.log --json --json-output /tmp/act-warnings-ci.json
           echo "✅ Tests completed successfully"
 

--- a/.github/workflows/e2e-deep.yml
+++ b/.github/workflows/e2e-deep.yml
@@ -102,6 +102,17 @@ jobs:
               --project=chromium \
               --reporter=list,junit,html \
               --retries=2
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "PR lane: running schedule/day-focused deep tests only"
+            npx playwright test \
+              tests/e2e/schedule-*.spec.ts \
+              tests/e2e/schedules*.spec.ts \
+              tests/e2e/dashboard-schedule-flow.spec.ts \
+              --config=playwright.config.ts \
+              --project=chromium \
+              --reporter=list,junit,html \
+              --retries=1 \
+              --workers=1
           else
             echo "Running all deep (non-smoke) tests"
             npx playwright test tests/e2e \

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -105,7 +105,13 @@ jobs:
           NODE_OPTIONS: '--max-old-space-size=4096'
         run: |
           set -o pipefail
-          TZ=Asia/Tokyo npm run test:ci 2>&1 | tee /tmp/vitest-smoke.log
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "PR lane: running required unit subset (test:ci:required)"
+            TZ=Asia/Tokyo npm run test:ci:required 2>&1 | tee /tmp/vitest-smoke.log
+          else
+            echo "Non-PR lane: running full unit suite (test:ci)"
+            TZ=Asia/Tokyo npm run test:ci 2>&1 | tee /tmp/vitest-smoke.log
+          fi
           node scripts/ci/check-act-warnings.mjs /tmp/vitest-smoke.log --json --json-output /tmp/act-warnings-smoke.json
       - name: Create/Update act warning regression issue
         if: ${{ failure() }}


### PR DESCRIPTION
## Summary
- avoid duplicate full vitest execution between CI and Smoke lanes on pull requests
- run 	est:ci:required for PR lanes while keeping full suite on non-PR lanes
- scope Deep Tests (Chromium) to schedule/day-focused specs on PRs; keep full deep run for non-PR events

## Why
- TypeCheck & Test and Unit Tests were both running 
pm run test:ci and timing out at 15 minutes
- Deep Tests (Chromium) was running broad 	ests/e2e (298 tests) on PRs and hitting 45-minute timeout

## Validation
- local: 
pm run test:ci:required passed
- local: schedule/day-focused playwright command executed (environment-specific failures remain)