### PR TITLE
feat(sp): add MonthlyRecord_Summary idempotency fallback telemetry

### DIFF
--- a/src/features/records/monthly/map.test.ts
+++ b/src/features/records/monthly/map.test.ts
@@ -1,9 +1,14 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { trackSpEvent } from '@/lib/telemetry/spTelemetry';
 import { BILLING_SUMMARY_CANDIDATES } from '@/sharepoint/fields/billingFields';
 
 import { toSharePointFields, upsertMonthlySummary } from './map';
 import type { MonthlySummary } from './types';
+
+vi.mock('@/lib/telemetry/spTelemetry', () => ({
+  trackSpEvent: vi.fn(),
+}));
 
 const baseSummary: MonthlySummary = {
   userId: 'I001',
@@ -24,7 +29,30 @@ const baseSummary: MonthlySummary = {
   lastEntryDate: '2026-04-29',
 };
 
+const monthlyFields = new Set([
+  'UserCode',
+  'YearMonth',
+  'DisplayName',
+  'LastAggregatedAt',
+  'TotalDays',
+  'PlannedRows',
+  'CompletedCount',
+  'PendingCount',
+  'EmptyCount',
+  'SpecialNoteCount',
+  'IncidentCount',
+  'CompletionRate',
+  'FirstEntryDate',
+  'LastEntryDate',
+  'Idempotency_x0020_Key',
+  'Key',
+]);
+
 describe('monthly record SharePoint mapping', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('keeps legacy Key as an intentional idempotency fallback candidate', () => {
     expect(BILLING_SUMMARY_CANDIDATES.idempotencyKey).toEqual([
       'Idempotency_x0020_Key',
@@ -43,6 +71,35 @@ describe('monthly record SharePoint mapping', () => {
     expect(fields.Key).toBeUndefined();
   });
 
+  it('does not emit fallback telemetry when canonical Idempotency_x0020_Key matches', async () => {
+    const findByIdempotencyKey = vi.fn().mockResolvedValueOnce({
+      Id: 42,
+      Idempotency_x0020_Key: 'I001#2026-04',
+      LastAggregatedAt: '2026-04-28T00:00:00.000Z',
+    });
+    const update = vi.fn().mockResolvedValue({ Id: 42 });
+    const create = vi.fn();
+
+    const client = {
+      getListFieldInternalNames: vi.fn().mockResolvedValue(monthlyFields),
+      findByIdempotencyKey,
+      create,
+      update,
+    };
+
+    const result = await upsertMonthlySummary(client, baseSummary);
+
+    expect(result).toEqual({ action: 'updated', itemId: 42 });
+    expect(findByIdempotencyKey).toHaveBeenCalledTimes(1);
+    expect(findByIdempotencyKey).toHaveBeenCalledWith(
+      'MonthlyRecord_Summary',
+      'Idempotency_x0020_Key',
+      'I001#2026-04'
+    );
+    expect(trackSpEvent).not.toHaveBeenCalled();
+    expect(create).not.toHaveBeenCalled();
+  });
+
   it('uses legacy Key lookup to update an existing monthly summary instead of creating a duplicate', async () => {
     const findByIdempotencyKey = vi
       .fn()
@@ -57,24 +114,7 @@ describe('monthly record SharePoint mapping', () => {
     const create = vi.fn();
 
     const client = {
-      getListFieldInternalNames: vi.fn().mockResolvedValue(new Set([
-        'UserCode',
-        'YearMonth',
-        'DisplayName',
-        'LastAggregatedAt',
-        'TotalDays',
-        'PlannedRows',
-        'CompletedCount',
-        'PendingCount',
-        'EmptyCount',
-        'SpecialNoteCount',
-        'IncidentCount',
-        'CompletionRate',
-        'FirstEntryDate',
-        'LastEntryDate',
-        'Idempotency_x0020_Key',
-        'Key',
-      ])),
+      getListFieldInternalNames: vi.fn().mockResolvedValue(monthlyFields),
       findByIdempotencyKey,
       create,
       update,
@@ -101,6 +141,14 @@ describe('monthly record SharePoint mapping', () => {
       'Key',
       'I001#2026-04'
     );
+    expect(trackSpEvent).toHaveBeenCalledWith('sp:idempotency_fallback_used', {
+      listName: 'MonthlyRecord_Summary',
+      key: 'I001#2026-04',
+      details: {
+        canonicalField: 'Idempotency_x0020_Key',
+        fallbackField: 'Key',
+      },
+    });
     expect(update).toHaveBeenCalledWith('MonthlyRecord_Summary', 42, expect.objectContaining({
       Idempotency_x0020_Key: 'I001#2026-04',
     }));

--- a/src/features/records/monthly/map.ts
+++ b/src/features/records/monthly/map.ts
@@ -11,6 +11,7 @@ import {
   joinOr,
 } from '@/sharepoint/query/builders';
 
+import { trackSpEvent } from '@/lib/telemetry/spTelemetry';
 import { BILLING_SUMMARY_CANDIDATES } from '@/sharepoint/fields/billingFields';
 import { resolveInternalNamesDetailed } from '@/lib/sp/helpers';
 
@@ -37,6 +38,13 @@ async function findExistingMonthlySummary(
   for (const fieldName of uniqueCandidates(primaryFieldName, ...getResolvedCandidates('idempotencyKey'))) {
     const existing = await client.findByIdempotencyKey(listName, fieldName, key);
     if (existing) {
+      if (fieldName !== primaryFieldName) {
+        trackSpEvent('sp:idempotency_fallback_used', {
+          listName,
+          key,
+          details: { canonicalField: primaryFieldName, fallbackField: fieldName },
+        });
+      }
       return existing;
     }
   }

--- a/src/lib/telemetry/spTelemetry.ts
+++ b/src/lib/telemetry/spTelemetry.ts
@@ -24,6 +24,7 @@ export type SpEventName =
   | 'provider_contract_violation'
   | 'sp:row_skipped'
   | 'sp:fetch_fallback_success'
+  | 'sp:idempotency_fallback_used'
   | 'provisioning_executed'
   | 'sp:approval_log_created'
   | 'sp:approval_log_skipped'


### PR DESCRIPTION
## Summary
- Add `sp:idempotency_fallback_used` telemetry event
- Emit telemetry when MonthlyRecord_Summary idempotency lookup falls back from canonical `Idempotency_x0020_Key` to another candidate such as legacy `Key`
- Keep canonical hit path silent
- Add tests for canonical no-telemetry and legacy `Key` fallback telemetry behavior

## Validation
- Unit coverage added in `src/features/records/monthly/map.test.ts`

## Notes
- Part of #1722 Step 2
- This PR does not migrate data
- This PR does not delete, rename, or disable `Key`
- Fallback telemetry is intentionally emitted for all fallback idempotency fields, not only `Key`, so Step 4 can use the data to prove all fallback paths are unused before removal