### PR TITLE
fix(daily): read observation as execution memo fallback

### DIFF
--- a/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
+++ b/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
@@ -330,6 +330,15 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
     return { completed, triggered, rate };
   }
 
+  private pickFirstNonEmptyString(...values: unknown[]): string {
+    for (const value of values) {
+      if (typeof value === 'string' && value.trim().length > 0) {
+        return value;
+      }
+    }
+    return '';
+  }
+
   private mapToDomain(item: JsonRecord, rf: ResolvedRowsFields): ExecutionRecord {
     const title = (item.Title || item.title || '') as string;
     let triggeredBipIds: string[] = [];
@@ -373,7 +382,12 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
       scheduleItemId,
       status: item[rf.status] as RecordStatus,
       triggeredBipIds,
-      memo: (item[rf.memo] || item[rf.payload] || '') as string,
+      memo: this.pickFirstNonEmptyString(
+        item[rf.memo],
+        item[rf.payload],
+        item.Observation,
+        item.observation,
+      ),
       recordedBy: (item[rf.staffName] || '') as string,
       recordedAt: (item[rf.recordedAt] || '') as string,
     };

--- a/src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts
+++ b/src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts
@@ -280,5 +280,117 @@ describe('SharePointExecutionRecordRepository', () => {
       expect(mapped.userId).toBe('4');
       expect(mapped.date).toBe('2026-05-08');
     });
+
+    it('uses Memo when Memo has content', () => {
+      const mockItem = {
+        Title: '2026-05-08-4-1',
+        User_x0020_ID: '4',
+        Status: 'completed',
+        Memo: 'memo-value',
+        Payload: 'payload-value',
+        Observation: 'observation-value',
+        Recorded_x0020_At: '2026-05-08T12:00:00Z',
+      };
+      const rf = {
+        parentId: 'Parent_x0020_ID',
+        userId: 'User_x0020_ID',
+        version: 'Version',
+        status: 'Status',
+        payload: 'Payload',
+        recordedAt: 'Recorded_x0020_At',
+        rowKey: 'Title',
+        rowNo: 'RowNo',
+        memo: 'Memo',
+        staffName: 'StaffName',
+        bipsJSON: 'BipsJSON',
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mapped = (repo as any).mapToDomain(mockItem, rf);
+      expect(mapped.memo).toBe('memo-value');
+    });
+
+    it('uses Payload when Memo is empty', () => {
+      const mockItem = {
+        Title: '2026-05-08-4-2',
+        User_x0020_ID: '4',
+        Status: 'completed',
+        Memo: '   ',
+        Payload: 'payload-value',
+        Observation: 'observation-value',
+        Recorded_x0020_At: '2026-05-08T12:00:00Z',
+      };
+      const rf = {
+        parentId: 'Parent_x0020_ID',
+        userId: 'User_x0020_ID',
+        version: 'Version',
+        status: 'Status',
+        payload: 'Payload',
+        recordedAt: 'Recorded_x0020_At',
+        rowKey: 'Title',
+        rowNo: 'RowNo',
+        memo: 'Memo',
+        staffName: 'StaffName',
+        bipsJSON: 'BipsJSON',
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mapped = (repo as any).mapToDomain(mockItem, rf);
+      expect(mapped.memo).toBe('payload-value');
+    });
+
+    it('uses Observation when Memo and Payload are empty', () => {
+      const mockItem = {
+        Title: '2026-05-08-4-3',
+        User_x0020_ID: '4',
+        Status: 'completed',
+        Memo: '',
+        Payload: '   ',
+        Observation: 'observation-value',
+        Recorded_x0020_At: '2026-05-08T12:00:00Z',
+      };
+      const rf = {
+        parentId: 'Parent_x0020_ID',
+        userId: 'User_x0020_ID',
+        version: 'Version',
+        status: 'Status',
+        payload: 'Payload',
+        recordedAt: 'Recorded_x0020_At',
+        rowKey: 'Title',
+        rowNo: 'RowNo',
+        memo: 'Memo',
+        staffName: 'StaffName',
+        bipsJSON: 'BipsJSON',
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mapped = (repo as any).mapToDomain(mockItem, rf);
+      expect(mapped.memo).toBe('observation-value');
+    });
+
+    it('skips empty strings and returns empty when all candidates are empty', () => {
+      const mockItem = {
+        Title: '2026-05-08-4-4',
+        User_x0020_ID: '4',
+        Status: 'completed',
+        Memo: '   ',
+        Payload: '',
+        Observation: '\n\t',
+        Recorded_x0020_At: '2026-05-08T12:00:00Z',
+      };
+      const rf = {
+        parentId: 'Parent_x0020_ID',
+        userId: 'User_x0020_ID',
+        version: 'Version',
+        status: 'Status',
+        payload: 'Payload',
+        recordedAt: 'Recorded_x0020_At',
+        rowKey: 'Title',
+        rowNo: 'RowNo',
+        memo: 'Memo',
+        staffName: 'StaffName',
+        bipsJSON: 'BipsJSON',
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mapped = (repo as any).mapToDomain(mockItem, rf);
+      expect(mapped.memo).toBe('');
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Read Observation as a fallback execution memo source when Memo/Payload are empty
- Skip empty strings when resolving memo content
- Restore detail display for existing DailyRecordRows where content was saved only in Observation
- Keep write behavior unchanged

## Background
Some DailyRecordRows contain support record content in Observation while Memo/Payload are empty because of SharePoint column drift. The app currently reads Memo/Payload only, so those records can appear empty in kiosk detail even though SharePoint contains content.

## Tests
- npx vitest run src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts