### PR TITLE
feat(isp): design Difference Insight reflection action

### DIFF
--- a/src/domain/isp/__tests__/differenceInsight.spec.ts
+++ b/src/domain/isp/__tests__/differenceInsight.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { summarizeIcebergSnapshot, calculateDifferenceInsight } from '../differenceInsight';
+import { summarizeIcebergSnapshot, calculateDifferenceInsight, buildReflectPreview, applyReflectPatch } from '../differenceInsight';
 import type { IcebergSnapshot } from '@/features/ibd/analysis/iceberg/icebergTypes';
 import type { SupportPlanningSheet, IcebergSummary } from '../schema';
 
@@ -109,6 +109,67 @@ describe('differenceInsight domain logic', () => {
 
       const insight = calculateDifferenceInsight(emptySummary, mockSheet);
       expect(insight).toBeNull();
+    });
+  });
+
+  describe('reflect actions (Pure Builders)', () => {
+    const mockSummary: IcebergSummary = {
+      sessionId: 'sess-1',
+      updatedAt: '2026-04-02',
+      primaryBehavior: 'パニック',
+      primaryFactor: '音過敏',
+    };
+
+    const mockSheet = {
+      id: 'sheet-1',
+      assessment: {
+        targetBehaviors: [{ name: '自傷' }],
+        hypotheses: [{ function: '要求' }],
+      }
+    } as unknown as SupportPlanningSheet;
+
+    it('buildReflectPreview: 差分がある場合にプレビュー用の変更点リストを生成すること', () => {
+      const insight = calculateDifferenceInsight(mockSummary, mockSheet)!;
+      const preview = buildReflectPreview(insight, mockSummary, mockSheet);
+
+      expect(preview.changes).toHaveLength(2);
+      expect(preview.changes[0]).toEqual({
+        type: 'behavior',
+        label: '対象行動の追加',
+        before: '(未登録)',
+        after: 'パニック',
+      });
+      expect(preview.changes[1]).toEqual({
+        type: 'factor',
+        label: '背景要因の追加',
+        before: '(未登録)',
+        after: '音過敏',
+      });
+    });
+
+    it('applyReflectPatch: 差分が正しくマージされた新しいシートを生成すること', () => {
+      const insight = calculateDifferenceInsight(mockSummary, mockSheet)!;
+      const updatedSheet = applyReflectPatch(insight, mockSummary, mockSheet);
+
+      // 元のオブジェクトが変更されていないこと
+      expect(mockSheet.assessment?.targetBehaviors).toHaveLength(1);
+
+      // 反映後の状態
+      expect(updatedSheet.assessment?.targetBehaviors).toHaveLength(2);
+      expect(updatedSheet.assessment?.targetBehaviors[1].name).toBe('パニック');
+      expect(updatedSheet.assessment?.targetBehaviors[1].operationalDefinition).toContain('氷山分析');
+
+      expect(updatedSheet.assessment?.hypotheses).toHaveLength(2);
+      expect(updatedSheet.assessment?.hypotheses[1].function).toBe('音過敏');
+    });
+
+    it('applyReflectPatch: すでに反映済みの場合は重複して追加しないこと', () => {
+      const insight = calculateDifferenceInsight(mockSummary, mockSheet)!;
+      const firstUpdate = applyReflectPatch(insight, mockSummary, mockSheet);
+      const secondUpdate = applyReflectPatch(insight, mockSummary, firstUpdate);
+
+      expect(secondUpdate.assessment?.targetBehaviors).toHaveLength(2);
+      expect(secondUpdate.assessment?.hypotheses).toHaveLength(2);
     });
   });
 });

--- a/src/domain/isp/differenceInsight.ts
+++ b/src/domain/isp/differenceInsight.ts
@@ -1,5 +1,5 @@
 import type { IcebergSnapshot } from '@/features/ibd/analysis/iceberg/icebergTypes';
