### PR TITLE
feat(daily): integrate official support procedure display and export

### DIFF
--- a/src/features/daily/components/split-stream/PlanSlotSelector.tsx
+++ b/src/features/daily/components/split-stream/PlanSlotSelector.tsx
@@ -126,7 +126,7 @@ function PlanSlotSelector({
             <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} sx={{ width: '100%' }}>
               <Box flex={1}>
                 <Typography variant="caption" color="text.secondary" fontWeight="bold">
-                  本人のやること (Activity)
+                  本人の動き (Activity)
                 </Typography>
                 <Typography variant="body1" fontWeight="bold">
                   {selectedSlot.activity}
@@ -134,6 +134,17 @@ function PlanSlotSelector({
                 <Typography variant="body2" color="text.secondary">
                   {selectedSlot.time}
                 </Typography>
+                
+                {selectedSlot.activityDetail && (
+                  <Box sx={{ mt: 1, p: 1, bgcolor: 'grey.50', borderRadius: 1, border: '1px solid', borderColor: 'divider' }}>
+                    <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.25, fontWeight: 700 }}>
+                      【本人の動き・手順詳解】
+                    </Typography>
+                    <Typography variant="body2">
+                      {selectedSlot.activityDetail}
+                    </Typography>
+                  </Box>
+                )}
               </Box>
               <Box
                 flex={1.5}
@@ -144,14 +155,30 @@ function PlanSlotSelector({
                   bgcolor: 'primary.50',
                   borderRadius: 1,
                   py: 1,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 1
                 }}
               >
-                <Typography variant="caption" color="primary.dark" fontWeight="bold">
-                  📋 支援者のやること (Instruction)
-                </Typography>
-                <Typography variant="body1" sx={{ whiteSpace: 'pre-wrap', fontWeight: 500 }}>
-                  {selectedSlot.instruction}
-                </Typography>
+                <Box>
+                  <Typography variant="caption" color="primary.dark" fontWeight="bold">
+                    📋 支援者の動き (Instruction)
+                  </Typography>
+                  <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', fontWeight: 500 }}>
+                    {selectedSlot.instructionDetail || selectedSlot.instruction}
+                  </Typography>
+                </Box>
+
+                {selectedSlot.condition && (
+                  <Box sx={{ mt: 'auto', pt: 1, borderTop: '1px dashed', borderColor: 'primary.200' }}>
+                    <Typography variant="caption" color="success.main" fontWeight="bold">
+                      💡 本人の様子・留意点 (Condition)
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      {selectedSlot.condition}
+                    </Typography>
+                  </Box>
+                )}
               </Box>
             </Stack>
           </Box>

--- a/src/features/daily/components/split-stream/ProcedurePanel.tsx
+++ b/src/features/daily/components/split-stream/ProcedurePanel.tsx
@@ -19,11 +19,14 @@ import { getParentOrderForChild } from '@/features/planning-sheet/constants/proc
 
 export type ScheduleItem = {
   id?: string;
+  rowNo?: number;
+  block?: 'morning' | 'afternoon' | 'outing';
   time: string;
   activity: string;
   instruction: string;
   activityDetail?: string;
   instructionDetail?: string;
+  condition?: string;
   isKey: boolean;
   linkedInterventionIds?: string[];
   source?: ProcedureSource;
@@ -146,6 +149,13 @@ const ProcedureStepRow = ({
                   {item.instructionDetail}
                 </Typography>
               )}
+
+              {item.condition && (
+                <Typography variant="caption" color="text.secondary" sx={{ display: 'flex', alignItems: 'center', gap: 0.5, lineHeight: 1.4 }}>
+                  <Box component="span" sx={{ bgcolor: 'success.100', px: 0.5, borderRadius: 0.5, fontSize: '0.65rem', fontWeight: 700, flexShrink: 0, color: 'success.dark' }}>様子</Box>
+                  {item.condition}
+                </Typography>
+              )}
             </Stack>
           </Box>
         </Stack>
@@ -182,39 +192,56 @@ export const ProcedurePanel = (props: ProcedurePanelProps): JSX.Element => {
 
   const groupedSchedule = useMemo(() => {
     type GroupedItem = { parent: ScheduleItem; children: ScheduleItem[] };
-    const parents: ScheduleItem[] = [];
-    const childrenByParentOrder = new Map<number, ScheduleItem[]>();
-    const standalones: ScheduleItem[] = [];
+    const morningItems: ScheduleItem[] = [];
+    const afternoonItems: ScheduleItem[] = [];
+    const outingItems: ScheduleItem[] = [];
+    const otherItems: ScheduleItem[] = [];
 
     for (const item of visibleSchedule) {
-      if (item.source === 'planning_sheet' && item.sourceStepOrder) {
-        const parentOrder = getParentOrderForChild({ source: item.source, sourceStepOrder: item.sourceStepOrder });
-        if (parentOrder != null) {
-          const list = childrenByParentOrder.get(parentOrder) ?? [];
-          list.push(item);
-          childrenByParentOrder.set(parentOrder, list);
-          continue;
-        }
-        parents.push(item);
+      if (item.block === 'morning') {
+        morningItems.push(item);
+      } else if (item.block === 'afternoon') {
+        afternoonItems.push(item);
+      } else if (item.block === 'outing') {
+        outingItems.push(item);
       } else {
-        standalones.push(item);
+        // block 情報がない場合（旧データなど）
+        if (item.sourceStepOrder && item.source === 'planning_sheet') {
+          const parentOrder = getParentOrderForChild({ source: item.source, sourceStepOrder: item.sourceStepOrder });
+          if (parentOrder != null) {
+             // 外活動系として扱う（旧ロジック互換）
+             outingItems.push(item);
+             continue;
+          }
+        }
+        otherItems.push(item);
       }
     }
 
+    // 基本は rowNo 順に並べる
     const result: GroupedItem[] = [];
-    for (const parent of parents) {
-      const children = childrenByParentOrder.get(parent.sourceStepOrder!) ?? [];
-      result.push({ parent, children: children.sort((a, b) => (a.sourceStepOrder ?? 0) - (b.sourceStepOrder ?? 0)) });
-      childrenByParentOrder.delete(parent.sourceStepOrder!);
+    
+    // morning -> afternoon -> outing の順で組み立て
+    [...morningItems, ...afternoonItems].sort((a, b) => (a.rowNo ?? 0) - (b.rowNo ?? 0)).forEach(item => {
+      result.push({ parent: item, children: [] });
+    });
+
+    // outing は AM/PM 日中活動の「子」として扱われていた旧 UI 表現を尊重しつつ、
+    // 新設計では 16, 17 行目として独立して並べる
+    if (outingItems.length > 0) {
+      // 日中活動（rowNo 5 or 10）の後ろに挿入するか、最後にまとめるか
+      // ここでは 17行フォームの順序に従い、午後の最後（rowNo 15）の後に配置
+      outingItems.sort((a, b) => (a.rowNo ?? 0) - (b.rowNo ?? 0)).forEach(item => {
+        result.push({ parent: item, children: [] });
+      });
     }
-    const extraItems = [...standalones];
-    childrenByParentOrder.forEach((children) => { extraItems.push(...children); });
-    const finalGrouped = result.concat(extraItems.map(item => ({ parent: item, children: [] })));
-    
-    const itemIndexMap = new Map<string, number>();
-    visibleSchedule.forEach((item, idx) => itemIndexMap.set(getItemScheduleKey(item), idx));
-    
-    return finalGrouped.sort((a, b) => (itemIndexMap.get(getItemScheduleKey(a.parent)) ?? 0) - (itemIndexMap.get(getItemScheduleKey(b.parent)) ?? 0));
+
+    // その他（あれば）
+    otherItems.forEach(item => {
+      result.push({ parent: item, children: [] });
+    });
+
+    return result;
   }, [visibleSchedule]);
 
   if (!isGuided) {

--- a/src/features/planning-sheet/hooks/usePlanningSheetToProcedureBridge.ts
+++ b/src/features/planning-sheet/hooks/usePlanningSheetToProcedureBridge.ts
@@ -35,6 +35,7 @@ export function usePlanningSheetToProcedureBridge(planningSheetId?: string) {
   return {
     schedule: bridgeResult.schedule,
     bridgeSource: bridgeResult.source,
+    sheetData,
     isLoading,
     error,
   };

--- a/src/pages/TimeBasedSupportRecordPage.tsx
+++ b/src/pages/TimeBasedSupportRecordPage.tsx
@@ -19,6 +19,8 @@ import { useIbdPageGuard } from '@/features/daily/hooks/useIbdPageGuard';
 import { useSupportRecordSubmit } from '@/pages/hooks/useSupportRecordSubmit';
 import { useTimeBasedSupportRecordPage } from '@/pages/hooks/useTimeBasedSupportRecordPage';
 import { usePlanningSheetToProcedureBridge } from '@/features/planning-sheet/hooks/usePlanningSheetToProcedureBridge';
+import { generateSupportProcedureExcel } from '@/features/official-forms/generateSupportProcedureExcel';
+import { bridgePlanningSheetToDailyProcedures as bridgeToOfficial } from '@/features/planning-sheet/logic/dailyProcedureMapper';
 import { CircularProgress } from '@mui/material';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
@@ -76,6 +78,7 @@ const TimeBasedSupportRecordPage: React.FC = () => {
   // ── Phase E: 支援計画シートからの手順取得 ──
   const { 
     schedule: overrideSchedule, 
+    sheetData,
     isLoading: isSheetLoading,
     error: sheetError,
     bridgeSource
@@ -233,6 +236,35 @@ const TimeBasedSupportRecordPage: React.FC = () => {
       // Fallback handled by snackbar
     }
   }, [executionStore, schedule, selectedUser, targetDate, wizard.wizardUserId, targetUserId, recentObservations]);
+  
+  const handleExportExcel = useCallback(async () => {
+    if (!sheetData) return;
+    
+    try {
+      // eslint-disable-next-line no-restricted-globals
+      const templateResponse = await fetch('/templates/seikatsu_kaigo_template.xlsx');
+      if (!templateResponse.ok) throw new Error('テンプレートが見つかりません');
+      const templateBuffer = await templateResponse.arrayBuffer();
+      
+      const doc = bridgeToOfficial(sheetData, {
+        userName: selectedUser?.FullName,
+        recordDate: targetDate,
+      });
+      
+      const output = await generateSupportProcedureExcel(templateBuffer, doc);
+      
+      const blob = new Blob([output.bytes], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = output.fileName;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error('Excel Export Error:', err);
+      setSubmitError(err instanceof Error ? err : new Error('Excelの書き出しに失敗しました'));
+    }
+  }, [sheetData, selectedUser, targetDate, setSubmitError]);
 
   // URL sync
   React.useEffect(() => {
@@ -311,14 +343,25 @@ const TimeBasedSupportRecordPage: React.FC = () => {
             lastAssessmentDate={selectedUser?.LastAssessmentDate}
           />
           {initialParams.planningSheetId && (
-            <Button
-              size="small"
-              variant="outlined"
-              onClick={() => navigate(`/support-planning-sheet/${initialParams.planningSheetId}`)}
-              sx={{ ml: 1, whiteSpace: 'nowrap' }}
-            >
-              元シートへ
-            </Button>
+            <React.Fragment>
+              <Button
+                size="small"
+                variant="contained"
+                color="primary"
+                onClick={handleExportExcel}
+                sx={{ ml: 1, whiteSpace: 'nowrap' }}
+              >
+                原紙出力 (Excel)
+              </Button>
+              <Button
+                size="small"
+                variant="outlined"
+                onClick={() => navigate(`/support-planning-sheet/${initialParams.planningSheetId}`)}
+                sx={{ ml: 1, whiteSpace: 'nowrap' }}
+              >
+                元シートへ
+              </Button>
+            </React.Fragment>
           )}
         </React.Fragment>
       }


### PR DESCRIPTION
## Summary
- enhance `/daily/support` to display official-form-aligned procedure details
- show person action, supporter action, and condition fields in procedure selection UI
- add Excel export entry point for the official support procedure form
- connect the daily support screen to the existing official-form mapping layer

## Why
The official support procedure mapping layer already defines the 17-row form structure. This change integrates that structure into the daily support UI so operators can review procedure details and export the official Excel form directly from `/daily/support`.

## Checks
- `./node_modules/.bin/vitest run src/features/planning-sheet/logic/__tests__/dailyProcedureMapper.spec.ts`