### PR TITLE
fix(health): avoid false fatal drift for SharePoint Title field

### DIFF
--- a/src/pages/HealthPage.tsx
+++ b/src/pages/HealthPage.tsx
@@ -352,7 +352,8 @@ function buildListSpecs(): ListSpec[] {
   }));
 
   // 2. Ensure essentials (ID, etc.) are present
-  const essentials = ["Id", "Title", ...essentialSet];
+  const skipTitleEssential = ["user_benefit_profile", "user_benefit_profile_ext", "plan_goals"].includes(entry.key);
+  const essentials = ["Id", ...(skipTitleEssential ? [] : ["Title"]), ...essentialSet];
   const combined: SpFieldSpec[] = [...provisionFields];
 
   for (const name of essentials) {

--- a/src/sharepoint/fields/__tests__/healthEssential.regression.spec.ts
+++ b/src/sharepoint/fields/__tests__/healthEssential.regression.spec.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { USER_BENEFIT_PROFILE_ESSENTIALS, USER_BENEFIT_PROFILE_EXT_ESSENTIALS } from '../userFields';
+import { PLAN_GOAL_ESSENTIALS } from '../planGoalFields';
+
+describe('Health Essential Schema Regression', () => {
+  it('does not treat SharePoint standard Title as fatal key in essential field lists', () => {
+    // これらのリストでは Title は必須契約（fatal）から除外されている必要がある
+    // (HealthPage.tsx の skipTitleEssential ロジックと整合していること)
+    
+    // Note: 定数には 'userId' 等のキーが入っており、'Title' という文字列そのものは入っていないはず
+    expect(USER_BENEFIT_PROFILE_ESSENTIALS).not.toContain('Title');
+    expect(USER_BENEFIT_PROFILE_ESSENTIALS).not.toContain('title');
+    
+    expect(USER_BENEFIT_PROFILE_EXT_ESSENTIALS).not.toContain('Title');
+    expect(USER_BENEFIT_PROFILE_EXT_ESSENTIALS).not.toContain('title');
+    
+    expect(PLAN_GOAL_ESSENTIALS).not.toContain('Title');
+    expect(PLAN_GOAL_ESSENTIALS).not.toContain('title');
+  });
+
+  it('should have userId as essential for benefit lists (but Title is a fallback, not the key)', () => {
+    expect(USER_BENEFIT_PROFILE_ESSENTIALS).toContain('userId');
+    expect(USER_BENEFIT_PROFILE_EXT_ESSENTIALS).toContain('userId');
+  });
+});

--- a/src/sharepoint/fields/__tests__/userBenefitProfileExtFields.drift.spec.ts
+++ b/src/sharepoint/fields/__tests__/userBenefitProfileExtFields.drift.spec.ts
@@ -13,20 +13,20 @@ function resolve(available: Set<string>) {
 }
 
 describe('USER_BENEFIT_PROFILE_EXT_CANDIDATES userId resolution', () => {
-  it('treats Title as canonical for userId in ext list', () => {
-    const { resolved, fieldStatus } = resolve(new Set(['Title', 'RecipientCertNumber']));
-    expect(resolved.userId).toBe('Title');
+  it('treats UserID as canonical for userId in ext list', () => {
+    const { resolved, fieldStatus } = resolve(new Set(['UserID', 'RecipientCertNumber']));
+    expect(resolved.userId).toBe('UserID');
     expect(fieldStatus.userId.isDrifted).toBe(false);
   });
 
-  it('keeps UserID as accepted alias (drift)', () => {
-    const { resolved, fieldStatus } = resolve(new Set(['UserID', 'RecipientCertNumber']));
-    expect(resolved.userId).toBe('UserID');
+  it('keeps Title as accepted alias (drift)', () => {
+    const { resolved, fieldStatus } = resolve(new Set(['Title', 'RecipientCertNumber']));
+    expect(resolved.userId).toBe('Title');
     expect(fieldStatus.userId.isDrifted).toBe(true);
   });
 
   it('is healthy when userId and recipient cert are resolved', () => {
-    const { resolved } = resolve(new Set(['Title', 'RecipientCertNumber']));
+    const { resolved } = resolve(new Set(['UserID', 'RecipientCertNumber']));
     expect(areEssentialFieldsResolved(resolved as Record<string, string | undefined>, essentials)).toBe(true);
   });
 });

--- a/src/sharepoint/fields/__tests__/userBenefitProfileFields.drift.spec.ts
+++ b/src/sharepoint/fields/__tests__/userBenefitProfileFields.drift.spec.ts
@@ -44,7 +44,7 @@ describe('USER_BENEFIT_PROFILE_CANDIDATES — 標準名', () => {
 
   it('必須 2 フィールドがすべて解決される', () => {
     const { resolved, missing } = resolve(available);
-    expect(resolved.userId).toBe('Title');
+    expect(resolved.userId).toBe('UserID');
     expect(resolved.recipientCertNumber).toBe('RecipientCertNumber');
     expect(missing).toHaveLength(0);
   });

--- a/src/sharepoint/fields/userFields.ts
+++ b/src/sharepoint/fields/userFields.ts
@@ -181,7 +181,7 @@ const CANDIDATE_GRANTED_DAYS_PER_MONTH = ['GrantedDaysPerMonth', 'DaysPerMonth',
 const CANDIDATE_USER_COPAY_LIMIT = ['UserCopayLimit', 'CopayLimit', 'UserCopayLimit0', 'cr013_userCopayLimit'];
 const CANDIDATE_MEAL_ADDITION = ['MealAddition', 'Meal', 'MealAddition0', 'cr013_mealAddition'];
 const CANDIDATE_COPAY_PAYMENT_METHOD = ['CopayPaymentMethod', 'PaymentMethod', 'CopayPaymentMethod0', 'cr013_copayPaymentMethod'];
-const CANDIDATE_USER_BENEFIT_USER_ID = ['Title', ...CANDIDATE_USER_ID];
+const CANDIDATE_USER_BENEFIT_USER_ID = [...CANDIDATE_USER_ID, 'Title'];
 
 /**
  * Users_Master リストのフィールド解除候補マップ (Drift Resistance)

--- a/src/sharepoint/spListRegistry.definitions.ts
+++ b/src/sharepoint/spListRegistry.definitions.ts
@@ -85,7 +85,7 @@ export const masterListEntries: readonly SpListEntry[] = [
       'UserID'
     ],
     provisioningFields: [
-      { internalName: 'UserID', type: 'Text', displayName: 'User ID', required: true, indexed: true, isSilent: true, candidates: ['Title', 'UserID'] },
+      { internalName: 'UserID', type: 'Text', displayName: 'User ID', required: true, indexed: true, isSilent: true, candidates: ['UserID', 'Title'] },
       // RecipientCertNumber moved to _Ext to avoid 8KB limit
       { internalName: 'RecipientCertExpiry', type: 'DateTime', displayName: 'Recipient Cert Expiry', dateTimeFormat: 'DateOnly', isSilent: true },
       { internalName: 'GrantMunicipality', type: 'Text', displayName: 'Grant Municipality', isSilent: true, candidates: ['GrantMunicipality', 'Grant_x0020_Municipality'] },
@@ -109,7 +109,7 @@ export const masterListEntries: readonly SpListEntry[] = [
       'UserID', 'RecipientCertNumber'
     ],
     provisioningFields: [
-      { internalName: 'UserID', type: 'Text', displayName: 'User ID', required: true, indexed: true, candidates: ['Title', 'UserID'] },
+      { internalName: 'UserID', type: 'Text', displayName: 'User ID', required: true, indexed: true, candidates: ['UserID', 'Title'] },
       { internalName: 'RecipientCertNumber', type: 'Text', displayName: 'Recipient Cert Number', required: true, isSilent: true, candidates: ['RecipientCertNumber', 'RecipientCertNumber0', 'Recipient_x0020_Cert_x0020_Numbe'] },
     ],
   },


### PR DESCRIPTION
## Summary
- Stop treating SharePoint standard Title as a fatal app-level essential field for UserBenefit_Profile, UserBenefit_Profile_Ext, and PlanGoal
- Keep UserID resolution preferred over Title fallback
- Add regression coverage for health essentials and benefit profile drift resolution

## Validation
- npm test src/sharepoint/fields/__tests__/userBenefitProfileFields.drift.spec.ts src/sharepoint/fields/__tests__/userBenefitProfileExtFields.drift.spec.ts src/sharepoint/fields/__tests__/healthEssential.regression.spec.ts
- npm run typecheck
- npm run lint

## Expected Result
Iceberg-PDCA environment diagnostics should return PASS 272 / WARN 0 / FAIL 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)