### PR TITLE
fix(kiosk): normalize status matching after save

### DIFF
--- a/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
+++ b/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
@@ -315,7 +315,7 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
       id: title,
       date: title.slice(0, 10), 
       userId: (item[rf.userId] || '') as string,
-      scheduleItemId: (item[rf.rowNo] || '') as string,
+      scheduleItemId: String(item[rf.rowNo] ?? '').trim(),
       status: item[rf.status] as RecordStatus,
       triggeredBipIds,
       memo: (item[rf.memo] || item[rf.payload] || '') as string,

--- a/src/features/kiosk/components/KioskProcedureListScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureListScreen.tsx
@@ -50,6 +50,7 @@ export const KioskProcedureListScreen: React.FC = () => {
   const doneCount = records.filter(r => r.status === 'completed').length;
   const attentionCount = records.filter(r => r.status === 'triggered').length;
   const progress = totalCount > 0 ? ((doneCount + attentionCount) / totalCount) * 100 : 0;
+  const normalizeScheduleItemId = (value: unknown): string => String(value ?? '').trim();
 
   if (isUserLoading) {
     return <Box sx={{ p: 4 }}>読み込み中...</Box>;
@@ -111,12 +112,13 @@ export const KioskProcedureListScreen: React.FC = () => {
       {/* 手順一覧 */}
       <Grid container spacing={2}>
         {procedures.map((step, index) => {
-          const scheduleItemId = step.id || index.toString();
-          // IDによる完全一致、または rowNo によるフォールバック一致の両方を試行する
-          const record = records.find(r => 
-            r.scheduleItemId === scheduleItemId || 
-            (step.rowNo && r.scheduleItemId === step.rowNo.toString())
-          );
+          // detail 画面の保存キー順（id -> rowNo -> index）に合わせる
+          const scheduleKeyCandidates = [
+            normalizeScheduleItemId(step.id),
+            normalizeScheduleItemId(step.rowNo),
+            index.toString(),
+          ].filter(Boolean);
+          const record = records.find((r) => scheduleKeyCandidates.includes(normalizeScheduleItemId(r.scheduleItemId)));
           const isCompleted = record?.status === 'completed';
           const isTriggered = record?.status === 'triggered';
           
@@ -204,4 +206,3 @@ export const KioskProcedureListScreen: React.FC = () => {
     </Box>
   );
 };
-

--- a/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
@@ -19,8 +19,8 @@ vi.mock('@/features/users/useUsers', () => ({
 }));
 
 const mockProcedures = [
-  { id: 'P001', time: '10:00', activity: '朝のバイタルチェック', instruction: '体温と血圧を測ります' },
-  { id: 'P002', time: '12:00', activity: '昼食の介助', instruction: '見守りを行います' }
+  { id: 'P001', rowNo: 1, time: '10:00', activity: '朝のバイタルチェック', instruction: '体温と血圧を測ります' },
+  { id: 'P002', rowNo: 2, time: '12:00', activity: '昼食の介助', instruction: '見守りを行います' }
 ];
 
 vi.mock('@/features/daily/hooks/useProcedureData', () => ({
@@ -72,6 +72,23 @@ describe('KioskProcedureListScreen', () => {
 
     await waitFor(() => {
       expect(screen.getByText('未実施')).toBeInTheDocument();
+    });
+  });
+
+  it('matches rowNo records even when scheduleItemId is returned as number-like value', async () => {
+    mockGetRecords.mockResolvedValue([
+      { scheduleItemId: 1 as unknown as string, status: 'triggered' },
+    ]);
+
+    render(
+      <MemoryRouter>
+        <KioskProcedureListScreen />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('実施状況: 1 / 2')).toBeInTheDocument();
+      expect(screen.getAllByText('注意あり').length).toBeGreaterThan(0);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Normalize schedule item key matching in kiosk procedure list
- Align list key candidates with detail save key order (id -> rowNo -> index)
- Normalize SharePoint rowNo to string when mapping execution records
- Add regression test for number/string rowNo mismatch

## Verification
- npm run test -- src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
- npm run test -- kiosk