### PR TITLE
chore: finalize production runtime environment settings

### DIFF
--- a/public/env.runtime.json
+++ b/public/env.runtime.json
@@ -34,5 +34,6 @@
   "VITE_SP_LIST_SCHEDULES": "Schedules",
   "VITE_FEATURE_NURSE_BETA": "true",
   "VITE_SCHEDULE_ADMINS_GROUP_ID": "b1271c8c-e89e-4e06-940d-05e850a6e49a",
-  "VITE_RECEPTION_GROUP_ID": "c6dc493c-410e-4edd-bded-3cbde4f8bd89"
+  "VITE_RECEPTION_GROUP_ID": "c6dc493c-410e-4edd-bded-3cbde4f8bd89",
+  "VITE_SP_ENABLED": "true"
 }

--- a/public/env.runtime.local.json
+++ b/public/env.runtime.local.json
@@ -1,9 +1,0 @@
-{
-  "MODE": "development",
-  "VITE_SKIP_SHAREPOINT": "1",
-  "VITE_SKIP_LOGIN": "1",
-  "VITE_DEMO_MODE": "1",
-  "VITE_DATA_PROVIDER": "memory",
-  "VITE_FORCE_SHAREPOINT": "0",
-  "VITE_FEATURE_SCHEDULES_SP": "0"
-}


### PR DESCRIPTION
Enables SharePoint connectivity in production by setting VITE_SP_ENABLED to true in env.runtime.json.