### PR TITLE
feat(kiosk): add observation chips to procedure detail record

### DIFF
--- a/src/features/daily/hooks/useExecutionRecord.ts
+++ b/src/features/daily/hooks/useExecutionRecord.ts
@@ -56,6 +56,26 @@ export function useExecutionRecord(date: string, userId: string, scheduleItemId:
     [record, upsertRecord],
   );
 
-  return { record, setStatus, setMemo, isLoading, refresh: fetchRecord } as const;
+  const saveRecord = useCallback(
+    async (status: RecordStatus, memo?: string, triggeredBipIds?: string[]) => {
+      const next: ExecutionRecord = {
+        id: makeRecordId(date, userId, scheduleItemId),
+        date,
+        userId,
+        scheduleItemId,
+        status,
+        memo: memo !== undefined ? memo : (record?.memo ?? ''),
+        triggeredBipIds: triggeredBipIds !== undefined ? triggeredBipIds : (record?.triggeredBipIds ?? []),
+        recordedBy: record?.recordedBy ?? '',
+        recordedAt: new Date().toISOString(),
+      };
+      setRecord(next);
+      await upsertRecord(next);
+    },
+    [date, userId, scheduleItemId, record, upsertRecord],
+  );
+
+  return { record, setStatus, setMemo, saveRecord, isLoading, refresh: fetchRecord } as const;
 }
+
 

--- a/src/features/daily/stores/executionStore.ts
+++ b/src/features/daily/stores/executionStore.ts
@@ -4,7 +4,7 @@
 // Zustand ベースのリアクティブストア + localStorage 永続化
 // デバイスローカル永続化（MVP段階）
 // ---------------------------------------------------------------------------
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { create } from 'zustand';
 
 import {
@@ -150,10 +150,10 @@ export function useExecutionStore() {
     [getRecords],
   );
 
-  return {
+  return useMemo(() => ({
     getRecords,
     getRecord,
     upsertRecord,
     getCompletionRate,
-  } as const;
+  }), [getRecords, getRecord, upsertRecord, getCompletionRate]);
 }

--- a/src/features/daily/stores/procedureStore.ts
+++ b/src/features/daily/stores/procedureStore.ts
@@ -6,7 +6,7 @@
 // ---------------------------------------------------------------------------
 import type { ScheduleItem } from '@/features/daily/components/split-stream/ProcedurePanel';
 import { PROCEDURE_ROWS } from '@/features/planning-sheet/constants/procedureRows';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { create } from 'zustand';
 
 export type ProcedureItem = ScheduleItem;
@@ -151,10 +151,10 @@ export function useProcedureStore() {
     return Object.keys(snapshot);
   }, [snapshot]);
 
-  return {
+  return useMemo(() => ({
     getByUser,
     save,
     hasUserData,
     registeredUserIds,
-  } as const;
+  }), [getByUser, save, hasUserData, registeredUserIds]);
 }

--- a/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
@@ -10,7 +10,7 @@ import { useProcedureData } from '@/features/daily/hooks/useProcedureData';
 import { useExecutionRecord } from '@/features/daily/hooks/useExecutionRecord';
 import { formatDateIso } from '@/lib/dateFormat';
 
-const MOOD_CHIPS = ['落ち着いていた', '不安そう', '拒否あり', '興興あり', '切り替え困難'];
+const MOOD_CHIPS = ['落ち着いていた', '不安そう', '拒否あり', '興奮あり', '切り替え困難'];
 const ACTION_CHIPS = ['見守り', '声かけ', '環境調整', '活動変更', '距離を取る', 'クールダウン'];
 const RESULT_CHIPS = ['改善した', '変化なし', '悪化した', '途中で落ち着いた'];
 

--- a/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Box, Typography, IconButton, Paper, Grid, Button, Chip, Stack, Alert, Snackbar } from '@mui/material';
+import { Box, Typography, IconButton, Paper, Grid, Button, Chip, Stack, Alert, Snackbar, TextField } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
@@ -9,6 +9,10 @@ import { useUser } from '@/features/users/useUsers';
 import { useProcedureData } from '@/features/daily/hooks/useProcedureData';
 import { useExecutionRecord } from '@/features/daily/hooks/useExecutionRecord';
 import { formatDateIso } from '@/lib/dateFormat';
