### PR TITLE
test(ci): eliminate act warning regression sources

### DIFF
--- a/scripts/ci/__tests__/check-act-warnings.spec.mjs
+++ b/scripts/ci/__tests__/check-act-warnings.spec.mjs
@@ -1,0 +1,44 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { buildResult } from '../check-act-warnings.mjs';
+
+describe('check-act-warnings buildResult', () => {
+  it('counts warnings using a plain vitest stderr header', () => {
+    const log = [
+      'stderr | tests/unit/demoGuard.spec.ts > Demo Mode Guards > case',
+      'Warning: An update to TestComponent inside a test was not wrapped in act(...).',
+    ].join('\n');
+
+    const result = buildResult(log);
+    expect(result.totalWarnings).toBe(1);
+    expect(result.affectedFiles).toBe(1);
+    expect(result.countsByFile['tests/unit/demoGuard.spec.ts']).toBe(1);
+  });
+
+  it('parses GitHub Actions prefixed logs with ANSI color escapes', () => {
+    const log = [
+      'quality\tUNKNOWN STEP\t2026-04-30T02:40:20.3918195Z \u001b[90mstderr\u001b[2m | src/pages/__tests__/DailyRecordMenuPage.test.tsx > DailyRecordMenuPage > case',
+      'quality\tUNKNOWN STEP\t2026-04-30T02:40:20.3920451Z \u001b[22m\u001b[39mWarning: An update to ForwardRef(ButtonBase) inside a test was not wrapped in act(...).',
+    ].join('\n');
+
+    const result = buildResult(log);
+    expect(result.totalWarnings).toBe(1);
+    expect(result.affectedFiles).toBe(1);
+    expect(result.countsByFile['src/pages/__tests__/DailyRecordMenuPage.test.tsx']).toBe(1);
+    expect(result.maxWarningsFile).toBe('src/pages/__tests__/DailyRecordMenuPage.test.tsx');
+  });
+
+  it('keeps the latest stderr header as the warning source file', () => {
+    const log = [
+      'stderr | tests/unit/demoGuard.spec.ts > suite > case',
+      'Warning: An update to TestComponent inside a test was not wrapped in act(...).',
+      'stderr | src/pages/__tests__/DailyRecordMenuPage.test.tsx > suite > case',
+      'Warning: An update to ForwardRef(ButtonBase) inside a test was not wrapped in act(...).',
+    ].join('\n');
+
+    const result = buildResult(log);
+    expect(result.totalWarnings).toBe(2);
+    expect(result.countsByFile['tests/unit/demoGuard.spec.ts']).toBe(1);
+    expect(result.countsByFile['src/pages/__tests__/DailyRecordMenuPage.test.tsx']).toBe(1);
+  });
+});

