### PR TITLE
chore(nightly): add orchestration health issue drafts

### DIFF
--- a/scripts/ops/buildIssueDrafts.mjs
+++ b/scripts/ops/buildIssueDrafts.mjs
@@ -259,6 +259,47 @@ function buildUntestedFeatureDrafts(untestedFeatures) {
   ];
 }
 
+/**
+ * Orchestration Health → Issue Draft
+ */
+function buildOrchestrationDrafts(orchestrationResults) {
+  if (!orchestrationResults || orchestrationResults.score >= 95) return [];
+
+  const sev = orchestrationResults.score < 80 ? 'critical' : 'high';
+  
+  return [
+    {
+      title: `[${sev}] [orchestration] Business Execution Health regression (${orchestrationResults.score}%)`,
+      severity: sev,
+      category: 'orchestration-health',
+      summary: [
+        '## Orchestration Health Regression',
+        '',
+        `- Overall Score: **${orchestrationResults.score}%**`,
+        `- Status: **${orchestrationResults.status}**`,
+        `- Open Failures: **${orchestrationResults.openCount || 0}**`,
+      ].join('\n'),
+      rationale: [
+        'ビジネスロジックの実行（Orchestration / Action Engine）で失敗が発生しています。',
+        'これらは現場でのデータ登録失敗や不整合に直結するリスクがあります。',
+        'nightly patrol / orchestration audit で検知。',
+      ].join('\n'),
+      targetFiles: ['src/lib/orchestration/'],
+      proposal: [
+        '1. `TelemetryDashboard` で直近の失敗内容を確認',
+        '2. 特に頻発している Action のエラー原因を特定し修正',
+        '3. 現場で発生した未解決エラーについて、解消記録（Resolved Audit）を実施',
+      ],
+      acceptanceCriteria: [
+        'Orchestration Health Score が 95% 以上に復帰すること',
+        '未解決 (Open) の Failure カウントが 0 になること',
+      ],
+      labels: ['orchestration', 'nightly-patrol', 'business-health', `priority-${sev}`],
+      fingerprint: 'orchestration:health-regression',
+    },
+  ];
+}
+
 // ─── Phase B-2 Draft Builders ───────────────────────────────────────────────
 
 /**
@@ -451,54 +492,67 @@ function buildContractDriftDrafts(contractResults) {
  */
 function buildIndexPressureDrafts(indexResults) {
   const targetResults = indexResults.filter((r) =>
-    ['action_required', 'critical'].includes(r.severity)
+    ['action_required', 'critical'].includes(r.severity) || r.status === 'FAIL'
   );
 
-  return targetResults.map((r) => ({
-    title: `[${r.severity}] [index-pressure] ${r.listKey}.${r.fieldName} index missing`,
-    severity: r.severity === 'critical' ? 'critical' : 'high',
-    category: 'index-pressure',
-    summary: [
-      '## Index Pressure Detected',
-      '',
-      `- List: ${r.listKey}`,
-      `- Field: ${r.fieldName}`,
-      `- Severity: ${r.severity}`,
-      `- Fingerprint: ${r.fingerprint}`,
-    ].join('\n'),
-    rationale: [
-      'SharePoint リストのクエリ性能が悪化し、スロットリングやタイムアウトのリスクがあります。',
-      '特にフィルタリングやソートに使用されるカラムはインデックス化が必須です。',
-      'nightly patrol / index-audit で検知。',
-    ].join('\n'),
-    targetFiles: [`sharepoint/lists/${r.listKey}`],
-    proposal: [
-      '## Dry-run remediation',
-      '',
-      '```bash',
-      r.dryRunCommand || `npm run ops:index-remediate -- --list ${r.listKey} --field ${r.fieldName} --dry-run`,
-      '```',
-      '',
-      r.dryRunLog ? [
-        '## Dry-run Evidence',
-        '```text',
-        r.dryRunLog,
-        '```'
-      ].join('\n') : '',
-      '',
-      '## Suggested reviewer action',
-      '',
-      '1. 上記 dry-run を実行して影響を確認',
-      '2. インデックスの必要性を確認',
-      '3. 手動適用または次の定期メンテナンスで修復を実行',
-    ],
-    acceptanceCriteria: [
-      `\`${r.listKey}\` の \`${r.fieldName}\` がインデックス化されていること`,
-      '対象リストのインデックス数が 20 個（SharePoint上限）を超えていないこと',
-    ],
-    labels: ['index-pressure', 'nightly-patrol', 'needs-review', 'priority-high'],
-    fingerprint: r.fingerprint,
-  }));
+  return targetResults.map((r) => {
+    const severity = r.severity === 'critical' || r.status === 'FAIL' ? 'critical' : 'high';
+    
+    // Consistency check for evidence logs
+    let evidenceLog = r.dryRunLog || '';
+    if (!evidenceLog && r.remediationResults && r.remediationResults.length > 0) {
+      evidenceLog = r.remediationResults.map(res => `[${res.outcome}] ${res.message}`).join('\n');
+    }
+
+    const listId = r.listKey || r.list;
+    const fieldId = r.fieldName || (r.missingIndexes && r.missingIndexes[0]);
+
+    return {
+      title: `[${severity}] [index-pressure] ${listId}.${fieldId} index missing`,
+      severity,
+      category: 'index-pressure',
+      summary: [
+        '## Index Pressure Detected',
+        '',
+        `- List: ${listId}`,
+        `- Field: ${r.fieldName || (r.missingIndexes && r.missingIndexes.join(', '))}`,
+        `- Severity: ${r.severity || 'FAIL'}`,
+        `- Fingerprint: ${r.fingerprint || `index-pressure:${listId}:${fieldId}`}`,
+      ].join('\n'),
+      rationale: [
+        'SharePoint リストのクエリ性能が悪化し、スロットリングやタイムアウトのリスクがあります。',
+        '特にフィルタリングやソートに使用されるカラムはインデックス化が必須です。',
+        'nightly patrol / index-audit で検知。',
+      ].join('\n'),
+      targetFiles: [`sharepoint/lists/${listId}`],
+      proposal: [
+        '## Dry-run remediation',
+        '',
+        '```bash',
+        r.dryRunCommand || `npm run ops:index-remediate -- --list ${listId} --field ${fieldId} --dry-run`,
+        '```',
+        '',
+        evidenceLog ? [
+          '## Dry-run Evidence',
+          '```text',
+          evidenceLog,
+          '```'
+        ].join('\n') : '',
+        '',
+        '## Suggested reviewer action',
+        '',
+        '1. 上記 dry-run を実行して影響を確認',
+        '2. インデックスの必要性を確認',
+        '3. 手動適用または次の定期メンテナンスで修復を実行',
+      ],
+      acceptanceCriteria: [
+        `\`${listId}\` の \`${fieldId}\` がインデックス化されていること`,
+        '対象リストのインデックス数が 20 個（SharePoint上限）を超えていないこと',
+      ],
+      labels: ['index-pressure', 'nightly-patrol', 'needs-review', 'priority-high'],
+      fingerprint: r.fingerprint || `index-pressure:${listId}:${fieldId}`,
+    };
+  });
 }
 
 // ─── Main ───────────────────────────────────────────────────────────────────
