### PR TITLE
fix(drift): add minimum select fallback for DriftEventsLog reads

### DIFF
--- a/src/features/diagnostics/drift/infra/SharePointDriftEventRepository.ts
+++ b/src/features/diagnostics/drift/infra/SharePointDriftEventRepository.ts
@@ -521,8 +521,11 @@ export class SharePointDriftEventRepository implements IDriftEventRepository {
         });
 
         // ── Threshold-Safe Query (+ 400 field fallback) ───────────────────────
+        const originalSelect = [...select];
+        const MAX_FIELD_PRUNE_ATTEMPTS = 5;
         let events: DriftEvent[] = [];
-        for (let attempt = 0; attempt < 5; attempt += 1) {
+        let succeeded = false;
+        for (let attempt = 0; attempt < MAX_FIELD_PRUNE_ATTEMPTS; attempt += 1) {
           try {
             events = await this.fetchEventsWithThresholdFallback(
               listTitle,
@@ -533,22 +536,20 @@ export class SharePointDriftEventRepository implements IDriftEventRepository {
               filter,
               signal,
             );
+            succeeded = true;
             break;
           } catch (err) {
             if (!this.isHttp400(err)) {
               throw err;
             }
             const missingField = this.extractMissingFieldFromError(err);
-            if (!missingField) {
-              throw err;
+            if (!missingField || !select.includes(missingField)) {
+              // 列名が抽出できない / select に無い 400 は段階的 prune では救えない。
+              // 最小 select fallback に流す。
+              break;
             }
 
-            const prevLength = select.length;
             select = select.filter((f) => f !== missingField);
-            if (select.length === prevLength) {
-              throw err;
-            }
-
             this.blockedPhysicalFields.add(missingField);
             this.availablePhysicalFields.delete(missingField);
 
@@ -557,7 +558,31 @@ export class SharePointDriftEventRepository implements IDriftEventRepository {
               'DriftEventRepository removed missing field from select and retried.',
               { listTitle, missingField, attempt: attempt + 1 },
             );
+
+            if (select.length === 0) {
+              break;
+            }
           }
+        }
+
+        // ── Minimum select fallback ───────────────────────────────────────────
+        // 段階的 prune で救えなかった場合 (抽出不可 400 / 試行上限到達 / select 空) は、
+        // 最も安定な (Id, Title) のみで 1 度だけ取り直す。失敗時は外側 catch の fail-open へ。
+        if (!succeeded) {
+          events = await this.fetchEventsWithThresholdFallback(
+            listTitle,
+            ['Id', 'Title'],
+            joinAnd(filters) || undefined,
+            'Id',
+            200,
+            filter,
+            signal,
+          );
+          auditLog.warn(
+            'diagnostics:drift',
+            'DriftEventRepository fell back to minimum select (Id,Title).',
+            { listTitle, originalSelect },
+          );
         }
 
         // クライアント側での日付フィルタリング (Threshold 回避のためサーバー側では行わない)

--- a/src/features/diagnostics/drift/infra/__tests__/SharePointDriftEventRepository.spec.ts
+++ b/src/features/diagnostics/drift/infra/__tests__/SharePointDriftEventRepository.spec.ts
@@ -282,6 +282,106 @@ describe('SharePointDriftEventRepository', () => {
     ]);
   });
 
+  it('falls back to minimum (Id,Title) select when 400 field name cannot be extracted', async () => {
+    const unparseable400 = Object.assign(
+      new Error('Bad Request'),
+      { status: 400 },
+    );
+    const getListItemsByTitle = vi
+      .fn()
+      .mockRejectedValueOnce(unparseable400)
+      .mockResolvedValueOnce([
+        { ID: 51, Title: 'Daily_Attendance:Status' },
+      ]);
+
+    const repo = new SharePointDriftEventRepository({
+      createItem: vi.fn(async () => ({})),
+      updateItemByTitle: vi.fn(async () => ({})),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      getListItemsByTitle: getListItemsByTitle as any,
+      getSchema: vi.fn(async () => [
+        'NameOfList',
+        'InternalName',
+        'OccurredAt',
+        'Level',
+        'Resolution',
+        'Category',
+        'IsResolved',
+      ]),
+    });
+
+    const events = await repo.getEvents();
+
+    expect(getListItemsByTitle).toHaveBeenCalledTimes(2);
+    const fallbackSelect = getListItemsByTitle.mock.calls[1][1];
+    expect(fallbackSelect).toEqual(['Id', 'Title']);
+    expect(events).toEqual([
+      {
+        id: '51',
+        listName: '',
+        fieldName: '',
+        detectedAt: '',
+        severity: 'info',
+        resolutionType: 'fuzzy_match',
+        driftType: 'unknown',
+        resolved: false,
+      },
+    ]);
+  });
+
+  it('falls back to minimum (Id,Title) select when 400 names a field absent from the select', async () => {
+    const phantom400 = Object.assign(
+      new Error("フィールドまたはプロパティ '_Level' は存在しません。"),
+      { status: 400 },
+    );
+    const getListItemsByTitle = vi
+      .fn()
+      .mockRejectedValueOnce(phantom400)
+      .mockResolvedValueOnce([{ ID: 61, Title: 'Daily:Status' }]);
+
+    const repo = new SharePointDriftEventRepository({
+      createItem: vi.fn(async () => ({})),
+      updateItemByTitle: vi.fn(async () => ({})),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      getListItemsByTitle: getListItemsByTitle as any,
+      // schema does NOT contain `_Level`, so the initial select cannot include it,
+      // yet SharePoint still complains about it (e.g. evaluated through computed columns).
+      getSchema: vi.fn(async () => [
+        'ListName',
+        'FieldName',
+        'DetectedAt',
+        'Severity',
+        'Resolved',
+      ]),
+    });
+
+    const events = await repo.getEvents();
+
+    expect(getListItemsByTitle).toHaveBeenCalledTimes(2);
+    expect(getListItemsByTitle.mock.calls[1][1]).toEqual(['Id', 'Title']);
+    expect(events).toHaveLength(1);
+    expect(events[0].id).toBe('61');
+  });
+
+  it('returns empty array when even the minimum (Id,Title) fallback fails', async () => {
+    const unparseable400 = Object.assign(new Error('Bad Request'), { status: 400 });
+    const getListItemsByTitle = vi
+      .fn()
+      .mockRejectedValueOnce(unparseable400)
+      .mockRejectedValueOnce(new Error('still broken'));
+
+    const repo = new SharePointDriftEventRepository({
+      createItem: vi.fn(async () => ({})),
+      updateItemByTitle: vi.fn(async () => ({})),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      getListItemsByTitle: getListItemsByTitle as any,
+      getSchema: vi.fn(async () => ['ListName', 'FieldName', 'DetectedAt']),
+    });
+
+    await expect(repo.getEvents()).resolves.toEqual([]);
+    expect(getListItemsByTitle).toHaveBeenCalledTimes(2);
+  });
+
   it('returns empty array on fetch failure (fail-open)', async () => {
     const repo = new SharePointDriftEventRepository({
       createItem: vi.fn(async () => ({})),


### PR DESCRIPTION
## Summary
- Add a final minimum-select fallback for DriftEventsLog reads
- Recover with `Id,Title` when 400 field pruning cannot identify or remove the problematic field
- Preserve fail-open behavior by returning an empty array if even the minimum read fails
- Add regression tests for unparseable 400, unknown-field 400, and minimum fallback failure

## Validation
- `tests/SharePointDriftEventRepository.spec.ts` — 13/13 pass
- diagnostics suite — 73/73 pass

## Notes
- `npm run typecheck` still reports an existing unrelated error in `titleEssentialToleration.spec.ts:91`
- This PR does not change `DRIFT_LOG_CANDIDATES`; physical field reconciliation can be handled separately after `m365 spo field list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)