+
+const MOOD_CHIPS = ['落ち着いていた', '不安そう', '拒否あり', '興興あり', '切り替え困難'];
+const ACTION_CHIPS = ['見守り', '声かけ', '環境調整', '活動変更', '距離を取る', 'クールダウン'];
+const RESULT_CHIPS = ['改善した', '変化なし', '悪化した', '途中で落ち着いた'];
 
 export const KioskProcedureDetailScreen: React.FC = () => {
   const navigate = useNavigate();
@@ -29,16 +33,63 @@ export const KioskProcedureDetailScreen: React.FC = () => {
 
   // scheduleItemId として ID もしくは インデックスを使用する
   const scheduleItemId = procedure?.id || slotKey || '';
-  const { record, setStatus } = useExecutionRecord(today, userId || '', scheduleItemId);
+  const { record, saveRecord, isLoading } = useExecutionRecord(today, userId || '', scheduleItemId);
   
   const [isSaving, setIsSaving] = useState(false);
   const [showSuccess, setShowSuccess] = useState(false);
+
+  // 観察チップ用ステート
+  const [selectedMood, setSelectedMood] = useState<string>('');
+  const [selectedAction, setSelectedAction] = useState<string>('');
+  const [selectedResult, setSelectedResult] = useState<string>('');
+  const [textMemo, setTextMemo] = useState<string>('');
+  const [showObservations, setShowObservations] = useState(false);
+  const [isInitialized, setIsInitialized] = useState(false);
+
+  // 以前の保存記録からステートを復元する（1回限り）
+  React.useEffect(() => {
+    if (isLoading || isInitialized || !record) return;
+    
+    const memoText = record.memo || '';
+    const moodMatch = memoText.match(/【様子】([^\n]+)/);
+    const actionMatch = memoText.match(/【対応】([^\n]+)/);
+    const resultMatch = memoText.match(/【変化】([^\n]+)/);
+    const textMatch = memoText.match(/【メモ】([\s\S]+)/);
+    
+    if (moodMatch) setSelectedMood(moodMatch[1].trim());
+    if (actionMatch) setSelectedAction(actionMatch[1].trim());
+    if (resultMatch) setSelectedResult(resultMatch[1].trim());
+    
+    if (textMatch) {
+      setTextMemo(textMatch[1].trim());
+    } else if (memoText.trim()) {
+      const hasLabels = memoText.includes('【様子】') || memoText.includes('【対応】') || memoText.includes('【変化】');
+      if (!hasLabels) {
+        setTextMemo(memoText.trim());
+      }
+    }
+    
+    if (record.status === 'triggered') {
+      setShowObservations(true);
+    }
+    setIsInitialized(true);
+  }, [record, isLoading, isInitialized]);
+
+  const serializeMemo = () => {
+    const parts: string[] = [];
+    if (selectedMood) parts.push(`【様子】${selectedMood}`);
+    if (selectedAction) parts.push(`【対応】${selectedAction}`);
+    if (selectedResult) parts.push(`【変化】${selectedResult}`);
+    if (textMemo.trim()) parts.push(`【メモ】${textMemo.trim()}`);
+    return parts.join('\n');
+  };
 
   const handleSave = async (newStatus: 'completed' | 'triggered') => {
     if (!userId) return;
     setIsSaving(true);
     try {
-      await setStatus(newStatus);
+      const finalMemo = newStatus === 'triggered' ? serializeMemo() : '';
+      await saveRecord(newStatus, finalMemo);
       setShowSuccess(true);
       // 成功フィードバックの後、少し待ってから一覧に戻る
       setTimeout(() => {
@@ -50,7 +101,11 @@ export const KioskProcedureDetailScreen: React.FC = () => {
     }
   };
 
-  if (isUserLoading) {
+  const handleTriggerClick = () => {
+    setShowObservations(!showObservations);
+  };
+
+  if (isUserLoading || isLoading) {
     return <Box sx={{ p: 4 }}>読み込み中...</Box>;
   }
 
@@ -114,7 +169,7 @@ export const KioskProcedureDetailScreen: React.FC = () => {
       </Box>
 
       {/* メインコンテンツ */}
-      <Grid container spacing={4} sx={{ flexGrow: 1 }}>
+      <Grid container spacing={4} sx={{ flexGrow: 1, mb: 4 }}>
         {/* 本人のやる事 */}
         <Grid size={{ xs: 12, md: 6 }}>
           <Paper 
@@ -165,30 +220,176 @@ export const KioskProcedureDetailScreen: React.FC = () => {
         </Grid>
       </Grid>
 
+      {/* 観察記録の入力パネル */}
+      {showObservations && (
+        <Paper
+          elevation={0}
+          sx={{
+            p: 4,
+            mb: 4,
+            borderRadius: 6,
+            border: '2px solid',
+            borderColor: 'warning.light',
+            bgcolor: 'warning.lighter',
+          }}
+          data-testid="kiosk-observation-panel"
+        >
+          <Typography variant="h5" color="warning.main" sx={{ mb: 3, fontWeight: 'bold', display: 'flex', alignItems: 'center' }}>
+            <Box sx={{ width: 8, height: 24, bgcolor: 'warning.main', mr: 2, borderRadius: 1 }} />
+            観察記録の追加 (注意あり)
+          </Typography>
+
+          <Stack spacing={4}>
+            {/* 1. 本人の様子 */}
+            <Box>
+              <Typography variant="h6" sx={{ fontWeight: 'bold', mb: 1.5, color: 'text.secondary' }}>
+                本人の様子
+              </Typography>
+              <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
+                {MOOD_CHIPS.map((chip) => {
+                  const active = selectedMood === chip;
+                  return (
+                    <Chip
+                      key={chip}
+                      label={chip}
+                      onClick={() => setSelectedMood(active ? '' : chip)}
+                      color={active ? 'warning' : 'default'}
+                      variant={active ? 'filled' : 'outlined'}
+                      sx={{ fontSize: '1.1rem', py: 2.5, px: 1, borderRadius: 3, fontWeight: active ? 'bold' : 'normal' }}
+                      data-testid={`mood-chip-${chip}`}
+                    />
+                  );
+                })}
+              </Stack>
+            </Box>
+
+            {/* 2. 支援者の対応 */}
+            <Box>
+              <Typography variant="h6" sx={{ fontWeight: 'bold', mb: 1.5, color: 'text.secondary' }}>
+                支援者の対応
+              </Typography>
+              <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
+                {ACTION_CHIPS.map((chip) => {
+                  const active = selectedAction === chip;
+                  return (
+                    <Chip
+                      key={chip}
+                      label={chip}
+                      onClick={() => setSelectedAction(active ? '' : chip)}
+                      color={active ? 'warning' : 'default'}
+                      variant={active ? 'filled' : 'outlined'}
+                      sx={{ fontSize: '1.1rem', py: 2.5, px: 1, borderRadius: 3, fontWeight: active ? 'bold' : 'normal' }}
+                      data-testid={`action-chip-${chip}`}
+                    />
+                  );
+                })}
+              </Stack>
+            </Box>
+
+            {/* 3. 変化 */}
+            <Box>
+              <Typography variant="h6" sx={{ fontWeight: 'bold', mb: 1.5, color: 'text.secondary' }}>
+                変化
+              </Typography>
+              <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
+                {RESULT_CHIPS.map((chip) => {
+                  const active = selectedResult === chip;
+                  return (
+                    <Chip
+                      key={chip}
+                      label={chip}
+                      onClick={() => setSelectedResult(active ? '' : chip)}
+                      color={active ? 'warning' : 'default'}
+                      variant={active ? 'filled' : 'outlined'}
+                      sx={{ fontSize: '1.1rem', py: 2.5, px: 1, borderRadius: 3, fontWeight: active ? 'bold' : 'normal' }}
+                      data-testid={`result-chip-${chip}`}
+                    />
+                  );
+                })}
+              </Stack>
+            </Box>
+
+            {/* 4. メモ */}
+            <Box>
+              <Typography variant="h6" sx={{ fontWeight: 'bold', mb: 1.5, color: 'text.secondary' }}>
+                メモ (自由記述)
+              </Typography>
+              <TextField
+                fullWidth
+                multiline
+                rows={3}
+                variant="outlined"
+                placeholder="様子や対応について、その他の補足事項があれば入力してください"
+                value={textMemo}
+                onChange={(e) => setTextMemo(e.target.value)}
+                sx={{
+                  bgcolor: 'background.paper',
+                  borderRadius: 3,
+                  '& .MuiOutlinedInput-root': {
+                    borderRadius: 3,
+                  }
+                }}
+                inputProps={{ 'data-testid': 'kiosk-observation-memo' }}
+              />
+            </Box>
+
+            {/* 操作ボタン */}
+            <Stack direction="row" spacing={2} justifyContent="flex-end" sx={{ pt: 2 }}>
+              <Button
+                variant="outlined"
+                color="inherit"
+                onClick={() => {
+                  setShowObservations(false);
+                  setSelectedMood('');
+                  setSelectedAction('');
+                  setSelectedResult('');
+                  setTextMemo('');
+                }}
+                sx={{ py: 1.5, px: 3, borderRadius: 3, fontSize: '1.1rem' }}
+                disabled={isSaving}
+              >
+                キャンセル
+              </Button>
+              <Button
+                variant="contained"
+                color="warning"
+                onClick={() => handleSave('triggered')}
+                sx={{ py: 1.5, px: 4, borderRadius: 3, fontSize: '1.1rem', fontWeight: 'bold' }}
+                disabled={isSaving}
+                data-testid="kiosk-observation-submit"
+              >
+                注意ありで保存する
+              </Button>
+            </Stack>
+          </Stack>
+        </Paper>
+      )}
+
       {/* フッター / アクションボタン */}
-      <Box sx={{ mt: 6, pt: 4, borderTop: '1px solid', borderColor: 'divider' }}>
+      <Box sx={{ mt: 'auto', pt: 4, borderTop: '1px solid', borderColor: 'divider' }}>
         <Stack direction="row" spacing={3} justifyContent="center">
           <Button 
-            variant={isTriggered ? "contained" : "outlined"}
+            variant={showObservations || isTriggered ? "contained" : "outlined"}
             color="warning"
             size="large" 
             startIcon={<ErrorOutlineIcon />}
-            onClick={() => handleSave('triggered')}
+            onClick={handleTriggerClick}
             sx={{ 
               py: 2, 
               px: 4, 
               borderRadius: 4, 
               fontSize: '1.2rem',
-              fontWeight: isTriggered ? 'bold' : 'normal',
-              ...(isTriggered ? {} : {
+              fontWeight: showObservations || isTriggered ? 'bold' : 'normal',
+              ...((showObservations || isTriggered) ? {} : {
                 color: 'text.secondary',
                 borderColor: 'divider',
               }),
-              '&:hover': { bgcolor: isTriggered ? 'warning.dark' : 'action.hover' }
+              '&:hover': { bgcolor: showObservations || isTriggered ? 'warning.dark' : 'action.hover' }
             }}
             disabled={isSaving || isCompleted}
+            data-testid="kiosk-trigger-btn"
           >
-            {isTriggered ? '記録済み' : '注意ありで記録'}
+            {showObservations ? '閉じる' : (isTriggered ? '記録済み（注意あり）' : '注意ありで記録')}
           </Button>
           <Button 
             variant="contained" 
@@ -204,7 +405,8 @@ export const KioskProcedureDetailScreen: React.FC = () => {
               fontWeight: 'bold',
               boxShadow: '0 8px 16px rgba(0,0,0,0.1)'
             }}
-            disabled={isSaving || isCompleted}
+            disabled={isSaving || isCompleted || showObservations}
+            data-testid="kiosk-complete-btn"
           >
             {isCompleted ? '実施済みです' : '実施済みにする'}
           </Button>
@@ -225,4 +427,3 @@ export const KioskProcedureDetailScreen: React.FC = () => {
     </Box>
   );
 };
-

--- a/src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx
@@ -12,6 +12,7 @@ vi.mock('react-router-dom', async () => {
     ...actual,
     useNavigate: () => mockNavigate,
     useParams: () => ({ userId: 'U001', slotKey: '0' }),
+    useLocation: () => ({ search: '' }),
   };
 });
 
@@ -20,7 +21,7 @@ vi.mock('@/features/users/useUsers', () => ({
 }));
 
 const mockProcedures = [
-  { id: 'P001', time: '10:00', activity: '朝のバイタルチェック', instruction: '体温と血圧を測ります' }
+  { id: 'P001', time: '10:00', activity: '朝のバイタルチェック', instruction: '体温と血圧を測ります。' }
 ];
 
 vi.mock('@/features/daily/hooks/useProcedureData', () => ({
@@ -29,11 +30,12 @@ vi.mock('@/features/daily/hooks/useProcedureData', () => ({
   }),
 }));
 
-const mockSetStatus = vi.fn().mockResolvedValue(undefined);
+const mockSaveRecord = vi.fn().mockResolvedValue(undefined);
 vi.mock('@/features/daily/hooks/useExecutionRecord', () => ({
   useExecutionRecord: () => ({
     record: null,
-    setStatus: mockSetStatus,
+    saveRecord: mockSaveRecord,
+    isLoading: false,
   }),
 }));
 
@@ -53,34 +55,51 @@ describe('KioskProcedureDetailScreen', () => {
     expect(screen.getByText('田中 太郎 様')).toBeInTheDocument();
   });
 
-  it('calls setStatus with "completed" when Complete button is clicked', async () => {
+  it('calls saveRecord with "completed" and empty memo when Complete button is clicked', async () => {
     render(
       <MemoryRouter>
         <KioskProcedureDetailScreen />
       </MemoryRouter>
     );
 
-    const completeButton = screen.getByText('実施済みにする');
+    const completeButton = screen.getByTestId('kiosk-complete-btn');
     fireEvent.click(completeButton);
 
-    expect(mockSetStatus).toHaveBeenCalledWith('completed');
+    expect(mockSaveRecord).toHaveBeenCalledWith('completed', '');
     
     await waitFor(() => {
       expect(screen.getByText('記録を保存しました')).toBeInTheDocument();
     }, { timeout: 3000 });
   });
 
-  it('calls setStatus with "triggered" when Triggered button is clicked', async () => {
+  it('expands observation panel when Trigger button is clicked, then saves with serialized memo', async () => {
     render(
       <MemoryRouter>
         <KioskProcedureDetailScreen />
       </MemoryRouter>
     );
 
-    const triggeredButton = screen.getByText('注意ありで記録');
-    fireEvent.click(triggeredButton);
+    const triggerButton = screen.getByTestId('kiosk-trigger-btn');
+    fireEvent.click(triggerButton);
 
-    expect(mockSetStatus).toHaveBeenCalledWith('triggered');
+    // Panel should appear
+    expect(screen.getByTestId('kiosk-observation-panel')).toBeInTheDocument();
+
+    // Select chips
+    fireEvent.click(screen.getByTestId('mood-chip-不安そう'));
+    fireEvent.click(screen.getByTestId('action-chip-声かけ'));
+    fireEvent.click(screen.getByTestId('result-chip-途中で落ち着いた'));
+
+    // Enter memo
+    const memoInput = screen.getByTestId('kiosk-observation-memo');
+    fireEvent.change(memoInput, { target: { value: '追加メモテスト' } });
+
+    // Submit
+    const submitBtn = screen.getByTestId('kiosk-observation-submit');
+    fireEvent.click(submitBtn);
+
+    const expectedMemo = `【様子】不安そう\n【対応】声かけ\n【変化】途中で落ち着いた\n【メモ】追加メモテスト`;
+    expect(mockSaveRecord).toHaveBeenCalledWith('triggered', expectedMemo);
   });
 
   it('navigates back when back button is clicked', () => {

--- a/tests/e2e/kiosk-procedure-detail.spec.ts
+++ b/tests/e2e/kiosk-procedure-detail.spec.ts
@@ -41,7 +41,14 @@ test.describe('Kiosk Procedure Detail', () => {
   });
 
   test('should save triggered status and reflect in procedure list', async ({ page }) => {
+    // 1. 最初の「注意ありで記録」をクリックしてパネルを開く
     await page.getByRole('button', { name: '注意ありで記録' }).click();
+    
+    // 観察パネルが表示されることを確認
+    await expect(page.getByTestId('kiosk-observation-panel')).toBeVisible();
+
+    // 2. パネル内の「注意ありで保存する」をクリック
+    await page.getByTestId('kiosk-observation-submit').click();
 
     await expect(page.getByText('記録を保存しました')).toBeVisible();
     await expect(page).toHaveURL(/.*\/kiosk\/users\/1\/procedures\/?(\?.*)?/);


### PR DESCRIPTION
## Summary
- Add observation chips to the kiosk procedure detail screen
- Allow staff to record the user's condition, support response, and observed change
- Add `saveRecord` to `useExecutionRecord` so status and memo are saved atomically
- Store observation details in the existing `ExecutionRecord.memo` field without adding SharePoint columns

## Why
The previous kiosk flow only allowed marking a procedure as completed or triggered.
For users requiring intensive behavioral support, this is not enough as an observation record.
This change lets the kiosk flow capture meaningful support observations while keeping the UI simple for field use.

## Validation
- npm run typecheck
- npx vitest run src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx
- npm run test:daily:mini

## Impact
- `/kiosk/users/:userId/procedures/:slotKey`
- ExecutionRecord memo content
- No SharePoint schema changes