### PR TITLE
fix(drift): harden noise suppression and resolve severeFlag drift

### DIFF
--- a/src/features/diagnostics/drift/infra/SharePointDriftEventRepository.ts
+++ b/src/features/diagnostics/drift/infra/SharePointDriftEventRepository.ts
@@ -23,8 +23,8 @@ const SP_TEXT_FIELD_MAX = 255;
  * 依存関係の境界遵守のためのローカルインターフェース
  */
 export interface ISpOperations {
-  createItem: (listTitle: string, payload: Record<string, unknown>) => Promise<unknown>;
-  updateItemByTitle: (listTitle: string, id: number, payload: Record<string, unknown>) => Promise<unknown>;
+  createItem: (listTitle: string, payload: Record<string, unknown>, options?: import('@/lib/sp/types').WriteItemOptions) => Promise<unknown>;
+  updateItemByTitle: (listTitle: string, id: number, payload: Record<string, unknown>, options?: import('@/lib/sp/types').UpdateItemOptions) => Promise<unknown>;
   getListItemsByTitle: <T>(listTitle: string, select?: string[], filter?: string, orderby?: string, top?: number, signal?: AbortSignal, options?: ListItemsOptions) => Promise<T[]>;
   getListFieldInternalNames?: (listTitle: string) => Promise<Set<string>>;
 }
