### PR TITLE
fix(daily): 17行記録保存時のOData型エラーを回避

### DIFF
--- a/src/features/daily/repositories/sharepoint/SharePointBehaviorRepository.ts
+++ b/src/features/daily/repositories/sharepoint/SharePointBehaviorRepository.ts
@@ -22,12 +22,35 @@ export class SharePointBehaviorRepository implements BehaviorRepository {
   private readonly sp: ReturnType<typeof createSpClient>;
   private readonly listTitle = LIST_CONFIG[ListKeys.DailyActivityRecords].title;
   private readonly defaultTop: number;
+  private entityType: string | null = null;
 
   constructor(options: SharePointBehaviorRepositoryOptions = {}) {
     this.ensureSharePointConfig();
     this.defaultTop = options.defaultTop ?? SP_QUERY_LIMITS.default;
     const { baseUrl } = ensureConfig();
     this.sp = options.sp ?? createSpClient(acquireSpAccessToken, baseUrl);
+  }
+
+  private async getEntityType(): Promise<string> {
+    if (this.entityType) return this.entityType;
+    try {
+      const url = `/lists/getbytitle('${encodeURIComponent(this.listTitle)}')?$select=ListItemEntityTypeFullName`;
+      const res = await this.sp.spFetch(url);
+      if (res.ok) {
+        const data = await res.json();
+        const type = data.ListItemEntityTypeFullName || data.d?.ListItemEntityTypeFullName;
+        if (type) {
+          this.entityType = type;
+          return type;
+        }
+      }
+    } catch (e) {
+      console.warn('[SharePointBehaviorRepository] Failed to fetch ListItemEntityTypeFullName:', e);
+    }
+    const cleanTitle = this.listTitle.replace(/[^a-zA-Z0-9]/g, '');
+    const fallback = `SP.Data.${cleanTitle}ListItem`;
+    this.entityType = fallback;
+    return fallback;
   }
 
   async add(observation: Omit<ABCRecord, 'id'>): Promise<ABCRecord> {
@@ -40,13 +63,17 @@ export class SharePointBehaviorRepository implements BehaviorRepository {
 
     const payload = this.toRequest(observation, internalNames);
     const url = `/lists/getbytitle('${encodeURIComponent(this.listTitle)}')/items`;
+    const typeName = await this.getEntityType();
     const res = await this.sp.spFetch(url, {
       method: 'POST',
       headers: {
         Accept: 'application/json;odata=nometadata',
         'Content-Type': 'application/json;odata=nometadata',
       },
-      body: JSON.stringify(payload),
+      body: JSON.stringify({
+        ...payload,
+        __metadata: { type: typeName },
+      }),
     });
     const data = (await res.json().catch(() => ({}))) as Record<string, unknown>;
     // SharePoint の作成レスポンスは列を省略する場合があるため、

--- a/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
+++ b/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
@@ -137,7 +137,7 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
     const createResponse = await this.spFetch(createUrl, {
       method: 'POST',
       body: JSON.stringify(body),
-      headers: { 'Content-Type': 'application/json;odata=verbose', 'Accept': 'application/json;odata=verbose' }
+      headers: { 'Content-Type': 'application/json;odata=nometadata', 'Accept': 'application/json;odata=nometadata' }
     });
 
     if (createResponse.ok) {
@@ -239,7 +239,8 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
           headers: {
             'X-HTTP-Method': 'MERGE',
             'If-Match': '*',
-            'Content-Type': 'application/json;odata=verbose'
+            'Content-Type': 'application/json;odata=nometadata',
+            'Accept': 'application/json;odata=nometadata'
           },
           body: JSON.stringify(body),
         });
@@ -248,7 +249,10 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
       const createUrl = `${this.resolvedChildPath}/items`;
       await this.spFetch(createUrl, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json;odata=verbose' },
+        headers: { 
+          'Content-Type': 'application/json;odata=nometadata',
+          'Accept': 'application/json;odata=nometadata'
+        },
         body: JSON.stringify(body),
       });
     }

--- a/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
+++ b/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
@@ -37,6 +37,7 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
   private resolvedChildPath: string | null = null;
   private availableFields = new Map<string, Set<string>>();
   private initPromises = new Map<string, Promise<void>>();
+  private entityTypes = new Map<string, string>();
 
   constructor(options: SharePointExecutionRecordRepositoryOptions) {
     this.spFetch = options.spFetch;
@@ -49,6 +50,30 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
       this.parentListTitle,
       options.getListFieldInternalNames
     );
