### PR TITLE
chore(monthly): finalize Phase 3 legacy summary field isolation

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -24,7 +24,7 @@ BASE_REF="${BASE_REF:-origin/main}"
 
 # Determine changed JS/TS files compared to base.
 # Exclude files matching .eslintignore patterns (e.g. Legacy/) to avoid ESLint 8 "file ignored" warnings.
-FILES="$(git diff --name-only --diff-filter=ACMR "$BASE_REF...HEAD" -- '*.ts' '*.tsx' '*.js' '*.jsx' | grep -v -E '(^|/)tests/|/Legacy/' || true)"
+FILES="$(git diff --name-only --diff-filter=ACMR "$BASE_REF...HEAD" -- '*.ts' '*.tsx' '*.js' '*.jsx' | grep -v -E '(^|/)tests/|/Legacy/|^scripts/' || true)"
 
 # If nothing to lint, skip.
 if [ -z "$FILES" ]; then

--- a/docs/planning/monthly-record-summary-audit-report.md
+++ b/docs/planning/monthly-record-summary-audit-report.md
@@ -45,9 +45,18 @@ We will proceed with a **Guarded Schema Alignment** (Non-Destructive).
 - [x] **Index Governance**: Ensured `UserId` and `YearMonth` are indexed to prevent performance degradation.
 - [x] **Idempotency Transition**: Verified existing records. (Healthcheck records were skipped as they lack UserId/YM).
 
-### Phase 3: Decommissioning (Post-Validation)
-- **Isolation**: Update all read/write paths to use ONLY the canonical fields (Ongoing).
-- **Purge**: Physically delete `TotalDays`, `Total_x0020_Days`, and `Key` once they are confirmed as zero-dependency zombies via `nightly-patrol`.
+### Phase 3: Legacy Field Isolation (Completed 2026-04-30)
+- [x] **Code Isolation**: Updated `toSharePointFields` to prefer `KPI_TotalDays` and `Idempotency_x0020_Key`.
+- [x] **IsLocked Integration**: Integrated `IsLocked` into the `MonthlySummary` type and mapping logic.
+- [x] **Registry Documentation**: Marked legacy fields in `BILLING_SUMMARY_CANDIDATES` with "LEGACY: Decommission pending" comments.
+- [x] **Priority Validation**: Added unit tests to ensure canonical fields are prioritized over legacy fallbacks.
+- [x] **Health Check Governance**: Implemented `legacyCandidates` system in the Health Diagnosis suite to distinguish between "Drift" (Warning) and "Legacy Tolerated" (Pass).
+
+### Phase 4: Physical Decommissioning (Target: After Stability Period)
+- **Monitoring**: Observe `nightly-patrol` reports for at least 7 days to ensure zero data drift between `KPI_TotalDays` and legacy `TotalDays`.
+- **Validation**: Verify that no external systems (Power Automate, Excel connectors) are reading from legacy fields.
+- **Execution**: Physically delete `TotalDays`, `Total_x0020_Days`, and `Key` from the SharePoint list.
+- **Cleanup**: Remove legacy field candidates from `billingFields.ts`.
 
 ---
 

--- a/docs/planning/monthly-record-summary-audit-report.md
+++ b/docs/planning/monthly-record-summary-audit-report.md
@@ -1,0 +1,62 @@
+# MonthlyRecord_Summary Schema Audit Report
+
+**Date:** 2026-04-30
+**Status:** Phase 2 Hardening Complete
+**Target List:** `MonthlyRecord_Summary` (Location: `/sites/welfare`)
+
+## 1. Executive Summary
+The audit of the `MonthlyRecord_Summary` list is complete. We have confirmed the site location, record count, and data integrity of the primary metrics. While triple redundancy exists for the "Total Days" field, the values are currently consistent across the active records (4/4). A clear path forward has been established to harden the schema without destructive operations.
+
+## 2. Field Reconciliation Matrix
+
+| Logical Key | Canonical Field | Actual Found | Status | Note |
+| :--- | :--- | :--- | :--- | :--- |
+| **userId** | `UserCode` | `UserCode` | ✅ OK | |
+| **yearMonth** | `YearMonth` | `YearMonth` | ✅ OK | |
+| **totalDays** | `KPI_TotalDays` | `KPI_TotalDays`, `TotalDays` | ⚠️ DUP | Consistent (4/4). `KPI_TotalDays` is SSOT. |
+| **idempotency**| `IdempotencyKey` | (None) | ❌ MISSING | Legacy `Key` exists but is empty. |
+| **isLocked** | `IsLocked` | (None) | ❌ MISSING | **Required** for upcoming billing features. |
+| **displayName**| `DisplayName` | `DisplayName` | ✅ OK | |
+
+## 3. Key Findings
+
+### 3.1. 📡 Production Probe Results
+- **Site**: `https://isogokatudouhome.sharepoint.com/sites/welfare`
+- **Count**: 4 records found.
+- **Integrity**: `KPI_TotalDays` and `TotalDays` matched perfectly on all records.
+- **Zombies**: `Key` and `Total_x0020_Days` are present but contain no data.
+- **False Positive**: The drift ledger reported 35 matches for `Key`; this was a grep false positive for the generic "Key" term in the source code.
+
+### 3.2. ⚠️ Missing Critical Fields
+- `IsLocked`: This field is missing from the physical schema but is required for the billing lock-down logic. It needs to be provisioned.
+- `IdempotencyKey`: The application expects `IdempotencyKey`, but the list uses an empty `Key` field.
+
+## 4. 🗺️ Migration & Alignment Strategy
+
+We will proceed with a **Guarded Schema Alignment** (Non-Destructive).
+
+### Phase 1: Code-Level Unification (Completed)
+- [x] Update `billingFields.ts` to prioritize `KPI_TotalDays`.
+- [x] Integrate `IsLocked` into candidate resolution.
+- [x] Implement drift detection logging in `map.ts` to catch future value discrepancies.
+
+### Phase 2: Schema Hardening (Completed 2026-04-30)
+- [x] **Safe Provisioning**: Added `IsLocked` (Boolean, Default: false) to the `/sites/welfare` list.
+- [x] **Index Governance**: Ensured `UserId` and `YearMonth` are indexed to prevent performance degradation.
+- [x] **Idempotency Transition**: Verified existing records. (Healthcheck records were skipped as they lack UserId/YM).
+
+### Phase 3: Decommissioning (Post-Validation)
+- **Isolation**: Update all read/write paths to use ONLY the canonical fields (Ongoing).
+- **Purge**: Physically delete `TotalDays`, `Total_x0020_Days`, and `Key` once they are confirmed as zero-dependency zombies via `nightly-patrol`.
+
+---
+
+## 🛡️ Safety Checklist
+- [x] No destructive deletions in this phase.
+- [x] No renaming of active columns.
+- [x] Read-only verification performed on production records.
+- [x] Data integrity confirmed via value-comparison probe.
+- [x] Environment location definitively identified.
+
+> [!IMPORTANT]
+> The repository is now ready for the **controlled provisioning of `IsLocked`** to the production environment.

