### PR TITLE
feat(isp): centralize Difference Insight domain logic

### DIFF
--- a/src/domain/isp/__tests__/differenceInsight.spec.ts
+++ b/src/domain/isp/__tests__/differenceInsight.spec.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { summarizeIcebergSnapshot, calculateDifferenceInsight } from '../differenceInsight';
+import type { IcebergSnapshot } from '@/features/ibd/analysis/iceberg/icebergTypes';
+import type { SupportPlanningSheet, IcebergSummary } from '../schema';
+
+describe('differenceInsight domain logic', () => {
+  describe('summarizeIcebergSnapshot', () => {
+    it('最新の行動ノードが主要行動として選択されること', () => {
+      const snapshot: IcebergSnapshot = {
+        sessionId: 'sess-1',
+        userId: 'user-1',
+        nodes: [
+          { id: 'n1', type: 'behavior', label: '古い行動', updatedAt: '2026-04-01T10:00:00Z' },
+          { id: 'n2', type: 'behavior', label: '新しい行動', updatedAt: '2026-04-02T10:00:00Z' },
+        ],
+        links: [],
+        updatedAt: '2026-04-02T10:00:00Z',
+      } as unknown as IcebergSnapshot;
+
+      const summary = summarizeIcebergSnapshot(snapshot);
+      expect(summary?.primaryBehavior).toBe('新しい行動');
+    });
+
+    it('信頼度の最も高いリンクの sourceNode が主要要因として選択されること', () => {
+      const snapshot: IcebergSnapshot = {
+        sessionId: 'sess-1',
+        userId: 'user-1',
+        nodes: [
+          { id: 'f-low', type: 'factor', label: '低い要因' },
+          { id: 'f-high', type: 'factor', label: '高い要因' },
+          { id: 'b1', type: 'behavior', label: '行動' },
+        ],
+        links: [
+          { id: 'l1', sourceNodeId: 'f-low', targetNodeId: 'b1', confidence: 'low' },
+          { id: 'l2', sourceNodeId: 'f-high', targetNodeId: 'b1', confidence: 'high' },
+        ],
+        updatedAt: '2026-04-01T10:00:00Z',
+      } as unknown as IcebergSnapshot;
+
+      const summary = summarizeIcebergSnapshot(snapshot);
+      expect(summary?.primaryFactor).toBe('高い要因');
+    });
+
+    it('ノードやリンクがない場合にフォールバックされること', () => {
+      const snapshot: IcebergSnapshot = {
+        sessionId: 'sess-1',
+        userId: 'user-1',
+        nodes: [],
+        links: [],
+        updatedAt: '2026-04-01T10:00:00Z',
+      } as unknown as IcebergSnapshot;
+
+      const summary = summarizeIcebergSnapshot(snapshot);
+      expect(summary?.primaryBehavior).toBe('—');
+      expect(summary?.primaryFactor).toBe('—');
+    });
+  });
+
+  describe('calculateDifferenceInsight', () => {
+    const mockSummary: IcebergSummary = {
+      sessionId: 'sess-1',
+      updatedAt: '2026-04-02',
+      primaryBehavior: 'パニック',
+      primaryFactor: '音過敏',
+    };
+
+    const mockSheet = {
+      assessment: {
+        targetBehaviors: [{ name: '自傷' }],
+        hypotheses: [{ function: '要求' }],
+      }
+    } as unknown as SupportPlanningSheet;
+
+    it('行動が未反映の場合、high レベルのインサイトを出すこと', () => {
+      const insight = calculateDifferenceInsight(mockSummary, mockSheet);
+      const behaviorChange = insight?.changes.find(c => c.label === '行動');
+      
+      expect(behaviorChange?.value).toBe('追加: パニック');
+      expect(behaviorChange?.level).toBe('high');
+    });
+
+    it('要因が未反映の場合、medium レベルのインサイトを出すこと', () => {
+      const insight = calculateDifferenceInsight(mockSummary, mockSheet);
+      const factorChange = insight?.changes.find(c => c.label === '要因');
+      
+      expect(factorChange?.value).toBe('要検討: 音過敏');
+      expect(factorChange?.level).toBe('medium');
+    });
+
+    it('すべて反映済みの場合、null を返すこと', () => {
+      const fullReflectedSheet = {
+        assessment: {
+          targetBehaviors: [{ name: 'パニック' }],
+          hypotheses: [{ function: '音過敏' }],
+        }
+      } as unknown as SupportPlanningSheet;
+
+      const insight = calculateDifferenceInsight(mockSummary, fullReflectedSheet);
+      expect(insight).toBeNull();
+    });
+
+    it('summary が "—" の場合は差分として検知しないこと', () => {
+      const emptySummary: IcebergSummary = {
+        sessionId: 'sess-1',
+        updatedAt: '2026-04-02',
+        primaryBehavior: '—',
+        primaryFactor: '—',
+      };
+
+      const insight = calculateDifferenceInsight(emptySummary, mockSheet);
+      expect(insight).toBeNull();
+    });
+  });
+});

