### PR TITLE
feat(e2e): stabilize support date governance validation

### DIFF
--- a/src/features/planning-sheet/hooks/useIspRepository.ts
+++ b/src/features/planning-sheet/hooks/useIspRepository.ts
@@ -1,0 +1,16 @@
+import { useMemo } from 'react';
+import { useDataProvider } from '@/lib/data/useDataProvider';
+import { DataProviderIspRepository } from '@/data/isp/infra/DataProviderIspRepository';
+import type { IspRepository } from '@/domain/isp/port';
+
+/**
+ * IspRepository インスタンスを提供する。
+ */
+export function useIspRepository(): IspRepository {
+  const { provider } = useDataProvider();
+
+  return useMemo(
+    () => new DataProviderIspRepository(provider),
+    [provider]
+  );
+}

--- a/src/pages/support-planning-sheet/SupportPlanningSheetView.tsx
+++ b/src/pages/support-planning-sheet/SupportPlanningSheetView.tsx
@@ -8,11 +8,10 @@ import Divider from '@mui/material/Divider';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 
-// import { createSharePointIspRepository } from '@/data/isp/sharepoint/SharePointIspRepository';
+import { useIspRepository } from '@/features/planning-sheet/hooks/useIspRepository';
 import { usePlanningSheetRepositories } from '@/features/planning-sheet/hooks/usePlanningSheetRepositories';
 import { usePlanPatchRepository } from '@/features/planning-sheet/hooks/usePlanPatchRepository';
 import { NewPlanningSheetForm } from '@/features/planning-sheet/components/NewPlanningSheetForm';
-// import { useSP } from '@/lib/spClient';
 import { TESTIDS, tid } from '@/testids';
 import {
   detectPlanNeedsUpdate,
@@ -21,7 +20,6 @@ import {
 } from '@/domain/isp/planPatch';
 
 import { type SupportPlanningSheetViewProps } from './types';
-import type { IspRepository } from '@/domain/isp/port';
 import { usePlanningSheetOrchestrator } from '@/features/planning-sheet/hooks/orchestrators/usePlanningSheetOrchestrator';
 import { ContextPanelSection } from './sections/ContextPanelSection';
 import { ImportDialogsSection } from './sections/ImportDialogsSection';
@@ -35,10 +33,7 @@ export const SupportPlanningSheetView: React.FC<SupportPlanningSheetViewProps> =
 }) => {
   const planningSheetRepo = usePlanningSheetRepositories();
   const planPatchRepository = usePlanPatchRepository();
-  // const spClient = useSP();
-  const ispRepo = React.useMemo(() => ({
-    getCurrentByUser: async () => null,
-  } as unknown as IspRepository), []);
+  const ispRepo = useIspRepository();
   const [pendingPatchCount, setPendingPatchCount] = React.useState(0);
   const [pendingPatches, setPendingPatches] = React.useState<PlanPatch[]>([]);
   const [patchActionMessage, setPatchActionMessage] = React.useState<string | null>(null);

--- a/tests/e2e/_helpers/setupSharePointStubs.ts
+++ b/tests/e2e/_helpers/setupSharePointStubs.ts
@@ -165,6 +165,7 @@ export async function setupSharePointStubs(page: Page, options: SetupSharePointS
     const url = new URL(request.url());
     const pathname = url.pathname;
     const method = request.method().toUpperCase();
+    console.log(`[Stub Request] ${method} ${pathname}${url.search}`);
     const headers = request.headers();
     const methodOverride = (headers['x-http-method'] ?? headers['x-http-method-override'] ?? '').toUpperCase();
     const effectiveMethod = (method === 'POST' && ['MERGE', 'PATCH', 'DELETE'].includes(methodOverride)) ? methodOverride : method;
@@ -214,6 +215,7 @@ export async function setupSharePointStubs(page: Page, options: SetupSharePointS
       if (!state && (isMetadataQuery || isDataQuery)) {
          state = { config: { name: match.key }, items: [], nextId: 1 };
          nameMap.set(normalizeName(match.key), state);
+         console.log(`[Stub] Auto-created state for list: ${match.key}`);
       }
 
       if (!state) {
@@ -292,6 +294,7 @@ export async function setupSharePointStubs(page: Page, options: SetupSharePointS
             TypeAsString: 'Text',
             Required: false,
           }));
+          console.log(`[Stub] Returning ${results.length} fields for list: ${state.config.name}`);
           await fulfill(route, { status: 200, body: { value: results } });
         }
         return;
@@ -327,27 +330,33 @@ export async function setupSharePointStubs(page: Page, options: SetupSharePointS
         if (method === 'GET') {
           const itemsSource = isSchedule ? scheduleStore : state.items;
           let results = itemsSource.map((item) => isSchedule ? normalizeScheduleRecord(cloneRecord(item as Record<string, unknown>)) : item);
-          
-          // Basic filtering support for common fields used in tests
+          // Improved filtering support
           const filter = url.searchParams.get('$filter');
           if (filter) {
-            // UserCode / cr013_userCode
-            const userMatch = filter.match(/(UserCode|cr013_userCode) eq '([^']+)'/i);
-            if (userMatch) {
-              const val = userMatch[2];
-              results = results.filter(r => String(r['UserCode'] || r['cr013_userCode']) === val);
-            }
-            
-            // ISPId / cr013_ispId
-            const ispMatch = filter.match(/(ISPId|cr013_ispId) eq '([^']+)'/i);
-            if (ispMatch) {
-              const val = ispMatch[2];
-              results = results.filter(r => String(r['ISPId'] || r['cr013_ispId']) === val);
-            }
+            const conditions = filter.split(/\s+and\s+/i);
+            for (const condition of conditions) {
+              const eqMatch = condition.match(/([a-zA-Z0-9_]+)\s+eq\s+(.+)/i);
+              if (eqMatch) {
+                const field = eqMatch[1];
+                const rawVal = eqMatch[2].trim();
 
-            // IsCurrent
-            if (filter.includes('IsCurrent eq true') || filter.includes('cr013_isCurrent eq true')) {
-              results = results.filter(r => r['IsCurrent'] === true || r['cr013_isCurrent'] === true);
+                // Handle quotes for strings
+                let val: any = rawVal;
+                if (rawVal.startsWith("'") && rawVal.endsWith("'")) {
+                  val = rawVal.substring(1, rawVal.length - 1);
+                } else if (rawVal.toLowerCase() === 'true') {
+                  val = true;
+                } else if (rawVal.toLowerCase() === 'false') {
+                  val = false;
+                } else if (!isNaN(Number(rawVal))) {
+                  val = Number(rawVal);
+                }
+
+                results = results.filter((r) => {
+                  const actualVal = r[field];
+                  return String(actualVal) === String(val) || actualVal === val;
+                });
+              }
             }
           }
 
@@ -393,6 +402,31 @@ export async function setupSharePointStubs(page: Page, options: SetupSharePointS
       await fulfill(route, await resolveFallback(request));
       return;
     }
+
+    // Global list creation support (when no list matched getbytitle)
+    if (method === 'POST' && (pathname.endsWith('/lists') || pathname.endsWith('/lists/'))) {
+      try {
+        const body = JSON.parse(request.postData() || '{}');
+        const title = body.Title || 'New List';
+        console.log(`[Stub] Global POST /lists creating: ${title}`);
+        const newState = { config: { name: title }, items: [], nextId: 1 };
+        nameMap.set(normalizeName(title), newState);
+        await fulfill(route, { 
+          status: 201, 
+          body: { 
+            d: { 
+              Id: `mock-id-${title}`, 
+              Title: title,
+              __metadata: { type: 'SP.List' }
+            } 
+          } 
+        });
+        return;
+      } catch (err) {
+        console.error(`[Stub Error] Failed to handle global POST /lists: ${err}`);
+      }
+    }
+
     await fulfill(route, await resolveFallback(request));
   });
 }

