### PR TITLE
fix(daily): bind SharePoint execution repository methods

### DIFF
--- a/src/features/daily/repositories/sharepoint/executionRepositoryFactory.ts
+++ b/src/features/daily/repositories/sharepoint/executionRepositoryFactory.ts
@@ -24,10 +24,6 @@ import type { ExecutionRecord } from '../../domain/legacy/executionRecordTypes';
 import { SharePointExecutionRecordRepository } from './SharePointExecutionRecordRepository';
 import type { SpFetchFn } from '@/lib/sp/spLists';
 
-
-
-
-
 // ────────────────────────────────────────────────────────────
 // Types
 // ────────────────────────────────────────────────────────────
@@ -53,7 +49,6 @@ const shouldUseLocalRepository = (): boolean => {
   );
 };
 
-
 const resolveKind = (forced?: ExecutionRepositoryKind): ExecutionRepositoryKind =>
   forced ?? (shouldUseLocalRepository() ? 'local' : 'sharepoint');
 
@@ -73,10 +68,10 @@ export type ExecutionStoreHooks = {
 };
 
 // ────────────────────────────────────────────────────────────
-// LocalStorage Adapter (wraps ExecutionStore)
+// Adapters
 //
-// Uses a plain object (not a class) so that methods work correctly
-// when destructured: `const { getRecord } = useExecutionData()`.
+// Uses plain objects so methods work correctly when destructured:
+// `const { getRecord } = useExecutionData()`.
 // Class methods lose `this` binding in that scenario.
 // ────────────────────────────────────────────────────────────
 
@@ -95,6 +90,20 @@ function createLocalStorageExecutionAdapter(
   };
 }
 
+function createSharePointExecutionAdapter(
+  repository: SharePointExecutionRecordRepository,
+): ExecutionRecordRepository {
+  return {
+    getRecords: async (date: string, userId: string) =>
+      repository.getRecords(date, userId),
+    getRecord: async (date: string, userId: string, scheduleItemId: string) =>
+      repository.getRecord(date, userId, scheduleItemId),
+    upsertRecord: async (record: ExecutionRecord) =>
+      repository.upsertRecord(record),
+    getCompletionRate: async (date: string, userId: string, totalSlots: number) =>
+      repository.getCompletionRate(date, userId, totalSlots),
+  };
+}
 
 // ────────────────────────────────────────────────────────────
 // Public API
@@ -137,13 +146,13 @@ export const getExecutionRepository = (
           '[ExecutionRepositoryFactory] spFetch is required for sharepoint repository.',
         );
       }
-      return new SharePointExecutionRecordRepository({
+      const repository = new SharePointExecutionRecordRepository({
         spFetch,
         getListFieldInternalNames,
         store: storeHooks,
       });
+      return createSharePointExecutionAdapter(repository);
     }
-
 
     default: {
       const _exhaustive: never = kind;


### PR DESCRIPTION
## Summary
- Wrap `SharePointExecutionRecordRepository` in a plain-object adapter before returning it from `getExecutionRepository`
- Keep the public `ExecutionRecordRepository` contract safe for destructuring, matching the localStorage adapter behavior
- Fix production `/kiosk/users` detail flow crash: `Cannot read properties of undefined (reading 'getResolvedFields')`

## Why
`useExecutionRecord` destructures repository methods from `useExecutionData`:

```ts
const { getRecord, upsertRecord } = useExecutionData();
```

The local adapter already returns a plain object because class methods lose `this` binding when destructured. The SharePoint path returned the class instance directly, so `getRecord()` executed with `this === undefined` and crashed when accessing `this.getResolvedFields()`.

## Validation
- Code-only hotfix; change is limited to `executionRepositoryFactory.ts`
- Recommended checks: `npm run typecheck`, `npm run test:daily:mini`, kiosk detail route smoke

## Impact
- `/kiosk/users/:userId/procedures/:slotKey` detail load
- Any SharePoint-mode consumer that destructures execution repository methods