### PR TITLE
fix(daily): apply schema-resolved fields to execution records

### DIFF
--- a/src/features/daily/repositories/repositoryFactory.ts
+++ b/src/features/daily/repositories/repositoryFactory.ts
@@ -61,11 +61,12 @@ const createRepository = (
   }
 
   const { baseUrl } = ensureConfig();
-  const { spFetch } = createSpClient(acquireToken, baseUrl);
+  const { spFetch, getListFieldInternalNames } = createSpClient(acquireToken, baseUrl);
 
   return new SharePointDailyRecordRepository({
     spFetch,
     listTitle: options?.listTitle,
+    getListFieldInternalNames,
   });
 };
 

--- a/src/features/daily/repositories/sharepoint/SharePointDailyRecordRepository.ts
+++ b/src/features/daily/repositories/sharepoint/SharePointDailyRecordRepository.ts
@@ -22,6 +22,7 @@ import { DailyIntegrityException } from '../../domain/integrity/dailyIntegrityCh
 type SharePointDailyRecordRepositoryOptions = {
   listTitle?: string;
   spFetch?: SpFetchFn;
+  getListFieldInternalNames?: (listTitle: string) => Promise<Set<string>>;
 };
 
 /**
@@ -47,7 +48,11 @@ export class SharePointDailyRecordRepository implements DailyRecordRepository {
     this.spFetch = options.spFetch;
     this.listTitle = options.listTitle ?? getListTitle();
 
-    this.schema = new DailyRecordSchemaResolver(this.spFetch, this.listTitle);
+    this.schema = new DailyRecordSchemaResolver(
+      this.spFetch, 
+      this.listTitle,
+      options.getListFieldInternalNames
+    );
     this.data = new DailyRecordDataAccess(this.spFetch);
     this.saver = new DailyRecordSaver(this.spFetch);
     this.integrity = new DailyRecordIntegrityScanner(this.spFetch);

--- a/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
+++ b/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
@@ -4,7 +4,6 @@ import type { ExecutionRecordRepository } from '../../domain/legacy/ExecutionRec
 import { 
   getListTitle, 
   getRowsListTitle, 
-  EXECUTION_RECORD_FIELDS, 
   DAILY_RECORD_FIELDS,
   SharePointResponse,
   type ResolvedRowsFields 

--- a/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
+++ b/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
@@ -6,9 +6,12 @@ import {
   getRowsListTitle, 
   EXECUTION_RECORD_FIELDS, 
   DAILY_RECORD_FIELDS,
-  SharePointResponse 
+  SharePointResponse,
+  type ResolvedRowsFields 
 } from './constants';
 import type { JsonRecord } from '@/lib/sp/types';
+import { DailyRecordSchemaResolver } from './modules/SchemaResolver';
+import { buildListPath } from './utils/Helpers';
 
 type SharePointExecutionRecordRepositoryOptions = {
   spFetch: SpFetchFn;
@@ -17,13 +20,16 @@ type SharePointExecutionRecordRepositoryOptions = {
 
 /**
  * SharePointExecutionRecordRepository — 19行記録の SharePoint 永続化アダプター
+ * スキーマドリフト（Payload vs Memo等）を動的に解決する。
  */
 export class SharePointExecutionRecordRepository implements ExecutionRecordRepository {
   private readonly spFetch: SpFetchFn;
   private readonly getListFieldInternalNames?: (listTitle: string) => Promise<Set<string>>;
   private readonly parentListTitle: string;
   private readonly childListTitle: string;
+  private readonly resolver: DailyRecordSchemaResolver;
   
+  private resolvedFields: ResolvedRowsFields | null = null;
   private availableFields = new Map<string, Set<string>>();
   private initPromises = new Map<string, Promise<void>>();
 
@@ -32,6 +38,19 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
     this.getListFieldInternalNames = options.getListFieldInternalNames;
     this.parentListTitle = getListTitle();
     this.childListTitle = getRowsListTitle();
+    this.resolver = new DailyRecordSchemaResolver(
+      this.spFetch, 
+      this.parentListTitle,
+      options.getListFieldInternalNames
+    );
+  }
+
+  private async getResolvedFields(): Promise<ResolvedRowsFields> {
+    if (this.resolvedFields) return this.resolvedFields;
+    
+    const rowsListPath = buildListPath(this.childListTitle);
+    this.resolvedFields = await this.resolver.resolveRowsFields(rowsListPath);
+    return this.resolvedFields;
   }
 
   private async initFields(listTitle: string): Promise<void> {
@@ -60,13 +79,14 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
     if (!fieldSet || fieldSet.size === 0) return payload; // fail-open
 
     const activePayload: Record<string, unknown> = {};
-    // Title is almost always required/present
     if (payload.Title !== undefined) activePayload.Title = payload.Title;
 
     for (const [k, v] of Object.entries(payload)) {
       if (k === 'Title') continue;
-      if (fieldSet.has(k)) {
-        activePayload[k] = v;
+      //Case-insensitive match check for SharePoint flexibility
+      const matchedKey = Array.from(fieldSet).find(f => f.toLowerCase() === k.toLowerCase());
+      if (matchedKey) {
+        activePayload[matchedKey] = v;
       }
     }
     return activePayload;
@@ -115,9 +135,10 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
   }
 
   async getRecords(date: string, userId: string): Promise<ExecutionRecord[]> {
+    const rf = await this.getResolvedFields();
     const dailyKey = `${date}-${userId}`;
     const rowKeyPrefix = dailyKey;
-    const filter = `startsWith(${EXECUTION_RECORD_FIELDS.rowKey}, '${rowKeyPrefix}')`;
+    const filter = `startsWith(${rf.rowKey}, '${rowKeyPrefix}')`;
     const url = `_api/web/lists/getbytitle('${this.childListTitle}')/items?$filter=${encodeURIComponent(filter)}`;
 
     const response = await this.spFetch(url);
@@ -126,12 +147,13 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
     const data: SharePointResponse<JsonRecord> = await response.json();
     if (!data.value) return [];
 
-    return data.value.map((item: JsonRecord) => this.mapToDomain(item));
+    return data.value.map((item: JsonRecord) => this.mapToDomain(item, rf));
   }
 
   async getRecord(date: string, userId: string, scheduleItemId: string): Promise<ExecutionRecord | undefined> {
+    const rf = await this.getResolvedFields();
     const rowKey = `${date}-${userId}-${scheduleItemId}`;
-    const filter = `${EXECUTION_RECORD_FIELDS.rowKey} eq '${rowKey}'`;
+    const filter = `${rf.rowKey} eq '${rowKey}'`;
     const url = `_api/web/lists/getbytitle('${this.childListTitle}')/items?$filter=${encodeURIComponent(filter)}`;
 
     const response = await this.spFetch(url);
@@ -140,10 +162,11 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
     const data: SharePointResponse<JsonRecord> = await response.json();
     if (!data.value || data.value.length === 0) return undefined;
 
-    return this.mapToDomain(data.value[0]);
+    return this.mapToDomain(data.value[0], rf);
   }
 
   async upsertRecord(record: ExecutionRecord): Promise<void> {
+    const rf = await this.getResolvedFields();
     const dailyKey = `${record.date}-${record.userId}`;
     const rowKey = `${dailyKey}-${record.scheduleItemId}`;
 
@@ -152,21 +175,26 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
 
     await this.initFields(this.childListTitle);
     const rawBody = {
-      [EXECUTION_RECORD_FIELDS.title]: record.id,
-      [EXECUTION_RECORD_FIELDS.rowKey]: rowKey,
-      [EXECUTION_RECORD_FIELDS.parentId]: parentId,
-      [EXECUTION_RECORD_FIELDS.userId]: record.userId,
-      [EXECUTION_RECORD_FIELDS.rowNo]: record.scheduleItemId,
-      [EXECUTION_RECORD_FIELDS.status]: record.status,
-      [EXECUTION_RECORD_FIELDS.memo]: record.memo,
-      [EXECUTION_RECORD_FIELDS.staffName]: record.recordedBy,
-      [EXECUTION_RECORD_FIELDS.recordedAt]: record.recordedAt,
-      [EXECUTION_RECORD_FIELDS.bipsJSON]: JSON.stringify(record.triggeredBipIds),
+      [rf.rowKey]: rowKey,
+      [rf.parentId]: parentId,
+      [rf.userId]: record.userId,
+      [rf.rowNo]: record.scheduleItemId,
+      [rf.status]: record.status,
+      [rf.memo]: record.memo,
+      [rf.staffName]: record.recordedBy,
+      [rf.recordedAt]: record.recordedAt,
+      [rf.bipsJSON]: JSON.stringify(record.triggeredBipIds),
     };
+    
+    // Title is needed for POST (creation) but often ignored in MERGE if it doesn't change
+    if (!existing) {
+        rawBody[DAILY_RECORD_FIELDS.title] = record.id;
+    }
+
     const body = this.filterPayload(this.childListTitle, rawBody);
 
     if (existing) {
-      const filter = `${EXECUTION_RECORD_FIELDS.rowKey} eq '${rowKey}'`;
+      const filter = `${rf.rowKey} eq '${rowKey}'`;
       const searchUrl = `_api/web/lists/getbytitle('${this.childListTitle}')/items?$filter=${encodeURIComponent(filter)}&$select=Id`;
       const searchResp = await this.spFetch(searchUrl);
       const searchData: SharePointResponse<JsonRecord> = await searchResp.json();
@@ -206,18 +234,18 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
     return { completed, triggered, rate };
   }
 
-  private mapToDomain(item: JsonRecord): ExecutionRecord {
-    const title = (item[EXECUTION_RECORD_FIELDS.title] || '') as string;
+  private mapToDomain(item: JsonRecord, rf: ResolvedRowsFields): ExecutionRecord {
+    const title = (item.Title || item.title || '') as string;
     return {
       id: title,
       date: title.slice(0, 10), 
-      userId: (item[EXECUTION_RECORD_FIELDS.userId] || '') as string,
-      scheduleItemId: (item[EXECUTION_RECORD_FIELDS.rowNo] || '') as string,
-      status: item[EXECUTION_RECORD_FIELDS.status] as RecordStatus,
-      triggeredBipIds: item[EXECUTION_RECORD_FIELDS.bipsJSON] ? JSON.parse(item[EXECUTION_RECORD_FIELDS.bipsJSON] as string) : [],
-      memo: (item[EXECUTION_RECORD_FIELDS.memo] || '') as string,
-      recordedBy: (item[EXECUTION_RECORD_FIELDS.staffName] || '') as string,
-      recordedAt: (item[EXECUTION_RECORD_FIELDS.recordedAt] || '') as string,
+      userId: (item[rf.userId] || '') as string,
+      scheduleItemId: (item[rf.rowNo] || '') as string,
+      status: item[rf.status] as RecordStatus,
+      triggeredBipIds: item[rf.bipsJSON] ? JSON.parse(item[rf.bipsJSON] as string) : [],
+      memo: (item[rf.memo] || item[rf.payload] || '') as string,
+      recordedBy: (item[rf.staffName] || '') as string,
+      recordedAt: (item[rf.recordedAt] || '') as string,
     };
   }
 }

--- a/src/features/daily/repositories/sharepoint/constants.ts
+++ b/src/features/daily/repositories/sharepoint/constants.ts
@@ -67,6 +67,12 @@ export type ResolvedRowsFields = {
     status: string;
     payload: string;
     recordedAt: string;
+    // Execution record specific
+    rowKey: string;
+    rowNo: string;
+    memo: string;
+    staffName: string;
+    bipsJSON: string;
 };
 
 /**

--- a/src/features/daily/repositories/sharepoint/executionRepositoryFactory.ts
+++ b/src/features/daily/repositories/sharepoint/executionRepositoryFactory.ts
@@ -113,6 +113,7 @@ function createLocalStorageExecutionAdapter(
 export const getExecutionRepository = (
   storeHooks?: ExecutionStoreHooks,
   spFetch?: SpFetchFn,
+  getListFieldInternalNames?: (listTitle: string) => Promise<Set<string>>,
 ): ExecutionRecordRepository => {
 
   const kind = resolveKind();
@@ -134,6 +135,7 @@ export const getExecutionRepository = (
       }
       return new SharePointExecutionRecordRepository({
         spFetch,
+        getListFieldInternalNames,
       });
     }
 

--- a/src/features/daily/repositories/sharepoint/modules/SchemaResolver.ts
+++ b/src/features/daily/repositories/sharepoint/modules/SchemaResolver.ts
@@ -2,6 +2,7 @@ import type { SpFetchFn } from '@/lib/sp/spLists';
 import { 
     DAILY_RECORD_FIELDS, 
     DAILY_RECORD_ROWS_FIELDS,
+    EXECUTION_RECORD_FIELDS,
     readNonEmptyEnv,
     type RowAggregateSource, 
     type ResolvedRowsFields,
@@ -32,7 +33,8 @@ export class DailyRecordSchemaResolver {
 
     constructor(
         private readonly spFetch: SpFetchFn,
-        private readonly listTitle: string
+        private readonly listTitle: string,
+        private readonly getListFieldInternalNames?: (listTitle: string) => Promise<Set<string>>
     ) {}
 
     public async resolveListPath(): Promise<string | null> {
@@ -190,12 +192,18 @@ export class DailyRecordSchemaResolver {
         );
 
         this.resolvedRowsFields = {
-            parentId: resolved.ParentID ?? DAILY_RECORD_ROWS_FIELDS.parentId,
-            userId: resolved.UserID ?? DAILY_RECORD_ROWS_FIELDS.userId,
+            parentId: resolved.parentId ?? DAILY_RECORD_ROWS_FIELDS.parentId,
+            userId: resolved.userId ?? DAILY_RECORD_ROWS_FIELDS.userId,
             version: resolved.version ?? DAILY_RECORD_ROWS_FIELDS.version,
             status: resolved.status ?? DAILY_RECORD_ROWS_FIELDS.status,
             payload: resolved.payload ?? DAILY_RECORD_ROWS_FIELDS.payload,
             recordedAt: resolved.recordedAt ?? DAILY_RECORD_ROWS_FIELDS.recordedAt,
+            // Execution record specific
+            rowKey: resolved.rowKey ?? EXECUTION_RECORD_FIELDS.rowKey,
+            rowNo: resolved.rowNo ?? EXECUTION_RECORD_FIELDS.rowNo,
+            memo: resolved.memo ?? EXECUTION_RECORD_FIELDS.memo,
+            staffName: resolved.staffName ?? EXECUTION_RECORD_FIELDS.staffName,
+            bipsJSON: resolved.bipsJSON ?? EXECUTION_RECORD_FIELDS.bipsJSON,
         };
 
         return this.resolvedRowsFields;
@@ -236,7 +244,7 @@ export class DailyRecordSchemaResolver {
                 DAILY_RECORD_ROW_AGGREGATE_CANDIDATES
             );
             const dateField = resolved.recordDate;
-            const userIdField = resolved.UserID;
+            const userIdField = resolved.userId;
             if (!dateField || !userIdField) continue;
 
             this.resolvedRowAggregateSource = {
@@ -271,6 +279,16 @@ export class DailyRecordSchemaResolver {
     }
 
     private async getListFieldNames(listPath: string): Promise<Set<string> | null> {
+        if (this.getListFieldInternalNames) {
+            try {
+                const match = listPath.match(/getbytitle\('([^']+)'\)/i);
+                const title = match ? match[1] : this.listTitle;
+                return await this.getListFieldInternalNames(title);
+            } catch (err) {
+                console.warn(`[SchemaResolver] getListFieldInternalNames failed for ${listPath}:`, err);
+            }
+        }
+
         try {
             const response = await this.spFetch(`${listPath}/fields?$select=InternalName&$top=500`);
             const payload = (await response.json()) as SharePointResponse<SharePointFieldItem>;

--- a/src/features/daily/repositories/sharepoint/modules/SchemaResolver.ts
+++ b/src/features/daily/repositories/sharepoint/modules/SchemaResolver.ts
@@ -170,6 +170,11 @@ export class DailyRecordSchemaResolver {
                 status: DAILY_RECORD_ROWS_FIELDS.status,
                 payload: DAILY_RECORD_ROWS_FIELDS.payload,
                 recordedAt: DAILY_RECORD_ROWS_FIELDS.recordedAt,
+                rowKey: EXECUTION_RECORD_FIELDS.rowKey,
+                rowNo: EXECUTION_RECORD_FIELDS.rowNo,
+                memo: EXECUTION_RECORD_FIELDS.memo,
+                staffName: EXECUTION_RECORD_FIELDS.staffName,
+                bipsJSON: EXECUTION_RECORD_FIELDS.bipsJSON,
             };
             return this.resolvedRowsFields;
         }
@@ -183,6 +188,11 @@ export class DailyRecordSchemaResolver {
                 status: DAILY_RECORD_ROWS_FIELDS.status,
                 payload: DAILY_RECORD_ROWS_FIELDS.payload,
                 recordedAt: DAILY_RECORD_ROWS_FIELDS.recordedAt,
+                rowKey: EXECUTION_RECORD_FIELDS.rowKey,
+                rowNo: EXECUTION_RECORD_FIELDS.rowNo,
+                memo: EXECUTION_RECORD_FIELDS.memo,
+                staffName: EXECUTION_RECORD_FIELDS.staffName,
+                bipsJSON: EXECUTION_RECORD_FIELDS.bipsJSON,
             };
         }
 

--- a/src/sharepoint/fields/dailyFields.ts
+++ b/src/sharepoint/fields/dailyFields.ts
@@ -134,8 +134,8 @@ export const DAILY_RECORD_CANONICAL_ESSENTIALS: (keyof typeof DAILY_RECORD_CANON
  */
 export const DAILY_RECORD_ROW_AGGREGATE_CANDIDATES = {
   title: ['Title'],
-  ParentID: ['ParentID', 'Parent_x0020_ID', 'cr013_parentid'],
-  UserID: ['UserID', 'UserCode', 'cr013_usercode', 'cr013_personId', 'userId', 'User_x0020_ID'],
+  parentId: ['ParentID', 'Parent_x0020_ID', 'cr013_parentid'],
+  userId: ['UserID', 'UserCode', 'cr013_usercode', 'cr013_personId', 'userId', 'User_x0020_ID'],
   recordDate: ['RecordDate', 'cr013_date', 'cr013_recorddate', 'Date', 'recordDate'],
   status: ['Status', 'status', 'cr013_status'],
   reporterName: ['ReporterName', 'reporterName', 'cr013_reporterName'],
@@ -144,11 +144,16 @@ export const DAILY_RECORD_ROW_AGGREGATE_CANDIDATES = {
   group: ['Group', 'group', 'cr013_group'],
   specialNote: ['SpecialNote', 'specialNote', 'cr013_specialnote'],
   version: ['Version', 'VersionNo', 'cr013_version'],
-  recordedAt: ['RecordedAt', 'Recorded_x0020_At', 'cr013_recordedAt'],
+  recordedAt: ['Recorded_x0020_At', 'RecordedAt', 'cr013_recordedAt'],
+  rowKey: ['RowKey'],
+  rowNo: ['RowNo'],
+  memo: ['Memo', 'Observation', 'Payload', 'payload'],
+  staffName: ['StaffName'],
+  bipsJSON: ['BipsJSON'],
 } as const;
 
 export const DAILY_RECORD_ROW_AGGREGATE_ESSENTIALS: (keyof typeof DAILY_RECORD_ROW_AGGREGATE_CANDIDATES)[] = [
-  'UserID', 'recordDate'
+  'userId', 'recordDate'
 ];
 
 // ActivityDiary フィールド定義は activityDiaryFields.ts に移動しました。


### PR DESCRIPTION
## Summary
- Harden execution record persistence against SharePoint field-name drift
- Use DailyRecordSchemaResolver in SharePointExecutionRecordRepository
- Resolve execution fields such as rowKey, rowNo, memo, staffName, and bipsJSON dynamically
- Fix resolver key casing for parentId / userId
- Pass SharePoint metadata capabilities through executionRepositoryFactory and DailyRecordRepository

## Background
After #1784 and #1785, DailyRecordRows payload resolution was hardened for daily row persistence.  
Browser verification still indicated that execution record persistence could hit SharePoint 400 errors when execution-specific fields differed from canonical names.

## Checks
- npm test -- SharePointExecutionRecordRepository.spec.ts
- npm test -- SharePointDailyRecordRepository.rowAggregate.spec.ts

## Notes
This PR extends the same schema-drift hardening pattern to execution record persistence. It also propagates `getListFieldInternalNames` to resolvers to leverage existing SharePoint field name caches.