@@ -456,7 +456,7 @@ export class SharePointDriftEventRepository implements IDriftEventRepository {
       }
 
       try {
-        await this.spClient.createItem(listTitle, activePayload);
+        await this.spClient.createItem(listTitle, activePayload, { spOptions: { quietStatuses: [400], silent: true } });
         this.sessionCache.add(dedupeKey);
         this.consecutiveFailures = 0;
         return;
@@ -487,7 +487,7 @@ export class SharePointDriftEventRepository implements IDriftEventRepository {
           const requiredOnlyPayload = this.buildCreatePayload(event, false);
           if (requiredOnlyPayload) {
             try {
-              await this.spClient.createItem(listTitle, requiredOnlyPayload);
+              await this.spClient.createItem(listTitle, requiredOnlyPayload, { spOptions: { quietStatuses: [400], silent: true } });
               this.sessionCache.add(dedupeKey);
               return;
             } catch (fallbackErr) {
@@ -509,7 +509,7 @@ export class SharePointDriftEventRepository implements IDriftEventRepository {
         const requiredOnlyPayload = this.buildCreatePayload(event, false);
         if (requiredOnlyPayload) {
           try {
-            await this.spClient.createItem(listTitle, requiredOnlyPayload);
+            await this.spClient.createItem(listTitle, requiredOnlyPayload, { spOptions: { quietStatuses: [400], silent: true } });
             this.sessionCache.add(dedupeKey);
             this.optionalWriteDisabled = true;
             return;
@@ -704,7 +704,7 @@ export class SharePointDriftEventRepository implements IDriftEventRepository {
       if (resolvedField) {
         await this.spClient.updateItemByTitle(listTitle, Number(id), {
           [resolvedField]: true
-        });
+        }, { spOptions: { quietStatuses: [400], silent: true } });
       }
     } catch (err) {
       auditLog.warn('diagnostics:drift', 'DriftEventRepository failed to mark event as resolved (fail-open).', err);

--- a/src/features/diagnostics/drift/infra/__tests__/SharePointDriftEventRepository.spec.ts
+++ b/src/features/diagnostics/drift/infra/__tests__/SharePointDriftEventRepository.spec.ts
@@ -41,7 +41,8 @@ describe('SharePointDriftEventRepository', () => {
     });
 
     expect(createItem).toHaveBeenCalledTimes(1);
-    const [, payload] = createItem.mock.calls[0];
+    const [, payload, options] = createItem.mock.calls[0];
+    expect(options).toMatchObject({ spOptions: { quietStatuses: [400], silent: true } });
     expect(payload).toMatchObject({
       Title: 'Daily_Attendance:Status',
       ListName: 'Daily_Attendance',
@@ -92,6 +93,8 @@ describe('SharePointDriftEventRepository', () => {
     });
 
     expect(createItem).toHaveBeenCalledTimes(2);
+    expect(createItem.mock.calls[0][2]).toMatchObject({ spOptions: { quietStatuses: [400], silent: true } });
+    expect(createItem.mock.calls[1][2]).toMatchObject({ spOptions: { quietStatuses: [400], silent: true } });
     const initialPayload = createItem.mock.calls[0][1];
     const fallbackPayload = createItem.mock.calls[1][1];
     expect(initialPayload).toHaveProperty('DriftType', 'suffix_mismatch');
@@ -128,6 +131,8 @@ describe('SharePointDriftEventRepository', () => {
     });
 
     expect(createItem).toHaveBeenCalledTimes(2);
+    expect(createItem.mock.calls[0][2]).toMatchObject({ spOptions: { quietStatuses: [400], silent: true } });
+    expect(createItem.mock.calls[1][2]).toMatchObject({ spOptions: { quietStatuses: [400], silent: true } });
     const initialPayload = createItem.mock.calls[0][1];
     const fallbackPayload = createItem.mock.calls[1][1];
     expect(initialPayload).toHaveProperty('List_x0020_Name', 'Daily_Attendance');
@@ -178,6 +183,8 @@ describe('SharePointDriftEventRepository', () => {
     });
 
     expect(createItem).toHaveBeenCalledTimes(2);
+    expect(createItem.mock.calls[0][2]).toMatchObject({ spOptions: { quietStatuses: [400], silent: true } });
+    expect(createItem.mock.calls[1][2]).toMatchObject({ spOptions: { quietStatuses: [400], silent: true } });
     const initialPayload = createItem.mock.calls[0][1];
     const fallbackPayload = createItem.mock.calls[1][1];
     expect(initialPayload).toHaveProperty('Severity', 'warn');
@@ -212,7 +219,8 @@ describe('SharePointDriftEventRepository', () => {
     });
 
     expect(createItem).toHaveBeenCalledTimes(1);
-    const [, payload] = createItem.mock.calls[0];
+    const [, payload, options] = createItem.mock.calls[0];
+    expect(options).toMatchObject({ spOptions: { quietStatuses: [400], silent: true } });
     expect(payload).toMatchObject({
       Title: 'Daily_Attendance:Status',
       List_x0020_Name: 'Daily_Attendance',
@@ -636,6 +644,6 @@ describe('SharePointDriftEventRepository', () => {
 
     expect(updateItemByTitle).toHaveBeenCalledWith('DriftEventsLog', 42, {
       IsResolved: true,
-    });
+    }, { spOptions: { quietStatuses: [400], silent: true } });
   });
 });

--- a/src/lib/sp/spListWrite.ts
+++ b/src/lib/sp/spListWrite.ts
@@ -12,8 +12,10 @@ export async function patchListItem<TBody extends object>(
   id: number,
   body: TBody,
   ifMatch?: string,
-  signal?: AbortSignal,
+  options?: { signal?: AbortSignal; spOptions?: import('./types').SpRequestOptions },
 ): Promise<Response> {
+  const signal = options?.signal;
+  const spOptions = options?.spOptions;
   const itemPath = buildItemPath(listIdentifier, id);
   const payload = JSON.stringify(body);
 
@@ -30,7 +32,7 @@ export async function patchListItem<TBody extends object>(
       },
       body: payload,
       signal,
-      spOptions: { skipRetry: true },
+      spOptions: { ...spOptions, skipRetry: true },
     });
   } catch (err) {
     // If NOT a 412 conflict, rethrow immediately
@@ -65,6 +67,7 @@ export async function patchListItem<TBody extends object>(
         },
         body: payload,
         signal,
+        spOptions,
       });
     } catch (secondErr) {
       // If it STILL fails with 412, don't infinite retry — throw specialized error
@@ -84,9 +87,9 @@ export async function updateItemByTitle<TBody extends object, TResult = unknown>
   listTitle: string,
   id: number,
   body: TBody,
-  options?: { ifMatch?: string; signal?: AbortSignal },
+  options?: import('./types').UpdateItemOptions,
 ): Promise<TResult> {
-  const res = await patchListItem<TBody>(spFetch, listTitle, id, body, options?.ifMatch, options?.signal);
+  const res = await patchListItem<TBody>(spFetch, listTitle, id, body, options?.ifMatch, options);
   return coerceResult<TResult>(res);
 }
 
@@ -98,9 +101,9 @@ export async function updateItem<TBody extends object, TResult = unknown>(
   listIdentifier: string,
   id: number,
   body: TBody,
-  options?: { ifMatch?: string; signal?: AbortSignal },
+  options?: import('./types').UpdateItemOptions,
 ): Promise<TResult> {
-  const res = await patchListItem<TBody>(spFetch, listIdentifier, id, body, options?.ifMatch, options?.signal);
+  const res = await patchListItem<TBody>(spFetch, listIdentifier, id, body, options?.ifMatch, options);
   return coerceResult<TResult>(res);
 }
 
@@ -112,7 +115,7 @@ export async function updateField(
   listTitle: string,
   fieldInternalName: string,
   properties: Record<string, unknown>,
-  options?: { signal?: AbortSignal }
+  options?: import('./types').WriteItemOptions
 ): Promise<void> {
   const path = `${resolveListPath(listTitle)}/fields/getbyinternalnameortitle('${fieldInternalName}')`;
   await spFetch(path, {
@@ -123,6 +126,7 @@ export async function updateField(
     },
     body: JSON.stringify(properties),
     signal: options?.signal,
+    spOptions: options?.spOptions,
   });
 }
 
@@ -132,13 +136,14 @@ export async function deleteItemByTitle(
   spFetch: SpFetchFn,
   listTitle: string,
   id: number,
-  options?: { signal?: AbortSignal },
+  options?: import('./types').WriteItemOptions,
 ): Promise<void> {
   const path = buildItemPath(listTitle, id);
   await spFetch(path, {
     method: 'DELETE',
     headers: { 'If-Match': '*' },
     signal: options?.signal,
+    spOptions: options?.spOptions,
   });
 }
 
@@ -146,13 +151,14 @@ export async function deleteItem(
   spFetch: SpFetchFn,
   listIdentifier: string,
   id: number,
-  options?: { signal?: AbortSignal },
+  options?: import('./types').WriteItemOptions,
 ): Promise<void> {
   const path = buildItemPath(listIdentifier, id);
   await spFetch(path, {
     method: 'DELETE',
     headers: { 'If-Match': '*' },
     signal: options?.signal,
+    spOptions: options?.spOptions,
   });
 }
 
@@ -162,7 +168,7 @@ export async function addListItemByTitle<TBody extends object, TResult = unknown
   spFetch: SpFetchFn,
   listTitle: string,
   body: TBody,
-  options?: { signal?: AbortSignal },
+  options?: import('./types').WriteItemOptions,
 ): Promise<TResult> {
   const path = `/lists/getbytitle('${listTitle}')/items`;
   const res = await spFetch(path, {
@@ -172,6 +178,7 @@ export async function addListItemByTitle<TBody extends object, TResult = unknown
     },
     body: JSON.stringify(body),
     signal: options?.signal,
+    spOptions: options?.spOptions,
   });
   return coerceResult<TResult>(res);
 }