--- a/src/domain/isp/differenceInsight.ts
+++ b/src/domain/isp/differenceInsight.ts
@@ -1,0 +1,79 @@
+import type { IcebergSnapshot } from '@/features/ibd/analysis/iceberg/icebergTypes';
+import type { SupportPlanningSheet, IcebergSummary, DifferenceInsight, DifferenceChange } from './schema';
+
+/**
+ * Iceberg スナップショットから主要な行動と要因を要約する。
+ */
+export function summarizeIcebergSnapshot(snapshot: IcebergSnapshot | null): IcebergSummary | null {
+  if (!snapshot) return null;
+
+  // 1. 主要対象行動: behavior ノードのうち、最も新しいものを選択
+  const behaviors = snapshot.nodes
+    .filter(n => n.type === 'behavior')
+    .sort((a, b) => (b.updatedAt ?? '').localeCompare(a.updatedAt ?? ''));
+  
+  const primaryBehavior = behaviors[0]?.label ?? '—';
+
+  // 2. 主要な要因: 信頼度(confidence)の高いリンクを優先的に選択
+  const confidencePriority: Record<string, number> = { 'high': 3, 'medium': 2, 'low': 1 };
+  const sortedLinks = [...snapshot.links].sort((a, b) => 
+    (confidencePriority[b.confidence] || 0) - (confidencePriority[a.confidence] || 0)
+  );
+  
+  const priorityLink = sortedLinks[0];
+  let primaryFactor = '—';
+  if (priorityLink) {
+    const sourceNode = snapshot.nodes.find(n => n.id === priorityLink.sourceNodeId);
+    if (sourceNode) {
+      primaryFactor = sourceNode.label;
+    }
+  }
+
+  return {
+    sessionId: snapshot.sessionId,
+    updatedAt: snapshot.updatedAt,
+    primaryBehavior,
+    primaryFactor,
+  };
+}
+
+/**
+ * Iceberg の要約と現在の支援計画シートを比較し、未反映のインサイトを算出する。
+ */
+export function calculateDifferenceInsight(
+  summary: IcebergSummary | null,
+  sheet: SupportPlanningSheet | null
+): DifferenceInsight | null {
+  if (!summary || !sheet) return null;
+
+  const changes: DifferenceChange[] = [];
+
+  // 1. 行動の差分 (レベル: high)
+  // 計画のアセスメントに含まれるターゲット行動と比較
+  const currentBehaviors = sheet.assessment?.targetBehaviors.map(b => b.name) || [];
+  if (summary.primaryBehavior !== '—' && !currentBehaviors.includes(summary.primaryBehavior)) {
+    changes.push({
+      label: '行動',
+      value: `追加: ${summary.primaryBehavior}`,
+      level: 'high'
+    });
+  }
+
+  // 2. 要因の差分 (レベル: medium)
+  // 計画のアセスメントに含まれる仮説の「機能/要因」と比較
+  const currentHypotheses = sheet.assessment?.hypotheses.map(h => h.function) || [];
+  if (summary.primaryFactor !== '—' && !currentHypotheses.includes(summary.primaryFactor)) {
+    changes.push({
+      label: '要因',
+      value: `要検討: ${summary.primaryFactor}`,
+      level: 'medium'
+    });
+  }
+
+  if (changes.length === 0) return null;
+
+  return {
+    changes,
+    sourceSessionId: summary.sessionId,
+  };
+}

