### PR TITLE
chore(sp): add dry-run check for 17-row DailyRecordRows columns

### DIFF
--- a/docs/ops/17-row-procedure-observation-log.md
+++ b/docs/ops/17-row-procedure-observation-log.md
@@ -92,3 +92,9 @@ The system has reached its final stabilization peak. The reduction of the persis
 - **Guardrail**:
   - `SourceFileName0` is mandatory and blocks readiness when absent.
   - guarded apply is split to the next PR.
+- **Dry-run Raw Output (summary)**:
+  - planned additions: 13
+  - conflicts: 0
+  - drift risks: 0
+  - `SourceFileName0`: present / required
+  - guarded apply readiness: ready

--- a/docs/ops/17-row-procedure-observation-log.md
+++ b/docs/ops/17-row-procedure-observation-log.md
@@ -98,3 +98,17 @@ The system has reached its final stabilization peak. The reduction of the persis
   - drift risks: 0
   - `SourceFileName0`: present / required
   - guarded apply readiness: ready
+- **Final 13-column list (proposed, no apply)**:
+  - `UserCode0`
+  - `RecordDate0`
+  - `RowNo0`
+  - `TimeSlot0`
+  - `Activity0`
+  - `PersonManual0`
+  - `SupporterManual0`
+  - `Situation0`
+  - `Completed0`
+  - `ProcedureType0`
+  - `ParentRowNo0`
+  - `CreatedByName0`
+  - `SourceFileName0`

--- a/docs/ops/17-row-procedure-observation-log.md
+++ b/docs/ops/17-row-procedure-observation-log.md
@@ -79,3 +79,16 @@ The system has reached its final stabilization peak. The reduction of the persis
 - [x] Reduce `localStorage` debounce to 100ms for improved navigation stability.
 - [x] Unify `useExecutionData` repository factories to prevent hydration drift.
 - [x] Conduct multi-date/multi-user regression testing (Verification: 2026-05-06).
+
+## SharePoint Provisioning Dry-Run (17-row columns)
+- **Date**: 2026-05-07
+- **Scope**: `DailyRecordRows` planned 17-row snapshot/audit fields (suffix `0` naming).
+- **Method**: Static dry-run only (`npm run sp:dry-run:17row-columns`), no SharePoint API apply.
+- **Outputs**:
+  - planned additions,
+  - exact internal-name conflicts against current `support_record_rows` provisioning fields,
+  - internal-name drift risks inferred from alias overlap,
+  - guarded apply readiness decision.
+- **Guardrail**:
+  - `SourceFileName0` is mandatory and blocks readiness when absent.
+  - guarded apply is split to the next PR.

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "patrol:exception-center": "node scripts/ops/export-exception-center-summary.mjs",
     "patrol:decision": "node scripts/ops/nightly-decision.mjs",
     "patrol:ledger": "tsx scripts/ops/build-drift-ledger.mjs",
+    "sp:dry-run:17row-columns": "tsx scripts/ops/dry-run-17row-dailyrecordrows-columns.ts",
     "patrol:purge": "tsx scripts/ops/execute-zombie-purge.mjs",
     "patrol:governance": "tsx scripts/ops/nightly-drift-governance.mjs",
     "ops:index-remediate": "tsx scripts/ops/index-remediate.ts",

--- a/scripts/ops/__tests__/dry-run-17row-dailyrecordrows-columns.spec.ts
+++ b/scripts/ops/__tests__/dry-run-17row-dailyrecordrows-columns.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { build17RowColumnsDryRunReport } from '../dry-run-17row-dailyrecordrows-columns';
+
+describe('build17RowColumnsDryRunReport', () => {
+  it('marks guarded apply ready when no exact conflicts and SourceFileName0 exists', () => {
+    const report = build17RowColumnsDryRunReport(
+      [
+        { internalName: 'ParentID', candidates: ['ParentID'] },
+        { internalName: 'UserID', candidates: ['UserID'] },
+      ],
+      [
+        { internalName: 'UserCode0', type: 'Text', displayName: 'User Code', candidates: ['UserCode0', 'UserCode'] },
+        { internalName: 'SourceFileName0', type: 'Text', displayName: 'Source File Name', required: true, candidates: ['SourceFileName0'] },
+      ]
+    );
+
+    expect(report.conflicts).toEqual([]);
+    expect(report.requiredAuditFieldPresent).toBe(true);
+    expect(report.guardedApplyReady).toBe(true);
+  });
+
+  it('reports conflict when proposed internal name already exists', () => {
+    const report = build17RowColumnsDryRunReport(
+      [{ internalName: 'RowNo0', candidates: ['RowNo0'] }],
+      [
+        { internalName: 'RowNo0', type: 'Number', displayName: 'Row No', candidates: ['RowNo0', 'RowNo'] },
+        { internalName: 'SourceFileName0', type: 'Text', displayName: 'Source File Name', required: true, candidates: ['SourceFileName0'] },
+      ]
+    );
+
+    expect(report.conflicts).toEqual(['RowNo0']);
+    expect(report.guardedApplyReady).toBe(false);
+  });
+
+  it('detects drift risk via alias overlap', () => {
+    const report = build17RowColumnsDryRunReport(
+      [{ internalName: 'UserID', candidates: ['User_x0020_ID', 'UserCode'] }],
+      [
+        { internalName: 'UserCode0', type: 'Text', displayName: 'User Code', candidates: ['UserCode0', 'UserCode'] },
+        { internalName: 'SourceFileName0', type: 'Text', displayName: 'Source File Name', required: true, candidates: ['SourceFileName0'] },
+      ]
+    );
+
+    expect(report.internalNameDriftRisks).toEqual([
+      { internalName: 'UserCode0', matchedAliases: ['UserCode'] },
+    ]);
+  });
+});

