### PR TITLE
feat(daily): isolate overall sheet remarks into user procedure sheet notes

### DIFF
--- a/src/features/diagnostics/health/__tests__/governanceIntegration.spec.ts
+++ b/src/features/diagnostics/health/__tests__/governanceIntegration.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import type { Mock } from 'vitest';
 import { runHealthChecks } from '../checks';
 import type { HealthContext, ListSpec } from '../types';
 import type { SpAdapter } from '../spAdapter';
@@ -35,13 +36,13 @@ describe('Governance Integration — runHealthChecks Flow', () => {
     };
 
     // Mocks
-    (mockSp.getCurrentUser as any).mockResolvedValue({ id: 1 });
-    (mockSp.getWebTitle as any).mockResolvedValue('Site');
-    (mockSp.getListByTitle as any).mockResolvedValue({ id: '1', title: 'TestList' });
-    (mockSp.getItemsTop1 as any).mockResolvedValue([]);
+    (mockSp.getCurrentUser as Mock).mockResolvedValue({ id: 1 });
+    (mockSp.getWebTitle as Mock).mockResolvedValue('Site');
+    (mockSp.getListByTitle as Mock).mockResolvedValue({ id: '1', title: 'TestList' });
+    (mockSp.getItemsTop1 as Mock).mockResolvedValue([]);
     
     // actual fields has "fullname" (case mismatch)
-    (mockSp.getFields as any).mockResolvedValue([{ internalName: 'fullname', staticName: 'fullname' }]);
+    (mockSp.getFields as Mock).mockResolvedValue([{ internalName: 'fullname', staticName: 'fullname' }]);
 
     const results = await runHealthChecks({ ...baseCtx, listSpecs: () => [spec] }, mockSp);
 
@@ -69,13 +70,13 @@ describe('Governance Integration — runHealthChecks Flow', () => {
       updateItem: {},
     };
 
-    (mockSp.getCurrentUser as any).mockResolvedValue({ id: 1 });
-    (mockSp.getWebTitle as any).mockResolvedValue('Site');
-    (mockSp.getListByTitle as any).mockResolvedValue({ id: '1', title: 'TestList' });
-    (mockSp.getItemsTop1 as any).mockResolvedValue([]);
+    (mockSp.getCurrentUser as Mock).mockResolvedValue({ id: 1 });
+    (mockSp.getWebTitle as Mock).mockResolvedValue('Site');
+    (mockSp.getListByTitle as Mock).mockResolvedValue({ id: '1', title: 'TestList' });
+    (mockSp.getItemsTop1 as Mock).mockResolvedValue([]);
     
     // suffix mismatch
-    (mockSp.getFields as any).mockResolvedValue([{ internalName: 'Status0', staticName: 'Status0' }]);
+    (mockSp.getFields as Mock).mockResolvedValue([{ internalName: 'Status0', staticName: 'Status0' }]);
 
     const results = await runHealthChecks({ ...baseCtx, listSpecs: () => [spec] }, mockSp);
 

--- a/src/features/planning-sheet/constants/userProcedureDetails.ts
+++ b/src/features/planning-sheet/constants/userProcedureDetails.ts
@@ -1,5 +1,5 @@
 import { PROCEDURE_ROWS, ProcedureRow } from './procedureRows';
-import type { UserProcedureDetail } from '../domain/userProcedureDetail';
+import type { UserProcedureDetail, UserProcedureSheetNotes } from '../domain/userProcedureDetail';
 
 // 石渡さん（Id: 4, UserID: 'U-002'）用の手技データ
 // 原紙「石渡さん_重度加算（外出入り）.xls」から、本人の動き・支援者の動きを行単位で転記。
@@ -108,10 +108,18 @@ export const USER_PROCEDURE_DETAILS: UserProcedureDetail[] = [
   },
 ];
 
+function isIshiwataUserId(userId: string | number): boolean {
+  const s = String(userId);
+  return s === '4' || s === 'U-002' || s === 'U-003';
+}
+
 export function findUserProcedureDetail(userId: string | number, rowNo: number): UserProcedureDetail | undefined {
-  return USER_PROCEDURE_DETAILS.find(
-    (detail) => String(detail.userId) === String(userId) && detail.rowNo === rowNo
-  );
+  return USER_PROCEDURE_DETAILS.find((detail) => {
+    const isUserMatch = isIshiwataUserId(detail.userId)
+      ? isIshiwataUserId(userId)
+      : String(detail.userId) === String(userId);
+    return isUserMatch && detail.rowNo === rowNo;
+  });
 }
 
 export function buildUserProcedureRows(userId: string | number): ProcedureRow[] {
@@ -125,3 +133,22 @@ export function buildUserProcedureRows(userId: string | number): ProcedureRow[] 
     };
   });
 }
