### PR TITLE
chore(git): ignore cleanup audit artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ sp-telemetry*.backup.json
 lane-assertion-result.json
 .token.local
 artifacts/purge-backups/
+.cleanup-audit/


### PR DESCRIPTION
## Summary
- Add .cleanup-audit/ to .gitignore
- Prevent local cleanup audit backups and branch/stash inventory files from being committed accidentally

## Context
This follows the branch/stash cleanup audit and keeps local audit artifacts out of source control.

## Validation
- .gitignore-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)