### PR TITLE
feat(kiosk): add isolated kiosk home route with large action buttons

### DIFF
--- a/src/app/AppShell.kiosk-route.spec.tsx
+++ b/src/app/AppShell.kiosk-route.spec.tsx
@@ -84,5 +84,14 @@ describe('AppShell kiosk query routing', () => {
     const stored = JSON.parse(localStorage.getItem(SETTINGS_STORAGE_KEY) ?? '{}');
     expect(stored.layoutMode).toBe('normal');
   });
+
+  it('enables kiosk mode when /kiosk route is accessed', async () => {
+    renderAppShell('/kiosk');
+
+    const appShell = screen.getByTestId('app-shell');
+    await waitFor(() => {
+      expect(appShell).toHaveAttribute('data-kiosk', 'true');
+    });
+  });
 });
 

--- a/src/app/components/KioskBackToToday.tsx
+++ b/src/app/components/KioskBackToToday.tsx
@@ -13,7 +13,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { useKioskDetection } from '@/features/settings/hooks/useKioskDetection';
 
 /** Today系パス（完全一致でのみバーを非表示にする） */
-const TODAY_EXACT_PATHS = new Set(['/today']);
+const TODAY_EXACT_PATHS = new Set(['/today', '/kiosk']);
 
 export const KioskBackToToday: React.FC = () => {
   const location = useLocation();

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -24,6 +24,7 @@ import { safetyRoutes } from './routes/safetyRoutes';
 import { scheduleRoutes } from './routes/scheduleRoutes';
 import { supportPlanRoutes } from './routes/supportPlanRoutes';
 import { transportRoutes } from './routes/transportRoutes';
+import { kioskRoutes } from './routes/kioskRoutes';
 
 // ── Route composition ────────────────────────────────────────────────────
 
@@ -40,6 +41,7 @@ const childRoutes: RouteObject[] = [
   ...scheduleRoutes,
   ...transportRoutes,
   ...callLogRoutes,
+  ...kioskRoutes,
   nurseRoutes(),
 ];
 

--- a/src/app/routes/appRoutePaths.ts
+++ b/src/app/routes/appRoutePaths.ts
@@ -101,6 +101,7 @@ export const APP_ROUTE_PATHS = [
   'admin/telemetry',
   'monitoring-meeting/:userId',
   'call-logs',
+  'kiosk',
 ] as const;
 
 export type AppRoutePath = typeof APP_ROUTE_PATHS[number];

--- a/src/app/routes/kioskRoutes.tsx
+++ b/src/app/routes/kioskRoutes.tsx
@@ -1,0 +1,12 @@
+/**
+ * Kiosk mode routes: /kiosk/*
+ */
+import { type RouteObject } from 'react-router-dom';
+import { SuspendedKioskHomePage } from './lazyPages';
+
+export const kioskRoutes: RouteObject[] = [
+  {
+    path: 'kiosk',
+    element: <SuspendedKioskHomePage />,
+  },
+];

--- a/src/app/routes/lazyPages.tsx
+++ b/src/app/routes/lazyPages.tsx
@@ -194,5 +194,7 @@ export const SuspendedTransportAssignmentPage = createSuspended(TransportAssignm
 const TelemetryDashboardPage = React.lazy(() => import('@/pages/admin/TelemetryDashboardPage'));
 export const SuspendedTelemetryDashboardPage = createSuspended(TelemetryDashboardPage, 'テレメトリダッシュボードを読み込んでいます…');
 
+const KioskHomePage = React.lazy(() => import('@/pages/kiosk/KioskHomePage'));
 const HealthPage = React.lazy(() => import('@/pages/HealthPage'));
 export const SuspendedHealthPage = createSuspended(HealthPage, '環境診断を読み込んでいます…');
+export const SuspendedKioskHomePage = createSuspended(KioskHomePage, 'キオスク画面を読み込んでいます…');

--- a/src/features/kiosk/components/KioskHomeScreen.tsx
+++ b/src/features/kiosk/components/KioskHomeScreen.tsx
@@ -1,0 +1,160 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import Grid from '@mui/material/Grid';
+import PlayCircleOutlineIcon from '@mui/icons-material/PlayCircleOutline';
+import LoginIcon from '@mui/icons-material/Login';
+import LogoutIcon from '@mui/icons-material/Logout';
+import EventNoteIcon from '@mui/icons-material/EventNote';
+
+/**
+ * KioskHomeScreen - キオスクモードの入口画面
+ * 
+ * タブレットでの操作を想定し、押しやすい大きなボタンを配置。
+ * 「支援手順を実施する」を最優先の導線として強調。
+ */
+export const KioskHomeScreen: React.FC = () => {
+  // ボタンクリック時の挙動は今回はプレースホルダー（アラート等は出さない）
+  const handlePlaceholder = () => {
+    // 今後のPRで実装予定
+  };
+
+  return (
+    <Box 
+      sx={{ 
+        p: { xs: 2, md: 4 }, 
+        maxWidth: 800, 
+        mx: 'auto', 
+        mt: { xs: 2, md: 6 },
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center'
+      }}
+    >
+      <Typography 
+        variant="h3" 
+        component="h1" 
+        gutterBottom 
+        sx={{ 
+          fontWeight: 900, 
+          color: 'primary.main',
+          mb: 1
+        }}
+      >
+        キオスクモード
+      </Typography>
+      <Typography 
+        variant="h6" 
+        sx={{ 
+          mb: 6, 
+          color: 'text.secondary',
+          fontWeight: 500
+        }}
+      >
+        今日の操作を選んでください
+      </Typography>
+
+      <Grid container spacing={3}>
+        {/* メインアクション: 支援手順を実施する */}
+        <Grid size={12}>
+          <Button
+            fullWidth
+            variant="contained"
+            size="large"
+            color="primary"
+            data-testid="kiosk-action-execute-steps"
+            startIcon={<PlayCircleOutlineIcon sx={{ fontSize: '2.5rem !important' }} />}
+            sx={{
+              py: 6,
+              fontSize: '1.75rem',
+              fontWeight: 'bold',
+              borderRadius: 6,
+              boxShadow: '0 8px 24px rgba(0,0,0,0.12)',
+              '&:active': {
+                transform: 'scale(0.98)',
+              },
+              transition: 'transform 0.1s ease-in-out',
+            }}
+            onClick={handlePlaceholder}
+          >
+            支援手順を実施する
+          </Button>
+        </Grid>
+
+        {/* サブアクション: 通所・退所 */}
+        <Grid size={6}>
+          <Button
+            fullWidth
+            variant="outlined"
+            size="large"
+            data-testid="kiosk-action-attendance"
+            startIcon={<LoginIcon sx={{ fontSize: '1.5rem !important' }} />}
+            sx={{
+              py: 4,
+              fontSize: '1.25rem',
+              fontWeight: 'bold',
+              borderRadius: 4,
+              borderWidth: 2,
+              '&:hover': {
+                borderWidth: 2,
+              },
+            }}
+            onClick={handlePlaceholder}
+          >
+            通所する
+          </Button>
+        </Grid>
+        <Grid size={6}>
+          <Button
+            fullWidth
+            variant="outlined"
+            size="large"
+            data-testid="kiosk-action-leave"
+            startIcon={<LogoutIcon sx={{ fontSize: '1.5rem !important' }} />}
+            sx={{
+              py: 4,
+              fontSize: '1.25rem',
+              fontWeight: 'bold',
+              borderRadius: 4,
+              borderWidth: 2,
+              '&:hover': {
+                borderWidth: 2,
+              },
+            }}
+            onClick={handlePlaceholder}
+          >
+            退所する
+          </Button>
+        </Grid>
+
+        {/* サブアクション: 今日の予定 */}
+        <Grid size={12}>
+          <Button
+            fullWidth
+            variant="outlined"
+            size="large"
+            data-testid="kiosk-action-schedule"
+            startIcon={<EventNoteIcon sx={{ fontSize: '1.5rem !important' }} />}
+            sx={{
+              py: 3,
+              fontSize: '1.1rem',
+              fontWeight: 'bold',
+              borderRadius: 3,
+              borderWidth: 2,
+              '&:hover': {
+                borderWidth: 2,
+              },
+              mt: 2
+            }}
+            onClick={handlePlaceholder}
+          >
+            今日の予定を見る
+          </Button>
+        </Grid>
+      </Grid>
+
+      {/* 管理者向け情報は出さないが、開発用IDなどは data-属性に隠すことは許容 */}
+    </Box>
+  );
+};

--- a/src/features/settings/hooks/useKioskDetection.ts
+++ b/src/features/settings/hooks/useKioskDetection.ts
@@ -17,16 +17,19 @@ export function useKioskDetection() {
   const location = useLocation();
 
   const isKioskMode = useMemo(() => {
+    // 1. パスによる判定 (/kiosk ルートは常にキオスクモード)
+    if (location.pathname.startsWith('/kiosk')) return true;
+
     const params = new URLSearchParams(location.search);
     const kioskParam = params.get('kiosk');
     
-    // URLパラメータがあればそれを優先
+    // 2. URLパラメータがあればそれを優先
     if (kioskParam === '1' || kioskParam === 'true') return true;
     if (kioskParam === '0' || kioskParam === 'false') return false;
     
-    // パラメータがなければ設定に従う
+    // 3. パラメータがなければ設定に従う
     return settings.layoutMode === 'kiosk';
-  }, [location.search, settings.layoutMode]);
+  }, [location.pathname, location.search, settings.layoutMode]);
 
   return { isKioskMode };
 }

