### PR TITLE
fix(kiosk): reflect saved procedure status in list

### DIFF
--- a/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
+++ b/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
@@ -158,14 +158,10 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
       [DAILY_RECORD_FIELDS.userRowsJSON]: '[]',
     };
     const body = this.filterPayload(this.parentListTitle, rawBody);
-    const parentEntityType = await this.getEntityType(this.parentListTitle);
 
     const createResponse = await this.spFetch(createUrl, {
       method: 'POST',
-      body: JSON.stringify({
-        ...body,
-        __metadata: { type: parentEntityType },
-      }),
+      body: JSON.stringify(body),
       headers: { 'Content-Type': 'application/json;odata=nometadata', 'Accept': 'application/json;odata=nometadata' }
     });
 
@@ -253,7 +249,6 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
     }
 
     const body = this.filterPayload(this.childListTitle, rawBody);
-    const childEntityType = await this.getEntityType(this.childListTitle);
 
     if (existing) {
       const filter = `${rf.rowKey} eq '${rowKey}'`;
@@ -272,10 +267,7 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
             'Content-Type': 'application/json;odata=nometadata',
             'Accept': 'application/json;odata=nometadata'
           },
-          body: JSON.stringify({
-            ...body,
-            __metadata: { type: childEntityType },
-          }),
+          body: JSON.stringify(body),
         });
       }
     } else {
@@ -286,10 +278,7 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
           'Content-Type': 'application/json;odata=nometadata',
           'Accept': 'application/json;odata=nometadata'
         },
-        body: JSON.stringify({
-          ...body,
-          __metadata: { type: childEntityType },
-        }),
+        body: JSON.stringify(body),
       });
     }
 

--- a/src/features/demo/DemoProcedureSeeder.tsx
+++ b/src/features/demo/DemoProcedureSeeder.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { useProcedureStore } from '@/features/daily/hooks/legacy-stores/procedureStore';
+import { useProcedureStore } from '@/features/daily/stores/procedureStore';
 import { getTargetUserDemoProcedures } from './seedTargetProcedures';
 import { isDemoModeEnabled } from '@/lib/env';
 

--- a/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
@@ -32,7 +32,9 @@ export const KioskProcedureDetailScreen: React.FC = () => {
   }, [userId, slotKey, procedureRepo]);
 
   // scheduleItemId として ID もしくは インデックスを使用する
-  const scheduleItemId = procedure?.id || slotKey || '';
+  // 読み込み時は ID 優先だが、保存済みデータとの不一致を防ぐため hook 内部でのマッチングに任せるか、
+  // ここで安定した identifier を決定する。
+  const scheduleItemId = procedure?.id || procedure?.rowNo?.toString() || slotKey || '';
   const { record, saveRecord, isLoading } = useExecutionRecord(today, userId || '', scheduleItemId);
   
   const [isSaving, setIsSaving] = useState(false);

--- a/src/features/kiosk/components/KioskProcedureListScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureListScreen.tsx
@@ -112,7 +112,11 @@ export const KioskProcedureListScreen: React.FC = () => {
       <Grid container spacing={2}>
         {procedures.map((step, index) => {
           const scheduleItemId = step.id || index.toString();
-          const record = records.find(r => r.scheduleItemId === scheduleItemId);
+          // IDによる完全一致、または rowNo によるフォールバック一致の両方を試行する
+          const record = records.find(r => 
+            r.scheduleItemId === scheduleItemId || 
+            (step.rowNo && r.scheduleItemId === step.rowNo.toString())
+          );
           const isCompleted = record?.status === 'completed';
           const isTriggered = record?.status === 'triggered';
           

--- a/src/features/kiosk/components/KioskUserSelectScreen.tsx
+++ b/src/features/kiosk/components/KioskUserSelectScreen.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Typography, Grid, Card, CardActionArea, CardContent, IconButton, CircularProgress } from '@mui/material';
+import { Box, Typography, Grid, Card, CardActionArea, CardContent, IconButton, CircularProgress, Chip } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { useLocation, Link as RouterLink } from 'react-router-dom';
 import { appendKioskSearchParams } from '../utils/navigation';
@@ -63,9 +63,29 @@ export const KioskUserSelectScreen: React.FC = () => {
                     >
                       {user.Furigana || '　'}
                     </Typography>
-                    <Typography variant="h4" sx={{ fontWeight: 'bold' }}>
+                    <Typography variant="h4" sx={{ fontWeight: 'bold', mb: 1 }}>
                       {user.FullName}
                     </Typography>
+                    <Box sx={{ display: 'flex', justifyContent: 'center', gap: 1, mt: 1 }}>
+                      {user.IsHighIntensitySupportTarget && (
+                        <Chip 
+                          label="強度行動障害支援対象" 
+                          size="small" 
+                          color="error" 
+                          variant="outlined"
+                          sx={{ fontWeight: 'bold', borderRadius: 1 }}
+                        />
+                      )}
+                      {user.IsSupportProcedureTarget && !user.IsHighIntensitySupportTarget && (
+                        <Chip 
+                          label="支援手順対象" 
+                          size="small" 
+                          color="primary" 
+                          variant="outlined"
+                          sx={{ fontWeight: 'bold', borderRadius: 1 }}
+                        />
+                      )}
+                    </Box>
                   </CardContent>
                 </CardActionArea>
               </Card>


### PR DESCRIPTION
## Summary
- Fix kiosk procedure status reflection after saving records
- Align DemoProcedureSeeder with the procedure store used by kiosk screens
- Support both seeded scheduleItemId and rowNo fallback matching
- Fix SharePoint execution record persistence payload
- Keep UI terminology unified as 強度行動障害支援対象

## Verification
- /kiosk/users shows target users with 強度行動障害支援対象 badge
- Selecting a target user expands 17 procedure rows
- Saving a procedure record updates progress
- Returning to the list shows 注意あり instead of 未実施

## Checks
- npm run typecheck (pass)
- npm run lint -- --max-warnings=0 (fail: existing 117 warnings in unrelated files)
- npm run test -- kiosk (pass)
- npx playwright test tests/e2e/kiosk-procedure-detail.spec.ts tests/e2e/kiosk-procedure-list.spec.ts (pass)