+  }
+
+  private async getEntityType(listTitle: string): Promise<string> {
+    const cached = this.entityTypes.get(listTitle);
+    if (cached) return cached;
+    try {
+      const base = listTitle.startsWith('/') ? listTitle : `/lists/getbytitle('${encodeURIComponent(listTitle)}')`;
+      const url = `${base}?$select=ListItemEntityTypeFullName`;
+      const res = await this.spFetch(url);
+      if (res.ok) {
+        const data = await res.json();
+        const type = data.ListItemEntityTypeFullName || data.d?.ListItemEntityTypeFullName;
+        if (type) {
+          this.entityTypes.set(listTitle, type);
+          return type;
+        }
+      }
+    } catch (e) {
+      console.warn(`[ExecutionRepo] Failed to fetch ListItemEntityTypeFullName for ${listTitle}:`, e);
+    }
+    const cleanTitle = listTitle.replace(/[^a-zA-Z0-9]/g, '');
+    const fallback = `SP.Data.${cleanTitle}ListItem`;
+    this.entityTypes.set(listTitle, fallback);
+    return fallback;
   }
 
   private async getResolvedFields(): Promise<ResolvedRowsFields> {
@@ -133,16 +158,20 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
       [DAILY_RECORD_FIELDS.userRowsJSON]: '[]',
     };
     const body = this.filterPayload(this.parentListTitle, rawBody);
+    const parentEntityType = await this.getEntityType(this.parentListTitle);
 
     const createResponse = await this.spFetch(createUrl, {
       method: 'POST',
-      body: JSON.stringify(body),
+      body: JSON.stringify({
+        ...body,
+        __metadata: { type: parentEntityType },
+      }),
       headers: { 'Content-Type': 'application/json;odata=nometadata', 'Accept': 'application/json;odata=nometadata' }
     });
 
     if (createResponse.ok) {
       const result = await createResponse.json();
-      return result.d.Id;
+      return result.d ? result.d.Id : result.Id;
     }
 
     const secondAttemptResponse = await this.spFetch(url, { method: 'GET' });
@@ -224,6 +253,7 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
     }
 
     const body = this.filterPayload(this.childListTitle, rawBody);
+    const childEntityType = await this.getEntityType(this.childListTitle);
 
     if (existing) {
       const filter = `${rf.rowKey} eq '${rowKey}'`;
@@ -242,7 +272,10 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
             'Content-Type': 'application/json;odata=nometadata',
             'Accept': 'application/json;odata=nometadata'
           },
-          body: JSON.stringify(body),
+          body: JSON.stringify({
+            ...body,
+            __metadata: { type: childEntityType },
+          }),
         });
       }
     } else {
@@ -253,7 +286,10 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
           'Content-Type': 'application/json;odata=nometadata',
           'Accept': 'application/json;odata=nometadata'
         },
-        body: JSON.stringify(body),
+        body: JSON.stringify({
+          ...body,
+          __metadata: { type: childEntityType },
+        }),
       });
     }
 

--- a/src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts
+++ b/src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts
@@ -130,4 +130,79 @@ describe('SharePointExecutionRecordRepository', () => {
     // Should include StaffName as filtering was skipped (fallback to full payload)
     expect(body[EXECUTION_RECORD_FIELDS.staffName]).toBe('Staff A');
   });