-import type { SupportPlanningSheet, IcebergSummary, DifferenceInsight, DifferenceChange } from './schema';
+import type { SupportPlanningSheet, IcebergSummary, DifferenceInsight, DifferenceChange, ReflectPreview, ReflectPreviewChange } from './schema';
 
 /**
  * Iceberg スナップショットから主要な行動と要因を要約する。
@@ -76,4 +76,83 @@ export function calculateDifferenceInsight(
     changes,
     sourceSessionId: summary.sessionId,
   };
+}
+
+/**
+ * 差分インサイトから反映プレビューを生成する (Pure Builder)。
+ */
+export function buildReflectPreview(
+  insight: DifferenceInsight,
+  summary: IcebergSummary,
+  _sheet: SupportPlanningSheet
+): ReflectPreview {
+  const changes: ReflectPreviewChange[] = [];
+
+  insight.changes.forEach(change => {
+    if (change.level === 'high' && change.label === '行動') {
+      changes.push({
+        type: 'behavior',
+        label: '対象行動の追加',
+        before: '(未登録)',
+        after: summary.primaryBehavior,
+      });
+    }
+    if (change.level === 'medium' && change.label === '要因') {
+      changes.push({
+        type: 'factor',
+        label: '背景要因の追加',
+        before: '(未登録)',
+        after: summary.primaryFactor,
+      });
+    }
+  });
+
+  return {
+    changes,
+    sourceSessionId: insight.sourceSessionId,
+  };
+}
+
+/**
+ * 差分インサイトを支援計画シートに反映した新しいオブジェクトを生成する (Pure Builder)。
+ */
+export function applyReflectPatch(
+  insight: DifferenceInsight,
+  summary: IcebergSummary,
+  sheet: SupportPlanningSheet
+): SupportPlanningSheet {
+  const updatedSheet = { ...sheet };
+  const updatedAssessment = { 
+    ...sheet.assessment,
+    targetBehaviors: [...(sheet.assessment?.targetBehaviors || [])],
+    hypotheses: [...(sheet.assessment?.hypotheses || [])],
+  };
+
+  insight.changes.forEach(change => {
+    if (change.level === 'high' && change.label === '行動') {
+      const exists = updatedAssessment.targetBehaviors.some(b => b.name === summary.primaryBehavior);
+      if (!exists && summary.primaryBehavior !== '—') {
+        updatedAssessment.targetBehaviors.push({
+          name: summary.primaryBehavior,
+          operationalDefinition: '(氷山分析より反映)',
+          frequency: '',
+          intensity: '',
+          duration: ''
+        });
+      }
+    }
+    if (change.level === 'medium' && change.label === '要因') {
+      const exists = updatedAssessment.hypotheses.some(h => h.function === summary.primaryFactor);
+      if (!exists && summary.primaryFactor !== '—') {
+        updatedAssessment.hypotheses.push({
+          function: summary.primaryFactor,
+          evidence: '(氷山分析より反映)',
+          confidence: 'medium'
+        });
+      }
+    }
+  });
+
+  updatedSheet.assessment = updatedAssessment;
+  return updatedSheet;
 }

--- a/src/domain/isp/schema/ispViewTypes.ts
+++ b/src/domain/isp/schema/ispViewTypes.ts
@@ -95,3 +95,26 @@ export interface IcebergSummary {
   /** 主要な要因（信頼度の高いリンクの sourceNode） */
   primaryFactor: string;
 }
+// ─────────────────────────────────────────────
+// 反映・アクション用型
+// ─────────────────────────────────────────────
+
+/** 反映プレビュー用の個別の変更点 */
+export interface ReflectPreviewChange {
+  /** 変更の種類 (例: "behavior", "factor") */
+  type: 'behavior' | 'factor';
+  /** 表示用ラベル (例: "対象行動の追加", "背景要因の追加") */
+  label: string;
+  /** 反映前の状態（表示用） */
+  before: string;
+  /** 反映後の内容（表示用） */
+  after: string;
+}
+
+/** 反映プレビュー全体 */
+export interface ReflectPreview {
+  /** 変更点リスト */
+  changes: ReflectPreviewChange[];
+  /** 元となった Iceberg セッション ID */
+  sourceSessionId: string;
+}

