### PR TITLE
fix(planning-sheet): clarify import preview dialog guidance

### DIFF
--- a/src/features/planning-sheet/components/ImportPreviewDialog.tsx
+++ b/src/features/planning-sheet/components/ImportPreviewDialog.tsx
@@ -55,6 +55,7 @@ export const ImportPreviewDialog: React.FC<Props> = ({
   if (!preview) return null;
 
   const { items, summary } = preview;
+  const inferredSource = responderInfo ? '特性アンケート' : '氷山分析';
 
   // セクションごとにグループ化
   const grouped = React.useMemo(() => {
@@ -79,13 +80,22 @@ export const ImportPreviewDialog: React.FC<Props> = ({
         <Stack direction="row" spacing={1} alignItems="center">
           <SupportAgentRoundedIcon color="primary" />
           <Typography variant="h6" fontWeight={700}>
-            取込プレビュー
+            {inferredSource}の取込プレビュー
           </Typography>
         </Stack>
       </DialogTitle>
 
       <DialogContent dividers>
         <Stack spacing={2}>
+          <Alert severity="info" variant="outlined" icon={false}>
+            <Typography variant="body2">
+              以下の内容を新規支援計画シートの各項目に反映します。入力済みの項目がある場合は上書きせず追記します。
+            </Typography>
+            <Typography variant="caption" color="warning.main" sx={{ display: 'block', mt: 1, fontWeight: 700 }}>
+              ※ここで反映しても、まだ保存は完了しません。最後に「支援計画シートを作成」を押すと正式に保存されます。
+            </Typography>
+          </Alert>
+
           {/* ── 回答者情報 ── */}
           {responderInfo && (
             <Alert severity="info" variant="outlined" icon={false}>
@@ -211,7 +221,7 @@ export const ImportPreviewDialog: React.FC<Props> = ({
           disabled={items.length === 0}
           startIcon={<SupportAgentRoundedIcon />}
         >
-          この内容で取り込む
+          確認してフォームに反映する
         </Button>
       </DialogActions>
     </Dialog>


### PR DESCRIPTION
## Summary
- Clarify whether the preview is for Iceberg analysis or Tokusei survey import
- Add guidance that the preview reflects values into the new planning sheet form without saving to SharePoint yet
- Rename the confirm action to make it clear that it reflects data into the form

## Design note
This follows the UX review after PR #1850. The goal is a small, safe UI copy improvement rather than a behavior change.

The dialog still keeps `取込プレビュー` in the title so existing E2E role-name checks continue to match. No caller changes are needed; the dialog infers the source from `responderInfo` presence:

- `responderInfo` present: 特性アンケート
- `responderInfo` absent: 氷山分析

## Checks
Created from GitHub-side edits. CI should be treated as the authoritative verification before merge.

Recommended local checks:

```bash
npm run typecheck
npx playwright test tests/e2e/planning-sheet-creation-iceberg.spec.ts
```