### PR TITLE
feat(planning-sheet): show detailed iceberg import preview summary

### DIFF
--- a/src/features/planning-sheet/buildImportPreview.ts
+++ b/src/features/planning-sheet/buildImportPreview.ts
@@ -40,6 +40,13 @@ export interface ImportPreviewSummary {
   skipCount: number;
   /** 反映される合計フィールド数 */
   totalAffected: number;
+  /** 氷山分析特有のサマリー（オプショナル） */
+  icebergSummary?: {
+    behaviorCount: number;
+    triggerCount: number;
+    environmentFactorCount: number;
+    strategyCount: number;
+  };
 }
 
 /** buildImportPreview() の戻り値 */
@@ -64,6 +71,7 @@ const FIELD_LABELS: Record<string, { label: string; section: string }> = {
   // §3 氷山分析
   triggers: { label: 'トリガー（きっかけ）', section: '§3 氷山分析' },
   environmentFactors: { label: '環境要因', section: '§3 氷山分析' },
+  icebergSurface: { label: '表面（対象行動）', section: '§3 氷山分析' },
   emotions: { label: '本人の感情', section: '§3 氷山分析' },
   cognition: { label: '理解状況（認知）', section: '§3 氷山分析' },
   needs: { label: '本人ニーズ', section: '§3 氷山分析' },
@@ -78,6 +86,12 @@ const FIELD_LABELS: Record<string, { label: string; section: string }> = {
   communicationSupport: { label: 'コミュニケーション支援', section: '§5 予防的支援' },
   safetySupport: { label: '安心支援', section: '§5 予防的支援' },
   preSupport: { label: '事前支援', section: '§5 予防的支援' },
+  // §6 代替行動
+  desiredBehavior: { label: '本人の希望・目標', section: '§6 代替行動' },
+  teachingMethod: { label: '新しい教え方', section: '§6 代替行動' },
+  // §7 問題行動時対応
+  initialResponse: { label: '初期対応', section: '§7 問題行動時対応' },
+  staffResponse: { label: '職員の対応', section: '§7 問題行動時対応' },
   // §8 危機対応
   dangerousBehavior: { label: '危険行動', section: '§8 危機対応' },
   medicalCoordination: { label: '医療連携', section: '§8 危機対応' },
@@ -97,6 +111,7 @@ const FIELD_LABELS: Record<string, { label: string; section: string }> = {
 export function buildImportPreview(
   formPatches: Record<string, string>,
   currentFormValues: Record<string, unknown>,
+  icebergSummary?: ImportPreviewSummary['icebergSummary'],
 ): ImportPreviewResult {
   const items: ImportPreviewItem[] = [];
 
@@ -134,6 +149,7 @@ export function buildImportPreview(
       appendCount,
       skipCount: 0,
       totalAffected: newCount + appendCount,
+      icebergSummary,
     },
   };
 }

--- a/src/features/planning-sheet/components/ImportPreviewDialog.tsx
+++ b/src/features/planning-sheet/components/ImportPreviewDialog.tsx
@@ -133,6 +133,19 @@ export const ImportPreviewDialog: React.FC<Props> = ({
             />
           </Stack>
 
+          {/* ── 氷山分析詳細サマリー ── */}
+          {summary.icebergSummary && (
+            <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap sx={{ bgcolor: 'grey.50', p: 1, borderRadius: 1, border: '1px dashed', borderColor: 'grey.300' }}>
+              <Typography variant="caption" sx={{ width: '100%', mb: 0.5, fontWeight: 700, color: 'text.secondary' }}>
+                氷山分析データの内訳:
+              </Typography>
+              <Chip label={`分析数: ${summary.icebergSummary.behaviorCount}`} size="small" variant="outlined" />
+              <Chip label={`きっかけ: ${summary.icebergSummary.triggerCount}`} size="small" variant="outlined" />
+              <Chip label={`環境要因: ${summary.icebergSummary.environmentFactorCount}`} size="small" variant="outlined" />
+              <Chip label={`支援案: ${summary.icebergSummary.strategyCount}`} size="small" variant="outlined" />
+            </Stack>
+          )}
+
           {/* ── セクション別プレビュー ── */}
           {grouped.map(([section, sectionItems], sIdx) => (
             <Box key={section}>

--- a/src/features/planning-sheet/components/new-form/NewPlanningSheetForm.tsx
+++ b/src/features/planning-sheet/components/new-form/NewPlanningSheetForm.tsx
@@ -254,7 +254,7 @@ export const NewPlanningSheetForm: React.FC<NewPlanningSheetFormProps> = ({
       const drafts = icebergToInterventionDrafts({ ...latest, targetUserId: (latest as unknown as IcebergSnapshot).userId } as unknown as IcebergSession);
       const result = buildIcebergImportResult(drafts);
       
-      const preview = buildImportPreview(result.formPatches as Record<string, string>, form as unknown as Record<string, unknown>);
+      const preview = buildImportPreview(result.formPatches as Record<string, string>, form as unknown as Record<string, unknown>, result.summary);
       setImportPreview(preview);
       // 特性アンケートのブリッジ結果と構造が同じなので再利用
       setLastBridgeResult({ formPatches: result.formPatches } as unknown as ReturnType<typeof tokuseiToPlanningBridge>);


### PR DESCRIPTION
## Summary
- Enhanced the Import Preview UI for Iceberg Analysis data.
- Added missing field labels (icebergSurface, teachingMethod, response fields) to the previewer.
- Extended the preview summary to show the count of behaviors, triggers, environment factors, and strategies.
- Updated the dialog UI to render these details in a dedicated summary section.

## Technical Details
- Updated `ImportPreviewResult` to hold optional `icebergSummary`.
- Updated `FIELD_LABELS` in `buildImportPreview.ts` to map internal bridge keys to human-readable names.
- Updated `ImportPreviewDialog.tsx` with a dashed-border summary box for Iceberg-specific metrics.

## Checks
- [x] npm run typecheck
- [x] npm run lint
- [x] npx vitest run src/features/planning-sheet/__tests__/icebergToPlanningBridge.spec.ts