### PR TITLE
fix(health): avoid fatal schema failure for tolerated Title drift

### DIFF
--- a/src/features/diagnostics/health/__tests__/titleEssentialToleration.spec.ts
+++ b/src/features/diagnostics/health/__tests__/titleEssentialToleration.spec.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest';
+import { runHealthChecks } from '../checks';
+import type { HealthContext, ListSpec } from '../types';
+import type { SpAdapter } from '../spAdapter';
+
+describe('Health Checks — Title Essential Toleration', () => {
+  const mockSp: SpAdapter = {
+    getCurrentUser: vi.fn().mockResolvedValue({ id: 1, title: 'Test User' }),
+    getWebTitle: vi.fn().mockResolvedValue('Test Site'),
+    getListByTitle: vi.fn().mockResolvedValue({ id: 'guid', title: 'TestList' }),
+    getFields: vi.fn(),
+    getItemsTop1: vi.fn().mockResolvedValue([]),
+    createItem: vi.fn().mockResolvedValue({ id: 101 }),
+    updateItem: vi.fn().mockResolvedValue(undefined),
+    deleteItem: vi.fn().mockResolvedValue(undefined),
+  };
+
+  const baseCtx: HealthContext = {
+    env: {
+      VITE_SP_RESOURCE: 'https://tenant.sharepoint.com',
+      VITE_MSAL_CLIENT_ID: 'client-id',
+      VITE_MSAL_TENANT_ID: 'tenant-id',
+    },
+    siteUrl: 'https://tenant.sharepoint.com/sites/test',
+    listSpecs: () => [],
+    isProductionLike: true,
+    autonomyLevel: 'F',
+  };
+
+  it('Title のみ missing essential の場合、FAIL にならず WARN になる', async () => {
+    const spec: ListSpec = {
+      key: 'test_list',
+      displayName: 'テストリスト',
+      resolvedTitle: 'TestList',
+      requiredFields: [
+        { internalName: 'Title', isEssential: true, typeHint: 'Text' }
+      ],
+      createItem: {},
+      updateItem: {},
+    };
+
+    // getFields で Title が見つからない状態をシミュレート
+    vi.mocked(mockSp.getFields).mockResolvedValueOnce([]);
+
+    const ctx = { ...baseCtx, listSpecs: () => [spec] };
+    const results = await runHealthChecks(ctx, mockSp);
+
+    const schemaCheck = results.find(r => r.key === 'schema.fields.test_list');
+    expect(schemaCheck?.status).toBe('warn');
+    expect(schemaCheck?.summary).toContain('Title 列が物理列一覧で解決できませんでした');
+  });
+
+  it('Title + 他の essential が missing の場合、FAIL になる', async () => {
+    const spec: ListSpec = {
+      key: 'test_list',
+      displayName: 'テストリスト',
+      resolvedTitle: 'TestList',
+      requiredFields: [
+        { internalName: 'Title', isEssential: true, typeHint: 'Text' },
+        { internalName: 'EssentialField', isEssential: true, typeHint: 'Text' }
+      ],
+      createItem: {},
+      updateItem: {},
+    };
+
+    // どちらも見つからない
+    vi.mocked(mockSp.getFields).mockResolvedValueOnce([]);
+
+    const ctx = { ...baseCtx, listSpecs: () => [spec] };
+    const results = await runHealthChecks(ctx, mockSp);
+
+    const schemaCheck = results.find(r => r.key === 'schema.fields.test_list');
+    expect(schemaCheck?.status).toBe('fail');
+    expect(schemaCheck?.detail).toContain('EssentialField');
+  });
+
+  it('Title 以外の essential が missing の場合、従来通り FAIL になる', async () => {
+    const spec: ListSpec = {
+      key: 'test_list',
+      displayName: 'テストリスト',
+      resolvedTitle: 'TestList',
+      requiredFields: [
+        { internalName: 'EssentialField', isEssential: true, typeHint: 'Text' }
+      ],
+      createItem: {},
+      updateItem: {},
+    };
+
+    // EssentialField が見つからないが、Title は存在する（が必須ではない）
+    vi.mocked(mockSp.getFields).mockResolvedValueOnce([
+      { internalName: 'Title' }
+    ]);
+
+    const ctx = { ...baseCtx, listSpecs: () => [spec] };
+    const results = await runHealthChecks(ctx, mockSp);
+
+    const schemaCheck = results.find(r => r.key === 'schema.fields.test_list');
+    expect(schemaCheck?.status).toBe('fail');
+    expect(schemaCheck?.detail).toContain('EssentialField');
+  });
+});

