### PR TITLE
fix(sp): clean up UserBenefit accepted aliases

### DIFF
--- a/docs/nightly-patrol/userbenefit-drift-classification.md
+++ b/docs/nightly-patrol/userbenefit-drift-classification.md
@@ -32,9 +32,9 @@ Related: #1632
 | DisabilitySupportLevel | optional_missing | optional_missing_or_provision_candidate | Missing in SharePoint | Provision |
 | GrantedDaysPerMonth | optional_missing | optional_missing_or_provision_candidate | Missing in SharePoint | Provision |
 | LinkTitle2 | zombie_candidate (usage: 0) | zombie_cleanup_candidate | SharePoint internal | Purge |
-| SelectTitle | zombie_candidate (usage: 1) | accepted_alias | System field | Review usage |
-| Last_x0020_Modified | zombie_candidate (usage: 1) | accepted_alias | System field | Review usage |
-| Created_x0020_Date | zombie_candidate (usage: 1) | accepted_alias | System field | Review usage |
+| SelectTitle | zombie_candidate (usage: 1) | ignored_system | SharePoint computed system field (`SP_SYSTEM_FIELDS`) | Ignore in drift decisions |
+| Last_x0020_Modified | zombie_candidate (usage: 1) | ignored_system | SharePoint computed system field (`SP_SYSTEM_FIELDS`) | Ignore in drift decisions |
+| Created_x0020_Date | zombie_candidate (usage: 1) | ignored_system | SharePoint computed system field (`SP_SYSTEM_FIELDS`) | Ignore in drift decisions |
 | FSObjType | zombie_candidate (usage: 1) | accepted_alias | System field | None |
 | PermMask | zombie_candidate (usage: 0) | zombie_cleanup_candidate | System field | Purge |
 | PrincipalCount | zombie_candidate (usage: 0) | zombie_cleanup_candidate | System field | Purge |
@@ -52,13 +52,13 @@ Related: #1632
 |---|---|---|---|---|
 | Title | fuzzy_match (usage: 412) | canonical | Mapped to UserID in registry | None |
 | Recipient_x0020_Cert_x0020_Numbe | fuzzy_match (usage: 0) | accepted_alias | Mapped to RecipientCertNumber | Maintain mapping |
-| UserID | zombie_candidate (usage: 399) | accepted_alias | Redundant UserID column (Title is canonical) | Verify usage in Ext context |
+| UserID | zombie_candidate (usage: 399) | accepted_alias | Backward-compatible alias for ext join key (canonical is Title) | Keep as accepted alias |
 | Recipient_x0020_Cert_x0020_Expir | zombie_candidate (usage: 0) | zombie_cleanup_candidate | No data, no usage | Purge |
 | Disability_x0020_Support_x0020_L | zombie_candidate (usage: 0) | zombie_cleanup_candidate | No data, no usage | Purge |
 | LinkTitle2 | zombie_candidate (usage: 0) | zombie_cleanup_candidate | System field | Purge |
-| SelectTitle | zombie_candidate (usage: 1) | accepted_alias | System field | None |
-| Last_x0020_Modified | zombie_candidate (usage: 1) | accepted_alias | System field | None |
-| Created_x0020_Date | zombie_candidate (usage: 1) | accepted_alias | System field | None |
+| SelectTitle | zombie_candidate (usage: 1) | ignored_system | SharePoint computed system field (`SP_SYSTEM_FIELDS`) | Ignore in drift decisions |
+| Last_x0020_Modified | zombie_candidate (usage: 1) | ignored_system | SharePoint computed system field (`SP_SYSTEM_FIELDS`) | Ignore in drift decisions |
+| Created_x0020_Date | zombie_candidate (usage: 1) | ignored_system | SharePoint computed system field (`SP_SYSTEM_FIELDS`) | Ignore in drift decisions |
 | FSObjType | zombie_candidate (usage: 1) | accepted_alias | System field | None |
 | PermMask | zombie_candidate (usage: 0) | zombie_cleanup_candidate | System field | Purge |
 | PrincipalCount | zombie_candidate (usage: 0) | zombie_cleanup_candidate | System field | Purge |

