### PR TITLE
fix(daily): apply schema-resolved field names to daily record persistence

### DIFF
--- a/src/features/daily/repositories/sharepoint/SharePointDailyRecordRepository.ts
+++ b/src/features/daily/repositories/sharepoint/SharePointDailyRecordRepository.ts
@@ -67,15 +67,18 @@ export class SharePointDailyRecordRepository implements DailyRecordRepository {
         throw new Error(`Daily records list not found: ${this.listTitle}`);
     }
     const rowsListPath = buildListPath(this.getRowsListTitle());
+    const resolvedRowsFields = await this.schema.resolveRowsFields(rowsListPath);
     const existingItem = await this.data.findItemByDate(input.date, listPath, params?.signal);
 
-    return this.saver.save(input, listPath, rowsListPath, existingItem, params);
+    return this.saver.save(input, listPath, rowsListPath, existingItem, resolvedRowsFields, params);
   }
 
   async load(date: string): Promise<DailyRecordItem | null> {
     const listPath = await this.schema.resolveListPath();
     if (!listPath) return null;
-    return this.data.load(date, listPath, this.getRowsListTitle());
+    const rowsListPath = buildListPath(this.getRowsListTitle());
+    const resolvedRowsFields = await this.schema.resolveRowsFields(rowsListPath);
+    return this.data.load(date, listPath, this.getRowsListTitle(), resolvedRowsFields);
   }
 
   async list(params: DailyRecordRepositoryListParams & { limit?: number }): Promise<DailyRecordItem[]> {
@@ -106,7 +109,9 @@ export class SharePointDailyRecordRepository implements DailyRecordRepository {
   async scanIntegrity(dates: string[], signal?: AbortSignal): Promise<DailyIntegrityException[]> {
     const listPath = await this.schema.resolveListPath();
     if (!listPath) return [];
-    return this.integrity.scan(dates, listPath, this.getRowsListTitle(), signal);
+    const rowsListPath = buildListPath(this.getRowsListTitle());
+    const resolvedRowsFields = await this.schema.resolveRowsFields(rowsListPath);
+    return this.integrity.scan(dates, listPath, this.getRowsListTitle(), resolvedRowsFields, signal);
   }
 
   async checkListExists(): Promise<boolean> {

--- a/src/features/daily/repositories/sharepoint/modules/DataAccess.ts
+++ b/src/features/daily/repositories/sharepoint/modules/DataAccess.ts
@@ -1,9 +1,9 @@
 import type { SpFetchFn } from '@/lib/sp/spLists';
 import { 
     DAILY_RECORD_FIELDS, 
-    DAILY_RECORD_ROWS_FIELDS, 
     type RawSharePointItem,
-    type SharePointResponse 
+    type SharePointResponse,
+    type ResolvedRowsFields 
 } from '../constants';
 import { 
     buildListPath, 
@@ -17,7 +17,12 @@ import { auditLog } from '@/lib/debugLogger';
 export class DailyRecordDataAccess {
     constructor(private readonly spFetch: SpFetchFn) {}
 
-    public async load(date: string, listPath: string, rowsListTitle: string): Promise<DailyRecordItem | null> {
+    public async load(
+        date: string, 
+        listPath: string, 
+        rowsListTitle: string,
+        resolvedRowsFields: ResolvedRowsFields
+    ): Promise<DailyRecordItem | null> {
         const item = await this.findItemByDate(date, listPath);
         if (!item) return null;
 
@@ -28,15 +33,18 @@ export class DailyRecordDataAccess {
             const latestVersion = (item as unknown as Record<string, number>)[DAILY_RECORD_FIELDS.latestVersion] || 0;
             const rowsListPath = buildListPath(rowsListTitle);
             const filter = latestVersion > 0
-                ? `${DAILY_RECORD_ROWS_FIELDS.parentId} eq ${item.Id} and ${DAILY_RECORD_ROWS_FIELDS.version} eq ${latestVersion}`
-                : `${DAILY_RECORD_ROWS_FIELDS.parentId} eq ${item.Id}`;
+                ? `${resolvedRowsFields.parentId} eq ${item.Id} and ${resolvedRowsFields.version} eq ${latestVersion}`
+                : `${resolvedRowsFields.parentId} eq ${item.Id}`;
 
-            const res = await this.spFetch(`${rowsListPath}/items?$filter=${filter}&$select=Payload`);
+            const res = await this.spFetch(`${rowsListPath}/items?$filter=${encodeURIComponent(filter)}&$select=${resolvedRowsFields.payload}`);
             const json = await res.json();
             const rows = json.value || [];
 
             if (rows.length > 0) {
-                record.userRows = rows.map((r: { Payload: string }) => JSON.parse(r.Payload));
+                record.userRows = rows.map((r: Record<string, unknown>) => {
+                    const payloadJson = r[resolvedRowsFields.payload] as string;
+                    return payloadJson ? JSON.parse(payloadJson) : null;
+                }).filter(Boolean);
                 auditLog.debug('daily', `Loaded via version v${latestVersion}`, { count: rows.length });
             } else {
                 auditLog.debug('daily', 'Loaded from legacy JSON fallback', { count: record.userRows.length });

--- a/src/features/daily/repositories/sharepoint/modules/IntegrityScanner.ts
+++ b/src/features/daily/repositories/sharepoint/modules/IntegrityScanner.ts
@@ -1,9 +1,9 @@
 import type { SpFetchFn } from '@/lib/sp/spLists';
 import { 
     DAILY_RECORD_FIELDS, 
-    DAILY_RECORD_ROWS_FIELDS, 
     readNonEmptyEnv,
-    type SharePointItem
+    type SharePointItem,
+    type ResolvedRowsFields
 } from '../constants';
 import { buildListPath } from '../utils/Helpers';
 import { 
@@ -20,7 +20,8 @@ export class DailyRecordIntegrityScanner {
     public async scan(
         dates: string[], 
         listPath: string, 
-        rowsListTitle: string, 
+        rowsListTitle: string,
+        resolvedRowsFields: ResolvedRowsFields,
         signal?: AbortSignal
     ): Promise<DailyIntegrityException[]> {
         if (dates.length === 0) return [];
@@ -43,19 +44,19 @@ export class DailyRecordIntegrityScanner {
             if (parents.length === 0) return [];
 
             const parentIds = parents.map(p => p.id);
-            const idFilters = parentIds.map(id => `${DAILY_RECORD_ROWS_FIELDS.parentId} eq ${id}`).join(' or ');
-            const childUrl = `${rowsListPath}/items?$filter=${idFilters}&$select=ParentID,UserID,Version,Status,Payload,RecordedAt`;
+            const idFilters = parentIds.map(id => `${resolvedRowsFields.parentId} eq ${id}`).join(' or ');
+            const childUrl = `${rowsListPath}/items?$filter=${encodeURIComponent(idFilters)}&$select=${resolvedRowsFields.parentId},${resolvedRowsFields.userId},${resolvedRowsFields.version},${resolvedRowsFields.status},${resolvedRowsFields.payload},${resolvedRowsFields.recordedAt}`;
 
             const cRes = await this.spFetch(childUrl, { signal });
             const cData = await cRes.json();
             const rawChildren = cData.value || [];
 
             const children: ScanSourceChild[] = rawChildren.map((c: Record<string, unknown>) => ({
-                parentId: String(c.ParentID),
-                userId: c.UserID as string,
-                version: (c.Version as number) || 0,
-                status: c.Status as string,
-                recordedAt: c.RecordedAt as string,
+                parentId: String(c[resolvedRowsFields.parentId]),
+                userId: c[resolvedRowsFields.userId] as string,
+                version: (c[resolvedRowsFields.version] as number) || 0,
+                status: c[resolvedRowsFields.status] as string,
+                recordedAt: c[resolvedRowsFields.recordedAt] as string,
             }));
 
             const userIds = [...new Set(children.map(c => c.userId))];
@@ -67,13 +68,13 @@ export class DailyRecordIntegrityScanner {
                     const transportListPath = buildListPath(transportListTitle);
                     for (let i = 0; i < userIds.length; i += 20) {
                         const chunk = userIds.slice(i, i + 20);
-                        const userFilters = chunk.map(uid => `${DAILY_RECORD_ROWS_FIELDS.userId} eq '${uid}'`).join(' or ');
-                        const transportUrl = `${transportListPath}/items?$filter=${userFilters}&$select=UserID`;
+                        const userFilters = chunk.map(uid => `${resolvedRowsFields.userId} eq '${uid}'`).join(' or ');
+                        const transportUrl = `${transportListPath}/items?$filter=${encodeURIComponent(userFilters)}&$select=${resolvedRowsFields.userId}`;
                         const tRes = await this.spFetch(transportUrl, { signal });
                         const tData = await tRes.json();
                         accessories.push(...(tData.value || []).map((t: Record<string, unknown>) => ({
                             type: 'transport' as const,
-                            userId: t.UserID as string,
+                            userId: t[resolvedRowsFields.userId] as string,
                         })));
                     }
                 } catch (accError) {

--- a/src/features/daily/repositories/sharepoint/modules/Saver.ts
+++ b/src/features/daily/repositories/sharepoint/modules/Saver.ts
@@ -1,8 +1,8 @@
 import type { SpFetchFn } from '@/lib/sp/spLists';
 import { 
-    DAILY_RECORD_FIELDS,
-    DAILY_RECORD_ROWS_FIELDS, 
-    type SharePointItem 
+    DAILY_RECORD_FIELDS, 
+    type SharePointItem,
+    type ResolvedRowsFields
 } from '../constants';
 import { 
     SaveDailyRecordInput, 
@@ -24,6 +24,7 @@ export class DailyRecordSaver {
         listPath: string, 
         rowsListPath: string,
         existingItem: SharePointItem | null,
+        resolvedRowsFields: ResolvedRowsFields,
         _params?: DailyRecordRepositoryMutationParams
     ): Promise<void> {
         const finishSpan = startFeatureSpan(HYDRATION_FEATURES.daily.save, {
@@ -77,8 +78,8 @@ export class DailyRecordSaver {
             // Cleanup existing children if update
             if (existingItem) {
                 try {
-                    const filter = `${DAILY_RECORD_ROWS_FIELDS.parentId} eq ${parentId}`;
-                    const res = await this.spFetch(`${rowsListPath}/items?$filter=${filter}&$select=Id`);
+                    const filter = `${resolvedRowsFields.parentId} eq ${parentId}`;
+                    const res = await this.spFetch(`${rowsListPath}/items?$filter=${encodeURIComponent(filter)}&$select=Id`);
                     const json = await res.json();
                     const itemsToDelete = json.value || [];
                     
@@ -98,11 +99,11 @@ export class DailyRecordSaver {
             // Save new children
             for (const row of input.userRows) {
                 const rowPayload = {
-                    [DAILY_RECORD_ROWS_FIELDS.parentId]: parentId,
-                    [DAILY_RECORD_ROWS_FIELDS.userId]: row.userId,
-                    [DAILY_RECORD_ROWS_FIELDS.status]: 'done',
-                    [DAILY_RECORD_ROWS_FIELDS.payload]: JSON.stringify(row),
-                    [DAILY_RECORD_ROWS_FIELDS.recordedAt]: new Date().toISOString(),
+                    [resolvedRowsFields.parentId]: parentId,
+                    [resolvedRowsFields.userId]: row.userId,
+                    [resolvedRowsFields.status]: 'done',
+                    [resolvedRowsFields.payload]: JSON.stringify(row),
+                    [resolvedRowsFields.recordedAt]: new Date().toISOString(),
                 };
                 await this.spFetch(`${rowsListPath}/items`, {
                     method: 'POST',


### PR DESCRIPTION
Resolve '保存反映されない' issue by applying dynamic field resolution results to Saver, DataAccess, and IntegrityScanner modules. This ensures that the application actually uses the resolved field names (e.g., PayloadJSON, SupportRecordPayload) during save and load operations.