--- a/docs/planning/support-planning-sheet-l2-flow.md
+++ b/docs/planning/support-planning-sheet-l2-flow.md
@@ -1,0 +1,83 @@
+# 支援計画シート（L2）記録フロー・ウォークスルー
+— planning-sheet-list から SharePoint 保存完了まで —
+
+本ドキュメントでは、`http://localhost:5173/planning-sheet-list` から始まり、強度行動障害支援計画シート（L2）の入力・記録が完了するまでのシステムフローを解説します。
+
+## 1. エントリポイント：一覧画面
+**URL**: `/planning-sheet-list`  
+**Page Component**: `PlanningSheetListPage.tsx`
+
+1.  **利用者選択**: `UserSelectionGrid` コンポーネントにて対象の利用者を選択します。
+2.  **データの取得**: `usePlanningSheetListOrchestrator` が起動し、`PlanningSheetRepository` を通じて当該利用者のシート一覧を取得します。
+3.  **遷移選択**:
+    *   **新規作成**: `handlers.onNewSheet` が呼ばれます。**詳細入力前に SharePoint 側へ初期レコードを作成し、その ID を `planningSheetId` として詳細画面へ遷移します。** そのため、詳細画面に入った時点で SharePoint 上に空レコード（または基本情報のみのレコード）が既に存在します。
+    *   **既存編集**: テーブルの行をクリックすると `handlers.onNavigateToSheet` が呼ばれ、詳細画面へ遷移します。
+
+## 2. 詳細画面：入力・構成
+**URL**: `/support-planning-sheet/:planningSheetId`  
+**Page Component**: `SupportPlanningSheetPage.tsx`
+
+この画面は **L2 スクリーン責務境界パターン（Orchestrator パターン）** に基づき、以下の 3 層構造で動作します。
+
+### A. オーケストレーター (`useSupportPlanningSheetOrchestrator`)
+*   **状態管理**: `isEditing`（編集モード）の状態や、選択中のタブ `activeTab` を管理します。
+*   **データ収集**: 支援記録（ABC記録）や氷山分析（PDCA）のデータをバックエンドから取得し、ViewModel へ供給します。
+*   **ブリッジ接続**: `assessmentBridge` などを介して、アセスメント情報から支援設計への「根拠」の紐付けを仲介します。
+
+### B. フォーム・ロジック (`usePlanningSheetForm`)
+*   **スキーマ管理**: `SupportPlanningSheet` ドメインモデルに基づき、`intake`、`assessment`、`planning`（支援設計）の各セクションを構造化された状態で保持します。
+
+### C. ビュー (`SupportPlanningSheetView`)
+*   **モード切替**: 「編集」ボタン押下で `isEditing` が true になり、入力が可能になります。
+
+## 3. 記録プロセス：永続化
+1.  **保存アクション**: ユーザーがヘッダーの「保存」ボタンをクリックします。
+2.  **ハンドラ実行**: オーケストレーターの `handleSave` が `form.save()` を呼び出します。
+3.  **リポジトリ経由の書き込み**:
+    *   `DataProviderPlanningSheetRepository.update()` が実行されます。
+    *   内部で `DataProvider.updateItem`（SharePoint API への PATCH リクエスト）が呼ばれ、サーバーへデータが送信されます。
+
+### 記録完了の定義
+**SharePoint への PATCH が成功し、保存成功トーストが表示され、編集モードが解除された状態** を「記録完了」と定義します。
+
+## 4. 異常系への対応
+
+| 異常系シナリオ | 挙動 / 対策 |
+| :--- | :--- |
+| **保存失敗・通信失敗** | 保存に失敗した場合は、エラートーストを表示し、**編集モードを維持**します。これにより、入力内容を失わずに通信環境の復旧を待って再試行することが可能です。 |
+| **権限不足** | 閲覧権限はあるが編集権限がない場合、画面上部に警告が表示される、または「編集」ボタンが無効化（もしくは非表示）になります。実際の編集可否は画面側の権限制御に従います。 |
+| **編集中離脱** | ブラウザを閉じたり、保存せずに一覧へ戻ろうとした場合、未保存変更がある場合は「変更が保存されない可能性があります」という警告（BeforeUnload ガード）を表示する設計です。未実装の場合は、今後の安全対策として追加対象になります。 |
+
+---
+
+> [!NOTE]
+> **ISPガイド（L1）との挙動の違いについて**
+> `SupportPlanGuidePage`（個別支援計画ガイド）では `localStorage` を利用した **オートセーブ機構**（「最新の状態です」の表示）が実装されていますが、本機能（L2 支援計画シート）は SharePoint への直接保存を基本とするため、**手動保存ボタンによる確実な記録** を採用しています。
+
+## データの流れ図 (Mermaid)
+
+```mermaid
+sequenceDiagram
+    participant User as ユーザー
+    participant View as SupportPlanningSheetView
+    participant Orc as Orchestrator
+    participant Form as usePlanningSheetForm
+    participant Repo as PlanningSheetRepository
+    participant SP as SharePoint (Backend)
+
+    Note over User, SP: 新規作成時はこの前に ID 発行済み
+    User->>View: 編集ボタン押下
+    View->>Orc: setIsEditing(true)
+    User->>View: 各セクションの内容を入力
+    View->>Form: update section state
+    User->>View: 保存ボタン押下
+    View->>Orc: handleSave()
+    Orc->>Form: save()
+    Form->>Repo: update(id, data)
+    Repo->>SP: PATCH /items(id)
+    SP-->>Repo: 200 OK
+    Repo-->>Form: Success
+    Form-->>Orc: Done
+    Orc->>View: setToast("保存しました")
+    Orc->>View: setIsEditing(false)
+```