--- a/src/pages/support-planning-sheet/hooks/supportPlanningSheetViewModelMapper.ts
+++ b/src/pages/support-planning-sheet/hooks/supportPlanningSheetViewModelMapper.ts
@@ -19,7 +19,7 @@ import type { TrendDays } from '@/features/planning-sheet/hooks/useStrategyUsage
 import type { IUserMaster } from '@/features/users/types';
 import type { UserAssessment } from '@/features/assessment/domain/types';
 import type { IcebergSnapshot } from '@/features/ibd/analysis/iceberg/icebergTypes';
-import { summarizeIcebergSnapshot, calculateDifferenceInsight } from '@/domain/isp/differenceInsight';
+import { summarizeIcebergSnapshot, calculateDifferenceInsight, buildReflectPreview } from '@/domain/isp/differenceInsight';
 
 export interface MapperInput {
   planningSheetId: string;
@@ -123,6 +123,9 @@ export function mapToSupportPlanningSheetViewModel(input: MapperInput): SupportP
   // 3. Iceberg 要約と差分インサイトの算出 (ドメインロジックへ委譲)
   const icebergSummary = summarizeIcebergSnapshot(latestIcebergSnapshot) || undefined;
   const differenceInsight = calculateDifferenceInsight(icebergSummary || null, sheet) || undefined;
+  const reflectPreview = (differenceInsight && icebergSummary) 
+    ? buildReflectPreview(differenceInsight, icebergSummary, sheet) 
+    : undefined;
 
   return {
     planningSheetId,
@@ -163,5 +166,6 @@ export function mapToSupportPlanningSheetViewModel(input: MapperInput): SupportP
     diffSummary,
     icebergSummary,
     differenceInsight,
+    reflectPreview,
   };
 }

--- a/src/pages/support-planning-sheet/types.tsx
+++ b/src/pages/support-planning-sheet/types.tsx
@@ -62,7 +62,7 @@ export const TabPanel: React.FC<{
 // ViewModel & ActionHandlers
 // ─────────────────────────────────────────────
 
-import type { SupportPlanningSheet, IcebergSummary, DifferenceInsight } from '@/domain/isp/schema';
+import type { SupportPlanningSheet, IcebergSummary, DifferenceInsight, ReflectPreview } from '@/domain/isp/schema';
 import { type WorkflowPhase } from '@/app/services/bridgeProxy';
 import type { IcebergEvidenceBySheet } from '@/domain/regulatory/findingEvidenceSummary';
 import type { UsePlanningSheetFormReturn } from '@/features/planning-sheet/hooks/usePlanningSheetForm';
@@ -134,6 +134,8 @@ export interface SupportPlanningSheetViewModel {
   // New: Iceberg synchronization insights
   icebergSummary?: IcebergSummary;
   differenceInsight?: DifferenceInsight;
+  /** 反映プレビューデータ（差分がある場合のみ算出） */
+  reflectPreview?: ReflectPreview;
 }
 
 export interface SupportPlanningSheetActionHandlers {


### PR DESCRIPTION
## Summary
Difference Insight を支援計画シートへ安全に反映するための基礎設計と Pure Builder を実装しました。

### Changes
- **Types**: ReflectPreview, ReflectPreviewChange 型を定義
- **Domain**: buildReflectPreview (プレビュー生成) と applyReflectPatch (非破壊マージ) を実装
- **ViewModel**: SupportPlanningSheetViewModel に reflectPreview を追加
- **Mapper**: ViewModel 構築時にプレビューデータを算出するように更新
- **Test**: 反映ロジックの正当性を検証するユニットテストを追加

### Importance
ADR-006 に基づき、UI層に書き込みロジックを持たせず、Domain層の Pure 関数で「反映後の状態」を計算できる構造を確立しました。
これにより、次フェーズでの Preview / Confirm UI 実装が安全に行えます。
