### PR TITLE
fix(drift): retry audit log writes with essential payload

### DIFF
--- a/src/features/diagnostics/drift/infra/SharePointDriftEventRepository.ts
+++ b/src/features/diagnostics/drift/infra/SharePointDriftEventRepository.ts
@@ -446,12 +446,26 @@ export class SharePointDriftEventRepository implements IDriftEventRepository {
           }
         }
 
-        // 欠落列を特定できない 400 は、再試行しても改善しない可能性が高いため停止。
+        // 欠落列を特定できない 400 でも、任意列由来の型不一致が多いため
+        // 必須列のみで 1 回だけ再試行して fail-open で吸収する。
+        const requiredOnlyPayload = this.buildCreatePayload(event, false);
+        if (requiredOnlyPayload) {
+          try {
+            await this.spClient.createItem(listTitle, requiredOnlyPayload);
+            this.sessionCache.add(dedupeKey);
+            this.optionalWriteDisabled = true;
+            return;
+          } catch (fallbackErr) {
+            if (!this.isHttp400(fallbackErr)) throw fallbackErr;
+          }
+        }
+
+        // required-only でも失敗する場合は同一セッションで停止
         this.optionalWriteDisabled = true;
         this.writeDisabled = true;
         auditLog.warn(
           'diagnostics:drift',
-          'DriftEventRepository disabled writing after unclassified 400.',
+          'DriftEventRepository disabled writing after unclassified 400 (including required-only fallback).',
           { detail },
         );
       }

--- a/src/features/diagnostics/drift/infra/__tests__/SharePointDriftEventRepository.spec.ts
+++ b/src/features/diagnostics/drift/infra/__tests__/SharePointDriftEventRepository.spec.ts
@@ -151,12 +151,15 @@ describe('SharePointDriftEventRepository', () => {
     expect(fallbackPayload).not.toHaveProperty('NameOfList');
   });
 
-  it('fails fast without retry when 400 does not identify a field', async () => {
+  it('retries once with required-only payload when 400 does not identify a field', async () => {
     const badRequest = Object.assign(
       new Error("JSON リーダーから読み取り中に予期しない 'StartObject' ノードが見つかりました。"),
       { status: 400 },
     );
-    const createItem = vi.fn().mockRejectedValueOnce(badRequest);
+    const createItem = vi
+      .fn()
+      .mockRejectedValueOnce(badRequest)
+      .mockResolvedValueOnce({});
 
     const repo = new SharePointDriftEventRepository({
       createItem,
@@ -174,7 +177,11 @@ describe('SharePointDriftEventRepository', () => {
       resolved: false,
     });
 
-    expect(createItem).toHaveBeenCalledTimes(1);
+    expect(createItem).toHaveBeenCalledTimes(2);
+    const initialPayload = createItem.mock.calls[0][1];
+    const fallbackPayload = createItem.mock.calls[1][1];
+    expect(initialPayload).toHaveProperty('Severity', 'warn');
+    expect(fallbackPayload).not.toHaveProperty('Severity');
   });
 
   it('writes duplicate required encoded/plain fields when both exist in list schema', async () => {


### PR DESCRIPTION
## Summary
- Retry DriftEventsLog_v2 audit writes with an essential-only payload when a 400 response does not identify a specific invalid field
- Preserve fail-open behavior if the reduced payload still fails
- Update repository tests for the new fallback behavior

## Background
The observed 400 was emitted by the drift audit log write path, not by the primary business save path.
To reduce noisy repeated failures, the repository now attempts one safe reduced-payload retry before disabling the audit write path.

## Validation
- \src/features/diagnostics/drift/infra/__tests__/SharePointDriftEventRepository.spec.ts\
- 14 tests passed