### PR TITLE
fix(registry): absorb high-usage drift candidates

### DIFF
--- a/src/sharepoint/spListRegistry.definitions.ts
+++ b/src/sharepoint/spListRegistry.definitions.ts
@@ -169,6 +169,12 @@ export const masterListEntries: readonly SpListEntry[] = [
     operations: ['R'],
     category: 'master',
     lifecycle: 'required',
+    essentialFields: ['Date', 'Type'],
+    provisioningFields: [
+      { internalName: 'Date', type: 'DateTime', displayName: 'Date', required: true, dateTimeFormat: 'DateOnly', indexed: true, candidates: ['Date', 'HolidayDate', 'TargetDate', 'RecordDate'] },
+      { internalName: 'Type', type: 'Text', displayName: 'Type', candidates: ['Type', 'Category', 'HolidayType'] },
+      { internalName: 'IsActive', type: 'Boolean', displayName: 'Is Active', default: true, candidates: ['IsActive', 'Active', 'Enabled'] },
+    ],
   },
 ];
 
@@ -653,10 +659,10 @@ export const handoffListEntries: readonly SpListEntry[] = [
     essentialFields: ['Title', 'UserID0', 'Phase0'],
     provisioningFields: [
       { internalName: 'Title', type: 'Text', displayName: 'Title', required: true },
-      { internalName: 'UserID0', type: 'Text', displayName: 'User ID', required: true, indexed: true },
+      { internalName: 'UserID0', type: 'Text', displayName: 'User ID', required: true, indexed: true, candidates: ['UserID0', 'userId', 'UserID', 'UserCode'] },
       { internalName: 'PlanningSheetId', type: 'Text', displayName: 'Planning Sheet ID' },
-      { internalName: 'Summary0', type: 'Note', displayName: 'Summary', richText: false },
-      { internalName: 'Phase0', type: 'Text', displayName: 'Phase' },
+      { internalName: 'Summary0', type: 'Note', displayName: 'Summary', richText: false, candidates: ['Summary0', 'summary'] },
+      { internalName: 'Phase0', type: 'Text', displayName: 'Phase', candidates: ['Phase0', 'phase'] },
     ],
   },
   {


### PR DESCRIPTION
## Summary
- Add registry definitions for high-usage drift candidates in holiday_master
- Add candidate mappings for iceberg_pdca camelCase field names
- Reduce phantom drift caused by registry under-definition
- Keep Diagnostic Mode Mismatch as a separate environment configuration issue
- Avoid large spListRegistry refactoring in this PR

## Validation
- npm run typecheck
- npm run lint
- node scripts/ops/nightly-patrol.mjs --dry-run
- npm run patrol:decision

## Production safety note
- This PR only adjusts registry definitions and candidate mappings
- It does not change runtime SharePoint read/write behavior
- Drift ledger count may remain stale locally without live SharePoint scan
- Full reduction should be verified in the next real Nightly Patrol run