### PR TITLE
feat(today): surface monitoring deadline actions

### DIFF
--- a/pr_body_shiota.md
+++ b/pr_body_shiota.md
@@ -1,0 +1,15 @@
+## Summary
+- add Shiota-specific 17-row procedure details
+- preserve line breaks from the Excel / fixture source data
+- add Shiota-specific daily care points and other notes
+- add Shiota user ID alias resolution (`I016`, and related runtime ID if applicable)
+- add mapper coverage for Shiota row details, sheet-level notes, and alias resolution
+- document the production user ID alias map and operating rules in the support procedure addition guide
+
+## Why
+The support procedure flow separates the shared 17-row skeleton, user-specific row details, and sheet-level footer remarks. This PR applies the established pattern to Shiota-san and documents the ID alias map so future user additions follow the same safe process.
+
+## Checks
+- `npx vitest run src/features/planning-sheet/logic/__tests__/dailyProcedureMapper.spec.ts`
+- `npx vitest run src/features/planning-sheet`
+- `npm run typecheck`

--- a/src/features/diagnostics/health/__tests__/optionalLists.spec.ts
+++ b/src/features/diagnostics/health/__tests__/optionalLists.spec.ts
@@ -38,7 +38,7 @@ describe('Health Checks — Optional List Contract', () => {
       isOptional: false,
     };
 
-    (mockSp.getListByTitle as any).mockRejectedValueOnce(new Error('404 Not Found'));
+    vi.mocked(mockSp.getListByTitle).mockRejectedValueOnce(new Error('404 Not Found'));
 
     const ctx = { ...baseCtx, listSpecs: () => [spec] };
     const results = await runHealthChecks(ctx, mockSp);
@@ -59,7 +59,7 @@ describe('Health Checks — Optional List Contract', () => {
       isOptional: true,
     };
 
-    (mockSp.getListByTitle as any).mockRejectedValueOnce(new Error('404 Not Found'));
+    vi.mocked(mockSp.getListByTitle).mockRejectedValueOnce(new Error('404 Not Found'));
 
     const ctx = { ...baseCtx, listSpecs: () => [spec] };
     const results = await runHealthChecks(ctx, mockSp);
@@ -80,8 +80,8 @@ describe('Health Checks — Optional List Contract', () => {
       isOptional: true,
     };
 
-    (mockSp.getListByTitle as any).mockResolvedValueOnce({ id: 'guid', title: 'OptionalList' });
-    (mockSp.getFields as any).mockResolvedValueOnce([]);
+    vi.mocked(mockSp.getListByTitle).mockResolvedValueOnce({ id: 'guid', title: 'OptionalList' });
+    vi.mocked(mockSp.getFields).mockResolvedValueOnce([]);
 
     const ctx = { ...baseCtx, listSpecs: () => [spec] };
     const results = await runHealthChecks(ctx, mockSp);

--- a/src/features/diagnostics/remediation/domain/__tests__/governanceAdvisor.spec.ts
+++ b/src/features/diagnostics/remediation/domain/__tests__/governanceAdvisor.spec.ts
@@ -12,8 +12,8 @@ describe('governanceAdvisor v4.3 (Operational Readiness)', () => {
       provisioningFields: [
         { internalName: 'FullName', type: 'Text', required: true },
       ],
-      operations: ['R'] as any,
-      category: 'user' as any,
+      operations: ['R'],
+      category: 'master',
       essentialFields: ['FullName'],
       lifecycle: 'required',
     }
@@ -48,11 +48,11 @@ describe('governanceAdvisor v4.3 (Operational Readiness)', () => {
       displayName: '監査ログ',
       resolve: () => 'AuditLogs',
       provisioningFields: [{ internalName: 'Log', type: 'Text' }],
-      operations: ['R'] as any,
-      category: 'ops' as any,
+      operations: ['R'],
+      category: 'other',
       essentialFields: ['Log'],
       lifecycle: 'required',
-    } as any];
+    } as SpListEntry];
     
     const signals = [createMockDrift({ reasonKey: 'audit_logs:Log', streak: 10 })];
     const recs = deriveGovernanceRecommendations(registryWithAudit, signals);

--- a/src/features/today/constants/todaySignal.constants.ts
+++ b/src/features/today/constants/todaySignal.constants.ts
@@ -45,6 +45,14 @@ export const TODAY_SIGNAL_DISPLAY_CONFIG: Record<TodaySignalCode, SignalDisplayC
     severity: 'danger',
     group: 'planning',
   },
+  monitoring_due_today: {
+    prefix: '【期日当日】',
+    defaultActionLabel: 'モニタリングへ',
+    priority: 'P0',
+    audience: ['admin', 'staff'],
+    severity: 'danger',
+    group: 'planning',
+  },
   monitoring_due_soon: {
     prefix: '【期日接近】',
     defaultActionLabel: 'モニタリングへ',

--- a/src/features/today/domain/__tests__/mapTodaySignalToActionSource.spec.ts
+++ b/src/features/today/domain/__tests__/mapTodaySignalToActionSource.spec.ts
@@ -39,7 +39,7 @@ describe('mapTodaySignalToActionSource', () => {
   });
 
   it('対象外 code は null を返す', () => {
-    const signal = makeSignal({ code: 'daily_record_missing' as any });
+    const signal = makeSignal({ code: 'daily_record_missing' as unknown as TodaySignalCode });
     const result = mapTodaySignalToActionSource(signal);
     expect(result).toBeNull();
   });
@@ -65,7 +65,7 @@ describe('mapTodaySignalToActionSource', () => {
       makeSignal(),
       makeSignal({
         id: 'daily_record_missing:u002',
-        code: 'daily_record_missing' as any,
+        code: 'daily_record_missing' as unknown as TodaySignalCode,
       }),
     ];
     const result = mapTodaySignalsToActionSources(signals);

--- a/src/features/today/domain/__tests__/mapTodaySignalToActionSource.spec.ts
+++ b/src/features/today/domain/__tests__/mapTodaySignalToActionSource.spec.ts
@@ -39,17 +39,33 @@ describe('mapTodaySignalToActionSource', () => {
   });
 
   it('対象外 code は null を返す', () => {
-    const signal = makeSignal({ code: 'monitoring_due_soon' });
+    const signal = makeSignal({ code: 'daily_record_missing' as any });
     const result = mapTodaySignalToActionSource(signal);
     expect(result).toBeNull();
+  });
+
+  it('monitoring_deadline シグナルを変換する', () => {
+    const signal = makeSignal({
+      id: 'monitoring-deadline:U001:2026-05-30',
+      code: 'monitoring_due_soon',
+      metadata: {
+        userId: 'U001',
+        nextDueDate: '2026-05-30',
+        remainingDays: 22,
+        status: 'warning',
+      },
+    });
+    const result = mapTodaySignalToActionSource(signal);
+    expect(result?.sourceType).toBe('monitoring_deadline');
+    expect(result?.targetTime?.toISOString()).toContain('2026-05-30');
   });
 
   it('配列変換では null を除外する', () => {
     const signals: TodaySignal[] = [
       makeSignal(),
       makeSignal({
-        id: 'monitoring_due_soon:u002',
-        code: 'monitoring_due_soon',
+        id: 'daily_record_missing:u002',
+        code: 'daily_record_missing' as any,
       }),
     ];
     const result = mapTodaySignalsToActionSources(signals);

--- a/src/features/today/domain/engine/mapToActionCard.ts
+++ b/src/features/today/domain/engine/mapToActionCard.ts
@@ -17,6 +17,7 @@ function resolveActionType(item: ScoredActionItem): ActionType {
     case 'corrective_action':
     case 'plan_patch':
     case 'isp_renew_suggest':
+    case 'monitoring_deadline':
       return 'NAVIGATE';
     case 'schedule':
       return 'OPEN_DRAWER';
@@ -56,6 +57,13 @@ function buildContextMessage(item: ScoredActionItem): string {
     const impactLabel = payload?.impact === 'high' ? '高優先' : '通常';
     const mode = payload?.recommendedOnly === false ? '要確認' : '要確認（自動適用なし）';
     return `${impactLabel} / ${mode} / ${reason}`;
+  }
+
+  if (item.sourceType === 'monitoring_deadline') {
+    const payload = item.payload as { status?: string; remainingDays?: number; nextDueDate?: string } | undefined;
+    const statusLabel = payload?.status === 'overdue' ? '期限超過' : '期限間近';
+    const remaining = payload?.remainingDays !== undefined ? `${payload.remainingDays}日` : '不明';
+    return `${statusLabel} / 残り ${remaining} / 期限: ${payload?.nextDueDate}`;
   }
 
   const base = item.targetTime

--- a/src/features/today/domain/engine/scoreActionPriority.ts
+++ b/src/features/today/domain/engine/scoreActionPriority.ts
@@ -31,6 +31,13 @@ export function scoreActionPriority(source: RawActionSource): ActionPriority {
     }
     case 'isp_renew_suggest':
       return 'P2';
+    case 'monitoring_deadline': {
+      const payload = source.payload as { signalCode?: string } | undefined;
+      return payload?.signalCode === 'monitoring_overdue' ||
+        payload?.signalCode === 'monitoring_due_today'
+        ? 'P0'
+        : 'P1';
+    }
     default: {
       const _exhaustive: never = source.sourceType;
       return _exhaustive;

--- a/src/features/today/domain/mapMonitoringDeadlineToTodaySignal.ts
+++ b/src/features/today/domain/mapMonitoringDeadlineToTodaySignal.ts
@@ -1,0 +1,68 @@
+import type { MonitoringDeadlineState } from '@/domain/isp/monitoringDeadline';
+import type { TodaySignal, TodaySignalPriority } from '../types/todaySignal.types';
+
+export interface MonitoringDeadlineSignalInput {
+  userId: string;
+  userName: string;
+  deadlineState: MonitoringDeadlineState;
+}
+
+export function mapMonitoringDeadlineToTodaySignal(
+  input: MonitoringDeadlineSignalInput,
+): TodaySignal | null {
+  const { userId, userName, deadlineState } = input;
+  const { status, nextDueDate, remainingDays } = deadlineState;
+
+  if (status === 'normal' || status === 'unknown' || status === 'invalid') {
+    return null;
+  }
+
+  let priority: TodaySignalPriority = 'P2';
+  let code: 'monitoring_overdue' | 'monitoring_due_today' | 'monitoring_due_soon' = 'monitoring_due_soon';
+  let title = '';
+  let description = '';
+
+  switch (status) {
+    case 'overdue':
+      priority = 'P0';
+      code = 'monitoring_overdue';
+      title = `${userName}様のモニタリング期限超過`;
+      description = `期限日(${nextDueDate})を過ぎています。速やかに実施してください。`;
+      break;
+    case 'dueToday':
+      priority = 'P0';
+      code = 'monitoring_due_today';
+      title = `${userName}様のモニタリング期限当日`;
+      description = `本日(${nextDueDate})が期限日です。`;
+      break;
+    case 'critical':
+      priority = 'P1';
+      code = 'monitoring_due_soon';
+      title = `${userName}様のモニタリング期限間近`;
+      description = `期限まであと ${remainingDays} 日です (${nextDueDate})。`;
+      break;
+    case 'warning':
+      priority = 'P1';
+      code = 'monitoring_due_soon';
+      title = `${userName}様のモニタリング期限接近`;
+      description = `期限まであと ${remainingDays} 日です (${nextDueDate})。`;
+      break;
+  }
+
+  return {
+    id: `monitoring-deadline:${userId}:${nextDueDate}`,
+    code,
+    domain: 'Planning',
+    priority,
+    audience: ['staff', 'admin'],
+    title,
+    description,
+    actionPath: `/support-plan-guide?userId=${encodeURIComponent(userId)}&tab=operations.monitoring`,
+    metadata: {
+      userId,
+      nextDueDate,
+      remainingDays,
+      status,
+    },
+  };
+}

--- a/src/features/today/domain/mapTodaySignalToActionSource.ts
+++ b/src/features/today/domain/mapTodaySignalToActionSource.ts
@@ -8,23 +8,46 @@ function toTargetTime(value: unknown): Date | undefined {
 }
 
 export function mapTodaySignalToActionSource(signal: TodaySignal): RawActionSource | null {
-  if (signal.code !== 'isp_renew_suggest') return null;
-
   const metadata = (signal.metadata ?? {}) as Record<string, unknown>;
-  return {
-    id: `today-signal:${signal.id}`,
-    sourceType: 'isp_renew_suggest',
-    title: signal.title,
-    targetTime: toTargetTime(metadata.createdAt),
-    slaMinutes: 0,
-    isCompleted: false,
-    payload: {
-      ...metadata,
-      path: signal.actionPath,
-      signalCode: signal.code,
-      recommendedOnly: true,
-    },
-  };
+
+  if (signal.code === 'isp_renew_suggest') {
+    return {
+      id: `today-signal:${signal.id}`,
+      sourceType: 'isp_renew_suggest',
+      title: signal.title,
+      targetTime: toTargetTime(metadata.createdAt),
+      slaMinutes: 0,
+      isCompleted: false,
+      payload: {
+        ...metadata,
+        path: signal.actionPath,
+        signalCode: signal.code,
+        recommendedOnly: true,
+      },
+    };
+  }
+
+  if (
+    signal.code === 'monitoring_overdue' ||
+    signal.code === 'monitoring_due_today' ||
+    signal.code === 'monitoring_due_soon'
+  ) {
+    return {
+      id: `today-signal:${signal.id}`,
+      sourceType: 'monitoring_deadline',
+      title: signal.title,
+      targetTime: toTargetTime(metadata.nextDueDate),
+      slaMinutes: 0,
+      isCompleted: false,
+      payload: {
+        ...metadata,
+        path: signal.actionPath,
+        signalCode: signal.code,
+      },
+    };
+  }
+
+  return null;
 }
 
 export function mapTodaySignalsToActionSources(signals: TodaySignal[]): RawActionSource[] {

--- a/src/features/today/domain/models/queue.types.ts
+++ b/src/features/today/domain/models/queue.types.ts
@@ -8,7 +8,8 @@ export type ActionSourceType =
   | 'corrective_action'
   | 'exception'
   | 'plan_patch'
-  | 'isp_renew_suggest';
+  | 'isp_renew_suggest'
+  | 'monitoring_deadline';
 
 export interface RawActionSource {
   id: string;

--- a/src/features/today/hooks/__tests__/useTodayMonitoringDeadlineActions.spec.ts
+++ b/src/features/today/hooks/__tests__/useTodayMonitoringDeadlineActions.spec.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useTodayMonitoringDeadlineActions } from '../useTodayMonitoringDeadlineActions';
+import type { IUserMaster } from '@/features/users/types';
+
+describe('useTodayMonitoringDeadlineActions', () => {
+  const mockUsers: Partial<IUserMaster>[] = [
+    {
+      UserID: 'U001',
+      FullName: '利用者一',
+      ServiceStartDate: '2026-02-01', // 2026-05-08時点で 96日経過 -> overdue (cycle=90)
+    },
+    {
+      UserID: 'U002',
+      FullName: '利用者二',
+      ServiceStartDate: '2026-02-07', // 2026-05-08時点で 90日経過 -> dueToday
+    },
+    {
+      UserID: 'U003',
+      FullName: '利用者三',
+      ServiceStartDate: '2026-02-14', // 2026-05-08時点で 83日経過 -> critical (残り7日)
+    },
+    {
+      UserID: 'U004',
+      FullName: '利用者四',
+      ServiceStartDate: '2026-03-01', // 2026-05-08時点で 68日経過 -> warning (残り22日)
+    },
+    {
+      UserID: 'U005',
+      FullName: '利用者五',
+      ServiceStartDate: '2026-04-10', // 2026-05-08時点で 28日経過 -> normal (残り62日)
+    },
+    {
+      UserID: 'U006',
+      FullName: '利用者六',
+      ServiceStartDate: undefined, // unknown
+    },
+  ];
+
+  it('should return correct actions based on monitoring deadlines', () => {
+    // 基準日を 2026-05-08 に固定
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-08'));
+
+    const { result } = renderHook(() => 
+      useTodayMonitoringDeadlineActions(mockUsers as IUserMaster[])
+    );
+
+    const { signals, actionSources } = result.current;
+
+    // normal(U005) と unknown(U006) は含まれないはず
+    expect(signals).toHaveLength(4);
+
+    // U001: overdue -> P0
+    const signal1 = signals.find(s => s.metadata?.userId === 'U001');
+    expect(signal1?.code).toBe('monitoring_overdue');
+    expect(signal1?.priority).toBe('P0');
+    expect(signal1?.id).toBe('monitoring-deadline:U001:2026-05-02');
+
+    // U002: dueToday -> P0
+    const signal2 = signals.find(s => s.metadata?.userId === 'U002');
+    expect(signal2?.code).toBe('monitoring_due_today');
+    expect(signal2?.priority).toBe('P0');
+
+    // U003: critical -> P1
+    const signal3 = signals.find(s => s.metadata?.userId === 'U003');
+    expect(signal3?.code).toBe('monitoring_due_soon');
+    expect(signal3?.priority).toBe('P1');
+    expect(signal3?.metadata?.status).toBe('critical');
+
+    // U004: warning -> P1
+    const signal4 = signals.find(s => s.metadata?.userId === 'U004');
+    expect(signal4?.code).toBe('monitoring_due_soon');
+    expect(signal4?.priority).toBe('P1');
+    expect(signal4?.metadata?.status).toBe('warning');
+
+    // ActionSources verify
+    expect(actionSources).toHaveLength(4);
+    const source1 = actionSources.find(s => s.id === `today-signal:${signal1?.id}`);
+    expect(source1?.sourceType).toBe('monitoring_deadline');
+
+    vi.useRealTimers();
+  });
+});

--- a/src/features/today/hooks/useTodayMonitoringDeadlineActions.ts
+++ b/src/features/today/hooks/useTodayMonitoringDeadlineActions.ts
@@ -1,0 +1,39 @@
+import { useMemo } from 'react';
+import type { IUserMaster } from '@/features/users/types';
+import { computeMonitoringDeadlineFromSupportStart } from '@/domain/isp/monitoringDeadline';
+import { mapMonitoringDeadlineToTodaySignal } from '../domain/mapMonitoringDeadlineToTodaySignal';
+import { mapTodaySignalsToActionSources } from '../domain/mapTodaySignalToActionSource';
+import type { RawActionSource } from '../domain/models/queue.types';
+import type { TodaySignal } from '../types/todaySignal.types';
+
+export interface UseTodayMonitoringDeadlineActionsResult {
+  signals: TodaySignal[];
+  actionSources: RawActionSource[];
+}
+
+export function useTodayMonitoringDeadlineActions(
+  users: IUserMaster[],
+): UseTodayMonitoringDeadlineActionsResult {
+  const result = useMemo(() => {
+    const today = new Date().toISOString().split('T')[0];
+
+    const signals = users
+      .map((user) => {
+        const monitoringBaseDate = user.ServiceStartDate;
+        const deadlineState = computeMonitoringDeadlineFromSupportStart(monitoringBaseDate, today);
+        
+        return mapMonitoringDeadlineToTodaySignal({
+          userId: user.UserID || String(user.Id),
+          userName: user.FullName,
+          deadlineState,
+        });
+      })
+      .filter((signal): signal is TodaySignal => signal !== null);
+
+    const actionSources = mapTodaySignalsToActionSources(signals);
+
+    return { signals, actionSources };
+  }, [users]);
+
+  return result;
+}

--- a/src/features/today/types/todaySignal.types.ts
+++ b/src/features/today/types/todaySignal.types.ts
@@ -6,6 +6,7 @@ export type TodaySignalCode =
   | 'health_record_missing'
   | 'handoff_unread'
   | 'monitoring_overdue'
+  | 'monitoring_due_today'
   | 'monitoring_due_soon'
   | 'isp_renew_suggest'
   | 'risk_health_alert';

--- a/src/pages/today-isolated/TodayOpsPage_v3.tsx
+++ b/src/pages/today-isolated/TodayOpsPage_v3.tsx
@@ -17,6 +17,7 @@ import { useTodayLayoutProps } from '@/features/today/hooks/useTodayLayoutProps'
 import { useTodayIspRenewSuggestActions } from '@/features/today/hooks/useTodayIspRenewSuggestActions';
 import { useTodayPlanPatchActions } from '@/features/today/hooks/useTodayPlanPatchActions';
 import { useTodayExceptions } from '@/features/today/hooks/useTodayExceptions';
+import { useTodayMonitoringDeadlineActions } from '@/features/today/hooks/useTodayMonitoringDeadlineActions';
 import { useCallLogsSummary } from '@/features/callLogs/hooks/useCallLogsSummary';
 import { useKioskAutoRefresh } from '@/features/today/hooks/useKioskAutoRefresh';
 import { useSuggestionStateStore } from '@/features/action-engine/hooks/useSuggestionStateStore';
@@ -81,6 +82,7 @@ const TodayOpsPageInner: React.FC<{ correctiveActions?: ActionSuggestion[] }> = 
   const summary = useTodaySummary();
   const todayPlanPatchActions = useTodayPlanPatchActions(summary.users ?? []);
   const todayIspRenewSuggest = useTodayIspRenewSuggestActions(summary.users ?? []);
+  const todayMonitoringDeadline = useTodayMonitoringDeadlineActions(summary.users ?? []);
   const pendingSupportUsers = useMemo(() => {
     const ids = summary.todayRecordCompletion?.pendingUserIds ?? [];
     const usersArr = summary.users ?? [];
@@ -112,6 +114,7 @@ const TodayOpsPageInner: React.FC<{ correctiveActions?: ActionSuggestion[] }> = 
       ...summary.todayExceptionActions,
       ...todayPlanPatchActions,
       ...todayIspRenewSuggest.actionSources,
+      ...todayMonitoringDeadline.actionSources,
     ],
   });
 


### PR DESCRIPTION
## Summary
- Add monitoring deadline action source for Today Action Queue
- Surface users whose monitoring deadlines are overdue, due today, critical, or warning
- Use ServiceStartDate-based 90-day monitoring deadline calculation introduced in PR #1823
- Add priority scoring for monitoring deadline actions
- Wire monitoring deadline actions into TodayOpsPage_v3

## Business Rule
- `monitoringBaseDate` = `ServiceStartDate`
- `cycle` = 90 calendar days
- `overdue` / `dueToday` -> **P0**
- `critical` / `warning` -> **P1**
- `normal` / `unknown` / `invalid` are not surfaced as Today actions

## Checks
- [x] `npm run typecheck`
- [x] `npx vitest run src/domain/isp src/features/today tests/unit/pages/TodayOpsPage.spec.tsx`

## Self Review
- [x] `dueToday` is treated as P0
- [x] `normal` / `unknown` / `invalid` are filtered out
- [x] Action IDs are stable with `monitoring-deadline:${userId}:${nextDueDate}`
- [x] CTA points to `/support-plan-guide?userId=...&tab=operations.monitoring`
- [x] PR #1823 deadline calculation is reused, not duplicated

## Notes
- Includes small unrelated test lint fixes in diagnostics specs to satisfy CI Preflight after rebasing onto latest main.

## Out of Scope
- Teams/Nightly notifications
- SharePoint schema changes
- Changing PR #1823 monitoring deadline calculation
