### PR TITLE
fix(nightly): suppress MISSING signals when raw URL endpoints are not configured

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -24,7 +24,7 @@ BASE_REF="${BASE_REF:-origin/main}"
 
 # Determine changed JS/TS files compared to base.
 # Exclude files matching .eslintignore patterns (e.g. Legacy/) to avoid ESLint 8 "file ignored" warnings.
-FILES="$(git diff --name-only --diff-filter=ACMR "$BASE_REF...HEAD" -- '*.ts' '*.tsx' '*.js' '*.jsx' | grep -v '/Legacy/' || true)"
+FILES="$(git diff --name-only --diff-filter=ACMR "$BASE_REF...HEAD" -- '*.ts' '*.tsx' '*.js' '*.jsx' | grep -v -E '(^|/)tests/|/Legacy/' || true)"
 
 # If nothing to lint, skip.
 if [ -z "$FILES" ]; then

--- a/scripts/ops/nightly-decision.mjs
+++ b/scripts/ops/nightly-decision.mjs
@@ -665,6 +665,20 @@ function pushReason(list, message, codeList = null, code = null) {
   }
 }
 
+/**
+ * Returns true when an export summary signals "not configured" rather than
+ * a genuine data-quality failure.  Pattern:
+ *   missingInput=true + source.exists=false + source.error=null
+ * This happens when the raw URL env var was never set.
+ */
+function isNotConfiguredMissing(summaryData) {
+  if (!summaryData || typeof summaryData !== 'object') return false;
+  if (summaryData.missingInput !== true) return false;
+  const src = summaryData.source;
+  if (!src || typeof src !== 'object') return false;
+  return src.exists === false && !src.error;
+}
+
 function renderStatus(status) {
   const meta = STATUS_META[status] || STATUS_META.unknown;
   return `${meta.emoji} ${meta.label}`;
@@ -766,20 +780,27 @@ function main() {
     'criticalLists',
     'summary.criticalLists',
   ]) ?? 0;
-  const adminInputMissing = !adminStatus.exists
+  const adminNotConfigured = isNotConfiguredMissing(adminStatus.data);
+  const adminInputMissing = !adminNotConfigured && (
+    !adminStatus.exists
     || !!adminStatus.error
-    || adminStatus.data?.missingInput === true;
+    || adminStatus.data?.missingInput === true
+  );
   const adminStatusValue = adminInputMissing
     ? 'warn'
-    : adminOverall;
+    : adminNotConfigured
+      ? 'unknown'
+      : adminOverall;
   addCheck({
     id: 'admin-status',
     label: '/admin/status',
     status: adminStatus.exists ? adminStatusValue : 'warn',
     value: `overall=${adminOverallRaw || 'n/a'}, fail=${adminFailCount}, warn=${adminWarnCount}`,
-    note: adminInputMissing
-      ? '入力欠損（観測信頼性低下）'
-      : `管理画面診断の要約 / criticalLists=${adminCriticalListCount}`,
+    note: adminNotConfigured
+      ? 'raw URL 未設定（観測スキップ）'
+      : adminInputMissing
+        ? '入力欠損（観測信頼性低下）'
+        : `管理画面診断の要約 / criticalLists=${adminCriticalListCount}`,
   });
   if (adminInputMissing) {
     pushReason(warnReasons, '/admin/status summary が欠損（判定信頼性低下）', warnReasonCodes, 'ADMIN_STATUS_SUMMARY_MISSING');
@@ -1089,9 +1110,12 @@ function main() {
       'summary.repeatedExceptionKeys',
     ]) ?? 0
   );
-  const exceptionInputMissing = !exceptionCenter.exists
+  const exceptionNotConfigured = isNotConfiguredMissing(exceptionCenter.data);
+  const exceptionInputMissing = !exceptionNotConfigured && (
+    !exceptionCenter.exists
     || !!exceptionCenter.error
-    || exceptionCenter.data?.missingInput === true;
+    || exceptionCenter.data?.missingInput === true
+  );
 
   const actionResolveStatus = actionResolveRate === null
     ? 'unknown'
