### PR TITLE
fix(planning-sheet): dynamically omit missing SupportStartDate from write payload

### DIFF
--- a/src/data/isp/infra/DataProviderPlanningSheetRepository.ts
+++ b/src/data/isp/infra/DataProviderPlanningSheetRepository.ts
@@ -38,6 +38,52 @@ export function __resetPlanningSheetWarningCache(): void {
 }
 
 /**
+ * ペイロードキーを物理/ドリフト吸収後の列名に変換し、物理スキーマに存在しない項目をオミットする
+ */
+function adjustPayloadWithResolvedFields(
+  payload: Record<string, unknown>,
+  fields: Record<string, string | undefined>
+): Record<string, unknown> {
+  const adjusted: Record<string, unknown> = {};
+
+  const physicalToLogical: Record<string, string> = {
+    Title: 'title',
+    UserCode: 'userCode',
+    ISPId: 'ispId',
+    ISPLookupId: 'ispId',
+    TargetScene: 'targetScene',
+    Status: 'status',
+    VersionNo: 'versionNo',
+    IsCurrent: 'isCurrent',
+    FormDataJson: 'formDataJson',
+    IntakeJson: 'intakeJson',
+    AssessmentJson: 'assessmentJson',
+    PlanningJson: 'planningJson',
+    SupportStartDate: 'supportStartDate',
+    MonitoringCycleDays: 'monitoringCycleDays',
+  };
+
+  for (const [key, value] of Object.entries(payload)) {
+    const logicalKey = physicalToLogical[key];
+    if (logicalKey) {
+      const resolvedName = fields[logicalKey];
+      if (resolvedName) {
+        adjusted[resolvedName] = value;
+      } else {
+        // 物理スキーマに存在しない（undefined）フィールドはペイロードからオミットする
+        console.warn(`[DataProviderPlanningSheetRepository] Omit unresolved field from write payload: ${key}`);
+      }
+    } else {
+      // mapped candidatesに定義されていないフィールド（TargetDomain, ObservationFacts等）はそのまま通す
+      adjusted[key] = value;
+    }
+  }
+
+  return adjusted;
+}
+
+
+/**
  * DataProviderPlanningSheetRepository — 第2層 SupportPlanningSheet_Master
  */
 export class DataProviderPlanningSheetRepository implements PlanningSheetRepository {
@@ -176,10 +222,11 @@ export class DataProviderPlanningSheetRepository implements PlanningSheetReposit
   }
 
   async create(input: PlanningSheetCreateInput): Promise<SupportPlanningSheet> {
-    const { title } = await this.resolveSource();
+    const { title, fields } = await this.resolveSource();
     const payload = mapPlanningSheetCreateInputToPayload(input);
+    const adjustedPayload = adjustPayloadWithResolvedFields(payload as unknown as Record<string, unknown>, fields);
     
-    const created = await this.provider.createItem<SpPlanningSheetRow>(title, payload as unknown as Record<string, unknown>);
+    const created = await this.provider.createItem<SpPlanningSheetRow>(title, adjustedPayload);
     
     const refreshed = await this.getById(`sp-${created.Id}`);
     if (!refreshed) throw new Error('[PlanningSheetRepository] Failed to reload created item');
@@ -190,10 +237,11 @@ export class DataProviderPlanningSheetRepository implements PlanningSheetReposit
     const numericId = extractSpId(id);
     if (numericId === null) throw new Error(`Invalid ID: ${id}`);
 
-    const { title } = await this.resolveSource();
+    const { title, fields } = await this.resolveSource();
     const payload = mapPlanningSheetUpdateInputToPayload(input);
+    const adjustedPayload = adjustPayloadWithResolvedFields(payload as unknown as Record<string, unknown>, fields);
 
-    await this.provider.updateItem(title, numericId, payload as unknown as Record<string, unknown>);
+    await this.provider.updateItem(title, numericId, adjustedPayload);
     
     const updated = await this.getById(id);
     if (!updated) throw new Error(`[PlanningSheetRepository] Failed to reload updated item: ${id}`);

--- a/src/data/isp/infra/__tests__/DataProviderPlanningSheetRepository.spec.ts
+++ b/src/data/isp/infra/__tests__/DataProviderPlanningSheetRepository.spec.ts
@@ -230,4 +230,94 @@ describe('DataProviderPlanningSheetRepository', () => {
       expect(sheets).toHaveLength(1);
     });
   });
