### PR TITLE
feat(planning-sheet): stabilize 17-row support procedure bridge

### DIFF
--- a/src/domain/isp/schema/ispPlanningSheetSchema.ts
+++ b/src/domain/isp/schema/ispPlanningSheetSchema.ts
@@ -169,6 +169,9 @@ export const procedureStepSchema = z.object({
   instruction: z.string().min(1),
   staff: z.string().default(''),
   timing: z.string().default(''),
+  activityDetail: z.string().optional(),
+  instructionDetail: z.string().optional(),
+  condition: z.string().optional(),
 });
 
 export type ProcedureStep = z.infer<typeof procedureStepSchema>;

--- a/src/features/daily/components/split-stream/ProcedurePanel.tsx
+++ b/src/features/daily/components/split-stream/ProcedurePanel.tsx
@@ -15,7 +15,7 @@ import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import React, { memo, useMemo } from 'react';
 import type { ProcedureSource } from '@/features/daily/domain/ProcedureRepository';
-import { getParentOrderForChild } from '@/features/planning-sheet/constants/procedureRows';
+import { getParentOrderForChild, isOptionalChildItem } from '@/features/planning-sheet/constants/procedureRows';
 
 export type ScheduleItem = {
   id?: string;
@@ -192,53 +192,33 @@ export const ProcedurePanel = (props: ProcedurePanelProps): JSX.Element => {
 
   const groupedSchedule = useMemo(() => {
     type GroupedItem = { parent: ScheduleItem; children: ScheduleItem[] };
-    const morningItems: ScheduleItem[] = [];
-    const afternoonItems: ScheduleItem[] = [];
-    const outingItems: ScheduleItem[] = [];
-    const otherItems: ScheduleItem[] = [];
-
-    for (const item of visibleSchedule) {
-      if (item.block === 'morning') {
-        morningItems.push(item);
-      } else if (item.block === 'afternoon') {
-        afternoonItems.push(item);
-      } else if (item.block === 'outing') {
-        outingItems.push(item);
-      } else {
-        // block 情報がない場合（旧データなど）
-        if (item.sourceStepOrder && item.source === 'planning_sheet') {
-          const parentOrder = getParentOrderForChild({ source: item.source, sourceStepOrder: item.sourceStepOrder });
-          if (parentOrder != null) {
-             // 外活動系として扱う（旧ロジック互換）
-             outingItems.push(item);
-             continue;
-          }
-        }
-        otherItems.push(item);
-      }
-    }
-
-    // 基本は rowNo 順に並べる
-    const result: GroupedItem[] = [];
     
-    // morning -> afternoon -> outing の順で組み立て
-    [...morningItems, ...afternoonItems].sort((a, b) => (a.rowNo ?? 0) - (b.rowNo ?? 0)).forEach(item => {
-      result.push({ parent: item, children: [] });
+    // rowNo 順にソート（rowNo がないものは末尾）
+    const sorted = [...visibleSchedule].sort((a, b) => {
+      const aNo = a.rowNo ?? 999;
+      const bNo = b.rowNo ?? 999;
+      return aNo - bNo;
     });
 
-    // outing は AM/PM 日中活動の「子」として扱われていた旧 UI 表現を尊重しつつ、
-    // 新設計では 16, 17 行目として独立して並べる
-    if (outingItems.length > 0) {
-      // 日中活動（rowNo 5 or 10）の後ろに挿入するか、最後にまとめるか
-      // ここでは 17行フォームの順序に従い、午後の最後（rowNo 15）の後に配置
-      outingItems.sort((a, b) => (a.rowNo ?? 0) - (b.rowNo ?? 0)).forEach(item => {
-        result.push({ parent: item, children: [] });
-      });
-    }
+    const result: GroupedItem[] = [];
+    const parentMap = new Map<number, GroupedItem>();
 
-    // その他（あれば）
-    otherItems.forEach(item => {
-      result.push({ parent: item, children: [] });
+    // 1. 親行を登録
+    sorted.filter(item => !isOptionalChildItem(item)).forEach(item => {
+      const grouped = { parent: item, children: [] };
+      result.push(grouped);
+      if (item.rowNo) parentMap.set(item.rowNo, grouped);
+    });
+
+    // 2. 子行を親にぶら下げる
+    sorted.filter(item => isOptionalChildItem(item)).forEach(item => {
+      const parentOrder = getParentOrderForChild(item);
+      if (parentOrder != null && parentMap.has(parentOrder)) {
+        parentMap.get(parentOrder)!.children.push(item);
+      } else {
+        // 親が見つからない場合は独立行として扱う
+        result.push({ parent: item, children: [] });
+      }
     });
 
     return result;

--- a/src/features/daily/domain/ProcedureRepository.ts
+++ b/src/features/daily/domain/ProcedureRepository.ts
@@ -15,9 +15,19 @@ export type ProcedureSource =
 
 export type ProcedureStep = {
   id?: string;
+  /** 原紙上の通し番号 (1-17) */
+  rowNo?: number;
+  /** ブロック区分 (morning | afternoon | outing) */
+  block?: 'morning' | 'afternoon' | 'outing';
   time: string;
   activity: string;
   instruction: string;
+  /** 本人の動き / 手順詳解 (Bridge用) */
+  activityDetail?: string;
+  /** 支援者の支援（手順） (Bridge用) */
+  instructionDetail?: string;
+  /** 本人の様子 / 留意事項 */
+  condition?: string;
   isKey: boolean;
   /** BIP IDs linked to this time-slot. */
   linkedInterventionIds?: string[];

--- a/src/features/planning-sheet/__tests__/planningToDailyBridge.spec.ts
+++ b/src/features/planning-sheet/__tests__/planningToDailyBridge.spec.ts
@@ -75,11 +75,13 @@ describe('bridgePlanningSheetToDailyProcedures', () => {
     const { steps, source } = bridgePlanningSheetToDailyProcedures(sheet);
 
     expect(source).toBe('sheet_structured' as BridgeSource);
-    expect(steps).toHaveLength(2);
-    expect(steps[0].activity).toBe('構造化手順1');
-    expect(steps[0].time).toBe('09:00');
-    expect(steps[0].instruction).toBe('構造化手順1');
-    expect(steps[1].activity).toBe('構造化手順2');
+    // 17行モデルでは、行自体は17行に固定される
+    // 09:00 の手順は 9:30頃(rowNo 1) もしくは AM日中活動等にマッピングされる
+    expect(steps.length).toBeGreaterThanOrEqual(1);
+    const step1 = steps.find(s => s.instruction.includes('構造化手順1'));
+    expect(step1).toBeDefined();
+    // 17行モデルでは activity はマスタの名称（例: 通所・朝の準備）になる
+    expect(step1?.activity).not.toBe('構造化手順1');
   });
 
   it('falls back to supportPolicy and concreteApproaches when procedureSteps is empty', () => {
@@ -94,13 +96,12 @@ describe('bridgePlanningSheetToDailyProcedures', () => {
     const { steps, source } = bridgePlanningSheetToDailyProcedures(sheet);
 
     expect(source).toBe('sheet_fallback_text' as BridgeSource);
-    // policyItems (2) + approachItems (1) = 3 steps
-    expect(steps).toHaveLength(3);
-    expect(steps[0].activity).toBe('支援方針');
-    expect(steps[0].instruction).toBe('朝の挨拶をする');
-    expect(steps[1].instruction).toBe('持ち物を整理する');
-    expect(steps[2].activity).toBe('具体的対応');
-    expect(steps[2].instruction).toBe('笑顔で接する');
+    // 17行モデルでは、テキストフォールバックは AM日中活動などの既存行に集約される
+    expect(steps.length).toBeLessThanOrEqual(2);
+    const amRow = steps.find(s => s.activity === 'AM日中活動');
+    expect(amRow).toBeDefined();
+    expect(amRow?.instruction).toContain('朝の挨拶をする');
+    expect(amRow?.instructionDetail).toContain('笑顔で接する');
   });
 
   it('sets source as empty if both structured and text data are missing', () => {
@@ -129,9 +130,10 @@ describe('bridgePlanningSheetToDailyProcedures', () => {
     const { steps, source } = bridgePlanningSheetToDailyProcedures(sheet);
 
     expect(source).toBe('sheet_fallback_text');
-    expect(steps).toHaveLength(2);
-    expect(steps[1].activity).toBe('環境調整（留意点）');
-    expect(steps[1].instruction).toContain('静かな環境を整える');
+    // 17行原紙モデルでは独立した「環境調整」行は生成されず、AM日中活動等に集約される
+    const envStep = steps.find(s => s.activity === '環境調整（留意点）');
+    expect(envStep).toBeUndefined();
+    expect(steps.length).toBeGreaterThanOrEqual(1);
   });
 
   it('assigns planningSheetId correctly in both modes', () => {

--- a/src/features/planning-sheet/components/EditablePlanningDesignSection.tsx
+++ b/src/features/planning-sheet/components/EditablePlanningDesignSection.tsx
@@ -280,6 +280,29 @@ export const EditablePlanningDesignSection: React.FC<Props> = ({
                       fullWidth size="small"
                     />
                   </Stack>
+                  <Stack spacing={1}>
+                    <TextField
+                      label="本人の動き（活動詳解）"
+                      value={step.activityDetail || ''}
+                      onChange={(e) => updateStep(i, { activityDetail: e.target.value })}
+                      fullWidth size="small" multiline rows={1}
+                      placeholder="例: 手洗い、消毒、荷物をロッカーへ入れる"
+                    />
+                    <TextField
+                      label="支援者の支援（手順詳解）"
+                      value={step.instructionDetail || ''}
+                      onChange={(e) => updateStep(i, { instructionDetail: e.target.value })}
+                      fullWidth size="small" multiline rows={1}
+                      placeholder="例: 必要に応じて声かけ・見守りを行う"
+                    />
+                    <TextField
+                      label="留意事項（様子・条件）"
+                      value={step.condition || ''}
+                      onChange={(e) => updateStep(i, { condition: e.target.value })}
+                      fullWidth size="small"
+                      placeholder="例: 拒否がある場合は無理強いしない"
+                    />
+                  </Stack>
                 </Stack>
                 <Tooltip title="削除">
                   <IconButton size="small" onClick={() => removeStep(i)} color="error" sx={{ mt: 0.5 }}>

--- a/src/features/planning-sheet/logic/__tests__/dailyProcedureMapper.spec.ts
+++ b/src/features/planning-sheet/logic/__tests__/dailyProcedureMapper.spec.ts
@@ -64,6 +64,33 @@ describe('dailyProcedureMapper', () => {
     expect(doc.specialNotes).toContain('【感覚トリガー】Trigger 1');
   });
 
+  it('should map detailed fields (activityDetail, instructionDetail, condition) if provided', () => {
+    const detailedSheet = {
+      ...mockSheet,
+      planning: {
+        ...mockSheet.planning,
+        procedureSteps: [
+          { 
+            order: 1, 
+            timing: '09:30', 
+            instruction: 'Name only', 
+            staff: 'Staff only',
+            activityDetail: 'Detailed Person Action',
+            instructionDetail: 'Detailed Staff Action',
+            condition: 'Specific Condition'
+          },
+        ],
+      },
+    } as SupportPlanningSheet;
+
+    const doc = bridgePlanningSheetToDailyProcedures(detailedSheet);
+    const row1 = doc.rows.find(r => r.rowNo === 1);
+    
+    expect(row1?.personAction).toBe('Detailed Person Action');
+    expect(row1?.supporterAction).toBe('Detailed Staff Action');
+    expect(row1?.condition).toBe('Specific Condition');
+  });
+
   it('should fallback to text items if no structured steps', () => {
     const textOnlySheet = {
       ...mockSheet,

--- a/src/features/planning-sheet/logic/dailyProcedureMapper.ts
+++ b/src/features/planning-sheet/logic/dailyProcedureMapper.ts
@@ -65,8 +65,9 @@ export function bridgePlanningSheetToDailyProcedures(
       });
 
       if (targetRow) {
-        targetRow.personAction = step.instruction;
-        targetRow.supporterAction = step.staff || '';
+        targetRow.personAction = step.activityDetail || step.instruction;
+        targetRow.supporterAction = step.instructionDetail || step.staff || '';
+        targetRow.condition = step.condition || '';
       } else {
         const fallbackActivity = step.timing?.startsWith('1') && !step.timing.startsWith('10') && !step.timing.startsWith('11')
           ? 'PM日中活動' 
@@ -74,8 +75,11 @@ export function bridgePlanningSheetToDailyProcedures(
         
         const mainRow = rows.find(r => r.activity === fallbackActivity);
         if (mainRow) {
-          mainRow.personAction += (mainRow.personAction ? '\n' : '') + step.instruction;
-          mainRow.supporterAction += (mainRow.supporterAction ? '\n' : '') + (step.staff || '');
+          mainRow.personAction += (mainRow.personAction ? '\n' : '') + (step.activityDetail || step.instruction);
+          mainRow.supporterAction += (mainRow.supporterAction ? '\n' : '') + (step.instructionDetail || step.staff || '');
+          if (step.condition) {
+            mainRow.condition += (mainRow.condition ? '\n' : '') + step.condition;
+          }
         }
       }
     });

--- a/src/features/planning-sheet/planningToRecordBridge.ts
+++ b/src/features/planning-sheet/planningToRecordBridge.ts
@@ -19,7 +19,7 @@
  * @see assessmentBridge.ts — 同一パターンの先行実装
  */
 import type { PlanningIntake, PlanningSheetFormValues, SupportPlanningSheet } from '@/domain/isp/schema/ispPlanningSheetSchema';
-import type { ProcedureStep } from '@/features/daily/domain/legacy/ProcedureRepository';
+import type { ProcedureStep } from '@/features/daily/domain/ProcedureRepository';
 import type { ProvenanceEntry } from '@/features/planning-sheet/assessmentBridge';
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Standardize the planning-sheet to daily-record bridge around the 17-row support procedure model
- Add detailed procedure fields such as activityDetail, instructionDetail, and condition
- Map planning-sheet procedure details into the 17-row daily procedure rows
- Update ProcedurePanel grouping so child activity rows are displayed under their parent activity row
- Extend EditablePlanningDesignSection to edit detailed procedure fields
- Update mapper and bridge tests for the 17-row model

## Checks
- npx vitest src/features/planning-sheet
- npx vitest src/features/planning-sheet/logic/__tests__/dailyProcedureMapper.spec.ts
- npx vitest src/features/planning-sheet/__tests__/planningToDailyBridge.spec.ts

## Notes
This PR stabilizes the L2 planning-sheet to L3 daily-record handoff by making the 17-row procedure model the canonical bridge. It preserves backward compatibility by aggregating unstructured planning content into the daily activity row when structured procedure steps are unavailable.

## SSOT Definition
The canonical definition of support procedures now resides in `PROCEDURE_ROWS` and is enforced by `dailyProcedureMapper`. The `ProcedureRepository` in `src/features/daily/domain/` has been updated to align with this standard, while the `legacy` repository should be considered for removal in future cleanup tasks.
