### PR TITLE
feat(kiosk): add procedure detail screen

### DIFF
--- a/src/app/routes/kioskRoutes.tsx
+++ b/src/app/routes/kioskRoutes.tsx
@@ -6,6 +6,7 @@ import {
   SuspendedKioskHomePage, 
   SuspendedKioskUserSelectPage,
   SuspendedKioskProcedureListPage,
+  SuspendedKioskProcedureDetailPage,
 } from './lazyPages';
 
 export const kioskRoutes: RouteObject[] = [
@@ -32,7 +33,7 @@ export const kioskRoutes: RouteObject[] = [
               },
               {
                 path: ':slotKey',
-                element: <div>手順詳細（開発中）</div>,
+                element: <SuspendedKioskProcedureDetailPage />,
               },
             ],
           },

--- a/src/app/routes/lazyPages.tsx
+++ b/src/app/routes/lazyPages.tsx
@@ -202,3 +202,5 @@ const KioskUserSelectPage = React.lazy(() => import('@/pages/kiosk/KioskUserSele
 export const SuspendedKioskUserSelectPage = createSuspended(KioskUserSelectPage, '利用者選択を読み込んでいます…');
 const KioskProcedureListPage = React.lazy(() => import('@/pages/kiosk/KioskProcedureListPage'));
 export const SuspendedKioskProcedureListPage = createSuspended(KioskProcedureListPage, '支援手順一覧を読み込んでいます…');
+const KioskProcedureDetailPage = React.lazy(() => import('@/pages/kiosk/KioskProcedureDetailPage'));
+export const SuspendedKioskProcedureDetailPage = createSuspended(KioskProcedureDetailPage, '手順詳細を読み込んでいます…');

--- a/src/features/daily/hooks/useExecutionData.ts
+++ b/src/features/daily/hooks/useExecutionData.ts
@@ -21,11 +21,11 @@ import { useSP } from '@/lib/spClient'; // contract:allow-sp-direct
 
 export function useExecutionData(): ExecutionRecordRepository {
   const storeHooks = useExecutionStore();
-  const { spFetch } = useSP();
+  const { spFetch, getListFieldInternalNames } = useSP();
 
   return useMemo(
-    () => getExecutionRepository(storeHooks, spFetch),
-    [storeHooks, spFetch],
+    () => getExecutionRepository(storeHooks, spFetch, getListFieldInternalNames),
+    [storeHooks, spFetch, getListFieldInternalNames],
   );
 }
 

--- a/src/features/daily/infra/executionRepositoryFactory.ts
+++ b/src/features/daily/infra/executionRepositoryFactory.ts
@@ -113,6 +113,7 @@ function createLocalStorageExecutionAdapter(
 export const getExecutionRepository = (
   storeHooks?: ExecutionStoreHooks,
   spFetch?: SpFetchFn,
+  getListFieldInternalNames?: (listTitle: string) => Promise<Set<string>>,
 ): ExecutionRecordRepository => {
 
   const kind = resolveKind();
@@ -134,6 +135,7 @@ export const getExecutionRepository = (
       }
       return new SharePointExecutionRecordRepository({
         spFetch,
+        getListFieldInternalNames,
       });
     }
 

--- a/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
+++ b/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
@@ -12,6 +12,7 @@ import type { JsonRecord } from '@/lib/sp/types';
 
 type SharePointExecutionRecordRepositoryOptions = {
   spFetch: SpFetchFn;
+  getListFieldInternalNames?: (listTitle: string) => Promise<Set<string>>;
 };
 
 /**
@@ -19,13 +20,56 @@ type SharePointExecutionRecordRepositoryOptions = {
  */
 export class SharePointExecutionRecordRepository implements ExecutionRecordRepository {
   private readonly spFetch: SpFetchFn;
+  private readonly getListFieldInternalNames?: (listTitle: string) => Promise<Set<string>>;
   private readonly parentListTitle: string;
   private readonly childListTitle: string;
+  
+  private availableFields = new Map<string, Set<string>>();
+  private initPromises = new Map<string, Promise<void>>();
 
   constructor(options: SharePointExecutionRecordRepositoryOptions) {
     this.spFetch = options.spFetch;
+    this.getListFieldInternalNames = options.getListFieldInternalNames;
     this.parentListTitle = getListTitle();
     this.childListTitle = getRowsListTitle();
+  }
+
+  private async initFields(listTitle: string): Promise<void> {
+    if (!this.getListFieldInternalNames) return;
+    if (this.availableFields.has(listTitle)) return;
+    
+    let promise = this.initPromises.get(listTitle);
+    if (!promise) {
+      promise = (async () => {
+        try {
+          const fieldSet = await this.getListFieldInternalNames!(listTitle);
+          if (fieldSet) {
+            this.availableFields.set(listTitle, fieldSet);
+          }
+        } catch (err) {
+          console.warn(`[ExecutionRepo] Field resolution failed for ${listTitle}:`, err);
+        }
+      })();
+      this.initPromises.set(listTitle, promise);
+    }
+    return promise;
+  }
+
+  private filterPayload(listTitle: string, payload: Record<string, unknown>): Record<string, unknown> {
+    const fieldSet = this.availableFields.get(listTitle);
+    if (!fieldSet || fieldSet.size === 0) return payload; // fail-open
+
+    const activePayload: Record<string, unknown> = {};
+    // Title is almost always required/present
+    if (payload.Title !== undefined) activePayload.Title = payload.Title;
+
+    for (const [k, v] of Object.entries(payload)) {
+      if (k === 'Title') continue;
+      if (fieldSet.has(k)) {
+        activePayload[k] = v;
+      }
+    }
+    return activePayload;
   }
 
   private async ensureParentRecord(dailyKey: string, date: string, userId: string): Promise<number> {
@@ -41,15 +85,18 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
     }
 
     const createUrl = `_api/web/lists/getbytitle('${this.parentListTitle}')/items`;
-    const createBody = {
+    
+    await this.initFields(this.parentListTitle);
+    const rawBody = {
       [DAILY_RECORD_FIELDS.title]: dailyKey,
       [DAILY_RECORD_FIELDS.recordDate]: date,
       UserId: userId, 
     };
+    const body = this.filterPayload(this.parentListTitle, rawBody);
 
     const createResponse = await this.spFetch(createUrl, {
       method: 'POST',
-      body: JSON.stringify(createBody),
+      body: JSON.stringify(body),
       headers: { 'Content-Type': 'application/json;odata=verbose', 'Accept': 'application/json;odata=verbose' }
     });
 
@@ -103,7 +150,8 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
     const parentId = await this.ensureParentRecord(dailyKey, record.date, record.userId);
     const existing = await this.getRecord(record.date, record.userId, record.scheduleItemId);
 
-    const body = {
+    await this.initFields(this.childListTitle);
+    const rawBody = {
       [EXECUTION_RECORD_FIELDS.title]: record.id,
       [EXECUTION_RECORD_FIELDS.rowKey]: rowKey,
       [EXECUTION_RECORD_FIELDS.parentId]: parentId,
@@ -115,6 +163,7 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
       [EXECUTION_RECORD_FIELDS.recordedAt]: record.recordedAt,
       [EXECUTION_RECORD_FIELDS.bipsJSON]: JSON.stringify(record.triggeredBipIds),
     };
+    const body = this.filterPayload(this.childListTitle, rawBody);
 
     if (existing) {
       const filter = `${EXECUTION_RECORD_FIELDS.rowKey} eq '${rowKey}'`;

--- a/src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts
+++ b/src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SharePointExecutionRecordRepository } from '../SharePointExecutionRecordRepository';
+import { EXECUTION_RECORD_FIELDS } from '../constants';
+import type { ExecutionRecord } from '../../../domain/executionRecordTypes';
+
+describe('SharePointExecutionRecordRepository', () => {
+  const mockSpFetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ value: [] }),
+  });
+  
+  const mockGetFields = vi.fn().mockResolvedValue(new Set([
+    'Title',
+    'RecordDate',
+    'UserId',
+    EXECUTION_RECORD_FIELDS.rowKey,
+    EXECUTION_RECORD_FIELDS.status,
+    EXECUTION_RECORD_FIELDS.parentId,
+    EXECUTION_RECORD_FIELDS.userId,
+    EXECUTION_RECORD_FIELDS.rowNo,
+    EXECUTION_RECORD_FIELDS.recordedAt,
+    EXECUTION_RECORD_FIELDS.bipsJSON,
+    // Note: StaffName is intentionally missing in this mock schema to test filtering
+  ]));
+
+  const repo = new SharePointExecutionRecordRepository({
+    spFetch: mockSpFetch,
+    getListFieldInternalNames: mockGetFields,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('filters out non-existent fields from the payload', async () => {
+    const record: ExecutionRecord = {
+      id: 'R001',
+      date: '2024-01-01',
+      userId: 'U001',
+      scheduleItemId: 'S001',
+      status: 'completed',
+      memo: 'Test memo',
+      recordedAt: '2024-01-01T10:00:00Z',
+      recordedBy: 'Staff A',
+      triggeredBipIds: [],
+    };
+
+    // First call to ensureParentRecord
+    mockSpFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ value: [{ Id: 123 }] }),
+    });
+    
+    // Call to getRecord (checks if exists)
+    mockSpFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ value: [] }),
+    });
+
+    // Final call to createItem (the one we want to check)
+    mockSpFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ d: { Id: 456 } }),
+    });
+
+    await repo.upsertRecord(record);
+
+    // Verify fields in the POST request to child list
+    const createCall = mockSpFetch.mock.calls.find(call => 
+      call[0].includes('SupportRecord_DailyRows') && call[1]?.method === 'POST'
+    );
+    
+    expect(createCall).toBeDefined();
+    const body = JSON.parse(createCall![1]!.body as string);
+    
+    expect(body.Title).toBe('R001');
+    expect(body[EXECUTION_RECORD_FIELDS.status]).toBe('completed');
+    // StaffName should be filtered out as it was not in the mockGetFields set
+    expect(body[EXECUTION_RECORD_FIELDS.staffName]).toBeUndefined();
+  });
+
+  it('falls back to full payload if getListFieldInternalNames is not provided', async () => {
+    const repoNoFields = new SharePointExecutionRecordRepository({
+      spFetch: mockSpFetch,
+    });
+
+    const record: ExecutionRecord = {
+      id: 'R001',
+      date: '2024-01-01',
+      userId: 'U001',
+      scheduleItemId: 'S001',
+      status: 'completed',
+      memo: 'Test memo',
+      recordedAt: '2024-01-01T10:00:00Z',
+      recordedBy: 'Staff A',
+      triggeredBipIds: [],
+    };
+
+    mockSpFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ value: [{ Id: 123 }] }),
+    });
+
+    await repoNoFields.upsertRecord(record);
+
+    const createCall = mockSpFetch.mock.calls.find(call => 
+      call[0].includes('SupportRecord_DailyRows') && call[1]?.method === 'POST'
+    );
+    
+    const body = JSON.parse(createCall![1]!.body as string);
+    // Should include StaffName as filtering was skipped
+    expect(body[EXECUTION_RECORD_FIELDS.staffName]).toBe('Staff A');
+  });
+});

