### PR TITLE
feat(nav): add support review hub and streamline side menu

### DIFF
--- a/scratch/support-review-hub-pr-body.md
+++ b/scratch/support-review-hub-pr-body.md
@@ -1,0 +1,52 @@
+# feat(nav): add support review hub for assessment analysis and planning
+
+## Summary
+Simplifies the sidebar navigation by collapsing three highly-technical, abstract screens under the `'severe'` group into a single, user-friendly entry point labeled **「支援の確認・見直し」** routing to a brand new **Support Review Hub** (`/support-review`).
+
+This change drastically reduces cognitive load for care workers, presenting them with concrete, goal-oriented pathways rather than abstract system names, while preserving 100% of the underlying page logic, direct URL routes, and existing feature integrations.
+
+> [!IMPORTANT]
+> This PR does not merge the assessment, analysis, and planning features.
+> It only simplifies the navigation entry point and introduces a hub-and-spoke screen to reduce cognitive load for field staff.
+
+---
+
+## Detailed Changes
+
+### 1. Unified Side Navigation Entrance
+- **Sidebar Label Update**: Renamed navigation group `'severe'` (previously "🔍 分析して改善") to **「🔍 支援を見直す」** to align with the action of care quality reviews.
+- **Collapsing Sidebar Items**: Consolidated the three legacy items (支援計画シート, アセスメント, 分析ワークスペース) into a single unified item: **「支援の確認・見直し」** (`/support-review`), targeting the new Hub.
+- **Source Preservation**: Direct URLs to the existing paths (`/planning-sheet-list`, `/assessment`, `/analysis`) remain fully active to guarantee that deep links, page-to-page bridges, and automatic triggers function perfectly.
+
+### 2. Premium Support Review Hub Page (`/support-review`)
+Renders a responsive, high-fidelity grid of 4 goal-oriented action cards utilizing curated themed palettes, elevation cards, and hover micro-animations matching the codebase design language:
+1. **現在の支援計画を見る**: Links to `/planning-sheet-list` (いま有効な計画と見直しの進捗を確認).
+2. **本人の特性を確認する**: Links to `/assessment` (強み・困りごと・感覚特性の整理).
+3. **困りごとの背景を整理する**: Links to `/analysis` (氷山モデルを用いた環境要因・背景仮説の分析).
+4. **支援計画に反映する**: Links to `/support-planning-sheet/new` (分析結果やモニタリングを取り込んだ新期計画作成).
+
+### 3. Navigation Infrastructure & Testing
+- **Test ID Registry**: Appended the canonical `TESTIDS.nav.supportReviewHub` (`nav-support-review-hub`) in `src/testids.ts`.
+- **Router Configuration**: Registered route `/support-review` mapping to `<SuspendedSupportReviewHubPage />` inside `analysisRoutes.tsx` with standard viewer-role verification.
+- **Lazy Loading**: Added code-splitting for `SupportReviewHubPage` inside `lazyPages.tsx` to optimize build sizes.
+- **Unit Tests Updated**: Added a unit test assertion in `navigationConfig.test.ts` to enforce that the unified item correctly registers in the `'severe'` navigation group.
+
+---
+
+## Verification Results
+
+### Vitest Suite (18/18 Passed)
+All navigation configuration and Shell-routing unit tests are fully verified and pass successfully:
+```bash
+npx vitest run src/app/config/__tests__ src/app/__tests__/AppShell.navigation.spec.tsx
+```
+Output:
+```text
+✓ src/app/config/__tests__/navigationConfig.helpers.spec.ts (5 tests)
+✓ src/app/config/__tests__/navigationConfig.contract.spec.ts (3 tests)
+✓ src/app/config/__tests__/navigationConfig.test.ts (6 tests)
+✓ src/app/__tests__/AppShell.navigation.spec.tsx (4 tests)
+
+Test Files  4 passed (4)
+     Tests  18 passed (18)
+```

