### PR TITLE
fix(kiosk): require SharePoint records for completed procedure status

### DIFF
--- a/src/features/daily/repositories/sharepoint/__tests__/executionRepositoryFactory.spec.ts
+++ b/src/features/daily/repositories/sharepoint/__tests__/executionRepositoryFactory.spec.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const envState = {
+  isDev: false,
+  isTestMode: false,
+  isForceDemoEnabled: false,
+  isDemoModeEnabled: false,
+  shouldSkipLogin: false,
+  forceSharePoint: false,
+  dataProvider: undefined as string | undefined,
+};
+
+vi.mock('@/lib/env', () => ({
+  getAppConfig: () => ({ isDev: envState.isDev }),
+  isDemoModeEnabled: () => envState.isDemoModeEnabled,
+  isForceDemoEnabled: () => envState.isForceDemoEnabled,
+  isTestMode: () => envState.isTestMode,
+  shouldSkipLogin: () => envState.shouldSkipLogin,
+  readBool: (key: string, fallback = false) => (key === 'VITE_FORCE_SHAREPOINT' ? envState.forceSharePoint : fallback),
+  readOptionalEnv: (key: string) => (key === 'VITE_DATA_PROVIDER' ? envState.dataProvider : undefined),
+}));
+
+import { getCurrentExecutionRepositoryKind } from '../executionRepositoryFactory';
+
+describe('executionRepositoryFactory', () => {
+  beforeEach(() => {
+    envState.isDev = false;
+    envState.isTestMode = false;
+    envState.isForceDemoEnabled = false;
+    envState.isDemoModeEnabled = false;
+    envState.shouldSkipLogin = false;
+    envState.forceSharePoint = false;
+    envState.dataProvider = undefined;
+    window.history.pushState({}, '', '/');
+  });
+
+  it('forces sharepoint in kiosk runtime even when skipLogin is true', () => {
+    envState.shouldSkipLogin = true;
+    window.history.pushState({}, '', '/kiosk/users/6/procedures');
+
+    expect(getCurrentExecutionRepositoryKind()).toBe('sharepoint');
+  });
+
+  it('respects local provider hint outside kiosk runtime', () => {
+    envState.dataProvider = 'local';
+    window.history.pushState({}, '', '/daily/activity');
+
+    expect(getCurrentExecutionRepositoryKind()).toBe('local');
+  });
+
+  it('forces sharepoint when VITE_FORCE_SHAREPOINT is true', () => {
+    envState.forceSharePoint = true;
+    envState.dataProvider = 'local';
+
+    expect(getCurrentExecutionRepositoryKind()).toBe('sharepoint');
+  });
+});
+

--- a/src/features/daily/repositories/sharepoint/executionRepositoryFactory.ts
+++ b/src/features/daily/repositories/sharepoint/executionRepositoryFactory.ts
@@ -18,6 +18,7 @@ import {
     isTestMode,
     shouldSkipLogin,
     readBool,
+    readOptionalEnv,
 } from '@/lib/env';
 import type { ExecutionRecordRepository } from '../../domain/legacy/ExecutionRecordRepository';
 import type { ExecutionRecord } from '../../domain/legacy/executionRecordTypes';