@@ -527,6 +581,7 @@ export function buildIssueDrafts(patrolResults) {
     lastHandoffInfo = '',
     contractResults = [],
     indexResults = [],
+    orchestrationResults = null,
   } = patrolResults;
 
   const ledger = loadLedger();
@@ -540,6 +595,7 @@ export function buildIssueDrafts(patrolResults) {
     ...buildHandoffDraft(lastHandoffInfo),
     ...buildContractDriftDrafts(contractResults),
     ...buildIndexPressureDrafts(indexResults),
+    ...buildOrchestrationDrafts(orchestrationResults),
   ];
 
   const newDrafts = [];

--- a/scripts/ops/index-audit.ts
+++ b/scripts/ops/index-audit.ts
@@ -2,25 +2,29 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 // --- 1. Load Env FIRST ---
-function loadEnvLocal() {
-  const envPath = path.resolve(process.cwd(), '.env.local');
-  if (fs.existsSync(envPath)) {
-    const content = fs.readFileSync(envPath, 'utf8');
-    content.split('\n').forEach(line => {
-      const trimmed = line.trim();
-      if (!trimmed || trimmed.startsWith('#')) return;
-      const [rawKey, ...rest] = trimmed.split('=');
-      const key = rawKey.trim();
-      if (key && rest.length > 0) {
-        const val = rest.join('=').trim().replace(/^["']|["']$/g, '');
-        if (!process.env[key]) {
+function loadEnv() {
+  const root = process.cwd();
+  const envFiles = ['.env', '.env.local'];
+  
+  for (const file of envFiles) {
+    const envPath = path.resolve(root, file);
+    if (fs.existsSync(envPath)) {
+      const content = fs.readFileSync(envPath, 'utf8');
+      content.split('\n').forEach(line => {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith('#')) return;
+        const [rawKey, ...rest] = trimmed.split('=');
+        const key = rawKey.trim();
+        if (key && rest.length > 0) {
+          const val = rest.join('=').trim().replace(/^["']|["']$/g, '');
+          // local overrides base .env
           process.env[key] = val;
         }
-      }
-    });
+      });
+    }
   }
 }
-loadEnvLocal();
+loadEnv();
 
 type IndexPressureStatus = 'missing_index' | 'indexed_with_drift' | 'indexed';
 type IndexPressureSeverity = 'ok' | 'watch' | 'action_required' | 'critical';
@@ -115,7 +119,19 @@ async function main() {
     process.exit(1);
   }
 
-  const config = ensureConfig();
+  let config;
+  try {
+    config = ensureConfig();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (isJson) {
+      console.log(JSON.stringify({ error: `Config failed: ${msg}` }));
+    } else {
+      console.error(`❌ Configuration error: ${msg}`);
+    }
+    process.exit(1);
+  }
+
   const apiBaseUrl = config.baseUrl;
   if (!isJson) {
     console.log("--- SharePoint Index Governance Audit (Drift-Aware Mode) ---");

--- a/scripts/ops/nightly-patrol.mjs
+++ b/scripts/ops/nightly-patrol.mjs
@@ -652,7 +652,8 @@ const patrolResults = {
   todoHits, 
   lastHandoffInfo,
   contractResults: contractDriftSummary?.results || [],
-  indexResults: indexPressureSummary?.results || indexPressureResults || []
+  indexResults: indexPressureSummary?.results || indexPressureResults || [],
+  orchestrationResults: orchestrationAuditSummary
 };
 
 // --- Phase C-1: Structured PatrolResult for JSON + classify pipeline ---
@@ -711,21 +712,33 @@ console.log(`📊 JSON written: docs/nightly-patrol/${stamp}.json`);
 
 // --- Phase B.5: Index Dry-run Capture (Evidence for C-1) ---
 
-if (indexPressureSummary && indexPressureSummary.results?.length > 0) {
-  console.log('🧪 Capturing dry-run evidence for index pressure...');
-  for (const r of indexPressureSummary.results) {
-    if (['action_required', 'critical'].includes(r.severity)) {
+const allIndexResults = indexPressureSummary?.results || indexPressureResults || [];
+if (allIndexResults.length > 0) {
+  const needsEvidence = allIndexResults.filter(r => 
+    ['action_required', 'critical'].includes(r.severity) || r.status === 'FAIL'
+  );
+
+  if (needsEvidence.length > 0) {
+    console.log(`🧪 Capturing dry-run evidence for ${needsEvidence.length} index pressure issues...`);
+    for (const r of needsEvidence) {
+      const listKey = r.listKey || r.list;
+      const fieldName = r.fieldName || (r.missingIndexes && r.missingIndexes[0]);
+      if (!listKey || !fieldName) continue;
+
       try {
-        const cmd = `npm run ops:index-remediate -- --list ${r.listKey} --field ${r.fieldName} --dry-run`;
+        const cmd = `npm run ops:index-remediate -- --list ${listKey} --field ${fieldName} --dry-run`;
         const log = execSync(cmd, { encoding: 'utf8', env: { ...process.env, CI: 'true' } });
         r.dryRunLog = log;
       } catch (err) {
         r.dryRunLog = `❌ Dry-run failed: ${err.message}`;
       }
     }
+    
+    // Re-write summary if we updated indexPressureSummary
+    if (indexPressureSummary) {
+      fs.writeFileSync(INDEX_PRESSURE_PATH, JSON.stringify(indexPressureSummary, null, 2), 'utf8');
+    }
   }
-  // Re-write summary with logs
-  fs.writeFileSync(INDEX_PRESSURE_PATH, JSON.stringify(indexPressureSummary, null, 2), 'utf8');
 }
 
 const drafts = buildIssueDrafts(patrolResults);


### PR DESCRIPTION
## Summary
- Add `buildOrchestrationDrafts` to generate issue drafts for orchestration failures.
- Enhance `index-audit.ts` with better environment handling and error reporting.
- Refine `nightly-patrol.mjs` with improved index dry-run evidence capture.

Part of the nightly patrol orchestration hardening.