### PR TITLE
fix(drift): exclude SharePoint hidden level fields from log selects

### DIFF
--- a/src/features/diagnostics/drift/infra/SharePointDriftEventRepository.ts
+++ b/src/features/diagnostics/drift/infra/SharePointDriftEventRepository.ts
@@ -517,6 +517,11 @@ export class SharePointDriftEventRepository implements IDriftEventRepository {
         let select = selectRaw.filter((f): f is string => {
           if (!f) return false;
           if (f === 'Id' || f === 'Title') return true;
+          // SharePoint 組み込みの hidden 列 (例: _Level, _ModerationStatus) は
+          // REST OData 上は OData__Foo 形式でないと参照できず、生の `_Foo` を $select に
+          // 含めると 400 になる。drift の論理列に組み込み列が割り当たることはないので
+          // 防衛的に除外する。
+          if (f.startsWith('_')) return false;
           return !schemaKnown || this.availablePhysicalFields.has(f);
         });
 

--- a/src/features/diagnostics/drift/infra/__tests__/SharePointDriftEventRepository.spec.ts
+++ b/src/features/diagnostics/drift/infra/__tests__/SharePointDriftEventRepository.spec.ts
@@ -516,6 +516,36 @@ describe('SharePointDriftEventRepository', () => {
     expect(events[0].id).toBe('31');
   });
 
+  it('excludes underscore-prefixed system fields (e.g. _Level) from $select even when present in schema', async () => {
+    const getListItemsByTitle = vi.fn(async () => [] as Record<string, unknown>[]);
+
+    const repo = new SharePointDriftEventRepository({
+      createItem: vi.fn(async () => ({})),
+      updateItemByTitle: vi.fn(async () => ({})),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      getListItemsByTitle: getListItemsByTitle as any,
+      // SP の DriftEventsLog_v2 では Severity 列は存在せず、組み込み hidden 列の
+      // `_Level` (OData__Level) のみが返ってくる。これを $select に乗せると 400 になる。
+      getSchema: vi.fn(async () => [
+        'List_x0020_Name',
+        'Field_x0020_Name',
+        'Detected_x0020_At',
+        'DriftType',
+        '_Level',
+        '_ModerationStatus',
+      ]),
+    });
+
+    await repo.getEvents();
+
+    expect(getListItemsByTitle).toHaveBeenCalledTimes(1);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const select = (getListItemsByTitle as any).mock.calls[0][1] as string[];
+    expect(select).not.toContain('_Level');
+    expect(select).not.toContain('_ModerationStatus');
+    expect(select).toEqual(expect.arrayContaining(['Id', 'Title']));
+  });
+
   it('uses resolved physical field when marking resolved', async () => {
     const updateItemByTitle = vi.fn(async () => ({}));
 

--- a/src/sharepoint/fields/diagnosticsFields.ts
+++ b/src/sharepoint/fields/diagnosticsFields.ts
@@ -60,7 +60,7 @@ export const DRIFT_LOG_CANDIDATES = {
   fieldName: ['Field_x0020_Name', 'FieldName', 'InternalName', 'ColumnName', 'FieldName0', 'cr013_fieldName'],
   detectedAt: ['Detected_x0020_At', 'DetectedAt', 'OccurredAt', 'Detected_At', 'DetectedAt0', 'cr013_detectedAt'],
   loggedAt: ['Logged_x0020_At', 'LoggedAt', 'RecordedAt', 'LoggedAt0', 'cr013_loggedAt'],
-  severity: ['Severity', 'Level', 'Status', 'Severity0', '_Level', 'cr013_severity'],
+  severity: ['Severity', 'Level', 'Status', 'Severity0', 'cr013_severity'],
   resolutionType: ['ResolutionType', 'Resolution', 'Type', 'ResolutionType0', 'cr013_resolutionType'],
   resolved: ['Resolved', 'IsResolved', 'Fixed', 'Resolved0', 'cr013_resolved'],
   driftType: ['DriftType', 'Type', 'Category', 'DriftType0', 'cr013_driftType'],


### PR DESCRIPTION
## Summary
- Remove `_Level` from DriftEventsLog severity candidates because it is a SharePoint built-in hidden moderation field, not a drift severity field
- Add a defensive guard so underscore-prefixed SharePoint internal fields are not included in DriftEventsLog `$select`
- Add regression coverage for `_Level` / `_ModerationStatus` to prevent future 400s

## Root Cause
`DriftEventsLog_v2` does not have an application-level severity column. The schema resolver picked the SharePoint built-in hidden `_Level` field from the severity candidates, causing reads to issue `$select=_Level`. SharePoint REST rejects that property with 400 because the exposed OData property is `OData__Level`, not `_Level`.

Verified directly against the production tenant via m365 CLI:
- `$select=_Level` -> `Error: フィールドまたはプロパティ '_Level' は存在しません。`
- `$select=OData__Level` -> succeeds (returns SP moderation level Integer)

## Validation
- DriftEvent repository spec: 14/14 passed (including new regression for `_Level` / `_ModerationStatus` exclusion)
- Drift / helpers / observability related tests: 35/35 passed
- lint: clean on changed files
- typecheck: build config (`tsconfig.build.json`) passes; existing `titleEssentialToleration.spec.ts` `SpFieldInfo.staticName` error on `tsconfig.json` is unrelated and present on `main`

## Notes
`useDriftObservability`, `useSilentDriftSummary`, and the repository's `getEvents` already retain fail-open behavior. This PR prevents the known 400 at the source while keeping fail-open as a second safety layer.

## Test plan
- [ ] Verify `/admin/status` no longer logs 400 for `DriftEventsLog_v2`
- [ ] Confirm `sp:bootstrap_complete` continues to succeed
- [ ] Drift summary / observability remain non-blocking on any future schema mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)