--- a/src/domain/isp/schema/ispViewTypes.ts
+++ b/src/domain/isp/schema/ispViewTypes.ts
@@ -61,3 +61,37 @@ export interface ProcedureRecordEntryState {
   isDirty: boolean;
   validationErrors: string[];
 }
+
+// ─────────────────────────────────────────────
+// インサイト・差分分析用型
+// ─────────────────────────────────────────────
+
+/** 差分インサイトの個別の変更点 */
+export interface DifferenceChange {
+  /** 項目名 (例: "行動", "要因") */
+  label: string;
+  /** 内容 (例: "追加: 暴言") */
+  value: string;
+  /** 優先度/重要度 */
+  level: 'high' | 'medium' | 'low';
+}
+
+/** 氷山分析と支援計画の差分インサイト */
+export interface DifferenceInsight {
+  /** 検知された変更点リスト */
+  changes: DifferenceChange[];
+  /** 比較対象とした Iceberg セッション ID */
+  sourceSessionId: string;
+}
+
+/** Iceberg 分析の要約（計画反映チェック用） */
+export interface IcebergSummary {
+  /** セッション ID */
+  sessionId: string;
+  /** 更新日時 */
+  updatedAt: string;
+  /** 主要対象行動（最も新しい behavior ノード） */
+  primaryBehavior: string;
+  /** 主要な要因（信頼度の高いリンクの sourceNode） */
+  primaryFactor: string;
+}

--- a/src/pages/planning-sheet-list/hooks/__tests__/planningSheetListViewModelMapper.spec.ts
+++ b/src/pages/planning-sheet-list/hooks/__tests__/planningSheetListViewModelMapper.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { mapToPlanningSheetListViewModel, MapperInput } from '../planningSheetListViewModelMapper';
+import type { PlanningSheetListViewModel } from '../../types';
 import type { IcebergSnapshot } from '@/features/ibd/analysis/iceberg/icebergTypes';
 import type { SupportPlanningSheet } from '@/domain/isp/schema';
 import type { IUserMaster } from '@/features/users/types';

--- a/src/pages/planning-sheet-list/hooks/planningSheetListViewModelMapper.ts
+++ b/src/pages/planning-sheet-list/hooks/planningSheetListViewModelMapper.ts
@@ -2,6 +2,7 @@ import type { PlanningSheetStatus, PlanningSheetListItem, SupportPlanningSheet }
 import type { IcebergSnapshot } from '@/features/ibd/analysis/iceberg/icebergTypes';
 import type { PlanningSheetListViewModel } from '../types';
 import type { IUserMaster } from '@/features/users/types';
