### PR TITLE
ci(kiosk): add dedicated kiosk e2e workflow

### DIFF
--- a/.github/workflows/kiosk-e2e.yml
+++ b/.github/workflows/kiosk-e2e.yml
@@ -1,0 +1,64 @@
+name: kiosk-e2e
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: kiosk-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  kiosk-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+
+    env:
+      CI: true
+      VITE_E2E: '1'
+      VITE_E2E_MSAL_MOCK: '1'
+      VITE_SKIP_LOGIN: '1'
+      VITE_SKIP_SHAREPOINT: '1'
+      VITE_FORCE_DEMO: '1'
+      VITE_DEMO_MODE: '1'
+      VITE_MSAL_CLIENT_ID: 'e2e-mock-client-id-12345678'
+      VITE_MSAL_TENANT_ID: 'common'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers (chromium)
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Kiosk E2E tests
+        run: |
+          npm run -s test:e2e -- \
+            tests/e2e/kiosk-home-smoke.spec.ts \
+            tests/e2e/kiosk-user-selection.spec.ts \
+            tests/e2e/kiosk-procedure-list.spec.ts \
+            tests/e2e/kiosk-procedure-detail.spec.ts \
+            --project=chromium \
+            --workers=1
+
+      - name: Upload Playwright artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: kiosk-e2e-artifacts-${{ github.run_number }}
+          path: |
+            test-results
+            playwright-report
+          if-no-files-found: warn

--- a/tests/e2e/_helpers/bootKiosk.ts
+++ b/tests/e2e/_helpers/bootKiosk.ts
@@ -1,0 +1,131 @@
+import type { Page } from '@playwright/test';
+import { toLocalDateISO } from '../../../src/utils/getNow';
+import { setupPlaywrightEnv } from './setupPlaywrightEnv';
+
+const FEATURE_ENV: Record<string, string> = {
+  VITE_E2E: '1',
+  VITE_E2E_MSAL_MOCK: '1',
+  VITE_SKIP_LOGIN: '1',
+  VITE_SKIP_SHAREPOINT: '1',
+  VITE_FORCE_SHAREPOINT: '0',
+  VITE_FORCE_DEMO: '1',
+  VITE_DEMO_MODE: '1',
+};
+
+const FEATURE_STORAGE: Record<string, string> = {
+  skipLogin: '1',
+  demo: '1',
+};
+
+type KioskProcedure = {
+  id: string;
+  time: string;
+  activity: string;
+  instruction: string;
+  isKey?: boolean;
+};
+
+type KioskRecordSeed = {
+  scheduleItemId: string;
+  status: 'completed' | 'triggered' | 'skipped' | 'unrecorded';
+};
+
+export type BootKioskOptions = {
+  route?: string;
+  autoNavigate?: boolean;
+  provider?: 'memory' | 'local';
+  userId?: string;
+  procedures?: KioskProcedure[];
+  records?: KioskRecordSeed[];
+  envOverrides?: Record<string, string>;
+  storageOverrides?: Record<string, string>;
+};
+
+const DEFAULT_PROCEDURES: KioskProcedure[] = [
+  { id: 'base-0900', time: '09:00', activity: '朝の受け入れ', instruction: '視線を合わせて挨拶。体調チェックシート記入。', isKey: true },
+  { id: 'base-0915', time: '09:15', activity: '持ち物整理', instruction: 'ロッカーへの収納を支援。手順書を提示。' },
+  { id: 'base-1000', time: '10:00', activity: '作業活動', instruction: '作業手順の提示。失敗時は新しい部材を渡す。', isKey: true },
+  { id: 'base-1130', time: '11:30', activity: '昼食準備', instruction: '手洗い場へ誘導。' },
+  { id: 'base-1200', time: '12:00', activity: '昼食', instruction: '誤嚥に注意して見守り。', isKey: true },
+  { id: 'base-1300', time: '13:00', activity: '休憩', instruction: 'リラックスできる環境を提供。' },
+  { id: 'base-1500', time: '15:00', activity: '掃除', instruction: '担当箇所の清掃を一緒に行う。' },
+  { id: 'base-1545', time: '15:45', activity: '帰りの会', instruction: '一日の振り返り。ポジティブなフィードバック。', isKey: true },
+];
+
+export async function bootKiosk(page: Page, options: BootKioskOptions = {}): Promise<void> {
+  const provider = options.provider ?? 'memory';
+  const route = options.route ?? '/kiosk';
+  const autoNavigate = options.autoNavigate ?? true;
+  const userId = options.userId ?? '1';
+  const procedures = options.procedures ?? DEFAULT_PROCEDURES;
+  const records = options.records ?? [];
+
+  await setupPlaywrightEnv(page, {
+    envOverrides: {
+      ...FEATURE_ENV,
+      ...(options.envOverrides ?? {}),
+    },
+    storageOverrides: {
+      ...FEATURE_STORAGE,
+      ...(options.storageOverrides ?? {}),
+    },
+  });
+
+  const today = toLocalDateISO(new Date());
+  const executionData =
+    records.length > 0
+      ? {
+          [`${today}::${userId}`]: {
+            date: today,
+            userId,
+            records: records.map((r) => ({
+              id: `${today}-${userId}-${r.scheduleItemId}`,
+              date: today,
+              userId,
+              scheduleItemId: r.scheduleItemId,
+              status: r.status,
+              triggeredBipIds: [],
+              memo: '',
+              recordedBy: '',
+              recordedAt: new Date().toISOString(),
+            })),
+            updatedAt: new Date().toISOString(),
+          },
+        }
+      : {};
+
+  await page.addInitScript(
+    ({ targetUserId, seededProcedures, seededExecutionData }) => {
+      window.localStorage.setItem(
+        'procedureStore.v1',
+        JSON.stringify({
+          version: 1,
+          data: {
+            [targetUserId]: seededProcedures,
+          },
+        }),
+      );
+
+      window.localStorage.setItem(
+        'executionRecord.v1',
+        JSON.stringify({
+          version: 1,
+          data: seededExecutionData,
+        }),
+      );
+    },
+    {
+      targetUserId: userId,
+      seededProcedures: procedures,
+      seededExecutionData: executionData,
+    },
+  );
+
+  if (autoNavigate) {
+    const separator = route.includes('?') ? '&' : '?';
+    const target = route.includes('provider=') ? route : `${route}${separator}provider=${provider}`;
+    await page.goto(target, { waitUntil: 'load' });
+    await page.waitForLoadState('networkidle');
+  }
+}
+

