### PR TITLE
test(planning-sheet-list): add ADR-006 safety-net coverage

### DIFF
--- a/src/pages/planning-sheet-list/PlanningSheetListView.tsx
+++ b/src/pages/planning-sheet-list/PlanningSheetListView.tsx
@@ -121,6 +121,7 @@ export const PlanningSheetListView: React.FC<PlanningSheetListViewProps> = ({
         {isIcebergEnabled && icebergSummary && (
           <Paper 
             variant="outlined" 
+            data-testid="iceberg-summary-bar"
             sx={{ 
               p: 2, 
               bgcolor: alpha('#ed6c02', 0.04), 
@@ -186,6 +187,7 @@ export const PlanningSheetListView: React.FC<PlanningSheetListViewProps> = ({
           <Box sx={{ px: 1 }}>
             <Paper 
               variant="outlined" 
+              data-testid="difference-insight-bar"
               sx={{ 
                 p: 1.5, 
                 borderLeft: '4px solid #d32f2f',
@@ -246,15 +248,16 @@ export const PlanningSheetListView: React.FC<PlanningSheetListViewProps> = ({
               </Typography>
               <Stack direction="row" spacing={2}>
                 {isIcebergEnabled && isIcebergTarget && (
-                  <Button
-                    variant="contained"
-                    color="warning"
-                    startIcon={<AutoAwesomeRoundedIcon />}
-                    onClick={() => handlers.onCreateFromIceberg(userId)}
-                    sx={{ boxShadow: 3 }}
-                  >
-                    氷山分析から新規作成
-                  </Button>
+                    <Button
+                      variant="contained"
+                      color="warning"
+                      data-testid="create-from-iceberg-btn"
+                      startIcon={<AutoAwesomeRoundedIcon />}
+                      onClick={() => handlers.onCreateFromIceberg(userId)}
+                      sx={{ boxShadow: 3 }}
+                    >
+                      氷山分析から新規作成
+                    </Button>
                 )}
                 <Button
                   variant={isIcebergTarget ? "outlined" : "contained"}

--- a/src/pages/planning-sheet-list/__tests__/PlanningSheetListPage.regression.spec.tsx
+++ b/src/pages/planning-sheet-list/__tests__/PlanningSheetListPage.regression.spec.tsx
@@ -102,7 +102,7 @@ describe('PlanningSheetListPage Regression Tests', () => {
           applicableAddOnTypes: ['none'],
           authoredByQualification: 'unknown',
           reviewedAt: null,
-        } as any
+        } as unknown as (PlanningSheetListViewModel['sheets'][0])
       ]
     };
     render(

--- a/src/pages/planning-sheet-list/hooks/__tests__/planningSheetListViewModelMapper.spec.ts
+++ b/src/pages/planning-sheet-list/hooks/__tests__/planningSheetListViewModelMapper.spec.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import { mapToPlanningSheetListViewModel, MapperInput } from '../planningSheetListViewModelMapper';
+import type { IcebergSnapshot } from '@/features/ibd/analysis/iceberg/icebergTypes';
+import type { SupportPlanningSheet } from '@/domain/isp/schema';
+import type { IUserMaster } from '@/features/users/types';
+
+describe('planningSheetListViewModelMapper', () => {
+  const mockUser: IUserMaster = {
+    UserID: 'U001',
+    UserName: 'テスト太郎',
+    IsHighIntensitySupportTarget: true,
+  } as any;
+
+  const mockIceberg: IcebergSnapshot = {
+    sessionId: 'session-1',
+    updatedAt: '2026-05-01T10:00:00Z',
+    nodes: [
+      { id: 'n1', type: 'behavior', label: '他害(叩く)', updatedAt: '2026-05-01T10:00:00Z' },
+      { id: 'n2', type: 'background', label: '騒音', updatedAt: '2026-05-01T10:00:00Z' },
+    ],
+    links: [
+      { sourceNodeId: 'n2', targetNodeId: 'n1', confidence: 'high' }
+    ],
+  } as any;
+
+  const mockCurrentSheet: SupportPlanningSheet = {
+    assessment: {
+      targetBehaviors: [{ name: '自傷行為' }],
+      hypotheses: [{ function: '注意獲得' }],
+    }
+  } as any;
+
+  const baseInput: MapperInput = {
+    userId: 'U001',
+    sheets: [],
+    isLoading: false,
+    error: null,
+    allUsers: [mockUser],
+    latestIcebergSnapshot: null,
+    currentSheetDetails: null,
+  };
+
+  it('現行支援計画に氷山分析の主要行動が未反映の場合、高レベル insight を出すこと', () => {
+    const input: MapperInput = {
+      ...baseInput,
+      latestIcebergSnapshot: mockIceberg,
+      currentSheetDetails: mockCurrentSheet,
+    };
+    const vm = mapToPlanningSheetListViewModel(input);
+
+    expect(vm.differenceInsight).toBeDefined();
+    const behaviorChange = vm.differenceInsight?.changes.find(c => c.label === '行動');
+    expect(behaviorChange?.level).toBe('high');
+    expect(behaviorChange?.value).toContain('他害(叩く)');
+  });
+
+  it('背景要因が仮説に未反映の場合、中レベル insight を出すこと', () => {
+    // 行動は一致させて、要因だけ不一致にする
+    const currentSheetWithMatchingBehavior: SupportPlanningSheet = {
+      assessment: {
+        targetBehaviors: [{ name: '他害(叩く)' }],
+        hypotheses: [{ function: '空腹' }],
+      }
+    } as any;
+
+    const input: MapperInput = {
+      ...baseInput,
+      latestIcebergSnapshot: mockIceberg,
+      currentSheetDetails: currentSheetWithMatchingBehavior,
+    };
+    const vm = mapToPlanningSheetListViewModel(input);
+
+    expect(vm.differenceInsight).toBeDefined();
+    const factorChange = vm.differenceInsight?.changes.find(c => c.label === '要因');
+    expect(factorChange?.level).toBe('medium');
+    expect(factorChange?.value).toContain('騒音');
+  });
+
+  it('IsHighIntensitySupportTarget が false の場合、氷山分析導線を無効化すること', () => {
+    const nonTargetUser = { ...mockUser, IsHighIntensitySupportTarget: false };
+    const input: MapperInput = {
+      ...baseInput,
+      allUsers: [nonTargetUser],
+    };
+    const vm = mapToPlanningSheetListViewModel(input);
+
+    expect(vm.isIcebergTarget).toBe(false);
+  });
+
+  it('iceberg snapshot が存在しない場合、Difference Insight を出さないこと', () => {
+    const input: MapperInput = {
+      ...baseInput,
+      latestIcebergSnapshot: null,
+      currentSheetDetails: mockCurrentSheet,
+    };
+    const vm = mapToPlanningSheetListViewModel(input);
+
+    expect(vm.differenceInsight).toBeUndefined();
+    expect(vm.icebergSummary).toBeUndefined();
+  });
+
+  it('ステータスに応じた色が正しくマッピングされること', () => {
+    const input: MapperInput = {
+      ...baseInput,
+      sheets: [
+        { id: '1', status: 'active' } as any,
+        { id: '2', status: 'revision_pending' } as any,
+      ],
+    };
+    const vm = mapToPlanningSheetListViewModel(input);
+
+    expect(vm.sheets[0].statusColor).toBe('success');
+    expect(vm.sheets[1].statusColor).toBe('warning');
+  });
+});

--- a/src/pages/planning-sheet-list/hooks/__tests__/planningSheetListViewModelMapper.spec.ts
+++ b/src/pages/planning-sheet-list/hooks/__tests__/planningSheetListViewModelMapper.spec.ts
@@ -5,13 +5,13 @@ import type { SupportPlanningSheet } from '@/domain/isp/schema';
 import type { IUserMaster } from '@/features/users/types';
 
 describe('planningSheetListViewModelMapper', () => {
-  const mockUser: IUserMaster = {
+  const mockUser = {
     UserID: 'U001',
     UserName: 'テスト太郎',
     IsHighIntensitySupportTarget: true,
-  } as any;
+  } as unknown as IUserMaster;
 
-  const mockIceberg: IcebergSnapshot = {
+  const mockIceberg = {
     sessionId: 'session-1',
     updatedAt: '2026-05-01T10:00:00Z',
     nodes: [
@@ -21,14 +21,14 @@ describe('planningSheetListViewModelMapper', () => {
     links: [
       { sourceNodeId: 'n2', targetNodeId: 'n1', confidence: 'high' }
     ],
-  } as any;
+  } as unknown as IcebergSnapshot;
 
-  const mockCurrentSheet: SupportPlanningSheet = {
+  const mockCurrentSheet = {
     assessment: {
       targetBehaviors: [{ name: '自傷行為' }],
       hypotheses: [{ function: '注意獲得' }],
     }
-  } as any;
+  } as unknown as SupportPlanningSheet;
 
   const baseInput: MapperInput = {
     userId: 'U001',
@@ -56,12 +56,12 @@ describe('planningSheetListViewModelMapper', () => {
 
   it('背景要因が仮説に未反映の場合、中レベル insight を出すこと', () => {
     // 行動は一致させて、要因だけ不一致にする
-    const currentSheetWithMatchingBehavior: SupportPlanningSheet = {
+    const currentSheetWithMatchingBehavior = {
       assessment: {
         targetBehaviors: [{ name: '他害(叩く)' }],
         hypotheses: [{ function: '空腹' }],
       }
-    } as any;
+    } as unknown as SupportPlanningSheet;
 
     const input: MapperInput = {
       ...baseInput,
@@ -103,8 +103,8 @@ describe('planningSheetListViewModelMapper', () => {
     const input: MapperInput = {
       ...baseInput,
       sheets: [
-        { id: '1', status: 'active' } as any,
-        { id: '2', status: 'revision_pending' } as any,
+        { id: '1', status: 'active' } as unknown as (PlanningSheetListViewModel['sheets'][0]),
+        { id: '2', status: 'revision_pending' } as unknown as (PlanningSheetListViewModel['sheets'][0]),
       ],
     };
     const vm = mapToPlanningSheetListViewModel(input);

--- a/src/pages/planning-sheet-list/hooks/__tests__/usePlanningSheetListOrchestrator.spec.tsx
+++ b/src/pages/planning-sheet-list/hooks/__tests__/usePlanningSheetListOrchestrator.spec.tsx
@@ -1,0 +1,112 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { usePlanningSheetListOrchestrator } from '../usePlanningSheetListOrchestrator';
+import { MemoryRouter } from 'react-router-dom';
+import React from 'react';
+
+// Mocks
+const mockNavigate = vi.fn();
+const mockSearchParams = new URLSearchParams();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useSearchParams: () => [mockSearchParams],
+  };
+});
+
+const mockRepo = {
+  listCurrentByUser: vi.fn(),
+  getById: vi.fn(),
+};
+
+vi.mock('@/features/planning-sheet/hooks/usePlanningSheetRepositories', () => ({
+  usePlanningSheetRepositories: () => mockRepo,
+}));
+
+const mockIcebergRepo = {
+  getLatestByUser: vi.fn(),
+};
+
+vi.mock('@/features/ibd/analysis/iceberg/SharePointIcebergRepository', () => ({
+  useIcebergRepository: () => mockIcebergRepo,
+}));
+
+vi.mock('@/features/users/useUsers', () => ({
+  useUsers: () => ({ data: [{ UserID: 'U001', UserName: 'Test' }] }),
+}));
+
+describe('usePlanningSheetListOrchestrator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearchParams.delete('userId');
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <MemoryRouter>{children}</MemoryRouter>
+  );
+
+  it('userId 未選択時はシート一覧が空であること', async () => {
+    const { result } = renderHook(() => usePlanningSheetListOrchestrator(), { wrapper });
+    
+    expect(result.current.viewModel?.userId).toBeNull();
+    expect(result.current.viewModel?.sheets).toEqual([]);
+  });
+
+  it('userId 選択時、データフェッチが成功し viewModel が構築されること', async () => {
+    mockSearchParams.set('userId', 'U001');
+    mockRepo.listCurrentByUser.mockResolvedValue([{ id: 's1', isCurrent: true }]);
+    mockRepo.getById.mockResolvedValue({ id: 's1', assessment: { targetBehaviors: [] } });
+    mockIcebergRepo.getLatestByUser.mockResolvedValue(null);
+
+    const { result } = renderHook(() => usePlanningSheetListOrchestrator(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.viewModel?.sheets.length).toBe(1);
+      expect(result.current.viewModel?.isLoading).toBe(false);
+    });
+  });
+
+  it('フェッチエラー時に error 状態が更新されること', async () => {
+    mockSearchParams.set('userId', 'U001');
+    mockRepo.listCurrentByUser.mockRejectedValue(new Error('Fetch failed'));
+
+    const { result } = renderHook(() => usePlanningSheetListOrchestrator(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.viewModel?.error).toBe('Fetch failed');
+      expect(result.current.viewModel?.isLoading).toBe(false);
+    });
+  });
+
+  it('userId 切替時に古い fetch 結果が混入しないこと', async () => {
+    // 最初のユーザー
+    mockSearchParams.set('userId', 'U001');
+    mockRepo.listCurrentByUser.mockImplementation(() => new Promise(resolve => setTimeout(() => resolve([{ id: 's1' }]), 50)));
+    
+    const { result, rerender } = renderHook(() => usePlanningSheetListOrchestrator(), { wrapper });
+
+    // 完了前にユーザー切り替え
+    mockSearchParams.set('userId', 'U002');
+    mockRepo.listCurrentByUser.mockResolvedValue([{ id: 's2' }]);
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current.viewModel?.userId).toBe('U002');
+      expect(result.current.viewModel?.sheets[0]?.id).toBe('s2');
+    });
+  });
+
+  it('current sheet がない場合、details フェッチが行われないこと', async () => {
+    mockSearchParams.set('userId', 'U001');
+    mockRepo.listCurrentByUser.mockResolvedValue([{ id: 's1', isCurrent: false }]);
+    
+    renderHook(() => usePlanningSheetListOrchestrator(), { wrapper });
+
+    await waitFor(() => {
+      expect(mockRepo.getById).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add safety-net tests for planning-sheet-list ViewModel mapper
- Add orchestrator tests for loading/success/error and stale response prevention
- Add stable data-testid hooks to PlanningSheetListView
- Confirm ADR-006 responsibility boundaries remain intact

## Checks
- npm test src/pages/planning-sheet-list/
- npx eslint src/pages/planning-sheet-list/
- npx tsc --noEmit --project tsconfig.json

## Notes
This hardens the planning sheet list page before further expansion of Iceberg / ISP integration. The mapper remains pure, the orchestrator owns side effects, and the view remains passive.