### PR TITLE
fix(kiosk): prevent empty procedure record save

### DIFF
--- a/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
@@ -50,6 +50,7 @@ export const KioskProcedureDetailScreen: React.FC = () => {
   const [isSaving, setIsSaving] = useState(false);
   const [showSuccess, setShowSuccess] = useState(false);
   const [showSaveError, setShowSaveError] = useState(false);
+  const [showValidationError, setShowValidationError] = useState(false);
 
   // 観察チップ用ステート
   const [selectedMood, setSelectedMood] = useState<string>('');
@@ -96,9 +97,13 @@ export const KioskProcedureDetailScreen: React.FC = () => {
 
   const handleSave = async () => {
     if (!userId) return;
+    const finalMemo = serializeMemo();
+    if (!finalMemo.trim()) {
+      setShowValidationError(true);
+      return;
+    }
     setIsSaving(true);
     try {
-      const finalMemo = serializeMemo();
       await saveRecord('completed', finalMemo);
       setShowSuccess(true);
       // 成功フィードバックの後、少し待ってから一覧に戻る
@@ -380,6 +385,17 @@ export const KioskProcedureDetailScreen: React.FC = () => {
       >
         <Alert severity="error" sx={{ width: '100%' }}>
           記録の保存に失敗しました。再度お試しください。
+        </Alert>
+      </Snackbar>
+
+      <Snackbar
+        open={showValidationError}
+        autoHideDuration={3000}
+        onClose={() => setShowValidationError(false)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert severity="warning" sx={{ width: '100%' }}>
+          手順記録の内容を1つ以上入力してください。
         </Alert>
       </Snackbar>
     </Box>

--- a/src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx
@@ -127,6 +127,7 @@ describe('KioskProcedureDetailScreen (memory provider URL for local UI behavior 
 
     expect(mockUseExecutionRecord).toHaveBeenCalledWith('2026-05-07', 'U001', 'P001', ['0']);
 
+    fireEvent.click(screen.getByTestId('mood-chip-不安そう'));
     fireEvent.click(screen.getByTestId('kiosk-observation-submit'));
     await waitFor(() => {
       expect(mockSaveRecord).toHaveBeenCalled();
@@ -143,6 +144,7 @@ describe('KioskProcedureDetailScreen (memory provider URL for local UI behavior 
       </MemoryRouter>
     );
 
+    fireEvent.click(screen.getByTestId('mood-chip-不安そう'));
     fireEvent.click(screen.getByTestId('kiosk-observation-submit'));
     await Promise.resolve();
     await Promise.resolve();
@@ -170,10 +172,26 @@ describe('KioskProcedureDetailScreen (memory provider URL for local UI behavior 
       </MemoryRouter>
     );
 
+    fireEvent.click(screen.getByTestId('mood-chip-不安そう'));
     fireEvent.click(screen.getByTestId('kiosk-observation-submit'));
 
     await waitFor(() => {
       expect(screen.getByText('記録の保存に失敗しました。再度お試しください。')).toBeInTheDocument();
     });
+  });
+
+  it('blocks save when observation content is empty', async () => {
+    render(
+      <MemoryRouter>
+        <KioskProcedureDetailScreen />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByTestId('kiosk-observation-submit'));
+
+    await waitFor(() => {
+      expect(screen.getByText('手順記録の内容を1つ以上入力してください。')).toBeInTheDocument();
+    });
+    expect(mockSaveRecord).not.toHaveBeenCalled();
   });
 });

--- a/tests/e2e/kiosk-procedure-detail.spec.ts
+++ b/tests/e2e/kiosk-procedure-detail.spec.ts
@@ -30,13 +30,14 @@ test.describe('Kiosk Procedure Detail', () => {
     // 観察パネルが表示されることを確認
     await expect(page.getByTestId('kiosk-observation-panel')).toBeVisible();
 
-    // 1. 本人の様子を選択（バリデーション回避のため1つ以上選択が必要）
-    await page.getByTestId('mood-chip-落ち着いていた').click();
+    // 1. 自由記述メモを入力（バリデーション回避のため1つ以上入力が必要）
+    await page.getByTestId('kiosk-observation-memo').fill('E2E保存確認');
 
-    // 2. パネル内の「記録を保存する」をクリック
-    await page.getByRole('button', { name: '記録を保存する' }).click();
+    // 2. 「記録を保存する」ボタンをクリック（data-testidを使用）
+    await page.getByTestId('kiosk-observation-submit').click();
 
-    await expect(page.getByText('記録を保存しました')).toBeVisible();
+    // 成功メッセージが表示されるのを待つ（タイムアウトに注意）
+    await expect(page.getByText('記録を保存しました')).toBeVisible({ timeout: 5000 });
     await expect(page).toHaveURL(/.*\/kiosk\/users\/1\/procedures\/?(\?.*)?/);
 
     const firstCard = page.locator('[data-testid="kiosk-procedure-card-0"]');

--- a/tests/e2e/kiosk-procedure-detail.spec.ts
+++ b/tests/e2e/kiosk-procedure-detail.spec.ts
@@ -30,6 +30,9 @@ test.describe('Kiosk Procedure Detail', () => {
     // 観察パネルが表示されることを確認
     await expect(page.getByTestId('kiosk-observation-panel')).toBeVisible();
 
+    // 1. 本人の様子を選択（バリデーション回避のため1つ以上選択が必要）
+    await page.getByTestId('mood-chip-落ち着いていた').click();
+
     // 2. パネル内の「記録を保存する」をクリック
     await page.getByRole('button', { name: '記録を保存する' }).click();
 


### PR DESCRIPTION
## Summary
- Block kiosk procedure record save when no observation content is entered
- Show a dedicated warning message: 手順記録の内容を1つ以上入力してください。
- Keep this validation separate from save failure errors
- Prevent completed records with empty Memo/Payload from being created

## Background
Kiosk procedure detail could save a completed record with an empty memo when the user pressed save without entering any observation content. This could create records that appear completed but contain no actual support record content.

## Tests
- npx vitest run src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx

Result:
- 8 tests passed