### PR TITLE
feat(sp): add MonthlyRecord_Summary Key idempotency fallback

### DIFF
--- a/src/features/records/monthly/map.test.ts
+++ b/src/features/records/monthly/map.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { BILLING_SUMMARY_CANDIDATES } from '@/sharepoint/fields/billingFields';
+
+import { toSharePointFields, upsertMonthlySummary } from './map';
+import type { MonthlySummary } from './types';
+
+const baseSummary: MonthlySummary = {
+  userId: 'I001',
+  yearMonth: '2026-04',
+  displayName: '利用者A',
+  lastUpdatedUtc: '2026-04-29T00:00:00.000Z',
+  kpi: {
+    totalDays: 20,
+    plannedRows: 380,
+    completedRows: 300,
+    inProgressRows: 50,
+    emptyRows: 30,
+    specialNotes: 4,
+    incidents: 1,
+  },
+  completionRate: 78.9,
+  firstEntryDate: '2026-04-01',
+  lastEntryDate: '2026-04-29',
+};
+
+describe('monthly record SharePoint mapping', () => {
+  it('keeps legacy Key as an intentional idempotency fallback candidate', () => {
+    expect(BILLING_SUMMARY_CANDIDATES.idempotencyKey).toEqual([
+      'Idempotency_x0020_Key',
+      'IdempotencyKey',
+      'Key',
+      'cr013_idempotencyKey',
+    ]);
+  });
+
+  it('writes idempotency data to the canonical field when that field exists', () => {
+    const fields = toSharePointFields(baseSummary, {
+      idempotencyKey: 'Idempotency_x0020_Key',
+    });
+
+    expect(fields.Idempotency_x0020_Key).toBe('I001#2026-04');
+    expect(fields.Key).toBeUndefined();
+  });
+
+  it('uses legacy Key lookup to update an existing monthly summary instead of creating a duplicate', async () => {
+    const findByIdempotencyKey = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        Id: 42,
+        Key: 'I001#2026-04',
+        LastAggregatedAt: '2026-04-28T00:00:00.000Z',
+      });
+    const update = vi.fn().mockResolvedValue({ Id: 42 });
+    const create = vi.fn();
+
+    const client = {
+      getListFieldInternalNames: vi.fn().mockResolvedValue(new Set([
+        'UserCode',
+        'YearMonth',
+        'DisplayName',
+        'LastAggregatedAt',
+        'TotalDays',
+        'PlannedRows',
+        'CompletedCount',
+        'PendingCount',
+        'EmptyCount',
+        'SpecialNoteCount',
+        'IncidentCount',
+        'CompletionRate',
+        'FirstEntryDate',
+        'LastEntryDate',
+        'Idempotency_x0020_Key',
+        'Key',
+      ])),
+      findByIdempotencyKey,
+      create,
+      update,
+    };
+
+    const result = await upsertMonthlySummary(client, baseSummary);
+
+    expect(result).toEqual({ action: 'updated', itemId: 42 });
+    expect(findByIdempotencyKey).toHaveBeenNthCalledWith(
+      1,
+      'MonthlyRecord_Summary',
+      'Idempotency_x0020_Key',
+      'I001#2026-04'
+    );
+    expect(findByIdempotencyKey).toHaveBeenNthCalledWith(
+      2,
+      'MonthlyRecord_Summary',
+      'IdempotencyKey',
+      'I001#2026-04'
+    );
+    expect(findByIdempotencyKey).toHaveBeenNthCalledWith(
+      3,
+      'MonthlyRecord_Summary',
+      'Key',
+      'I001#2026-04'
+    );
+    expect(update).toHaveBeenCalledWith(42, expect.objectContaining({
+      Idempotency_x0020_Key: 'I001#2026-04',
+    }));
+    expect(create).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/records/monthly/map.test.ts
+++ b/src/features/records/monthly/map.test.ts
@@ -101,7 +101,7 @@ describe('monthly record SharePoint mapping', () => {
       'Key',
       'I001#2026-04'
     );
-    expect(update).toHaveBeenCalledWith(42, expect.objectContaining({
+    expect(update).toHaveBeenCalledWith('MonthlyRecord_Summary', 42, expect.objectContaining({
       Idempotency_x0020_Key: 'I001#2026-04',
     }));
     expect(create).not.toHaveBeenCalled();

--- a/src/features/records/monthly/map.ts
+++ b/src/features/records/monthly/map.ts
@@ -20,6 +20,36 @@ function asField(physical: string | undefined, fallback: string): string {
   return physical || fallback;
 }
 
+function getResolvedCandidates(key: keyof typeof BILLING_SUMMARY_CANDIDATES): readonly string[] {
+  return BILLING_SUMMARY_CANDIDATES[key];
+}
+
+function uniqueCandidates(...candidates: Array<string | undefined>): string[] {
+  return [...new Set(candidates.filter((candidate): candidate is string => Boolean(candidate)))];
+}
+
+async function findExistingMonthlySummary(
+  client: SharePointClient,
+  listName: string,
+  key: string,
+  primaryFieldName: string
+): Promise<Record<string, unknown> | null> {
+  for (const fieldName of uniqueCandidates(primaryFieldName, ...getResolvedCandidates('idempotencyKey'))) {
+    const existing = await client.findByIdempotencyKey(listName, fieldName, key);
+    if (existing) {
+      if (fieldName !== primaryFieldName) {
+        console.warn('[monthly-summary:legacy-idempotency-fallback-used]', {
+          primaryFieldName,
+          fallbackFieldName: fieldName,
+        });
+      }
+      return existing;
+    }
+  }
+
+  return null;
+}
+
 /** DailyRecord リストのフィールド定義 (OData フィルタ SSOT) */
 const DAILY_RECORD_FILTER_FIELDS = {
   recordDate: 'RecordDate',
@@ -304,8 +334,8 @@ export async function upsertMonthlySummary(
   const key = `${summary.userId}#${summary.yearMonth}`;
 
   try {
-    // 既存レコード検索
-    const existing = await client.findByIdempotencyKey(listName, idempotencyFieldName, key);
+    // 既存レコード検索: canonical first, then intentional legacy fallback (`Key`).
+    const existing = await findExistingMonthlySummary(client, listName, key, idempotencyFieldName);
 
     if (existing) {
       // 更新が必要かチェック

--- a/src/features/records/monthly/map.ts
+++ b/src/features/records/monthly/map.ts
@@ -37,12 +37,6 @@ async function findExistingMonthlySummary(
   for (const fieldName of uniqueCandidates(primaryFieldName, ...getResolvedCandidates('idempotencyKey'))) {
     const existing = await client.findByIdempotencyKey(listName, fieldName, key);
     if (existing) {
-      if (fieldName !== primaryFieldName) {
-        console.warn('[monthly-summary:legacy-idempotency-fallback-used]', {
-          primaryFieldName,
-          fallbackFieldName: fieldName,
-        });
-      }
       return existing;
     }
   }

--- a/src/sharepoint/fields/billingFields.ts
+++ b/src/sharepoint/fields/billingFields.ts
@@ -65,7 +65,9 @@ export const BILLING_SUMMARY_CANDIDATES = {
   completionRate: ['CompletionRate', 'cr013_completionRate'],
   firstEntryDate: ['First_x0020_Entry_x0020_Date', 'FirstEntryDate', 'cr013_firstEntryDate'],
   lastEntryDate: ['Last_x0020_Entry_x0020_Date', 'LastEntryDate', 'cr013_lastEntryDate'],
-  idempotencyKey: ['Idempotency_x0020_Key', 'IdempotencyKey', 'cr013_idempotencyKey'],
+  // `Key` is a legacy, data-bearing idempotency field. Keep it as an intentional
+  // fallback until #1722 migration copies historical values into the canonical field.
+  idempotencyKey: ['Idempotency_x0020_Key', 'IdempotencyKey', 'Key', 'cr013_idempotencyKey'],
 } as const;
 
 export const BILLING_SUMMARY_ESSENTIALS: (keyof typeof BILLING_SUMMARY_CANDIDATES)[] = [


### PR DESCRIPTION
## Summary
- Add legacy `Key` as an intentional idempotency fallback candidate for `MonthlyRecord_Summary`
- Keep canonical writes on `Idempotency_x0020_Key` when the canonical field exists
- Prevent duplicate monthly summary creation by searching canonical idempotency fields first, then legacy `Key`
- Add tests covering the legacy `Key` fallback update path

## Validation
- Added unit coverage for `BILLING_SUMMARY_CANDIDATES.idempotencyKey`
- Added unit coverage proving `Key` fallback updates an existing row instead of creating a duplicate

## Notes
- Part of #1722 Step 1
- `Key` remains purge-prohibited and is not deleted by this PR
- One-time data migration remains a later step