--- a/scripts/ops/dry-run-17row-dailyrecordrows-columns.ts
+++ b/scripts/ops/dry-run-17row-dailyrecordrows-columns.ts
@@ -1,0 +1,110 @@
+import { dailyListEntries, DAILY_RECORD_ROWS_17ROW_PROPOSED_FIELDS } from '../../src/sharepoint/spListRegistry.definitions';
+
+type ProvisioningField = {
+  internalName: string;
+  candidates?: readonly string[];
+};
+
+type ProposedField = (typeof DAILY_RECORD_ROWS_17ROW_PROPOSED_FIELDS)[number];
+
+export type DryRunReport = {
+  proposedFields: string[];
+  conflicts: string[];
+  internalNameDriftRisks: Array<{ internalName: string; matchedAliases: string[] }>;
+  requiredAuditFieldPresent: boolean;
+  guardedApplyReady: boolean;
+};
+
+const SUPPORT_RECORD_ROWS_KEY = 'support_record_rows';
+
+const getExistingRowsFields = (): ProvisioningField[] => {
+  const entry = dailyListEntries.find((item) => item.key === SUPPORT_RECORD_ROWS_KEY);
+  if (!entry?.provisioningFields) {
+    throw new Error(`Registry entry not found or has no provisioningFields: ${SUPPORT_RECORD_ROWS_KEY}`);
+  }
+  return entry.provisioningFields as ProvisioningField[];
+};
+
+export const build17RowColumnsDryRunReport = (
+  existingFields = getExistingRowsFields(),
+  proposedFields: readonly ProposedField[] = DAILY_RECORD_ROWS_17ROW_PROPOSED_FIELDS
+): DryRunReport => {
+  const existingInternalNames = new Set(existingFields.map((field) => field.internalName));
+  const existingAliasUniverse = new Set<string>();
+  for (const field of existingFields) {
+    existingAliasUniverse.add(field.internalName);
+    for (const alias of field.candidates ?? []) {
+      existingAliasUniverse.add(alias);
+    }
+  }
+
+  const proposedInternalNames = proposedFields.map((field) => field.internalName);
+  const conflicts = proposedInternalNames.filter((name) => existingInternalNames.has(name));
+  const internalNameDriftRisks: Array<{ internalName: string; matchedAliases: string[] }> = [];
+
+  for (const field of proposedFields) {
+    const aliases = (field.candidates ?? []).filter((alias) => alias !== field.internalName);
+    const matchedAliases = aliases.filter((alias) => existingAliasUniverse.has(alias));
+    if (matchedAliases.length > 0) {
+      internalNameDriftRisks.push({
+        internalName: field.internalName,
+        matchedAliases,
+      });
+    }
+  }
+
+  const requiredAuditFieldPresent = proposedInternalNames.includes('SourceFileName0');
+  const guardedApplyReady = requiredAuditFieldPresent && conflicts.length === 0;
+
+  return {
+    proposedFields: proposedInternalNames,
+    conflicts,
+    internalNameDriftRisks,
+    requiredAuditFieldPresent,
+    guardedApplyReady,
+  };
+};
+
+const printReport = (report: DryRunReport): void => {
+  console.log('=== DailyRecordRows 17-row columns dry-run ===');
+  console.log('');
+  console.log('[追加予定列]');
+  for (const field of report.proposedFields) {
+    console.log(`- ${field}`);
+  }
+
+  console.log('');
+  console.log('[既存列と衝突する列]');
+  if (report.conflicts.length === 0) {
+    console.log('- (none)');
+  } else {
+    for (const field of report.conflicts) {
+      console.log(`- ${field}`);
+    }
+  }
+
+  console.log('');
+  console.log('[internal name drift の可能性がある列]');
+  if (report.internalNameDriftRisks.length === 0) {
+    console.log('- (none)');
+  } else {
+    for (const risk of report.internalNameDriftRisks) {
+      console.log(`- ${risk.internalName}: aliases in use -> ${risk.matchedAliases.join(', ')}`);
+    }
+  }
+
+  console.log('');
+  console.log('[guarded apply 判定]');
+  console.log(`- SourceFileName0 present: ${report.requiredAuditFieldPresent ? 'yes' : 'no'}`);
+  console.log(`- guarded apply ready: ${report.guardedApplyReady ? 'yes' : 'no'}`);
+};
+
+const main = (): void => {
+  const report = build17RowColumnsDryRunReport();
+  printReport(report);
+  process.exit(report.guardedApplyReady ? 0 : 1);
+};
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/src/sharepoint/spListRegistry.definitions.ts
+++ b/src/sharepoint/spListRegistry.definitions.ts
@@ -349,6 +349,29 @@ export const dailyListEntries: readonly SpListEntry[] = [
   },
 ];
 
