### PR TITLE
fix(health): absorb planning sheet field drift

### DIFF
--- a/src/sharepoint/fields/__tests__/ispThreeLayerFields.drift.spec.ts
+++ b/src/sharepoint/fields/__tests__/ispThreeLayerFields.drift.spec.ts
@@ -192,6 +192,34 @@ describe('PLANNING_SHEET_CANDIDATES — 標準名・drift', () => {
     expect(resolved.status).toBe('cr013_status');
     expect(fieldStatus.status.isDrifted).toBe(true);
   });
+
+  it('userCode (小文字) が userCode として解決される（drift）', () => {
+    const available = new Set(['userCode', 'Status']);
+    const { resolved, fieldStatus } = resolveSheet(available);
+    expect(resolved.userCode).toBe('userCode');
+    expect(fieldStatus.userCode.isDrifted).toBe(true);
+  });
+
+  it('userId (小文字) が userCode として解決される（drift）', () => {
+    const available = new Set(['userId', 'Status']);
+    const { resolved, fieldStatus } = resolveSheet(available);
+    expect(resolved.userCode).toBe('userId');
+    expect(fieldStatus.userCode.isDrifted).toBe(true);
+  });
+
+  it('PlanningSheetId が ispId として解決される（drift）', () => {
+    const available = new Set(['UserCode', 'PlanningSheetId', 'Status']);
+    const { resolved, fieldStatus } = resolveSheet(available);
+    expect(resolved.ispId).toBe('PlanningSheetId');
+    expect(fieldStatus.ispId.isDrifted).toBe(true);
+  });
+
+  it('PlanningSheetLookupId が ispId として解決される（drift）', () => {
+    const available = new Set(['UserCode', 'PlanningSheetLookupId', 'Status']);
+    const { resolved, fieldStatus } = resolveSheet(available);
+    expect(resolved.ispId).toBe('PlanningSheetLookupId');
+    expect(fieldStatus.ispId.isDrifted).toBe(true);
+  });
 });
 
 describe('PLANNING_SHEET_ESSENTIALS FAIL/WARN 境界', () => {

--- a/src/sharepoint/fields/ispThreeLayerFields.ts
+++ b/src/sharepoint/fields/ispThreeLayerFields.ts
@@ -321,8 +321,8 @@ export function buildPlanningSheetSelectFields(existingInternalNames?: readonly 
 export const PLANNING_SHEET_CANDIDATES = {
   id: ['Id', 'ID'],
   title: ['Title'],
-  userCode: ['UserCode', 'UserID', 'User_ID', 'cr013_userCode'],
-  ispId: ['ISPId', 'ISPLookupId', 'cr013_ispId'],
+  userCode: ['UserCode', 'userCode', 'UserID', 'UserId', 'userId', 'User_ID', 'cr013_userCode'],
+  ispId: ['ISPId', 'ISPLookupId', 'PlanningSheetId', 'PlanningSheetLookupId', 'cr013_ispId'],
   targetScene: ['TargetScene', 'Scene', 'cr013_targetScene'],
   status: ['Status', 'UsageStatus', 'cr013_status'],
   versionNo: ['VersionNo', 'Version', 'cr013_versionNo'],


### PR DESCRIPTION
# Description

`planning_sheet_master` リスト（`SupportPlanningSheet_Master`）において発生している以下の 3 つのフィールド名ドリフトを、物理列追加（Provision）ではなく、候補定義（`candidates`）の拡張による自動解決（ドリフト吸収）で対応しました。

1. **`UserCode` ➔ `userCode`** (小文字)
2. **`UserId` ➔ `userId`** (小文字)
3. **`ISPLookupId` ➔ `PlanningSheetId`** / **`PlanningSheetLookupId`**

これにより、物理スキーマを破壊的に改修することなく、環境診断（`/admin/status`）における `WARN` ステータスを安全に解消させることができます。

> [!IMPORTANT]
> この Pull Request は、SharePoint ネットワークを絶縁した E2E テスト改善の **PR #1838** の変更点（ブランチ `fix/e2e-isolate-health-smoke-from-sharepoint`）をベースに作成しています。
> そのため、**PR #1838** がマージされた後に本 PR のマージをお願いいたします。

## Changes

### 1. `PLANNING_SHEET_CANDIDATES` 候補の拡張 ([ispThreeLayerFields.ts](file:///Users/yasutakesougo/audit-management-system-mvp/src/sharepoint/fields/ispThreeLayerFields.ts))
- `userCode` フィールドの解決候補に `'userCode'` (小文字), `'UserId'`, `'userId'` (小文字) を追加。
- `ispId` フィールドの解決候補に `'PlanningSheetId'`, `'PlanningSheetLookupId'` を追加。

### 2. ユニットテストの追加 ([ispThreeLayerFields.drift.spec.ts](file:///Users/yasutakesougo/audit-management-system-mvp/src/sharepoint/fields/__tests__/ispThreeLayerFields.drift.spec.ts))
- 追加した解決候補（`userCode`, `userId`, `PlanningSheetId`, `PlanningSheetLookupId`）が、正しく解決され、かつドリフト（`isDrifted: true`）として安全にマークされることを確認するテストケースを追加しました。

## Verification Status

- **Unit Tests**: 🟢 **PASS** (`npx vitest run src/sharepoint/fields/__tests__/ispThreeLayerFields.drift.spec.ts` - 42 tests passed)
- **E2E Smoke Tests**: 🟢 **PASS** (`VITE_SKIP_SHAREPOINT=1 npx playwright test tests/e2e/health.smoke.spec.ts` - 6 passed)