--- a/tests/e2e/kiosk-home-smoke.spec.ts
+++ b/tests/e2e/kiosk-home-smoke.spec.ts
@@ -1,15 +1,16 @@
 import { test, expect } from '@playwright/test';
+import { bootKiosk } from './_helpers/bootKiosk';
 
 test.describe('Kiosk Home Smoke', () => {
   test.use({
     baseURL: process.env.E2E_BASE_URL ?? 'http://127.0.0.1:5173',
   });
 
-  test('should display kiosk home page with action buttons and no sidebar', async ({ page }) => {
-    // /kiosk ルートに直接アクセス
-    await page.goto('/kiosk?provider=memory');
-    await page.waitForLoadState('networkidle');
+  test.beforeEach(async ({ page }) => {
+    await bootKiosk(page, { route: '/kiosk' });
+  });
 
+  test('should display kiosk home page with action buttons and no sidebar', async ({ page }) => {
     // 1. タイトルと説明の確認
     await expect(page.getByRole('heading', { name: 'キオスクモード' })).toBeVisible();
     await expect(page.getByText('今日の操作を選んでください')).toBeVisible();

--- a/tests/e2e/kiosk-procedure-detail.spec.ts
+++ b/tests/e2e/kiosk-procedure-detail.spec.ts
@@ -1,9 +1,18 @@
 import { test, expect } from '@playwright/test';
+import { bootKiosk } from './_helpers/bootKiosk';
 
 test.describe('Kiosk Procedure Detail', () => {
   test.beforeEach(async ({ page }) => {
-    // 確実にデータを読み込むために /kiosk/users から開始
-    await page.goto('/kiosk/users');
+    await bootKiosk(page, { route: '/kiosk' });
+    await expect(page.getByTestId('kiosk-action-execute-steps')).toBeVisible({ timeout: 10000 });
+    await page.getByTestId('kiosk-action-execute-steps').click();
+    await expect(page.getByText('利用者を選択してください')).toBeVisible({ timeout: 10000 });
+
+    const noUsersMessage = page.getByText('対象の利用者がいません');
+    if (await noUsersMessage.isVisible()) {
+      throw new Error('E2E前提データ不足: IsActive && IsSupportProcedureTarget を満たす利用者が0件です');
+    }
+
     const userCard = page.locator('[data-testid^="kiosk-user-card-"]').first();
     await userCard.waitFor({ state: 'visible', timeout: 10000 });
     await userCard.click();
@@ -13,7 +22,7 @@ test.describe('Kiosk Procedure Detail', () => {
     
     // 最初の手順カードをクリック
     const procCard = page.locator('[data-testid^="kiosk-procedure-card-"]').first();
-    await procCard.click();
+    await procCard.click({ force: true });
     
     // 詳細画面が表示されるのを待つ
     await expect(page.getByText('本人のすること')).toBeVisible({ timeout: 10000 });
@@ -27,13 +36,34 @@ test.describe('Kiosk Procedure Detail', () => {
     await expect(page.getByText('本人のすること')).toBeVisible();
     await expect(page.getByText('支援者がすること')).toBeVisible();
     
-    // 「実施済みにする」ボタンが無効状態で存在するか
-    const completeButton = page.getByText('実施済みにする (開発中)');
+    // 「実施済みにする」ボタンが存在するか
+    const completeButton = page.getByRole('button', { name: '実施済みにする' });
     await expect(completeButton).toBeVisible();
-    await expect(completeButton).toBeDisabled();
 
     // 戻るボタンで一覧に戻れるか
     await page.getByTestId('kiosk-procedure-detail-back').click();
     await expect(page.getByText('の支援手順')).toBeVisible();
+  });
+
+  test('should save completed status and reflect in procedure list', async ({ page }) => {
+    await page.getByRole('button', { name: '実施済みにする' }).click();
+
+    await expect(page.getByText('記録を保存しました')).toBeVisible();
+    await expect(page).toHaveURL(/\/kiosk\/users\/[^/]+\/procedures(\?.*)?$/);
+
+    const firstCard = page.locator('[data-testid="kiosk-procedure-card-0"]');
+    await expect(firstCard.getByText('実施済み')).toBeVisible();
+    await expect(page.getByText('実施状況: 1 / 8')).toBeVisible();
+  });
+
+  test('should save triggered status and reflect in procedure list', async ({ page }) => {
+    await page.getByRole('button', { name: '注意ありで記録' }).click();
+
+    await expect(page.getByText('記録を保存しました')).toBeVisible();
+    await expect(page).toHaveURL(/\/kiosk\/users\/[^/]+\/procedures(\?.*)?$/);
+
+    const firstCard = page.locator('[data-testid="kiosk-procedure-card-0"]');
+    await expect(firstCard.getByText('注意あり')).toBeVisible();
+    await expect(page.getByText('実施状況: 1 / 8')).toBeVisible();
   });
 });

--- a/tests/e2e/kiosk-procedure-list.spec.ts
+++ b/tests/e2e/kiosk-procedure-list.spec.ts
@@ -1,24 +1,29 @@
 import { test, expect } from '@playwright/test';
+import { bootKiosk } from './_helpers/bootKiosk';
 
 test.describe('Kiosk Procedure List', () => {
   test.beforeEach(async ({ page }) => {
-    // 確実にデータを読み込むために少し待つか、タイトルが出るのを待つ
-    await page.goto('/kiosk/users');
+    await bootKiosk(page, { route: '/kiosk' });
+    await expect(page.getByTestId('kiosk-action-execute-steps')).toBeVisible({ timeout: 10000 });
+    await page.getByTestId('kiosk-action-execute-steps').click();
     await expect(page.getByText('利用者を選択してください')).toBeVisible({ timeout: 10000 });
 
+    const noUsersMessage = page.getByText('対象の利用者がいません');
+    if (await noUsersMessage.isVisible()) {
+      throw new Error('E2E前提データ不足: IsActive && IsSupportProcedureTarget を満たす利用者が0件です');
+    }
+
     const userCard = page.locator('[data-testid^="kiosk-user-card-"]').first();
-    // 描画を待つ (demo repository の初期化に時間がかかる場合があるため)
-    await userCard.waitFor({ state: 'visible', timeout: 5000 });
-    
+    await userCard.waitFor({ state: 'visible', timeout: 10000 });
+
     const count = await page.locator('[data-testid^="kiosk-user-card-"]').count();
-    
+
     if (count > 0) {
       await userCard.click();
     } else {
-      console.log('[E2E] No cards, going to /1/ fallback');
-      await page.goto('/kiosk/users/1/procedures');
+      throw new Error('E2E前提データ不足: 利用者カードが描画されませんでした');
     }
-    
+
     // 手順一覧画面が表示されるのを待つ
     await expect(page.getByText('の支援手順')).toBeVisible({ timeout: 10000 });
   });
@@ -58,7 +63,7 @@ test.describe('Kiosk Procedure List', () => {
   });
 
   test('should navigate back to user selection from procedure list', async ({ page }) => {
-    await page.getByTestId('kiosk-procedure-list-back').click();
-    await expect(page).toHaveURL(/\/kiosk\/users$/);
+    await page.getByTestId('kiosk-procedure-list-back').click({ force: true });
+    await expect(page).toHaveURL(/\/kiosk\/users(\?.*)?$/);
   });
 });

--- a/tests/e2e/kiosk-user-selection.spec.ts
+++ b/tests/e2e/kiosk-user-selection.spec.ts
@@ -1,9 +1,9 @@
 import { test, expect } from '@playwright/test';
+import { bootKiosk } from './_helpers/bootKiosk';
 
 test.describe('Kiosk User Selection', () => {
   test.beforeEach(async ({ page }) => {
-    // キオスクホームへ移動
-    await page.goto('/kiosk');
+    await bootKiosk(page, { route: '/kiosk' });
     await expect(page.getByTestId('kiosk-action-execute-steps')).toBeVisible();
   });
 
@@ -33,7 +33,7 @@ test.describe('Kiosk User Selection', () => {
     await page.getByTestId('kiosk-user-select-back').click();
 
     // キオスクホームに戻ることを確認
-    await expect(page).toHaveURL(/\/kiosk$/);
+    await expect(page).toHaveURL(/\/kiosk(\?.*)?$/);
     await expect(page.getByTestId('kiosk-action-execute-steps')).toBeVisible();
   });
 });


### PR DESCRIPTION
### 📝 変更概要

* **新規ワークフロー追加**: `.github/workflows/kiosk-e2e.yml`

  * `pull_request` と `workflow_dispatch` をトリガーとしたキオスク用E2Eテスト専用ジョブです。
  * ジョブ名は `kiosk-e2e` で、`ubuntu-latest` にNode 24環境を構築。
  * PlaywrightはChromiumプロジェクトのみを実行し、ワーカー数は1に固定。
  * 実行対象テストは次の4 spec計8件に限定：

    * `kiosk-home-smoke.spec.ts`
    * `kiosk-user-selection.spec.ts`
    * `kiosk-procedure-list.spec.ts`
    * `kiosk-procedure-detail.spec.ts`
* **アーティファクトの保存**: 成否に関わらずテスト結果ディレクトリ（`test-results`と`playwright-report`）を `kiosk-e2e-artifacts-*` 名でアップロードするようにしました。

### ⚙️ 実行コマンド

ワークフロー内では以下のコマンドでテストを実行しています。

```bash
npm run -s test:e2e -- tests/e2e/kiosk-home-smoke.spec.ts \
                        tests/e2e/kiosk-user-selection.spec.ts \
                        tests/e2e/kiosk-procedure-list.spec.ts \
                        tests/e2e/kiosk-procedure-detail.spec.ts \
                        --project=chromium --workers=1 --reporter=list
```

### ✅ 期待結果 / 確認ポイント

1. **ジョブ名確認**: Actionsタブで `kiosk-e2e` が表示されていること。
2. **テスト実行数**: 上記4 spec、計8件のキオスクE2Eテストが実行されること。
3. **アーティファクト保存**: 成功・失敗に関わらず、`kiosk-e2e-artifacts-*` という名前でテスト結果やレポートが保存されていること。
4. **ブランチ保護設定**: リポジトリ設定で `kiosk-e2e` ジョブを「Required checks」として追加する予定です。
