### PR TITLE
docs(handoff): add timeline touchpoints runbook

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,11 @@
 ## Changes
 - [ ]
 
+## Touchpoints
+- [ ] Yes（該当する touchpoints を更新した）
+- [ ] No（画面仕様変更なし / 更新不要）
+- Updated files: <!-- 例: docs/runbooks/today-ops-touchpoints.md -->
+
 ## Verification
 - [ ] Required checks are green
 - [ ] (If relevant) Smoke E2E passed

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -8,6 +8,7 @@
 - [TodayOpsPage Touchpoints](./today-ops-touchpoints.md)
 - [DailyRecordPage Touchpoints](./daily-record-touchpoints.md)
 - [CallLogPage Touchpoints](./call-log-touchpoints.md)
+- [HandoffTimelinePage Touchpoints](./handoff-touchpoints.md)
 
 ## Template
 
@@ -52,3 +53,4 @@
 - 新しい touchpoints を追加するときは `page-touchpoints-template.md` を使う。
 - 1画面につき1ファイルで管理する。
 - 関連PRを必ず記載し、変更履歴を追えるようにする。
+- 画面仕様を変更したPRでは、該当 touchpoints を同PRで更新する。

--- a/docs/runbooks/handoff-touchpoints.md
+++ b/docs/runbooks/handoff-touchpoints.md
@@ -1,0 +1,71 @@
+# HandoffTimelinePage Touchpoints
+
+申し送りタイムライン画面の確認ポイントと修正起点を、運用・開発の両方で共通化する。
+
+## 対象
+
+- HandoffTimelinePage（`/handoff/timeline`）
+
+## 前提
+
+- 日付ナビゲーション（日 / 週 / 月）と date picker
+- Day view の Hero / Priority Queue / フィルタ群
+- 重要度（重要 / 要注意 / 通常）とステータス（未対応 / 対応中 / 対応済）
+- 利用者状態のクイック登録ダイアログ
+
+## 画面で確認する場所
+
+- ヘッダー下の日付ナビ（前後移動 / 今日 / 日週月トグル）
+- Day view の UrgentHandoffHero（最優先1件）
+- HandoffActionQueue（残り要対応の優先キュー）
+- Day view フィルタ（会議モード / 時間帯 / 表示モード / ステータス）
+- 日次サマリー（件数表示、フィルタ中チップ）
+
+## コードで修正する場所
+
+- ページオーケストレーション（日付ナビ・view切替）: `src/pages/HandoffTimelinePage.tsx:45`
+- 日付レンジ切替/日付遷移ハンドラ: `src/pages/HandoffTimelinePage.tsx:52`
+- Day view レンダリングと操作ハンドラ: `src/features/handoff/views/HandoffDayView.tsx:81`
+- Day view state（表示モード/ステータスフィルタ/meeting mode）: `src/features/handoff/hooks/useHandoffDayViewState.ts:85`
+- 重要度グループ化ロジック: `src/features/handoff/domain/groupHandoffsByPriority.ts:49`
+- 最優先1件選出ロジック: `src/features/handoff/domain/resolveNextHandoffAction.ts:50`
+- ステータスフィルタロジック: `src/features/handoff/domain/filterHandoffsByStatus.ts:51`
+- 読み込み/更新アクション境界: `src/features/handoff/useHandoffTimeline.ts:56`
+
+## 変更目的ごとの入口
+
+- 文言だけ直す:
+  - `src/pages/HandoffTimelinePage.tsx:135`
+  - `src/features/handoff/views/HandoffDayView.tsx:145`
+  - `src/features/handoff/domain/filterHandoffsByStatus.ts:24`
+- 並び順/フィルタ条件を直す:
+  - `src/features/handoff/domain/groupHandoffsByPriority.ts:30`
+  - `src/features/handoff/domain/resolveNextHandoffAction.ts:36`
+  - `src/features/handoff/domain/filterHandoffsByStatus.ts:51`
+- 重要度ラベル・表示条件を直す:
+  - `src/features/handoff/domain/groupHandoffsByPriority.ts:32`
+  - `src/features/handoff/domain/resolveNextHandoffAction.ts:30`
+- 状態更新（既読/対応済）導線を直す:
+  - `src/features/handoff/views/HandoffDayView.tsx:118`
+  - `src/features/handoff/useHandoffTimeline.ts:154`
+  - `src/features/handoff/useHandoffTimeline.ts:168`
+- 画面確認だけしたい:
+  - 日付ナビ -> Hero -> Priority Queue -> フィルタ切替 -> サマリー件数確認
+
+## 最短確認手順（30秒）
+
+1. `/handoff/timeline` を開く
+2. `日` 表示で Hero が1件表示されるか確認
+3. ステータスフィルタを `要対応` -> `未対応のみ` -> `すべて` に切り替える
+4. Priority Queue の件数とサマリー件数が連動することを確認
+5. 1件を `対応済` にして Hero/Queue から外れることを確認
+
+## 関連PR
+
+- #1145 Touchpoints テンプレ追加
+- #1148 runbooks 入口 README 追加
+
+## 備考
+
+- HandoffTimelinePage は薄いオーケストレーターで、主要な表示ロジックは DayView と domain 関数に分離されている。
+- 行番号は前後する可能性があるため、`resolveNextHandoffAction` / `groupHandoffsByPriority` / `filterHandoffsByStatus` でも検索する。


### PR DESCRIPTION
## Summary
- Add HandoffTimelinePage touchpoints runbook (`docs/runbooks/handoff-touchpoints.md`)
- Register the handoff touchpoints doc in `docs/runbooks/README.md` index + add a "same-PR update" rule
- Add a Touchpoints checklist section to the PR template

## Why
The Touchpoints runbook series (today-ops, daily-record, call-log, support-planning-sheet) was missing the `/handoff/timeline` page. This salvages the docs-only portion of the abandoned `docs/handoff-touchpoints` branch (which was 1446 commits behind main) and updates all line references to current source.

## Notes
- Docs/PR-template only — no source changes
- All `file:line` references in the runbook were re-verified against current main (e.g. `HandoffTimelinePage.tsx:45 → export default function`, `useHandoffTimeline.ts:154 → const updateHandoffStatus`)
- Old `docs/handoff-touchpoints` branch retained locally as `salvage/docs-handoff-touchpoints`

## Test plan
- [ ] Render `docs/runbooks/handoff-touchpoints.md` in GitHub preview
- [ ] Spot-check that linked file:line locations open the right symbol on `main`
- [ ] Confirm PR template renders with the new "Touchpoints" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)