+import { summarizeIcebergSnapshot, calculateDifferenceInsight } from '@/domain/isp/differenceInsight';
 
 function getStatusColor(status: PlanningSheetStatus): 'default' | 'info' | 'success' | 'warning' {
   switch (status) {
@@ -50,71 +51,9 @@ export function mapToPlanningSheetListViewModel(input: MapperInput): PlanningShe
   const isIcebergTarget = !!selectedUser?.IsHighIntensitySupportTarget;
   const isIcebergEnabled = true; // フィーチャーフラグ相当
 
-  // Iceberg 要約の抽出 (標準化された選定ルールに基づき抽出)
-  let icebergSummary: PlanningSheetListViewModel['icebergSummary'] | undefined;
-  if (latestIcebergSnapshot) {
-    // 1. 主要対象行動: behavior ノードのうち、最も新しいものを選択
-    const behaviors = latestIcebergSnapshot.nodes
-      .filter(n => n.type === 'behavior')
-      .sort((a, b) => (b.updatedAt ?? '').localeCompare(a.updatedAt ?? ''));
-    
-    const primaryBehavior = behaviors[0]?.label ?? '—';
-
-    // 2. 主要な要因: 信頼度(confidence)の高いリンクを優先的に選択
-    const confidencePriority = { 'high': 3, 'medium': 2, 'low': 1 };
-    const sortedLinks = [...latestIcebergSnapshot.links].sort((a, b) => 
-      (confidencePriority[b.confidence] || 0) - (confidencePriority[a.confidence] || 0)
-    );
-    
-    const priorityLink = sortedLinks[0];
-    let primaryFactor = '—';
-    if (priorityLink) {
-      const sourceNode = latestIcebergSnapshot.nodes.find(n => n.id === priorityLink.sourceNodeId);
-      if (sourceNode) {
-        primaryFactor = sourceNode.label;
-      }
-    }
-
-    icebergSummary = {
-      sessionId: latestIcebergSnapshot.sessionId,
-      updatedAt: latestIcebergSnapshot.updatedAt,
-      primaryBehavior,
-      primaryFactor,
-    };
-  }
-
-  // --- Difference Insight (差分分析) ---
-  let differenceInsight: PlanningSheetListViewModel['differenceInsight'] | undefined;
-  if (icebergSummary && currentSheetDetails) {
-    const changes: NonNullable<PlanningSheetListViewModel['differenceInsight']>['changes'] = [];
-
-    // 1. 行動の差分 (レベル: 高)
-    const currentBehaviors = currentSheetDetails.assessment?.targetBehaviors.map(b => b.name) || [];
-    if (!currentBehaviors.includes(icebergSummary.primaryBehavior) && icebergSummary.primaryBehavior !== '—') {
-      changes.push({
-        label: '行動',
-        value: `追加: ${icebergSummary.primaryBehavior}`,
-        level: 'high'
-      });
-    }
-
-    // 2. 要因の差分 (レベル: 中)
-    const currentHypotheses = currentSheetDetails.assessment?.hypotheses.map(h => h.function) || [];
-    if (!currentHypotheses.includes(icebergSummary.primaryFactor) && icebergSummary.primaryFactor !== '—') {
-      changes.push({
-        label: '要因',
-        value: `要検討: ${icebergSummary.primaryFactor}`,
-        level: 'medium'
-      });
-    }
-
-    if (changes.length > 0) {
-      differenceInsight = {
-        changes,
-        sourceSessionId: icebergSummary.sessionId,
-      };
-    }
-  }
+  // Iceberg 要約と差分インサイトの算出 (ドメインロジックへ委譲)
+  const icebergSummary = summarizeIcebergSnapshot(latestIcebergSnapshot) || undefined;
+  const differenceInsight = calculateDifferenceInsight(icebergSummary || null, currentSheetDetails) || undefined;
 
   return {
     userId,

--- a/src/pages/support-planning-sheet/SupportPlanningSheetView.tsx
+++ b/src/pages/support-planning-sheet/SupportPlanningSheetView.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
 import ArrowBackRoundedIcon from '@mui/icons-material/ArrowBackRounded';
+import InsightsRoundedIcon from '@mui/icons-material/InsightsRounded';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
 import CircularProgress from '@mui/material/CircularProgress';
 import Divider from '@mui/material/Divider';
 import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
+import { alpha } from '@mui/material/styles';
 
 // import { createSharePointIspRepository } from '@/data/isp/sharepoint/SharePointIspRepository';
 import { usePlanningSheetRepositories } from '@/features/planning-sheet/hooks/usePlanningSheetRepositories';
@@ -129,6 +133,8 @@ export const SupportPlanningSheetView: React.FC<SupportPlanningSheetViewProps> =
     monitoringBridge,
     source,
     diffSummary,
+    icebergSummary,
+    differenceInsight,
   } = viewModel;
 
   if (isLoading) {
@@ -182,6 +188,80 @@ export const SupportPlanningSheetView: React.FC<SupportPlanningSheetViewProps> =
   return (
     <Box sx={{ display: 'flex', position: 'relative' }}>
       <Box sx={{ flex: 1, p: { xs: 2, md: 3 }, pb: 4 }} {...tid(TESTIDS['planning-sheet-page'])}>
+        {/* Iceberg Summary & Difference Insight */}
+        <Stack spacing={1.5} sx={{ mb: 2 }}>
+          {icebergSummary && (
+            <Paper 
+              variant="outlined" 
+              sx={{ 
+                p: 1.5, 
+                bgcolor: alpha('#ed6c02', 0.04), 
+                borderColor: alpha('#ed6c02', 0.2),
+                borderRadius: 2
+              }}
+            >
+              <Stack direction="row" spacing={2} alignItems="center">
+                <Typography variant="subtitle2" fontWeight={700} color="warning.dark" sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <InsightsRoundedIcon fontSize="small" />
+                  最新の氷山分析
+                </Typography>
+                <Divider orientation="vertical" flexItem />
+                <Box>
+                  <Typography variant="caption" color="text.secondary" display="block">行動</Typography>
+                  <Typography variant="body2" fontWeight={600}>{icebergSummary.primaryBehavior}</Typography>
+                </Box>
+                <Box>
+                  <Typography variant="caption" color="text.secondary" display="block">要因</Typography>
+                  <Typography variant="body2" fontWeight={600}>{icebergSummary.primaryFactor}</Typography>
+                </Box>
+                <Box sx={{ flex: 1 }} />
+                <Typography variant="caption" color="text.disabled">
+                  {new Date(icebergSummary.updatedAt).toLocaleDateString()} 更新
+                </Typography>
+              </Stack>
+            </Paper>
+          )}
+
+          {differenceInsight && differenceInsight.changes.length > 0 && (
+            <Paper 
+              variant="outlined" 
+              data-testid="difference-insight-bar"
+              sx={{ 
+                p: 1.5, 
+                borderLeft: '4px solid #d32f2f',
+                bgcolor: alpha('#d32f2f', 0.02),
+                borderRadius: '0 8px 8px 0'
+              }}
+            >
+              <Stack spacing={1}>
+                <Typography variant="caption" fontWeight={700} color="error.main" sx={{ letterSpacing: 1 }}>
+                  計画未反映の変更検知 (DIFFERENCE INSIGHT)
+                </Typography>
+                <Stack direction="row" spacing={3} sx={{ flexWrap: 'wrap', gap: 2 }}>
+                  {differenceInsight.changes.map((change, idx) => (
+                    <Box key={idx} sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                      <Chip 
+                        label={change.label} 
+                        size="small" 
+                        color={change.level === 'high' ? 'error' : change.level === 'medium' ? 'warning' : 'default'}
+                        variant="outlined" 
+                        sx={{ height: 20, fontSize: '0.65rem' }} 
+                      />
+                      <Typography 
+                        variant="body2" 
+                        fontWeight={600} 
+                        color={change.level === 'high' ? 'error.main' : change.level === 'medium' ? 'warning.main' : 'text.primary'}
+                      >
+                        {change.value}
+                      </Typography>
+                    </Box>
+                  ))}
+                </Stack>
+              </Stack>
+            </Paper>
+          )}
+        </Stack>
+
         {hasPendingPlanUpdate ? (
           <Alert severity="warning" sx={{ mb: 2 }}>
             未反映の計画更新案が {pendingPatchCount} 件あります。モニタリング会議の結果を確認し、必要に応じて計画へ反映してください。

--- a/src/pages/support-planning-sheet/hooks/__tests__/supportPlanningSheetViewModelMapper.spec.ts
+++ b/src/pages/support-planning-sheet/hooks/__tests__/supportPlanningSheetViewModelMapper.spec.ts
@@ -7,6 +7,7 @@ import type { UserAssessment } from '@/features/assessment/domain/types';
 import type { ContextPanelData } from '@/features/context/domain/contextPanelLogic';
 import type { UsePlanningSheetFormReturn } from '@/features/planning-sheet/hooks/usePlanningSheetForm';
 import type { BehaviorMonitoringRecord } from '@/domain/isp/behaviorMonitoring';
+import type { IcebergSnapshot } from '@/features/ibd/analysis/iceberg/icebergTypes';
 
 // Mock dependencies
 vi.mock('@/app/services/bridgeProxy', () => ({
@@ -33,7 +34,7 @@ describe('supportPlanningSheetViewModelMapper', () => {
     monitoringDialogOpen: false,
     contextOpen: false,
     historyFilter: { type: 'all' },
-    sessionProvenance: [{ id: 'prov-session', type: 'iceberg', label: 'Session Prov' }],
+    sessionProvenance: [{ field: 'goal', source: 'assessment_sensory', sourceLabel: 'Session Prov', reason: 'reason', value: 'value', importedAt: '2026-04-01' }],
   } as unknown as SupportPlanningSheetUiState;
 
   const baseInput: MapperInput = {
@@ -45,12 +46,16 @@ describe('supportPlanningSheetViewModelMapper', () => {
     monitoringBridge: null,
     targetUser: { FullName: '利用者 太郎' } as unknown as IUserMaster,
     currentAssessment: { id: 'as-1' } as unknown as UserAssessment,
-    persistedProvenance: [{ id: 'prov-1', type: 'iceberg', label: 'Persisted Prov' }],
+    persistedProvenance: [{ field: 'goal', source: 'assessment_sensory', sourceLabel: 'Persisted Prov', reason: 'reason', value: 'value', importedAt: '2026-04-01' }],
     auditRecords: [],
     filteredAuditRecords: [],
     icebergEvidence: null,
     latestMonitoringRecord: null,
-    evidenceLinks: {},
+    evidenceLinks: {
+      antecedentStrategies: [],
+      teachingStrategies: [],
+      consequenceStrategies: [],
+    },
     abcRecords: [],
     pdcaItems: [],
     strategyUsage: null,
@@ -63,6 +68,7 @@ describe('supportPlanningSheetViewModelMapper', () => {
     form: {} as unknown as UsePlanningSheetFormReturn,
     source: null,
     diffSummary: null,
+    latestIcebergSnapshot: null,
   };
 
   it('ViewModel が正しくマッピングされること', () => {
@@ -79,8 +85,8 @@ describe('supportPlanningSheetViewModelMapper', () => {
     const vm = mapToSupportPlanningSheetViewModel(baseInput);
 
     expect(vm.allProvenanceEntries.length).toBe(2);
-    expect(vm.allProvenanceEntries[0].id).toBe('prov-1');
-    expect(vm.allProvenanceEntries[1].id).toBe('prov-session');
+    expect(vm.allProvenanceEntries[0].sourceLabel).toBe('Persisted Prov');
+    expect(vm.allProvenanceEntries[1].sourceLabel).toBe('Session Prov');
   });
 
   it('アセスメントの有無が正しく判定されること', () => {
@@ -103,5 +109,28 @@ describe('supportPlanningSheetViewModelMapper', () => {
 
     const vmWithoutMonitoring = mapToSupportPlanningSheetViewModel(baseInput);
     expect(vmWithoutMonitoring.hasMonitoringRecord).toBe(false);
+  });
+
+  it('氷山分析との差分がある場合、differenceInsight が算出されること', () => {
+    const inputWithDiff: MapperInput = {
+      ...baseInput,
+      latestIcebergSnapshot: {
+        sessionId: 'sess-new',
+        nodes: [{ type: 'behavior', label: 'パニック', updatedAt: '2026-05-01T10:00:00Z' }],
+        links: [],
+        updatedAt: '2026-05-01T10:00:00Z',
+      } as unknown as IcebergSnapshot,
+      sheet: {
+        ...mockSheet,
+        assessment: {
+          targetBehaviors: [{ name: '自傷' }], // 'パニック' が含まれていない
+          hypotheses: [],
+        },
+      } as unknown as SupportPlanningSheet,
+    };
+
+    const vm = mapToSupportPlanningSheetViewModel(inputWithDiff);
+    expect(vm.differenceInsight).toBeDefined();
+    expect(vm.differenceInsight?.changes[0].value).toContain('パニック');
   });
 });

--- a/src/pages/support-planning-sheet/hooks/supportPlanningSheetViewModelMapper.ts
+++ b/src/pages/support-planning-sheet/hooks/supportPlanningSheetViewModelMapper.ts
@@ -18,6 +18,8 @@ import type { IcebergEvidenceBySheet } from '@/domain/regulatory/findingEvidence
 import type { TrendDays } from '@/features/planning-sheet/hooks/useStrategyUsageTrend';
 import type { IUserMaster } from '@/features/users/types';
 import type { UserAssessment } from '@/features/assessment/domain/types';
+import type { IcebergSnapshot } from '@/features/ibd/analysis/iceberg/icebergTypes';
+import { summarizeIcebergSnapshot, calculateDifferenceInsight } from '@/domain/isp/differenceInsight';
 
 export interface MapperInput {
   planningSheetId: string;
@@ -60,6 +62,9 @@ export interface MapperInput {
   // Handoff
   source: string | null;
   diffSummary: string | null;
+
+  // Iceberg
+  latestIcebergSnapshot: IcebergSnapshot | null;
 }
 
 /**
@@ -94,6 +99,7 @@ export function mapToSupportPlanningSheetViewModel(input: MapperInput): SupportP
     form,
     source,
     diffSummary,
+    latestIcebergSnapshot,
   } = input;
 
   // 1. セッションと永続化された Provenance の統合
@@ -113,6 +119,10 @@ export function mapToSupportPlanningSheetViewModel(input: MapperInput): SupportP
       isCurrent: true,
     },
   });
+
+  // 3. Iceberg 要約と差分インサイトの算出 (ドメインロジックへ委譲)
+  const icebergSummary = summarizeIcebergSnapshot(latestIcebergSnapshot) || undefined;
+  const differenceInsight = calculateDifferenceInsight(icebergSummary || null, sheet) || undefined;
 
   return {
     planningSheetId,
@@ -151,5 +161,7 @@ export function mapToSupportPlanningSheetViewModel(input: MapperInput): SupportP
     monitoringBridge,
     source,
     diffSummary,
+    icebergSummary,
+    differenceInsight,
   };
 }

--- a/src/pages/support-planning-sheet/hooks/useSupportPlanningSheetOrchestrator.ts
+++ b/src/pages/support-planning-sheet/hooks/useSupportPlanningSheetOrchestrator.ts
@@ -15,6 +15,8 @@ import { useStrategyUsageCounts } from '@/features/planning-sheet/hooks/useStrat
 import { useStrategyUsageTrend, type TrendDays } from '@/features/planning-sheet/hooks/useStrategyUsageTrend';
 import { useUsers } from '@/features/users/useUsers';
 import { usePdcaCycleState } from '@/features/ibd/analysis/pdca/queries/usePdcaCycleState';
+import { useIcebergRepository } from '@/features/ibd/analysis/iceberg/SharePointIcebergRepository';
+import type { IcebergSnapshot } from '@/features/ibd/analysis/iceberg/icebergTypes';
 import { getMonitoringToPlanningBridge, getMonitoringRecordFromMeeting } from '@/app/services/bridgeProxy';
 import type { SupportPlanningSheet } from '@/domain/isp/schema';
 import type { MonitoringRecord } from '@/domain/isp/types';
@@ -41,11 +43,25 @@ export function useSupportPlanningSheetOrchestrator(): {
   const { state: uiState, actions: uiActions } = useSupportPlanningSheetUiState();
 
   const planningSheetRepo = usePlanningSheetRepositories();
-  // spClient は repository hooks 内に隠蔽されました
+  const icebergRepo = useIcebergRepository();
 
+
+  const searchParams = new URLSearchParams(window.location.search);
+  const userIdParam = searchParams.get('userId');
+  const source = searchParams.get('source');
+  const diffSummary = searchParams.get('diffSummary');
 
   // 1. データフェッチ
   const { data: sheet, isLoading, error, refetch } = usePlanningSheetData(planningSheetId, planningSheetRepo);
+  const [latestIcebergSnapshot, setLatestIcebergSnapshot] = React.useState<IcebergSnapshot | null>(null);
+
+  React.useEffect(() => {
+    const userId = sheet?.userId || userIdParam;
+    if (userId && icebergRepo) {
+      icebergRepo.getLatestByUser(userId).then(setLatestIcebergSnapshot).catch(console.error);
+    }
+  }, [sheet?.userId, userIdParam, icebergRepo]);
+
   const form = usePlanningSheetForm(sheet, planningSheetRepo, (updated) => {
     uiActions.setToast({ open: true, message: `「${updated.title}」を保存しました`, severity: 'success' });
     uiActions.setIsEditing(false);
@@ -68,10 +84,6 @@ export function useSupportPlanningSheetOrchestrator(): {
 
   const { getByUserId: getAssessment } = useAssessmentStore();
   const { data: users } = useUsers();
-  const searchParams = new URLSearchParams(window.location.search);
-  const userIdParam = searchParams.get('userId');
-  const source = searchParams.get('source');
-  const diffSummary = searchParams.get('diffSummary');
 
   const { account } = useAuth();
   const { saveAuditRecord, getAllProvenance, getBySheetId } = useImportAuditStore();
@@ -215,6 +227,7 @@ export function useSupportPlanningSheetOrchestrator(): {
       form,
       source,
       diffSummary,
+      latestIcebergSnapshot,
     });
   }, [
     planningSheetId, sheet, isLoading, error, uiState, 
@@ -222,7 +235,8 @@ export function useSupportPlanningSheetOrchestrator(): {
     auditRecords, filteredAuditRecords, latestMonitoringRecord, 
     icebergEvidence, evidenceLinks, abcRecords, pdcaItems, 
     strategyUsage, strategyUsageLoading, trendResult, trendDays, 
-    trendLoading, contextUserName, contextData, form, source, diffSummary
+    trendLoading, contextUserName, contextData, form, source, diffSummary,
+    latestIcebergSnapshot
   ]);
 
   // 差分引き継ぎの監査ログ記録

--- a/src/pages/support-planning-sheet/types.tsx
+++ b/src/pages/support-planning-sheet/types.tsx
@@ -62,7 +62,7 @@ export const TabPanel: React.FC<{
 // ViewModel & ActionHandlers
 // ─────────────────────────────────────────────
 
-import type { SupportPlanningSheet } from '@/domain/isp/schema';
+import type { SupportPlanningSheet, IcebergSummary, DifferenceInsight } from '@/domain/isp/schema';
 import { type WorkflowPhase } from '@/app/services/bridgeProxy';
 import type { IcebergEvidenceBySheet } from '@/domain/regulatory/findingEvidenceSummary';
 import type { UsePlanningSheetFormReturn } from '@/features/planning-sheet/hooks/usePlanningSheetForm';
@@ -130,6 +130,10 @@ export interface SupportPlanningSheetViewModel {
   // Handoff / Audit
   source: string | null;
   diffSummary: string | null;
+
+  // New: Iceberg synchronization insights
+  icebergSummary?: IcebergSummary;
+  differenceInsight?: DifferenceInsight;
 }
 
 export interface SupportPlanningSheetActionHandlers {


### PR DESCRIPTION
## Summary
- Centralize Difference Insight calculation in the ISP domain layer
- Add typed DifferenceInsight / DifferenceChange / IcebergSummary contracts
- Refactor planning-sheet-list mapper to use the shared domain service
- Add DifferenceInsightBar support to support-planning-sheet detail view
- Fetch latest Iceberg evidence in the detail orchestrator for current-plan comparison
- Add domain-level tests for behavior/factor extraction and difference detection

## Checks
- npm test src/domain/isp/__tests__/differenceInsight.spec.ts src/pages/support-planning-sheet/hooks/__tests__/supportPlanningSheetViewModelMapper.spec.ts src/pages/planning-sheet-list/hooks/__tests__/planningSheetListViewModelMapper.spec.ts
- npx eslint src/domain/isp src/pages/planning-sheet-list src/pages/support-planning-sheet
- npx tsc --noEmit --project tsconfig.json

## Notes
This makes the Iceberg-to-ISP synchronization contract reusable across the list page, detail page, future audit surfaces, and automated PDCA checks.