--- a/src/pages/kiosk/KioskHomePage.tsx
+++ b/src/pages/kiosk/KioskHomePage.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { KioskHomeScreen } from '@/features/kiosk/components/KioskHomeScreen';
+
+/**
+ * KioskHomePage — /kiosk ルートのメインページ
+ */
+export default function KioskHomePage() {
+  return <KioskHomeScreen />;
+}

--- a/tests/e2e/kiosk-home-smoke.spec.ts
+++ b/tests/e2e/kiosk-home-smoke.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Kiosk Home Smoke', () => {
+  test.use({
+    baseURL: process.env.E2E_BASE_URL ?? 'http://127.0.0.1:5173',
+  });
+
+  test('should display kiosk home page with action buttons and no sidebar', async ({ page }) => {
+    // /kiosk ルートに直接アクセス
+    await page.goto('/kiosk?provider=memory');
+    await page.waitForLoadState('networkidle');
+
+    // 1. タイトルと説明の確認
+    await expect(page.getByRole('heading', { name: 'キオスクモード' })).toBeVisible();
+    await expect(page.getByText('今日の操作を選んでください')).toBeVisible();
+
+    // 2. 4つの大ボタンが表示されていることを確認
+    await expect(page.getByTestId('kiosk-action-execute-steps')).toBeVisible();
+    await expect(page.getByTestId('kiosk-action-attendance')).toBeVisible();
+    await expect(page.getByTestId('kiosk-action-leave')).toBeVisible();
+    await expect(page.getByTestId('kiosk-action-schedule')).toBeVisible();
+
+    // 3. 最上位導線が「支援手順を実施する」であることを確認（テキストが含まれているか）
+    await expect(page.getByTestId('kiosk-action-execute-steps')).toHaveText(/支援手順を実施する/);
+
+    // 4. 通常のナビゲーション（サイドバーやヘッダー）が非表示であることを確認
+    // AppShellState の isFullscreenMode によりサイドバーとヘッダーは消えるはず
+    const sidebar = page.getByTestId('app-shell-sidebar'); // navigationConfig 等で定義されている可能性がある
+    await expect(sidebar).toHaveCount(0);
+
+    const header = page.getByTestId('app-shell-header');
+    await expect(header).toHaveCount(0);
+
+    // 5. AppShell に data-kiosk="true" が付与されていることを確認
+    const appShell = page.getByTestId('app-shell');
+    await expect(appShell).toHaveAttribute('data-kiosk', 'true');
+  });
+});


### PR DESCRIPTION
## Summary
- Add isolated `/kiosk` home route
- Add kiosk home page with large touch-friendly action buttons
- Make 「支援手順を実施する」 the primary top-level action
- Auto-enable kiosk layout for `/kiosk`
- Hide the normal kiosk back-to-today bar on the `/kiosk` home screen
- Add unit and E2E smoke coverage

## Scope
This PR only adds the kiosk entry screen.

Not included:
- user selection
- procedure list
- procedure detail
- save operations
- attendance check-in/check-out actions

## Validation
- npm run typecheck
- npm run lint
- npx vitest run src/app/AppShell.kiosk-route.spec.tsx
- npx playwright test tests/e2e/kiosk-home-smoke.spec.ts

## Next
Next PR will connect the kiosk flow to user selection and the support procedure list.