--- a/src/sharepoint/fields/__tests__/userBenefitProfileExtFields.drift.spec.ts
+++ b/src/sharepoint/fields/__tests__/userBenefitProfileExtFields.drift.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { areEssentialFieldsResolved, resolveInternalNamesDetailed } from '@/lib/sp/helpers';
+import {
+  USER_BENEFIT_PROFILE_EXT_CANDIDATES,
+  USER_BENEFIT_PROFILE_EXT_ESSENTIALS,
+} from '../userFields';
+
+const cands = USER_BENEFIT_PROFILE_EXT_CANDIDATES as unknown as Record<string, string[]>;
+const essentials = USER_BENEFIT_PROFILE_EXT_ESSENTIALS as unknown as string[];
+
+function resolve(available: Set<string>) {
+  return resolveInternalNamesDetailed(available, cands);
+}
+
+describe('USER_BENEFIT_PROFILE_EXT_CANDIDATES userId resolution', () => {
+  it('treats Title as canonical for userId in ext list', () => {
+    const { resolved, fieldStatus } = resolve(new Set(['Title', 'RecipientCertNumber']));
+    expect(resolved.userId).toBe('Title');
+    expect(fieldStatus.userId.isDrifted).toBe(false);
+  });
+
+  it('keeps UserID as accepted alias (drift)', () => {
+    const { resolved, fieldStatus } = resolve(new Set(['UserID', 'RecipientCertNumber']));
+    expect(resolved.userId).toBe('UserID');
+    expect(fieldStatus.userId.isDrifted).toBe(true);
+  });
+
+  it('is healthy when userId and recipient cert are resolved', () => {
+    const { resolved } = resolve(new Set(['Title', 'RecipientCertNumber']));
+    expect(areEssentialFieldsResolved(resolved as Record<string, string | undefined>, essentials)).toBe(true);
+  });
+});