@@ -1179,17 +1203,21 @@ function main() {
       || overdueExceptions >= thresholds.overdueExceptionsWarn
       || exceptionInputMissing
       ? 'warn'
-      : exceptionCenter.exists
-        ? 'pass'
-        : 'unknown';
+      : exceptionNotConfigured
+        ? 'unknown'
+        : exceptionCenter.exists
+          ? 'pass'
+          : 'unknown';
   addCheck({
     id: 'exception-center',
     label: 'Exception Center',
     status: exceptionStatus,
     value: `high=${unresolvedHighSeverity}, overdue=${overdueExceptions}, stale=${staleExceptions}, recurring=${recurringExceptions}`,
-    note: exceptionInputMissing
-      ? '入力欠損（観測信頼性低下）'
-      : '未対応高優先・期限超過・放置・再発の件数',
+    note: exceptionNotConfigured
+      ? 'raw URL 未設定（観測スキップ）'
+      : exceptionInputMissing
+        ? '入力欠損（観測信頼性低下）'
+        : '未対応高優先・期限超過・放置・再発の件数',
   });
   if (exceptionInputMissing) {
     pushReason(warnReasons, 'ExceptionCenter summary が欠損（判定信頼性低下）', warnReasonCodes, 'EXCEPTION_CENTER_SUMMARY_MISSING');

--- a/tests/unit/scripts/nightly-decision.reason-codes.spec.ts
+++ b/tests/unit/scripts/nightly-decision.reason-codes.spec.ts
@@ -458,4 +458,100 @@ describe('nightly-decision reason codes', () => {
       cleanupDates([date, prev1, prev2]);
     }
   });
+
+  it('raw URL 未設定（not configured）の場合は MISSING reason code を発火しない', () => {
+    const date = '2100-01-12';
+    const dir = mkTmpDir();
+    const logPath = path.join(dir, 'nightly.log');
+    const adminSummaryPath = path.join(dir, 'admin-not-configured.json');
+    const exceptionSummaryPath = path.join(dir, 'exception-not-configured.json');
+
+    writeRequiredInputs(date, 'stable');
+    writeFileSync(logPath, '', 'utf8');
+
+    // Simulate export output when raw URL is not configured:
+    // missingInput=true + source.exists=false + source.error=null
+    writeFileSync(adminSummaryPath, JSON.stringify({
+      overall: 'unknown',
+      failCount: 0,
+      warnCount: 0,
+      missingInput: true,
+      source: { path: null, exists: false, error: null },
+    }), 'utf8');
+    writeFileSync(exceptionSummaryPath, JSON.stringify({
+      highSeverityCount: 0,
+      overdueCount: 0,
+      staleExceptionCount: 0,
+      recurringExceptionCount: 0,
+      missingInput: true,
+      source: { path: null, exists: false, error: null },
+    }), 'utf8');
+
+    try {
+      runDecision(date, {
+        ADMIN_STATUS_SUMMARY_PATH: adminSummaryPath,
+        EXCEPTION_CENTER_SUMMARY_PATH: exceptionSummaryPath,
+        LOG_FILE: logPath,
+      });
+
+      const result = readDecision(date);
+      // Should NOT contain MISSING codes
+      expect(result.reasonCodes.warn).not.toEqual(
+        expect.arrayContaining(['ADMIN_STATUS_SUMMARY_MISSING']),
+      );
+      expect(result.reasonCodes.warn).not.toEqual(
+        expect.arrayContaining(['EXCEPTION_CENTER_SUMMARY_MISSING']),
+      );
+      // Should be stable (no warn/fail from these sources)
+      expect(result.final.label).toBe('stable');
+    } finally {
+      cleanupDateArtifacts(date);
+    }
+  });
+
+  it('raw URL 設定済みで fetch 失敗した場合は従来通り MISSING を発火する', () => {
+    const date = '2100-01-13';
+    const dir = mkTmpDir();
+    const logPath = path.join(dir, 'nightly.log');
+    const adminSummaryPath = path.join(dir, 'admin-broken.json');
+    const exceptionSummaryPath = path.join(dir, 'exception-broken.json');
+
+    writeRequiredInputs(date, 'stable');
+    writeFileSync(logPath, '', 'utf8');
+
+    // Simulate export output when raw URL is set but fetch failed:
+    // missingInput=true + source.exists=false + source.error="HTTP 500: ..."
+    writeFileSync(adminSummaryPath, JSON.stringify({
+      overall: 'unknown',
+      failCount: 0,
+      warnCount: 0,
+      missingInput: true,
+      source: { path: '/tmp/admin-raw.json', exists: false, error: 'HTTP 500: Internal Server Error' },
+    }), 'utf8');
+    writeFileSync(exceptionSummaryPath, JSON.stringify({
+      highSeverityCount: 0,
+      overdueCount: 0,
+      staleExceptionCount: 0,
+      recurringExceptionCount: 0,
+      missingInput: true,
+      source: { path: '/tmp/exception-raw.json', exists: false, error: 'HTTP 500: Internal Server Error' },
+    }), 'utf8');
+
+    try {
+      runDecision(date, {
+        ADMIN_STATUS_SUMMARY_PATH: adminSummaryPath,
+        EXCEPTION_CENTER_SUMMARY_PATH: exceptionSummaryPath,
+        LOG_FILE: logPath,
+      });
+
+      const result = readDecision(date);
+      // SHOULD contain MISSING codes because fetch actually failed
+      expect(result.reasonCodes.warn).toEqual(
+        expect.arrayContaining(['ADMIN_STATUS_SUMMARY_MISSING', 'EXCEPTION_CENTER_SUMMARY_MISSING']),
+      );
+      assertReasonCodeActions(result);
+    } finally {
+      cleanupDateArtifacts(date);
+    }
+  });
 });


