### PR TITLE
feat(planning-sheet): show monitoring origin status

### DIFF
--- a/src/data/isp/mapper.ts
+++ b/src/data/isp/mapper.ts
@@ -283,6 +283,8 @@ export function mapPlanningSheetRowToListItem(row: SpPlanningSheetRow): Planning
       : ['none'],
     authoredByQualification: row.AuthoredByQualification ?? 'unknown',
     reviewedAt: row.ReviewedAt ?? null,
+    supportStartDate: row.SupportStartDate ?? null,
+    appliedFrom: row.AppliedFrom ?? null,
   });
 }
 

--- a/src/domain/isp/schema/ispPlanningSheetSchema.ts
+++ b/src/domain/isp/schema/ispPlanningSheetSchema.ts
@@ -377,6 +377,10 @@ export const planningSheetListItemSchema = z.object({
   authoredByQualification: staffQualificationSchema.default('unknown'),
   /** 最終レビュー日（再評価日として加算判定に使用） */
   reviewedAt: z.string().nullable().default(null),
+  /** 支援開始日（モニタリング起点用） */
+  supportStartDate: z.string().nullable().default(null),
+  /** 計画適用日（Provisional起点用フォールバック） */
+  appliedFrom: z.string().nullable().default(null),
 });
 
 export type PlanningSheetListItem = z.infer<typeof planningSheetListItemSchema>;

--- a/src/pages/planning-sheet-list/PlanningSheetListView.tsx
+++ b/src/pages/planning-sheet-list/PlanningSheetListView.tsx
@@ -19,6 +19,7 @@ import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Typography from '@mui/material/Typography';
+import Tooltip from '@mui/material/Tooltip';
 import { alpha } from '@mui/material/styles';
 import { UserSelectionGrid } from '@/features/users/components/UserSelectionGrid';
 import { TESTIDS } from '@/testids';