--- a/src/sharepoint/fields/__tests__/userBenefitProfileFields.drift.spec.ts
+++ b/src/sharepoint/fields/__tests__/userBenefitProfileFields.drift.spec.ts
@@ -36,7 +36,7 @@ function isHealthy(resolved: ReturnType<typeof resolve>['resolved']) {
 
 describe('USER_BENEFIT_PROFILE_CANDIDATES — 標準名', () => {
   const available = new Set([
-    'Id', 'Title', 'userId', 'RecipientCertNumber', 'RecipientCertExpiry',
+    'Id', 'Title', 'UserID', 'RecipientCertNumber', 'RecipientCertExpiry',
     'GrantMunicipality', 'GrantPeriodStart', 'GrantPeriodEnd',
     'DisabilitySupportLevel', 'GrantedDaysPerMonth', 'UserCopayLimit',
     'MealAddition', 'CopayPaymentMethod',
@@ -44,16 +44,14 @@ describe('USER_BENEFIT_PROFILE_CANDIDATES — 標準名', () => {
 
   it('必須 2 フィールドがすべて解決される', () => {
     const { resolved, missing } = resolve(available);
-    expect(resolved.userId).toBe('userId');
+    expect(resolved.userId).toBe('Title');
     expect(resolved.recipientCertNumber).toBe('RecipientCertNumber');
     expect(missing).toHaveLength(0);
   });
 
   it('drift フラグが false（完全一致）', () => {
     const { fieldStatus } = resolve(available);
-    // SSOT (userFields.ts) では依然として UserID が基準のため、userId (小文字) は現状 drift (true) となる。
-    // Acceptance check 優先のため、green になるよう期待値を調整。
-    expect(fieldStatus.userId.isDrifted).toBe(true);
+    expect(fieldStatus.userId.isDrifted).toBe(false);
     expect(fieldStatus.recipientCertNumber.isDrifted).toBe(false);
   });
 

--- a/src/sharepoint/fields/userFields.ts
+++ b/src/sharepoint/fields/userFields.ts
@@ -181,6 +181,7 @@ const CANDIDATE_GRANTED_DAYS_PER_MONTH = ['GrantedDaysPerMonth', 'DaysPerMonth',
 const CANDIDATE_USER_COPAY_LIMIT = ['UserCopayLimit', 'CopayLimit', 'UserCopayLimit0', 'cr013_userCopayLimit'];
 const CANDIDATE_MEAL_ADDITION = ['MealAddition', 'Meal', 'MealAddition0', 'cr013_mealAddition'];
 const CANDIDATE_COPAY_PAYMENT_METHOD = ['CopayPaymentMethod', 'PaymentMethod', 'CopayPaymentMethod0', 'cr013_copayPaymentMethod'];
+const CANDIDATE_USER_BENEFIT_USER_ID = ['Title', ...CANDIDATE_USER_ID];
 
 /**
  * Users_Master リストのフィールド解除候補マップ (Drift Resistance)
@@ -356,7 +357,7 @@ export function resolveUserSelectFields(mode: UserSelectMode = 'core'): readonly
  * essentialFields (registry): ['UserID', 'RecipientCertNumber']
  */
 export const USER_BENEFIT_PROFILE_CANDIDATES = {
-  userId: [...CANDIDATE_USER_ID, 'Title'],
+  userId: CANDIDATE_USER_BENEFIT_USER_ID,
   recipientCertNumber: CANDIDATE_RECIPIENT_CERT_NUMBER,
   recipientCertExpiry: CANDIDATE_RECIPIENT_CERT_EXPIRY,
   grantMunicipality: CANDIDATE_GRANT_MUNICIPALITY,
@@ -399,7 +400,7 @@ export const USER_TRANSPORT_SETTINGS_ESSENTIALS: (keyof typeof USER_TRANSPORT_SE
 
 // ── User Benefit Profile EXT (user_benefit_profile_ext) ──
 export const USER_BENEFIT_PROFILE_EXT_CANDIDATES = {
-  userId: [...CANDIDATE_USER_ID, 'Title'],
+  userId: CANDIDATE_USER_BENEFIT_USER_ID,
   recipientCertNumber: CANDIDATE_RECIPIENT_CERT_NUMBER,
 } as const;
 

--- a/src/sharepoint/spListRegistry.definitions.ts
+++ b/src/sharepoint/spListRegistry.definitions.ts
@@ -85,7 +85,7 @@ export const masterListEntries: readonly SpListEntry[] = [
       'UserID'
     ],
     provisioningFields: [
-      { internalName: 'UserID', type: 'Text', displayName: 'User ID', required: true, indexed: true, isSilent: true, candidates: ['UserID', 'Title'] },
+      { internalName: 'UserID', type: 'Text', displayName: 'User ID', required: true, indexed: true, isSilent: true, candidates: ['Title', 'UserID'] },
       // RecipientCertNumber moved to _Ext to avoid 8KB limit
       { internalName: 'RecipientCertExpiry', type: 'DateTime', displayName: 'Recipient Cert Expiry', dateTimeFormat: 'DateOnly', isSilent: true },
       { internalName: 'GrantMunicipality', type: 'Text', displayName: 'Grant Municipality', isSilent: true, candidates: ['GrantMunicipality', 'Grant_x0020_Municipality'] },
@@ -109,7 +109,7 @@ export const masterListEntries: readonly SpListEntry[] = [
       'UserID', 'RecipientCertNumber'
     ],
     provisioningFields: [
-      { internalName: 'UserID', type: 'Text', displayName: 'User ID', required: true, indexed: true, candidates: ['UserID', 'Title'] },
+      { internalName: 'UserID', type: 'Text', displayName: 'User ID', required: true, indexed: true, candidates: ['Title', 'UserID'] },
       { internalName: 'RecipientCertNumber', type: 'Text', displayName: 'Recipient Cert Number', required: true, isSilent: true, candidates: ['RecipientCertNumber', 'RecipientCertNumber0', 'Recipient_x0020_Cert_x0020_Numbe'] },
     ],
   },


### PR DESCRIPTION
## Summary
- harden UserBenefit user-id mapping by making Title canonical for user_benefit_profile / _ext
- keep UserID as backward-compatible accepted alias (no destructive SharePoint ops)
- reclassify SelectTitle / Last_x0020_Modified / Created_x0020_Date as ignored SharePoint system fields in drift classification docs
- add drift regression test for USER_BENEFIT_PROFILE_EXT_CANDIDATES

## Scope
- code-only cleanup (mapping / registry / drift classification / tests)
- no SharePoint schema mutation, purge, or provisioning behavior change

## Validation
- npm run -s test -- src/sharepoint/fields/__tests__/userBenefitProfileFields.drift.spec.ts src/sharepoint/fields/__tests__/userBenefitProfileExtFields.drift.spec.ts src/sharepoint/fields/__tests__/userFields.ssot.drift.spec.ts ✅
- npm run -s typecheck ✅
- npm run -s lint ✅ (existing warnings only)

Closes #1652
