### PR TITLE
fix(dev): honor local runtime env and avoid SharePoint access in memory mode

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,97 @@
+#############################################
+# Example Environment Configuration
+# Copy to .env and adjust values.
+#############################################
+
+# Required Microsoft Entra / SharePoint settings
+VITE_MSAL_CLIENT_ID=00000000-0000-0000-0000-000000000000
+VITE_MSAL_TENANT_ID=dummy
+VITE_SP_RESOURCE=https://contoso.sharepoint.com
+VITE_SP_SITE_RELATIVE=/sites/Audit
+VITE_SP_SCOPE_DEFAULT=
+
+# Optional Microsoft Entra overrides (HTTPS recommended for local dev)
+# VITE_MSAL_REDIRECT_URI=https://localhost:5173
+VITE_MSAL_REDIRECT_URI=
+VITE_MSAL_AUTHORITY=
+VITE_MSAL_SCOPES=
+VITE_LOGIN_SCOPES=
+VITE_MSAL_LOGIN_SCOPES=
+VITE_RUNTIME_ENV_PATH=/env.runtime.local.json
+
+# Audit + sync tuning (defaults shown)
+VITE_AUDIT_DEBUG=0
+VITE_AUDIT_BATCH_SIZE=
+VITE_AUDIT_RETRY_MAX=
+VITE_AUDIT_RETRY_BASE=
+
+# SharePoint retry controls (defaults match application fallbacks)
+VITE_SP_RETRY_MAX=4
+VITE_SP_RETRY_BASE_MS=400
+VITE_SP_RETRY_MAX_DELAY_MS=5000
+
+# Token refresh threshold (seconds)
+VITE_MSAL_TOKEN_REFRESH_MIN=300
+
+# Auth / demo toggles
+VITE_DEMO_MODE=1
+VITE_SKIP_LOGIN=1
+VITE_SKIP_SHAREPOINT=1
+VITE_E2E_MSAL_MOCK=0
+VITE_WRITE_ENABLED=1
+VITE_ALLOW_WRITE_FALLBACK=0
+VITE_SKIP_ENSURE_SCHEDULE=0
+
+# --- Firebase / Firestore (PDCA persistence) ---
+# Firebase project config (from Firebase Console)
+VITE_FIREBASE_API_KEY=dummy-api-key
+VITE_FIREBASE_AUTH_DOMAIN=dummy-project.firebaseapp.com
+VITE_FIREBASE_PROJECT_ID=dummy-project
+VITE_FIREBASE_APP_ID=1:000000000000:web:0000000000000000000000
+
+# Firestore local emulator (for development without auth/billing)
+VITE_FIRESTORE_USE_EMULATOR=0
+VITE_FIRESTORE_EMULATOR_HOST=localhost
+VITE_FIRESTORE_EMULATOR_PORT=8080
+
+# Firebase Auth emulator (for local dev, disabled by default in production)
+VITE_FIREBASE_AUTH_USE_EMULATOR=0
+VITE_FIREBASE_AUTH_EMULATOR_URL=http://localhost:9099
+
+
+# --- Schedules Feature Flags ---
+VITE_FEATURE_SCHEDULES=0
+VITE_FEATURE_SCHEDULES_CREATE=0
+VITE_FEATURE_SCHEDULES_GRAPH=0
+VITE_FEATURE_SCHEDULE_STAFF_TEXT_COLUMNS=1
+# Optional: display timezone for Graph schedules
+VITE_SCHEDULES_TZ=Asia/Tokyo
+
+# --- Authorization (Entra ID Group IDs) ---
+# Set to Entra group IDs for reception and schedule admin roles.
+# Users in these groups can edit schedules on the Day tab.
+# Week/Timeline/Month tabs are read-only for all users.
+VITE_RECEPTION_GROUP_ID=
+VITE_SCHEDULE_ADMINS_GROUP_ID=
+
+# --- Schedules tuning (optional) ---
+VITE_SCHEDULES_CACHE_TTL=60
+VITE_GRAPH_RETRY_MAX=2
+VITE_GRAPH_RETRY_BASE_MS=300
+VITE_GRAPH_RETRY_CAP_MS=2000
+VITE_SCHEDULES_WEEK_START=1
+
+# Feature flags (other)
+VITE_FEATURE_COMPLIANCE_FORM=0
+VITE_FEATURE_USERS_CRUD=0
+
+# SharePoint list overrides (optional)
+VITE_SP_LIST_SCHEDULES=Schedules
+VITE_SP_LIST_USERS=Users
+VITE_SP_LIST_STAFF=Staff
+VITE_SP_LIST_STAFF_GUID=
+VITE_SP_LIST_ACTIVITY_DIARY=ActivityDiary
+VITE_SP_LIST_DAILY=SupportRecord_Daily
+VITE_SP_LIST_PLAN_GOAL=PlanGoal
+
+# Remove all placeholders (<yourtenant>, <SiteName>, __FILL_ME__) before running.