--- a/scratch/support-review-hub-pr-body.md
+++ b/scratch/support-review-hub-pr-body.md
@@ -3,7 +3,7 @@
 ## Summary
 Simplifies the sidebar navigation by collapsing three highly-technical, abstract screens under the `'severe'` group into a single, user-friendly entry point labeled **「支援の確認・見直し」** routing to a brand new **Support Review Hub** (`/support-review`).
 
-This change drastically reduces cognitive load for care workers, presenting them with concrete, goal-oriented pathways rather than abstract system names, while preserving 100% of the underlying page logic, direct URL routes, and existing feature integrations.
+This change drastically reduces cognitive load for care workers, presenting them with concrete, goal-oriented pathways rather than abstract system names, while preserving the existing page logic, direct URL routes, and current feature integrations.
 
 > [!IMPORTANT]
 > This PR does not merge the assessment, analysis, and planning features.
@@ -16,7 +16,7 @@ This change drastically reduces cognitive load for care workers, presenting them
 ### 1. Unified Side Navigation Entrance
 - **Sidebar Label Update**: Renamed navigation group `'severe'` (previously "🔍 分析して改善") to **「🔍 支援を見直す」** to align with the action of care quality reviews.
 - **Collapsing Sidebar Items**: Consolidated the three legacy items (支援計画シート, アセスメント, 分析ワークスペース) into a single unified item: **「支援の確認・見直し」** (`/support-review`), targeting the new Hub.
-- **Source Preservation**: Direct URLs to the existing paths (`/planning-sheet-list`, `/assessment`, `/analysis`) remain fully active to guarantee that deep links, page-to-page bridges, and automatic triggers function perfectly.
+- **Source Preservation**: Direct URLs to the existing paths (`/planning-sheet-list`, `/assessment`, `/analysis`) remain fully active to guarantee that deep links, page-to-page bridges, and automatic triggers function correctly.
 
 ### 2. Premium Support Review Hub Page (`/support-review`)
 Renders a responsive, high-fidelity grid of 4 goal-oriented action cards utilizing curated themed palettes, elevation cards, and hover micro-animations matching the codebase design language:

--- a/src/app/config/__tests__/navigationConfig.test.ts
+++ b/src/app/config/__tests__/navigationConfig.test.ts
@@ -48,6 +48,9 @@ describe("Navigation Configuration", () => {
 
     const masterItems = map.get("master") || [];
     expect(masterItems.some((i) => i.label === "利用者")).toBe(true);
+
+    const severeItems = map.get("severe") || [];
+    expect(severeItems.some((i) => i.label === "支援の確認・見直し")).toBe(true);
   });
 
   it("hides admin items when feature flag/permissions omit them", () => {

--- a/src/app/config/navigationConfig.ts
+++ b/src/app/config/navigationConfig.ts
@@ -142,10 +142,9 @@ export function createNavItems(config: CreateNavItemsConfig): NavItem[] {
     PLANNING_ROUTES.ISP_EDITOR(isFieldStaffShell),
     
     createHubNavItem('severe', {
-      isActive: (pathname) => pathname === '/severe' || pathname.startsWith('/severe/'),
+      isActive: (pathname) => pathname === '/severe' || pathname.startsWith('/severe/') || pathname.startsWith('/support-review'),
     }),
-    SEVERE_ROUTES.PLANNING_SHEET(isFieldStaffShell),
-    SEVERE_ROUTES.ASSESSMENT(isFieldStaffShell),
+    SEVERE_ROUTES.SUPPORT_REVIEW_HUB(isFieldStaffShell),
 
     // --- 3. 記録・参照 (records) ---
     RECORD_ROUTES.DASHBOARD(isFieldStaffShell),

--- a/src/app/config/navigationConfig.types.ts
+++ b/src/app/config/navigationConfig.types.ts
@@ -114,7 +114,7 @@ export const groupLabel: Record<NavGroupKey, string> = {
   schedules: '🗓️ スケジュール',
   records: '📚 記録を参照',
   planning: '🗓️ 計画・調整',
-  severe: '🔍 分析して改善',
+  severe: '🔍 支援を見直す',
   operations: '⚙️ 拠点運営',
   billing: '💰 請求処理',
   master: '👥 利用者・職員',

--- a/src/app/config/routeGroups/severeRoutes.ts
+++ b/src/app/config/routeGroups/severeRoutes.ts
@@ -3,41 +3,17 @@
  *
  * NavItem constants for the 重症児支援 navigation group.
  */
-import { PREFETCH_KEYS } from '@/prefetch/routes';
 import { TESTIDS } from '@/testids';
 import type { NavAudience, NavGroupKey, NavItem } from '../navigationConfig.types';
 import { NAV_AUDIENCE } from '../navigationConfig.types';
 
 export const SEVERE_ROUTES = {
-  PLANNING_SHEET: (_isFieldStaffShell: boolean): NavItem => ({
-    label: '支援計画シート',
-    to: '/planning-sheet-list',
-    isActive: (pathname: string) => pathname.startsWith('/planning-sheet-list') || pathname.startsWith('/support-planning-sheet'),
+  SUPPORT_REVIEW_HUB: (_isFieldStaffShell: boolean): NavItem => ({
+    label: '支援の確認・見直し',
+    to: '/support-review',
+    isActive: (pathname: string) => pathname.startsWith('/support-review'),
     icon: undefined,
-    testId: TESTIDS.nav.planningSheet,
-    audience: NAV_AUDIENCE.staff as NavAudience,
-    group: 'severe' as NavGroupKey,
-  }),
-  
-  ASSESSMENT: (_isFieldStaffShell: boolean): NavItem => ({
-    label: 'アセスメント',
-    to: '/assessment',
-    isActive: (pathname: string) => pathname.startsWith('/assessment'),
-    icon: undefined,
-    prefetchKey: PREFETCH_KEYS.assessmentDashboard,
-    testId: TESTIDS.nav.assessment,
-    audience: NAV_AUDIENCE.staff as NavAudience,
-    group: 'severe' as NavGroupKey,
-  }),
-  
-  // From legacy ibdRoutes
-  ANALYSIS: (_isFieldStaffShell: boolean): NavItem => ({
-    label: '分析ワークスペース',
-    to: '/analysis',
-    isActive: (pathname: string) => pathname.startsWith('/analysis'),
-    icon: undefined,
-    prefetchKey: PREFETCH_KEYS.analysisDashboard,
-    testId: TESTIDS.nav.analysis,
+    testId: TESTIDS.nav.supportReviewHub,
     audience: NAV_AUDIENCE.staff as NavAudience,
     group: 'severe' as NavGroupKey,
   }),

--- a/src/app/routes/analysisRoutes.tsx
+++ b/src/app/routes/analysisRoutes.tsx
@@ -12,6 +12,7 @@ import {
     SuspendedIcebergAnalysisPage,
     SuspendedIcebergPdcaPage,
     SuspendedInterventionDashboardPage,
+    SuspendedSupportReviewHubPage,
     SuspendedTokuseiSurveyResultsPage,
 } from './lazyPages';
 
@@ -93,6 +94,14 @@ export const analysisRoutes: RouteObject[] = [
     element: (
       <RequireAudience requiredRole="admin">
         <SuspendedTokuseiSurveyResultsPage />
+      </RequireAudience>
+    ),
+  },
+  {
+    path: 'support-review',
+    element: (
+      <RequireAudience requiredRole="viewer">
+        <SuspendedSupportReviewHubPage />
       </RequireAudience>
     ),
   },

--- a/src/app/routes/lazyPages.tsx
+++ b/src/app/routes/lazyPages.tsx
@@ -26,6 +26,7 @@ const TimeBasedSupportRecordPage = React.lazy(() => import('@/pages/TimeBasedSup
 const HealthObservationPage = React.lazy(() => import('@/pages/HealthObservationPage'));
 const AnalysisDashboardPage = React.lazy(() => import('@/pages/AnalysisDashboardPage'));
 const AssessmentDashboardPage = React.lazy(() => import('@/pages/AssessmentDashboardPage'));
+const SupportReviewHubPage = React.lazy(() => import('@/pages/SupportReviewHubPage'));
 const TokuseiSurveyResultsPage = React.lazy(() => import('@/pages/TokuseiSurveyResultsPage'));
 const IcebergPdcaPage = React.lazy(() => import('@/pages/IcebergPdcaPage'));
 const IcebergAnalysisPage = React.lazy(() => import('@/pages/IcebergAnalysisPage'));
@@ -119,6 +120,7 @@ export const SuspendedIcebergPdcaPage = createSuspended(IcebergPdcaPage, '氷山
 export const SuspendedIcebergAnalysisPage = createSuspended(IcebergAnalysisPage, '氷山分析ワークスペースを読み込んでいます…');
 export const SuspendedInterventionDashboardPage = createSuspended(InterventionDashboardPage, '行動対応プランを読み込んでいます…');
 export const SuspendedAssessmentDashboardPage = createSuspended(AssessmentDashboardPage, 'アセスメント管理ページを読み込んでいます…');
+export const SuspendedSupportReviewHubPage = createSuspended(SupportReviewHubPage, '支援の確認・見直しハブを読み込んでいます…');
 export const SuspendedTokuseiSurveyResultsPage = createSuspended(TokuseiSurveyResultsPage, '特性アンケート結果を読み込んでいます…');
 export const SuspendedHealthObservationPage = createSuspended(HealthObservationPage, '身体記録画面を読み込んでいます…');
 export const SuspendedStaffDashboardPage = createSuspended(StaffDashboardPage, 'ダッシュボードを読み込んでいます…');

--- a/src/pages/SupportReviewHubPage.tsx
+++ b/src/pages/SupportReviewHubPage.tsx
@@ -1,0 +1,166 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import CardActionArea from '@mui/material/CardActionArea';
+import CardContent from '@mui/material/CardContent';
+import Container from '@mui/material/Container';
+import Divider from '@mui/material/Divider';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import AssessmentIcon from '@mui/icons-material/Assessment';
+import PersonIcon from '@mui/icons-material/Person';
+import PsychologyIcon from '@mui/icons-material/Psychology';
+import BuildIcon from '@mui/icons-material/Build';
+import RateReviewIcon from '@mui/icons-material/RateReview';
+
+interface HubItem {
+  id: string;
+  title: string;
+  description: string;
+  actionText: string;
+  to: string;
+  icon: React.ReactNode;
+  color: string;
+}
+
+export const SupportReviewHubPage: React.FC = () => {
+  const navigate = useNavigate();
+  const theme = useTheme();
+
+  const items: HubItem[] = [
+    {
+      id: 'plan-list',
+      title: '1. 現在の支援計画を見る',
+      description: 'いま有効な支援計画の一覧と、それらの見直し（モニタリング・再評価）の状況を確認します。',
+      actionText: '計画シート一覧を表示する',
+      to: '/planning-sheet-list',
+      icon: <AssessmentIcon sx={{ fontSize: 32 }} />,
+      color: theme.palette.primary.main,
+    },
+    {
+      id: 'assessment',
+      title: '2. 本人の特性を確認する',
+      description: '利用者の強み、困りごと、感覚特性（感覚プロファイル）などを整理し、見取り図を作成・更新します。',
+      actionText: 'アセスメント管理を開く',
+      to: '/assessment',
+      icon: <PersonIcon sx={{ fontSize: 32 }} />,
+      color: theme.palette.success.main,
+    },
+    {
+      id: 'analysis',
+      title: '3. 困りごとの背景を整理する',
+      description: '生活上生じている課題行動の背景にある環境要因や引き金（トリガー）を、氷山モデルを用いて構造分析します。',
+      actionText: '分析ワークスペースを開く',
+      to: '/analysis',
+      icon: <PsychologyIcon sx={{ fontSize: 32 }} />,
+      color: theme.palette.warning.main,
+    },
+    {
+      id: 'new-plan',
+      title: '4. 支援計画に反映する',
+      description: 'アセスメント特性や氷山分析の結果（背景要因・介入案）を取り込み、新期・更新用の個別支援計画シートを作成します。',
+      actionText: '新しい計画シートを作成する',
+      to: '/support-planning-sheet/new',
+      icon: <BuildIcon sx={{ fontSize: 32 }} />,
+      color: theme.palette.info.main,
+    },
+  ];
+
+  return (
+    <Container maxWidth="xl" sx={{ py: 4 }} data-testid="support-review-hub-page">
+      {/* Page Header */}
+      <Box sx={{ mb: 4 }}>
+        <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 1 }}>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 48,
+              height: 48,
+              borderRadius: 2,
+              bgcolor: 'action.selected',
+              color: 'primary.main',
+            }}
+          >
+            <RateReviewIcon sx={{ fontSize: 28 }} />
+          </Box>
+          <Box>
+            <Typography variant="h5" fontWeight={700} color="text.primary">
+              支援の確認・見直し
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              利用者の支援状況を総合的に把握し、特性・背景分析・支援計画をチームで連動させながら改善します。
+            </Typography>
+          </Box>
+        </Stack>
+        <Divider sx={{ mt: 3 }} />
+      </Box>
+
+      {/* Grid of Pathways */}
+      <Box
+        sx={{
+          display: 'grid',
+          gap: 3,
+          gridTemplateColumns: {
+            xs: '1fr',
+            md: '1fr 1fr',
+          },
+        }}
+      >
+        {items.map((item) => (
+          <Card
+            key={item.id}
+            variant="outlined"
+            sx={{
+              borderRadius: 3,
+              overflow: 'hidden',
+              transition: 'all 0.2s ease-in-out',
+              '&:hover': {
+                transform: 'translateY(-4px)',
+                boxShadow: theme.shadows[4],
+                borderColor: item.color,
+              },
+            }}
+          >
+            <CardActionArea
+              onClick={() => navigate(item.to)}
+              sx={{ height: '100%', display: 'flex', alignItems: 'stretch' }}
+            >
+              {/* Vertical Color Indicator */}
+              <Box sx={{ width: 8, bgcolor: item.color }} />
+
+              <CardContent sx={{ flex: 1, p: 3, display: 'flex', flexDirection: 'column', gap: 2 }}>
+                {/* Header Block */}
+                <Stack direction="row" spacing={2} alignItems="flex-start" justifyContent="space-between">
+                  <Box>
+                    <Typography variant="h6" fontWeight={700} sx={{ mb: 0.5 }}>
+                      {item.title}
+                    </Typography>
+                  </Box>
+                  <Box sx={{ color: item.color, mt: 0.5 }}>
+                    {item.icon}
+                  </Box>
+                </Stack>
+
+                <Typography variant="body2" color="text.secondary" sx={{ flex: 1, lineHeight: 1.6 }}>
+                  {item.description}
+                </Typography>
+
+                <Stack direction="row" spacing={1} alignItems="center" sx={{ color: item.color, fontWeight: 600, fontSize: '0.875rem', mt: 'auto', pt: 1 }}>
+                  <span>{item.actionText}</span>
+                  <ArrowForwardIcon sx={{ fontSize: 16 }} />
+                </Stack>
+              </CardContent>
+            </CardActionArea>
+          </Card>
+        ))}
+      </Box>
+    </Container>
+  );
+};
+
+export default SupportReviewHubPage;

--- a/src/testids.ts
+++ b/src/testids.ts
@@ -26,6 +26,7 @@ const NAV_TESTIDS = {
   operationFlowSettings: 'nav-operation-flow-settings',
   planningSheet: 'nav-planning-sheet',
   exceptionCenter: 'nav-exception-center',
+  supportReviewHub: 'nav-support-review-hub',
 } as const;
 
 const FOOTER_TESTIDS = {


### PR DESCRIPTION
# feat(nav): add support review hub for assessment analysis and planning

## Summary
Simplifies the sidebar navigation by collapsing three highly-technical, abstract screens under the `'severe'` group into a single, user-friendly entry point labeled **「支援の確認・見直し」** routing to a brand new **Support Review Hub** (`/support-review`).

This change drastically reduces cognitive load for care workers, presenting them with concrete, goal-oriented pathways rather than abstract system names, while preserving the existing page logic, direct URL routes, and current feature integrations.

> [!IMPORTANT]
> This PR does not merge the assessment, analysis, and planning features.
> It only simplifies the navigation entry point and introduces a hub-and-spoke screen to reduce cognitive load for field staff.

---

## Detailed Changes

### 1. Unified Side Navigation Entrance
- **Sidebar Label Update**: Renamed navigation group `'severe'` (previously "🔍 分析して改善") to **「🔍 支援を見直す」** to align with the action of care quality reviews.
- **Collapsing Sidebar Items**: Consolidated the three legacy items (支援計画シート, アセスメント, 分析ワークスペース) into a single unified item: **「支援の確認・見直し」** (`/support-review`), targeting the new Hub.
- **Source Preservation**: Direct URLs to the existing paths (`/planning-sheet-list`, `/assessment`, `/analysis`) remain fully active to guarantee that deep links, page-to-page bridges, and automatic triggers function correctly.

### 2. Premium Support Review Hub Page (`/support-review`)
Renders a responsive, high-fidelity grid of 4 goal-oriented action cards utilizing curated themed palettes, elevation cards, and hover micro-animations matching the codebase design language:
1. **現在の支援計画を見る**: Links to `/planning-sheet-list` (いま有効な計画と見直しの進捗を確認).
2. **本人の特性を確認する**: Links to `/assessment` (強み・困りごと・感覚特性の整理).
3. **困りごとの背景を整理する**: Links to `/analysis` (氷山モデルを用いた環境要因・背景仮説の分析).
4. **支援計画に反映する**: Links to `/support-planning-sheet/new` (分析結果やモニタリングを取り込んだ新期計画作成).

### 3. Navigation Infrastructure & Testing
- **Test ID Registry**: Appended the canonical `TESTIDS.nav.supportReviewHub` (`nav-support-review-hub`) in `src/testids.ts`.
- **Router Configuration**: Registered route `/support-review` mapping to `<SuspendedSupportReviewHubPage />` inside `analysisRoutes.tsx` with standard viewer-role verification.
- **Lazy Loading**: Added code-splitting for `SupportReviewHubPage` inside `lazyPages.tsx` to optimize build sizes.
- **Unit Tests Updated**: Added a unit test assertion in `navigationConfig.test.ts` to enforce that the unified item correctly registers in the `'severe'` navigation group.

---

## Verification Results

### Vitest Suite (18/18 Passed)
All navigation configuration and Shell-routing unit tests are fully verified and pass successfully:
```bash
npx vitest run src/app/config/__tests__ src/app/__tests__/AppShell.navigation.spec.tsx
```
Output:
```text
✓ src/app/config/__tests__/navigationConfig.helpers.spec.ts (5 tests)
✓ src/app/config/__tests__/navigationConfig.contract.spec.ts (3 tests)
✓ src/app/config/__tests__/navigationConfig.test.ts (6 tests)
✓ src/app/__tests__/AppShell.navigation.spec.tsx (4 tests)

Test Files  4 passed (4)
     Tests  18 passed (18)
```