+
+  it('dynamically resolves list entity type name and parses flat parent ID (no .d wrapper)', async () => {
+    const record: ExecutionRecord = {
+      id: 'R999',
+      date: '2024-01-01',
+      userId: 'U999',
+      scheduleItemId: 'S999',
+      status: 'completed',
+      memo: 'Resilience test',
+      recordedAt: '2024-01-01T11:00:00Z',
+      recordedBy: 'Staff B',
+      triggeredBipIds: [],
+    };
+
+    // Reset mocks for sequence-independent URL-based implementation mock
+    mockSpFetch.mockReset();
+    mockSpFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url.includes('$select=ListItemEntityTypeFullName')) {
+        if (url.includes('SupportRecord_Daily') || url.includes('DailyRecords')) {
+          return {
+            ok: true,
+            json: async () => ({ ListItemEntityTypeFullName: 'SP.Data.SupportRecord_DailyListItem' })
+          };
+        }
+        if (url.includes('DailyRecordRows')) {
+          return {
+            ok: true,
+            json: async () => ({ ListItemEntityTypeFullName: 'SP.Data.DailyRecordRowsListItem' })
+          };
+        }
+      }
+      if (url.includes('items') && init?.method === 'POST') {
+        if (url.includes('SupportRecord_Daily') || url.includes('DailyRecords')) {
+          return {
+            ok: true,
+            json: async () => ({ Id: 777 }) // flat response JSON
+          };
+        }
+        return {
+          ok: true,
+          json: async () => ({ Id: 888 })
+        };
+      }
+      // Default empty responses for probe paths
+      return {
+        ok: true,
+        json: async () => ({ value: [] })
+      };
+    });
+
+    await repo.upsertRecord(record);
+
+    // Verify parent list entity type name request was made
+    const parentMetaCall = mockSpFetch.mock.calls.find(call => 
+      call[0].includes('SupportRecord_Daily') && call[0].includes('$select=ListItemEntityTypeFullName')
+    );
+    expect(parentMetaCall).toBeDefined();
+
+    // Verify parent creation payload has __metadata with correct type
+    const parentCreateCall = mockSpFetch.mock.calls.find(call =>
+      call[0].includes('SupportRecord_Daily') && call[1]?.method === 'POST'
+    );
+    expect(parentCreateCall).toBeDefined();
+    const parentBody = JSON.parse(parentCreateCall![1]!.body as string);
+    expect(parentBody.__metadata).toEqual({ type: 'SP.Data.SupportRecord_DailyListItem' });
+
+    // Verify child creation payload has parentId set to the parsed flat ID (777)
+    const childCreateCall = mockSpFetch.mock.calls.find(call =>
+      call[0].includes('DailyRecordRows') && call[1]?.method === 'POST'
+    );
+    expect(childCreateCall).toBeDefined();
+    const childBody = JSON.parse(childCreateCall![1]!.body as string);
+    expect(childBody[EXECUTION_RECORD_FIELDS.parentId]).toBe(777);
+    expect(childBody.__metadata).toEqual({ type: 'SP.Data.DailyRecordRowsListItem' });
+  });
 });


### PR DESCRIPTION
## 概要

17行記録（ExecutionRecord / ABCRecord）の保存・更新時に、SharePoint Online 環境で `ListItemEntityTypeFullName` が未指定のためOData型エラー（400 Bad Request）が発生し保存できない障害を修正。

## 変更内容

### 追加
- `SharePointBehaviorRepository` に `getEntityType()` ヘルパーを追加（`ListItemEntityTypeFullName` を動的取得・キャッシュ）
- `SharePointExecutionRecordRepository` に `getEntityType(listTitle)` ヘルパーを追加（親リスト・子リスト両方に対応）
- `SharePointExecutionRecordRepository.spec.ts` に動的型解決・フラットIDパースの自動テストを追加

### 変更
- `SharePointBehaviorRepository.add()` の POST payload に `__metadata: { type }` を付与
- `SharePointExecutionRecordRepository.ensureParentRecord()` の POST payload に `__metadata: { type }` を付与
- `SharePointExecutionRecordRepository.upsertRecord()` の POST / MERGE payload に `__metadata: { type }` を付与
- 親レコード作成レスポンスの ID 取得を `result.d.Id`（verbose）だけでなく `result.Id`（nometadata / minimalmetadata）にもフォールバック対応
- `odata=verbose` → `odata=nometadata` への統一（既存の他リポジトリとの一貫性確保）

## 変更ファイル一覧

| ファイル | 変更種別 | 変更内容 |
|---------|---------|---------|
| `SharePointBehaviorRepository.ts` | 変更 | `getEntityType()` 追加、POST 時の `__metadata` 設定 |
| `SharePointExecutionRecordRepository.ts` | 変更 | `getEntityType()` 追加、POST/MERGE 時の `__metadata` 設定、flat/nested レスポンスパースのロバスト化 |
| `SharePointExecutionRecordRepository.spec.ts` | 追加 | entity type 動的解決と flat ID parse のテストケース追加 |

## テスト
- [x] 既存テスト通過（`npm run test:daily:mini`）
- [x] 型チェック通過（`npm run typecheck`）
- [x] 新規テスト追加（動的型解決、フラットIDパースの自動テスト）

## セルフレビュー
- [x] `console.log` 残していない
- [x] `any` 使っていない
- [x] 責務分離を守っている
- [x] 600行ルール違反なし

## 影響範囲
- `/daily/support` 記録保存（17行 ExecutionRecord）
- `/daily/support` ABC記録保存（BehaviorRecord）
- SharePoint Online 接続時の全 POST / MERGE 操作