### PR TITLE
fix(kiosk): show save and fetch error snackbar

### DIFF
--- a/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
@@ -38,6 +38,7 @@ export const KioskProcedureDetailScreen: React.FC = () => {
   
   const [isSaving, setIsSaving] = useState(false);
   const [showSuccess, setShowSuccess] = useState(false);
+  const [showSaveError, setShowSaveError] = useState(false);
 
   // 観察チップ用ステート
   const [selectedMood, setSelectedMood] = useState<string>('');
@@ -95,6 +96,7 @@ export const KioskProcedureDetailScreen: React.FC = () => {
       }, 1500);
     } catch (error) {
       console.error('Failed to save execution record:', error);
+      setShowSaveError(true);
       setIsSaving(false);
     }
   };
@@ -356,6 +358,17 @@ export const KioskProcedureDetailScreen: React.FC = () => {
       >
         <Alert severity="success" sx={{ width: '100%', fontSize: '1.2rem', fontWeight: 'bold' }}>
           記録を保存しました
+        </Alert>
+      </Snackbar>
+
+      <Snackbar
+        open={showSaveError}
+        autoHideDuration={4000}
+        onClose={() => setShowSaveError(false)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert severity="error" sx={{ width: '100%' }}>
+          記録の保存に失敗しました。再度お試しください。
         </Alert>
       </Snackbar>
     </Box>

--- a/src/features/kiosk/components/KioskProcedureListScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureListScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Box, Typography, Grid, Card, CardActionArea, IconButton, Chip, LinearProgress } from '@mui/material';
+import { Box, Typography, Grid, Card, CardActionArea, IconButton, Chip, LinearProgress, Snackbar, Alert } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import AccessTimeIcon from '@mui/icons-material/AccessTime';
@@ -46,6 +46,7 @@ export const KioskProcedureListScreen: React.FC = () => {
   const executionRepositoryKind = getCurrentExecutionRepositoryKind();
   
   const [records, setRecords] = useState<ExecutionRecord[]>([]);
+  const [showFetchError, setShowFetchError] = useState(false);
 
   // 実施記録の取得
   useEffect(() => {
@@ -56,6 +57,7 @@ export const KioskProcedureListScreen: React.FC = () => {
         setRecords(data);
       } catch (error) {
         console.error('Failed to fetch execution records:', error);
+        setShowFetchError(true);
       }
     };
     void fetchRecords();
@@ -256,6 +258,17 @@ export const KioskProcedureListScreen: React.FC = () => {
           </Grid>
         )}
       </Grid>
+
+      <Snackbar
+        open={showFetchError}
+        autoHideDuration={4000}
+        onClose={() => setShowFetchError(false)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert severity="error" sx={{ width: '100%' }}>
+          記録の取得に失敗しました。再読み込みしてください。
+        </Alert>
+      </Snackbar>
     </Box>
   );
 };

--- a/src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { KioskProcedureDetailScreen } from '../KioskProcedureDetailScreen';
 import { MemoryRouter } from 'react-router-dom';
@@ -88,6 +88,7 @@ describe('KioskProcedureDetailScreen', () => {
 
     const expectedMemo = `【様子】不安そう\n【対応】声かけ\n【変化】途中で落ち着いた\n【メモ】追加メモテスト`;
     expect(mockSaveRecord).toHaveBeenCalledWith('completed', expectedMemo);
+    expect(screen.queryByText('記録の保存に失敗しました。再度お試しください。')).toBeNull();
   });
 
   it('navigates back when back button is clicked', () => {
@@ -111,5 +112,21 @@ describe('KioskProcedureDetailScreen', () => {
     );
 
     expect(screen.getAllByText('記録を保存する')).toHaveLength(1);
+  });
+
+  it('shows save error snackbar when save fails', async () => {
+    mockSaveRecord.mockRejectedValueOnce(new Error('save failed'));
+
+    render(
+      <MemoryRouter>
+        <KioskProcedureDetailScreen />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByTestId('kiosk-observation-submit'));
+
+    await waitFor(() => {
+      expect(screen.getByText('記録の保存に失敗しました。再度お試しください。')).toBeInTheDocument();
+    });
   });
 });

--- a/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
@@ -304,4 +304,18 @@ describe('KioskProcedureListScreen', () => {
       );
     });
   });
+
+  it('shows fetch error snackbar when repository fetch fails', async () => {
+    mockGetRecords.mockRejectedValue(new Error('fetch failed'));
+
+    render(
+      <MemoryRouter>
+        <KioskProcedureListScreen />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('記録の取得に失敗しました。再読み込みしてください。')).toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Show an error snackbar when kiosk procedure records fail to load
- Show an error snackbar when kiosk procedure record save fails
- Keep console.error logging for diagnostics
- Ensure successful load/save paths do not show error UI

## Tests
- npx vitest run src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx

Result: 19 passed
