### PR TITLE
fix(kiosk): prioritize instructionDetail for supporter task display

### DIFF
--- a/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
@@ -119,11 +119,9 @@ export const KioskProcedureDetailScreen: React.FC = () => {
     );
   }
 
-  // instruction を「本人」と「支援者」に分割して表示（。で区切られた最初の文を本人のタスクとする）
-  // 将来的なスキーマ拡張で明示的なフィールドに移行予定
-  const parts = procedure.instruction.split('。').filter(Boolean);
-  const personTask = parts[0] || '手順に従って進めましょう';
-  const staffTask = parts.slice(1).join('。') || '適宜見守り、必要に応じて声掛けを行います';
+  const parts = (procedure.instruction || '').split('。').filter(Boolean);
+  const personTask = procedure.activityDetail || parts[0] || '手順に従って進めましょう';
+  const staffTask = procedure.instructionDetail || parts.slice(1).join('。') || '適宜見守り、必要に応じて声掛けを行います';
 
   const isCompleted = record?.status === 'completed';
 

--- a/src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx
@@ -21,7 +21,14 @@ vi.mock('@/features/users/useUsers', () => ({
 }));
 
 const mockProcedures = [
-  { id: 'P001', time: '10:00', activity: '朝のバイタルチェック', instruction: '体温と血圧を測ります。' }
+  {
+    id: 'P001',
+    time: '10:00',
+    activity: '朝のバイタルチェック',
+    instruction: '体温と血圧を測ります。',
+    activityDetail: '体温と血圧を測る',
+    instructionDetail: '測定の声かけと記録を行う',
+  }
 ];
 
 vi.mock('@/features/daily/hooks/useProcedureData', () => ({
@@ -53,6 +60,8 @@ describe('KioskProcedureDetailScreen', () => {
 
     expect(screen.getByText('10:00 - 朝のバイタルチェック')).toBeInTheDocument();
     expect(screen.getByText('田中 太郎 様')).toBeInTheDocument();
+    expect(screen.getByText('体温と血圧を測る')).toBeInTheDocument();
+    expect(screen.getByText('測定の声かけと記録を行う')).toBeInTheDocument();
   });
 
   it('saves with serialized memo from the main "記録を保存する" action', async () => {


### PR DESCRIPTION
## Summary
- prioritize `activityDetail` for "本人のすること" display on kiosk procedure detail
- prioritize `instructionDetail` for "支援者がすること" display on kiosk procedure detail
- keep existing fallback behavior to split `instruction` text when detailed fields are absent
- add/adjust kiosk detail screen test coverage for detail-priority rendering

## Why
On production, supporter instructions were shown as generic/fallback text because the screen was still using instruction-splitting logic. This change makes the detail screen reflect user-specific procedure data (`instructionDetail`) correctly.

## Checks
- `npx vitest run src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx`
- `npm run typecheck`
