### PR TITLE
fix(kiosk): stabilize past-date procedure entry tests

### DIFF
--- a/src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx
@@ -39,13 +39,13 @@ vi.mock('@/features/daily/hooks/useProcedureData', () => ({
 }));
 
 const mockSaveRecord = vi.fn().mockResolvedValue(undefined);
-const mockUseExecutionRecord = vi.fn(() => ({
+const mockUseExecutionRecord = vi.fn((_date?: string, _userId?: string, _scheduleItemId?: string, _fallbackScheduleItemIds?: string[]) => ({
   record: null,
   saveRecord: mockSaveRecord,
   isLoading: false,
 }));
 vi.mock('@/features/daily/hooks/useExecutionRecord', () => ({
-  useExecutionRecord: (...args: unknown[]) => mockUseExecutionRecord(...args),
+  useExecutionRecord: (date: string, userId: string, scheduleItemId: string, fallbackScheduleItemIds?: string[]) => mockUseExecutionRecord(date, userId, scheduleItemId, fallbackScheduleItemIds),
 }));
 
 describe('KioskProcedureDetailScreen (memory provider URL for local UI behavior tests)', () => {

--- a/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
@@ -31,7 +31,7 @@ vi.mock('@/features/daily/hooks/useProcedureData', () => ({
 
 const mockGetRecords = vi.fn();
 const mockGetStoreRecords = vi.fn();
-const mockGetCurrentExecutionRepositoryKind = vi.fn(() => 'local' as const);
+const mockGetCurrentExecutionRepositoryKind = vi.fn(() => 'local' as 'local' | 'sharepoint');
 
 vi.mock('@/features/daily/stores/executionStore', () => ({
   useExecutionStore: () => ({
@@ -51,7 +51,7 @@ vi.mock('@/features/daily/repositories/sharepoint/executionRepositoryFactory', (
 
 describe('KioskProcedureListScreen (includes local/memory-style recorded-state checks)', () => {
   beforeEach(() => {
-    vi.useFakeTimers();
+    vi.useFakeTimers({ toFake: ['Date'] });
     vi.setSystemTime(new Date(2026, 4, 8));
     vi.clearAllMocks();
     mockGetCurrentExecutionRepositoryKind.mockReturnValue('local');


### PR DESCRIPTION
## Summary
- Support `date=YYYY-MM-DD` query parameter on kiosk procedure list/detail screens
- Load and save procedure records for the selected date instead of always using today
- Fallback to today when date is missing or invalid
- Preserve date query across list/detail/back navigation
- Stabilize kiosk past-date procedure tests by faking only `Date`
- Align `useExecutionRecord` test mock signature with fallback schedule item IDs
- Keep SharePoint repository and schema unchanged

Closes #1822

## Changes
- `KioskProcedureListScreen.spec.tsx`
  - Changed `vi.useFakeTimers()` to `vi.useFakeTimers({ toFake: ['Date'] })`
  - Prevents React 18 Scheduler / Testing Library `waitFor` timers from being blocked in Vitest
  - Resolves the previous list screen test timeout

- `KioskProcedureDetailScreen.spec.tsx`
  - Updated `useExecutionRecord` mock signature to include the 4th argument, `fallbackScheduleItemIds`
  - Fixes mock argument mismatch after the hook signature change

## Validation
- npx vitest run src/features/kiosk
- npx tsc --noEmit
- npx eslint src/features/kiosk/components/__tests__/*.tsx

## Notes
- No SharePoint schema changes
- No production persistence contract changes
- Scope is limited to kiosk previous-date support and test stabilization