@@ -180,7 +187,7 @@ export async function createItem<TBody extends object, TResult = unknown>(
   spFetch: SpFetchFn,
   listIdentifier: string,
   body: TBody,
-  options?: { signal?: AbortSignal },
+  options?: import('./types').WriteItemOptions,
 ): Promise<TResult> {
   const path = `${resolveListPath(listIdentifier)}/items`;
   const res = await spFetch(path, {
@@ -190,6 +197,7 @@ export async function createItem<TBody extends object, TResult = unknown>(
     },
     body: JSON.stringify(body),
     signal: options?.signal,
+    spOptions: options?.spOptions,
   });
   return coerceResult<TResult>(res);
 }

--- a/src/lib/sp/spLists.ts
+++ b/src/lib/sp/spLists.ts
@@ -13,7 +13,7 @@
  *                      addFieldToList, ensureListExists
  */
 
-import type { EnsureListOptions, JsonRecord, ListItemsOptions, SpFieldDef, SpRequestInit, SpRequestOptions } from './types';
+import type { EnsureListOptions, JsonRecord, ListItemsOptions, SpFieldDef, SpRequestInit, SpRequestOptions, UpdateItemOptions, WriteItemOptions } from './types';
 
 // Sub-module imports
 import {
@@ -109,7 +109,7 @@ export function createListOperations(
   function addListItemByTitle<TBody extends object, TResult = unknown>(
     listTitle: string,
     body: TBody,
-    options?: { signal?: AbortSignal },
+    options?: WriteItemOptions,
   ): Promise<TResult> {
     return _addListItemByTitle<TBody, TResult>(spFetch, listTitle, body, options);
   }
@@ -117,7 +117,7 @@ export function createListOperations(
   function createItem<TBody extends object, TResult = unknown>(
     listTitle: string,
     body: TBody,
-    options?: { signal?: AbortSignal },
+    options?: WriteItemOptions,
   ): Promise<TResult> {
     return _createItem<TBody, TResult>(spFetch, listTitle, body, options);
   }
@@ -137,7 +137,7 @@ export function createListOperations(
     listTitle: string,
     id: number,
     body: TBody,
-    options?: { ifMatch?: string; signal?: AbortSignal },
+    options?: UpdateItemOptions,
   ): Promise<TResult> {
     return _updateItemByTitle<TBody, TResult>(spFetch, listTitle, id, body, options);
   }
@@ -146,7 +146,7 @@ export function createListOperations(
     listIdentifier: string,
     id: number,
     body: TBody,
-    options?: { ifMatch?: string; signal?: AbortSignal },
+    options?: UpdateItemOptions,
   ): Promise<TResult> {
     return _updateItem<TBody, TResult>(spFetch, listIdentifier, id, body, options);
   }
@@ -156,7 +156,7 @@ export function createListOperations(
   function deleteItemByTitle(
     listTitle: string, 
     id: number, 
-    options?: { signal?: AbortSignal }
+    options?: WriteItemOptions
   ): Promise<void> {
     return _deleteItemByTitle(spFetch, listTitle, id, options);
   }
@@ -164,7 +164,7 @@ export function createListOperations(
   function deleteItem(
     listIdentifier: string, 
     id: number, 
-    options?: { signal?: AbortSignal }
+    options?: WriteItemOptions
   ): Promise<void> {
     return _deleteItem(spFetch, listIdentifier, id, options);
   }

--- a/src/lib/sp/types.ts
+++ b/src/lib/sp/types.ts
@@ -202,6 +202,15 @@ export type ListItemsOptions = {
   spOptions?: SpRequestOptions;
 };
 
+export type WriteItemOptions = {
+  signal?: AbortSignal;
+  spOptions?: SpRequestOptions;
+};
+
+export type UpdateItemOptions = WriteItemOptions & {
+  ifMatch?: string;
+};
+
 // ─── Staff identifier ────────────────────────────────────────────
 
 export type StaffIdentifier = { type: 'guid' | 'title'; value: string };

--- a/src/sharepoint/fields/userFields.ts
+++ b/src/sharepoint/fields/userFields.ts
@@ -127,7 +127,7 @@ export const USERS_MASTER_CORE_FIELD_MAP = {
   serviceEndDate: 'ServiceEndDate',
   isHighIntensitySupportTarget: 'IsHighIntensitySupportTarget',
   isSupportProcedureTarget: 'IsSupportProcedureTarget',
-  severeFlag: 'SevereFlag', // Deprecated/Legacy fallback
+  severeFlag: 'severeFlag',
   isActive: 'IsActive',
   usageStatus: 'UsageStatus',
   attendanceDays: 'AttendanceDays',
@@ -154,7 +154,7 @@ const CANDIDATE_SERVICE_START_DATE = ['ServiceStartDate', 'StartDate', 'cr013_se
 const CANDIDATE_SERVICE_END_DATE = ['ServiceEndDate', 'EndDate', 'cr013_serviceEndDate'];
 const CANDIDATE_IS_HIGH_INTENSITY = ['IsHighIntensitySupportTarget', 'IntensityTarget', 'IsHighIntensitySupportTarget0', 'cr013_isHighIntensity'];
 const CANDIDATE_IS_SUPPORT_PROCEDURE = ['IsSupportProcedureTarget', 'ProcedureTarget', 'cr013_isSupportProcedure'];
-const CANDIDATE_SEVERE_FLAG = ['SevereFlag', 'severeFlag', 'HighSeverityFlag', 'cr013_severeFlag'];
+const CANDIDATE_SEVERE_FLAG = ['severeFlag', 'SevereFlag', 'HighSeverityFlag', 'cr013_severeFlag'];
 const CANDIDATE_IS_ACTIVE = ['IsActive', 'Active', 'IsEnabled', 'cr013_isActive'];
 const CANDIDATE_USAGE_STATUS = ['UsageStatus', 'Status', 'UsageStatus0', 'cr013_usageStatus'];
 const CANDIDATE_ATTENDANCE_DAYS = ['AttendanceDays', 'WorkDays', 'cr013_attendanceDays'];


### PR DESCRIPTION
## Changes\n- Implemented silent write fallback for DriftEventsLog_v2 (quieting 400 errors in console)\n- Absorbed Users_Master SevereFlag case drift (SevereFlag -> severeFlag)\n- Hardened spClient write operations to support spOptions\n- Fully passing full test suite (10,459 tests)