@@ -281,6 +282,7 @@ export const PlanningSheetListView: React.FC<PlanningSheetListViewProps> = ({
                   <TableCell>タイトル</TableCell>
                   <TableCell>対象場面</TableCell>
                   <TableCell>ステータス</TableCell>
+                  <TableCell>起点ステータス</TableCell>
                   <TableCell>サービス</TableCell>
                   <TableCell>次回見直し</TableCell>
                   <TableCell align="right">操作</TableCell>
@@ -325,6 +327,17 @@ export const PlanningSheetListView: React.FC<PlanningSheetListViewProps> = ({
                         label={PLANNING_SHEET_STATUS_DISPLAY[sheet.status]}
                         color={sheet.statusColor}
                       />
+                    </TableCell>
+                    <TableCell>
+                      <Tooltip title={sheet.monitoringOriginHelper} arrow>
+                        <Chip
+                          size="small"
+                          label={sheet.monitoringOriginLabel}
+                          color={sheet.monitoringOriginColor}
+                          data-testid="monitoring-origin-chip"
+                          variant="filled"
+                        />
+                      </Tooltip>
                     </TableCell>
                     <TableCell>
                       <Typography variant="caption">{sheet.applicableServiceType}</Typography>

--- a/src/pages/planning-sheet-list/__tests__/PlanningSheetListPage.regression.spec.tsx
+++ b/src/pages/planning-sheet-list/__tests__/PlanningSheetListPage.regression.spec.tsx
@@ -148,4 +148,41 @@ describe('PlanningSheetListPage Regression Tests', () => {
 
     expect(screen.queryByTestId(TESTIDS.DIFFERENCE_INSIGHT_BAR)).not.toBeInTheDocument();
   });
+
+  test('起点ステータスのChipが正しく表示されること', () => {
+    const vm = { 
+      ...baseViewModel, 
+      sheets: [
+        {
+          id: 's1',
+          userId: 'I009',
+          ispId: 'isp1',
+          title: 'テスト計画',
+          targetScene: '食事',
+          status: 'active' as const,
+          isCurrent: true,
+          statusColor: 'success' as const,
+          nextReviewAt: null,
+          applicableServiceType: 'other',
+          applicableAddOnTypes: ['none'],
+          authoredByQualification: 'unknown',
+          reviewedAt: null,
+          supportStartDate: '2026-05-01',
+          appliedFrom: null,
+          monitoringOriginStatus: 'official' as const,
+          monitoringOriginLabel: '確定',
+          monitoringOriginHelper: '支援開始日を起点に90日モニタリングを管理しています',
+          monitoringOriginColor: 'success' as const,
+        } as unknown as (PlanningSheetListViewModel['sheets'][0])
+      ]
+    };
+    render(
+      <MemoryRouter>
+        <PlanningSheetListView viewModel={vm} handlers={mockHandlers} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('確定')).toBeInTheDocument();
+    expect(screen.getByTestId('monitoring-origin-chip')).toBeInTheDocument();
+  });
 });

--- a/src/pages/planning-sheet-list/hooks/__tests__/planningSheetListViewModelMapper.spec.ts
+++ b/src/pages/planning-sheet-list/hooks/__tests__/planningSheetListViewModelMapper.spec.ts
@@ -104,13 +104,82 @@ describe('planningSheetListViewModelMapper', () => {
     const input: MapperInput = {
       ...baseInput,
       sheets: [
-        { id: '1', status: 'active' } as unknown as (PlanningSheetListViewModel['sheets'][0]),
-        { id: '2', status: 'revision_pending' } as unknown as (PlanningSheetListViewModel['sheets'][0]),
+        { id: '1', userId: 'U001', status: 'active' } as unknown as (PlanningSheetListViewModel['sheets'][0]),
+        { id: '2', userId: 'U001', status: 'revision_pending' } as unknown as (PlanningSheetListViewModel['sheets'][0]),
       ],
     };
     const vm = mapToPlanningSheetListViewModel(input);
 
     expect(vm.sheets[0].statusColor).toBe('success');
     expect(vm.sheets[1].statusColor).toBe('warning');
+  });
+
+  describe('Monitoring Origin Status', () => {
+    it('支援開始日が設定されている場合、official と判定されること', () => {
+      const input: MapperInput = {
+        ...baseInput,
+        sheets: [
+          { id: '1', userId: 'U001', supportStartDate: '2026-05-01' } as unknown as PlanningSheetListViewModel['sheets'][0],
+        ],
+      };
+      const vm = mapToPlanningSheetListViewModel(input);
+      expect(vm.sheets[0].monitoringOriginStatus).toBe('official');
+      expect(vm.sheets[0].monitoringOriginColor).toBe('success');
+      expect(vm.sheets[0].monitoringOriginLabel).toBe('確定');
+    });
+
+    it('支援開始日がなく、利用者マスタにServiceStartDateがある場合、official と判定されること', () => {
+      const userWithServiceStart = { ...mockUser, ServiceStartDate: '2026-04-01' };
+      const input: MapperInput = {
+        ...baseInput,
+        allUsers: [userWithServiceStart],
+        sheets: [
+          { id: '1', userId: 'U001', supportStartDate: null } as unknown as PlanningSheetListViewModel['sheets'][0],
+        ],
+      };
+      const vm = mapToPlanningSheetListViewModel(input);
+      expect(vm.sheets[0].monitoringOriginStatus).toBe('official');
+      expect(vm.sheets[0].monitoringOriginColor).toBe('success');
+      expect(vm.sheets[0].monitoringOriginLabel).toBe('確定');
+    });
+
+    it('支援開始日がなく、appliedFrom (計画適用日) がある場合、provisional と判定されること', () => {
+      const input: MapperInput = {
+        ...baseInput,
+        sheets: [
+          { id: '1', userId: 'U001', supportStartDate: null, appliedFrom: '2026-05-05' } as unknown as PlanningSheetListViewModel['sheets'][0],
+        ],
+      };
+      const vm = mapToPlanningSheetListViewModel(input);
+      expect(vm.sheets[0].monitoringOriginStatus).toBe('provisional');
+      expect(vm.sheets[0].monitoringOriginColor).toBe('warning');
+      expect(vm.sheets[0].monitoringOriginLabel).toBe('暫定');
+    });
+
+    it('日付が一切設定されていない場合、unset と判定されること', () => {
+      const input: MapperInput = {
+        ...baseInput,
+        sheets: [
+          { id: '1', userId: 'U001', supportStartDate: null, appliedFrom: null } as unknown as PlanningSheetListViewModel['sheets'][0],
+        ],
+      };
+      const vm = mapToPlanningSheetListViewModel(input);
+      expect(vm.sheets[0].monitoringOriginStatus).toBe('unset');
+      expect(vm.sheets[0].monitoringOriginColor).toBe('error');
+      expect(vm.sheets[0].monitoringOriginLabel).toBe('未設定');
+    });
+
+    it('日付形式が不正な場合、invalid と判定されること', () => {
+      const input: MapperInput = {
+        ...baseInput,
+        sheets: [
+          { id: '1', userId: 'U001', supportStartDate: 'invalid-date' } as unknown as PlanningSheetListViewModel['sheets'][0],
+        ],
+      };
+      const vm = mapToPlanningSheetListViewModel(input);
+      expect(vm.sheets[0].monitoringOriginStatus).toBe('invalid');
+      expect(vm.sheets[0].monitoringOriginColor).toBe('error');
+      expect(vm.sheets[0].monitoringOriginLabel).toBe('不正');
+    });
   });
 });

--- a/src/pages/planning-sheet-list/hooks/planningSheetListViewModelMapper.ts
+++ b/src/pages/planning-sheet-list/hooks/planningSheetListViewModelMapper.ts
@@ -3,6 +3,8 @@ import type { IcebergSnapshot } from '@/features/ibd/analysis/iceberg/icebergTyp
 import type { PlanningSheetListViewModel } from '../types';
 import type { IUserMaster } from '@/features/users/types';
 import { summarizeIcebergSnapshot, calculateDifferenceInsight } from '@/domain/isp/differenceInsight';