@@ -40,13 +41,41 @@ export type ExecutionRepositoryKind = 'local' | 'sharepoint';
 // ────────────────────────────────────────────────────────────
 
 const shouldUseLocalRepository = (): boolean => {
+  const providerParam =
+    typeof window !== 'undefined' ? new URLSearchParams(window.location.search).get('provider') : undefined;
+  const providerEnv = readOptionalEnv('VITE_DATA_PROVIDER');
+  const providerHint = (providerParam ?? providerEnv ?? '').trim().toLowerCase();
+
   if (readBool('VITE_FORCE_SHAREPOINT', false)) {
     return false;
   }
+
   const { isDev } = getAppConfig();
+  const isTest = isTestMode();
+  const isKioskRuntime =
+    typeof window !== 'undefined' && window.location.pathname.startsWith('/kiosk');
+
+  // Kiosk in non-dev runtime must never rely on local-only records.
+  // Even when demo/skip flags are accidentally enabled, prefer SharePoint.
+  if (isKioskRuntime && !isDev && !isTest) {
+    if (providerHint === 'local' || providerHint === 'memory' || shouldSkipLogin()) {
+      console.warn(
+        '[ExecutionRepositoryFactory] local/memory hint detected in kiosk runtime; forcing SharePoint adapter.',
+      );
+    }
+    return false;
+  }
+
+  if (providerHint === 'sharepoint') {
+    return false;
+  }
+  if (providerHint === 'local' || providerHint === 'memory') {
+    return true;
+  }
+
   return (
     isDev ||
-    isTestMode() ||
+    isTest ||
     isForceDemoEnabled() ||
     isDemoModeEnabled() ||
     shouldSkipLogin()

--- a/src/features/kiosk/components/KioskProcedureListScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureListScreen.tsx
@@ -12,6 +12,7 @@ import { formatDateJapanese, formatDateIso } from '@/lib/dateFormat';
 import { ExecutionRecord } from '@/features/daily/domain/executionRecordTypes';
 import { normalizeScheduleItemId } from '@/features/daily/utils/normalizeScheduleItemId';
 import { useExecutionStore } from '@/features/daily/stores/executionStore';
+import { getCurrentExecutionRepositoryKind } from '@/features/daily/repositories/sharepoint/executionRepositoryFactory';
 
 export const KioskProcedureListScreen: React.FC = () => {
   const navigate = useNavigate();
@@ -42,6 +43,7 @@ export const KioskProcedureListScreen: React.FC = () => {
 
   const { getRecords: getStoreRecords } = useExecutionStore();
   const storeRecords = getStoreRecords(todayIso || '', userId || '');
+  const executionRepositoryKind = getCurrentExecutionRepositoryKind();
   
   const [records, setRecords] = useState<ExecutionRecord[]>([]);
 
@@ -74,11 +76,11 @@ export const KioskProcedureListScreen: React.FC = () => {
   const totalCount = procedures.length;
   const recordsByScheduleItemId = React.useMemo(() => {
     const map = new Map<string, ExecutionRecord>();
-    
-    // storeRecords は Zustand から、records は Repository (SharePoint) から。
-    // 同じ scheduleItemId があれば、入力がある方を優先する。
-    // (保存直後は store にあり fetch にはまだない、または fetch が空の場合があるため)
-    const allCandidateRecords = [...storeRecords, ...records];
+
+    // In sharepoint mode, treat repository result as source of truth to avoid
+    // local-only "記録済み" labels that don't survive across devices.
+    const allCandidateRecords =
+      executionRepositoryKind === 'local' ? [...storeRecords, ...records] : [...records];
     
     for (const record of allCandidateRecords) {
       const key = normalizeScheduleItemId(record.scheduleItemId);
@@ -91,7 +93,7 @@ export const KioskProcedureListScreen: React.FC = () => {
       }
     }
     return map;
-  }, [storeRecords, records, hasRecordInput]);
+  }, [executionRepositoryKind, storeRecords, records, hasRecordInput]);
   const getRecordedRecordForProcedure = React.useCallback((procedure: { id?: unknown; rowNo?: unknown }, index: number) => {
     const primaryCandidates = [
       normalizeScheduleItemId(procedure.id),

--- a/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
@@ -31,6 +31,7 @@ vi.mock('@/features/daily/hooks/useProcedureData', () => ({
 
 const mockGetRecords = vi.fn();
 const mockGetStoreRecords = vi.fn();
+const mockGetCurrentExecutionRepositoryKind = vi.fn(() => 'local' as const);
 
 vi.mock('@/features/daily/stores/executionStore', () => ({
   useExecutionStore: () => ({
@@ -44,9 +45,14 @@ vi.mock('@/features/daily/hooks/useExecutionData', () => ({
   }),
 }));
 
+vi.mock('@/features/daily/repositories/sharepoint/executionRepositoryFactory', () => ({
+  getCurrentExecutionRepositoryKind: () => mockGetCurrentExecutionRepositoryKind(),
+}));
+
 describe('KioskProcedureListScreen', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetCurrentExecutionRepositoryKind.mockReturnValue('local');
     mockGetStoreRecords.mockReturnValue([]);
     mockGetRecords.mockResolvedValue([]);
   });
@@ -234,6 +240,27 @@ describe('KioskProcedureListScreen', () => {
       const firstCard = screen.getByTestId('kiosk-procedure-card-0');
       expect(within(firstCard).getByText('記録済み')).toBeInTheDocument();
       expect(screen.getByText('実施状況: 1 / 2')).toBeInTheDocument();
+    });
+  });
+
+  it('does not show "記録済み" from store-only data when repository kind is sharepoint', async () => {
+    mockGetCurrentExecutionRepositoryKind.mockReturnValue('sharepoint');
+    mockGetRecords.mockResolvedValue([]);
+    mockGetStoreRecords.mockReturnValue([
+      { scheduleItemId: '1', status: 'completed', id: 'STORE-1' },
+    ]);
+
+    render(
+      <MemoryRouter>
+        <KioskProcedureListScreen />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      const firstCard = screen.getByTestId('kiosk-procedure-card-0');
+      expect(within(firstCard).queryByText('記録済み')).toBeNull();
+      expect(within(firstCard).getByText('未実施')).toBeInTheDocument();
+      expect(screen.getByText('実施状況: 0 / 2')).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary
- Force kiosk production execution repository to use SharePoint
- Prevent store/local-only records from marking procedures as completed in SharePoint mode
- Keep local merge behavior only when the selected execution repository is local
- Add regression coverage for repository selection and kiosk completed-state behavior

## Background
Kiosk procedure completion could appear on the same device but disappear on another device because:
1. the execution repository could fall back to local in kiosk mode
2. the kiosk procedure list always merged local store records into completion detection

This made local-only records look completed even when they were not persisted to DailyRecordRows.

## Changes
- `executionRepositoryFactory.ts`
  - `VITE_FORCE_SHAREPOINT=true` always selects SharePoint
  - kiosk + non-dev/non-test always selects SharePoint
  - local hints such as skip-login are ignored in kiosk production
- `KioskProcedureListScreen.tsx`
  - SharePoint mode uses repository `records` only
  - local mode keeps `storeRecords + records` merge behavior

## Tests
```bash
npx vitest run \
  src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx \
  src/features/daily/repositories/sharepoint/__tests__/executionRepositoryFactory.spec.ts
```

Result: 16 passed
