### PR TITLE
feat(isp): implement Difference Insight reflect preview and confirm UI

### DIFF
--- a/pr_body_phase2.txt
+++ b/pr_body_phase2.txt
@@ -1,0 +1,16 @@
+## Description
+Implement the 2nd stage of the Difference Insight reflection workflow: Preview and Confirm UI.
+
+## Changes
+- Extracted `DifferenceInsightBar` into a separate component.
+- Added `ReflectPreviewDialog` to show before/after changes.
+- Integrated reflection logic into `SupportPlanningSheetOrchestrator` to update form values in-memory upon confirmation.
+- Added interaction tests for the reflection workflow.
+
+## Verification
+- Run `npx vitest src/pages/support-planning-sheet/__tests__/SupportPlanningSheetReflection.spec.tsx`
+- Verified manual interaction in the UI.
+
+## ADR-006 Compliance
+- Maintains pure domain logic for patch generation.
+- Orchestrator handles UI state and form updates without direct repository persistence (Stage 2).

--- a/src/pages/support-planning-sheet/SupportPlanningSheetView.tsx
+++ b/src/pages/support-planning-sheet/SupportPlanningSheetView.tsx
@@ -1,16 +1,12 @@
 import React from 'react';
 import ArrowBackRoundedIcon from '@mui/icons-material/ArrowBackRounded';
-import InsightsRoundedIcon from '@mui/icons-material/InsightsRounded';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
-import Chip from '@mui/material/Chip';
 import CircularProgress from '@mui/material/CircularProgress';
 import Divider from '@mui/material/Divider';
 import Paper from '@mui/material/Paper';
-import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-import { alpha } from '@mui/material/styles';
 
 // import { createSharePointIspRepository } from '@/data/isp/sharepoint/SharePointIspRepository';
 import { usePlanningSheetRepositories } from '@/features/planning-sheet/hooks/usePlanningSheetRepositories';
@@ -30,6 +26,8 @@ import { usePlanningSheetOrchestrator } from '@/features/planning-sheet/hooks/or
 import { ContextPanelSection } from './sections/ContextPanelSection';
 import { ImportDialogsSection } from './sections/ImportDialogsSection';
 import { PlanningMainStackSection } from './sections/PlanningMainStackSection';