--- a/tests/e2e/support-date-governance.spec.ts
+++ b/tests/e2e/support-date-governance.spec.ts
@@ -1,0 +1,153 @@
+import { expect, test } from '@playwright/test';
+import { setupSharePointStubs } from './_helpers/setupSharePointStubs';
+
+import usersFixture from './_fixtures/users.master.dev.v1.json';
+
+test.describe('Support Date Governance — E2E Propagation', () => {
+  test('New Planning Sheet propagates SupportStartDate to list view as Official', async ({ page }) => {
+    // 0. Setup E2E Environment — Inject complete mocked env.runtime.json
+    await page.route('**/env.runtime.json', async (route) => {
+      console.log('[E2E] Serving mocked env.runtime.json');
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          "MODE": "development",
+          "VITE_MSAL_CLIENT_ID": "e2e-client-id",
+          "VITE_MSAL_TENANT_ID": "e2e-tenant-id",
+          "VITE_SP_RESOURCE": "https://isogokatudouhome.sharepoint.com",
+          "VITE_SP_SITE_RELATIVE": "/sites/welfare",
+          "VITE_SP_SITE_URL": "https://isogokatudouhome.sharepoint.com/sites/welfare",
+          "VITE_SP_BASE_URL": "https://isogokatudouhome.sharepoint.com/sites/welfare",
+          "VITE_SCHEDULES_TZ": "Asia/Tokyo",
+          "VITE_SKIP_SHAREPOINT": "0",
+          "VITE_SKIP_LOGIN": "1",
+          "VITE_DEMO_MODE": "0",
+          "VITE_DATA_PROVIDER": "sharepoint",
+          "VITE_FORCE_SHAREPOINT": "1",
+          "VITE_SKIP_PROVISIONING": "1",
+          "VITE_FEATURE_SCHEDULES_SP": "1",
+          "VITE_FEATURE_SCHEDULES": "1",
+          "VITE_ALLOW_SHAREPOINT_OUTSIDE_SPFX": "1",
+          "VITE_SP_LIST_USERS": "Users_Master",
+          "VITE_SP_LIST_STAFF": "Staff_Master",
+          "VITE_SP_LIST_ORG_MASTER": "Org_Master",
+          "VITE_SP_LIST_OFFICES": "Offices",
+          "VITE_SP_LIST_DAILY_RECORD": "SupportRecord_Daily",
+          "VITE_SP_LIST_ATTENDANCE": "Daily_Attendance",
+          "VITE_SP_LIST_SCHEDULES": "Schedules",
+          "VITE_SP_ENABLED": "true",
+          "VITE_E2E": "1",
+          "VITE_E2E_MSAL_MOCK": "1",
+          "VITE_AUDIT_DEBUG": "1"
+        })
+      });
+    });
+
+    await page.addInitScript(() => {
+      console.log('[E2E] Initializing MSAL mocks');
+      // Mock MSAL global to avoid initialization errors
+      (window as any).__MSAL_PUBLIC_CLIENT__ = {
+        initialize: async () => {},
+        handleRedirectPromise: async () => null,
+        getActiveAccount: () => ({ username: 'e2e@example.com', name: 'E2E User' }),
+        getAllAccounts: () => [{ username: 'e2e@example.com', name: 'E2E User' }],
+        setActiveAccount: () => {},
+      };
+    });
+
+    // 1. Setup stubs
+    // We use UX-001 (氷見 しずく) from the fixture.
+    await setupSharePointStubs(page, {
+      lists: [
+        {
+          name: 'Users_Master',
+          items: usersFixture.users,
+        },
+        {
+          name: 'SupportPlanningSheet_Master',
+          items: [],
+          onCreate: (payload: any, { takeNextId }) => ({
+            Id: takeNextId(),
+            ...payload,
+            Created: new Date().toISOString(),
+          }),
+        },
+        {
+          name: 'ISP_Master',
+          items: [
+            { Id: 5001, UserCode: 'UX-001', IsCurrent: true, Title: '現行個別支援計画' }
+          ]
+        },
+        {
+          name: 'MonitoringMeetings',
+          items: []
+        },
+        {
+          name: 'SupportRecord_Daily',
+          items: []
+        },
+        {
+          name: 'Schedules',
+          items: []
+        }
+      ]
+    });
+
+    page.on('console', msg => console.log(`[PAGE] ${msg.text()}`));
+
+    // 2. Navigate to the New Planning Sheet form
+    // userId=UX-001 should auto-select the user
+    await page.goto('/support-planning-sheet/new?userId=UX-001');
+
+    // Wait for the form to be ready (user selection and ISP binding)
+    // We check for the presence of the section title which only appears when canProceedToForm is true
+    await expect(page.getByRole('heading', { name: '基本情報' })).toBeVisible({ timeout: 10000 });
+    
+    // Also verify the ISP binding success message
+    await expect(page.getByText(/現行個別支援計画と紐付けます/)).toBeVisible();
+
+    // 3. Fill Section 1: Basic Information
+    const testTitle = `E2E Support Date Governance ${Date.now()}`;
+    const testDate = '2026-06-01';
+    
+    await page.getByLabel('計画タイトル').fill(testTitle);
+    
+    // SupportStartDate field - use fill with date string YYYY-MM-DD
+    const dateInput = page.getByLabel('支援開始日（モニタリング起点）');
+    await dateInput.fill(testDate);
+    
+    // 4. Navigate through all 10 sections to reach the submit button
+    // We use forced clicks or wait for animations if necessary, but Playwright usually handles this.
+    for (let i = 0; i < 9; i++) {
+      const nextBtn = page.getByRole('button', { name: '次へ' });
+      await nextBtn.click();
+    }
+
+    // 5. Submit the form
+    const submitBtn = page.getByRole('button', { name: '支援計画シートを作成' });
+    await expect(submitBtn).toBeVisible();
+    await submitBtn.click();
+
+    // 6. Verify navigation to the detail page (or wait for the redirect)
+    // The app redirects to /support-planning-sheet/{id}
+    await expect(page).toHaveURL(/\/support-planning-sheet\/(sp-)?\d+/);
+
+    // 7. Navigate to the Planning Sheet List to verify the governance status
+    await page.goto(`/planning-sheet-list?userId=UX-001`);
+
+    // 8. Find the created sheet in the table and check the Monitoring Origin Status
+    const row = page.getByRole('row').filter({ hasText: testTitle });
+    await expect(row).toBeVisible();
+
+    // The "起点ステータス" column should show "確定" (Official)
+    const originChip = row.getByTestId('monitoring-origin-chip');
+    await expect(originChip).toBeVisible();
+    await expect(originChip).toContainText('確定');
+
+    // Tooltip check (optional but good for regression)
+    await originChip.hover();
+    const tooltip = page.getByRole('tooltip');
+    await expect(tooltip).toContainText('支援開始日を起点に90日モニタリングを管理しています');
+  });
+});


### PR DESCRIPTION
## E2E validation
- Add support-date-governance E2E coverage
- Verify SupportStartDate entered in /support-planning-sheet/new is persisted and shown as 確定 in /planning-sheet-list
- Stabilize SharePoint stubs for OData AND / boolean filters
- Replace temporary ISP repository stub with real DataProviderIspRepository hook

## Checks
- [x] npm run typecheck
- [x] npm run lint
- [x] npx playwright test tests/e2e/support-date-governance.spec.ts