### PR TITLE
fix(planning): dedupe severe-addon and regulatory reads after users load

### DIFF
--- a/src/features/regulatory/__tests__/useRegulatoryRealDataDedupe.spec.tsx
+++ b/src/features/regulatory/__tests__/useRegulatoryRealDataDedupe.spec.tsx
@@ -1,0 +1,111 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useSevereAddonRealData } from '../hooks/useSevereAddonRealData';
+import { useRegulatoryFindingsRealData } from '../hooks/useRegulatoryFindingsRealData';
+import type { PlanningSheetRepository, ProcedureRecordRepository } from '@/domain/isp/port';
+import type { MonitoringMeetingRepository } from '@/domain/isp/monitoringMeetingRepository';
+import type { IUserMaster } from '@/sharepoint/fields';
+
+function createPlanningSheetRepo(listCurrentByUser = vi.fn().mockResolvedValue([])): PlanningSheetRepository {
+  return {
+    getById: vi.fn(),
+    listByIsp: vi.fn(),
+    listByUser: vi.fn(),
+    listCurrentByUser,
+    listBySeries: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+  } as unknown as PlanningSheetRepository;
+}
+
+function createMonitoringMeetingRepo(listByUser = vi.fn().mockResolvedValue([])): MonitoringMeetingRepository {
+  return {
+    save: vi.fn(),
+    getAll: vi.fn(),
+    getById: vi.fn(),
+    listByUser,
+    listByIsp: vi.fn(),
+    delete: vi.fn(),
+  };
+}
+
+function createProcedureRecordRepo(): ProcedureRecordRepository {
+  return {
+    getById: vi.fn(),
+    listByPlanningSheet: vi.fn(),
+    listByUserAndDate: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+  } as unknown as ProcedureRecordRepository;
+}
+
+function buildUsers(): IUserMaster[] {
+  return [
+    {
+      Id: 1,
+      UserID: 'U001',
+      FullName: 'テスト利用者',
+      IsActive: true,
+    } as IUserMaster,
+  ];
+}
+
+describe('regulatory real-data hook dedupe', () => {
+  it('does not re-fetch planning sheets in severe-addon hook for identical user key rerenders', async () => {
+    const listCurrentByUser = vi.fn().mockResolvedValue([]);
+    const planningRepo = createPlanningSheetRepo(listCurrentByUser);
+    const users = buildUsers();
+
+    const { rerender } = renderHook(
+      ({ currentUsers }) =>
+        useSevereAddonRealData(currentUsers, [], false, null, planningRepo, null, null),
+      { initialProps: { currentUsers: users } },
+    );
+
+    await waitFor(() => {
+      expect(listCurrentByUser).toHaveBeenCalledTimes(1);
+    });
+
+    rerender({ currentUsers: [...users] });
+
+    await waitFor(() => {
+      expect(listCurrentByUser).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('does not re-fetch planning/monitoring in regulatory hook for identical user key rerenders', async () => {
+    const listCurrentByUser = vi.fn().mockResolvedValue([]);
+    const listByUser = vi.fn().mockResolvedValue([]);
+    const planningRepo = createPlanningSheetRepo(listCurrentByUser);
+    const monitoringRepo = createMonitoringMeetingRepo(listByUser);
+    const procedureRepo = createProcedureRecordRepo();
+    const users = buildUsers();
+
+    const { rerender } = renderHook(
+      ({ currentUsers }) =>
+        useRegulatoryFindingsRealData(
+          currentUsers,
+          [],
+          false,
+          null,
+          planningRepo,
+          procedureRepo,
+          monitoringRepo,
+        ),
+      { initialProps: { currentUsers: users } },
+    );
+
+    await waitFor(() => {
+      expect(listCurrentByUser).toHaveBeenCalledTimes(1);
+      expect(listByUser).toHaveBeenCalledTimes(1);
+    });
+
+    rerender({ currentUsers: [...users] });
+
+    await waitFor(() => {
+      expect(listCurrentByUser).toHaveBeenCalledTimes(1);
+      expect(listByUser).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/features/regulatory/hooks/useRegulatoryFindingsRealData.ts
+++ b/src/features/regulatory/hooks/useRegulatoryFindingsRealData.ts
@@ -16,7 +16,7 @@
  * @see auditChecks.ts — buildRegulatoryFindings
  */
 
-import { useMemo, useEffect, useState, useCallback } from 'react';
+import { useMemo, useEffect, useState, useCallback, useRef } from 'react';
 
 import type { IUserMaster } from '@/sharepoint/fields';
 import type { Staff } from '@/types';
@@ -96,13 +96,31 @@ export function useRegulatoryFindingsRealData(
       .filter(u => u.IsActive !== false)
       .map(u => u.UserID ?? `user-${u.Id}`);
   }, [users, isLoading, error]);
+  const activeUserIdsKey = useMemo(() => activeUserIds.join('|'), [activeUserIds]);
+  const planningFetchStateRef = useRef<{ inFlightKey: string | null; completedKey: string | null }>({
+    inFlightKey: null,
+    completedKey: null,
+  });
+  const meetingFetchStateRef = useRef<{ inFlightKey: string | null; completedKey: string | null }>({
+    inFlightKey: null,
+    completedKey: null,
+  });
 
   // ── Phase 1: PlanningSheet 取得 ──
   const fetchPlanningSheets = useCallback(async () => {
     if (!planningSheetRepo || activeUserIds.length === 0) {
       setSheetsByUser(new Map());
+      planningFetchStateRef.current = { inFlightKey: null, completedKey: null };
       return;
     }
+    const requestKey = activeUserIdsKey;
+    if (
+      planningFetchStateRef.current.inFlightKey === requestKey ||
+      planningFetchStateRef.current.completedKey === requestKey
+    ) {
+      return;
+    }
+    planningFetchStateRef.current.inFlightKey = requestKey;
 
     setSheetsLoading(true);
     setSheetsError(null);
@@ -122,14 +140,19 @@ export function useRegulatoryFindingsRealData(
 
       await Promise.all(promises);
       setSheetsByUser(results);
+      planningFetchStateRef.current.completedKey = requestKey;
     } catch (err) {
       const e = err instanceof Error ? err : new Error(String(err));
       setSheetsError(e);
       console.warn('[useRegulatoryFindingsRealData] PlanningSheet fetch failed:', e.message);
+      planningFetchStateRef.current.completedKey = null;
     } finally {
+      if (planningFetchStateRef.current.inFlightKey === requestKey) {
+        planningFetchStateRef.current.inFlightKey = null;
+      }
       setSheetsLoading(false);
     }
-  }, [planningSheetRepo, activeUserIds]);
+  }, [planningSheetRepo, activeUserIds, activeUserIdsKey]);
 
   useEffect(() => {
     fetchPlanningSheets();
@@ -194,8 +217,17 @@ export function useRegulatoryFindingsRealData(
   const fetchMonitoringMeetings = useCallback(async () => {
     if (!monitoringMeetingRepo || activeUserIds.length === 0) {
       setMeetingsByUser(new Map());
+      meetingFetchStateRef.current = { inFlightKey: null, completedKey: null };
       return;
     }
+    const requestKey = activeUserIdsKey;
+    if (
+      meetingFetchStateRef.current.inFlightKey === requestKey ||
+      meetingFetchStateRef.current.completedKey === requestKey
+    ) {
+      return;
+    }
+    meetingFetchStateRef.current.inFlightKey = requestKey;
 
     setMeetingsLoading(true);
     try {
@@ -213,10 +245,14 @@ export function useRegulatoryFindingsRealData(
 
       await Promise.all(promises);
       setMeetingsByUser(results);
+      meetingFetchStateRef.current.completedKey = requestKey;
     } finally {
+      if (meetingFetchStateRef.current.inFlightKey === requestKey) {
+        meetingFetchStateRef.current.inFlightKey = null;
+      }
       setMeetingsLoading(false);
     }
-  }, [monitoringMeetingRepo, activeUserIds]);
+  }, [monitoringMeetingRepo, activeUserIds, activeUserIdsKey]);
 
   useEffect(() => {
     fetchMonitoringMeetings();

--- a/src/features/regulatory/hooks/useSevereAddonRealData.ts
+++ b/src/features/regulatory/hooks/useSevereAddonRealData.ts
@@ -37,7 +37,7 @@
  * @see assignmentQualificationChecker.ts — 配置資格判定
  */
 
-import { useMemo, useEffect, useState, useCallback } from 'react';
+import { useMemo, useEffect, useState, useCallback, useRef } from 'react';
 
 import type { IUserMaster } from '@/sharepoint/fields';
 import type { Staff } from '@/types';
@@ -178,12 +178,26 @@ export function useSevereAddonRealData(
       .filter(u => u.IsActive !== false)
       .map(u => u.UserID ?? `user-${u.Id}`);
   }, [users, isLoading, error]);
+  const activeUserIdsKey = useMemo(() => activeUserIds.join('|'), [activeUserIds]);
+  const planningFetchStateRef = useRef<{ inFlightKey: string | null; completedKey: string | null }>({
+    inFlightKey: null,
+    completedKey: null,
+  });
 
   const fetchPlanningSheets = useCallback(async () => {
     if (!planningSheetRepo || activeUserIds.length === 0) {
       setSheetsByUser(new Map());
+      planningFetchStateRef.current = { inFlightKey: null, completedKey: null };
       return;
     }
+    const requestKey = activeUserIdsKey;
+    if (
+      planningFetchStateRef.current.inFlightKey === requestKey ||
+      planningFetchStateRef.current.completedKey === requestKey
+    ) {
+      return;
+    }
+    planningFetchStateRef.current.inFlightKey = requestKey;
 
     setSheetsLoading(true);
     setSheetsError(null);
@@ -206,14 +220,19 @@ export function useSevereAddonRealData(
 
       await Promise.all(promises);
       setSheetsByUser(results);
+      planningFetchStateRef.current.completedKey = requestKey;
     } catch (err) {
       const e = err instanceof Error ? err : new Error(String(err));
       setSheetsError(e);
       console.warn('[useSevereAddonRealData] PlanningSheet fetch failed:', e.message);
+      planningFetchStateRef.current.completedKey = null;
     } finally {
+      if (planningFetchStateRef.current.inFlightKey === requestKey) {
+        planningFetchStateRef.current.inFlightKey = null;
+      }
       setSheetsLoading(false);
     }
-  }, [planningSheetRepo, activeUserIds]);
+  }, [planningSheetRepo, activeUserIds, activeUserIdsKey]);
 
   useEffect(() => {
     fetchPlanningSheets();


### PR DESCRIPTION
## Summary
- Addresses #1657 by deduping repeated SharePoint reads triggered after users load updates.
- Keeps fail-open behavior while reducing telemetry noise from repeated identical reads.

## What changed
- `useSevereAddonRealData`
  - Added user-key based request dedupe for PlanningSheet fetch (`inFlight` + `completed` key guard).
- `useRegulatoryFindingsRealData`
  - Added the same dedupe guard for PlanningSheet fetch.
  - Added the same dedupe guard for MonitoringMeetings fetch.
- Added regression tests:
  - `src/features/regulatory/__tests__/useRegulatoryRealDataDedupe.spec.tsx`
  - Verifies identical-user rerenders do not trigger repeated fetches for:
    - severe-addon PlanningSheet reads
    - regulatory PlanningSheet / MonitoringMeeting reads

## Why this approach
- Prioritized minimal hook-level stabilization (stable user-key + dedupe) before repository-level cache.
- Avoids broad behavior changes while directly targeting repeated same-condition reads.

## Validation
- `npx vitest run src/features/regulatory/__tests__/useRegulatoryRealDataDedupe.spec.tsx`
- `npx vitest run src/domain/regulatory/__tests__/auditCheckInputBuilder.spec.ts`
- `npm run typecheck`
- `npm run lint` (existing warning-only baseline)

## Acceptance criteria mapping
- Repeated identical `SupportPlanningSheet_Master` / `MonitoringMeetings` reads are deduped at hook layer after users load.
- severe-addon / regulatory UI behavior is preserved (no functional logic changes to findings generation).
- fail-open behavior remains (errors still handled and fallback paths unchanged).

Closes #1657
