### PR TITLE
fix(daily): prevent duplicate SharePoint API path in execution save

### DIFF
--- a/docs/ops/17-row-procedure-observation-log.md
+++ b/docs/ops/17-row-procedure-observation-log.md
@@ -26,21 +26,31 @@ This log documents the observation of the 17-row standard support procedure mode
 - **Integration Note**: While the model is generated, saving/reading historical execution data encountered a schema mismatch error (see Critical Issues).
 
 ### 4. Critical Issues & Discrepancies
+
 > [!IMPORTANT]
 > **SharePoint Schema Mismatch (RESOLVED)**
 > - **Status**: ✅ Resolved in PR #1784, #1785, #1786.
-> - **Solution**: Implemented `SchemaResolver` with dynamic internal name resolution for the `Payload` field.
 > - **Verification**: Persistence now functions correctly across diverse tenant lists.
+> - **Hotfix**: Resolved URL double-prefixing (`_api/web/_api/web`) in `SharePointExecutionRecordRepository.ts`.
 
 > [!IMPORTANT]
 > **Dashboard UI Discrepancy (RESOLVED)**
 > - **Status**: ✅ Resolved in PR #1783.
 > - **Verification**: `DailyRecordMenuPage.tsx` now correctly displays "1日17行の支援手順展開".
 
+## Final Verification (Save → Reload → Display)
+- **Date**: 2026-05-06
+- **Status**: ✅ COMPLETED
+- **Structural Check**: Confirmed exactly 17 rows (Regular Routine 1-15 + External 16-17) are rendered in the wizard.
+- **Persistence Check**: 
+    - Verified that saving a record updates the progress counter (e.g., 0/17 to 1/17) and shows a green checkmark.
+    - Resolved a critical 404/400 error caused by `_api/web/` double-prefixing in the repository layer.
+    - End-to-end data flow is now structurally sound for the 17-row model.
+
 ## Conclusion
-The 17-row procedure model is **structurally stable and correctly reflects planning data** across diverse users. The row ordering and external activity integration are verified. The previously reported SharePoint schema mismatch and UI text discrepancies have been fully resolved. The system is now ready for production-connected stability testing (Save → Reload → Display).
+The 17-row procedure model is **fully integrated and structurally verified**. All legacy 19-row references have been purged, and the repository layer has been hardened against schema drift and URL routing errors. The system is now operational under the 17-row SSOT.
 
 ## Next Steps
 1.  [x] Resolve `Payload` column naming in `DailyRecordRows` list (via Schema Hardening).
 2.  [x] Resolved Dashboard UI "19行" text discrepancy (PR #1783).
-3.  [ ] Conduct a final production UI validation (Save → Reload → Display) to confirm end-to-end data flow stability.
+3.  [x] Conduct a final production UI validation (Save → Reload → Display) to confirm end-to-end data flow stability.

--- a/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
+++ b/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
@@ -93,7 +93,7 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
 
   private async ensureParentRecord(dailyKey: string, date: string, userId: string): Promise<number> {
     const filter = `${DAILY_RECORD_FIELDS.title} eq '${dailyKey}'`;
-    const url = `_api/web/lists/getbytitle('${this.parentListTitle}')/items?$filter=${encodeURIComponent(filter)}&$select=Id`;
+    const url = `lists/getbytitle('${this.parentListTitle}')/items?$filter=${encodeURIComponent(filter)}&$select=Id`;
     
     const response = await this.spFetch(url, { method: 'GET' });
     if (!response.ok) throw new Error(`[ExecutionRepo] Parent lookup failed: ${response.statusText}`);
@@ -103,7 +103,7 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
       return data.value[0].Id as number;
     }
 
-    const createUrl = `_api/web/lists/getbytitle('${this.parentListTitle}')/items`;
+    const createUrl = `lists/getbytitle('${this.parentListTitle}')/items`;
     
     await this.initFields(this.parentListTitle);
     const rawBody = {
@@ -138,7 +138,7 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
     const dailyKey = `${date}-${userId}`;
     const rowKeyPrefix = dailyKey;
     const filter = `startsWith(${rf.rowKey}, '${rowKeyPrefix}')`;
-    const url = `_api/web/lists/getbytitle('${this.childListTitle}')/items?$filter=${encodeURIComponent(filter)}`;
+    const url = `lists/getbytitle('${this.childListTitle}')/items?$filter=${encodeURIComponent(filter)}`;
 
     const response = await this.spFetch(url);
     if (!response.ok) return [];
@@ -153,7 +153,7 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
     const rf = await this.getResolvedFields();
     const rowKey = `${date}-${userId}-${scheduleItemId}`;
     const filter = `${rf.rowKey} eq '${rowKey}'`;
-    const url = `_api/web/lists/getbytitle('${this.childListTitle}')/items?$filter=${encodeURIComponent(filter)}`;
+    const url = `lists/getbytitle('${this.childListTitle}')/items?$filter=${encodeURIComponent(filter)}`;
 
     const response = await this.spFetch(url);
     if (!response.ok) return undefined;
@@ -195,13 +195,13 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
 
     if (existing) {
       const filter = `${rf.rowKey} eq '${rowKey}'`;
-      const searchUrl = `_api/web/lists/getbytitle('${this.childListTitle}')/items?$filter=${encodeURIComponent(filter)}&$select=Id`;
+      const searchUrl = `lists/getbytitle('${this.childListTitle}')/items?$filter=${encodeURIComponent(filter)}&$select=Id`;
       const searchResp = await this.spFetch(searchUrl);
       const searchData: SharePointResponse<JsonRecord> = await searchResp.json();
       
       if (searchData.value && searchData.value.length > 0) {
         const internalId = searchData.value[0].Id;
-        const updateUrl = `_api/web/lists/getbytitle('${this.childListTitle}')/items(${internalId})`;
+        const updateUrl = `lists/getbytitle('${this.childListTitle}')/items(${internalId})`;
         await this.spFetch(updateUrl, {
           method: 'POST',
           headers: {


### PR DESCRIPTION
## Summary
- Fix duplicate `_api/web` path construction in SharePointExecutionRecordRepository
- Resolve production save failure caused by malformed SharePoint request URL
- Update 17-row procedure observation log with final Save → Reload → Display verification result

## Background
During final production-connected verification for the 17-row procedure model, execution record saving reached the SharePoint repository layer but failed due to duplicated `_api/web` in the request path, resulting in a 404.

## Checks
- Browser verification: Save → Reload → Display
- grep -r "_api/web" src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
- git diff --stat

## Notes
This is a persistence URL construction fix. It does not change the 17-row procedure model or schema resolution behavior.
