### PR TITLE
fix(daily): correct support procedure row count text in menu

### DIFF
--- a/src/pages/DailyRecordMenuPage.tsx
+++ b/src/pages/DailyRecordMenuPage.tsx
@@ -406,7 +406,7 @@ const DailyRecordMenuPage: React.FC = () => {
                   • 個別支援計画テンプレート
                 </Typography>
                 <Typography variant="body2" color="text.secondary">
-                  • 1日19行の支援手順展開
+                  • 1日17行の支援手順展開
                 </Typography>
                 <Typography variant="body2" color="text.secondary">
                   • 本人の様子・反応記録


### PR DESCRIPTION
## Summary
- Update static text in  from '19行' to '17行' to match the actual SSOT ()
- This is a wording correction discovered during 17-row procedure model observation

## Checks
- Text-only change in UI component
- Matches  definition