--- a/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
@@ -1,11 +1,13 @@
-import React from 'react';
-import { Box, Typography, IconButton, Paper, Grid, Button, Chip, Stack } from '@mui/material';
+import React, { useState } from 'react';
+import { Box, Typography, IconButton, Paper, Grid, Button, Chip, Stack, Alert, Snackbar } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useUser } from '@/features/users/useUsers';
 import { useProcedureData } from '@/features/daily/hooks/useProcedureData';
+import { useExecutionRecord } from '@/features/daily/hooks/useExecutionRecord';
+import { formatDateIso } from '@/lib/dateFormat';
 
 export const KioskProcedureDetailScreen: React.FC = () => {
   const navigate = useNavigate();
@@ -14,12 +16,37 @@ export const KioskProcedureDetailScreen: React.FC = () => {
   const isUserLoading = status === 'loading' || status === 'idle';
   const procedureRepo = useProcedureData();
   
+  const today = React.useMemo(() => formatDateIso(new Date()), []);
+  
   const procedure = React.useMemo(() => {
     if (!userId || slotKey === undefined) return null;
     const procedures = procedureRepo.getByUser(userId);
     const index = parseInt(slotKey, 10);
     return procedures[index] || null;
   }, [userId, slotKey, procedureRepo]);
+
+  // scheduleItemId として ID もしくは インデックスを使用する
+  const scheduleItemId = procedure?.id || slotKey || '';
+  const { record, setStatus } = useExecutionRecord(today, userId || '', scheduleItemId);
+  
+  const [isSaving, setIsSaving] = useState(false);
+  const [showSuccess, setShowSuccess] = useState(false);
+
+  const handleSave = async (newStatus: 'completed' | 'triggered') => {
+    if (!userId) return;
+    setIsSaving(true);
+    try {
+      await setStatus(newStatus);
+      setShowSuccess(true);
+      // 成功フィードバックの後、少し待ってから一覧に戻る
+      setTimeout(() => {
+        navigate(`/kiosk/users/${userId}/procedures`);
+      }, 1500);
+    } catch (error) {
+      console.error('Failed to save execution record:', error);
+      setIsSaving(false);
+    }
+  };
 
   if (isUserLoading) {
     return <Box sx={{ p: 4 }}>読み込み中...</Box>;
@@ -41,11 +68,14 @@ export const KioskProcedureDetailScreen: React.FC = () => {
     );
   }
 
-  // 暫定的に instruction を「本人」と「支援者」に分けるロジック
-  // 本来はスキーマ拡張が必要だが、Phase 4 ではモック的な表示を優先する
+  // instruction を「本人」と「支援者」に分割して表示（。で区切られた最初の文を本人のタスクとする）
+  // 将来的なスキーマ拡張で明示的なフィールドに移行予定
   const parts = procedure.instruction.split('。').filter(Boolean);
   const personTask = parts[0] || '手順に従って進めましょう';
   const staffTask = parts.slice(1).join('。') || '適宜見守り、必要に応じて声掛けを行います';
+
+  const isCompleted = record?.status === 'completed';
+  const isTriggered = record?.status === 'triggered';
 
   return (
     <Box sx={{ p: 4, height: '100%', display: 'flex', flexDirection: 'column' }}>
@@ -68,9 +98,17 @@ export const KioskProcedureDetailScreen: React.FC = () => {
             </Typography>
           </Box>
         </Box>
-        {procedure.isKey && (
-          <Chip label="最優先" color="primary" sx={{ fontWeight: 'bold', px: 1 }} />
-        )}
+        <Stack direction="row" spacing={1} alignItems="center">
+          {procedure.isKey && (
+            <Chip label="最優先" color="primary" sx={{ fontWeight: 'bold', px: 1 }} />
+          )}
+          {isCompleted && (
+            <Chip label="実施済み" color="success" icon={<CheckCircleOutlineIcon />} sx={{ fontWeight: 'bold' }} />
+          )}
+          {isTriggered && (
+            <Chip label="注意あり" color="warning" icon={<ErrorOutlineIcon />} sx={{ fontWeight: 'bold' }} />
+          )}
+        </Stack>
       </Box>
 
       {/* メインコンテンツ */}
@@ -129,26 +167,33 @@ export const KioskProcedureDetailScreen: React.FC = () => {
       <Box sx={{ mt: 6, pt: 4, borderTop: '1px solid', borderColor: 'divider' }}>
         <Stack direction="row" spacing={3} justifyContent="center">
           <Button 
-            variant="outlined" 
+            variant={isTriggered ? "contained" : "outlined"}
+            color="warning"
             size="large" 
             startIcon={<ErrorOutlineIcon />}
+            onClick={() => handleSave('triggered')}
             sx={{ 
               py: 2, 
               px: 4, 
               borderRadius: 4, 
               fontSize: '1.2rem',
-              color: 'text.secondary',
-              borderColor: 'divider',
-              '&:hover': { bgcolor: 'action.hover' }
+              fontWeight: isTriggered ? 'bold' : 'normal',
+              ...(isTriggered ? {} : {
+                color: 'text.secondary',
+                borderColor: 'divider',
+              }),
+              '&:hover': { bgcolor: isTriggered ? 'warning.dark' : 'action.hover' }
             }}
-            disabled
+            disabled={isSaving || isCompleted}
           >
-            注意ありで記録 (開発中)
+            {isTriggered ? '記録済み' : '注意ありで記録'}
           </Button>
           <Button 
             variant="contained" 
+            color={isCompleted ? "success" : "primary"}
             size="large" 
             startIcon={<CheckCircleOutlineIcon />}
+            onClick={() => handleSave('completed')}
             sx={{ 
               py: 2, 
               px: 8, 
@@ -157,12 +202,25 @@ export const KioskProcedureDetailScreen: React.FC = () => {
               fontWeight: 'bold',
               boxShadow: '0 8px 16px rgba(0,0,0,0.1)'
             }}
-            disabled
+            disabled={isSaving || isCompleted}
           >
-            実施済みにする (開発中)
+            {isCompleted ? '実施済みです' : '実施済みにする'}
           </Button>
         </Stack>
       </Box>
+
+      {/* 成功メッセージ */}
+      <Snackbar 
+        open={showSuccess} 
+        autoHideDuration={3000} 
+        onClose={() => setShowSuccess(false)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert severity="success" sx={{ width: '100%', fontSize: '1.2rem', fontWeight: 'bold' }}>
+          記録を保存しました
+        </Alert>
+      </Snackbar>
     </Box>
   );
 };
+

--- a/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
@@ -1,0 +1,168 @@
+import React from 'react';
+import { Box, Typography, IconButton, Paper, Grid, Button, Chip, Stack } from '@mui/material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useUser } from '@/features/users/useUsers';
+import { useProcedureData } from '@/features/daily/hooks/useProcedureData';
+
+export const KioskProcedureDetailScreen: React.FC = () => {
+  const navigate = useNavigate();
+  const { userId, slotKey } = useParams<{ userId: string; slotKey: string }>();
+  const { data: user, status } = useUser(userId || '');
+  const isUserLoading = status === 'loading' || status === 'idle';
+  const procedureRepo = useProcedureData();
+  
+  const procedure = React.useMemo(() => {
+    if (!userId || slotKey === undefined) return null;
+    const procedures = procedureRepo.getByUser(userId);
+    const index = parseInt(slotKey, 10);
+    return procedures[index] || null;
+  }, [userId, slotKey, procedureRepo]);
+
+  if (isUserLoading) {
+    return <Box sx={{ p: 4 }}>読み込み中...</Box>;
+  }
+
+  if (!user || !procedure) {
+    return (
+      <Box sx={{ p: 4, textAlign: 'center' }}>
+        <Typography variant="h5">情報が見つかりません</Typography>
+        <Button 
+          variant="contained" 
+          onClick={() => navigate(`/kiosk/users/${userId}/procedures`)} 
+          sx={{ mt: 2 }}
+          startIcon={<ArrowBackIcon />}
+        >
+          一覧に戻る
+        </Button>
+      </Box>
+    );
+  }
+
+  // 暫定的に instruction を「本人」と「支援者」に分けるロジック
+  // 本来はスキーマ拡張が必要だが、Phase 4 ではモック的な表示を優先する
+  const parts = procedure.instruction.split('。').filter(Boolean);
+  const personTask = parts[0] || '手順に従って進めましょう';
+  const staffTask = parts.slice(1).join('。') || '適宜見守り、必要に応じて声掛けを行います';
+
+  return (
+    <Box sx={{ p: 4, height: '100%', display: 'flex', flexDirection: 'column' }}>
+      {/* ヘッダー */}
+      <Box sx={{ mb: 4, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <Box sx={{ display: 'flex', alignItems: 'center' }}>
+          <IconButton 
+            onClick={() => navigate(`/kiosk/users/${userId}/procedures`)} 
+            sx={{ mr: 2, bgcolor: 'action.hover' }}
+            data-testid="kiosk-procedure-detail-back"
+          >
+            <ArrowBackIcon fontSize="large" />
+          </IconButton>
+          <Box>
+            <Typography variant="h6" color="text.secondary" sx={{ mb: -0.5 }}>
+              {procedure.time} - {procedure.activity}
+            </Typography>
+            <Typography variant="h4" component="h1" sx={{ fontWeight: 'bold' }}>
+              {user.FullName} 様
+            </Typography>
+          </Box>
+        </Box>
+        {procedure.isKey && (
+          <Chip label="最優先" color="primary" sx={{ fontWeight: 'bold', px: 1 }} />
+        )}
+      </Box>
+
+      {/* メインコンテンツ */}
+      <Grid container spacing={4} sx={{ flexGrow: 1 }}>
+        {/* 本人のやる事 */}
+        <Grid size={{ xs: 12, md: 6 }}>
+          <Paper 
+            elevation={0} 
+            sx={{ 
+              p: 4, 
+              height: '100%', 
+              bgcolor: 'primary.lighter', 
+              borderRadius: 6,
+              border: '2px solid',
+              borderColor: 'primary.light',
+              display: 'flex',
+              flexDirection: 'column'
+            }}
+          >
+            <Typography variant="h5" color="primary.main" sx={{ mb: 3, fontWeight: 'bold', display: 'flex', alignItems: 'center' }}>
+              <Box sx={{ width: 8, height: 24, bgcolor: 'primary.main', mr: 2, borderRadius: 1 }} />
+              本人のすること
+            </Typography>
+            <Typography variant="h3" sx={{ fontWeight: 'bold', lineHeight: 1.4, flexGrow: 1 }}>
+              {personTask}
+            </Typography>
+          </Paper>
+        </Grid>
+
+        {/* 支援者のやる事 */}
+        <Grid size={{ xs: 12, md: 6 }}>
+          <Paper 
+            elevation={0} 
+            sx={{ 
+              p: 4, 
+              height: '100%', 
+              bgcolor: 'action.hover', 
+              borderRadius: 6,
+              border: '2px solid transparent',
+              display: 'flex',
+              flexDirection: 'column'
+            }}
+          >
+            <Typography variant="h5" color="text.secondary" sx={{ mb: 3, fontWeight: 'bold', display: 'flex', alignItems: 'center' }}>
+              <Box sx={{ width: 8, height: 24, bgcolor: 'text.disabled', mr: 2, borderRadius: 1 }} />
+              支援者がすること
+            </Typography>
+            <Typography variant="h4" sx={{ color: 'text.secondary', lineHeight: 1.5, flexGrow: 1 }}>
+              {staffTask}
+            </Typography>
+          </Paper>
+        </Grid>
+      </Grid>
+
+      {/* フッター / アクションボタン */}
+      <Box sx={{ mt: 6, pt: 4, borderTop: '1px solid', borderColor: 'divider' }}>
+        <Stack direction="row" spacing={3} justifyContent="center">
+          <Button 
+            variant="outlined" 
+            size="large" 
+            startIcon={<ErrorOutlineIcon />}
+            sx={{ 
+              py: 2, 
+              px: 4, 
+              borderRadius: 4, 
+              fontSize: '1.2rem',
+              color: 'text.secondary',
+              borderColor: 'divider',
+              '&:hover': { bgcolor: 'action.hover' }
+            }}
+            disabled
+          >
+            注意ありで記録 (開発中)
+          </Button>
+          <Button 
+            variant="contained" 
+            size="large" 
+            startIcon={<CheckCircleOutlineIcon />}
+            sx={{ 
+              py: 2, 
+              px: 8, 
+              borderRadius: 4, 
+              fontSize: '1.5rem', 
+              fontWeight: 'bold',
+              boxShadow: '0 8px 16px rgba(0,0,0,0.1)'
+            }}
+            disabled
+          >
+            実施済みにする (開発中)
+          </Button>
+        </Stack>
+      </Box>
+    </Box>
+  );
+};

--- a/src/features/kiosk/components/KioskProcedureListScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureListScreen.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Box, Typography, Grid, Card, CardActionArea, IconButton, Chip, LinearProgress } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
@@ -7,7 +7,9 @@ import AccessTimeIcon from '@mui/icons-material/AccessTime';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useUser } from '@/features/users/useUsers';
 import { useProcedureData } from '@/features/daily/hooks/useProcedureData';
-import { formatDateJapanese } from '@/lib/dateFormat';
+import { useExecutionData } from '@/features/daily/hooks/useExecutionData';
+import { formatDateJapanese, formatDateIso } from '@/lib/dateFormat';
+import type { ExecutionRecord } from '@/features/daily/domain/executionRecordTypes';
 
 export const KioskProcedureListScreen: React.FC = () => {
   const navigate = useNavigate();
@@ -15,19 +17,37 @@ export const KioskProcedureListScreen: React.FC = () => {
   const { data: user, status } = useUser(userId || '');
   const isUserLoading = status === 'loading' || status === 'idle';
   const procedureRepo = useProcedureData();
+  const executionRepo = useExecutionData();
   
+  const [records, setRecords] = useState<ExecutionRecord[]>([]);
+
+  const todayIso = React.useMemo(() => formatDateIso(new Date()), []);
+  const todayStr = formatDateJapanese(new Date());
+
   const procedures = React.useMemo(() => {
     if (!userId) return [];
     return procedureRepo.getByUser(userId);
   }, [userId, procedureRepo]);
 
-  const todayStr = formatDateJapanese(new Date());
+  // 実施記録の取得
+  useEffect(() => {
+    const fetchRecords = async () => {
+      if (!userId) return;
+      try {
+        const data = await executionRepo.getRecords(todayIso, userId);
+        setRecords(data);
+      } catch (error) {
+        console.error('Failed to fetch execution records:', error);
+      }
+    };
+    void fetchRecords();
+  }, [userId, executionRepo, todayIso]);
 
-  // 進捗サマリーの計算（現在は枠だけ用意、すべて「未実施」とする）
+  // 進捗サマリーの計算
   const totalCount = procedures.length;
-  const doneCount = 0;
-  const attentionCount = 0;
-  const progress = totalCount > 0 ? (doneCount / totalCount) * 100 : 0;
+  const doneCount = records.filter(r => r.status === 'completed').length;
+  const attentionCount = records.filter(r => r.status === 'triggered').length;
+  const progress = totalCount > 0 ? ((doneCount + attentionCount) / totalCount) * 100 : 0;
 
   if (isUserLoading) {
     return <Box sx={{ p: 4 }}>読み込み中...</Box>;
@@ -69,66 +89,101 @@ export const KioskProcedureListScreen: React.FC = () => {
         {/* 進捗サマリー */}
         <Box sx={{ minWidth: 200, textAlign: 'right' }}>
           <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-            実施状況: {doneCount} / {totalCount}
+            実施状況: {doneCount + attentionCount} / {totalCount}
           </Typography>
           <LinearProgress 
             variant="determinate" 
             value={progress} 
-            sx={{ height: 10, borderRadius: 5, mb: 1 }} 
+            sx={{ height: 12, borderRadius: 6, mb: 1, bgcolor: 'action.hover' }} 
           />
           <Box sx={{ display: 'flex', gap: 1, justifyContent: 'flex-end' }}>
             {attentionCount > 0 && (
-              <Chip icon={<WarningIcon />} label={`${attentionCount} 注意`} color="error" size="small" />
+              <Chip icon={<WarningIcon />} label={`${attentionCount} 注意`} color="warning" size="small" sx={{ fontWeight: 'bold' }} />
             )}
-            <Chip icon={<CheckCircleIcon />} label={`${doneCount} 完了`} color="success" size="small" variant="outlined" />
+            <Chip icon={<CheckCircleIcon />} label={`${doneCount} 完了`} color="success" size="small" variant={doneCount > 0 ? "filled" : "outlined"} sx={{ fontWeight: 'bold' }} />
           </Box>
         </Box>
       </Box>
 
       {/* 手順一覧 */}
       <Grid container spacing={2}>
-        {procedures.map((step, index) => (
-          <Grid key={index} size={12}>
-            <Card 
-              sx={{ 
-                borderRadius: 3,
-                boxShadow: '0 2px 8px rgba(0,0,0,0.05)',
-                borderLeft: '6px solid',
-                borderLeftColor: step.isKey ? 'primary.main' : 'divider',
-              }}
-              data-testid={`kiosk-procedure-card-${index}`}
-            >
-              <CardActionArea 
-                onClick={() => navigate(`/kiosk/users/${userId}/procedures/${index}`)}
-                sx={{ p: 2 }}
+        {procedures.map((step, index) => {
+          const scheduleItemId = step.id || index.toString();
+          const record = records.find(r => r.scheduleItemId === scheduleItemId);
+          const isCompleted = record?.status === 'completed';
+          const isTriggered = record?.status === 'triggered';
+          
+          return (
+            <Grid key={index} size={12}>
+              <Card 
+                sx={{ 
+                  borderRadius: 3,
+                  boxShadow: '0 2px 8px rgba(0,0,0,0.05)',
+                  borderLeft: '6px solid',
+                  borderLeftColor: step.isKey ? 'primary.main' : 'divider',
+                  bgcolor: isCompleted ? 'success.lighter' : isTriggered ? 'warning.lighter' : 'background.paper',
+                  opacity: isCompleted ? 0.8 : 1,
+                  transition: 'all 0.2s',
+                  '&:hover': {
+                    transform: 'translateY(-2px)',
+                    boxShadow: '0 4px 12px rgba(0,0,0,0.1)',
+                  }
+                }}
+                data-testid={`kiosk-procedure-card-${index}`}
               >
-                <Grid container alignItems="center" spacing={2}>
-                  <Grid size={2} sx={{ textAlign: 'center' }}>
-                    <Typography variant="h5" sx={{ fontWeight: 'bold', color: 'text.secondary' }}>
-                      {step.time}
-                    </Typography>
+                <CardActionArea 
+                  onClick={() => navigate(`/kiosk/users/${userId}/procedures/${index}`)}
+                  sx={{ p: 2.5 }}
+                >
+                  <Grid container alignItems="center" spacing={2}>
+                    <Grid size={2} sx={{ textAlign: 'center' }}>
+                      <Typography variant="h5" sx={{ fontWeight: 'bold', color: isCompleted ? 'success.main' : 'text.secondary' }}>
+                        {step.time}
+                      </Typography>
+                    </Grid>
+                    <Grid size={7}>
+                      <Typography variant="h6" sx={{ 
+                        fontWeight: 'bold', 
+                        mb: 0.5,
+                        color: isCompleted ? 'success.dark' : 'text.primary',
+                        textDecoration: isCompleted ? 'line-through' : 'none'
+                      }}>
+                        {step.activity}
+                      </Typography>
+                      <Typography variant="body2" color="text.secondary" noWrap>
+                        {step.instruction}
+                      </Typography>
+                    </Grid>
+                    <Grid size={3} sx={{ textAlign: 'right' }}>
+                      {isCompleted ? (
+                        <Chip 
+                          icon={<CheckCircleIcon />} 
+                          label="実施済み" 
+                          color="success"
+                          sx={{ borderRadius: 2, fontWeight: 'bold' }}
+                        />
+                      ) : isTriggered ? (
+                        <Chip 
+                          icon={<WarningIcon />} 
+                          label="注意あり" 
+                          color="warning"
+                          sx={{ borderRadius: 2, fontWeight: 'bold' }}
+                        />
+                      ) : (
+                        <Chip 
+                          icon={<AccessTimeIcon />} 
+                          label="未実施" 
+                          variant="outlined" 
+                          sx={{ borderRadius: 2, color: 'text.disabled', borderColor: 'divider' }}
+                        />
+                      )}
+                    </Grid>
                   </Grid>
-                  <Grid size={8}>
-                    <Typography variant="h6" sx={{ fontWeight: 'bold', mb: 0.5 }}>
-                      {step.activity}
-                    </Typography>
-                    <Typography variant="body2" color="text.secondary" noWrap>
-                      {step.instruction}
-                    </Typography>
-                  </Grid>
-                  <Grid size={2} sx={{ textAlign: 'right' }}>
-                    <Chip 
-                      icon={<AccessTimeIcon />} 
-                      label="未実施" 
-                      variant="outlined" 
-                      sx={{ borderRadius: 2 }}
-                    />
-                  </Grid>
-                </Grid>
-              </CardActionArea>
-            </Card>
-          </Grid>
-        ))}
+                </CardActionArea>
+              </Card>
+            </Grid>
+          );
+        })}
         {procedures.length === 0 && (
           <Grid size={12}>
             <Box sx={{ p: 8, textAlign: 'center', bgcolor: 'action.hover', borderRadius: 4 }}>
@@ -142,3 +197,4 @@ export const KioskProcedureListScreen: React.FC = () => {
     </Box>
   );
 };
+

--- a/src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { KioskProcedureDetailScreen } from '../KioskProcedureDetailScreen';
+import { MemoryRouter } from 'react-router-dom';
+
+// Mock dependencies
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useParams: () => ({ userId: 'U001', slotKey: '0' }),
+  };
+});
+
+vi.mock('@/features/users/useUsers', () => ({
+  useUser: () => ({ data: { FullName: '田中 太郎' }, status: 'success' }),
+}));
+
+const mockProcedures = [
+  { id: 'P001', time: '10:00', activity: '朝のバイタルチェック', instruction: '体温と血圧を測ります' }
+];
+
+vi.mock('@/features/daily/hooks/useProcedureData', () => ({
+  useProcedureData: () => ({
+    getByUser: () => mockProcedures
+  }),
+}));
+
+const mockSetStatus = vi.fn().mockResolvedValue(undefined);
+vi.mock('@/features/daily/hooks/useExecutionRecord', () => ({
+  useExecutionRecord: () => ({
+    record: null,
+    setStatus: mockSetStatus,
+  }),
+}));
+
+describe('KioskProcedureDetailScreen', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders procedure details correctly', () => {
+    render(
+      <MemoryRouter>
+        <KioskProcedureDetailScreen />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('10:00 - 朝のバイタルチェック')).toBeInTheDocument();
+    expect(screen.getByText('田中 太郎 様')).toBeInTheDocument();
+  });
+
+  it('calls setStatus with "completed" when Complete button is clicked', async () => {
+    render(
+      <MemoryRouter>
+        <KioskProcedureDetailScreen />
+      </MemoryRouter>
+    );
+
+    const completeButton = screen.getByText('実施済みにする');
+    fireEvent.click(completeButton);
+
+    expect(mockSetStatus).toHaveBeenCalledWith('completed');
+    
+    await waitFor(() => {
+      expect(screen.getByText('記録を保存しました')).toBeInTheDocument();
+    }, { timeout: 3000 });
+  });
+
+  it('calls setStatus with "triggered" when Triggered button is clicked', async () => {
+    render(
+      <MemoryRouter>
+        <KioskProcedureDetailScreen />
+      </MemoryRouter>
+    );
+
+    const triggeredButton = screen.getByText('注意ありで記録');
+    fireEvent.click(triggeredButton);
+
+    expect(mockSetStatus).toHaveBeenCalledWith('triggered');
+  });
+
+  it('navigates back when back button is clicked', () => {
+    render(
+      <MemoryRouter>
+        <KioskProcedureDetailScreen />
+      </MemoryRouter>
+    );
+
+    const backButton = screen.getByTestId('kiosk-procedure-detail-back');
+    fireEvent.click(backButton);
+
+    expect(mockNavigate).toHaveBeenCalledWith('/kiosk/users/U001/procedures');
+  });
+});

--- a/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { KioskProcedureListScreen } from '../KioskProcedureListScreen';
+import { MemoryRouter } from 'react-router-dom';
+
+// Mock dependencies
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => vi.fn(),
+    useParams: () => ({ userId: 'U001' }),
+  };
+});
+
+vi.mock('@/features/users/useUsers', () => ({
+  useUser: () => ({ data: { FullName: '田中 太郎' }, status: 'success' }),
+}));
+
+const mockProcedures = [
+  { id: 'P001', time: '10:00', activity: '朝のバイタルチェック', instruction: '体温と血圧を測ります' },
+  { id: 'P002', time: '12:00', activity: '昼食の介助', instruction: '見守りを行います' }
+];
+
+vi.mock('@/features/daily/hooks/useProcedureData', () => ({
+  useProcedureData: () => ({
+    getByUser: () => mockProcedures
+  }),
+}));
+
+const mockGetRecords = vi.fn().mockResolvedValue([
+  { scheduleItemId: 'P001', status: 'completed' }
+]);
+
+vi.mock('@/features/daily/hooks/useExecutionData', () => ({
+  useExecutionData: () => ({
+    getRecords: mockGetRecords
+  }),
+}));
+
+describe('KioskProcedureListScreen', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders procedure list and calculates progress correctly', async () => {
+    render(
+      <MemoryRouter>
+        <KioskProcedureListScreen />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/田中 太郎/)).toBeInTheDocument();
+    expect(screen.getByText('朝のバイタルチェック')).toBeInTheDocument();
+    expect(screen.getByText('昼食の介助')).toBeInTheDocument();
+
+    await waitFor(() => {
+      // P001 is completed, so 1 / 2
+      expect(screen.getByText('実施状況: 1 / 2')).toBeInTheDocument();
+      // P001 should have an "実施済み" chip
+      expect(screen.getByText('実施済み')).toBeInTheDocument();
+    });
+  });
+
+  it('shows "未実施" for procedures without records', async () => {
+    render(
+      <MemoryRouter>
+        <KioskProcedureListScreen />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('未実施')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/pages/kiosk/KioskProcedureDetailPage.tsx
+++ b/src/pages/kiosk/KioskProcedureDetailPage.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { KioskProcedureDetailScreen } from '@/features/kiosk/components/KioskProcedureDetailScreen';
+
+const KioskProcedureDetailPage: React.FC = () => {
+  return <KioskProcedureDetailScreen />;
+};
+
+export default KioskProcedureDetailPage;

--- a/tests/e2e/kiosk-procedure-detail.spec.ts
+++ b/tests/e2e/kiosk-procedure-detail.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Kiosk Procedure Detail', () => {
+  test.beforeEach(async ({ page }) => {
+    // 確実にデータを読み込むために /kiosk/users から開始
+    await page.goto('/kiosk/users');
+    const userCard = page.locator('[data-testid^="kiosk-user-card-"]').first();
+    await userCard.waitFor({ state: 'visible', timeout: 10000 });
+    await userCard.click();
+    
+    // 一覧画面が表示されるのを待つ
+    await expect(page.getByText('の支援手順')).toBeVisible({ timeout: 10000 });
+    
+    // 最初の手順カードをクリック
+    const procCard = page.locator('[data-testid^="kiosk-procedure-card-"]').first();
+    await procCard.click();
+    
+    // 詳細画面が表示されるのを待つ
+    await expect(page.getByText('本人のすること')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('should display procedure details and navigate back', async ({ page }) => {
+    // 利用者名が表示されているか
+    await expect(page.locator('h1')).toBeVisible();
+    
+    // 本人と支援者のセクションがあるか
+    await expect(page.getByText('本人のすること')).toBeVisible();
+    await expect(page.getByText('支援者がすること')).toBeVisible();
+    
+    // 「実施済みにする」ボタンが無効状態で存在するか
+    const completeButton = page.getByText('実施済みにする (開発中)');
+    await expect(completeButton).toBeVisible();
+    await expect(completeButton).toBeDisabled();
+
+    // 戻るボタンで一覧に戻れるか
+    await page.getByTestId('kiosk-procedure-detail-back').click();
+    await expect(page.getByText('の支援手順')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- Implemented Kiosk Procedure Detail Phase 5 save/record workflow
- Added completed / needs-attention execution recording from the kiosk detail screen
- Refreshed the kiosk procedure list to reflect today’s saved execution records
- Added real-data based progress summary and status chips
- Added strict SharePoint pre-flight validation for execution record writes
- Added tests for kiosk detail, kiosk list, and SharePoint execution repository validation

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm run test -- src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts`

## Notes
This change is designed to tolerate known residual SharePoint drift/zombie columns by filtering write payloads against the actual list schema before sending requests. If schema lookup fails, the repository remains fail-open to preserve existing behavior.
