### PR TITLE
ci(smoke): skip all-smoke E2E on pull_request after #1673

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -224,6 +224,7 @@ jobs:
 
       - name: E2E all smoke tests
         id: smoke_all
+        if: github.event_name != 'pull_request'
         env:
           TZ: Asia/Tokyo
           PLAYWRIGHT_BASE_URL: http://127.0.0.1:5173


### PR DESCRIPTION
## 背景\n- 本PRは #1673 で実施した CI 短縮（PR時 timeout 改善）後の追加微調整です。\n- #1670 は MERGED（5c3f965a）、#1673 は MERGED（8349882f）済み。\n\n## 変更内容\n- .github/workflows/smoke.yml の E2E all smoke tests ステップに以下を追加\n  - if: github.event_name != 'pull_request'\n\n## 意図\n- PR時は required / scope 限定の検証を優先し、重い E2E all smoke は nightly または手動実行に寄せます。\n- 品質ゲートを完全に外すのではなく、PR feedback loop の安定化と待ち時間削減が目的です。\n- E2E core smoke tests は引き続き実行されるため、最小限のE2Eゲートは維持されます。\n\n## 検証\n- 
ode scripts/ci/check-node24-workflows.mjs --json-output /tmp/node24-workflow-guard.json（Node24 workflow guard）\n- ローカル ctionlint は未導入のため未実行