### PR TITLE
feat(kiosk): add user selection screen

### DIFF
--- a/src/app/components/KioskBackToToday.tsx
+++ b/src/app/components/KioskBackToToday.tsx
@@ -21,10 +21,10 @@ export const KioskBackToToday: React.FC = () => {
   const theme = useTheme();
   const { isKioskMode } = useKioskDetection();
 
-  // Today 画面にいるなら非表示（完全一致のみ）
-  const isOnToday = TODAY_EXACT_PATHS.has(location.pathname);
-
-  if (!isKioskMode || isOnToday) return null;
+  // Today 画面 または キオスク関連画面 にいるなら非表示
+  const isExcluded = TODAY_EXACT_PATHS.has(location.pathname) || location.pathname.startsWith('/kiosk');
+  
+  if (!isKioskMode || isExcluded) return null;
 
   return (
     <Box

--- a/src/app/routes/appRoutePaths.ts
+++ b/src/app/routes/appRoutePaths.ts
@@ -102,6 +102,8 @@ export const APP_ROUTE_PATHS = [
   'monitoring-meeting/:userId',
   'call-logs',
   'kiosk',
+  'kiosk-users',
+  'kiosk-procedures',
 ] as const;
 
 export type AppRoutePath = typeof APP_ROUTE_PATHS[number];

--- a/src/app/routes/kioskRoutes.tsx
+++ b/src/app/routes/kioskRoutes.tsx
@@ -2,11 +2,29 @@
  * Kiosk mode routes: /kiosk/*
  */
 import { type RouteObject } from 'react-router-dom';
-import { SuspendedKioskHomePage } from './lazyPages';
+import { SuspendedKioskHomePage, SuspendedKioskUserSelectPage } from './lazyPages';
 
 export const kioskRoutes: RouteObject[] = [
   {
     path: 'kiosk',
-    element: <SuspendedKioskHomePage />,
+    children: [
+      {
+        index: true,
+        element: <SuspendedKioskHomePage />,
+      },
+      {
+        path: 'users',
+        children: [
+          {
+            index: true,
+            element: <SuspendedKioskUserSelectPage />,
+          },
+          {
+            path: ':userId/procedures',
+            element: <div>支援手順一覧（開発中）</div>,
+          },
+        ],
+      },
+    ],
   },
 ];

--- a/src/app/routes/lazyPages.tsx
+++ b/src/app/routes/lazyPages.tsx
@@ -198,3 +198,5 @@ const KioskHomePage = React.lazy(() => import('@/pages/kiosk/KioskHomePage'));
 const HealthPage = React.lazy(() => import('@/pages/HealthPage'));
 export const SuspendedHealthPage = createSuspended(HealthPage, '環境診断を読み込んでいます…');
 export const SuspendedKioskHomePage = createSuspended(KioskHomePage, 'キオスク画面を読み込んでいます…');
+const KioskUserSelectPage = React.lazy(() => import('@/pages/kiosk/KioskUserSelectPage'));
+export const SuspendedKioskUserSelectPage = createSuspended(KioskUserSelectPage, '利用者選択を読み込んでいます…');

--- a/src/features/kiosk/components/KioskHomeScreen.tsx
+++ b/src/features/kiosk/components/KioskHomeScreen.tsx
@@ -7,6 +7,7 @@ import PlayCircleOutlineIcon from '@mui/icons-material/PlayCircleOutline';
 import LoginIcon from '@mui/icons-material/Login';
 import LogoutIcon from '@mui/icons-material/Logout';
 import EventNoteIcon from '@mui/icons-material/EventNote';
+import { useNavigate } from 'react-router-dom';
 
 /**
  * KioskHomeScreen - キオスクモードの入口画面
@@ -15,6 +16,7 @@ import EventNoteIcon from '@mui/icons-material/EventNote';
  * 「支援手順を実施する」を最優先の導線として強調。
  */
 export const KioskHomeScreen: React.FC = () => {
+  const navigate = useNavigate();
   // ボタンクリック時の挙動は今回はプレースホルダー（アラート等は出さない）
   const handlePlaceholder = () => {
     // 今後のPRで実装予定
@@ -76,7 +78,7 @@ export const KioskHomeScreen: React.FC = () => {
               },
               transition: 'transform 0.1s ease-in-out',
             }}
-            onClick={handlePlaceholder}
+            onClick={() => navigate('/kiosk/users')}
           >
             支援手順を実施する
           </Button>

--- a/src/features/kiosk/components/KioskUserSelectScreen.tsx
+++ b/src/features/kiosk/components/KioskUserSelectScreen.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { Box, Typography, Grid, Card, CardActionArea, CardContent, IconButton, CircularProgress } from '@mui/material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import { useNavigate } from 'react-router-dom';
+import { useUsers } from '@/features/users/useUsers';
+
+export const KioskUserSelectScreen: React.FC = () => {
+  const navigate = useNavigate();
+  const { data: users, isLoading } = useUsers({ selectMode: 'core' });
+
+  // キオスクモードでは「有効かつ支援手順対象」の利用者のみを表示
+  const activeUsers = users.filter(u => u.IsActive && u.IsSupportProcedureTarget);
+
+  return (
+    <Box sx={{ p: 4, height: '100%', display: 'flex', flexDirection: 'column' }}>
+      <Box sx={{ mb: 4, display: 'flex', alignItems: 'center' }}>
+        <IconButton 
+          onClick={() => navigate('/kiosk')} 
+          sx={{ mr: 2, bgcolor: 'action.hover' }}
+          data-testid="kiosk-user-select-back"
+        >
+          <ArrowBackIcon fontSize="large" />
+        </IconButton>
+        <Typography variant="h4" component="h1" sx={{ fontWeight: 'bold' }}>
+          利用者を選択してください
+        </Typography>
+      </Box>
+
+      {isLoading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', flexGrow: 1 }}>
+          <CircularProgress size={60} />
+        </Box>
+      ) : (
+        <Grid container spacing={3}>
+          {activeUsers.map((user) => (
+            <Grid key={user.Id} size={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
+              <Card 
+                sx={{ 
+                  height: '100%',
+                  borderRadius: 4,
+                  boxShadow: '0 4px 12px rgba(0,0,0,0.08)',
+                  '&:active': { transform: 'scale(0.98)' },
+                  transition: 'transform 0.1s'
+                }}
+                data-testid={`kiosk-user-card-${user.Id}`}
+              >
+                <CardActionArea 
+                  onClick={() => navigate(`/kiosk/users/${user.Id}/procedures`)}
+                  sx={{ height: '100%', p: 3 }}
+                >
+                  <CardContent sx={{ textAlign: 'center' }}>
+                    <Typography 
+                      variant="body1" 
+                      color="text.secondary" 
+                      sx={{ mb: 1, letterSpacing: '0.1em' }}
+                    >
+                      {user.Furigana || '　'}
+                    </Typography>
+                    <Typography variant="h4" sx={{ fontWeight: 'bold' }}>
+                      {user.FullName}
+                    </Typography>
+                  </CardContent>
+                </CardActionArea>
+              </Card>
+            </Grid>
+          ))}
+          {activeUsers.length === 0 && (
+            <Grid size={12}>
+              <Box sx={{ p: 8, textAlign: 'center', bgcolor: 'action.hover', borderRadius: 4 }}>
+                <Typography variant="h6" color="text.secondary">
+                  対象の利用者がいません
+                </Typography>
+              </Box>
+            </Grid>
+          )}
+        </Grid>
+      )}
+    </Box>
+  );
+};

--- a/src/pages/kiosk/KioskUserSelectPage.tsx
+++ b/src/pages/kiosk/KioskUserSelectPage.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { KioskUserSelectScreen } from '@/features/kiosk/components/KioskUserSelectScreen';
+
+const KioskUserSelectPage: React.FC = () => {
+  return <KioskUserSelectScreen />;
+};
+
+export default KioskUserSelectPage;

--- a/tests/e2e/kiosk-user-selection.spec.ts
+++ b/tests/e2e/kiosk-user-selection.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Kiosk User Selection', () => {
+  test.beforeEach(async ({ page }) => {
+    // キオスクホームへ移動
+    await page.goto('/kiosk');
+    await expect(page.getByTestId('kiosk-action-execute-steps')).toBeVisible();
+  });
+
+  test('should navigate to user selection and show user cards', async ({ page }) => {
+    // 「支援手順を実施する」をクリック
+    await page.getByTestId('kiosk-action-execute-steps').click();
+
+    // 利用者選択画面が表示されることを確認
+    await expect(page).toHaveURL(/\/kiosk\/users/);
+    await expect(page.getByText('利用者を選択してください')).toBeVisible();
+
+    // 利用者カードが表示されていることを確認（モックデータがある前提）
+    // もしデータがない場合は「対象の利用者がいません」が出るはず
+    const noUsers = await page.getByText('対象の利用者がいません').isVisible();
+    if (!noUsers) {
+      const cards = page.locator('[data-testid^="kiosk-user-card-"]');
+      const count = await cards.count();
+      expect(count).toBeGreaterThan(0);
+    }
+  });
+
+  test('should navigate back to kiosk home from user selection', async ({ page }) => {
+    await page.getByTestId('kiosk-action-execute-steps').click();
+    await expect(page).toHaveURL(/\/kiosk\/users/);
+
+    // 戻るボタンをクリック
+    await page.getByTestId('kiosk-user-select-back').click();
+
+    // キオスクホームに戻ることを確認
+    await expect(page).toHaveURL(/\/kiosk$/);
+    await expect(page.getByTestId('kiosk-action-execute-steps')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- Add `/kiosk/users` route for user selection
- Implement `KioskUserSelectScreen` with large, touch-friendly user cards
- Filter users by `IsActive` and `IsSupportProcedureTarget`
- Add "Back" navigation to return to the kiosk home
- Hide the "Back to Today" bar on all kiosk paths
- Add E2E coverage for user selection flow

## Scope
This PR adds the user selection phase.

Not included:
- procedure list
- procedure detail
- save operations
- attendance check-in/check-out actions

## Validation
- npm run typecheck
- npm run lint
- npx playwright test tests/e2e/kiosk-user-selection.spec.ts