### PR TITLE
fix(daily): throw on SharePoint execution save failures

### DIFF
--- a/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
+++ b/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
@@ -198,7 +198,9 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
     const url = `${this.resolvedChildPath}/items?$filter=${encodeURIComponent(filter)}`;
 
     const response = await this.spFetch(url);
-    if (!response.ok) return [];
+    if (!response.ok) {
+      throw new Error(`[ExecutionRepo] getRecords failed: ${response.status} ${response.statusText}`);
+    }
 
     const data: SharePointResponse<JsonRecord> = await response.json();
     if (!data.value) return [];
@@ -273,12 +275,15 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
       const filter = `${rf.rowKey} eq '${rowKey}'`;
       const searchUrl = `${this.resolvedChildPath}/items?$filter=${encodeURIComponent(filter)}&$select=Id`;
       const searchResp = await this.spFetch(searchUrl);
+      if (!searchResp.ok) {
+        throw new Error(`[ExecutionRepo] row search failed: ${searchResp.status} ${searchResp.statusText}`);
+      }
       const searchData: SharePointResponse<JsonRecord> = await searchResp.json();
       
       if (searchData.value && searchData.value.length > 0) {
         const internalId = searchData.value[0].Id;
         const updateUrl = `${this.resolvedChildPath}/items(${internalId})`;
-        await this.spFetch(updateUrl, {
+        const updateResp = await this.spFetch(updateUrl, {
           method: 'POST',
           headers: {
             'X-HTTP-Method': 'MERGE',
@@ -288,10 +293,13 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
           },
           body: JSON.stringify(body),
         });
+        if (!updateResp.ok) {
+          throw new Error(`[ExecutionRepo] row update failed: ${updateResp.status} ${updateResp.statusText}`);
+        }
       }
     } else {
       const createUrl = `${this.resolvedChildPath}/items`;
-      await this.spFetch(createUrl, {
+      const createResp = await this.spFetch(createUrl, {
         method: 'POST',
         headers: { 
           'Content-Type': 'application/json;odata=nometadata',
@@ -299,6 +307,9 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
         },
         body: JSON.stringify(body),
       });
+      if (!createResp.ok) {
+        throw new Error(`[ExecutionRepo] row create failed: ${createResp.status} ${createResp.statusText}`);
+      }
     }
 
     // Sync to local store

--- a/src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts
+++ b/src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts
@@ -176,4 +176,43 @@ describe('SharePointExecutionRecordRepository', () => {
     const childBody = JSON.parse(childCreateCall![1]!.body as string);
     expect(childBody[EXECUTION_RECORD_FIELDS.parentId]).toBe(777);
   });
+
+  it('throws when child row create fails', async () => {
+    const record: ExecutionRecord = {
+      id: 'R500',
+      date: '2024-01-01',
+      userId: 'U500',
+      scheduleItemId: 'S500',
+      status: 'completed',
+      memo: 'create fail test',
+      recordedAt: '2024-01-01T11:00:00Z',
+      recordedBy: 'Staff C',
+      triggeredBipIds: [],
+    };
+
+    mockSpFetch.mockReset();
+    mockSpFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+      // Ensure parent lookup returns existing parent
+      if (url.includes('SupportRecord_Daily') && url.includes('/items?$filter=')) {
+        return { ok: true, json: async () => ({ value: [{ Id: 123 }] }) };
+      }
+      // Existing child row lookup returns empty so repo goes to create
+      if (url.includes('DailyRecordRows') && url.includes('/items?$filter=')) {
+        return { ok: true, json: async () => ({ value: [] }) };
+      }
+      // Child create fails
+      if (url.includes('DailyRecordRows') && url.includes('/items') && init?.method === 'POST') {
+        return {
+          ok: false,
+          status: 500,
+          statusText: 'Internal Server Error',
+          json: async () => ({ error: { message: 'failed' } }),
+        };
+      }
+      // Default for resolver probes
+      return { ok: true, json: async () => ({ value: [] }) };
+    });
+
+    await expect(repo.upsertRecord(record)).rejects.toThrow('row create failed');
+  });
 });


### PR DESCRIPTION
## Summary
- Throw when SharePoint execution record fetch returns ok=false
- Throw when child row search/update/create returns ok=false during upsert
- Ensure failed SharePoint saves are surfaced as errors instead of being treated as successful
- Let existing kiosk error snackbar flow handle save failures correctly

## Background
Kiosk completed status now relies on SharePoint-backed records. If SharePoint save failed but the repository treated it as success, the UI could show a success path while the procedure remained incomplete after reload or on another device.

## Tests
- npx vitest run src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts

Result: 1 file, 4 tests passed