### PR TITLE
test(kiosk): document memory provider test intent

### DIFF
--- a/src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx
@@ -12,6 +12,8 @@ vi.mock('react-router-dom', async () => {
     ...actual,
     useNavigate: () => mockNavigate,
     useParams: () => ({ userId: 'U001', slotKey: '0' }),
+    // provider=memory is intentional for component-level kiosk flow checks in local test context.
+    // Production kiosk execution persistence is SharePoint-backed.
     useLocation: () => ({ search: '?kiosk=1&provider=memory' }),
   };
 });
@@ -46,7 +48,7 @@ vi.mock('@/features/daily/hooks/useExecutionRecord', () => ({
   }),
 }));
 
-describe('KioskProcedureDetailScreen', () => {
+describe('KioskProcedureDetailScreen (memory provider URL for local UI behavior tests)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });

--- a/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
@@ -49,7 +49,7 @@ vi.mock('@/features/daily/repositories/sharepoint/executionRepositoryFactory', (
   getCurrentExecutionRepositoryKind: () => mockGetCurrentExecutionRepositoryKind(),
 }));
 
-describe('KioskProcedureListScreen', () => {
+describe('KioskProcedureListScreen (includes local/memory-style recorded-state checks)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetCurrentExecutionRepositoryKind.mockReturnValue('local');

--- a/tests/e2e/_helpers/bootKiosk.ts
+++ b/tests/e2e/_helpers/bootKiosk.ts
@@ -62,6 +62,8 @@ const DEFAULT_PROCEDURES: KioskProcedure[] = [
 ];
 
 export async function bootKiosk(page: Page, options: BootKioskOptions = {}): Promise<void> {
+  // E2E kiosk tests default to memory provider so UI flow and form behavior can be
+  // validated deterministically in local/demo runs. Production kiosk is SharePoint-fixed.
   const provider = options.provider ?? 'memory';
   const route = options.route ?? '/kiosk';
   const autoNavigate = options.autoNavigate ?? true;
@@ -144,4 +146,3 @@ export async function bootKiosk(page: Page, options: BootKioskOptions = {}): Pro
     // networkidle は Vite の HMR 等で不安定になることがあるため、load までで止める
   }
 }
-

--- a/tests/e2e/kiosk-home-smoke.spec.ts
+++ b/tests/e2e/kiosk-home-smoke.spec.ts
@@ -1,12 +1,14 @@
 import { test, expect } from '@playwright/test';
 import { bootKiosk } from './_helpers/bootKiosk';
 
-test.describe('Kiosk Home Smoke', () => {
+test.describe('Kiosk Home Smoke (memory provider for local kiosk flow checks)', () => {
   test.use({
     baseURL: process.env.E2E_BASE_URL ?? 'http://127.0.0.1:5173',
   });
 
   test.beforeEach(async ({ page }) => {
+    // bootKiosk defaults to provider=memory for local/demo E2E stability.
+    // This does not represent production kiosk storage mode (SharePoint-fixed).
     await bootKiosk(page, { route: '/kiosk' });
   });
 

--- a/tests/e2e/kiosk-ux-regression.smoke.spec.ts
+++ b/tests/e2e/kiosk-ux-regression.smoke.spec.ts
@@ -1,11 +1,13 @@
 import { test, expect } from '@playwright/test';
 
-test.describe('Kiosk UX Regression (Smoke)', () => {
+test.describe('Kiosk UX Regression (Smoke, memory provider for local UI verification)', () => {
   test.use({
     baseURL: process.env.E2E_BASE_URL ?? 'http://127.0.0.1:5173',
   });
 
   test('kiosk mode: 1-tap navigation to schedule and back to today', async ({ page }) => {
+    // NOTE: provider=memory here is for local deterministic UI regression checks.
+    // Production kiosk uses SharePoint-backed execution repository.
     // 1. 事前準備: UIからの設定切替ではなく、localStorageへの流し込みで確実・高速にキオスクモードをON
     await page.addInitScript(() => {
       window.localStorage.setItem(


### PR DESCRIPTION
## Summary
- Document why kiosk tests intentionally use provider=memory
- Clarify that memory provider coverage is for local/demo UI and form-flow stability
- Clarify that production kiosk execution is forced to SharePoint
- Keep implementation logic unchanged

## Tests
- npx vitest run src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx

Result: 2 files / 19 tests passed

## Notes
- Existing React Router future flag and act(...) warnings remain unchanged
