### PR TITLE
fix(health): align Users_Master essential field with UserID

### DIFF
--- a/src/sharepoint/__tests__/driftProbeRegistry.spec.ts
+++ b/src/sharepoint/__tests__/driftProbeRegistry.spec.ts
@@ -25,7 +25,7 @@ describe('DriftProbeRegistry / Dynamic Discovery', () => {
     // Id and Title are automatically added by the mapper if missing
     expect(users?.selectFields).toContain('Id');
     expect(users?.selectFields).toContain('Title');
-    expect(users?.selectFields).toContain('userCode');
+    expect(users?.selectFields).toContain('UserID');
     expect(users?.selectFields).toContain('FullName');
   });
 

--- a/src/sharepoint/spListRegistry.definitions.ts
+++ b/src/sharepoint/spListRegistry.definitions.ts
@@ -13,7 +13,7 @@ export const masterListEntries: readonly SpListEntry[] = [
     category: 'master',
     lifecycle: 'required', // 制度管理の基盤となるため required
     essentialFields: [
-      'userCode', 'FullName', 'IsActive', 'UsageStatus'
+      'UserID', 'FullName', 'IsActive', 'UsageStatus'
     ],
     provisioningFields: [
       { internalName: 'UserID', type: 'Text', displayName: 'User Code', required: true, indexed: true, candidates: ['UserID', 'userCode', 'UserCode'] },


### PR DESCRIPTION
## Summary
- Replace Users_Master essential field userCode with physical SharePoint internal name UserID
- Keep userCode as the application/domain property name
- Fix Iceberg-PDCA FAIL caused by stale essentialFields definition

## Design note
This is code-side drift absorption.
No SharePoint columns are added, renamed, or migrated.

## Checks
- npm run typecheck
- npx vitest run src/sharepoint
- node scripts/ops/nightly-patrol.mjs --dry-run