### PR TITLE
fix(actions): unblock UserBenefit zombie purge auth

### DIFF
--- a/.github/workflows/userbenefit-zombie-purge.yml
+++ b/.github/workflows/userbenefit-zombie-purge.yml
@@ -46,7 +46,7 @@ jobs:
           AAD_APP_ID: ${{ secrets.AAD_APP_ID }}
           SPO_CERT_BASE64: ${{ secrets.SPO_CERT_BASE64 }}
           SPO_CERT_PASSWORD: ${{ secrets.SPO_CERT_PASSWORD }}
-          VITE_SP_SITE_URL: ${{ vars.VITE_SP_SITE_URL }}
+          VITE_SP_SITE_URL: ${{ vars.VITE_SP_SITE_URL || secrets.SHAREPOINT_SITE || secrets.SP_SITE_URL }}
         run: |
           test -n "$AAD_TENANT_ID" || (echo "Missing secret: AAD_TENANT_ID" && exit 1)
           test -n "$AAD_APP_ID" || (echo "Missing secret: AAD_APP_ID" && exit 1)
@@ -69,7 +69,7 @@ jobs:
       - name: UserBenefit zombie purge (dry-run)
         if: ${{ inputs.mode == 'dry-run' }}
         env:
-          VITE_SP_SITE_URL: ${{ vars.VITE_SP_SITE_URL }}
+          VITE_SP_SITE_URL: ${{ vars.VITE_SP_SITE_URL || secrets.SHAREPOINT_SITE || secrets.SP_SITE_URL }}
         run: |
           node scripts/ops/purge-userbenefit-zombie-columns.mjs \
             --list "${{ inputs.list }}" \
@@ -78,7 +78,7 @@ jobs:
       - name: UserBenefit zombie purge (execute)
         if: ${{ inputs.mode == 'execute' }}
         env:
-          VITE_SP_SITE_URL: ${{ vars.VITE_SP_SITE_URL }}
+          VITE_SP_SITE_URL: ${{ vars.VITE_SP_SITE_URL || secrets.SHAREPOINT_SITE || secrets.SP_SITE_URL }}
         run: |
           node scripts/ops/purge-userbenefit-zombie-columns.mjs \
             --execute \

--- a/.github/workflows/userbenefit-zombie-purge.yml
+++ b/.github/workflows/userbenefit-zombie-purge.yml
@@ -44,9 +44,27 @@ jobs:
         env:
           AAD_TENANT_ID: ${{ secrets.AAD_TENANT_ID }}
           AAD_APP_ID: ${{ secrets.AAD_APP_ID }}
-          SPO_CLIENT_SECRET: ${{ secrets.SPO_CLIENT_SECRET }}
+          SPO_CERT_BASE64: ${{ secrets.SPO_CERT_BASE64 }}
+          SPO_CERT_PASSWORD: ${{ secrets.SPO_CERT_PASSWORD }}
+          VITE_SP_SITE_URL: ${{ vars.VITE_SP_SITE_URL }}
         run: |
-          npx -y @pnp/cli-microsoft365 login --appId "$AAD_APP_ID" --tenant "$AAD_TENANT_ID" --secret "$SPO_CLIENT_SECRET"
+          test -n "$AAD_TENANT_ID" || (echo "Missing secret: AAD_TENANT_ID" && exit 1)
+          test -n "$AAD_APP_ID" || (echo "Missing secret: AAD_APP_ID" && exit 1)
+          test -n "$SPO_CERT_BASE64" || (echo "Missing secret: SPO_CERT_BASE64" && exit 1)
+          test -n "$SPO_CERT_PASSWORD" || (echo "Missing secret: SPO_CERT_PASSWORD" && exit 1)
+          test -n "$VITE_SP_SITE_URL" || (echo "Missing variable: VITE_SP_SITE_URL" && exit 1)
+
+          npx -y --package @pnp/cli-microsoft365 m365 login \
+            --authType certificate \
+            --appId "$AAD_APP_ID" \
+            --tenant "$AAD_TENANT_ID" \
+            --certificateBase64Encoded "$SPO_CERT_BASE64" \
+            --password "$SPO_CERT_PASSWORD"
+
+          SITE_ORIGIN="$(node -e "console.log(new URL(process.argv[1]).origin)" "$VITE_SP_SITE_URL")"
+          SP_TOKEN="$(npx -y --package @pnp/cli-microsoft365 m365 util accesstoken get --resource "$SITE_ORIGIN" --output text)"
+          echo "::add-mask::$SP_TOKEN"
+          echo "VITE_SP_TOKEN=$SP_TOKEN" >> "$GITHUB_ENV"
 
       - name: UserBenefit zombie purge (dry-run)
         if: ${{ inputs.mode == 'dry-run' }}


### PR DESCRIPTION
## Summary\n- reopen #1650 follow-up: fix auth blocker before execute\n- switch UserBenefit Zombie Purge login to certificate-based M365 auth\n- replace unstable npx invocation with explicit package+binary form\n- mint and export VITE_SP_TOKEN after login for purge script\n- add explicit missing-secret/variable guards for faster diagnostics\n\n## Why\nCurrent dry-run fails before purge execution:\n- SPO_CLIENT_SECRET is not configured in repo/environment secrets\n- login step used an npx form that can fail with \
pm error could not determine executable to run\\n\n## Scope\n- only .github/workflows/userbenefit-zombie-purge.yml auth step changed\n\nRefs #1650