### PR TITLE
fix: stabilize runtime patrol and daily records

### DIFF
--- a/scripts/ops/nightly-runtime-patrol.ts
+++ b/scripts/ops/nightly-runtime-patrol.ts
@@ -767,7 +767,12 @@ async function fetchRealEvents(
   };
 
   const isListViewThresholdResponse = (res: Response, text: string): boolean =>
-    res.status === 500 && /list view threshold/i.test(text);
+    res.status === 500 &&
+    (
+      /list view threshold/i.test(text) ||
+      /SPQueryThrottledException/i.test(text) ||
+      /-2147024860/.test(text)
+    );
 
   const mapDriftItemToEvent = (item: any): RawEvent => {
     let eType: RawEvent['eventType'] = 'drift';
@@ -794,6 +799,15 @@ async function fetchRealEvents(
   try {
     let driftFetchSucceeded = false;
     let diagnosticsFetchSucceeded = false;
+    let diagnosticsOptionalUnavailable = false;
+    const sinceMs = Date.parse(filterDate);
+
+    const filterRecentItems = (items: any[]): any[] =>
+      items.filter((item: any) => {
+        const timestamp = item.DetectedAt || item.Detected_x0020_At || item.Created;
+        const time = Date.parse(timestamp);
+        return Number.isNaN(time) || Number.isNaN(sinceMs) ? true : time >= sinceMs;
+      });
 
     // 1. DriftEventsLog fetches
     const driftUrl = `${siteUrl}/_api/web/lists/getbytitle('DriftEventsLog')/items?$filter=Created ge datetime'${filterDate}'`;
@@ -801,42 +815,40 @@ async function fetchRealEvents(
 
     if (driftAttempt.res.ok) {
       driftFetchSucceeded = true;
-      driftAttempt.data.value.forEach((item: any) => {
+      const items = Array.isArray(driftAttempt.data.value) ? driftAttempt.data.value : [];
+      items.forEach((item: any) => {
         events.push(mapDriftItemToEvent(item));
       });
-      driftLogReadStats.scannedCount = driftAttempt.data.value.length;
-      driftLogReadStats.filteredCount = driftAttempt.data.value.length;
+      driftLogReadStats.scannedCount = items.length;
+      driftLogReadStats.filteredCount = items.length;
       driftLogReadStats.safety = classifyDriftLogSafety(driftLogReadStats.scannedCount);
-      console.log(`  └ Fetched ${driftAttempt.data.value.length} DriftEventsLog events.`);
-    } else if (isListViewThresholdResponse(driftAttempt.res, driftAttempt.text)) {
-      console.warn(`⚠️ DriftEventsLog threshold detected. Falling back to Id desc top ${DRIFT_LOG_FALLBACK_TOP}.`);
+      console.log(`  └ Fetched ${items.length} DriftEventsLog events.`);
+    } else {
+      if (isListViewThresholdResponse(driftAttempt.res, driftAttempt.text)) {
+        console.warn(`⚠️ DriftEventsLog threshold detected. Falling back to top ${DRIFT_LOG_FALLBACK_TOP} + local date filter.`);
+      } else {
+        console.warn(`⚠️ DriftEventsLog filtered query failed (${driftAttempt.res.status} ${driftAttempt.res.statusText}). Falling back to top ${DRIFT_LOG_FALLBACK_TOP} + local date filter.`);
+      }
       driftLogReadStats.fallbackUsed = true;
       const fallbackUrl =
         `${siteUrl}/_api/web/lists/getbytitle('DriftEventsLog')/items` +
         `?$select=Id,Title,Created,DetectedAt,Detected_x0020_At,ListName,List_x0020_Name,FieldName,Field_x0020_Name,Severity,ResolutionType,ErrorMessage` +
-        `&$orderby=Id desc&$top=${DRIFT_LOG_FALLBACK_TOP}`;
+        `&$top=${DRIFT_LOG_FALLBACK_TOP}`;
       const fallbackAttempt = await fetchJson(fallbackUrl);
       if (fallbackAttempt.res.ok) {
         driftFetchSucceeded = true;
-        const filtered = (fallbackAttempt.data.value as any[])
-          .filter((item: any) => {
-            const timestamp = item.DetectedAt || item.Detected_x0020_At || item.Created;
-            const time = Date.parse(timestamp);
-            const since = Date.parse(filterDate);
-            return Number.isNaN(time) || Number.isNaN(since) ? true : time >= since;
-          });
+        const scanned = Array.isArray(fallbackAttempt.data.value) ? fallbackAttempt.data.value : [];
+        const filtered = filterRecentItems(scanned);
         filtered.forEach((item: any) => {
           events.push(mapDriftItemToEvent(item));
         });
-        driftLogReadStats.scannedCount = fallbackAttempt.data.value.length;
+        driftLogReadStats.scannedCount = scanned.length;
         driftLogReadStats.filteredCount = filtered.length;
         driftLogReadStats.safety = classifyDriftLogSafety(driftLogReadStats.scannedCount);
-        console.log(`  └ Fetched ${filtered.length} DriftEventsLog events via fallback (${fallbackAttempt.data.value.length} scanned).`);
+        console.log(`  └ Fetched ${filtered.length} DriftEventsLog events via fallback (${scanned.length} scanned).`);
       } else {
         console.warn(`⚠️ Failed to fetch DriftEventsLog fallback: ${fallbackAttempt.res.status} ${fallbackAttempt.res.statusText}`);
       }
-    } else {
-      console.warn(`⚠️ Failed to fetch DriftEventsLog: ${driftAttempt.res.status} ${driftAttempt.res.statusText}`);
     }
 
     // 2. DiagnosticsReports fetches
@@ -845,7 +857,9 @@ async function fetchRealEvents(
     if (diagRes.ok) {
         diagnosticsFetchSucceeded = true;
         const data = await diagRes.json();
-        data.value.forEach((item: any) => {
+        const scanned = Array.isArray(data.value) ? data.value : [];
+        const filtered = filterRecentItems(scanned);
+        filtered.forEach((item: any) => {
             const isCritical = item.Status === 'FAIL' || item.Title?.includes('FAIL');
             const hasThrottle = item.Payload?.includes('429');
             
@@ -859,12 +873,17 @@ async function fetchRealEvents(
                 message: item.Title || 'Diagnostic error reported.'
             });
         });
-        console.log(`  └ Fetched ${data.value.length} DiagnosticsReports events.`);
+        console.log(`  └ Fetched ${filtered.length} DiagnosticsReports events (${scanned.length} scanned).`);
     } else {
-        console.warn(`⚠️ Failed to fetch DiagnosticsReports: ${diagRes.status} ${diagRes.statusText} (List may not exist yet)`);
+        if (diagRes.status === 404) {
+          diagnosticsOptionalUnavailable = true;
+          console.warn('⚠️ DiagnosticsReports is optional and was not found (404). Continuing.');
+        } else {
+          console.warn(`⚠️ Failed to fetch DiagnosticsReports: ${diagRes.status} ${diagRes.statusText} (List may not exist yet)`);
+        }
     }
 
-    if (requireSharePoint && !driftFetchSucceeded && !diagnosticsFetchSucceeded) {
+    if (requireSharePoint && !driftFetchSucceeded && !diagnosticsFetchSucceeded && !diagnosticsOptionalUnavailable) {
       throw new Error('Failed to fetch both DriftEventsLog and DiagnosticsReports while NIGHTLY_REQUIRE_SP=1.');
     }
 

--- a/src/features/daily/components/split-stream/RecordPanel.tsx
+++ b/src/features/daily/components/split-stream/RecordPanel.tsx
@@ -3,6 +3,7 @@ import AccessTimeIcon from '@mui/icons-material/AccessTime';
 import LockIcon from '@mui/icons-material/Lock';
 import PersonOffIcon from '@mui/icons-material/PersonOff';
 import SaveIcon from '@mui/icons-material/Save';
+import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
@@ -133,6 +134,7 @@ export function RecordPanel(props: RecordPanelProps): JSX.Element {
   const [memo, setMemo] = useState('');
   const [durationMinutes, setDurationMinutes] = useState(5);
   const [userMood, setUserMood] = useState<BehaviorMood | null>(null);
+  const [submitFeedback, setSubmitFeedback] = useState<string | null>(null);
   const observationRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
   const selectedActivityRef = useRef<HTMLDivElement>(null);
 
@@ -237,11 +239,21 @@ export function RecordPanel(props: RecordPanelProps): JSX.Element {
         observationLength: observationText.length,
       });
     }
-    if (isLocked) return;
+    if (isLocked) {
+      setSubmitFeedback('入力ロック中です。対象者と手順を確認してください。');
+      return;
+    }
     const observation = actualObservation.trim();
-    if (!observation) return;
-    if (requiresPlanSlot && !selectedSlot) return;
+    if (!observation) {
+      setSubmitFeedback('「本人の様子・実施記録」を入力してください。');
+      return;
+    }
+    if (requiresPlanSlot && !selectedSlot) {
+      setSubmitFeedback('上部の時間帯チップを選択してから保存してください。');
+      return;
+    }
     try {
+      setSubmitFeedback(null);
       await onSubmit({
         recordedAt: new Date().toISOString(),
         planSlotKey: selectedSlot ? getScheduleKey(selectedSlot.time, selectedSlot.activity) : undefined,
@@ -273,8 +285,9 @@ export function RecordPanel(props: RecordPanelProps): JSX.Element {
       setUserMood(null);
       onAfterSubmit?.(selectedSlot ? getScheduleKey(selectedSlot.time, selectedSlot.activity) : null);
     } catch (err) {
-      // 🚨 error は store.error に入ってるので、ここでは何もしない
-      console.debug('[RecordPanel.handleSubmit] error already in store:', err);
+      const message = err instanceof Error ? err.message : '保存に失敗しました。';
+      setSubmitFeedback(message);
+      console.debug('[RecordPanel.handleSubmit] submit failed:', err);
     }
   };
 
@@ -461,6 +474,11 @@ export function RecordPanel(props: RecordPanelProps): JSX.Element {
       </CardContent>
 
       <Box sx={{ p: 2, borderTop: 1, borderColor: 'divider' }}>
+        {submitFeedback ? (
+          <Alert severity="warning" sx={{ mb: 1 }}>
+            {submitFeedback}
+          </Alert>
+        ) : null}
         <Button
           fullWidth
           variant="contained"

--- a/src/features/sp/health/indexAdvisor/spIndexKnownConfig.ts
+++ b/src/features/sp/health/indexAdvisor/spIndexKnownConfig.ts
@@ -79,9 +79,9 @@ export const KNOWN_REQUIRED_INDEXED_FIELDS: Record<string, IndexFieldSpec[]> = {
   ],
   SupportRecord_Daily: [
     {
-      internalName: 'UserCode',
-      displayName: '利用者コード',
-      reason: '利用者別履歴取得のキー',
+      internalName: 'UserId',
+      displayName: '利用者ID',
+      reason: '利用者別履歴取得のキー（現行リスト列: UserId）',
     },
     {
       internalName: 'RecordDate',
@@ -114,16 +114,8 @@ export const KNOWN_REQUIRED_INDEXED_FIELDS: Record<string, IndexFieldSpec[]> = {
     },
   ],
   UserBenefit_Profile: [
-    {
-      internalName: 'UserID',
-      displayName: '利用者ID',
-      reason: '結合・取得の主キー',
-    },
-    {
-      internalName: 'RecipientCertNumber',
-      displayName: '受給者証番号',
-      reason: '支給決定情報の検索用',
-    },
+    // UserID / RecipientCertNumber are managed in UserBenefit_Profile_Ext.
+    // Keep required indexes here aligned with fields that physically exist on this list.
     {
       internalName: 'GrantPeriodEnd',
       displayName: '支給終了日',

--- a/src/pages/hooks/useTimeBasedSupportRecordPage.ts
+++ b/src/pages/hooks/useTimeBasedSupportRecordPage.ts
@@ -58,6 +58,16 @@ export function useTimeBasedSupportRecordPage({
     [behaviorRecords, targetUserId],
   );
   const scheduleKeys = useMemo(() => schedule.map((item) => getScheduleKey(item.time, item.activity)), [schedule]);
+  const resolveStepKeyFromSchedule = useCallback((rawStepKey?: string | null): string | null => {
+    if (!rawStepKey) return null;
+    if (scheduleKeys.includes(rawStepKey)) return rawStepKey;
+
+    // URL 由来の step は活動文言差分で不一致になることがあるため、時刻だけで救済する。
+    const rawTime = rawStepKey.split('|')[0]?.trim();
+    if (!rawTime) return null;
+    const matched = scheduleKeys.find((key) => key.split('|')[0]?.trim() === rawTime);
+    return matched ?? null;
+  }, [scheduleKeys]);
   const filledStepIds = useMemo(() => {
     if (!schedule.length || recentObservations.length === 0) return new Set<string>();
     const filled = new Set<string>();
@@ -197,17 +207,20 @@ export function useTimeBasedSupportRecordPage({
       return;
     }
     if (selectedStepId && !scheduleKeys.includes(selectedStepId)) {
-      setSelectedStepId(null);
+      const resolved = resolveStepKeyFromSchedule(selectedStepId);
+      setSelectedStepId(resolved);
     }
-  }, [schedule, scheduleKeys, selectedStepId]);
+  }, [resolveStepKeyFromSchedule, schedule, scheduleKeys, selectedStepId]);
 
   useEffect(() => {
     if (!initialStepKey) return;
     if (didApplyInitialStepRef.current) return;
     didApplyInitialStepRef.current = true;
-    setSelectedStepId(initialStepKey);
-    setScrollToStepId(initialStepKey);
-  }, [initialStepKey]);
+    const resolved = resolveStepKeyFromSchedule(initialStepKey);
+    if (!resolved) return;
+    setSelectedStepId(resolved);
+    setScrollToStepId(resolved);
+  }, [initialStepKey, resolveStepKeyFromSchedule]);
 
   useEffect(() => {
     if (!showUnfilledOnly) return;

--- a/src/pages/support-planning-sheet/SupportPlanningSheetView.tsx
+++ b/src/pages/support-planning-sheet/SupportPlanningSheetView.tsx
@@ -71,6 +71,20 @@ export const SupportPlanningSheetView: React.FC<SupportPlanningSheetViewProps> =
     };
   }, [planPatchRepository, planningSheetId]);
 
+  const { handleApplyPatch: orchestratorApplyPatch, handleUpdatePatchStatus } = usePlanningSheetOrchestrator({
+    planningSheetRepo,
+    planPatchRepo: planPatchRepository,
+    showSnack: (_severity, msg) => setPatchActionMessage(msg),
+    refresh: async () => {
+      if (!planningSheetId || planningSheetId === 'new') return;
+      // In a real VM setup, this would trigger a refetch in the VM.
+      // For now, we simulate by re-fetching patches locally.
+      const patches = await planPatchRepository.findPending(planningSheetId);
+      setPendingPatches(patches);
+      setPendingPatchCount(patches.length);
+    }
+  });
+
   if (!viewModel) {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: 300 }}>
@@ -153,19 +167,6 @@ export const SupportPlanningSheetView: React.FC<SupportPlanningSheetViewProps> =
       </Box>
     );
   }
-
-  const { handleApplyPatch: orchestratorApplyPatch, handleUpdatePatchStatus } = usePlanningSheetOrchestrator({
-    planningSheetRepo,
-    planPatchRepo: planPatchRepository,
-    showSnack: (severity, msg) => setPatchActionMessage(msg),
-    refresh: async () => {
-      // In a real VM setup, this would trigger a refetch in the VM.
-      // For now, we simulate by re-fetching patches locally.
-      const patches = await planPatchRepository.findPending(planningSheetId!);
-      setPendingPatches(patches);
-      setPendingPatchCount(patches.length);
-    }
-  });
 
   const handlePatchStatusChange = async (
     patchId: string,


### PR DESCRIPTION
## Summary
- Keep planning sheet orchestrator hook order stable
- Align known SharePoint index field names
- Resolve support step keys by time in daily records
- Show validation feedback in the record panel
- Tolerate diagnostics report exceptions in nightly runtime patrol

## Validation
- CI checked via GitHub Actions
