### PR TITLE
chore(sp): harden hidden field candidate filtering

### DIFF
--- a/src/features/diagnostics/drift/infra/SharePointDriftEventRepository.ts
+++ b/src/features/diagnostics/drift/infra/SharePointDriftEventRepository.ts
@@ -521,7 +521,8 @@ export class SharePointDriftEventRepository implements IDriftEventRepository {
           // REST OData 上は OData__Foo 形式でないと参照できず、生の `_Foo` を $select に
           // 含めると 400 になる。drift の論理列に組み込み列が割り当たることはないので
           // 防衛的に除外する。
-          if (f.startsWith('_')) return false;
+          // ただし、_x0020_ 等のエンコードされた名前は除外しないように _x プレフィックスを許容する。
+          if (f.startsWith('_') && !f.startsWith('_x')) return false;
           return !schemaKnown || this.availablePhysicalFields.has(f);
         });
 

--- a/src/features/sp/health/indexAdvisor/spIndexLogic.ts
+++ b/src/features/sp/health/indexAdvisor/spIndexLogic.ts
@@ -39,7 +39,7 @@ const SYSTEM_FIELDS = new Set([
  * システム管理フィールドかどうかを判定する
  */
 export function isSystemField(internalName: string): boolean {
-  return SYSTEM_FIELDS.has(internalName) || internalName.startsWith('_');
+  return SYSTEM_FIELDS.has(internalName) || (internalName.startsWith('_') && !internalName.startsWith('_x'));
 }
 
 // ── Deletion reason heuristics ────────────────────────────────────────────────

--- a/src/lib/sp/helpers.ts
+++ b/src/lib/sp/helpers.ts
@@ -231,7 +231,14 @@ export async function fetchRawItemsWithFieldFallback(
   options: { signal?: AbortSignal } = {}
 ): Promise<{ items: unknown[]; isTruncated: boolean; skippedFields: string[] }> {
   const skippedFields: string[] = [];
-  let fields = Array.from(selectFields);
+  // Proactively remove hidden system fields (starting with _ but not _x) that cause 400 errors in $select
+  let fields = selectFields.filter((f) => {
+    if (f.startsWith('_') && !f.startsWith('_x')) {
+      skippedFields.push(f);
+      return false;
+    }
+    return true;
+  });
 
   for (;;) {
     try {

--- a/src/sharepoint/__tests__/driftProbeRegistry.spec.ts
+++ b/src/sharepoint/__tests__/driftProbeRegistry.spec.ts
@@ -20,7 +20,8 @@ describe('DriftProbeRegistry / Dynamic Discovery', () => {
     const users = targets.find(t => t.key === 'users_master');
     
     expect(users).toBeDefined();
-    expect(users?.listTitle).toBe('Users_Master');
+    const expectedTitle = SP_LIST_REGISTRY.find(e => e.key === 'users_master')?.resolve();
+    expect(users?.listTitle).toBe(expectedTitle);
     // Id and Title are automatically added by the mapper if missing
     expect(users?.selectFields).toContain('Id');
     expect(users?.selectFields).toContain('Title');

--- a/src/sharepoint/spListRegistry.definitions.ts
+++ b/src/sharepoint/spListRegistry.definitions.ts
@@ -793,7 +793,7 @@ export const complianceListEntries: readonly SpListEntry[] = [
       { internalName: 'FieldName', type: 'Text', displayName: 'Field Name', required: true, indexed: true, candidates: ['Field_x0020_Name', 'FieldName', 'cr013_fieldName'] },
       { internalName: 'DetectedAt', type: 'DateTime', displayName: 'Detected At', required: true, candidates: ['Detected_x0020_At', 'DetectedAt', 'cr013_detectedAt'] },
       { internalName: 'LoggedAt', type: 'DateTime', displayName: 'Logged At', candidates: ['Logged_x0020_At', 'LoggedAt', 'cr013_loggedAt'] },
-      { internalName: 'Severity', type: 'Text', displayName: 'Severity', isSilent: true, candidates: ['Severity', 'Level', '_Level', 'cr013_severity'] },
+      { internalName: 'Severity', type: 'Text', displayName: 'Severity', isSilent: true, candidates: ['Severity', 'Level', 'cr013_severity'] },
       { internalName: 'ResolutionType', type: 'Text', displayName: 'Resolution Type', isSilent: true, candidates: ['Resolution_x0020_Type', 'ResolutionType', 'cr013_resolutionType'] },
       { internalName: 'DriftType', type: 'Text', displayName: 'Drift Type', isSilent: true, candidates: ['Drift_x0020_Type', 'DriftType', 'cr013_driftType'] },
       { internalName: 'Resolved', type: 'Boolean', displayName: 'Resolved', default: false, isSilent: true, candidates: ['Resolved', 'IsResolved', 'cr013_resolved'] },


### PR DESCRIPTION
## Summary
- Remove the remaining `_Level` candidate from the SharePoint list registry
- Refine hidden/system field filtering so SharePoint encoded internal names such as `_x0053_pO2` are allowed
- Add proactive filtering in `fetchRawItemsWithFieldFallback` so hidden SharePoint fields are skipped before causing `$select` 400s
- Align index advisor system-field detection with the same `_xHHHH_` exception rule

## Context
PR #1692 fixed the known `DriftEventsLog_v2` failure caused by `$select=_Level`.

This follow-up adds broader guardrails so underscore-prefixed SharePoint system fields are filtered proactively while preserving valid SharePoint-encoded custom fields such as `_x0053_pO2`.

## Validation
- `npm test src/sharepoint/__tests__/driftProbeRegistry.spec.ts src/features/diagnostics/drift/infra/__tests__/SharePointDriftEventRepository.spec.ts`
- Verified with `VITE_SP_LIST_USERS=Users_Master` where local env differs from test expectations

## Notes
This PR is defensive hardening only. It does not introduce write/delete operations or modify SharePoint tenant schema.