### PR DESCRIPTION
## Summary

When `ADMIN_STATUS_RAW_URL` / `EXCEPTION_CENTER_RAW_URL` are **not set** in GitHub repository variables, the Nightly Patrol decision engine was firing `ADMIN_STATUS_SUMMARY_MISSING` / `EXCEPTION_CENTER_SUMMARY_MISSING` on every run — accumulating watch-streak escalations and polluting the decision signal.

## Root cause

The 3-stage data pipeline (fetch → export → decision) cascades a "URL not configured" state into `missingInput: true` in the export summary JSON, which the decision engine previously treated identically to a genuine fetch failure.

## Fix

Added `isNotConfiguredMissing()` helper to `nightly-decision.mjs` that distinguishes:
- **Not configured**: `missingInput=true` + `source.exists=false` + `source.error=null` → status = `unknown`, no MISSING signal
- **Actually broken**: `missingInput=true` + `source.error != null` → status = `warn`, MISSING signal fires (preserving the existing behavior)

## Changes

| File | Change |
|------|--------|
| `scripts/ops/nightly-decision.mjs` | Add `isNotConfiguredMissing()`, update admin & exception input checks |
| `tests/unit/scripts/nightly-decision.reason-codes.spec.ts` | Add 2 test cases: not-configured suppression + broken-fetch fires MISSING |
| `.husky/pre-push` | Exclude `tests/` from eslint diff-check (align with `.eslintignore`) |

## Test results

```
✓ raw URL 未設定（not configured）の場合は MISSING reason code を発火しない
✓ raw URL 設定済みで fetch 失敗した場合は従来通り MISSING を発火する
9 passed (9), 0 failed
```

## Behavior after URL configuration

When `vars.ADMIN_STATUS_RAW_URL` / `vars.EXCEPTION_CENTER_RAW_URL` are eventually set:
- Successful fetch → normal pass/warn/fail flow
- Failed fetch → MISSING signal fires (correctly)