+
+  describe('create and update with dynamic schema resolution', () => {
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    it('omits SupportStartDate and MonitoringCycleDays if they are missing from physical schema', async () => {
+      let capturedPayload: any = null;
+      provider.createItem = async (_title, payload) => {
+        capturedPayload = payload;
+        return { Id: 123, ...payload } as any;
+      };
+
+      repo.getById = async () => {
+        return { id: 'sp-123', intake: {}, assessment: {}, planning: {} } as any;
+      };
+
+      await repo.create({
+        title: 'New Sheet',
+        userId: 'U-001',
+        ispId: 'sp-456',
+        supportStartDate: '2026-05-10',
+        monitoringCycleDays: 90,
+      } as any);
+
+      expect(capturedPayload).toBeDefined();
+      expect(capturedPayload.SupportStartDate).toBeUndefined();
+      expect(capturedPayload.MonitoringCycleDays).toBeUndefined();
+      expect(capturedPayload.UserCode).toBe('U-001');
+      expect(capturedPayload.Title).toBe('New Sheet');
+    });
+
+    it('retains SupportStartDate and MonitoringCycleDays if they exist in physical schema', async () => {
+      provider.getFieldInternalNames = async () => new Set([
+        'Id', 'Title', 'UserCode', 'ISPId', 'VersionNo', 'IsCurrent', 'Status',
+        'SupportStartDate', 'MonitoringCycleDays'
+      ]);
+
+      let capturedPayload: any = null;
+      provider.createItem = async (_title, payload) => {
+        capturedPayload = payload;
+        return { Id: 123, ...payload } as any;
+      };
+
+      repo.getById = async () => {
+        return { id: 'sp-123', intake: {}, assessment: {}, planning: {} } as any;
+      };
+
+      await repo.create({
+        title: 'New Sheet with dates',
+        userId: 'U-001',
+        ispId: 'sp-456',
+        supportStartDate: '2026-05-10',
+        monitoringCycleDays: 90,
+      } as any);
+
+      expect(capturedPayload).toBeDefined();
+      expect(capturedPayload.SupportStartDate).toBe('2026-05-10');
+      expect(capturedPayload.MonitoringCycleDays).toBe(90);
+    });
+
+    it('retains and translates SupportStartDate and MonitoringCycleDays if they exist as drifted names', async () => {
+      provider.getFieldInternalNames = async () => new Set([
+        'Id', 'Title', 'UserCode', 'ISPId', 'VersionNo', 'IsCurrent', 'Status',
+        'cr013_supportStartDate', 'cr013_monitoringCycleDays'
+      ]);
+
+      let capturedPayload: any = null;
+      provider.createItem = async (_title, payload) => {
+        capturedPayload = payload;
+        return { Id: 123, ...payload } as any;
+      };
+
+      repo.getById = async () => {
+        return { id: 'sp-123', intake: {}, assessment: {}, planning: {} } as any;
+      };
+
+      await repo.create({
+        title: 'New Sheet with dates',
+        userId: 'U-001',
+        ispId: 'sp-456',
+        supportStartDate: '2026-05-10',
+        monitoringCycleDays: 90,
+      } as any);
+
+      expect(capturedPayload).toBeDefined();
+      expect(capturedPayload.cr013_supportStartDate).toBe('2026-05-10');
+      expect(capturedPayload.cr013_monitoringCycleDays).toBe(90);
+      expect(capturedPayload.SupportStartDate).toBeUndefined();
+      expect(capturedPayload.MonitoringCycleDays).toBeUndefined();
+    });
+  });
 });
+


### PR DESCRIPTION
### 🚨 Problem / Issue
In provisional or live SharePoint tenant environments, new columns like `SupportStartDate` or `MonitoringCycleDays` might not be physically provisioned on the `SupportPlanningSheet_Master` list yet. Because these fields were unconditionally hardcoded into the write payloads, SharePoint rejected creation/update requests with a `400 Bad Request`:
> `プロパティ 'SupportStartDate' は型 'SP.Data.SupportPlanningSheet_x005f_MasterListItem' に存在しません。`

### 🛠️ Solution
Implemented dynamic payload sanitization based on resolved physical schema inside the repository:
1. **Repository Write Sanitization**: Created the `adjustPayloadWithResolvedFields` helper function inside `DataProviderPlanningSheetRepository.ts`.
2. **Schema Drift Absorption**:
   - Maps standard write payload keys (e.g., `SupportStartDate`, `MonitoringCycleDays`) back to their logical candidates.
   - Looks up the logical key in the resolved physical field names map (obtained via `resolveSource()`).
   - If the field is physically present (as a standard or drifted column name), we use the resolved name as the payload key.
   - If the field is physically **missing** (`undefined`), we safely **omit** it from the payload to avoid `400 Bad Request` schema alignment failures.
3. **Robust Unit Testing**: Added comprehensive unit tests inside `DataProviderPlanningSheetRepository.spec.ts` ensuring missing fields are omitted, standard fields are preserved, and drifted fields are translated correctly.

All unit tests are completely green! 🟢