--- a/src/features/diagnostics/health/checks.ts
+++ b/src/features/diagnostics/health/checks.ts
@@ -131,6 +131,14 @@ async function safeWithRetry<T>(
   return { ok: false, err: "retry loop exited unexpectedly", attempts: maxAttempts };
 }
 
+/**
+ * 実行時に欠落していても致命的エラー（FAIL）とせず、警告（WARN）で済ませる列の判定。
+ * SharePoint の Title 列は既定で存在するが、物理的に解決できない場合でも
+ * repository が動作可能であれば FAIL を抑制する。
+ */
+const isRuntimeToleratedMissingEssential = (internalName: string): boolean =>
+  internalName === 'Title';
+
 export async function runHealthChecks(
   ctx: HealthContext,
   sp: SpAdapter
@@ -425,6 +433,14 @@ async function runListChecks(
     const missingEssential = spec.requiredFields.filter(
       (f) => f.isEssential && missing.includes(f.internalName)
     );
+
+    // ✅ 致命的な欠落（Title 以外）と、許容される欠落（Title のみ）を分離
+    const fatalMissingEssential = missingEssential.filter(
+      (f) => !isRuntimeToleratedMissingEssential(f.internalName)
+    );
+    const titleOnlyEssentialMissing =
+      missingEssential.length > 0 && fatalMissingEssential.length === 0;
+
     const missingOptional = spec.requiredFields.filter(
       (f) => !f.isEssential && !f.isSilent && missing.includes(f.internalName)
     );
@@ -435,25 +451,39 @@ async function runListChecks(
     );
 
     // 4. Report Results
-    if (missingEssential.length > 0) {
+    if (fatalMissingEssential.length > 0) {
       results.push(
         fail({
           key: `schema.fields.${spec.key}`,
           label: `スキーマ構成違反：${spec.displayName}`,
           category: "schema",
           summary: `致命的エラー：アプリ稼働に必須な列が存在しません。システムは正常に稼働できません。`,
-          detail: `以下の必須列が見つかりません: ${missingEssential.map(f => f.internalName).join(", ")}\nインフラ管理者に連絡し、列を追加してください。`,
+          detail: `以下の必須列が見つかりません: ${fatalMissingEssential.map(f => f.internalName).join(", ")}\nインフラ管理者に連絡し、列を追加してください。`,
           evidence: {
             listTitle: spec.resolvedTitle,
-            missing: missingEssential.map(f => f.internalName),
+            missing: fatalMissingEssential.map(f => f.internalName),
           },
           nextActions: [
             {
               kind: "copy",
               label: "インフラ管理者に連絡",
-              value: `リスト「${spec.resolvedTitle}」に必須列が不足しており、システムが異常終了します。不足列: ${missingEssential.map(f => f.internalName).join(", ")}`
+              value: `リスト「${spec.resolvedTitle}」に必須列が不足しており、システムが異常終了します。不足列: ${fatalMissingEssential.map(f => f.internalName).join(", ")}`
             }
           ]
+        })
+      );
+    } else if (titleOnlyEssentialMissing) {
+      results.push(
+        warn({
+          key: `schema.fields.${spec.key}`,
+          label: `スキーマ（Title 欠落）：${spec.displayName}`,
+          category: "schema",
+          summary: `Title 列が物理列一覧で解決できませんでしたが、runtime 必須列ではないため致命的エラーにはしません。`,
+          detail: `SharePoint の Title は既定列として扱われる場合があり、repository が実データを読める構成では FAIL ではなく drift として扱います。`,
+          evidence: {
+            listTitle: spec.resolvedTitle,
+            missing: ["Title"],
+          },
         })
       );
     } else if (drifted.length > 0) {


### PR DESCRIPTION
## Summary
- Avoid fatal health schema failures when only SharePoint Title is missing from essential field resolution
- Preserve FAIL behavior for non-Title essential field drift
- Classify Title-only essential drift as non-fatal so runtime-readable repositories do not block health checks

## Validation
- npm run typecheck
- npm run lint
- npm test -- src/features/diagnostics
- npm test -- src/sharepoint

## Notes
This follows the established contract: if the repository can operate, diagnostics should not mark the app as fatally broken for tolerated SharePoint default-field drift.

### Follow-up
- Replaced unsafe test casts with vi.mocked() to satisfy max-warnings=0 pre-push lint policy.