+
+// 石渡さん（Id: 4, UserID: 'U-002'）用のシート単位補足データ（下部欄）
+// 原紙「石渡さん_重度加算（外出入り）.xls」から、一日を通して気を付ける事・その他を転記。
+export const USER_PROCEDURE_SHEET_NOTES: UserProcedureSheetNotes[] = [
+  {
+    userId: 4,
+    dailyCarePoints: '自発的な排泄要望がないため、こまめな支援者間の情報共有が必要。',
+    otherNotes: '個別のタイミングを考慮した声掛けと、手洗い・消毒用の設備配置。',
+  },
+];
+
+export function findUserProcedureSheetNotes(userId: string | number): UserProcedureSheetNotes | undefined {
+  return USER_PROCEDURE_SHEET_NOTES.find((notes) => {
+    return isIshiwataUserId(notes.userId)
+      ? isIshiwataUserId(userId)
+      : String(notes.userId) === String(userId);
+  });
+}
+

--- a/src/features/planning-sheet/domain/userProcedureDetail.ts
+++ b/src/features/planning-sheet/domain/userProcedureDetail.ts
@@ -5,3 +5,10 @@ export type UserProcedureDetail = {
   supporterAction: string;   // 支援者の動き
   condition?: string;        // 留意点・本人の様子の初期文言
 };
+
+export type UserProcedureSheetNotes = {
+  userId: string | number;
+  dailyCarePoints: string;   // 一日を通して気を付ける事
+  otherNotes: string;        // その他
+};
+

--- a/src/features/planning-sheet/logic/__tests__/dailyProcedureMapper.spec.ts
+++ b/src/features/planning-sheet/logic/__tests__/dailyProcedureMapper.spec.ts
@@ -268,5 +268,12 @@ describe('dailyProcedureMapper', () => {
       expect(row17?.personAction).toContain('出発前のトイレ');
       expect(row17?.supporterAction).toContain('自動ドアの前で写真を撮る');
     });
+
+    it('should map overall sheet notes (dailyCarePoints, otherNotes) unique to Ishiwata-san', () => {
+      const doc = bridgePlanningSheetToDailyProcedures(ISHIWATA_SEVERE_SUPPORT_SHEET);
+
+      expect(doc.dailyCarePoints).toBe('自発的な排泄要望がないため、こまめな支援者間の情報共有が必要。');
+      expect(doc.otherNotes).toBe('個別のタイミングを考慮した声掛けと、手洗い・消毒用の設備配置。');
+    });
   });
 });

--- a/src/features/planning-sheet/logic/dailyProcedureMapper.ts
+++ b/src/features/planning-sheet/logic/dailyProcedureMapper.ts
@@ -9,6 +9,8 @@ import {
   type DailySupportProcedureDocument
 } from '../domain/dailySupportProcedure';
 import { type BridgeSource } from '../planningToRecordBridge';
+import { findUserProcedureSheetNotes } from '../constants/userProcedureDetails';
+
 
 /**
  * 支援計画シートを原紙（支援手順書兼実施記録）ドキュメント形式に変換する。
@@ -111,6 +113,10 @@ export function bridgePlanningSheetToDailyProcedures(
     sheet.intake?.medicalFlags?.length > 0 ? `【医療上の留意点】${sheet.intake.medicalFlags.join('、')}` : '',
   ].filter(Boolean).join('\n');
 
+  const sheetNotes = findUserProcedureSheetNotes(sheet.userId);
+  const dailyCarePoints = sheetNotes?.dailyCarePoints || (sheet.supportPolicy ? (sheet.supportPolicy.slice(0, 100) + (sheet.supportPolicy.length > 100 ? '...' : '')) : '');
+  const otherNotes = sheetNotes?.otherNotes || '';
+
   // 5. ドキュメント全体の組み立て
   return {
     title: '支援手順書兼実施記録',
@@ -118,8 +124,8 @@ export function bridgePlanningSheetToDailyProcedures(
     recordDate: options?.recordDate || new Date().toLocaleDateString('ja-JP'),
     staffName: options?.staffName || sheet.authoredByStaffId || '',
     rows,
-    dailyCarePoints: sheet.supportPolicy.slice(0, 100) + (sheet.supportPolicy.length > 100 ? '...' : ''),
-    otherNotes: '',
+    dailyCarePoints,
+    otherNotes,
     specialNotes: specialNotes,
   };
 }


### PR DESCRIPTION
## Summary
- add `UserProcedureSheetNotes` for user-level sheet footer remarks
- define Ishiwata-specific `dailyCarePoints` and `otherNotes`
- resolve user ID aliases for Ishiwata across real data and test fixtures
- map user-specific sheet notes into `DailySupportProcedureDocument`
- add mapper coverage for Ishiwata daily care points and other notes

## Why
The official support procedure form separates row-level procedure details from sheet-level footer remarks such as “一日を通して気を付ける事” and “その他”. This change models those footer values separately so they can be mapped into Excel/PDF output without mixing them into row-level procedure details.

## Checks
- `npx vitest run src/features/planning-sheet`
- `npx vitest run src/features/planning-sheet/logic/__tests__/dailyProcedureMapper.spec.ts`