### PR TITLE
refactor(planning-sheet): clarify iceberg bridge field mapping contract

### DIFF
--- a/src/features/planning-sheet/__tests__/icebergToPlanningBridge.spec.ts
+++ b/src/features/planning-sheet/__tests__/icebergToPlanningBridge.spec.ts
@@ -59,7 +59,7 @@ describe('icebergToPlanningBridge', () => {
       }
     ];
 
-    it('should map targetBehavior and icegergSurface', () => {
+    it('should map targetBehavior and icebergSurface', () => {
       const result = icebergToPlanningBridge(mockDrafts);
       expect(result.targetBehavior).toBe('パニック');
       expect(result.icebergSurface).toBe('パニック');

--- a/src/features/planning-sheet/__tests__/icebergToPlanningBridge.spec.ts
+++ b/src/features/planning-sheet/__tests__/icebergToPlanningBridge.spec.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import { 
+  icebergToPlanningBridge, 
+  classifyTriggerFactor,
+  buildIcebergImportResult 
+} from '../icebergToPlanningBridge';
+import type { BehaviorInterventionPlan } from '@/features/analysis/domain/interventionTypes';
+
+describe('icebergToPlanningBridge', () => {
+  describe('classifyTriggerFactor', () => {
+    it('should classify environment related keywords as environment', () => {
+      expect(classifyTriggerFactor('騒がしい部屋')).toBe('environment');
+      expect(classifyTriggerFactor('明るい光')).toBe('environment');
+      expect(classifyTriggerFactor('人込み')).toBe('environment');
+    });
+
+    it('should classify others as trigger', () => {
+      expect(classifyTriggerFactor('指示されたとき')).toBe('trigger');
+      expect(classifyTriggerFactor('待ち時間')).toBe('trigger');
+      expect(classifyTriggerFactor('予定の変更')).toBe('trigger');
+    });
+  });
+
+  describe('mapping logic', () => {
+    const mockDrafts: BehaviorInterventionPlan[] = [
+      {
+        id: '1',
+        userId: 'user1',
+        targetBehavior: 'パニック',
+        targetBehaviorNodeId: 'node-b1',
+        triggerFactors: [
+          { label: '指示された', nodeId: 'node-t1' },
+          { label: '騒がしい部屋', nodeId: 'node-e1' },
+        ],
+        strategies: {
+          prevention: 'イヤーマフ装着',
+          alternative: '「うるさい」と伝える',
+          reactive: '静かな場所へ移動',
+        },
+        createdAt: '',
+        updatedAt: '',
+      },
+      {
+        id: '2',
+        userId: 'user1',
+        targetBehavior: 'パニック', // 同じ行動
+        targetBehaviorNodeId: 'node-b1',
+        triggerFactors: [
+          { label: '指示された', nodeId: 'node-t1' }, // 重複
+          { label: '予定の変更', nodeId: 'node-t2' },
+        ],
+        strategies: {
+          prevention: 'イヤーマフ装着', // 重複
+          alternative: 'タイマーを使う',
+          reactive: '深呼吸を促す',
+        },
+        createdAt: '',
+        updatedAt: '',
+      }
+    ];
+
+    it('should map targetBehavior and icegergSurface', () => {
+      const result = icebergToPlanningBridge(mockDrafts);
+      expect(result.targetBehavior).toBe('パニック');
+      expect(result.icebergSurface).toBe('パニック');
+    });
+
+    it('should separate triggers and environment factors with deduplication', () => {
+      const result = icebergToPlanningBridge(mockDrafts);
+      // '指示された' は重複排除され triggers へ
+      // '予定の変更' は triggers へ
+      // '騒がしい部屋' は environmentFactors へ
+      expect(result.triggers).toBe('指示された, 予定の変更');
+      expect(result.environmentFactors).toBe('騒がしい部屋');
+    });
+
+    it('should map strategies to planning sections', () => {
+      const result = icebergToPlanningBridge(mockDrafts);
+      
+      // §5 予防的支援
+      expect(result.environmentalAdjustment).toBe('イヤーマフ装着');
+      
+      // §6 代替行動 (alternative は teachingMethod へ)
+      expect(result.teachingMethod).toContain('「うるさい」と伝える');
+      expect(result.teachingMethod).toContain('タイマーを使う');
+      
+      // §7 問題行動時対応 (reactive は initialResponse/staffResponse へ)
+      expect(result.initialResponse).toContain('静かな場所へ移動');
+      expect(result.initialResponse).toContain('深呼吸を促す');
+      expect(result.staffResponse).toBe(result.initialResponse);
+    });
+
+    it('should handle empty drafts', () => {
+      expect(icebergToPlanningBridge([])).toEqual({});
+    });
+  });
+
+  describe('buildIcebergImportResult', () => {
+    const mockDrafts: BehaviorInterventionPlan[] = [
+      {
+        id: '1',
+        userId: 'user1',
+        targetBehavior: '行動A',
+        targetBehaviorNodeId: 'n1',
+        triggerFactors: [
+          { label: '要因1', nodeId: 'f1' },
+          { label: '静かな部屋', nodeId: 'f2' },
+        ],
+        strategies: {
+          prevention: '予防A',
+          alternative: '',
+          reactive: '事後A',
+        },
+        createdAt: '',
+        updatedAt: '',
+      }
+    ];
+
+    it('should return patches and accurate summary', () => {
+      const result = buildIcebergImportResult(mockDrafts);
+      expect(result.formPatches.targetBehavior).toBe('行動A');
+      expect(result.summary).toEqual({
+        behaviorCount: 1,
+        triggerCount: 1, // '要因1'
+        environmentFactorCount: 1, // '静かな部屋'
+        strategyCount: 2, // '予防A', '事後A'
+      });
+    });
+  });
+});

--- a/src/features/planning-sheet/icebergToPlanningBridge.ts
+++ b/src/features/planning-sheet/icebergToPlanningBridge.ts
@@ -69,7 +69,8 @@ export function icebergToPlanningBridge(drafts: BehaviorInterventionPlan[]): Par
     
     // §7 問題行動時対応
     initialResponse: uniqueLabels(reactiveStrategies).join('\n'),
-    staffResponse: uniqueLabels(reactiveStrategies).join('\n'), // 重複するが、職員対応にも入れる
+    // 初期対応と職員対応は現行BIPでは分離できないため、同じ reactive 案を初期値として入れる
+    staffResponse: uniqueLabels(reactiveStrategies).join('\n'),
   };
 }
 

--- a/src/features/planning-sheet/icebergToPlanningBridge.ts
+++ b/src/features/planning-sheet/icebergToPlanningBridge.ts
@@ -2,23 +2,74 @@ import type { BehaviorInterventionPlan } from '@/features/analysis/domain/interv
 import type { FormState } from './components/new-form/types';
 
 /**
- * 氷山分析の Draft 群を PlanningSheet の FormState にマッピングする。
+ * ラベル群を重複排除してトリミングする
+ */
+function uniqueLabels(items: string[]): string[] {
+  return Array.from(new Set(items.map(s => s.trim()).filter(Boolean)));
+}
+
+/**
+ * 氷山モデルの要因ラベルを「きっかけ(Trigger)」か「環境(Environment)」かに分類する
+ */
+export function classifyTriggerFactor(label: string): 'trigger' | 'environment' {
+  const envKeywords = [
+    '場所', '部屋', '環境', '光', '音', '声', '匂い', '感覚',
+    '混雑', '人込み', '騒がしい', '明るい', '暗い', '暑い', '寒い',
+    '座席', '配置', '視覚', '聴覚', '触覚', '圧迫',
+  ];
+
+  const lowerLabel = label.toLowerCase();
+  const isEnv = envKeywords.some(kw => lowerLabel.includes(kw));
+
+  return isEnv ? 'environment' : 'trigger';
+}
+
+/**
+ * 氷山分析の BehaviorInterventionPlan 群を PlanningSheet の FormState にマッピングする。
  * 
  * マッピング方針:
- * - targetBehavior: 最初の行動ノードをセット（空の場合のみ）
- * - triggers: 全ての triggerFactors をカンマ区切りで集約
- * - environmentFactors: 同上（重複を許容するか、triggers と分けるかは運用次第。ここでは triggers に集約）
+ * - targetBehavior: 最初の行動ノードをセット
+ * - triggers: 直接的なきっかけをカンマ区切りで集約
+ * - environmentFactors: 場所や感覚などの背景要因をカンマ区切りで集約
+ * - strategies: 予防・代替・事後の各戦略を適切なフィールドへ展開
  */
 export function icebergToPlanningBridge(drafts: BehaviorInterventionPlan[]): Partial<FormState> {
   if (drafts.length === 0) return {};
 
   const firstDraft = drafts[0];
-  const allTriggers = Array.from(new Set(drafts.flatMap(d => d.triggerFactors.map(t => t.label))));
+
+  const allFactorLabels = drafts.flatMap(d => d.triggerFactors.map(t => t.label));
+  const triggers: string[] = [];
+  const environments: string[] = [];
+
+  allFactorLabels.forEach(label => {
+    if (classifyTriggerFactor(label) === 'environment') {
+      environments.push(label);
+    } else {
+      triggers.push(label);
+    }
+  });
+
+  const preventionStrategies = drafts.map(d => d.strategies.prevention);
+  const alternativeStrategies = drafts.map(d => d.strategies.alternative);
+  const reactiveStrategies = drafts.map(d => d.strategies.reactive);
 
   return {
     targetBehavior: firstDraft.targetBehavior,
-    triggers: allTriggers.join(', '),
-    environmentFactors: allTriggers.join(', '), // Iceberg では区別が難しいため両方に入れる
+    icebergSurface: firstDraft.targetBehavior, // 氷山分析の「表面」にもセット
+    triggers: uniqueLabels(triggers).join(', '),
+    environmentFactors: uniqueLabels(environments).join(', '),
+    
+    // §5 予防的支援
+    environmentalAdjustment: uniqueLabels(preventionStrategies).join('\n'),
+    
+    // §6 代替行動
+    desiredBehavior: '', // ここは手動入力が基本だが、文脈的に alternative を教え方に入れる
+    teachingMethod: uniqueLabels(alternativeStrategies).join('\n'),
+    
+    // §7 問題行動時対応
+    initialResponse: uniqueLabels(reactiveStrategies).join('\n'),
+    staffResponse: uniqueLabels(reactiveStrategies).join('\n'), // 重複するが、職員対応にも入れる
   };
 }
 
@@ -27,18 +78,31 @@ export interface IcebergImportResult {
   summary: {
     behaviorCount: number;
     triggerCount: number;
+    environmentFactorCount: number;
+    strategyCount: number;
   };
 }
 
 export function buildIcebergImportResult(drafts: BehaviorInterventionPlan[]): IcebergImportResult {
   const patches = icebergToPlanningBridge(drafts);
-  const allTriggers = Array.from(new Set(drafts.flatMap(d => d.triggerFactors.map(t => t.label))));
+  
+  const allFactorLabels = drafts.flatMap(d => d.triggerFactors.map(t => t.label));
+  const triggers = allFactorLabels.filter(l => classifyTriggerFactor(l) === 'trigger');
+  const environments = allFactorLabels.filter(l => classifyTriggerFactor(l) === 'environment');
+
+  const strategyInputs = drafts.flatMap(d => [
+    d.strategies.prevention,
+    d.strategies.alternative,
+    d.strategies.reactive
+  ]).filter(Boolean);
 
   return {
     formPatches: patches,
     summary: {
       behaviorCount: drafts.length,
-      triggerCount: allTriggers.length,
+      triggerCount: uniqueLabels(triggers).length,
+      environmentFactorCount: uniqueLabels(environments).length,
+      strategyCount: uniqueLabels(strategyInputs).length,
     }
   };
 }


### PR DESCRIPTION
## Summary
- Split Iceberg trigger factors into direct triggers and environment factors using heuristic classification.
- Map prevention / alternative / reactive strategies from Iceberg into Planning Sheet fields (§5, §6, §7).
- Extend import summary with environment factor and strategy counts for better feedback.
- Add pure mapper tests to ensure bridge contract stability.

## Mapping Contract (Heuristic & Conservative)
- Factors containing keywords like 'room', 'light', 'sound', 'senses' are classified as 'environmentFactors'.
- Ambiguous or unknown factors are assigned to 'triggers' to ensure they are visible to staff for later adjustment.
- Strategy fields are concatenated with line breaks if multiple nodes are imported.

## Technical Details
- This PR only clarifies the pure mapping contract from `BehaviorInterventionPlan` to Planning Sheet `FormState`.
- It does not add UI, persistence changes, or import-preview interaction changes.

## Checks
- [x] npm run typecheck
- [x] npm run lint
- [x] npx vitest run src/features/planning-sheet/__tests__/icebergToPlanningBridge.spec.ts