### PR TITLE
fix(drift): prevent hidden field writes in DriftEventsLog

### DIFF
--- a/src/features/diagnostics/drift/infra/SharePointDriftEventRepository.ts
+++ b/src/features/diagnostics/drift/infra/SharePointDriftEventRepository.ts
@@ -115,6 +115,14 @@ export class SharePointDriftEventRepository implements IDriftEventRepository {
     return true;
   }
 
+  /**
+   * SharePoint hidden/system fields (e.g. _Level) cannot be safely targeted in write payloads.
+   * Keep `_xNNNN_` encoded user columns allowed.
+   */
+  private isUnsafeWriteFieldName(fieldName: string): boolean {
+    return fieldName.startsWith('_') && !fieldName.startsWith('_x');
+  }
+
   private getWritablePhysicalNames(
     key: keyof typeof DRIFT_LOG_CANDIDATES,
     required: boolean,
@@ -223,6 +231,9 @@ export class SharePointDriftEventRepository implements IDriftEventRepository {
       }
 
       for (const physicalName of physicalNames) {
+        if (this.isUnsafeWriteFieldName(physicalName)) {
+          continue;
+        }
         payload[physicalName] = value;
       }
       return true;

--- a/src/features/diagnostics/drift/infra/__tests__/SharePointDriftEventRepository.spec.ts
+++ b/src/features/diagnostics/drift/infra/__tests__/SharePointDriftEventRepository.spec.ts
@@ -358,7 +358,7 @@ describe('SharePointDriftEventRepository', () => {
         listName: 'Daily_Attendance',
         fieldName: 'Status0',
         detectedAt: '2026-04-04T01:00:00.000Z',
-        severity: 'warn',
+        severity: 'info',
         resolutionType: 'fallback',
         driftType: 'suffix_mismatch',
         resolved: false,
@@ -545,7 +545,7 @@ describe('SharePointDriftEventRepository', () => {
         listName: 'Daily_Attendance',
         fieldName: 'Status0',
         detectedAt: '2026-04-10T10:00:00.000Z',
-        severity: 'warn',
+        severity: 'info',
         resolutionType: 'fallback',
         driftType: 'suffix_mismatch',
         resolved: false,
@@ -628,6 +628,38 @@ describe('SharePointDriftEventRepository', () => {
     expect(select).not.toContain('_Level');
     expect(select).not.toContain('_ModerationStatus');
     expect(select).toEqual(expect.arrayContaining(['Id', 'Title']));
+  });
+
+  it('does not include hidden system fields (e.g. _Level) in write payloads', async () => {
+    const createItem = vi.fn(async (_listTitle: string, _payload: Record<string, unknown>) => ({}));
+
+    const repo = new SharePointDriftEventRepository({
+      createItem,
+      updateItemByTitle: vi.fn(async () => ({})),
+      getListItemsByTitle: vi.fn(async () => []),
+      getSchema: vi.fn(async () => [
+        'List_x0020_Name',
+        'Field_x0020_Name',
+        'Detected_x0020_At',
+        'Logged_x0020_At',
+        'DriftType',
+        '_Level',
+      ]),
+    });
+
+    await repo.logEvent({
+      listName: 'Daily_Attendance',
+      fieldName: 'Status',
+      detectedAt: '2026-04-05T00:00:00.000Z',
+      severity: 'warn',
+      resolutionType: 'fallback',
+      driftType: 'suffix_mismatch',
+      resolved: false,
+    });
+
+    expect(createItem).toHaveBeenCalledTimes(1);
+    const [, payload] = createItem.mock.calls[0];
+    expect(payload).not.toHaveProperty('_Level');
   });
 
   it('uses resolved physical field when marking resolved', async () => {

--- a/src/sharepoint/fields/diagnosticsFields.ts
+++ b/src/sharepoint/fields/diagnosticsFields.ts
@@ -60,7 +60,7 @@ export const DRIFT_LOG_CANDIDATES = {
   fieldName: ['Field_x0020_Name', 'FieldName', 'InternalName', 'ColumnName', 'FieldName0', 'cr013_fieldName'],
   detectedAt: ['Detected_x0020_At', 'DetectedAt', 'OccurredAt', 'Detected_At', 'DetectedAt0', 'cr013_detectedAt'],
   loggedAt: ['Logged_x0020_At', 'LoggedAt', 'RecordedAt', 'LoggedAt0', 'cr013_loggedAt'],
-  severity: ['Severity', 'Level', 'Status', 'Severity0', 'cr013_severity'],
+  severity: ['Severity', 'DriftSeverity', 'Status', 'Severity0', 'cr013_severity'],
   resolutionType: ['ResolutionType', 'Resolution', 'Type', 'ResolutionType0', 'cr013_resolutionType'],
   resolved: ['Resolved', 'IsResolved', 'Fixed', 'Resolved0', 'cr013_resolved'],
   driftType: ['DriftType', 'Type', 'Category', 'DriftType0', 'cr013_driftType'],


### PR DESCRIPTION
## Summary
- Prevent DriftEventsLog_v2 write payloads from targeting SharePoint hidden/system fields such as `_Level`
- Remove `Level` from severity field candidates to avoid fuzzy resolution to SharePoint built-in `_Level`
- Add regression coverage to ensure `_Level` is not included in write payloads

## Background
The welfare environment can resolve `severity -> _Level` through fuzzy schema matching.
`_Level` is a SharePoint built-in hidden/system field and can trigger HTTP 400 on write.

This is handled as a Watch/noise-suppression fix for optional diagnostics and remains separated from `/admin/status` Go/No-Go logic.

## Checks
- `npx vitest run src/features/diagnostics/drift/infra/__tests__/SharePointDriftEventRepository.spec.ts --no-file-parallelism`
- `npm run -s typecheck`