+import { resolveSupportStartDateDetailed } from '@/features/planning-sheet/monitoringSchedule';
+import type { MonitoringOriginStatus } from '../types';
 
 function getStatusColor(status: PlanningSheetStatus): 'default' | 'info' | 'success' | 'warning' {
   switch (status) {
@@ -42,10 +44,52 @@ export function mapToPlanningSheetListViewModel(input: MapperInput): PlanningShe
   const currentCount = sheets.filter(s => s.isCurrent).length;
   const totalCount = sheets.length;
 
-  const mappedSheets = sheets.map(sheet => ({
-    ...sheet,
-    statusColor: getStatusColor(sheet.status),
-  }));
+  const mappedSheets = sheets.map(sheet => {
+    const user = allUsers.find(u => u.UserID === sheet.userId);
+    const serviceStartDate = user?.ServiceStartDate;
+
+    const resolved = resolveSupportStartDateDetailed(
+      sheet.supportStartDate,
+      serviceStartDate,
+      sheet.appliedFrom
+    );
+
+    let monitoringOriginStatus: MonitoringOriginStatus = 'unset';
+    let monitoringOriginLabel = '未設定';
+    let monitoringOriginHelper = '90日モニタリングの起点となる支援開始日が未設定です。利用者マスタまたは支援計画シートで設定してください';
+    let monitoringOriginColor: 'success' | 'warning' | 'error' | 'default' = 'error';
+
+    if (resolved.date) {
+      const parsed = new Date(resolved.date);
+      if (isNaN(parsed.getTime())) {
+        monitoringOriginStatus = 'invalid';
+        monitoringOriginLabel = '不正';
+        monitoringOriginHelper = '支援開始日または計画適用日の日付形式を確認してください';
+        monitoringOriginColor = 'error';
+      } else {
+        if (resolved.source === 'planning' || resolved.source === 'master') {
+          monitoringOriginStatus = 'official';
+          monitoringOriginLabel = '確定';
+          monitoringOriginHelper = '支援開始日を起点に90日モニタリングを管理しています';
+          monitoringOriginColor = 'success';
+        } else if (resolved.source === 'fallback') {
+          monitoringOriginStatus = 'provisional';
+          monitoringOriginLabel = '暫定';
+          monitoringOriginHelper = '正式な支援開始日が未設定のため、計画適用日から暫定計算しています';
+          monitoringOriginColor = 'warning';
+        }
+      }
+    }
+
+    return {
+      ...sheet,
+      statusColor: getStatusColor(sheet.status),
+      monitoringOriginStatus,
+      monitoringOriginLabel,
+      monitoringOriginHelper,
+      monitoringOriginColor,
+    };
+  });
 
   const selectedUser = allUsers.find(u => u.UserID === userId);
   const isIcebergTarget = !!selectedUser?.IsHighIntensitySupportTarget;

--- a/src/pages/planning-sheet-list/types.tsx
+++ b/src/pages/planning-sheet-list/types.tsx
@@ -1,9 +1,17 @@
 import type { PlanningSheetListItem } from '@/domain/isp/schema';
 import type { IUserMaster } from '@/features/users/types';
 
+export type MonitoringOriginStatus = 'official' | 'provisional' | 'unset' | 'invalid';
+
 export interface PlanningSheetListViewModel {
   userId: string | null;
-  sheets: (PlanningSheetListItem & { statusColor: 'default' | 'info' | 'success' | 'warning' })[];
+  sheets: (PlanningSheetListItem & {
+    statusColor: 'default' | 'info' | 'success' | 'warning';
+    monitoringOriginStatus: MonitoringOriginStatus;
+    monitoringOriginLabel: string;
+    monitoringOriginHelper: string;
+    monitoringOriginColor: 'success' | 'warning' | 'error' | 'default';
+  })[];
   isLoading: boolean;
   error: string | null;
   allUsers: IUserMaster[];


### PR DESCRIPTION
## Summary
- Add Monitoring Origin Status to planning-sheet-list
- Extend PlanningSheetListItem with supportStartDate and appliedFrom
- Map SupportStartDate / AppliedFrom from SharePoint rows
- Reuse resolveSupportStartDateDetailed to classify official / provisional / unset / invalid
- Add 起点ステータス column with Tooltip + Chip display
- Add ViewModel and regression tests for monitoring origin status

## Design note
planning-sheet-list is the L2 monitoring hub for support planning sheets.

Monitoring origin resolution follows the existing Support Date Governance rule:

1. SupportPlanningSheet.SupportStartDate
2. UserMaster.ServiceStartDate
3. appliedFrom as provisional fallback

appliedFrom is not treated as official.
reviewedAt / updatedAt are not used as monitoring origin fallback.

This keeps the responsibility boundary clear:
- L2 owns and visualizes monitoring origin status
- L3 / Today consume resolved origin and warn

## Checks
- npm run typecheck
- npx vitest run src/pages/planning-sheet-list
- npx vitest run src/features/planning-sheet/__tests__/monitoringSchedule.spec.ts
