### PR TITLE
fix(kiosk): use rowNo for procedure schedule item id

### DIFF
--- a/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
@@ -31,8 +31,10 @@ export const KioskProcedureDetailScreen: React.FC = () => {
     return procedures[index] || null;
   }, [userId, slotKey, procedureRepo]);
 
-  const scheduleItemId = normalizeScheduleItemId(procedure?.id) ||
-    normalizeScheduleItemId(procedure?.rowNo) ||
+  // rowNo is the canonical slot identity for kiosk procedure completion tracking.
+  // Some procedure IDs can vary by source/runtime, so prefer rowNo for persistence keys.
+  const scheduleItemId = normalizeScheduleItemId(procedure?.rowNo) ||
+    normalizeScheduleItemId(procedure?.id) ||
     normalizeScheduleItemId(slotKey);
   const { record, saveRecord, isLoading } = useExecutionRecord(today, userId || '', scheduleItemId);
   


### PR DESCRIPTION
## Summary
- Prefer procedure rowNo when building kiosk procedure detail scheduleItemId
- Align detail save keys with list completed-state detection
- Reduce mismatch risk between saved records and completed chips

## Background
Kiosk completed status relies on SharePoint-backed records. If detail save uses procedure.id while the list resolves completion by rowNo/slot-style keys, a saved record may not match the list completed-state lookup.

## Tests
- npx vitest run src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx

Result: 2 files / 19 tests passed