### PR TITLE
fix(daily): resolve procedureStore test regression after 17-row bridge merge

### DIFF
--- a/src/features/daily/hooks/legacy-stores/__tests__/procedureStore.spec.ts
+++ b/src/features/daily/hooks/legacy-stores/__tests__/procedureStore.spec.ts
@@ -45,7 +45,7 @@ describe('procedureStore', () => {
     const items = result.current.getByUser('unknown-user');
 
     expect(items.length).toBeGreaterThan(0);
-    expect(items[0].id).toBe('base-0900');
+    expect(items[0].id).toBe('base-1');
   });
 
   it('save → getByUser ラウンドトリップ', () => {
@@ -156,7 +156,7 @@ describe('procedureStore', () => {
     const { result } = renderHook(() => useProcedureStore());
     // フォールバックの BASE_STEPS が返る
     const items = result.current.getByUser('anyone');
-    expect(items[0].id).toBe('base-0900');
+    expect(items[0].id).toBe('base-1');
     // 壊れたデータは削除されている
     expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
   });

--- a/src/features/daily/stores/__tests__/procedureStore.spec.ts
+++ b/src/features/daily/stores/__tests__/procedureStore.spec.ts
@@ -45,7 +45,7 @@ describe('procedureStore', () => {
     const items = result.current.getByUser('unknown-user');
 
     expect(items.length).toBeGreaterThan(0);
-    expect(items[0].id).toBe('base-0900');
+    expect(items[0].id).toBe('base-1');
   });
 
   it('save → getByUser ラウンドトリップ', () => {
@@ -156,7 +156,7 @@ describe('procedureStore', () => {
     const { result } = renderHook(() => useProcedureStore());
     // フォールバックの BASE_STEPS が返る
     const items = result.current.getByUser('anyone');
-    expect(items[0].id).toBe('base-0900');
+    expect(items[0].id).toBe('base-1');
     // 壊れたデータは削除されている
     expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
   });


### PR DESCRIPTION
The merge of PR #1777 introduced a regression in procedureStore tests because the default 'base-0900' ID changed to 'base-1' with the new official 17-row model. This PR updates the tests to expect the correct IDs.