--- a/public/env.runtime.local.json
+++ b/public/env.runtime.local.json
@@ -1,0 +1,9 @@
+{
+  "MODE": "development",
+  "VITE_SKIP_SHAREPOINT": "1",
+  "VITE_SKIP_LOGIN": "1",
+  "VITE_DEMO_MODE": "1",
+  "VITE_DATA_PROVIDER": "memory",
+  "VITE_FORCE_SHAREPOINT": "0",
+  "VITE_FEATURE_SCHEDULES_SP": "0"
+}

--- a/src/features/monitoring/data/useMonitoringMeetingRepository.ts
+++ b/src/features/monitoring/data/useMonitoringMeetingRepository.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { useDataProvider } from '@/lib/data/useDataProvider';
 import { DataProviderMonitoringMeetingRepository } from './DataProviderMonitoringMeetingRepository';
+import { localMonitoringMeetingRepository } from '@/infra/localStorage/localMonitoringMeetingRepository';
 
 /**
  * useMonitoringMeetingRepository
@@ -9,9 +10,12 @@ import { DataProviderMonitoringMeetingRepository } from './DataProviderMonitorin
  * 実行時 backend (SharePoint / InMemory) の切り替えに自動対応。
  */
 export function useMonitoringMeetingRepository() {
-  const { provider } = useDataProvider();
+  const { provider, type } = useDataProvider();
 
   return useMemo(() => {
+    if (type !== 'sharepoint') {
+      return localMonitoringMeetingRepository;
+    }
     return new DataProviderMonitoringMeetingRepository(provider);
-  }, [provider]);
+  }, [provider, type]);
 }

--- a/src/features/monitoring/repositories/createMonitoringMeetingRepository.ts
+++ b/src/features/monitoring/repositories/createMonitoringMeetingRepository.ts
@@ -7,6 +7,8 @@
 
 import type { MonitoringMeetingRepository } from '@/domain/isp/monitoringMeetingRepository';
 import type { UseSP } from '@/lib/spClient';
+import { useMemo } from 'react';
+import { useDataProvider } from '@/lib/data/useDataProvider';
 import { localMonitoringMeetingRepository } from '@/infra/localStorage/localMonitoringMeetingRepository';
 import { SharePointDataProvider } from '@/lib/sp/spDataProvider';
 import { DataProviderMonitoringMeetingRepository } from '../data/DataProviderMonitoringMeetingRepository';
@@ -27,10 +29,6 @@ export function createMonitoringMeetingRepository(
   const provider = new SharePointDataProvider(options.spClient);
   return new DataProviderMonitoringMeetingRepository(provider);
 }
-
-import { useMemo } from 'react';
-import { useDataProvider } from '@/lib/data/useDataProvider';
-import { localMonitoringMeetingRepository } from '@/infra/localStorage/localMonitoringMeetingRepository';
 
 /**
  * React Hook: MonitoringMeetingRepository を取得する

--- a/src/features/monitoring/repositories/createMonitoringMeetingRepository.ts
+++ b/src/features/monitoring/repositories/createMonitoringMeetingRepository.ts
@@ -29,18 +29,19 @@ export function createMonitoringMeetingRepository(
 }
 
 import { useMemo } from 'react';
-import { useSP } from '@/lib/spClient';
-import { SP_ENABLED } from '@/lib/env';
+import { useDataProvider } from '@/lib/data/useDataProvider';
+import { localMonitoringMeetingRepository } from '@/infra/localStorage/localMonitoringMeetingRepository';
 
 /**
  * React Hook: MonitoringMeetingRepository を取得する
  */
 export function useMonitoringMeetingRepository(): MonitoringMeetingRepository {
-  const spClient = useSP();
+  const { provider, type } = useDataProvider();
   return useMemo(() => {
-    // SharePoint が有効かつクライアントが存在する場合のみ SharePoint モード
-    const mode = (SP_ENABLED && spClient) ? 'sharepoint' : 'local';
-    return createMonitoringMeetingRepository(mode, { spClient });
-  }, [spClient]);
+    if (type !== 'sharepoint') {
+      return localMonitoringMeetingRepository;
+    }
+    return new DataProviderMonitoringMeetingRepository(provider);
+  }, [provider, type]);
 }
 


### PR DESCRIPTION
## Summary
- Add local runtime env path for memory/demo validation
- Define local runtime flags to skip SharePoint access
- Route Monitoring repository selection through DataProvider
- Prevent MonitoringMeetings schema resolution from running in memory mode

## Validation
- Confirmed `[DataProvider] Active backend: memory`
- Confirmed no SharePoint `[audit:sp] http_error`
- Confirmed no MonitoringMeetings schema/self-healing warnings

## Notes
This closes the local-dev issue where runtime env and Monitoring repository selection could still force SharePoint access even when `.env` was configured for memory/demo mode.