+import { DifferenceInsightBar } from './components/DifferenceInsightBar';
+import { ReflectPreviewDialog } from './components/ReflectPreviewDialog';
 
 export const SupportPlanningSheetView: React.FC<SupportPlanningSheetViewProps> = ({
   viewModel,
@@ -135,6 +133,8 @@ export const SupportPlanningSheetView: React.FC<SupportPlanningSheetViewProps> =
     diffSummary,
     icebergSummary,
     differenceInsight,
+    reflectPreview,
+    reflectPreviewOpen,
   } = viewModel;
 
   if (isLoading) {
@@ -189,78 +189,11 @@ export const SupportPlanningSheetView: React.FC<SupportPlanningSheetViewProps> =
     <Box sx={{ display: 'flex', position: 'relative' }}>
       <Box sx={{ flex: 1, p: { xs: 2, md: 3 }, pb: 4 }} {...tid(TESTIDS['planning-sheet-page'])}>
         {/* Iceberg Summary & Difference Insight */}
-        <Stack spacing={1.5} sx={{ mb: 2 }}>
-          {icebergSummary && (
-            <Paper 
-              variant="outlined" 
-              sx={{ 
-                p: 1.5, 
-                bgcolor: alpha('#ed6c02', 0.04), 
-                borderColor: alpha('#ed6c02', 0.2),
-                borderRadius: 2
-              }}
-            >
-              <Stack direction="row" spacing={2} alignItems="center">
-                <Typography variant="subtitle2" fontWeight={700} color="warning.dark" sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                  <InsightsRoundedIcon fontSize="small" />
-                  最新の氷山分析
-                </Typography>
-                <Divider orientation="vertical" flexItem />
-                <Box>
-                  <Typography variant="caption" color="text.secondary" display="block">行動</Typography>
-                  <Typography variant="body2" fontWeight={600}>{icebergSummary.primaryBehavior}</Typography>
-                </Box>
-                <Box>
-                  <Typography variant="caption" color="text.secondary" display="block">要因</Typography>
-                  <Typography variant="body2" fontWeight={600}>{icebergSummary.primaryFactor}</Typography>
-                </Box>
-                <Box sx={{ flex: 1 }} />
-                <Typography variant="caption" color="text.disabled">
-                  {new Date(icebergSummary.updatedAt).toLocaleDateString()} 更新
-                </Typography>
-              </Stack>
-            </Paper>
-          )}
-
-          {differenceInsight && differenceInsight.changes.length > 0 && (
-            <Paper 
-              variant="outlined" 
-              data-testid={TESTIDS.DIFFERENCE_INSIGHT_BAR}
-              sx={{ 
-                p: 1.5, 
-                borderLeft: '4px solid #d32f2f',
-                bgcolor: alpha('#d32f2f', 0.02),
-                borderRadius: '0 8px 8px 0'
-              }}
-            >
-              <Stack spacing={1}>
-                <Typography variant="caption" fontWeight={700} color="error.main" sx={{ letterSpacing: 1 }}>
-                  計画未反映の変更検知 (DIFFERENCE INSIGHT)
-                </Typography>
-                <Stack direction="row" spacing={3} sx={{ flexWrap: 'wrap', gap: 2 }}>
-                  {differenceInsight.changes.map((change, idx) => (
-                    <Box key={idx} sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                      <Chip 
-                        label={change.label} 
-                        size="small" 
-                        color={change.level === 'high' ? 'error' : change.level === 'medium' ? 'warning' : 'default'}
-                        variant="outlined" 
-                        sx={{ height: 20, fontSize: '0.65rem' }} 
-                      />
-                      <Typography 
-                        variant="body2" 
-                        fontWeight={600} 
-                        color={change.level === 'high' ? 'error.main' : change.level === 'medium' ? 'warning.main' : 'text.primary'}
-                      >
-                        {change.value}
-                      </Typography>
-                    </Box>
-                  ))}
-                </Stack>
-              </Stack>
-            </Paper>
-          )}
-        </Stack>
+        <DifferenceInsightBar 
+          icebergSummary={icebergSummary}
+          differenceInsight={differenceInsight}
+          onOpenPreview={handlers.onOpenReflectPreview}
+        />
 
         {hasPendingPlanUpdate ? (
           <Alert severity="warning" sx={{ mb: 2 }}>
@@ -412,6 +345,13 @@ export const SupportPlanningSheetView: React.FC<SupportPlanningSheetViewProps> =
           monitoringDialogOpen={monitoringDialogOpen}
           onCloseMonitoringDialog={handlers.onCloseMonitoringDialog}
           onImportMonitoring={handlers.onPerformMonitoringImport}
+        />
+
+        <ReflectPreviewDialog 
+          open={reflectPreviewOpen}
+          preview={reflectPreview}
+          onClose={handlers.onCloseReflectPreview}
+          onConfirm={handlers.onConfirmReflect}
         />
       </Box>
 

--- a/src/pages/support-planning-sheet/__tests__/SupportPlanningSheetReflection.spec.tsx
+++ b/src/pages/support-planning-sheet/__tests__/SupportPlanningSheetReflection.spec.tsx
@@ -1,0 +1,192 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { SupportPlanningSheetView } from '../SupportPlanningSheetView';
+import { MemoryRouter } from 'react-router-dom';
+import { SupportPlanningSheetViewModel, SupportPlanningSheetActionHandlers } from '../types';
+
+vi.mock('@/features/planning-sheet/hooks/orchestrators/usePlanningSheetOrchestrator', () => ({
+  usePlanningSheetOrchestrator: () => ({
+    handleApplyPatch: vi.fn(),
+    handleUpdatePatchStatus: vi.fn(),
+  }),
+}));
+
+vi.mock('@/features/planning-sheet/hooks/usePlanningSheetRepositories', () => ({
+  usePlanningSheetRepositories: () => ({}),
+}));
+
+vi.mock('@/features/planning-sheet/hooks/usePlanPatchRepository', () => ({
+  usePlanPatchRepository: () => ({
+    findPending: vi.fn().mockResolvedValue([]),
+  }),
+}));
+
+vi.mock('../hooks/supportPlanningSheetViewModelMapper', () => ({
+  mapToSupportPlanningSheetViewModel: vi.fn(),
+}));
+
+const mockHandlers: SupportPlanningSheetActionHandlers = {
+  onBack: vi.fn(),
+  onEdit: vi.fn(),
+  onReset: vi.fn(),
+  onSave: vi.fn(),
+  onImportAssessment: vi.fn(),
+  onImportMonitoring: vi.fn(),
+  onCloseImportDialog: vi.fn(),
+  onCloseMonitoringDialog: vi.fn(),
+  onPerformAssessmentImport: vi.fn(),
+  onPerformMonitoringImport: vi.fn(),
+  onCloseToast: vi.fn(),
+  onTabChange: vi.fn(),
+  onBannerNavigate: vi.fn(),
+  onJumpToMonitoringHistory: vi.fn(),
+  onJumpToPlanningTab: vi.fn(),
+  onTrendDaysChange: vi.fn(),
+  onHistoryFilterChange: vi.fn(),
+  onToggleContext: vi.fn(),
+  onCloseContext: vi.fn(),
+  onEvidenceLinksChange: vi.fn(),
+  onEvidenceClick: vi.fn(),
+  onReflectCandidate: vi.fn(),
+  onNavigateToExecution: vi.fn(),
+  onNavigateToPdca: vi.fn(),
+  onOpenReflectPreview: vi.fn(),
+  onCloseReflectPreview: vi.fn(),
+  onConfirmReflect: vi.fn(),
+};
+
+const mockViewModel: SupportPlanningSheetViewModel = {
+  planningSheetId: 'test-id',
+  sheet: {
+    id: 'test-id',
+    userId: 'user-1',
+    title: 'テスト太郎',
+    status: 'active',
+    assessment: {
+      behaviorSummary: '既存の行動',
+      factorAnalysis: '既存の要因',
+    },
+    planning: { procedureSteps: [] },
+    monitoringCycleDays: 90,
+    supportStartDate: '2024-01-01',
+    reviewedAt: '2024-01-01',
+    createdAt: '2024-01-01',
+    updatedAt: '2024-01-01',
+  } as any,
+  isLoading: false,
+  error: null,
+  isEditing: false,
+  activeTab: 'overview',
+  toast: { open: false, message: '', severity: 'success' },
+  importDialogOpen: false,
+  monitoringDialogOpen: false,
+  contextOpen: false,
+  historyFilter: 'all',
+  currentPhase: null,
+  hasAssessment: true,
+  currentAssessment: null,
+  hasMonitoringRecord: false,
+  icebergEvidence: null,
+  allProvenanceEntries: [],
+  auditRecords: [],
+  filteredAuditRecords: [],
+  latestMonitoringRecord: null,
+  evidenceLinks: {},
+  abcRecords: [],
+  pdcaItems: [],
+  strategyUsage: null,
+  strategyUsageLoading: false,
+  trendResult: null,
+  trendDays: 30,
+  trendLoading: false,
+  contextUserName: 'テスト太郎',
+  contextData: { 
+    personalHistory: [], 
+    traits: [], 
+    supportPolicies: [], 
+    alerts: [],
+    summary: 'テストサマリー',
+    prompts: [],
+    supportPlan: { status: 'none', goals: [] },
+    handoffs: [],
+    recentRecords: [],
+  } as any,
+  form: { 
+    values: {}, 
+    setValues: vi.fn(),
+    isDirty: false,
+    isSaving: false,
+    isValid: true,
+    validationErrors: [],
+  } as any,
+  monitoringBridge: null,
+  source: null,
+  diffSummary: null,
+  reflectPreviewOpen: false,
+};
+
+describe('SupportPlanningSheetReflection UI Interaction', () => {
+  it('反映内容を確認ボタンをクリックすると onOpenReflectPreview が呼ばれること', () => {
+    const vmWithDiff = {
+      ...mockViewModel,
+      differenceInsight: {
+        changes: [{ label: '行動', value: '新しい行動', level: 'high' }]
+      }
+    };
+    
+    render(
+      <MemoryRouter>
+        <SupportPlanningSheetView viewModel={vmWithDiff as any} handlers={mockHandlers} />
+      </MemoryRouter>
+    );
+    
+    const reflectBtn = screen.getByText('反映内容を確認');
+    fireEvent.click(reflectBtn);
+    
+    expect(mockHandlers.onOpenReflectPreview).toHaveBeenCalled();
+  });
+
+  it('reflectPreviewOpen が true の場合、プレビューダイアログが表示されること', () => {
+    const vmWithPreview = {
+      ...mockViewModel,
+      reflectPreviewOpen: true,
+      reflectPreview: {
+        changes: [
+          { label: '行動', before: '既存の行動', after: '新しい行動' }
+        ]
+      }
+    };
+    
+    render(
+      <MemoryRouter>
+        <SupportPlanningSheetView viewModel={vmWithPreview as any} handlers={mockHandlers} />
+      </MemoryRouter>
+    );
+    
+    expect(screen.getByText('支援計画への反映プレビュー')).toBeInTheDocument();
+    expect(screen.getByText('既存の行動')).toBeInTheDocument();
+    expect(screen.getByText('新しい行動')).toBeInTheDocument();
+  });
+
+  it('ダイアログの「反映する」をクリックすると onConfirmReflect が呼ばれること', () => {
+    const vmWithPreview = {
+      ...mockViewModel,
+      reflectPreviewOpen: true,
+      reflectPreview: {
+        changes: [{ label: '行動', before: '既存', after: '新規' }]
+      }
+    };
+    
+    render(
+      <MemoryRouter>
+        <SupportPlanningSheetView viewModel={vmWithPreview as any} handlers={mockHandlers} />
+      </MemoryRouter>
+    );
+    
+    const confirmBtn = screen.getByText('反映する');
+    fireEvent.click(confirmBtn);
+    
+    expect(mockHandlers.onConfirmReflect).toHaveBeenCalled();
+  });
+});

--- a/src/pages/support-planning-sheet/__tests__/SupportPlanningSheetReflection.spec.tsx
+++ b/src/pages/support-planning-sheet/__tests__/SupportPlanningSheetReflection.spec.tsx
@@ -73,7 +73,7 @@ const mockViewModel: SupportPlanningSheetViewModel = {
     reviewedAt: '2024-01-01',
     createdAt: '2024-01-01',
     updatedAt: '2024-01-01',
-  } as any,
+  } as unknown as SupportPlanningSheet,
   isLoading: false,
   error: null,
   isEditing: false,
@@ -111,15 +111,15 @@ const mockViewModel: SupportPlanningSheetViewModel = {
     supportPlan: { status: 'none', goals: [] },
     handoffs: [],
     recentRecords: [],
-  } as any,
+  } as unknown as ContextPanelData,
   form: { 
     values: {}, 
     setValues: vi.fn(),
     isDirty: false,
     isSaving: false,
     isValid: true,
-    validationErrors: [],
-  } as any,
+    validationErrors: {},
+  } as unknown as UsePlanningSheetFormReturn,
   monitoringBridge: null,
   source: null,
   diffSummary: null,
@@ -137,7 +137,7 @@ describe('SupportPlanningSheetReflection UI Interaction', () => {
     
     render(
       <MemoryRouter>
-        <SupportPlanningSheetView viewModel={vmWithDiff as any} handlers={mockHandlers} />
+        <SupportPlanningSheetView viewModel={vmWithDiff as unknown as SupportPlanningSheetViewModel} handlers={mockHandlers} />
       </MemoryRouter>
     );
     
@@ -160,7 +160,7 @@ describe('SupportPlanningSheetReflection UI Interaction', () => {
     
     render(
       <MemoryRouter>
-        <SupportPlanningSheetView viewModel={vmWithPreview as any} handlers={mockHandlers} />
+        <SupportPlanningSheetView viewModel={vmWithPreview as unknown as SupportPlanningSheetViewModel} handlers={mockHandlers} />
       </MemoryRouter>
     );
     
@@ -180,7 +180,7 @@ describe('SupportPlanningSheetReflection UI Interaction', () => {
     
     render(
       <MemoryRouter>
-        <SupportPlanningSheetView viewModel={vmWithPreview as any} handlers={mockHandlers} />
+        <SupportPlanningSheetView viewModel={vmWithPreview as unknown as SupportPlanningSheetViewModel} handlers={mockHandlers} />
       </MemoryRouter>
     );
     

--- a/src/pages/support-planning-sheet/components/DifferenceInsightBar.tsx
+++ b/src/pages/support-planning-sheet/components/DifferenceInsightBar.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import InsightsRoundedIcon from '@mui/icons-material/InsightsRounded';
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import Divider from '@mui/material/Divider';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import { alpha } from '@mui/material/styles';
+import { TESTIDS } from '@/testids';
+import type { IcebergSummary, DifferenceInsight } from '@/domain/isp/schema';
+
+interface DifferenceInsightBarProps {
+  icebergSummary?: IcebergSummary;
+  differenceInsight?: DifferenceInsight;
+  onOpenPreview?: () => void;
+}
+
+export const DifferenceInsightBar: React.FC<DifferenceInsightBarProps> = ({
+  icebergSummary,
+  differenceInsight,
+  onOpenPreview,
+}) => {
+  if (!icebergSummary && (!differenceInsight || differenceInsight.changes.length === 0)) {
+    return null;
+  }
+
+  return (
+    <Stack spacing={1.5} sx={{ mb: 2 }}>
+      {icebergSummary && (
+        <Paper 
+          variant="outlined" 
+          sx={{ 
+            p: 1.5, 
+            bgcolor: alpha('#ed6c02', 0.04), 
+            borderColor: alpha('#ed6c02', 0.2),
+            borderRadius: 2
+          }}
+        >
+          <Stack direction="row" spacing={2} alignItems="center">
+            <Typography variant="subtitle2" fontWeight={700} color="warning.dark" sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <InsightsRoundedIcon fontSize="small" />
+              最新の氷山分析
+            </Typography>
+            <Divider orientation="vertical" flexItem />
+            <Box>
+              <Typography variant="caption" color="text.secondary" display="block">行動</Typography>
+              <Typography variant="body2" fontWeight={600}>{icebergSummary.primaryBehavior}</Typography>
+            </Box>
+            <Box>
+              <Typography variant="caption" color="text.secondary" display="block">要因</Typography>
+              <Typography variant="body2" fontWeight={600}>{icebergSummary.primaryFactor}</Typography>
+            </Box>
+            <Box sx={{ flex: 1 }} />
+            <Typography variant="caption" color="text.disabled">
+              {new Date(icebergSummary.updatedAt).toLocaleDateString()} 更新
+            </Typography>
+          </Stack>
+        </Paper>
+      )}
+
+      {differenceInsight && differenceInsight.changes.length > 0 && (
+        <Paper 
+          variant="outlined" 
+          data-testid={TESTIDS.DIFFERENCE_INSIGHT_BAR}
+          sx={{ 
+            p: 1.5, 
+            borderLeft: '4px solid #d32f2f',
+            bgcolor: alpha('#d32f2f', 0.02),
+            borderRadius: '0 8px 8px 0'
+          }}
+        >
+          <Stack direction="row" spacing={2} alignItems="center" justifyContent="space-between">
+            <Stack spacing={0.5}>
+              <Typography variant="caption" fontWeight={700} color="error.main" sx={{ letterSpacing: 1 }}>
+                計画未反映の変更検知 (DIFFERENCE INSIGHT)
+              </Typography>
+              <Stack direction="row" spacing={2} sx={{ flexWrap: 'wrap', gap: 1.5 }}>
+                {differenceInsight.changes.map((change, idx) => (
+                  <Box key={idx} sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                    <Chip 
+                      label={change.label} 
+                      size="small" 
+                      color={change.level === 'high' ? 'error' : change.level === 'medium' ? 'warning' : 'default'}
+                      variant="outlined" 
+                      sx={{ height: 20, fontSize: '0.65rem' }} 
+                    />
+                    <Typography 
+                      variant="body2" 
+                      fontWeight={600} 
+                      color={change.level === 'high' ? 'error.main' : change.level === 'medium' ? 'warning.main' : 'text.primary'}
+                    >
+                      {change.value}
+                    </Typography>
+                  </Box>
+                ))}
+              </Stack>
+            </Stack>
+            
+            <Button 
+              variant="contained" 
+              color="error" 
+              size="small"
+              onClick={onOpenPreview}
+              sx={{ 
+                borderRadius: 2,
+                fontWeight: 700,
+                boxShadow: 'none',
+                '&:hover': { boxShadow: 'none', bgcolor: 'error.dark' }
+              }}
+            >
+              反映内容を確認
+            </Button>
+          </Stack>
+        </Paper>
+      )}
+    </Stack>
+  );
+};

--- a/src/pages/support-planning-sheet/components/ReflectPreviewDialog.tsx
+++ b/src/pages/support-planning-sheet/components/ReflectPreviewDialog.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+import Stack from '@mui/material/Stack';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import ArrowForwardRoundedIcon from '@mui/icons-material/ArrowForwardRounded';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import CheckCircleRoundedIcon from '@mui/icons-material/CheckCircleRounded';
+import { alpha } from '@mui/material/styles';
+import type { ReflectPreview } from '@/domain/isp/schema';
+
+interface ReflectPreviewDialogProps {
+  open: boolean;
+  preview?: ReflectPreview;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+export const ReflectPreviewDialog: React.FC<ReflectPreviewDialogProps> = ({
+  open,
+  preview,
+  onClose,
+  onConfirm,
+}) => {
+  if (!preview) return null;
+
+  return (
+    <Dialog 
+      open={open} 
+      onClose={onClose}
+      maxWidth="sm"
+      fullWidth
+      PaperProps={{
+        sx: { borderRadius: 3, p: 1 }
+      }}
+    >
+      <DialogTitle sx={{ fontWeight: 700, pb: 1 }}>
+        支援計画への反映プレビュー
+      </DialogTitle>
+      <DialogContent>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+          氷山分析の結果に基づき、以下の内容を支援計画のアセスメント欄へ追加します。内容を確認してください。
+        </Typography>
+
+        <Stack spacing={2}>
+          {preview.changes.map((change, idx) => (
+            <Box 
+              key={idx}
+              sx={{ 
+                p: 2, 
+                borderRadius: 2, 
+                border: '1px solid',
+                borderColor: 'divider',
+                bgcolor: alpha('#f5f5f5', 0.5)
+              }}
+            >
+              <Typography variant="subtitle2" fontWeight={700} sx={{ mb: 1.5, display: 'flex', alignItems: 'center', gap: 1 }}>
+                <CheckCircleRoundedIcon fontSize="small" color="primary" />
+                {change.label}
+              </Typography>
+              
+              <Stack direction="row" spacing={2} alignItems="center">
+                <Box sx={{ flex: 1 }}>
+                  <Typography variant="caption" color="text.disabled" display="block">現状</Typography>
+                  <Typography variant="body2" sx={{ color: 'text.disabled', fontStyle: 'italic' }}>
+                    {change.before}
+                  </Typography>
+                </Box>
+                <ArrowForwardRoundedIcon color="disabled" fontSize="small" />
+                <Box sx={{ flex: 1 }}>
+                  <Typography variant="caption" color="primary" fontWeight={700} display="block">反映後</Typography>
+                  <Typography variant="body2" fontWeight={600} color="primary.main">
+                    {change.after}
+                  </Typography>
+                </Box>
+              </Stack>
+            </Box>
+          ))}
+        </Stack>
+
+        <Box 
+          sx={{ 
+            mt: 3, 
+            p: 1.5, 
+            borderRadius: 2, 
+            bgcolor: alpha('#0288d1', 0.05),
+            border: '1px solid',
+            borderColor: alpha('#0288d1', 0.2),
+            display: 'flex',
+            gap: 1.5
+          }}
+        >
+          <InfoOutlinedIcon fontSize="small" color="info" sx={{ mt: 0.3 }} />
+          <Typography variant="caption" color="info.main" sx={{ lineHeight: 1.5 }}>
+            この操作ではまだ保存されません。反映後、支援計画の内容を確認してから「保存」ボタンを押してください。
+            また、既に同じ内容が登録されている場合は、重複して追加されることはありません。
+          </Typography>
+        </Box>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={onClose} color="inherit" sx={{ fontWeight: 700 }}>
+          キャンセル
+        </Button>
+        <Button 
+          onClick={onConfirm} 
+          variant="contained" 
+          color="primary"
+          sx={{ 
+            borderRadius: 2, 
+            px: 3,
+            fontWeight: 700,
+            boxShadow: 'none',
+            '&:hover': { boxShadow: 'none' }
+          }}
+        >
+          反映する
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/src/pages/support-planning-sheet/hooks/supportPlanningSheetViewModelMapper.ts
+++ b/src/pages/support-planning-sheet/hooks/supportPlanningSheetViewModelMapper.ts
@@ -65,6 +65,7 @@ export interface MapperInput {
 
   // Iceberg
   latestIcebergSnapshot: IcebergSnapshot | null;
+  reflectPreviewOpen: boolean;
 }
 
 /**
@@ -167,5 +168,6 @@ export function mapToSupportPlanningSheetViewModel(input: MapperInput): SupportP
     icebergSummary,
     differenceInsight,
     reflectPreview,
+    reflectPreviewOpen: uiState.reflectPreviewDialogOpen,
   };
 }

--- a/src/pages/support-planning-sheet/hooks/useSupportPlanningSheetOrchestrator.ts
+++ b/src/pages/support-planning-sheet/hooks/useSupportPlanningSheetOrchestrator.ts
@@ -33,6 +33,7 @@ import { useSupportPlanningContextPanel } from './useSupportPlanningContextPanel
 import { useSupportPlanningPageHandlers } from './useSupportPlanningPageHandlers';
 import { useSupportPlanningSheetUiState } from './useSupportPlanningSheetUiState';
 import { mapToSupportPlanningSheetViewModel } from './supportPlanningSheetViewModelMapper';
+import { applyReflectPatch } from '@/domain/isp/differenceInsight';
 
 export function useSupportPlanningSheetOrchestrator(): {
   viewModel: SupportPlanningSheetViewModel | null;
@@ -206,6 +207,7 @@ export function useSupportPlanningSheetOrchestrator(): {
       isLoading,
       error,
       uiState,
+      reflectPreviewOpen: uiState.reflectPreviewDialogOpen,
       targetUser,
       currentAssessment: currentAssessment ?? null,
       persistedProvenance,
@@ -285,6 +287,26 @@ export function useSupportPlanningSheetOrchestrator(): {
     },
     onNavigateToExecution: handleNavigateToExecution,
     onNavigateToPdca: handleNavigateToPdca,
+    onOpenReflectPreview: () => uiActions.setReflectPreviewDialogOpen(true),
+    onCloseReflectPreview: () => uiActions.setReflectPreviewDialogOpen(false),
+    onConfirmReflect: () => {
+      const icebergSummary = viewModel?.icebergSummary;
+      const differenceInsight = viewModel?.differenceInsight;
+      if (!icebergSummary || !differenceInsight || !sheet) return;
+
+      const updatedSheet = applyReflectPatch(differenceInsight, icebergSummary, sheet);
+      
+      // フォームの値を更新（アセスメント情報を上書き）
+      form.setAssessment(updatedSheet.assessment);
+
+      uiActions.setReflectPreviewDialogOpen(false);
+      uiActions.setIsEditing(true); // 編集モードに自動移行
+      uiActions.setToast({
+        open: true,
+        message: '氷山分析の結果を反映しました。保存ボタンを押すまで確定されません。',
+        severity: 'info'
+      });
+    }
   };
 
   return { viewModel, handlers };

--- a/src/pages/support-planning-sheet/hooks/useSupportPlanningSheetUiState.ts
+++ b/src/pages/support-planning-sheet/hooks/useSupportPlanningSheetUiState.ts
@@ -15,6 +15,7 @@ export interface SupportPlanningSheetUiState {
   sessionProvenance: ProvenanceEntry[];
   contextOpen: boolean;
   historyFilter: AuditHistoryFilter;
+  reflectPreviewDialogOpen: boolean;
 }
 
 export type SupportPlanningSheetUiActions = {
@@ -26,6 +27,7 @@ export type SupportPlanningSheetUiActions = {
   setSessionProvenance: React.Dispatch<React.SetStateAction<ProvenanceEntry[]>>;
   setContextOpen: React.Dispatch<React.SetStateAction<boolean>>;
   setHistoryFilter: React.Dispatch<React.SetStateAction<AuditHistoryFilter>>;
+  setReflectPreviewDialogOpen: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 export function useSupportPlanningSheetUiState(): {
@@ -48,6 +50,7 @@ export function useSupportPlanningSheetUiState(): {
   const [sessionProvenance, setSessionProvenance] = React.useState<ProvenanceEntry[]>([]);
   const [contextOpen, setContextOpen] = React.useState(false);
   const [historyFilter, setHistoryFilter] = React.useState<AuditHistoryFilter>('all');
+  const [reflectPreviewDialogOpen, setReflectPreviewDialogOpen] = React.useState(false);
 
   const state = React.useMemo(
     () => ({
@@ -59,8 +62,9 @@ export function useSupportPlanningSheetUiState(): {
       sessionProvenance,
       contextOpen,
       historyFilter,
+      reflectPreviewDialogOpen,
     }),
-    [activeTab, isEditing, toast, importDialogOpen, monitoringDialogOpen, sessionProvenance, contextOpen, historyFilter],
+    [activeTab, isEditing, toast, importDialogOpen, monitoringDialogOpen, sessionProvenance, contextOpen, historyFilter, reflectPreviewDialogOpen],
   );
 
   const actions = React.useMemo(
@@ -73,6 +77,7 @@ export function useSupportPlanningSheetUiState(): {
       setSessionProvenance,
       setContextOpen,
       setHistoryFilter,
+      setReflectPreviewDialogOpen,
     }),
     [],
   );

--- a/src/pages/support-planning-sheet/types.tsx
+++ b/src/pages/support-planning-sheet/types.tsx
@@ -136,6 +136,8 @@ export interface SupportPlanningSheetViewModel {
   differenceInsight?: DifferenceInsight;
   /** 反映プレビューデータ（差分がある場合のみ算出） */
   reflectPreview?: ReflectPreview;
+  /** 反映プレビューダイアログの開閉状態 */
+  reflectPreviewOpen: boolean;
 }
 
 export interface SupportPlanningSheetActionHandlers {
@@ -165,6 +167,12 @@ export interface SupportPlanningSheetActionHandlers {
   onNavigateToExecution: () => void;
   /** 見直し・PDCAボタン: /analysis/iceberg-pdca へ遷移 */
   onNavigateToPdca: () => void;
+  /** 反映プレビューダイアログを開く */
+  onOpenReflectPreview: () => void;
+  /** 反映プレビューダイアログを閉じる */
+  onCloseReflectPreview: () => void;
+  /** 反映を実行する（UI上でのマージ） */
+  onConfirmReflect: () => void;
 }
 
 export interface SupportPlanningSheetViewProps {


### PR DESCRIPTION
## Description
Implement the 2nd stage of the Difference Insight reflection workflow: Preview and Confirm UI.

## Changes
- Extracted `DifferenceInsightBar` into a separate component.
- Added `ReflectPreviewDialog` to show before/after changes.
- Integrated reflection logic into `SupportPlanningSheetOrchestrator` to update form values in-memory upon confirmation.
- Added interaction tests for the reflection workflow.

## Verification
- Run `npx vitest src/pages/support-planning-sheet/__tests__/SupportPlanningSheetReflection.spec.tsx`
- Verified manual interaction in the UI.

## ADR-006 Compliance
- Maintains pure domain logic for patch generation.
- Orchestrator handles UI state and form updates without direct repository persistence (Stage 2).
