### PR TITLE
fix(analysis): include high-intensity users in dashboard targets

### DIFF
--- a/src/pages/AnalysisDashboardPage.tsx
+++ b/src/pages/AnalysisDashboardPage.tsx
@@ -67,7 +67,7 @@ const AnalysisDashboardPage: React.FC = () => {
 
   // 行動分析対象者のみに絞り込み
   const ibdUsers = useMemo(
-    () => users.filter((u) => u.IsSupportProcedureTarget === true),
+    () => users.filter((u) => u.IsSupportProcedureTarget === true || u.IsHighIntensitySupportTarget === true),
     [users],
   );
   const ibdUserCodes = useMemo(


### PR DESCRIPTION
## Summary
- Align `/analysis/dashboard` target-user filtering with kiosk and exception-center semantics
- Include users marked as either `IsSupportProcedureTarget` or `IsHighIntensitySupportTarget`
- Fix cases where high-intensity support users were available in kiosk but missing from the analysis dashboard selector

## Context
Other operational surfaces already treat support-procedure targets and high-intensity support targets as the same practical analysis/support population:

- Kiosk user selection uses `IsSupportProcedureTarget || IsHighIntensitySupportTarget`
- Exception Center maps `isSupportProcedureTarget` as support-procedure target OR high-intensity target

The analysis dashboard was the outlier and only accepted `IsSupportProcedureTarget === true`.

## Checks
Created from GitHub-side edits. CI should be treated as the authoritative verification before merge.

Recommended local check:

```bash
npm run typecheck
```