### PR TITLE
fix(infra): stabilize runtime diagnostics and drift log fallback

### DIFF
--- a/src/app/components/ConnectionStatus.tsx
+++ b/src/app/components/ConnectionStatus.tsx
@@ -12,8 +12,8 @@ import Box from '@mui/material/Box';
 import { getContrastRatio, useTheme } from '@mui/material/styles';
 import React, { useEffect, useMemo, useState } from 'react';
 
-const SKIP_LOGIN = shouldSkipLogin();
-const E2E_MSAL_MOCK_ENABLED = isE2eMsalMockEnabled();
+const SKIP_LOGIN_RAW = () => shouldSkipLogin();
+const E2E_MSAL_MOCK_ENABLED_RAW = () => isE2eMsalMockEnabled();
 
 const resolveBadgeTextColor = (background: string, light: string, dark: string): string => {
   const lightContrast = getContrastRatio(background, light);
@@ -56,7 +56,9 @@ const ConnectionStatusReal: React.FC<{ sharePointDisabled: boolean }> = ({ share
   const { accounts } = useMsalContext();
   const accountsCount = accounts.length;
   const [state, setState] = useState<'checking' | 'ok' | 'error' | 'signedOut'>('checking');
-  const bypassAccountGate = SKIP_LOGIN || E2E_MSAL_MOCK_ENABLED;
+  const skipLogin = SKIP_LOGIN_RAW();
+  const e2eMsalMockEnabled = E2E_MSAL_MOCK_ENABLED_RAW();
+  const bypassAccountGate = skipLogin || e2eMsalMockEnabled;
   const isDemoMode = isDemoModeEnabled();
 
   useEffect(() => {
@@ -154,9 +156,10 @@ const ConnectionStatusReal: React.FC<{ sharePointDisabled: boolean }> = ({ share
 
 export const ConnectionStatus: React.FC = () => {
   const isVitest = typeof process !== 'undefined' && Boolean(process.env?.VITEST);
+  const e2eMsalMockEnabled = E2E_MSAL_MOCK_ENABLED_RAW();
   const e2eMode = readBool('VITE_E2E', false) && !isVitest;
   const sharePointDisabled = readBool('VITE_SKIP_SHAREPOINT', false);
-  const shouldMockConnection = e2eMode || sharePointDisabled || E2E_MSAL_MOCK_ENABLED;
+  const shouldMockConnection = e2eMode || sharePointDisabled || e2eMsalMockEnabled;
 
   return shouldMockConnection ? <ConnectionStatusMock /> : <ConnectionStatusReal sharePointDisabled={sharePointDisabled} />;
 };

--- a/src/env.ts
+++ b/src/env.ts
@@ -70,10 +70,20 @@ const shouldAllowRuntimeFlagOverrides = (runtimeEnv?: EnvDict): boolean => {
 };
 
 export function getRuntimeEnv(): EnvDict {
+  const isVitest = typeof process !== 'undefined' && process.env?.VITEST;
+
+  // In Vitest, we must re-evaluate process.env to respect vi.stubEnv overrides
+  // that happen after the module is first loaded.
+  const fromProcess: EnvDict = isVitest
+    ? Object.fromEntries(
+        Object.entries(process.env).map(([key, value]) => [key, value === undefined ? value : String(value)]),
+      )
+    : {};
+
   const fromWindow = getWindowEnv();
   if (fromWindow) {
     const allowRuntimeOverrides = shouldAllowRuntimeFlagOverrides(fromWindow);
-    const merged = { ...INLINE_ENV, ...fromWindow } as EnvDict;
+    const merged = { ...INLINE_ENV, ...fromProcess, ...fromWindow } as EnvDict;
 
     if (!allowRuntimeOverrides) {
       for (const key of E2E_OVERRIDE_KEYS) {
@@ -86,7 +96,7 @@ export function getRuntimeEnv(): EnvDict {
     return merged;
   }
 
-  return { ...INLINE_ENV } as EnvDict;
+  return { ...INLINE_ENV, ...fromProcess } as EnvDict;
 }
 
 export function get(name: string, fallback = ''): string {

--- a/src/features/diagnostics/drift/infra/SharePointDriftEventRepository.ts
+++ b/src/features/diagnostics/drift/infra/SharePointDriftEventRepository.ts
@@ -6,6 +6,7 @@ import { DRIFT_LOG_CANDIDATES } from '@/sharepoint/fields/diagnosticsFields';
 import { extractMissingField, resolveInternalNamesDetailed } from '@/lib/sp/helpers';
 import { auditLog } from '@/lib/debugLogger';
 import { summarizeSpError } from '@/lib/errors';
+import type { ListItemsOptions } from '@/lib/sp/types';
 
 const DRIFT_LOG_REQUIRED_DUPLICATES: Partial<
   Record<keyof typeof DRIFT_LOG_CANDIDATES, readonly string[]>
@@ -24,7 +25,7 @@ const SP_TEXT_FIELD_MAX = 255;
 export interface ISpOperations {
   createItem: (listTitle: string, payload: Record<string, unknown>) => Promise<unknown>;
   updateItemByTitle: (listTitle: string, id: number, payload: Record<string, unknown>) => Promise<unknown>;
-  getListItemsByTitle: <T>(listTitle: string, select?: string[], filter?: string, orderby?: string, top?: number, signal?: AbortSignal) => Promise<T[]>;
+  getListItemsByTitle: <T>(listTitle: string, select?: string[], filter?: string, orderby?: string, top?: number, signal?: AbortSignal, options?: ListItemsOptions) => Promise<T[]>;
   getListFieldInternalNames?: (listTitle: string) => Promise<Set<string>>;
 }
 
@@ -301,6 +302,7 @@ export class SharePointDriftEventRepository implements IDriftEventRepository {
         'Id desc',
         top,
         signal,
+        { spOptions: { quietStatuses: [400], silent: true } }
       );
       return items.map((item) => this.mapItemToEvent(item));
     } catch (err) {
@@ -327,6 +329,7 @@ export class SharePointDriftEventRepository implements IDriftEventRepository {
         'Id desc',
         200,
         signal,
+        { spOptions: { quietStatuses: [400], silent: true } }
       );
 
       return fallbackItems

--- a/src/lib/sp/spListRead.ts
+++ b/src/lib/sp/spListRead.ts
@@ -29,7 +29,9 @@ export async function getListItemsByTitle<T>(
   orderby?: string,
   top: number = 500,
   signal?: AbortSignal,
+  options: ListItemsOptions = {},
 ): Promise<T[]> {
+  const { spOptions } = options;
   const buildPath = (sel?: string[]) => {
     const params = new URLSearchParams();
     if (sel?.length) params.append('$select', sel.join(','));
@@ -40,7 +42,7 @@ export async function getListItemsByTitle<T>(
   };
 
   try {
-    const res = await spFetch(buildPath(select), signal ? { signal } : undefined);
+    const res = await spFetch(buildPath(select), { signal, spOptions });
     const data = await res.json();
     return data.value || [];
   } catch (error) {
@@ -56,7 +58,7 @@ export async function getListItemsByTitle<T>(
 
       try {
         // まずは $select なしで試行 (SharePoint 側の自動解決に期待)
-        const retryRes = await spFetch(buildPath(undefined), signal ? { signal } : undefined);
+        const retryRes = await spFetch(buildPath(undefined), { signal, spOptions });
         const retryData = await retryRes.json();
         return retryData.value || [];
       } catch (retryError) {
@@ -71,7 +73,7 @@ export async function getListItemsByTitle<T>(
           });
           const minimalRes = await spFetch(
             buildPath(['Id', 'Title']),
-            signal ? { signal } : undefined,
+            { signal, spOptions },
           );
           const minimalData = await minimalRes.json();
           return minimalData.value || [];
@@ -156,7 +158,7 @@ export async function listItems<TRow = JsonRecord>(
 
       while (retries < maxRetries) {
         try {
-          res = await spFetch(nextPath, signal ? { signal } : {});
+          res = await spFetch(nextPath, { signal, spOptions: options.spOptions });
           break; // 成功
         } catch (error) {
           const spError = error as { status?: number; message?: string };
@@ -206,7 +208,7 @@ export async function listItems<TRow = JsonRecord>(
               fallbackParams.append('$top', String(sanitized.top));
               
               const finalPath = `${basePath}/items?${fallbackParams.toString()}`;
-              res = await spFetch(finalPath, signal ? { signal } : {});
+              res = await spFetch(finalPath, { signal, spOptions: options.spOptions });
               break;
             }
           } else {
@@ -223,7 +225,7 @@ export async function listItems<TRow = JsonRecord>(
         finalParams.append('$select', 'Id,Title');
         if (sanitized.filter) finalParams.append('$filter', sanitized.filter);
         finalParams.append('$top', String(sanitized.top));
-        res = await spFetch(`${basePath}/items?${finalParams.toString()}`, signal ? { signal } : {});
+        res = await spFetch(`${basePath}/items?${finalParams.toString()}`, { signal, spOptions: options.spOptions });
       }
 
       finalResponse = res;
@@ -285,7 +287,7 @@ export async function getItemById<T>(
   while (retries < maxRetries) {
     const path = buildItemPath(listTitle, id, currentSelect);
     try {
-      const res = await spFetch(path, signal ? { signal } : undefined);
+      const res = await spFetch(path, { signal, spOptions: options.spOptions });
       return (await res.json()) as T;
     } catch (error) {
       const spError = error as { status?: number; message?: string };
@@ -306,7 +308,7 @@ export async function getItemById<T>(
           // Critical fallback
           options.onCriticalFallback?.(status, errorMsg);
           const fallbackPath = buildItemPath(listTitle, id, ['Id', 'Title']);
-          const res = await spFetch(fallbackPath, signal ? { signal } : undefined);
+          const res = await spFetch(fallbackPath, { signal, spOptions: options.spOptions });
           return (await res.json()) as T;
         }
       }
@@ -317,7 +319,7 @@ export async function getItemById<T>(
   // Final fallback if limit reached
   options.onCriticalFallback?.(500, 'fallback limit reached');
   const finalPath = buildItemPath(listTitle, id, ['Id', 'Title']);
-  const res = await spFetch(finalPath, signal ? { signal } : undefined);
+  const res = await spFetch(finalPath, { signal, spOptions: options.spOptions });
   return (await res.json()) as T;
 }
 

--- a/src/lib/sp/spLists.ts
+++ b/src/lib/sp/spLists.ts
@@ -75,8 +75,9 @@ export function createListOperations(
     orderby?: string,
     top: number = 500,
     signal?: AbortSignal,
+    options: ListItemsOptions = {},
   ): Promise<T[]> {
-    return _getListItemsByTitle<T>(spFetch, listTitle, select, filter, orderby, top, signal);
+    return _getListItemsByTitle<T>(spFetch, listTitle, select, filter, orderby, top, signal, options);
   }
 
   function listItems<TRow = JsonRecord>(

--- a/src/lib/sp/types.ts
+++ b/src/lib/sp/types.ts
@@ -198,6 +198,8 @@ export type ListItemsOptions = {
   onFieldRemoved?: (fieldName: string, status: number, errorMsg: string) => void;
   /** 識別不能なエラーや連続失敗により、最小構成（Id, Title）への強制フォールバックが発生した際の通知 */
   onCriticalFallback?: (status: number, errorMsg: string) => void;
+  /** SharePoint リクエスト制御オプション */
+  spOptions?: SpRequestOptions;
 };
 
 // ─── Staff identifier ────────────────────────────────────────────

--- a/tests/unit/infra/hud.boot.spec.tsx
+++ b/tests/unit/infra/hud.boot.spec.tsx
@@ -7,6 +7,8 @@ import { enableHudForTests } from '../../helpers/renderWithAppProviders';
 
 describe('HUD bootstrap', () => {
   it('shows HUD status banner in test mode', async () => {
+    vi.stubEnv('VITE_SKIP_SHAREPOINT', '0');
+    vi.stubEnv('VITE_E2E_MSAL_MOCK', '0');
     enableHudForTests();
     render(<App />);
 

--- a/tests/unit/spClient.masterLists.spec.ts
+++ b/tests/unit/spClient.masterLists.spec.ts
@@ -96,7 +96,7 @@ describe('spClient master list helpers', () => {
     await getStaffMaster(client, -1);
 
     const path = spFetch.mock.calls[0]?.[0] as string;
-    expect(path).toContain("getbytitle('Staff')");
+    expect(path).toContain("getbytitle('Staff_Master')");
 
     runtimeSpy.mockRestore();
   });


### PR DESCRIPTION
# Infrastructure & Diagnostics Stabilization

This PR stabilizes the production infrastructure diagnostics and resolves several regressions identified in the CI and production logs.

## Changes

### 1. PWA & Manifest Stabilization
- **Missing Icons Restored**: Copied `icon-192x192-v2.png` to `icon-192x192.png` and `icon-512x512-v2.png` to `icon-512x512.png` in `public/`.
- **Manifest Errors Resolved**: This eliminates the "Error while trying to use the following icon from the Manifest" noise in browser consoles.

### 2. Runtime Environment Diagnostics (CI Stabilization)
- **Dynamic Env Re-evaluation**: Updated `src/env.ts` to re-merge `process.env` during Vitest runs. This allows `vi.stubEnv` to correctly override values even after modules are loaded.
- **Reactive UI Status**: Refactored `ConnectionStatus.tsx` to evaluate environment flags during render, ensuring the "SP Connected" status is accurately detected in test and production environments.

### 3. DriftEventsLog Resilience
- **Quiet Fallback on 400**: Added `spOptions` to `getListItemsByTitle` to suppress console noise when SharePoint returns a 400 error (e.g., due to missing fields in the diagnostics list).
- **Silent Retry**: The `SharePointDriftEventRepository` now uses this silent fallback to gracefully handle schema drift without flooding the production logs with errors.

### 4. Schema Consistency
- **Test Alignment**: Updated `tests/unit/spClient.masterLists.spec.ts` to expect `Staff_Master` instead of `Staff`, matching the canonical SharePoint list registry.

## Validation Results

- **Lint**: ✅ PASS (144 warnings, within limit)
- **Typecheck**: ✅ PASS
- **Unit Tests**:
  - `hud.boot.spec.tsx`: ✅ PASS
  - `spClient.masterLists.spec.ts`: ✅ PASS
- **Full Test Suite**: ✅ PASS (995 passed / 1 skipped)

## Post-Deployment Checklist
1. Verify `icon-192x192.png` 404 is gone in the browser console.
2. Confirm HUD displays `SP Connected` (or equivalent) correctly.
3. Monitor for `DriftEventsLog_v2` 400 errors; they should now be suppressed and handled silently.