--- a/scripts/ci/check-act-warnings.mjs
+++ b/scripts/ci/check-act-warnings.mjs
@@ -1,6 +1,13 @@
 #!/usr/bin/env node
 
 import fs from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const ANSI_ESCAPE_PATTERN = /\u001b\[[0-9;]*m/g;
+
+function stripAnsi(text) {
+  return text.replace(ANSI_ESCAPE_PATTERN, "");
+}
 
 function printUsage() {
   console.error(
@@ -41,15 +48,16 @@ function parseArgs(argv) {
   };
 }
 
-function buildResult(logText) {
+export function buildResult(logText) {
   const warningPattern = /not wrapped in act/i;
-  const stderrHeaderPattern = /^stderr \|\s+(.+?)\s+>/;
+  const stderrHeaderPattern = /stderr\s+\|\s+(.+?)\s+>/i;
 
   let currentFile = "";
   let totalWarnings = 0;
   const counts = new Map();
 
-  for (const line of logText.split(/\r?\n/)) {
+  for (const rawLine of logText.split(/\r?\n/)) {
+    const line = stripAnsi(rawLine);
     const headerMatch = line.match(stderrHeaderPattern);
     if (headerMatch) {
       currentFile = headerMatch[1];
@@ -128,4 +136,10 @@ function main() {
   process.exit(result.totalWarnings > 0 ? 1 : 0);
 }
 
-main();
+const isDirectRun =
+  typeof process.argv[1] === "string" &&
+  import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isDirectRun) {
+  main();
+}

--- a/src/pages/__tests__/DailyRecordMenuPage.test.tsx
+++ b/src/pages/__tests__/DailyRecordMenuPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
+import type { ReactNode } from 'react';
 import DailyRecordMenuPage from '@/pages/DailyRecordMenuPage';
 
 // ---------------------------------------------------------------------------
@@ -37,7 +38,9 @@ vi.mock('@/features/attendance/store', () => ({
 
 // Mock Components
 vi.mock('@/features/dashboard/components/CommandBar', () => ({
-  CommandBar: ({ children }: any) => <div data-testid="bento-command-bar">{children}</div>,
+  CommandBar: ({ children }: { children?: ReactNode }) => (
+    <div data-testid="bento-command-bar">{children}</div>
+  ),
 }));
 
 // Mock Navigate & SearchParams
@@ -45,7 +48,7 @@ const mockNavigate = vi.fn();
 let mockSearchParams = new URLSearchParams('');
 
 vi.mock('react-router-dom', async () => {
-  const actual = (await vi.importActual('react-router-dom')) as any;
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
   return {
     ...actual,
     useNavigate: () => mockNavigate,

--- a/src/pages/__tests__/DailyRecordMenuPage.test.tsx
+++ b/src/pages/__tests__/DailyRecordMenuPage.test.tsx
@@ -1,5 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import DailyRecordMenuPage from '@/pages/DailyRecordMenuPage';
@@ -86,7 +85,6 @@ describe('DailyRecordMenuPage', () => {
   });
 
   it('from=today のとき戻るボタンが表示され、クリックで遷移すること', async () => {
-    const user = userEvent.setup();
     mockSearchParams = new URLSearchParams('from=today&date=2026-04-01');
     render(
       <MemoryRouter>
@@ -98,8 +96,10 @@ describe('DailyRecordMenuPage', () => {
     expect(returnBtn).toBeInTheDocument();
     expect(returnBtn.textContent).toContain('今日の運用へ');
 
-    await user.click(returnBtn);
-    expect(mockNavigate).toHaveBeenCalledWith('/today?date=2026-04-01');
+    fireEvent.click(returnBtn);
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/today?date=2026-04-01');
+    });
   });
 
   it('from が無いとき戻るボタンは表示されない', async () => {

--- a/tests/unit/demoGuard.spec.ts
+++ b/tests/unit/demoGuard.spec.ts
@@ -1,18 +1,18 @@
 import { renderHook } from '@testing-library/react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import * as envModule from '@/lib/env';
-import { useSchedules } from '@/features/schedules/hooks/useSchedules';
-import { useDaily } from '@/features/daily/hooks/useDaily';
-import { useAttendanceStore } from '@/features/attendance/store';
 import { 
+  useAttendanceRepository,
   resetAttendanceRepository, 
   getCurrentAttendanceRepositoryKind 
 } from '@/features/attendance/repositoryFactory';
 import { 
+  useDailyRecordRepository,
   resetDailyRecordRepository, 
   getCurrentDailyRecordRepositoryKind 
 } from '@/features/daily/repositoryFactory';
 import { 
+  useScheduleRepository,
   resetScheduleRepository, 
   getCurrentScheduleRepositoryKind 
 } from '@/features/schedules/repositoryFactory';
@@ -60,7 +60,7 @@ describe('Demo Mode Guards', () => {
       vi.mocked(envModule.isDemoModeEnabled).mockReturnValue(false);
       vi.mocked(envModule.isTestMode).mockReturnValue(false);
       
-      renderHook(() => useAttendanceStore());
+      renderHook(() => useAttendanceRepository());
       expect(getCurrentAttendanceRepositoryKind()).toBe('demo');
     });
 
@@ -68,7 +68,7 @@ describe('Demo Mode Guards', () => {
       vi.mocked(envModule.isDemoModeEnabled).mockReturnValue(true);
       vi.mocked(envModule.isTestMode).mockReturnValue(false);
       
-      renderHook(() => useAttendanceStore());
+      renderHook(() => useAttendanceRepository());
       expect(getCurrentAttendanceRepositoryKind()).toBe('demo');
     });
   });
@@ -78,7 +78,7 @@ describe('Demo Mode Guards', () => {
       vi.mocked(envModule.isDemoModeEnabled).mockReturnValue(false);
       vi.mocked(envModule.isTestMode).mockReturnValue(false);
       
-      renderHook(() => useDaily());
+      renderHook(() => useDailyRecordRepository());
       expect(getCurrentDailyRecordRepositoryKind()).toBe('demo');
     });
 
@@ -86,7 +86,7 @@ describe('Demo Mode Guards', () => {
       vi.mocked(envModule.isDemoModeEnabled).mockReturnValue(true);
       vi.mocked(envModule.isTestMode).mockReturnValue(false);
       
-      renderHook(() => useDaily());
+      renderHook(() => useDailyRecordRepository());
       expect(getCurrentDailyRecordRepositoryKind()).toBe('demo');
     });
   });
@@ -96,7 +96,7 @@ describe('Demo Mode Guards', () => {
       vi.mocked(envModule.isDemoModeEnabled).mockReturnValue(false);
       vi.mocked(envModule.isTestMode).mockReturnValue(false);
       
-      renderHook(() => useSchedules());
+      renderHook(() => useScheduleRepository());
       expect(getCurrentScheduleRepositoryKind()).toBe('demo');
     });
 
@@ -104,7 +104,7 @@ describe('Demo Mode Guards', () => {
       vi.mocked(envModule.isDemoModeEnabled).mockReturnValue(true);
       vi.mocked(envModule.isTestMode).mockReturnValue(false);
       
-      renderHook(() => useSchedules());
+      renderHook(() => useScheduleRepository());
       expect(getCurrentScheduleRepositoryKind()).toBe('demo');
     });
   });


### PR DESCRIPTION
## Summary
- Fix act(...) warning sources detected by #1708
- Refactor demoGuard tests to avoid store hooks with async side effects
- Replace userEvent click path in DailyRecordMenuPage test with fireEvent + waitFor to avoid MUI ripple act noise
- Harden check-act-warnings parser for ANSI output and GitHub Actions `stderr | ...` prefixes
- Add regression tests for the parser
- Note: the prior detector collapsed warnings into `<unknown>`, which made this look like `1 file`; actual sources were 2 test files plus parser hardening

## Validation
- npx vitest run scripts/ci/__tests__/check-act-warnings.spec.mjs tests/unit/demoGuard.spec.ts src/pages/__tests__/DailyRecordMenuPage.test.tsx --reporter=verbose
- node scripts/ci/check-act-warnings.mjs /tmp/vitest-act-target.log --json
- Confirmed totalWarnings=0 on the targeted log
- Confirmed old CI log is parsed with concrete file attribution instead of <unknown>

## Issue
Closes #1708
