### PR TITLE
test(nav): allow kiosk routes as intentional orphans

### DIFF
--- a/src/app/navigation/diagnostics/pathUtils.ts
+++ b/src/app/navigation/diagnostics/pathUtils.ts
@@ -135,6 +135,9 @@ export const ORPHAN_ALLOWLIST_DETAILS: AllowlistRoute[] = [
   { path: '/survey/tokusei', category: 'Admin', reason: '特性計時アンケート結果（計画ハブからリンク経由）' },
   { path: '/schedule-ops', category: 'Drilldown', reason: 'スケジュール運用ページ（スケジュール画面からリンク経由）' },
   { path: '/users/hub/:userId', category: 'Detail', reason: '利用者の「活動・実績ハブ」画面（利用者詳細からリンク経由）' },
+  { path: '/kiosk', category: 'Kiosk', reason: 'キオスクモード専用 — キオスク入口画面（通常Navに露出しない）' },
+  { path: '/kiosk-users', category: 'Kiosk', reason: 'キオスクモード専用 — 利用者選択画面（通常Navに露出しない）' },
+  { path: '/kiosk-procedures', category: 'Kiosk', reason: 'キオスクモード専用 — 支援手順一覧画面（通常Navに露出しない）' },
 ].map(item => ({ ...item, path: normalizeRouterPath(item.path) }));
 
 export const ORPHAN_ALLOWLIST = new Set(ORPHAN_ALLOWLIST_DETAILS.map(d => d.path));


### PR DESCRIPTION
## 背景
`nav-router-consistency.spec.ts` で `/kiosk` が orphan route として検出され、意図的な非Nav露出ルートとの不整合が発生していました。

## 変更内容
`src/app/navigation/diagnostics/pathUtils.ts` の `ORPHAN_ALLOWLIST_DETAILS` に以下の Kiosk ルートを追加しました。
- `/kiosk`
- `/kiosk-users`
- `/kiosk-procedures`

いずれも「キオスクモード専用で通常Navに露出しない」ルートとして明示しています。

## 確認結果
- `npm run test -- tests/unit/app/navigation/nav-router-consistency.spec.ts` ✅
- `npm run lint -- src/app/navigation/diagnostics/pathUtils.ts` ✅（エラーなし）

## 期待効果
キオスク導線が Nav 露出対象外であることを診断ロジック上でも一貫して扱えるようになり、Nav/Router整合性チェックの誤検知を防止します。