### PR TITLE
fix(sp): select existing MonthlyRecord_Summary migration fields

### DIFF
--- a/scripts/ops/monthlyrecord-summary-migration-dry-run.mjs
+++ b/scripts/ops/monthlyrecord-summary-migration-dry-run.mjs
@@ -105,6 +105,50 @@ async function fetchAllItems(siteApiRoot, listTitle, selectFields, auth) {
   return rows;
 }
 
+async function fetchExistingFieldNames(siteApiRoot, listTitle, auth) {
+  const encodedListTitle = listTitle.replace(/'/g, "''");
+  let nextUrl = `${siteApiRoot}/lists/getbytitle('${encodedListTitle}')/fields?$select=InternalName&$top=5000`;
+  const names = new Set();
+
+  while (nextUrl) {
+    const data = await spFetch(nextUrl, auth);
+    for (const field of data.value || []) {
+      const internalName = field?.InternalName;
+      if (typeof internalName === 'string' && internalName.trim()) {
+        names.add(internalName);
+      }
+    }
+    nextUrl = data['@odata.nextLink'] || '';
+  }
+
+  return names;
+}
+
+function buildExistingSelectFields(groups, existingFields) {
+  const requestedFields = new Set(['Id']);
+  const missingFields = [];
+
+  for (const def of Object.values(groups)) {
+    for (const name of [...def.canonical, ...def.fallback]) {
+      requestedFields.add(name);
+    }
+  }
+
+  const selectedFields = new Set();
+  for (const name of requestedFields) {
+    if (existingFields.has(name)) {
+      selectedFields.add(name);
+    } else {
+      missingFields.push(name);
+    }
+  }
+
+  return {
+    selectedFields,
+    missingCandidateFields: Array.from(new Set(missingFields)).sort(),
+  };
+}
+
 function evaluateGroup(row, groupDef) {
   let canonicalField = null;
   let canonicalValue = undefined;
@@ -254,14 +298,14 @@ async function main() {
     ? siteUrl
     : `${siteUrl.replace(/\/$/, '')}/_api/web`;
 
-  const selectFields = new Set(['Id']);
-  for (const def of Object.values(MONTHLY_SUMMARY_MIGRATION_GROUPS)) {
-    for (const c of def.canonical) selectFields.add(c);
-    for (const f of def.fallback) selectFields.add(f);
-  }
+  const existingFields = await fetchExistingFieldNames(siteApiRoot, listTitle, auth);
+  const { selectedFields, missingCandidateFields } = buildExistingSelectFields(
+    MONTHLY_SUMMARY_MIGRATION_GROUPS,
+    existingFields,
+  );
 
   console.log(`🔎 Running dry-run migration report for list: ${listTitle}`);
-  const rows = await fetchAllItems(siteApiRoot, listTitle, selectFields, auth);
+  const rows = await fetchAllItems(siteApiRoot, listTitle, selectedFields, auth);
   const { summary, byGroup } = aggregate(rows);
 
   const report = {
@@ -269,6 +313,10 @@ async function main() {
     generatedAt: new Date().toISOString(),
     listTitle,
     mode: 'dry-run',
+    metadata: {
+      selectedFields: Array.from(selectedFields).sort(),
+      missingCandidateFields,
+    },
     summary,
     byGroup,
     safety: {

--- a/scripts/ops/monthlyrecord-summary-migration-guarded.mjs
+++ b/scripts/ops/monthlyrecord-summary-migration-guarded.mjs
@@ -142,6 +142,50 @@ async function fetchAllItems(siteApiRoot, listTitle, selectFields, auth) {
   return rows;
 }
 
+async function fetchExistingFieldNames(siteApiRoot, listTitle, auth) {
+  const encodedListTitle = listTitle.replace(/'/g, "''");
+  let nextUrl = `${siteApiRoot}/lists/getbytitle('${encodedListTitle}')/fields?$select=InternalName&$top=5000`;
+  const names = new Set();
+
+  while (nextUrl) {
+    const data = await spFetchJson(nextUrl, auth);
+    for (const field of data.value || []) {
+      const internalName = field?.InternalName;
+      if (typeof internalName === 'string' && internalName.trim()) {
+        names.add(internalName);
+      }
+    }
+    nextUrl = data['@odata.nextLink'] || '';
+  }
+
+  return names;
+}
+
+function buildExistingSelectFields(groups, existingFields) {
+  const requestedFields = new Set(['Id']);
+  const missingFields = [];
+
+  for (const def of Object.values(groups)) {
+    for (const name of [...def.canonical, ...def.fallback]) {
+      requestedFields.add(name);
+    }
+  }
+
+  const selectedFields = new Set();
+  for (const name of requestedFields) {
+    if (existingFields.has(name)) {
+      selectedFields.add(name);
+    } else {
+      missingFields.push(name);
+    }
+  }
+
+  return {
+    selectedFields,
+    missingCandidateFields: Array.from(new Set(missingFields)).sort(),
+  };
+}
+
 function evaluateGroup(row, groupDef) {
   let canonicalField = null;
   let canonicalValue = undefined;
@@ -184,11 +228,11 @@ function evaluateGroup(row, groupDef) {
   return { outcome: 'empty', canonicalField, fallbackField, canonicalValue, fallbackValue };
 }
 
-function pickCanonicalTarget(groupDef) {
-  return groupDef.canonical[0];
+function pickCanonicalTarget(groupDef, existingFields) {
+  return groupDef.canonical.find((name) => existingFields.has(name)) || null;
 }
 
-function buildPlan(rows) {
+function buildPlan(rows, existingFields) {
   const updates = [];
   const byGroup = {};
   const sampleConflictRowIds = [];
@@ -198,6 +242,7 @@ function buildPlan(rows) {
       fallbackOnlyCount: 0,
       bothDifferentCount: 0,
       plannedUpdates: 0,
+      missingCanonicalTargetCount: 0,
     };
   }
 
@@ -219,8 +264,12 @@ function buildPlan(rows) {
       if (result.outcome !== 'fallbackOnly') continue;
 
       byGroup[groupName].fallbackOnlyCount += 1;
-      const canonicalTarget = pickCanonicalTarget(def);
-      if (!canonicalTarget || !isPresent(result.fallbackValue)) continue;
+      const canonicalTarget = pickCanonicalTarget(def, existingFields);
+      if (!canonicalTarget) {
+        byGroup[groupName].missingCanonicalTargetCount += 1;
+        continue;
+      }
+      if (!isPresent(result.fallbackValue)) continue;
 
       byGroup[groupName].plannedUpdates += 1;
       updates.push({
@@ -239,6 +288,7 @@ function buildPlan(rows) {
     groupsWithPlannedUpdates: Object.values(byGroup).filter((g) => g.plannedUpdates > 0).length,
     conflictCount: Object.values(byGroup).reduce((acc, g) => acc + g.bothDifferentCount, 0),
     fallbackOnlyCount: Object.values(byGroup).reduce((acc, g) => acc + g.fallbackOnlyCount, 0),
+    missingCanonicalTargetCount: Object.values(byGroup).reduce((acc, g) => acc + g.missingCanonicalTargetCount, 0),
     destructiveOperationIncluded: false,
   };
 
@@ -293,10 +343,10 @@ function summarizeForMarkdown(report) {
   lines.push('');
   lines.push('## By Group');
   lines.push('');
-  lines.push('| Group | fallbackOnlyCount | bothDifferentCount | plannedUpdates |');
-  lines.push('| --- | ---: | ---: | ---: |');
+  lines.push('| Group | fallbackOnlyCount | bothDifferentCount | plannedUpdates | missingCanonicalTargetCount |');
+  lines.push('| --- | ---: | ---: | ---: | ---: |');
   for (const [group, stats] of Object.entries(report.byGroup)) {
-    lines.push(`| ${group} | ${stats.fallbackOnlyCount} | ${stats.bothDifferentCount} | ${stats.plannedUpdates} |`);
+    lines.push(`| ${group} | ${stats.fallbackOnlyCount} | ${stats.bothDifferentCount} | ${stats.plannedUpdates} | ${stats.missingCanonicalTargetCount} |`);
   }
 
   if (report.sampleConflictRowIds.length > 0) {
@@ -360,15 +410,15 @@ async function main() {
     ? siteUrl
     : `${siteUrl.replace(/\/$/, '')}/_api/web`;
 
-  const selectFields = new Set(['Id']);
-  for (const def of Object.values(MONTHLY_SUMMARY_MIGRATION_GROUPS)) {
-    for (const c of def.canonical) selectFields.add(c);
-    for (const f of def.fallback) selectFields.add(f);
-  }
+  const existingFields = await fetchExistingFieldNames(siteApiRoot, listTitle, auth);
+  const { selectedFields, missingCandidateFields } = buildExistingSelectFields(
+    MONTHLY_SUMMARY_MIGRATION_GROUPS,
+    existingFields,
+  );
 
   console.log(`🔎 Building guarded migration plan for list: ${listTitle}`);
-  const rows = await fetchAllItems(siteApiRoot, listTitle, selectFields, auth);
-  const plan = buildPlan(rows);
+  const rows = await fetchAllItems(siteApiRoot, listTitle, selectedFields, auth);
+  const plan = buildPlan(rows, existingFields);
 
   const report = {
     version: 1,
@@ -377,6 +427,10 @@ async function main() {
     mode: writeAllowed ? 'execute' : 'dry-run',
     dryRunReportPath: reportPath,
     dryRunConflictCount,
+    metadata: {
+      selectedFields: Array.from(selectedFields).sort(),
+      missingCandidateFields,
+    },
     summary: plan.summary,
     byGroup: plan.byGroup,
     sampleConflictRowIds: plan.sampleConflictRowIds,


### PR DESCRIPTION
## Summary
- Make MonthlyRecord_Summary migration scripts select only fields that exist in the target SharePoint list
- Report missing candidate fields via metadata.missingCandidateFields
- Use the first existing canonical candidate as the guarded migration target
- Track missing canonical targets without planning unsafe updates

## Validation
- node --check scripts/ops/monthlyrecord-summary-migration-dry-run.mjs
- node --check scripts/ops/monthlyrecord-summary-migration-guarded.mjs
- Production dry-run succeeded with VITE_SP_SITE_URL set
- Guarded no-execute run succeeded with writeAllowed:false

## Production review result
- conflictCount: 0
- fallbackOnlyCount: 0
- migrationCandidateCount: 0
- plannedUpdateCount: 0
- missingCandidateFields includes non-existing candidates such as IdempotencyKey

## Safety
- No SharePoint update
- No migration execution
- No column deletion
- No provisioning changes
- No purge behavior
- --execute remains unused

Follow-up of #1713