### PR TITLE
chore(sp): provision UserBenefit optional fields

### DIFF
--- a/provision/schema.userbenefit.optional.json
+++ b/provision/schema.userbenefit.optional.json
@@ -1,0 +1,27 @@
+{
+  "lists": [
+    {
+      "title": "UserBenefit_Profile",
+      "fields": [
+        {
+          "displayName": "RecipientCertExpiry",
+          "internalName": "RecipientCertExpiry",
+          "type": "DateTime",
+          "required": false
+        },
+        {
+          "displayName": "DisabilitySupportLevel",
+          "internalName": "DisabilitySupportLevel",
+          "type": "Text",
+          "required": false
+        },
+        {
+          "displayName": "GrantedDaysPerMonth",
+          "internalName": "GrantedDaysPerMonth",
+          "type": "Text",
+          "required": false
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/provision-spo.ps1
+++ b/scripts/provision-spo.ps1
@@ -71,14 +71,14 @@ function EnsureList {
     $msg = "Recreate list: $Title (delete & create)"
     if ($WhatIfMode) { LogChange $msg; return }
     LogChange $msg
-  Remove-PnPList -Identity $Title -Force -WhatIf:$WhatIfMode.IsPresent
+  Remove-PnPList -Identity $Title -Force
     $list = $null
   }
   if (-not $list) {
     $msg = "Create list: $Title"
     if ($WhatIfMode) { LogChange $msg; return }
     LogChange $msg
-  New-PnPList -Title $Title -Template GenericList -OnQuickLaunch -WhatIf:$WhatIfMode.IsPresent | Out-Null
+  New-PnPList -Title $Title -Template GenericList -OnQuickLaunch | Out-Null
   } else {
     LogChange ("List exists: {0}" -f $Title)
   }
@@ -110,7 +110,7 @@ function EnsureLookupField {
     LogChange $msg
     $multiAttr = if ($AllowMultiple) { 'TRUE' } else { 'FALSE' }
     $xml = "<Field Type='Lookup' DisplayName='$DisplayName' Required='FALSE' EnforceUniqueValues='FALSE' List='$LookupListTitle' ShowField='$LookupField' StaticName='$InternalName' Name='$InternalName' AllowMultipleValues='$multiAttr' />"
-  Add-PnPFieldFromXml -List $ListTitle -FieldXml $xml -AddToDefaultView:$AddToDefaultView.IsPresent -WhatIf:$WhatIfMode.IsPresent | Out-Null
+  Add-PnPFieldFromXml -List $ListTitle -FieldXml $xml -AddToDefaultView:$AddToDefaultView.IsPresent | Out-Null
     return
   }
   if ($existingType -ne 'Lookup') {
@@ -120,7 +120,7 @@ function EnsureLookupField {
       if ($WhatIfMode) { LogChange ("    - Replacement: {0} (Lookup)" -f $newName); return }
       $multiAttr = if ($AllowMultiple) { 'TRUE' } else { 'FALSE' }
       $xml = "<Field Type='Lookup' DisplayName='$DisplayName' List='$LookupListTitle' ShowField='$LookupField' StaticName='$newName' Name='$newName' AllowMultipleValues='$multiAttr' />"
-  Add-PnPFieldFromXml -List $ListTitle -FieldXml $xml -AddToDefaultView:$AddToDefaultView.IsPresent -WhatIf:$WhatIfMode.IsPresent | Out-Null
+  Add-PnPFieldFromXml -List $ListTitle -FieldXml $xml -AddToDefaultView:$AddToDefaultView.IsPresent | Out-Null
       LogChange ("    - Replacement added: {0}" -f $newName)
     } else { LogChange '    - Skipped type change (forceTypeReplace=false)' }
   } else {
@@ -131,7 +131,7 @@ function EnsureLookupField {
         if ($WhatIfMode) { LogChange ("  - Lookup multi enable: {0}" -f $InternalName) }
         else {
           $xml = $f.SchemaXml -replace 'AllowMultipleValues="FALSE"','AllowMultipleValues="TRUE"'
-          Set-PnPField -List $ListTitle -Identity $InternalName -Values @{ SchemaXml = $xml } -WhatIf:$WhatIfMode.IsPresent | Out-Null
+          Set-PnPField -List $ListTitle -Identity $InternalName -Values @{ SchemaXml = $xml } | Out-Null
           LogChange ("  - Lookup multi enabled: {0}" -f $InternalName)
         }
       } elseif (-not $AllowMultiple -and $currentMulti) {
@@ -159,7 +159,7 @@ function EnsureUserField {
     LogChange $msg
     $multiAttr = if ($AllowMultiple) { 'TRUE' } else { 'FALSE' }
     $xml = "<Field Type='User' DisplayName='$DisplayName' List='UserInfo' ShowField='ImnName' StaticName='$InternalName' Name='$InternalName' UserSelectionScope='0' UserSelectionMode='$selectionMode' AllowMultipleValues='$multiAttr' />"
-  Add-PnPFieldFromXml -List $ListTitle -FieldXml $xml -AddToDefaultView:$AddToDefaultView.IsPresent -WhatIf:$WhatIfMode.IsPresent | Out-Null
+  Add-PnPFieldFromXml -List $ListTitle -FieldXml $xml -AddToDefaultView:$AddToDefaultView.IsPresent | Out-Null
     return
   }
   if ($existingType -ne 'User') {
@@ -169,7 +169,7 @@ function EnsureUserField {
       if ($WhatIfMode) { LogChange ("    - Replacement: {0} (User)" -f $newName); return }
       $multiAttr = if ($AllowMultiple) { 'TRUE' } else { 'FALSE' }
       $xml = "<Field Type='User' DisplayName='$DisplayName' StaticName='$newName' Name='$newName' UserSelectionMode='$selectionMode' AllowMultipleValues='$multiAttr' />"
-  Add-PnPFieldFromXml -List $ListTitle -FieldXml $xml -AddToDefaultView:$AddToDefaultView.IsPresent -WhatIf:$WhatIfMode.IsPresent | Out-Null
+  Add-PnPFieldFromXml -List $ListTitle -FieldXml $xml -AddToDefaultView:$AddToDefaultView.IsPresent | Out-Null
       LogChange ("    - Replacement added: {0}" -f $newName)
     } else { LogChange '    - Skipped type change (forceTypeReplace=false)' }
   } else {
@@ -180,7 +180,7 @@ function EnsureUserField {
         if ($WhatIfMode) { LogChange ("  - User multi enable: {0}" -f $InternalName) }
         else {
           $xml = $f.SchemaXml -replace 'AllowMultipleValues="FALSE"','AllowMultipleValues="TRUE"'
-          Set-PnPField -List $ListTitle -Identity $InternalName -Values @{ SchemaXml = $xml } -WhatIf:$WhatIfMode.IsPresent | Out-Null
+          Set-PnPField -List $ListTitle -Identity $InternalName -Values @{ SchemaXml = $xml } | Out-Null
           LogChange ("  - User multi enabled: {0}" -f $InternalName)
         }
       } elseif (-not $AllowMultiple -and $currentMulti) {
@@ -253,7 +253,7 @@ function EnsureField {
     $msg = ("  - Add field: {0} ({1})" -f $InternalName, $Type)
     if ($WhatIfMode) { LogChange $msg; return }
     LogChange $msg
-  Add-PnPField -List $ListTitle -DisplayName $DisplayName -InternalName $InternalName -Type $Type -AddToDefaultView:$AddToDefaultView.IsPresent -WhatIf:$WhatIfMode.IsPresent | Out-Null
+  Add-PnPField -List $ListTitle -DisplayName $DisplayName -InternalName $InternalName -Type $Type -AddToDefaultView:$AddToDefaultView.IsPresent | Out-Null
     return
   }
   if ($existingType -ne $Type) {
@@ -261,12 +261,12 @@ function EnsureField {
     if ($ForceTypeReplace) {
       $newName = "${InternalName}_v2"
       if ($WhatIfMode) { LogChange ("    - Replacement: {0} ({1}) & migrate" -f $newName, $Type); return }
-  Add-PnPField -List $ListTitle -DisplayName $DisplayName -InternalName $newName -Type $Type -AddToDefaultView:$AddToDefaultView.IsPresent -WhatIf:$WhatIfMode.IsPresent | Out-Null
+  Add-PnPField -List $ListTitle -DisplayName $DisplayName -InternalName $newName -Type $Type -AddToDefaultView:$AddToDefaultView.IsPresent | Out-Null
       $items = Get-PnPListItem -List $ListTitle -PageSize 2000
       foreach ($it in $items) {
         $val = $it[$InternalName]
         if ($null -ne $val -and $val -ne '') {
-          Set-PnPListItem -List $ListTitle -Identity $it.Id -Values @{ $newName = $val } -WhatIf:$WhatIfMode.IsPresent | Out-Null
+          Set-PnPListItem -List $ListTitle -Identity $it.Id -Values @{ $newName = $val } | Out-Null
         }
       }
       LogChange ("    - Migration done: {0} -> {1}" -f $InternalName, $newName)


### PR DESCRIPTION
Closes #1651

## Summary
- add a scoped provisioning schema for `UserBenefit_Profile` optional-field rollout only
- provision only these missing optional fields:
  - `RecipientCertExpiry`
  - `DisabilitySupportLevel`
  - `GrantedDaysPerMonth`
- fix provisioning script compatibility by removing unsupported `-WhatIf` passthrough on PnP commands (WhatIf behavior remains guarded by script-level branching)

## Scope / Safety
- no destructive SharePoint operation
- no column deletion/replacement
- no #1650 zombie purge work mixed in this PR

## Validation
- `npm run typecheck` ✅
- `npm run lint` ✅ (existing repo warnings only)
- Workflow dry-run (scoped schema):
  - run `25035668614` succeeded and planned only the 3 target field additions
- Workflow apply (scoped schema):
  - run `25035836436` succeeded
- Post-apply dry-run (scoped schema):
  - run `25035863184` succeeded
  - `changes.json` contains no `Add field` entries (no pending additions)