### PR TITLE
feat(isp): implement Save Phase contract for Difference Insight reflection

### DIFF
--- a/src/features/planning-sheet/hooks/__tests__/usePlanningSheetFormReflection.spec.ts
+++ b/src/features/planning-sheet/hooks/__tests__/usePlanningSheetFormReflection.spec.ts
@@ -1,0 +1,105 @@
+import { renderHook, act } from '@testing-library/react';
+import { usePlanningSheetForm } from '../usePlanningSheetForm';
+import type { SupportPlanningSheet, PlanningAssessment } from '@/domain/isp/schema';
+import { describe, it, expect, vi } from 'vitest';
+import type { PlanningSheetRepository } from '@/domain/isp/port';
+
+describe('usePlanningSheetForm Reflection Contract', () => {
+  const mockSheet: SupportPlanningSheet = {
+    id: 'sheet-1',
+    userId: 'user-1',
+    ispId: 'isp-1',
+    title: 'テスト計画',
+    status: 'draft',
+    assessment: {
+      targetBehaviors: ['既存の行動'],
+      abcEvents: [],
+      hypotheses: [],
+      riskLevel: 'low',
+      healthFactors: [],
+      teamConsensusNote: '',
+    },
+    intake: { 
+      presentingProblem: '', 
+      targetBehaviorsDraft: [], 
+      behaviorItemsTotal: null, 
+      incidentSummaryLast30d: '', 
+      communicationModes: [], 
+      sensoryTriggers: [], 
+      medicalFlags: [], 
+      consentScope: [], 
+      consentDate: null 
+    },
+    planning: { 
+      supportPriorities: [], 
+      antecedentStrategies: [], 
+      teachingStrategies: [], 
+      consequenceStrategies: [], 
+      procedureSteps: [], 
+      crisisThresholds: null, 
+      restraintPolicy: 'prohibited_except_emergency', 
+      reviewCycleDays: 180 
+    },
+    monitoringCycleDays: 90,
+    observationFacts: '行動観察',
+    interpretationHypothesis: '分析・仮説',
+    supportIssues: '支援課題',
+    supportPolicy: '対応方針',
+    concreteApproaches: '具体策',
+    authoredByStaffId: 'staff-1',
+    authoredByQualification: 'practical_training',
+    applicableServiceType: 'other',
+    applicableAddOnTypes: ['none'],
+    createdAt: '2024-01-01',
+    updatedAt: '2024-01-01',
+  } as unknown as SupportPlanningSheet;
+
+  const mockRepo = {
+    update: vi.fn().mockResolvedValue({ ...mockSheet }),
+  };
+
+  it('反映アクションによって assessment が更新された場合、isDirty が true になること', () => {
+    const { result } = renderHook(() => usePlanningSheetForm(mockSheet, mockRepo as unknown as PlanningSheetRepository));
+
+    expect(result.current.isDirty).toBe(false);
+
+    const updatedAssessment: PlanningAssessment = {
+      ...mockSheet.assessment,
+      targetBehaviors: ['反映後の行動'],
+    };
+
+    act(() => {
+      result.current.setAssessment(updatedAssessment);
+    });
+
+    expect(result.current.assessment.targetBehaviors).toContain('反映後の行動');
+    // 現状の実装では values のみが dirty 判定対象のため、ここが失敗するはず
+    expect(result.current.isDirty).toBe(true);
+  });
+
+  it('反映アクション後の save() が、更新された assessment をリポジトリに送ること', async () => {
+    const { result } = renderHook(() => usePlanningSheetForm(mockSheet, mockRepo as unknown as PlanningSheetRepository));
+
+    const updatedAssessment: PlanningAssessment = {
+      ...mockSheet.assessment,
+      targetBehaviors: ['反映後の行動'],
+    };
+
+    act(() => {
+      result.current.setAssessment(updatedAssessment);
+    });
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(mockRepo.update).toHaveBeenCalledWith(
+      'sheet-1',
+      expect.objectContaining({
+        assessment: expect.objectContaining({
+          targetBehaviors: ['反映後の行動'],
+        }),
+      })
+    );
+  });
+});

--- a/src/features/planning-sheet/hooks/usePlanningSheetForm.ts
+++ b/src/features/planning-sheet/hooks/usePlanningSheetForm.ts
@@ -212,7 +212,18 @@ export function usePlanningSheetForm(
   }, [initialValues, sheet]);
 
   // ── Computed State ──
-  const isDirty = useMemo(() => isFormDirty(values, initialValues), [values, initialValues]);
+  const isDirty = useMemo(() => {
+    const valuesDirty = isFormDirty(values, initialValues);
+    const initialAssessment = sheet?.assessment ?? defaultAssessment;
+    const initialIntake = sheet?.intake ?? defaultIntake;
+    const initialPlanning = sheet?.planning ?? defaultPlanning;
+
+    const assessmentDirty = JSON.stringify(assessmentState) !== JSON.stringify(initialAssessment);
+    const intakeDirty = JSON.stringify(intakeState) !== JSON.stringify(initialIntake);
+    const planningDirty = JSON.stringify(planningState) !== JSON.stringify(initialPlanning);
+
+    return valuesDirty || assessmentDirty || intakeDirty || planningDirty;
+  }, [values, initialValues, assessmentState, intakeState, planningState, sheet]);
   const validationErrors = useMemo(() => validateForm(values), [values]);
   const isValid = useMemo(() => Object.keys(validationErrors).length === 0, [validationErrors]);
 


### PR DESCRIPTION
## Objective
Apply / Reflect Phase 3: Save Implementation の初期段階として、反映後のフォーム状態を既存保存フローへ正しく橋渡しするための設計と検証を行いました。

## Changes
- **usePlanningSheetForm の isDirty 修正**:
  - これまで `values` (基本属性) のみで判定されていた `isDirty` に、構造化セクション (`assessment`, `intake`, `planning`) の変更検知を追加しました。
  - これにより、氷山分析からの反映（`setAssessment`）直後に UI 上で「保存」ボタンが有効化されるようになります。
- **Contract Test の追加**:
  - `usePlanningSheetFormReflection.spec.ts` を新規作成し、以下の要件を満たすことを自動テストで担保しました。
    1. 反映アクションによって `assessment` が更新された場合、`isDirty` が `true` になること。
    2. 反映後の `save()` 実行時に、更新されたデータが `PlanningSheetRepository.update` に正しく渡されること。

## Verification Result
- `npx vitest run src/features/planning-sheet/hooks/__tests__` が全件 pass することを確認済み。
