### PR TITLE
fix(auth): gate regulatory real-data hooks until auth is ready

### DIFF
--- a/src/features/regulatory/__tests__/useRegulatoryRealDataDedupe.spec.tsx
+++ b/src/features/regulatory/__tests__/useRegulatoryRealDataDedupe.spec.tsx
@@ -1,11 +1,16 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
+import { AuthRequiredError } from '@/lib/errors';
 
 import { useSevereAddonRealData } from '../hooks/useSevereAddonRealData';
 import { useRegulatoryFindingsRealData } from '../hooks/useRegulatoryFindingsRealData';
 import type { PlanningSheetRepository, ProcedureRecordRepository } from '@/domain/isp/port';
 import type { MonitoringMeetingRepository } from '@/domain/isp/monitoringMeetingRepository';
 import type { IUserMaster } from '@/sharepoint/fields';
+
+vi.mock('@/auth/useAuth', () => ({
+  useAuth: () => ({ isAuthReady: true }),
+}));
 
 function createPlanningSheetRepo(listCurrentByUser = vi.fn().mockResolvedValue([])): PlanningSheetRepository {
   return {
@@ -52,6 +57,62 @@ function buildUsers(): IUserMaster[] {
 }
 
 describe('regulatory real-data hook dedupe', () => {
+  it('does not start per-user fetch when auth is not ready', async () => {
+    const listCurrentByUser = vi.fn().mockResolvedValue([]);
+    const listByUser = vi.fn().mockResolvedValue([]);
+    const planningRepo = createPlanningSheetRepo(listCurrentByUser);
+    const monitoringRepo = createMonitoringMeetingRepo(listByUser);
+    const procedureRepo = createProcedureRecordRepo();
+    const users = Array.from({ length: 32 }).map((_, i) => ({
+      Id: i + 1,
+      UserID: `U-${String(i + 1).padStart(3, '0')}`,
+      FullName: `User ${i + 1}`,
+      IsActive: true,
+    })) as IUserMaster[];
+
+    renderHook(() =>
+      useRegulatoryFindingsRealData(
+        users,
+        [],
+        false,
+        null,
+        planningRepo,
+        procedureRepo,
+        monitoringRepo,
+        false,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(listCurrentByUser).toHaveBeenCalledTimes(0);
+      expect(listByUser).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  it('suppresses repeated AUTH_REQUIRED warnings per user and treats as auth skip', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const listCurrentByUser = vi.fn().mockRejectedValue(new AuthRequiredError());
+    const planningRepo = createPlanningSheetRepo(listCurrentByUser);
+    const users = Array.from({ length: 32 }).map((_, i) => ({
+      Id: i + 1,
+      UserID: `U-${String(i + 1).padStart(3, '0')}`,
+      FullName: `User ${i + 1}`,
+      IsActive: true,
+    })) as IUserMaster[];
+
+    const { result } = renderHook(() =>
+      useSevereAddonRealData(users, [], false, null, planningRepo, null, null, true),
+    );
+
+    await waitFor(() => {
+      expect(result.current.error).toBeNull();
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(warnSpy).toHaveBeenCalledTimes(0);
+    warnSpy.mockRestore();
+  });
+
   it('does not re-fetch planning sheets in severe-addon hook for identical user key rerenders', async () => {
     const listCurrentByUser = vi.fn().mockResolvedValue([]);
     const planningRepo = createPlanningSheetRepo(listCurrentByUser);

--- a/src/features/regulatory/hooks/useRegulatoryFindingsRealData.ts
+++ b/src/features/regulatory/hooks/useRegulatoryFindingsRealData.ts
@@ -17,6 +17,8 @@
  */
 
 import { useMemo, useEffect, useState, useCallback, useRef } from 'react';
+import { useAuth } from '@/auth/useAuth';
+import { AuthRequiredError } from '@/lib/errors';
 
 import type { IUserMaster } from '@/sharepoint/fields';
 import type { Staff } from '@/types';
@@ -74,7 +76,30 @@ export function useRegulatoryFindingsRealData(
   planningSheetRepo?: PlanningSheetRepository | null,
   procedureRecordRepo?: ProcedureRecordRepository | null,
   monitoringMeetingRepo?: MonitoringMeetingRepository | null,
+  authReadyOverride?: boolean,
 ): RegulatoryFindingsRealDataResult {
+  const { isAuthReady } = useAuth();
+  const authReady = authReadyOverride ?? isAuthReady;
+  const authSkipLoggedRef = useRef(false);
+
+  const isAuthRequiredError = useCallback((err: unknown): boolean => {
+    if (err instanceof AuthRequiredError) return true;
+    if (!(err instanceof Error)) return false;
+    const code = (err as { code?: string }).code;
+    return (
+      err.name === 'AuthRequiredError' ||
+      err.message === 'AUTH_REQUIRED' ||
+      code === 'AUTH_REQUIRED'
+    );
+  }, []);
+
+  const logAuthSkipOnce = useCallback(() => {
+    if (authSkipLoggedRef.current) return;
+    authSkipLoggedRef.current = true;
+    if (import.meta.env.DEV) {
+      console.info('[auth] skip real data fetch: account not ready');
+    }
+  }, []);
 
   // ── PlanningSheet を非同期に取得 ──
   const [sheetsByUser, setSheetsByUser] = useState<Map<string, PlanningSheetListItem[]>>(new Map());
@@ -108,6 +133,12 @@ export function useRegulatoryFindingsRealData(
 
   // ── Phase 1: PlanningSheet 取得 ──
   const fetchPlanningSheets = useCallback(async () => {
+    if (!authReady) {
+      logAuthSkipOnce();
+      setSheetsByUser(new Map());
+      planningFetchStateRef.current = { inFlightKey: null, completedKey: null };
+      return;
+    }
     if (!planningSheetRepo || activeUserIds.length === 0) {
       setSheetsByUser(new Map());
       planningFetchStateRef.current = { inFlightKey: null, completedKey: null };
@@ -133,6 +164,11 @@ export function useRegulatoryFindingsRealData(
           const sheets = await planningSheetRepo.listCurrentByUser(userId);
           results.set(userId, sheets);
         } catch (err) {
+          if (isAuthRequiredError(err)) {
+            logAuthSkipOnce();
+            results.set(userId, []);
+            return;
+          }
           console.warn(`[useRegulatoryFindingsRealData] Failed to fetch sheets for ${userId}:`, err);
           results.set(userId, []);
         }
@@ -143,6 +179,11 @@ export function useRegulatoryFindingsRealData(
       planningFetchStateRef.current.completedKey = requestKey;
     } catch (err) {
       const e = err instanceof Error ? err : new Error(String(err));
+      if (isAuthRequiredError(e)) {
+        logAuthSkipOnce();
+        planningFetchStateRef.current.completedKey = null;
+        return;
+      }
       setSheetsError(e);
       console.warn('[useRegulatoryFindingsRealData] PlanningSheet fetch failed:', e.message);
       planningFetchStateRef.current.completedKey = null;
@@ -152,7 +193,7 @@ export function useRegulatoryFindingsRealData(
       }
       setSheetsLoading(false);
     }
-  }, [planningSheetRepo, activeUserIds, activeUserIdsKey]);
+  }, [planningSheetRepo, activeUserIds, activeUserIdsKey, authReady, isAuthRequiredError, logAuthSkipOnce]);
 
   useEffect(() => {
     fetchPlanningSheets();
@@ -160,6 +201,11 @@ export function useRegulatoryFindingsRealData(
 
   // ── Phase 2: ProcedureRecord 取得（PlanningSheet 確定後） ──
   const fetchProcedureRecords = useCallback(async () => {
+    if (!authReady) {
+      logAuthSkipOnce();
+      setRecordsBySheet(new Map());
+      return;
+    }
     if (!procedureRecordRepo || sheetsByUser.size === 0 || sheetsLoading) {
       setRecordsBySheet(new Map());
       return;
@@ -197,6 +243,11 @@ export function useRegulatoryFindingsRealData(
             })),
           );
         } catch (err) {
+          if (isAuthRequiredError(err)) {
+            logAuthSkipOnce();
+            results.set(sheetId, []);
+            return;
+          }
           console.warn(`[useRegulatoryFindingsRealData] Failed to fetch records for sheet ${sheetId}:`, err);
           results.set(sheetId, []);
         }
@@ -207,7 +258,7 @@ export function useRegulatoryFindingsRealData(
     } finally {
       setRecordsLoading(false);
     }
-  }, [procedureRecordRepo, sheetsByUser, sheetsLoading]);
+  }, [procedureRecordRepo, sheetsByUser, sheetsLoading, authReady, isAuthRequiredError, logAuthSkipOnce]);
 
   useEffect(() => {
     fetchProcedureRecords();
@@ -215,6 +266,12 @@ export function useRegulatoryFindingsRealData(
 
   // ── Phase 3: MonitoringMeeting 取得 ──
   const fetchMonitoringMeetings = useCallback(async () => {
+    if (!authReady) {
+      logAuthSkipOnce();
+      setMeetingsByUser(new Map());
+      meetingFetchStateRef.current = { inFlightKey: null, completedKey: null };
+      return;
+    }
     if (!monitoringMeetingRepo || activeUserIds.length === 0) {
       setMeetingsByUser(new Map());
       meetingFetchStateRef.current = { inFlightKey: null, completedKey: null };
@@ -238,6 +295,11 @@ export function useRegulatoryFindingsRealData(
           const meetings = await monitoringMeetingRepo.listByUser(userId);
           results.set(userId, meetings);
         } catch (err) {
+          if (isAuthRequiredError(err)) {
+            logAuthSkipOnce();
+            results.set(userId, []);
+            return;
+          }
           console.warn(`[useRegulatoryFindingsRealData] Failed to fetch meetings for ${userId}:`, err);
           results.set(userId, []);
         }
@@ -252,14 +314,14 @@ export function useRegulatoryFindingsRealData(
       }
       setMeetingsLoading(false);
     }
-  }, [monitoringMeetingRepo, activeUserIds, activeUserIdsKey]);
+  }, [monitoringMeetingRepo, activeUserIds, activeUserIdsKey, authReady, isAuthRequiredError, logAuthSkipOnce]);
 
   useEffect(() => {
     fetchMonitoringMeetings();
   }, [fetchMonitoringMeetings]);
 
   // ── 統合状態 ──
-  const combinedLoading = isLoading || sheetsLoading || recordsLoading || meetingsLoading;
+  const combinedLoading = isLoading || (authReady && (sheetsLoading || recordsLoading || meetingsLoading));
   const combinedError = error || sheetsError;
 
   // ── findings 構築 ──

--- a/src/features/regulatory/hooks/useRegulatoryFindingsRealData.ts
+++ b/src/features/regulatory/hooks/useRegulatoryFindingsRealData.ts
@@ -18,6 +18,7 @@
 
 import { useMemo, useEffect, useState, useCallback, useRef } from 'react';
 import { useAuth } from '@/auth/useAuth';
+import { isDevMode } from '@/lib/env';
 import { AuthRequiredError } from '@/lib/errors';
 
 import type { IUserMaster } from '@/sharepoint/fields';
@@ -96,7 +97,7 @@ export function useRegulatoryFindingsRealData(
   const logAuthSkipOnce = useCallback(() => {
     if (authSkipLoggedRef.current) return;
     authSkipLoggedRef.current = true;
-    if (import.meta.env.DEV) {
+    if (isDevMode()) {
       console.info('[auth] skip real data fetch: account not ready');
     }
   }, []);

--- a/src/features/regulatory/hooks/useSevereAddonRealData.ts
+++ b/src/features/regulatory/hooks/useSevereAddonRealData.ts
@@ -39,6 +39,7 @@
 
 import { useMemo, useEffect, useState, useCallback, useRef } from 'react';
 import { useAuth } from '@/auth/useAuth';
+import { isDevMode } from '@/lib/env';
 import { AuthRequiredError } from '@/lib/errors';
 
 import type { IUserMaster } from '@/sharepoint/fields';
@@ -186,7 +187,7 @@ export function useSevereAddonRealData(
   const logAuthSkipOnce = useCallback(() => {
     if (authSkipLoggedRef.current) return;
     authSkipLoggedRef.current = true;
-    if (import.meta.env.DEV) {
+    if (isDevMode()) {
       console.info('[auth] skip real data fetch: account not ready');
     }
   }, []);

--- a/src/features/regulatory/hooks/useSevereAddonRealData.ts
+++ b/src/features/regulatory/hooks/useSevereAddonRealData.ts
@@ -38,6 +38,8 @@
  */
 
 import { useMemo, useEffect, useState, useCallback, useRef } from 'react';
+import { useAuth } from '@/auth/useAuth';
+import { AuthRequiredError } from '@/lib/errors';
 
 import type { IUserMaster } from '@/sharepoint/fields';
 import type { Staff } from '@/types';
@@ -164,7 +166,30 @@ export function useSevereAddonRealData(
   planningSheetRepo?: PlanningSheetRepository | null,
   weeklyObsRepo?: WeeklyObservationRepository | null,
   assignmentRepo?: QualificationAssignmentRepository | null,
+  authReadyOverride?: boolean,
 ): SevereAddonRealDataResult {
+  const { isAuthReady } = useAuth();
+  const authReady = authReadyOverride ?? isAuthReady;
+  const authSkipLoggedRef = useRef(false);
+
+  const isAuthRequiredError = useCallback((err: unknown): boolean => {
+    if (err instanceof AuthRequiredError) return true;
+    if (!(err instanceof Error)) return false;
+    const code = (err as { code?: string }).code;
+    return (
+      err.name === 'AuthRequiredError' ||
+      err.message === 'AUTH_REQUIRED' ||
+      code === 'AUTH_REQUIRED'
+    );
+  }, []);
+
+  const logAuthSkipOnce = useCallback(() => {
+    if (authSkipLoggedRef.current) return;
+    authSkipLoggedRef.current = true;
+    if (import.meta.env.DEV) {
+      console.info('[auth] skip real data fetch: account not ready');
+    }
+  }, []);
 
   // ── Phase B: 支援計画シートの再評価日を非同期に取得 ──
   const [sheetsByUser, setSheetsByUser] = useState<Map<string, PlanningSheetListItem[]>>(new Map());
@@ -185,6 +210,12 @@ export function useSevereAddonRealData(
   });
 
   const fetchPlanningSheets = useCallback(async () => {
+    if (!authReady) {
+      logAuthSkipOnce();
+      setSheetsByUser(new Map());
+      planningFetchStateRef.current = { inFlightKey: null, completedKey: null };
+      return;
+    }
     if (!planningSheetRepo || activeUserIds.length === 0) {
       setSheetsByUser(new Map());
       planningFetchStateRef.current = { inFlightKey: null, completedKey: null };
@@ -213,6 +244,11 @@ export function useSevereAddonRealData(
           const sheets = await planningSheetRepo.listCurrentByUser(userId);
           results.set(userId, sheets);
         } catch (err) {
+          if (isAuthRequiredError(err)) {
+            logAuthSkipOnce();
+            results.set(userId, []);
+            return;
+          }
           console.warn(`[useSevereAddonRealData] Failed to fetch sheets for ${userId}:`, err);
           results.set(userId, []);
         }
@@ -223,6 +259,11 @@ export function useSevereAddonRealData(
       planningFetchStateRef.current.completedKey = requestKey;
     } catch (err) {
       const e = err instanceof Error ? err : new Error(String(err));
+      if (isAuthRequiredError(e)) {
+        logAuthSkipOnce();
+        planningFetchStateRef.current.completedKey = null;
+        return;
+      }
       setSheetsError(e);
       console.warn('[useSevereAddonRealData] PlanningSheet fetch failed:', e.message);
       planningFetchStateRef.current.completedKey = null;
@@ -232,7 +273,7 @@ export function useSevereAddonRealData(
       }
       setSheetsLoading(false);
     }
-  }, [planningSheetRepo, activeUserIds, activeUserIdsKey]);
+  }, [planningSheetRepo, activeUserIds, activeUserIdsKey, authReady, isAuthRequiredError, logAuthSkipOnce]);
 
   useEffect(() => {
     fetchPlanningSheets();
@@ -244,6 +285,11 @@ export function useSevereAddonRealData(
   const [obsError, setObsError] = useState<Error | null>(null);
 
   const fetchObservations = useCallback(async () => {
+    if (!authReady) {
+      logAuthSkipOnce();
+      setAllObservations([]);
+      return;
+    }
     if (!weeklyObsRepo || activeUserIds.length === 0) {
       setAllObservations([]);
       return;
@@ -262,6 +308,10 @@ export function useSevereAddonRealData(
             results.push({ userId: r.userId, observationDate: r.observationDate });
           }
         } catch (err) {
+          if (isAuthRequiredError(err)) {
+            logAuthSkipOnce();
+            return;
+          }
           console.warn(`[useSevereAddonRealData] Failed to fetch observations for ${userId}:`, err);
         }
       });
@@ -270,12 +320,16 @@ export function useSevereAddonRealData(
       setAllObservations(results);
     } catch (err) {
       const e = err instanceof Error ? err : new Error(String(err));
+      if (isAuthRequiredError(e)) {
+        logAuthSkipOnce();
+        return;
+      }
       setObsError(e);
       console.warn('[useSevereAddonRealData] Observation fetch failed:', e.message);
     } finally {
       setObsLoading(false);
     }
-  }, [weeklyObsRepo, activeUserIds]);
+  }, [weeklyObsRepo, activeUserIds, authReady, isAuthRequiredError, logAuthSkipOnce]);
 
   useEffect(() => {
     fetchObservations();
@@ -287,6 +341,11 @@ export function useSevereAddonRealData(
   const [assignError, setAssignError] = useState<Error | null>(null);
 
   const fetchAssignments = useCallback(async () => {
+    if (!authReady) {
+      logAuthSkipOnce();
+      setAllAssignments([]);
+      return;
+    }
     if (!assignmentRepo || activeUserIds.length === 0) {
       setAllAssignments([]);
       return;
@@ -308,19 +367,23 @@ export function useSevereAddonRealData(
       );
     } catch (err) {
       const e = err instanceof Error ? err : new Error(String(err));
+      if (isAuthRequiredError(e)) {
+        logAuthSkipOnce();
+        return;
+      }
       setAssignError(e);
       console.warn('[useSevereAddonRealData] Assignment fetch failed:', e.message);
     } finally {
       setAssignLoading(false);
     }
-  }, [assignmentRepo, activeUserIds]);
+  }, [assignmentRepo, activeUserIds, authReady, isAuthRequiredError, logAuthSkipOnce]);
 
   useEffect(() => {
     fetchAssignments();
   }, [fetchAssignments]);
 
   // ── メイン BulkInput 構築 ──
-  const combinedLoading = isLoading || sheetsLoading || obsLoading || assignLoading;
+  const combinedLoading = isLoading || (authReady && (sheetsLoading || obsLoading || assignLoading));
   const combinedError = error || sheetsError || obsError || assignError;
 
   const input = useMemo<SevereAddonBulkInput | null>(() => {


### PR DESCRIPTION
## Summary
- Gate regulatory real-data hooks until auth readiness is confirmed
- Prevent per-user SharePoint fetches from starting when MSAL has no active account
- Treat AuthRequiredError / AUTH_REQUIRED as auth-not-ready skip instead of noisy warnings
- Use env helper for dev-only auth-skip logging

## Validation
- npx vitest run src/features/regulatory/__tests__/useRegulatoryRealDataDedupe.spec.tsx --reporter=verbose
- npm run typecheck
- npm run lint
- Build succeeded
- Wrangler deploy succeeded

## Deployment
- URL: https://audit-management-system-mvp.momosantanuki.workers.dev
- Version ID: de33ac24-e627-4f38-92a8-513ba5df63a3

## Notes
Direct push to main was correctly blocked by repository rules. This PR reflects the already validated auth guard fix into main through the protected branch workflow.