### PR TITLE
fix(drift): strictly pre-flight fields to eliminate browser 400 logs

### DIFF
--- a/src/features/diagnostics/drift/infra/SharePointDriftEventRepository.ts
+++ b/src/features/diagnostics/drift/infra/SharePointDriftEventRepository.ts
@@ -445,12 +445,13 @@ export class SharePointDriftEventRepository implements IDriftEventRepository {
       // Even if buildCreatePayload handles mapping, we must double-check against
       // the actually discovered availablePhysicalFields to be safe in stale environments.
       const activePayload: Record<string, unknown> = {};
-      const schemaKnown = this.availablePhysicalFields.size > 0;
       for (const [k, v] of Object.entries(payloadRaw)) {
         if (v === undefined) {
           continue;
         }
-        if (k === 'Title' || !schemaKnown || this.availablePhysicalFields.has(k)) {
+        // Strict pre-flight: Only include fields that are confirmed to exist in the schema.
+        // If schema is unknown, we fall back to Title-only to avoid triggering 400 errors in DevTools.
+        if (k === 'Title' || this.availablePhysicalFields.has(k)) {
           activePayload[k] = v;
         }
       }

--- a/src/features/diagnostics/drift/infra/__tests__/SharePointDriftEventRepository.spec.ts
+++ b/src/features/diagnostics/drift/infra/__tests__/SharePointDriftEventRepository.spec.ts
@@ -102,15 +102,8 @@ describe('SharePointDriftEventRepository', () => {
     expect(fallbackPayload).toHaveProperty('LoggedAt');
   });
 
-  it('uses stable required duplicate keys when schema fetch is unavailable and optional write fails', async () => {
-    const badRequest = Object.assign(
-      new Error("フィールドまたはプロパティ 'Severity' は存在しません。"),
-      { status: 400 },
-    );
-    const createItem = vi
-      .fn()
-      .mockRejectedValueOnce(badRequest)
-      .mockResolvedValueOnce({});
+  it('sends only Title when schema fetch is unavailable (strict pre-flight to avoid 400)', async () => {
+    const createItem = vi.fn().mockResolvedValueOnce({});
 
     const repo = new SharePointDriftEventRepository({
       createItem,
@@ -130,30 +123,9 @@ describe('SharePointDriftEventRepository', () => {
       resolved: false,
     });
 
-    expect(createItem).toHaveBeenCalledTimes(2);
-    expect(createItem.mock.calls[0][2]).toMatchObject({ spOptions: { quietStatuses: [400], silent: true } });
-    expect(createItem.mock.calls[1][2]).toMatchObject({ spOptions: { quietStatuses: [400], silent: true } });
-    const initialPayload = createItem.mock.calls[0][1];
-    const fallbackPayload = createItem.mock.calls[1][1];
-    expect(initialPayload).toHaveProperty('List_x0020_Name', 'Daily_Attendance');
-    expect(initialPayload).toHaveProperty('ListName', 'Daily_Attendance');
-    expect(initialPayload).toHaveProperty('Field_x0020_Name', 'Status');
-    expect(initialPayload).toHaveProperty('FieldName', 'Status');
-    expect(initialPayload).toHaveProperty('Detected_x0020_At', '2026-04-05');
-    expect(initialPayload).toHaveProperty('DetectedAt', '2026-04-05');
-    expect(initialPayload).toHaveProperty('Logged_x0020_At', expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/));
-    expect(initialPayload).not.toHaveProperty('NameOfList');
-    expect(initialPayload).toHaveProperty('Severity', 'warn');
-
-    expect(fallbackPayload).not.toHaveProperty('Severity');
-    expect(fallbackPayload).toHaveProperty('List_x0020_Name', 'Daily_Attendance');
-    expect(fallbackPayload).toHaveProperty('ListName', 'Daily_Attendance');
-    expect(fallbackPayload).toHaveProperty('Field_x0020_Name', 'Status');
-    expect(fallbackPayload).toHaveProperty('FieldName', 'Status');
-    expect(fallbackPayload).toHaveProperty('Detected_x0020_At', '2026-04-05');
-    expect(fallbackPayload).toHaveProperty('DetectedAt', '2026-04-05');
-    expect(fallbackPayload).toHaveProperty('Logged_x0020_At', expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/));
-    expect(fallbackPayload).not.toHaveProperty('NameOfList');
+    expect(createItem).toHaveBeenCalledTimes(1);
+    const [, payload] = createItem.mock.calls[0];
+    expect(payload).toEqual({ Title: 'Daily_Attendance:Status' });
   });
 
   it('retries once with required-only payload when 400 does not identify a field', async () => {
@@ -170,6 +142,7 @@ describe('SharePointDriftEventRepository', () => {
       createItem,
       updateItemByTitle: vi.fn(async () => ({})),
       getListItemsByTitle: vi.fn(async () => []),
+      getSchema: vi.fn(async () => ['Severity', 'ListName', 'FieldName', 'DetectedAt', 'LoggedAt']),
     });
 
     await repo.logEvent({


### PR DESCRIPTION
Eliminate browser Network 400 logs by pre-filtering payload fields against confirmed SharePoint schema. Falls back to Title-only if schema is unknown.