--- a/scripts/ops/diagnose-monthly-schema.ts
+++ b/scripts/ops/diagnose-monthly-schema.ts
@@ -1,0 +1,63 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+function loadEnv() {
+  const root = process.cwd();
+  const envFiles = ['.env', '.env.local'];
+  
+  for (const file of envFiles) {
+    const envPath = path.resolve(root, file);
+    if (fs.existsSync(envPath)) {
+      const content = fs.readFileSync(envPath, 'utf8');
+      content.split('\n').forEach(line => {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith('#')) return;
+        const [rawKey, ...rest] = trimmed.split('=');
+        const key = rawKey.trim();
+        if (key && rest.length > 0) {
+          const val = rest.join('=').trim().replace(/^["']|["']$/g, '');
+          if (!process.env[key]) {
+            process.env[key] = val;
+          }
+        }
+      });
+    }
+  }
+}
+loadEnv();
+
+async function main() {
+  console.log("Initializing SharePoint Client...");
+  
+  const { getSharePointClient } = await import('../../src/sharepoint/client/index.ts');
+  const { LIST_REGISTRY } = await import('../../src/sharepoint/fields/listRegistry.ts');
+
+  const listId = LIST_REGISTRY.billing_summary.id;
+  
+  if (!listId) {
+    console.error("List ID for billing_summary not found!");
+    process.exit(1);
+  }
+
+  const spClient = await getSharePointClient();
+  console.log(`Fetching fields for list: ${listId}...`);
+  
+  try {
+    const fields = await spClient.read.getFields(listId);
+    console.log(`\n=== MonthlyRecord_Summary Fields (${fields.length}) ===`);
+    
+    fields.sort((a, b) => a.InternalName.localeCompare(b.InternalName));
+    
+    fields.forEach(f => {
+      if (!f.Hidden && !f.ReadOnlyField && f.InternalName !== 'ContentType' && f.InternalName !== 'Attachments') {
+         console.log(`- ${f.InternalName.padEnd(30)} [${f.TypeAsString}] (Title: ${f.Title})`);
+      }
+    });
+
+    console.log('\nDone.');
+  } catch (err) {
+    console.error("Failed to fetch fields:", err.message);
+  }
+}
+
+main().catch(console.error);

--- a/scripts/ops/diagnose-monthly-schema.ts
+++ b/scripts/ops/diagnose-monthly-schema.ts
@@ -1,62 +1,142 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
+/**
+ * MonthlyRecord_Summary (月次請求サマリー) Schema Diagnosis Script
+ * 
+ * This script connects to SharePoint and fetches the actual field definitions
+ * for the list defined by VITE_SP_LIST_BILLING_SUMMARY.
+ * It does not perform any write operations.
+ */
+
 function loadEnv() {
   const root = process.cwd();
-  const envFiles = ['.env', '.env.local'];
   
-  for (const file of envFiles) {
-    const envPath = path.resolve(root, file);
-    if (fs.existsSync(envPath)) {
-      const content = fs.readFileSync(envPath, 'utf8');
-      content.split('\n').forEach(line => {
-        const trimmed = line.trim();
-        if (!trimmed || trimmed.startsWith('#')) return;
-        const [rawKey, ...rest] = trimmed.split('=');
-        const key = rawKey.trim();
-        if (key && rest.length > 0) {
-          const val = rest.join('=').trim().replace(/^["']|["']$/g, '');
-          if (!process.env[key]) {
-            process.env[key] = val;
-          }
-        }
+  // 1. Load from .env (Base Defaults)
+  const baseEnvPath = path.resolve(root, '.env');
+  if (fs.existsSync(baseEnvPath)) {
+    const content = fs.readFileSync(baseEnvPath, 'utf8');
+    content.split('\n').forEach(line => {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) return;
+      const [rawKey, ...rest] = trimmed.split('=');
+      const key = rawKey.trim();
+      if (key && rest.length > 0) {
+        const val = rest.join('=').trim().replace(/^["']|["']$/g, '');
+        process.env[key] = val;
+      }
+    });
+  }
+
+  // 2. Load from public/env.runtime.json (Production OVERRIDES base .env)
+  const runtimeJsonPath = path.resolve(root, 'public/env.runtime.json');
+  if (fs.existsSync(runtimeJsonPath)) {
+    try {
+      const runtimeEnv = JSON.parse(fs.readFileSync(runtimeJsonPath, 'utf8'));
+      Object.keys(runtimeEnv).forEach(key => {
+        // ALWAYS set from runtime.json if present
+        process.env[key] = runtimeEnv[key];
       });
+    } catch (e) {
+      console.warn("⚠️ Warning: Failed to parse public/env.runtime.json");
+    }
+  }
+
+  // 3. Load from .env.local (User Specific OVERRIDES everything)
+  const localEnvPath = path.resolve(root, '.env.local');
+  if (fs.existsSync(localEnvPath)) {
+    const content = fs.readFileSync(localEnvPath, 'utf8');
+    content.split('\n').forEach(line => {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) return;
+      const [rawKey, ...rest] = trimmed.split('=');
+      const key = rawKey.trim();
+      if (key && rest.length > 0) {
+        const val = rest.join('=').trim().replace(/^["']|["']$/g, '');
+        process.env[key] = val;
+      }
+    });
+  }
+
+  // 4. Check for .token.local
+  const tokenPath = path.resolve(root, '.token.local');
+  if (fs.existsSync(tokenPath)) {
+    const token = fs.readFileSync(tokenPath, 'utf8').trim();
+    if (token) {
+      process.env.SP_TOKEN = token;
     }
   }
 }
+
 loadEnv();
 
 async function main() {
-  console.log("Initializing SharePoint Client...");
+  const token = process.env.SP_TOKEN || process.env.VITE_SP_TOKEN;
+  const listIdOrTitle = process.env.VITE_SP_LIST_BILLING_SUMMARY || 'MonthlyRecord_Summary';
+  const siteRelativePath = process.env.VITE_SP_SITE_RELATIVE || '/sites/welfare';
+  const resource = process.env.VITE_SP_RESOURCE || 'https://isogokatudouhome.sharepoint.com';
   
-  const { getSharePointClient } = await import('../../src/sharepoint/client/index.ts');
-  const { LIST_REGISTRY } = await import('../../src/sharepoint/fields/listRegistry.ts');
-
-  const listId = LIST_REGISTRY.billing_summary.id;
-  
-  if (!listId) {
-    console.error("List ID for billing_summary not found!");
+  if (!token) {
+    console.error("❌ Error: SP_TOKEN or VITE_SP_TOKEN is not set, and .token.local is missing or empty.");
     process.exit(1);
   }
 
-  const spClient = await getSharePointClient();
-  console.log(`Fetching fields for list: ${listId}...`);
+  const apiBaseUrl = `${resource.replace(/\/$/, '')}${siteRelativePath.startsWith('/') ? '' : '/'}${siteRelativePath}/_api/web`;
+  
+  // Decide accessor
+  const listAccessor = /^[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}$/i.test(listIdOrTitle)
+    ? `lists(guid'${listIdOrTitle}')`
+    : `lists/getbytitle('${encodeURIComponent(listIdOrTitle)}')`;
+
+  console.log(`Connecting to: ${apiBaseUrl}`);
+  console.log(`Target List: ${listIdOrTitle}`);
+  console.log(`Accessor: ${listAccessor}`);
+
+  const url = `${apiBaseUrl}/${listAccessor}/fields?$select=InternalName,Title,TypeAsString,Hidden,ReadOnlyField`;
   
   try {
-    const fields = await spClient.read.getFields(listId);
-    console.log(`\n=== MonthlyRecord_Summary Fields (${fields.length}) ===`);
+    const res = await fetch(url, {
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Accept': 'application/json;odata=nometadata',
+      },
+    });
+
+    if (!res.ok) {
+      const errorText = await res.text();
+      console.error(`\n❌ API Error: ${res.status} ${res.statusText}`);
+      console.error(`URL: ${url}`);
+      console.error(`Response: ${errorText}`);
+      process.exit(1);
+    }
+
+    const data = await res.json() as { value: any[] };
+    const fields = data.value;
+
+    console.log(`\n=== MonthlyRecord_Summary Actual Fields (${fields.length}) ===`);
     
     fields.sort((a, b) => a.InternalName.localeCompare(b.InternalName));
     
     fields.forEach(f => {
+      // Show non-hidden, or specifically relevant hidden fields
       if (!f.Hidden && !f.ReadOnlyField && f.InternalName !== 'ContentType' && f.InternalName !== 'Attachments') {
-         console.log(`- ${f.InternalName.padEnd(30)} [${f.TypeAsString}] (Title: ${f.Title})`);
+         console.log(`- ${f.InternalName.padEnd(30)} [${f.TypeAsString.padEnd(12)}] (Title: ${f.Title})`);
+      }
+    });
+
+    // Also look for specific drift candidates
+    console.log('\n=== Checking for drift candidates ===');
+    const specificCandidates = ['UserId', 'YearMonth', 'KPI_TotalDays', 'TotalSupportDays', 'BillableDays'];
+    fields.forEach(f => {
+      if (specificCandidates.includes(f.InternalName)) {
+        console.log(`✅ Found: ${f.InternalName} [${f.TypeAsString}]`);
       }
     });
 
     console.log('\nDone.');
   } catch (err) {
-    console.error("Failed to fetch fields:", err.message);
+    console.error("\n💥 Failed to fetch fields:", err.message);
+    process.exit(1);
   }
 }
 

--- a/src/features/diagnostics/health/checks.ts
+++ b/src/features/diagnostics/health/checks.ts
@@ -538,38 +538,67 @@ async function runListChecks(
         })
       );
     } else if (drifted.length > 0) {
-      // Execute governance decision logic
-      const primaryDrift = drifted[0];
-      const driftType = fieldStatus[primaryDrift.internalName].driftType as DriftType;
-      const isEssential = Boolean(primaryDrift.isEssential);
-      
-      const decision = decideGovernanceAction(driftType, ctx.autonomyLevel, isEssential);
+      // 乖離（Drift）をレガシー許容と通常の警告に分類
+      const legacyDrifted = drifted.filter(f => {
+        const resName = fieldStatus[f.internalName].resolvedName;
+        return f.isLegacy || (resName && f.legacyCandidates?.includes(resName));
+      });
+      const regularDrifted = drifted.filter(f => !legacyDrifted.includes(f));
 
-      results.push(
-        warn({
-          key: `schema.fields.${spec.key}`,
-          label: `スキーマ（内部名乖離）：${spec.displayName}`,
-          category: "schema",
-          summary: `${drifted.length}個の列で内部名の乖離（Drift）を検出しました。`,
-          detail: `SharePoint上の内部名にサフィックスが付与されていますが、アプリ側で自動吸収しています。\n乖離項目: ${drifted.map(f => `${f.internalName} → ${fieldStatus[f.internalName].resolvedName}`).join(", ")}`,
-          evidence: {
-            listTitle: spec.resolvedTitle,
-            drifted: drifted.map(f => ({
-              expected: f.internalName,
-              actual: fieldStatus[f.internalName].resolvedName,
-              driftType: fieldStatus[f.internalName].driftType
-            }))
-          },
-          governance: decision,
-          nextActions: [
-            {
-              kind: "copy",
-              label: "乖離列の確認依頼",
-              value: `リスト「${spec.resolvedTitle}」の「${drifted[0].internalName}」が「${fieldStatus[drifted[0].internalName].resolvedName}」として解決されています。`,
+      // 1. レガシー許容された乖離の報告
+      if (legacyDrifted.length > 0) {
+        results.push(
+          pass({
+            key: `schema.fields.${spec.key}.legacy`,
+            label: `スキーマ（レガシー列）: ${spec.displayName}`,
+            category: "schema",
+            summary: `退役予定のレガシー列（${legacyDrifted.map(f => f.internalName).join(", ")}）が検出されました。`,
+            detail: `この列は将来的に削除される予定ですが、現在は後方互換性のために保持されています。\n解決名: ${legacyDrifted.map(f => `${f.internalName} → ${fieldStatus[f.internalName].resolvedName}`).join(", ")}`,
+            evidence: {
+              listTitle: spec.resolvedTitle,
+              drifted: legacyDrifted.map(f => ({
+                expected: f.internalName,
+                actual: fieldStatus[f.internalName].resolvedName,
+                driftType: "legacy_tolerated"
+              }))
             },
-          ],
-        })
-      );
+          })
+        );
+      }
+
+      // 2. 通常の乖離の報告
+      if (regularDrifted.length > 0) {
+        const primaryDrift = regularDrifted[0];
+        const driftType = fieldStatus[primaryDrift.internalName].driftType as DriftType;
+        const isEssential = Boolean(primaryDrift.isEssential);
+        const decision = decideGovernanceAction(driftType, ctx.autonomyLevel, isEssential);
+
+        results.push(
+          warn({
+            key: `schema.fields.${spec.key}`,
+            label: `スキーマ（内部名乖離）：${spec.displayName}`,
+            category: "schema",
+            summary: `${regularDrifted.length}個の列で内部名の乖離（Drift）を検出しました。`,
+            detail: `SharePoint上の内部名にサフィックスが付与されていますが、アプリ側で自動吸収しています。\n乖離項目: ${regularDrifted.map(f => `${f.internalName} → ${fieldStatus[f.internalName].resolvedName}`).join(", ")}`,
+            evidence: {
+              listTitle: spec.resolvedTitle,
+              drifted: regularDrifted.map(f => ({
+                expected: f.internalName,
+                actual: fieldStatus[f.internalName].resolvedName,
+                driftType: fieldStatus[f.internalName].driftType
+              }))
+            },
+            governance: decision,
+            nextActions: [
+              {
+                kind: "copy",
+                label: "乖離列の確認依頼",
+                value: `リスト「${spec.resolvedTitle}」の「${regularDrifted[0].internalName}」が「${fieldStatus[regularDrifted[0].internalName].resolvedName}」として解決されています。`,
+              },
+            ],
+          })
+        );
+      }
     } else if (missingOptional.length > 0) {
       results.push(
         warn({

--- a/src/features/diagnostics/health/types.ts
+++ b/src/features/diagnostics/health/types.ts
@@ -52,8 +52,12 @@ export type SpFieldSpec = {
   typeHint?: string; // "Text" | "DateTime" | "Number" | "Choice" | "Lookup" など（表示用）
   /** drift 吸収用の候補名リスト。未指定時は [internalName] のみで解決 */
   candidates?: string[];
+  /** 退役予定のレガシーな物理列名リスト（検出時に WARN ではなく tolerated と表示する） */
+  legacyCandidates?: string[];
   /** 欠落していても WARN を出さない（isSilent） */
   isSilent?: boolean;
+  /** 退役予定のレガシー列（解決時に WARN ではなく tolerated と表示する） */
+  isLegacy?: boolean;
 };
 
 export type ListSpec = {

--- a/src/features/records/monthly/map.ts
+++ b/src/features/records/monthly/map.ts
@@ -161,6 +161,7 @@ export function toSharePointFields(
     [get('completionRate', 'CompletionRate')]: summary.completionRate,
     [get('firstEntryDate', 'FirstEntryDate')]: summary.firstEntryDate || undefined,
     [get('lastEntryDate', 'LastEntryDate')]: summary.lastEntryDate || undefined,
+    [get('isLocked', 'IsLocked')]: summary.isLocked ?? false,
     [get('idempotencyKey', 'IdempotencyKey')]: `${summary.userId}#${summary.yearMonth}`,
   };
 }
@@ -182,6 +183,7 @@ export interface SharePointMonthlyItem {
   CompletionRate?: number;
   FirstEntryDate?: string;
   LastEntryDate?: string;
+  IsLocked?: boolean;
   IdempotencyKey: string;
 }
 
@@ -275,6 +277,7 @@ export function fromSharePointFields(
     completionRate: num(getWithFallback('completionRate', 'CompletionRate')),
     firstEntryDate,
     lastEntryDate,
+    isLocked: Boolean(getWithFallback('isLocked', 'IsLocked')),
   };
 }
 

--- a/src/features/records/monthly/types.ts
+++ b/src/features/records/monthly/types.ts
@@ -34,6 +34,7 @@ export interface MonthlySummary extends MonthlyRecordKey {
   firstEntryDate?: IsoDate;   // 月初の初回記録日（YYYY-MM-DD）
   lastEntryDate?: IsoDate;    // 月内の最終記録日（YYYY-MM-DD）
   carryOverNotes?: number;    // 翌月持ち越しメモ数（拡張）
+  isLocked?: boolean;         // 請求確定後のロック状態
 }
 
 // 日次記録からの集計用インターフェース

--- a/src/lib/sp/types.ts
+++ b/src/lib/sp/types.ts
@@ -99,6 +99,15 @@ export interface SpFieldDef {
    */
   isSilent?: boolean;
   /**
+   * 退役予定のレガシーな物理列名リスト。
+   * 検出時に「乖離（Drift）」警告を出さず、「レガシー許容（Tolerated）」として扱う。
+   */
+  legacyCandidates?: readonly string[];
+  /**
+   * フィールド自体がレガシーであることを示すフラグ。
+   */
+  isLegacy?: boolean;
+  /**
    * インフラ統治の 4 階層モデル (Phase 2):
    * - allow: レジストリ定義済み（正常）
    * - candidate: レジストリ未定義だがコード使用あり（レジストリ追加候補）

--- a/src/pages/HealthPage.tsx
+++ b/src/pages/HealthPage.tsx
@@ -348,6 +348,8 @@ function buildListSpecs(): ListSpec[] {
     isEssential: essentialSet.has(f.internalName),
     typeHint: f.type,
     candidates: driftOverride?.[f.internalName] ?? (f.candidates ? [...f.candidates] : undefined),
+    legacyCandidates: f.legacyCandidates ? [...f.legacyCandidates] : undefined,
+    isLegacy: f.isLegacy,
     isSilent: f.isSilent,
   }));
 

--- a/src/sharepoint/fields/__tests__/billingFields.drift.spec.ts
+++ b/src/sharepoint/fields/__tests__/billingFields.drift.spec.ts
@@ -39,6 +39,14 @@ describe('BILLING_SUMMARY_CANDIDATES drift', () => {
     expect(resolved.yearMonth).toBe('Year_x0020_Month');
     expect(fieldStatus.userId.isDrifted).toBe(true);
   });
+  
+  it('KPI_TotalDays が TotalDays より優先される', () => {
+    const available = new Set([
+      'KPI_TotalDays', 'TotalDays', 'Total_x0020_Days'
+    ]);
+    const { resolved } = resolve(available);
+    expect(resolved.totalDays).toBe('KPI_TotalDays');
+  });
 
   it('必須フィールドが揃えば isHealthy=true', () => {
     const available = new Set(['UserId', 'YearMonth', 'TotalDays', 'WorkingDays']);

--- a/src/sharepoint/fields/billingFields.ts
+++ b/src/sharepoint/fields/billingFields.ts
@@ -55,7 +55,7 @@ export const BILLING_SUMMARY_CANDIDATES = {
   yearMonth: ['YearMonth', 'Year_x0020_Month', 'cr013_yearMonth'],
   displayName: ['Display_x0020_Name', 'DisplayName', 'cr013_displayName'],
   lastUpdated: ['LastAggregatedAt', 'LastUpdated', 'Last_x0020_Aggregated_x0020_At', 'cr013_lastUpdated'],
-  totalDays: ['TotalDays', 'Total_x0020_Days', 'KPI_TotalDays', 'cr013_totalDays'],
+  totalDays: ['KPI_TotalDays', 'TotalDays', 'Total_x0020_Days', 'cr013_totalDays'],
   plannedRows: ['Planned_x0020_Rows', 'KPI_PlannedRows', 'PlannedRows', 'cr013_plannedRows'],
   completedRows: ['Completed_x0020_Rows', 'KPI_CompletedRows', 'CompletedRows', 'cr013_completedRows'],
   inProgressRows: ['In_x0020_Progress_x0020_Rows', 'KPI_InProgressRows', 'InProgressRows', 'cr013_inProgressRows'],
@@ -65,6 +65,8 @@ export const BILLING_SUMMARY_CANDIDATES = {
   completionRate: ['CompletionRate', 'cr013_completionRate'],
   firstEntryDate: ['First_x0020_Entry_x0020_Date', 'FirstEntryDate', 'cr013_firstEntryDate'],
   lastEntryDate: ['Last_x0020_Entry_x0020_Date', 'LastEntryDate', 'cr013_lastEntryDate'],
+  // `IsLocked` is used for workflow locking in the actual SharePoint list.
+  isLocked: ['IsLocked', 'Locked'],
   // `Key` is a legacy, data-bearing idempotency field. Keep it as an intentional
   // fallback until #1722 migration copies historical values into the canonical field.
   idempotencyKey: ['Idempotency_x0020_Key', 'IdempotencyKey', 'Key', 'cr013_idempotencyKey'],

--- a/src/sharepoint/fields/billingFields.ts
+++ b/src/sharepoint/fields/billingFields.ts
@@ -55,7 +55,12 @@ export const BILLING_SUMMARY_CANDIDATES = {
   yearMonth: ['YearMonth', 'Year_x0020_Month', 'cr013_yearMonth'],
   displayName: ['Display_x0020_Name', 'DisplayName', 'cr013_displayName'],
   lastUpdated: ['LastAggregatedAt', 'LastUpdated', 'Last_x0020_Aggregated_x0020_At', 'cr013_lastUpdated'],
-  totalDays: ['KPI_TotalDays', 'TotalDays', 'Total_x0020_Days', 'cr013_totalDays'],
+  totalDays: [
+    'KPI_TotalDays', 
+    'TotalDays', // LEGACY: Decommission pending (#1713)
+    'Total_x0020_Days', // LEGACY: Decommission pending (#1713)
+    'cr013_totalDays'
+  ],
   plannedRows: ['Planned_x0020_Rows', 'KPI_PlannedRows', 'PlannedRows', 'cr013_plannedRows'],
   completedRows: ['Completed_x0020_Rows', 'KPI_CompletedRows', 'CompletedRows', 'cr013_completedRows'],
   inProgressRows: ['In_x0020_Progress_x0020_Rows', 'KPI_InProgressRows', 'InProgressRows', 'cr013_inProgressRows'],
@@ -69,7 +74,12 @@ export const BILLING_SUMMARY_CANDIDATES = {
   isLocked: ['IsLocked', 'Locked'],
   // `Key` is a legacy, data-bearing idempotency field. Keep it as an intentional
   // fallback until #1722 migration copies historical values into the canonical field.
-  idempotencyKey: ['Idempotency_x0020_Key', 'IdempotencyKey', 'Key', 'cr013_idempotencyKey'],
+  idempotencyKey: [
+    'Idempotency_x0020_Key', 
+    'IdempotencyKey', 
+    'Key', // LEGACY: Decommission pending (#1713)
+    'cr013_idempotencyKey'
+  ],
 } as const;
 
 export const BILLING_SUMMARY_ESSENTIALS: (keyof typeof BILLING_SUMMARY_CANDIDATES)[] = [

--- a/src/sharepoint/spListRegistry.definitions.ts
+++ b/src/sharepoint/spListRegistry.definitions.ts
@@ -900,7 +900,7 @@ export const otherListEntries: readonly SpListEntry[] = [
       { internalName: 'YearMonth', type: 'Text', displayName: 'Year Month', required: true, indexed: true, candidates: ['YearMonth', 'Year_x0020_Month'] },
       { internalName: 'DisplayName', type: 'Text', displayName: 'Display Name', isSilent: true, candidates: ['Display_x0020_Name', 'DisplayName', 'cr013_displayName'] },
       { internalName: 'LastUpdated', type: 'DateTime', displayName: 'Last Updated', isSilent: true, candidates: ['LastAggregatedAt', 'LastUpdated', 'Last_x0020_Updated'] },
-      { internalName: 'KPI_TotalDays', type: 'Number', displayName: 'Total Days', candidates: ['KPI_TotalDays', 'TotalDays', 'WorkingDays', 'Total_x0020_Days'] },
+      { internalName: 'KPI_TotalDays', type: 'Number', displayName: 'Total Days', candidates: ['KPI_TotalDays', 'TotalDays', 'WorkingDays', 'Total_x0020_Days'], legacyCandidates: ['TotalDays', 'Total_x0020_Days'] },
       { internalName: 'KPI_PlannedRows', type: 'Number', displayName: 'Planned Rows', isSilent: true, candidates: ['Planned_x0020_Rows', 'KPI_PlannedRows', 'PlannedRows', 'cr013_plannedRows'] },
       { internalName: 'KPI_CompletedRows', type: 'Number', displayName: 'Completed Rows', isSilent: true, candidates: ['Completed_x0020_Rows', 'KPI_CompletedRows', 'CompletedRows', 'CompletedCount', 'cr013_completedRows'] },
       { internalName: 'KPI_InProgressRows', type: 'Number', displayName: 'In Progress Rows', isSilent: true, candidates: ['In_x0020_Progress_x0020_Rows', 'KPI_InProgressRows', 'InProgressRows', 'PendingCount', 'cr013_inProgressRows'] },
@@ -910,7 +910,7 @@ export const otherListEntries: readonly SpListEntry[] = [
       { internalName: 'CompletionRate', type: 'Number', displayName: 'Completion Rate' },
       { internalName: 'FirstEntryDate', type: 'DateTime', displayName: 'First Entry Date', dateTimeFormat: 'DateOnly', isSilent: true, candidates: ['First_x0020_Entry_x0020_Date', 'FirstEntryDate', 'cr013_firstEntryDate'] },
       { internalName: 'LastEntryDate', type: 'DateTime', displayName: 'Last Entry Date', dateTimeFormat: 'DateOnly', isSilent: true, candidates: ['Last_x0020_Entry_x0020_Date', 'LastEntryDate', 'cr013_lastEntryDate'] },
-      { internalName: 'IdempotencyKey', type: 'Text', displayName: 'Idempotency Key', isSilent: true, candidates: ['Idempotency_x0020_Key', 'IdempotencyKey', 'Key', 'cr013_idempotencyKey'] },
+      { internalName: 'IdempotencyKey', type: 'Text', displayName: 'Idempotency Key', isSilent: true, candidates: ['Idempotency_x0020_Key', 'IdempotencyKey', 'Key', 'cr013_idempotencyKey'], legacyCandidates: ['Key'] },
     ],
   },
 


### PR DESCRIPTION
## Summary
- Add MonthlyRecord_Summary schema diagnosis script
- Add planning notes for safe migration audit
- Keep production SharePoint runtime overrides out of the commit
- Fix: exclude scripts/ from pre-push eslint check to avoid 'file ignored' errors

## Validation
- Repository cleaned before commit
- Removed temporary verification files
- Kept only TypeScript diagnostic script
- No environment override files committed
- Pre-push hook fixed and verified

## Safety
- No destructive SharePoint operation
- No production data mutation
- Audit-only preparation for future migration

## Phase 2 Hardening Result
- Provisioned `IsLocked` on `MonthlyRecord_Summary`
- Indexed `UserId` and `YearMonth`
- Verified `KPI_TotalDays` and `TotalDays` consistency across active production records
- Confirmed legacy fields remain physically present but are not the preferred application source

## Decommissioning Policy
Physical deletion of legacy fields such as `TotalDays`, `Total_x0020_Days`, and `Key` is deferred.
Phase 3 will first isolate them in code and diagnostics, then observe Nightly / UI behavior before any destructive cleanup.

## Phase 3 Legacy Isolation Result
- `KPI_TotalDays` is now the canonical total-days source for `MonthlyRecord_Summary`
- `IdempotencyKey` is prioritized over legacy `Key`
- `IsLocked` is wired into the monthly summary model/mapping layer
- Legacy fields `TotalDays`, `Total_x0020_Days`, and `Key` remain physically present but are isolated as fallback/decommission candidates
- Health diagnostics now classify those legacy candidates as tolerated visibility signals rather than active drift failures

## Phase 4 Exit Criteria
Physical deletion is deferred until after a 7-day stability window, targeted for 2026-05-07, provided:
- no `KPI_TotalDays` vs legacy `TotalDays` mismatch is observed
- no external Power Automate / Excel / manual connector dependency remains
- Nightly Patrol and Health diagnostics remain stable