### PR TITLE
test(support-planning-sheet): add ADR-006 safety-net and testid instrumentation

### DIFF
--- a/src/pages/support-planning-sheet/SheetHeader.tsx
+++ b/src/pages/support-planning-sheet/SheetHeader.tsx
@@ -139,6 +139,7 @@ const SheetHeader: React.FC<SheetHeaderProps> = ({
                 startIcon={<AssessmentRoundedIcon />}
                 onClick={onImportAssessment}
                 disabled={!hasAssessment || isSaving}
+                {...tid(TESTIDS['planning-sheet-btn-import-assessment'])}
               >
                 アセスメントから取込
               </Button>
@@ -149,6 +150,7 @@ const SheetHeader: React.FC<SheetHeaderProps> = ({
                 startIcon={<AssessmentRoundedIcon />}
                 onClick={onImportMonitoring}
                 disabled={!hasMonitoringRecord || isSaving}
+                {...tid(TESTIDS['planning-sheet-btn-import-monitoring'])}
               >
                 行動モニタリングから反映
               </Button>
@@ -158,6 +160,7 @@ const SheetHeader: React.FC<SheetHeaderProps> = ({
                 startIcon={<UndoRoundedIcon />}
                 onClick={onReset}
                 disabled={isSaving}
+                {...tid(TESTIDS['planning-sheet-btn-reset'])}
               >
                 リセット
               </Button>
@@ -167,6 +170,7 @@ const SheetHeader: React.FC<SheetHeaderProps> = ({
                 startIcon={isSaving ? <CircularProgress size={16} /> : <SaveRoundedIcon />}
                 onClick={onSave}
                 disabled={!isDirty || !isValid || isSaving}
+                {...tid(TESTIDS['planning-sheet-btn-save'])}
               >
                 {isSaving ? '保存中…' : '保存'}
               </Button>
@@ -177,6 +181,7 @@ const SheetHeader: React.FC<SheetHeaderProps> = ({
               variant="outlined"
               startIcon={<EditRoundedIcon />}
               onClick={onEdit}
+              {...tid(TESTIDS['planning-sheet-btn-edit'])}
             >
               編集
             </Button>

--- a/src/pages/support-planning-sheet/hooks/__tests__/supportPlanningSheetViewModelMapper.spec.ts
+++ b/src/pages/support-planning-sheet/hooks/__tests__/supportPlanningSheetViewModelMapper.spec.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mapToSupportPlanningSheetViewModel, MapperInput } from '../supportPlanningSheetViewModelMapper';
+import type { SupportPlanningSheet } from '@/domain/isp/schema';
+import type { SupportPlanningSheetUiState } from '../useSupportPlanningSheetUiState';
+import type { IUserMaster } from '@/features/users/types';
+import type { UserAssessment } from '@/features/assessment/domain/types';
+import type { ContextPanelData } from '@/features/context/domain/contextPanelLogic';
+import type { UsePlanningSheetFormReturn } from '@/features/planning-sheet/hooks/usePlanningSheetForm';
+import type { BehaviorMonitoringRecord } from '@/domain/isp/behaviorMonitoring';
+
+// Mock dependencies
+vi.mock('@/app/services/bridgeProxy', () => ({
+  getPlanningWorkflowPhaseForSheet: vi.fn(() => ({ phase: 'active_plan' })),
+}));
+
+describe('supportPlanningSheetViewModelMapper', () => {
+  const mockSheet = {
+    id: 'sheet-1',
+    userId: 'user-1',
+    title: 'テスト計画',
+    status: 'active',
+    supportStartDate: '2026-04-01',
+    monitoringCycleDays: 90,
+    planning: { procedureSteps: [{}, {}] },
+    reviewedAt: '2026-04-05',
+  } as unknown as SupportPlanningSheet;
+
+  const mockUiState = {
+    isEditing: false,
+    activeTab: 'overview',
+    toast: { open: false, message: '', severity: 'info' },
+    importDialogOpen: false,
+    monitoringDialogOpen: false,
+    contextOpen: false,
+    historyFilter: { type: 'all' },
+    sessionProvenance: [{ id: 'prov-session', type: 'iceberg', label: 'Session Prov' }],
+  } as unknown as SupportPlanningSheetUiState;
+
+  const baseInput: MapperInput = {
+    planningSheetId: 'sheet-1',
+    sheet: mockSheet,
+    isLoading: false,
+    error: null,
+    uiState: mockUiState,
+    monitoringBridge: null,
+    targetUser: { FullName: '利用者 太郎' } as unknown as IUserMaster,
+    currentAssessment: { id: 'as-1' } as unknown as UserAssessment,
+    persistedProvenance: [{ id: 'prov-1', type: 'iceberg', label: 'Persisted Prov' }],
+    auditRecords: [],
+    filteredAuditRecords: [],
+    icebergEvidence: null,
+    latestMonitoringRecord: null,
+    evidenceLinks: {},
+    abcRecords: [],
+    pdcaItems: [],
+    strategyUsage: null,
+    strategyUsageLoading: false,
+    trendResult: null,
+    trendDays: 30,
+    trendLoading: false,
+    contextUserName: '利用者 太郎',
+    contextData: {} as unknown as ContextPanelData,
+    form: {} as unknown as UsePlanningSheetFormReturn,
+    source: null,
+    diffSummary: null,
+  };
+
+  it('ViewModel が正しくマッピングされること', () => {
+    const vm = mapToSupportPlanningSheetViewModel(baseInput);
+
+    expect(vm.planningSheetId).toBe('sheet-1');
+    expect(vm.targetUserName).toBe('利用者 太郎');
+    expect(vm.isEditing).toBe(false);
+    expect(vm.activeTab).toBe('overview');
+    expect(vm.currentPhase).toBe('active_plan');
+  });
+
+  it('Provenance が結合されること (永続化 + セッション分)', () => {
+    const vm = mapToSupportPlanningSheetViewModel(baseInput);
+
+    expect(vm.allProvenanceEntries.length).toBe(2);
+    expect(vm.allProvenanceEntries[0].id).toBe('prov-1');
+    expect(vm.allProvenanceEntries[1].id).toBe('prov-session');
+  });
+
+  it('アセスメントの有無が正しく判定されること', () => {
+    const vmWithAssessment = mapToSupportPlanningSheetViewModel(baseInput);
+    expect(vmWithAssessment.hasAssessment).toBe(true);
+
+    const vmWithoutAssessment = mapToSupportPlanningSheetViewModel({
+      ...baseInput,
+      currentAssessment: null,
+    });
+    expect(vmWithoutAssessment.hasAssessment).toBe(false);
+  });
+
+  it('モニタリング記録の有無が正しく判定されること', () => {
+    const vmWithMonitoring = mapToSupportPlanningSheetViewModel({
+      ...baseInput,
+      latestMonitoringRecord: { id: 'mon-1' } as unknown as BehaviorMonitoringRecord,
+    });
+    expect(vmWithMonitoring.hasMonitoringRecord).toBe(true);
+
+    const vmWithoutMonitoring = mapToSupportPlanningSheetViewModel(baseInput);
+    expect(vmWithoutMonitoring.hasMonitoringRecord).toBe(false);
+  });
+});

--- a/src/pages/support-planning-sheet/hooks/__tests__/useSupportPlanningSheetOrchestrator.spec.tsx
+++ b/src/pages/support-planning-sheet/hooks/__tests__/useSupportPlanningSheetOrchestrator.spec.tsx
@@ -1,0 +1,161 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { useSupportPlanningSheetOrchestrator } from '../useSupportPlanningSheetOrchestrator';
+import { MemoryRouter } from 'react-router-dom';
+import React from 'react';
+
+// Mock React Router
+const mockNavigate = vi.fn();
+const mockParams = { planningSheetId: 'sheet-1' };
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useParams: () => mockParams,
+  };
+});
+
+// Mock UI State
+const mockUiActions = {
+  setToast: vi.fn(),
+  setIsEditing: vi.fn(),
+  setImportDialogOpen: vi.fn(),
+  setMonitoringDialogOpen: vi.fn(),
+  setActiveTab: vi.fn(),
+  setContextOpen: vi.fn(),
+  setHistoryFilter: vi.fn(),
+  setSessionProvenance: vi.fn(),
+};
+
+vi.mock('../useSupportPlanningSheetUiState', () => ({
+  useSupportPlanningSheetUiState: () => ({
+    state: {
+      isEditing: false,
+      activeTab: 'overview',
+      toast: { open: false, message: '', severity: 'info' },
+      importDialogOpen: false,
+      monitoringDialogOpen: false,
+      contextOpen: false,
+      historyFilter: { type: 'all' },
+      sessionProvenance: [],
+    },
+    actions: mockUiActions,
+  }),
+}));
+
+// Mock Domain Hooks
+vi.mock('@/features/planning-sheet/hooks/usePlanningSheetData', () => ({
+  usePlanningSheetData: vi.fn((id) => {
+    if (id === 'new') return { data: null, isLoading: false, error: null, refetch: vi.fn() };
+    return { data: { id: 'sheet-1', userId: 'user-1', status: 'active' }, isLoading: false, error: null, refetch: vi.fn() };
+  }),
+}));
+
+vi.mock('@/features/planning-sheet/hooks/usePlanningSheetForm', () => ({
+  usePlanningSheetForm: vi.fn(() => ({})),
+}));
+
+vi.mock('@/features/planning-sheet/hooks/usePlanningSheetRepositories', () => ({
+  usePlanningSheetRepositories: vi.fn(() => ({})),
+}));
+
+vi.mock('@/features/users/useUsers', () => ({
+  useUsers: vi.fn(() => ({ data: [{ UserID: 'user-1', FullName: 'Test User' }] })),
+}));
+
+vi.mock('@/auth/useAuth', () => ({
+  useAuth: vi.fn(() => ({ account: { name: 'Admin' } })),
+}));
+
+vi.mock('@/features/planning-sheet/stores/importAuditStore', () => ({
+  useImportAuditStore: vi.fn(() => ({
+    saveAuditRecord: vi.fn(),
+    getAllProvenance: vi.fn(() => []),
+    getBySheetId: vi.fn(() => []),
+  })),
+}));
+
+vi.mock('../useImportHandlers', () => ({
+  useImportHandlers: vi.fn(() => ({
+    handleAssessmentImport: vi.fn(),
+    handleMonitoringImport: vi.fn(),
+    handleReflectCandidate: vi.fn(),
+  })),
+}));
+
+vi.mock('../useSupportPlanningPageHandlers', () => ({
+  useSupportPlanningPageHandlers: vi.fn(() => ({
+    handleSave: vi.fn(),
+    handleReset: vi.fn(),
+    handleBannerNavigate: vi.fn(),
+    handleJumpToMonitoringHistory: vi.fn(),
+    handleEvidenceClick: vi.fn(),
+    handleNavigateToExecution: vi.fn(),
+    handleNavigateToPdca: vi.fn(),
+  })),
+}));
+
+vi.mock('../usePlanningEvidenceState', () => ({
+  usePlanningEvidenceState: vi.fn(() => ({ evidenceLinks: {}, abcRecords: [], pdcaItems: [] })),
+}));
+
+vi.mock('../useSupportPlanningContextPanel', () => ({
+  useSupportPlanningContextPanel: vi.fn(() => ({ contextData: {}, contextUserName: 'Test User' })),
+}));
+
+// More mocks for the remaining hooks...
+vi.mock('@/features/handoff/hooks/useHandoffData', () => ({ useHandoffData: () => ({ repo: {} }) }));
+vi.mock('@/features/ibd/analysis/pdca/queries/useIcebergEvidence', () => ({ useIcebergEvidence: () => ({ data: null }) }));
+vi.mock('@/features/planning-sheet/hooks/useStrategyUsageCounts', () => ({ useStrategyUsageCounts: () => ({ summary: null, loading: false }) }));
+vi.mock('@/features/planning-sheet/hooks/useStrategyUsageTrend', () => ({ useStrategyUsageTrend: () => ({ result: null, days: 30, setDays: vi.fn(), loading: false }) }));
+vi.mock('@/features/assessment/stores/assessmentStore', () => ({ useAssessmentStore: () => ({ getByUserId: vi.fn() }) }));
+vi.mock('@/features/planning-sheet/hooks/useLatestBehaviorMonitoring', () => ({ useLatestBehaviorMonitoring: () => ({ record: null }) }));
+vi.mock('@/features/monitoring/repositories/createMonitoringMeetingRepository', () => ({ useMonitoringMeetingRepository: () => ({ listByUser: vi.fn(async () => []) }) }));
+vi.mock('@/features/ibd/analysis/pdca/queries/usePdcaCycleState', () => ({ usePdcaCycleState: () => ({ state: {} }) }));
+vi.mock('@/app/services/bridgeProxy', () => ({
+  getPlanningWorkflowPhaseForSheet: vi.fn(() => ({ phase: 'active_plan' })),
+  getMonitoringToPlanningBridge: vi.fn(),
+  getMonitoringRecordFromMeeting: vi.fn(),
+}));
+
+describe('useSupportPlanningSheetOrchestrator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockParams.planningSheetId = 'sheet-1';
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <MemoryRouter>{children}</MemoryRouter>
+  );
+
+  it('既存シートを表示する場合、データがフェッチされ viewModel が構築されること', async () => {
+    const { result } = renderHook(() => useSupportPlanningSheetOrchestrator(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.viewModel).not.toBeNull();
+      expect(result.current.viewModel?.planningSheetId).toBe('sheet-1');
+    });
+  });
+
+  it('新規作成時 (planningSheetId="new")、仮想シートが生成されること', async () => {
+    mockParams.planningSheetId = 'new';
+    const { result } = renderHook(() => useSupportPlanningSheetOrchestrator(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.viewModel?.sheet.id).toBe('new');
+      expect(result.current.viewModel?.sheet.status).toBe('draft');
+    });
+  });
+
+  it('ハンドラが正しく公開されていること', () => {
+    const { result } = renderHook(() => useSupportPlanningSheetOrchestrator(), { wrapper });
+
+    expect(result.current.handlers.onEdit).toBeDefined();
+    expect(result.current.handlers.onSave).toBeDefined();
+    
+    result.current.handlers.onEdit();
+    expect(mockUiActions.setIsEditing).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/testids.ts
+++ b/src/testids.ts
@@ -482,6 +482,11 @@ export const TESTIDS = {
   'planning-sheet-tabs': 'planning-sheet-tabs',
   'planning-sheet-go-to-execution': 'planning-sheet-go-to-execution',
   'planning-sheet-go-to-pdca': 'planning-sheet-go-to-pdca',
+  'planning-sheet-btn-edit': 'planning-sheet-btn-edit',
+  'planning-sheet-btn-save': 'planning-sheet-btn-save',
+  'planning-sheet-btn-reset': 'planning-sheet-btn-reset',
+  'planning-sheet-btn-import-assessment': 'planning-sheet-btn-import-assessment',
+  'planning-sheet-btn-import-monitoring': 'planning-sheet-btn-import-monitoring',
 
   // Safety: Physical Restraint (P0-2)
   'safety-restraint-dialog': 'safety-restraint-dialog',


### PR DESCRIPTION
## Summary
- Add safety-net tests for support-planning-sheet ViewModel mapper
- Add orchestrator tests for sheet loading and virtual "new" sheet generation
- Add stable data-testid hooks to SheetHeader action buttons
- Register new testid constants in src/testids.ts

## Checks
- npm test src/pages/support-planning-sheet/
- npx eslint src/pages/support-planning-sheet/
- npx tsc --noEmit --project tsconfig.json

## Notes
This completes the ADR-006 hardening for the planning sheet detail page. All action buttons are now instrumented with stable IDs, and the core data mapping logic is protected by unit tests.