### PR TITLE
fix(env): point to correct runtime env path for production

### DIFF
--- a/.env
+++ b/.env
@@ -17,7 +17,7 @@ VITE_MSAL_AUTHORITY=
 VITE_MSAL_SCOPES=
 VITE_LOGIN_SCOPES=
 VITE_MSAL_LOGIN_SCOPES=
-VITE_RUNTIME_ENV_PATH=/env.runtime.local.json
+VITE_RUNTIME_ENV_PATH=/env.runtime.json
 
 # Audit + sync tuning (defaults shown)
 VITE_AUDIT_DEBUG=0


### PR DESCRIPTION
Fixes the misconfiguration where production build was pointing to /env.runtime.local.json instead of /env.runtime.json.