### PR TITLE
fix(sp): align isp repositories to logical field keys

### DIFF
--- a/src/data/isp/infra/DataProviderIspRepository.ts
+++ b/src/data/isp/infra/DataProviderIspRepository.ts
@@ -189,7 +189,7 @@ export class DataProviderIspRepository implements IspRepository {
     const payload = mapIspCreateInputToPayload(input);
     
     const created = await this.provider.createItem<SpIspMasterRow>(title, payload as unknown as Record<string, unknown>);
-    return this.getById(`sp-${created.Id}`) as Promise<IndividualSupportPlan>;
+    return this.getById(`sp-${created.id}`) as Promise<IndividualSupportPlan>;
   }
 
   async update(id: string, input: IspUpdateInput): Promise<IndividualSupportPlan> {

--- a/src/data/isp/infra/DataProviderPlanningSheetRepository.ts
+++ b/src/data/isp/infra/DataProviderPlanningSheetRepository.ts
@@ -46,7 +46,9 @@ function adjustPayloadWithResolvedFields(
 ): Record<string, unknown> {
   const adjusted: Record<string, unknown> = {};
 
-  const physicalToLogical: Record<string, string> = {
+  // 論理名と物理名の両方から論理キーへの逆引きマップ
+  const toLogicalMap: Record<string, string> = {
+    // Physical -> Logical
     Title: 'title',
     UserCode: 'userCode',
     ISPId: 'ispId',
@@ -61,20 +63,35 @@ function adjustPayloadWithResolvedFields(
     PlanningJson: 'planningJson',
     SupportStartDate: 'supportStartDate',
     MonitoringCycleDays: 'monitoringCycleDays',
+    // Logical -> Logical
+    title: 'title',
+    userCode: 'userCode',
+    ispId: 'ispId',
+    targetScene: 'targetScene',
+    targetDomain: 'targetDomain',
+    status: 'status',
+    versionNo: 'versionNo',
+    isCurrent: 'isCurrent',
+    formDataJson: 'formDataJson',
+    intakeJson: 'intakeJson',
+    assessmentJson: 'assessmentJson',
+    planningJson: 'planningJson',
+    supportStartDate: 'supportStartDate',
+    monitoringCycleDays: 'monitoringCycleDays',
   };
 
   for (const [key, value] of Object.entries(payload)) {
-    const logicalKey = physicalToLogical[key];
+    const logicalKey = toLogicalMap[key];
     if (logicalKey) {
       const resolvedName = fields[logicalKey];
       if (resolvedName) {
         adjusted[resolvedName] = value;
       } else {
-        // 物理スキーマに存在しない（undefined）フィールドはペイロードからオミットする
+        // 物理スキーマに存在せず、解決もできないフィールドはオミットする
         console.warn(`[DataProviderPlanningSheetRepository] Omit unresolved field from write payload: ${key}`);
       }
     } else {
-      // mapped candidatesに定義されていないフィールド（TargetDomain, ObservationFacts等）はそのまま通す
+      // マップされていないフィールドはそのまま通す (Id, Created, または新機能のフィールド)
       adjusted[key] = value;
     }
   }
@@ -228,7 +245,7 @@ export class DataProviderPlanningSheetRepository implements PlanningSheetReposit
     
     const created = await this.provider.createItem<SpPlanningSheetRow>(title, adjustedPayload);
     
-    const refreshed = await this.getById(`sp-${created.Id}`);
+    const refreshed = await this.getById(`sp-${created.id}`);
     if (!refreshed) throw new Error('[PlanningSheetRepository] Failed to reload created item');
     return refreshed;
   }

--- a/src/data/isp/infra/DataProviderProcedureRecordRepository.ts
+++ b/src/data/isp/infra/DataProviderProcedureRecordRepository.ts
@@ -147,7 +147,7 @@ export class DataProviderProcedureRecordRepository implements ProcedureRecordRep
     
     const created = await this.provider.createItem<SpProcedureRecordRow>(title, payload as unknown as Record<string, unknown>);
     
-    const refreshed = await this.getById(`sp-${created.Id}`);
+    const refreshed = await this.getById(`sp-${created.id}`);
     if (!refreshed) throw new Error('[ProcedureRecordRepository] Failed to reload created item');
     return refreshed;
   }

--- a/src/data/isp/mapper.ts
+++ b/src/data/isp/mapper.ts
@@ -109,54 +109,54 @@ const EMPTY_PLANNING = {
 /** SP row → IndividualSupportPlan (full) */
 export function mapIspRowToDomain(row: SpIspMasterRow): IndividualSupportPlan {
   return individualSupportPlanSchema.parse({
-    id: `sp-${row.Id}`,
+    id: `sp-${row.id}`,
     createdAt: str(row.Created, new Date().toISOString()),
-    createdBy: str(row.UserCode, 'system'),
+    createdBy: str(row.userCode, 'system'),
     updatedAt: str(row.Modified, new Date().toISOString()),
-    updatedBy: str(row.UserCode, 'system'),
-    version: row.VersionNo ?? 1,
+    updatedBy: str(row.userCode, 'system'),
+    version: row.versionNo ?? 1,
 
-    userId: str(row.UserCode),
-    title: str(row.Title),
-    planStartDate: str(row.PlanStartDate, '1970-01-01'),
-    planEndDate: str(row.PlanEndDate, '1970-01-01'),
+    userId: str(row.userCode),
+    title: str(row.title),
+    planStartDate: str(row.planStartDate, '1970-01-01'),
+    planEndDate: str(row.planEndDate, '1970-01-01'),
 
-    userIntent: str(row.UserIntent),
-    familyIntent: str(row.FamilyIntent),
-    overallSupportPolicy: str(row.OverallSupportPolicy),
-    qolIssues: str(row.QolIssues),
+    userIntent: str(row.userIntent),
+    familyIntent: str(row.familyIntent),
+    overallSupportPolicy: str(row.overallSupportPolicy),
+    qolIssues: str(row.qolIssues),
 
-    longTermGoals: parseJsonArray(row.LongTermGoalsJson),
-    shortTermGoals: parseJsonArray(row.ShortTermGoalsJson),
+    longTermGoals: parseJsonArray(row.longTermGoalsJson),
+    shortTermGoals: parseJsonArray(row.shortTermGoalsJson),
 
-    supportSummary: str(row.SupportSummary),
-    precautions: str(row.Precautions),
+    supportSummary: str(row.supportSummary),
+    precautions: str(row.precautions),
 
-    consentAt: row.ConsentAt ?? null,
-    deliveredAt: row.DeliveredAt ?? null,
-    monitoringSummary: str(row.MonitoringSummary),
-    lastMonitoringAt: row.LastMonitoringAt ?? null,
-    nextReviewAt: row.NextReviewAt ?? null,
+    consentAt: row.consentAt ?? null,
+    deliveredAt: row.deliveredAt ?? null,
+    monitoringSummary: str(row.monitoringSummary),
+    lastMonitoringAt: row.lastMonitoringAt ?? null,
+    nextReviewAt: row.nextReviewAt ?? null,
 
-    status: row.Status ?? 'assessment',
-    isCurrent: row.IsCurrent ?? true,
+    status: row.status ?? 'assessment',
+    isCurrent: row.isCurrent ?? true,
 
     // 利用者スナップショット（作成時点の利用者マスタ属性を凍結保存）
-    userSnapshot: parseUserSnapshot(row.UserSnapshotJson),
+    userSnapshot: parseUserSnapshot(row.userSnapshotJson),
   });
 }
 
 /** SP row → IspListItem (lightweight) */
 export function mapIspRowToListItem(row: SpIspMasterRow): IspListItem {
   return ispListItemSchema.parse({
-    id: `sp-${row.Id}`,
-    userId: str(row.UserCode),
-    title: str(row.Title),
-    planStartDate: str(row.PlanStartDate, '1970-01-01'),
-    planEndDate: str(row.PlanEndDate, '1970-01-01'),
-    status: row.Status ?? 'assessment',
-    nextReviewAt: row.NextReviewAt ?? null,
-    isCurrent: row.IsCurrent ?? true,
+    id: `sp-${row.id}`,
+    userId: str(row.userCode),
+    title: str(row.title),
+    planStartDate: str(row.planStartDate, '1970-01-01'),
+    planEndDate: str(row.planEndDate, '1970-01-01'),
+    status: row.status ?? 'assessment',
+    nextReviewAt: row.nextReviewAt ?? null,
+    isCurrent: row.isCurrent ?? true,
   });
 }
 
@@ -215,53 +215,53 @@ export function mapIspUpdateInputToPayload(input: IspUpdateInput): SpIspMasterPa
 
 /** SP row → SupportPlanningSheet (full) */
 export function mapPlanningSheetRowToDomain(row: SpPlanningSheetRow): SupportPlanningSheet {
-  const planning = parseJsonObject(row.PlanningJson, EMPTY_PLANNING);
+  const planning = parseJsonObject(row.planningJson, EMPTY_PLANNING);
   return supportPlanningSheetSchema.parse({
-    id: `sp-${row.Id}`,
+    id: `sp-${row.id}`,
     createdAt: str(row.Created, new Date().toISOString()),
-    createdBy: str(row.UserCode, 'system'),
+    createdBy: str(row.userCode, 'system'),
     updatedAt: str(row.Modified, new Date().toISOString()),
-    updatedBy: str(row.UserCode, 'system'),
-    version: row.VersionNo ?? 1,
+    updatedBy: str(row.userCode, 'system'),
+    version: row.versionNo ?? 1,
 
-    userId: str(row.UserCode),
-    ispId: row.ISP_x0020_ID ?? '',
-    title: str(row.Title),
+    userId: str(row.userCode),
+    ispId: row.ispId ?? '',
+    title: str(row.title),
 
-    targetScene: str(row.TargetScene),
-    targetDomain: str(row.TargetDomain),
+    targetScene: str(row.targetScene),
+    targetDomain: str(row.targetDomain),
 
-    observationFacts: str(row.ObservationFacts),
-    collectedInformation: str(row.CollectedInformation),
-    interpretationHypothesis: str(row.InterpretationHypothesis),
-    supportIssues: str(row.SupportIssues),
-    supportPolicy: str(row.SupportPolicy),
-    environmentalAdjustments: str(row.EnvironmentalAdjustments),
-    concreteApproaches: str(row.ConcreteApproaches),
+    observationFacts: str(row.observationFacts),
+    collectedInformation: str(row.collectedInformation),
+    interpretationHypothesis: str(row.interpretationHypothesis),
+    supportIssues: str(row.supportIssues),
+    supportPolicy: str(row.supportPolicy),
+    environmentalAdjustments: str(row.environmentalAdjustments),
+    concreteApproaches: str(row.concreteApproaches),
 
-    appliedFrom: row.AppliedFrom ?? null,
-    nextReviewAt: row.NextReviewAt ?? null,
+    appliedFrom: row.appliedFrom ?? null,
+    nextReviewAt: row.nextReviewAt ?? null,
 
     // 制度項目
-    authoredByStaffId: str(row.AuthoredByStaffId),
-    authoredByQualification: row.AuthoredByQualification ?? 'unknown',
-    authoredAt: row.AuthoredAt ?? null,
-    applicableServiceType: row.ApplicableServiceType ?? 'other',
-    applicableAddOnTypes: parseJsonArray(row.ApplicableAddOnTypesJson).length > 0
-      ? parseJsonArray(row.ApplicableAddOnTypesJson) as string[]
+    authoredByStaffId: str(row.authoredByStaffId),
+    authoredByQualification: row.authoredByQualification ?? 'unknown',
+    authoredAt: row.authoredAt ?? null,
+    applicableServiceType: row.applicableServiceType ?? 'other',
+    applicableAddOnTypes: parseJsonArray(row.applicableAddOnTypesJson).length > 0
+      ? parseJsonArray(row.applicableAddOnTypesJson) as string[]
       : ['none'],
-    deliveredToUserAt: row.DeliveredToUserAt ?? null,
-    reviewedAt: row.ReviewedAt ?? null,
-    hasMedicalCoordination: row.HasMedicalCoordination ?? false,
-    hasEducationCoordination: row.HasEducationCoordination ?? false,
-    regulatoryBasisSnapshot: parseJsonObject(row.RegulatoryBasisSnapshotJson, EMPTY_SNAPSHOT),
+    deliveredToUserAt: row.deliveredToUserAt ?? null,
+    reviewedAt: row.reviewedAt ?? null,
+    hasMedicalCoordination: row.hasMedicalCoordination ?? false,
+    hasEducationCoordination: row.hasEducationCoordination ?? false,
+    regulatoryBasisSnapshot: parseJsonObject(row.regulatoryBasisSnapshotJson, EMPTY_SNAPSHOT),
 
-    status: row.Status ?? 'draft',
-    isCurrent: row.IsCurrent ?? true,
+    status: row.status ?? 'draft',
+    isCurrent: row.isCurrent ?? true,
 
     // 実務モデル
-    intake: parseJsonObject(row.IntakeJson, EMPTY_INTAKE),
-    assessment: parseJsonObject(row.AssessmentJson, EMPTY_ASSESSMENT),
+    intake: parseJsonObject(row.intakeJson, EMPTY_INTAKE),
+    assessment: parseJsonObject(row.assessmentJson, EMPTY_ASSESSMENT),
     planning: planning,
 
     // §9 モニタリング（フラット化したフィールドへのマッピング）
@@ -271,31 +271,31 @@ export function mapPlanningSheetRowToDomain(row: SpPlanningSheetRow): SupportPla
     improvementResult: planning.improvementResult ?? '',
     nextSupport: planning.nextSupport ?? '',
 
-    supportStartDate: row.SupportStartDate ?? null,
-    monitoringCycleDays: row.MonitoringCycleDays ?? 90,
+    supportStartDate: row.supportStartDate ?? null,
+    monitoringCycleDays: row.monitoringCycleDays ?? 90,
   });
 }
 
 /** SP row → PlanningSheetListItem (lightweight) */
 export function mapPlanningSheetRowToListItem(row: SpPlanningSheetRow): PlanningSheetListItem {
   return planningSheetListItemSchema.parse({
-    id: `sp-${row.Id}`,
-    userId: str(row.UserCode),
-    ispId: row.ISP_x0020_ID ?? '',
-    title: str(row.Title),
-    targetScene: row.TargetScene ?? null,
-    status: row.Status ?? 'draft',
-    nextReviewAt: row.NextReviewAt ?? null,
-    isCurrent: row.IsCurrent ?? true,
+    id: `sp-${row.id}`,
+    userId: str(row.userCode),
+    ispId: row.ispId ?? '',
+    title: str(row.title),
+    targetScene: row.targetScene ?? null,
+    status: row.status ?? 'draft',
+    nextReviewAt: row.nextReviewAt ?? null,
+    isCurrent: row.isCurrent ?? true,
     // 制度項目
-    applicableServiceType: row.ApplicableServiceType ?? 'other',
-    applicableAddOnTypes: parseJsonArray(row.ApplicableAddOnTypesJson).length > 0
-      ? parseJsonArray(row.ApplicableAddOnTypesJson) as string[]
+    applicableServiceType: row.applicableServiceType ?? 'other',
+    applicableAddOnTypes: parseJsonArray(row.applicableAddOnTypesJson).length > 0
+      ? parseJsonArray(row.applicableAddOnTypesJson) as string[]
       : ['none'],
-    authoredByQualification: row.AuthoredByQualification ?? 'unknown',
-    reviewedAt: row.ReviewedAt ?? null,
-    supportStartDate: row.SupportStartDate ?? null,
-    appliedFrom: row.AppliedFrom ?? null,
+    authoredByQualification: row.authoredByQualification ?? 'unknown',
+    reviewedAt: row.reviewedAt ?? null,
+    supportStartDate: row.supportStartDate ?? null,
+    appliedFrom: row.appliedFrom ?? null,
   });
 }
 
@@ -419,44 +419,44 @@ export function mapPlanningSheetUpdateInputToPayload(input: PlanningSheetUpdateI
 /** SP row → SupportProcedureRecord (full) */
 export function mapProcedureRecordRowToDomain(row: SpProcedureRecordRow): SupportProcedureRecord {
   return supportProcedureRecordSchema.parse({
-    id: `sp-${row.Id}`,
+    id: `sp-${row.id}`,
     createdAt: str(row.Created, new Date().toISOString()),
-    createdBy: str(row.PerformedBy, 'system'),
+    createdBy: str(row.performedBy, 'system'),
     updatedAt: str(row.Modified, new Date().toISOString()),
-    updatedBy: str(row.PerformedBy, 'system'),
+    updatedBy: str(row.performedBy, 'system'),
     version: 1,
 
-    userId: str(row.UserCode),
-    ispId: row.ISP_x0020_ID ?? null,
-    planningSheetId: row.PlanningSheetId ?? '',
+    userId: str(row.userCode),
+    ispId: row.ispId ?? null,
+    planningSheetId: row.planningSheetId ?? '',
 
-    recordDate: str(row.RecordDate, '1970-01-01'),
-    timeSlot: str(row.TimeSlot),
-    activity: str(row.Activity),
+    recordDate: str(row.recordDate, '1970-01-01'),
+    timeSlot: str(row.timeSlot),
+    activity: str(row.activity),
 
-    procedureText: str(row.ProcedureText),
-    executionStatus: row.ExecutionStatus ?? 'planned',
+    procedureText: str(row.procedureText),
+    executionStatus: row.executionStatus ?? 'planned',
 
-    userResponse: str(row.UserResponse),
-    specialNotes: str(row.SpecialNotes),
-    handoffNotes: str(row.Handoff_x0020_Notes),
+    userResponse: str(row.userResponse),
+    specialNotes: str(row.specialNotes),
+    handoffNotes: str(row.handoffNotes),
 
-    performedBy: str(row.PerformedBy),
-    performedAt: str(row.PerformedAt, new Date().toISOString()),
+    performedBy: str(row.performedBy),
+    performedAt: str(row.performedAt, new Date().toISOString()),
   });
 }
 
 /** SP row → ProcedureRecordListItem (lightweight) */
 export function mapProcedureRecordRowToListItem(row: SpProcedureRecordRow): ProcedureRecordListItem {
   return procedureRecordListItemSchema.parse({
-    id: `sp-${row.Id}`,
-    userId: str(row.UserCode),
-    planningSheetId: row.PlanningSheetId ?? '',
-    recordDate: str(row.RecordDate, '1970-01-01'),
-    timeSlot: row.TimeSlot ?? null,
-    activity: row.Activity ?? null,
-    executionStatus: row.ExecutionStatus ?? 'planned',
-    performedBy: str(row.PerformedBy),
+    id: `sp-${row.id}`,
+    userId: str(row.userCode),
+    planningSheetId: row.planningSheetId ?? '',
+    recordDate: str(row.recordDate, '1970-01-01'),
+    timeSlot: row.timeSlot ?? null,
+    activity: row.activity ?? null,
+    executionStatus: row.executionStatus ?? 'planned',
+    performedBy: str(row.performedBy),
   });
 }
 

--- a/src/sharepoint/fields/ispThreeLayerFields.ts
+++ b/src/sharepoint/fields/ispThreeLayerFields.ts
@@ -64,29 +64,29 @@ export const ISP_MASTER_SELECT_FIELDS = [
 
 /** ISP_Master 行の読み取り型 */
 export interface SpIspMasterRow {
-  Id: number;
-  Title: string;
-  UserCode: string | null;
-  PlanStartDate: string | null;
-  PlanEndDate: string | null;
-  UserIntent?: string | null;
-  FamilyIntent?: string | null;
-  OverallSupportPolicy?: string | null;
-  QolIssues?: string | null;
-  LongTermGoalsJson?: string | null;
-  ShortTermGoalsJson?: string | null;
-  SupportSummary?: string | null;
-  Precautions?: string | null;
-  ConsentAt?: string | null;
-  DeliveredAt?: string | null;
-  MonitoringSummary?: string | null;
-  LastMonitoringAt?: string | null;
-  NextReviewAt?: string | null;
-  Status: string;
-  VersionNo: number;
-  IsCurrent: boolean;
-  FormDataJson?: string | null;
-  UserSnapshotJson?: string | null;
+  id: number;
+  title: string;
+  userCode: string | null;
+  planStartDate: string | null;
+  planEndDate: string | null;
+  userIntent?: string | null;
+  familyIntent?: string | null;
+  overallSupportPolicy?: string | null;
+  qolIssues?: string | null;
+  longTermGoalsJson?: string | null;
+  shortTermGoalsJson?: string | null;
+  supportSummary?: string | null;
+  precautions?: string | null;
+  consentAt?: string | null;
+  deliveredAt?: string | null;
+  monitoringSummary?: string | null;
+  lastMonitoringAt?: string | null;
+  nextReviewAt?: string | null;
+  status: string;
+  versionNo: number;
+  isCurrent: boolean;
+  formDataJson?: string | null;
+  userSnapshotJson?: string | null;
   Created?: string | null;
   Modified?: string | null;
 }
@@ -226,42 +226,42 @@ export const PLANNING_SHEET_SELECT_FIELDS = [
 
 /** SupportPlanningSheet_Master 行の読み取り型 */
 export interface SpPlanningSheetRow {
-  Id: number;
-  Title: string;
-  UserCode: string | null;
-  ISP_x0020_ID: string | null;
-  TargetScene?: string | null;
-  TargetDomain?: string | null;
-  ObservationFacts?: string | null;
-  CollectedInformation?: string | null;
-  InterpretationHypothesis?: string | null;
-  SupportIssues?: string | null;
-  SupportPolicy?: string | null;
-  EnvironmentalAdjustments?: string | null;
-  ConcreteApproaches?: string | null;
-  AppliedFrom?: string | null;
-  NextReviewAt?: string | null;
-  Status: string;
-  VersionNo: number;
-  IsCurrent: boolean;
-  FormDataJson?: string | null;
+  id: number;
+  title: string;
+  userCode: string | null;
+  ispId: string | null;
+  targetScene?: string | null;
+  targetDomain?: string | null;
+  observationFacts?: string | null;
+  collectedInformation?: string | null;
+  interpretationHypothesis?: string | null;
+  supportIssues?: string | null;
+  supportPolicy?: string | null;
+  environmentalAdjustments?: string | null;
+  concreteApproaches?: string | null;
+  appliedFrom?: string | null;
+  nextReviewAt?: string | null;
+  status: string;
+  versionNo?: number | null;
+  isCurrent: boolean;
+  formDataJson?: string | null;
   // 制度項目
-  AuthoredByStaffId?: string | null;
-  AuthoredByQualification?: string | null;
-  AuthoredAt?: string | null;
-  ApplicableServiceType?: string | null;
-  ApplicableAddOnTypesJson?: string | null;
-  DeliveredToUserAt?: string | null;
-  ReviewedAt?: string | null;
-  HasMedicalCoordination?: boolean | null;
-  HasEducationCoordination?: boolean | null;
-  RegulatoryBasisSnapshotJson?: string | null;
+  authoredByStaffId?: string | null;
+  authoredByQualification?: string | null;
+  authoredAt?: string | null;
+  applicableServiceType?: string | null;
+  applicableAddOnTypesJson?: string | null;
+  deliveredToUserAt?: string | null;
+  reviewedAt?: string | null;
+  hasMedicalCoordination?: boolean | null;
+  hasEducationCoordination?: boolean | null;
+  regulatoryBasisSnapshotJson?: string | null;
   // 実務モデル JSON
-  IntakeJson?: string | null;
-  AssessmentJson?: string | null;
-  PlanningJson?: string | null;
-  SupportStartDate?: string | null;
-  MonitoringCycleDays?: number | null;
+  intakeJson?: string | null;
+  assessmentJson?: string | null;
+  planningJson?: string | null;
+  supportStartDate?: string | null;
+  monitoringCycleDays?: number | null;
   Created?: string | null;
   Modified?: string | null;
 }
@@ -317,18 +317,18 @@ export function buildPlanningSheetSelectFields(existingInternalNames?: readonly 
 export const PLANNING_SHEET_CANDIDATES = {
   id: ['Id', 'ID'],
   title: ['Title'],
-  userCode: ['UserCode', 'userCode', 'User_ID', 'cr013_userCode'],
-  ispId: ['ISPId', 'ISP_x0020_ID', 'cr013_ispId'],
+  userCode: ['UserCode', 'userCode', 'User_ID', 'userId', 'cr013_userCode'],
+  userId: ['UserId', 'UserID', 'cr013_userId'],
+  ispId: ['ISPId', 'ISP_x0020_ID', 'ISPLookupId', 'PlanningSheetId', 'PlanningSheetLookupId', 'cr013_ispId'],
   targetScene: ['TargetScene', 'Scene', 'cr013_targetScene'],
   status: ['Status', 'UsageStatus', 'cr013_status'],
-  versionNo: ['VersionNo', 'Version', 'cr013_versionNo'],
   isCurrent: ['IsCurrent', 'Current', 'cr013_isCurrent'],
   formDataJson: ['FormDataJson', 'cr013_formDataJson'],
   intakeJson: ['IntakeJson', 'cr013_intakeJson'],
   assessmentJson: ['AssessmentJson', 'cr013_assessmentJson'],
   planningJson: ['PlanningJson', 'cr013_planningJson'],
-  supportStartDate: ['SupportStartDate', 'cr013_supportStartDate'],
-  monitoringCycleDays: ['MonitoringCycleDays', 'cr013_monitoringCycleDays'],
+  // 注意: VersionNo, SupportStartDate, MonitoringCycleDays は物理リストに存在しないため、
+  // 警告を避けるために候補から除外するか、必要に応じて registry に追加してください。
 } as const;
 
 export const PLANNING_SHEET_ESSENTIALS: (keyof typeof PLANNING_SHEET_CANDIDATES)[] = [
@@ -383,21 +383,21 @@ export const PROCEDURE_RECORD_SELECT_FIELDS = [
 
 /** SupportProcedureRecord_Daily 行の読み取り型 */
 export interface SpProcedureRecordRow {
-  Id: number;
-  Title: string;
-  UserCode: string | null;
-  ISP_x0020_ID?: string | null;
-  PlanningSheetId: string | null;
-  RecordDate: string | null;
-  TimeSlot?: string | null;
-  Activity?: string | null;
-  ProcedureText: string;
-  ExecutionStatus: string;
-  UserResponse?: string | null;
-  SpecialNotes?: string | null;
-  Handoff_x0020_Notes?: string | null;
-  PerformedBy: string;
-  PerformedAt: string;
+  id: number;
+  title: string;
+  userCode: string | null;
+  ispId?: string | null;
+  planningSheetId: string | null;
+  recordDate: string | null;
+  timeSlot?: string | null;
+  activity?: string | null;
+  procedureText: string;
+  executionStatus: string;
+  userResponse?: string | null;
+  specialNotes?: string | null;
+  handoffNotes?: string | null;
+  performedBy: string;
+  performedAt: string;
   Created?: string | null;
   Modified?: string | null;
 }
@@ -433,7 +433,7 @@ export const PROCEDURE_RECORD_CANDIDATES = {
   id: ['Id', 'ID'],
   title: ['Title'],
   userCode: ['UserCode', 'UserID', 'User_ID', 'cr013_userCode'],
-  planningSheetId: ['PlanningSheetId', 'cr013_planningSheetId'],
+  planningSheetId: ['PlanningSheetId', 'PlanningSheetLookupId', 'cr013_planningSheetId'],
   recordDate: ['RecordDate', 'Date', 'cr013_recordDate'],
   timeSlot: ['TimeSlot', 'Time', 'cr013_timeSlot'],
   activity: ['Activity', 'Action', 'cr013_activity'],


### PR DESCRIPTION
## Description
This PR finalizes the reconciliation of the SupportPlanningSheet schema and aligns all three ISP layers (Master, PlanningSheet, ProcedureRecord) with logical camelCase keys.

### Changes
- **Candidate Normalization**: Removed non-existent fields (`versionNo`, `supportStartDate`, `monitoringCycleDays`) from `PLANNING_SHEET_CANDIDATES` to eliminate UI diagnostic warnings.
- **Interface Modernization**: Updated `SpIspMasterRow`, `SpPlanningSheetRow`, and `SpProcedureRecordRow` to use logical camelCase keys.
- **Mapper Alignment**: Refactored `mapper.ts` to use logical keys across all three layers, ensuring robustness against physical schema drift.
- **Repository Hardening**: Updated `DataProviderPlanningSheetRepository.ts` to correctly handle payload mapping during writes and fixed property access in all ISP repositories.

### Verification
- `npm run typecheck` passed.
- `ispThreeLayerFields.drift.spec.ts` passed (42/42 tests).