+/**
+ * DailyRecordRows 17行モデル向け 追加予定列（dry-run 専用）
+ *
+ * 注意:
+ * - 本定義は guarded apply 前の候補整理用途。
+ * - 現時点では support_record_rows の provisioningFields へは反映しない。
+ */
+export const DAILY_RECORD_ROWS_17ROW_PROPOSED_FIELDS = [
+  { internalName: 'UserCode0', type: 'Text', displayName: '利用者コード', candidates: ['UserCode0', 'UserCode', 'User_x0020_Code'] },
+  { internalName: 'RecordDate0', type: 'DateTime', displayName: '記録日', dateTimeFormat: 'DateOnly', candidates: ['RecordDate0', 'RecordDate', 'Record_x0020_Date'] },
+  { internalName: 'RowNo0', type: 'Number', displayName: '行番号', candidates: ['RowNo0', 'RowNo'] },
+  { internalName: 'TimeSlot0', type: 'Text', displayName: '時間帯', candidates: ['TimeSlot0', 'TimeSlot', 'Time_x0020_Slot'] },
+  { internalName: 'Activity0', type: 'Text', displayName: '活動内容', candidates: ['Activity0', 'Activity'] },
+  { internalName: 'PersonManual0', type: 'Note', displayName: '本人の動き', richText: false, candidates: ['PersonManual0', 'PersonManual'] },
+  { internalName: 'SupporterManual0', type: 'Note', displayName: '支援者の動き', richText: false, candidates: ['SupporterManual0', 'SupporterManual'] },
+  { internalName: 'Situation0', type: 'Note', displayName: '当日の様子・記録', richText: false, candidates: ['Situation0', 'Situation'] },
+  { internalName: 'Completed0', type: 'Text', displayName: '実行ステータス', candidates: ['Completed0', 'Completed'] },
+  { internalName: 'ProcedureType0', type: 'Text', displayName: 'ブロックカテゴリ', candidates: ['ProcedureType0', 'ProcedureType'] },
+  { internalName: 'ParentRowNo0', type: 'Number', displayName: '親行番号', candidates: ['ParentRowNo0', 'ParentRowNo'] },
+  { internalName: 'CreatedByName0', type: 'Text', displayName: '記録者氏名', candidates: ['CreatedByName0', 'CreatedByName'] },
+  { internalName: 'SourceFileName0', type: 'Text', displayName: '取込元ファイル名', required: true, candidates: ['SourceFileName0', 'SourceFileName'] },
+] as const;
+
 export const attendanceListEntries: readonly SpListEntry[] = [
 // ── 3. 出席管理系 ──────────────────────────────────────
   {


### PR DESCRIPTION
## Summary
- add dry-run-only proposed field registry for 17-row `DailyRecordRows` column expansion (no apply)
- add `scripts/ops/dry-run-17row-dailyrecordrows-columns.ts` to report:
  - planned additions
  - exact name conflicts
  - internal-name drift risks (alias overlap)
  - guarded apply readiness
- enforce `SourceFileName0` as required audit field in dry-run readiness gate
- add unit tests for dry-run analyzer and update ops observation log

## Scope guard
- this PR does **not** add/alter production SharePoint columns
- guarded apply is intentionally deferred to next PR

## Validation
- `npm run sp:dry-run:17row-columns`
- `npx vitest run scripts/ops/__tests__/dry-run-17row-dailyrecordrows-columns.spec.ts --reporter=verbose --no-file-parallelism`
