### PR TITLE
feat(daily): collapse user picker by default in table view

### DIFF
--- a/src/features/daily/components/forms/TableDailyRecordForm.tsx
+++ b/src/features/daily/components/forms/TableDailyRecordForm.tsx
@@ -76,7 +76,7 @@ export function TableDailyRecordForm({
             <Box sx={{ flex: 1 }}>
               <TableDailyRecordUserPicker
                 {...vm.sections.picker}
-                defaultExpanded={variant === 'content'}
+                defaultExpanded={false}
                 autoFocusSearch={variant === 'content'}
               />
             </Box>

--- a/src/features/daily/forms/TableDailyRecordForm.tsx
+++ b/src/features/daily/forms/TableDailyRecordForm.tsx
@@ -97,7 +97,7 @@ export function TableDailyRecordForm({
                 filteredUsers={filteredUsers}
                 selectedUserIds={selectedUserIds}
                 onUserToggle={handleUserToggle}
-                defaultExpanded={variant === 'content'}
+                defaultExpanded={false}
                 autoFocusSearch={variant === 'content'}
               />
             </Box>


### PR DESCRIPTION
## 概要
日々の記録（一覧形式）において、利用者選択エリアをデフォルトで閉じた状態に変更しました。

## 変更内容
### 変更
- `TableDailyRecordForm` コンポーネントにて `TableDailyRecordUserPicker` の `defaultExpanded` プロパティを `false` に設定。

## 変更ファイル一覧
| ファイル | 変更種別 | 変更内容 |
|---------|---------|---------| 
| src/features/daily/components/forms/TableDailyRecordForm.tsx | 変更 | defaultExpanded を false に変更 |
| src/features/daily/forms/TableDailyRecordForm.tsx | 変更 | defaultExpanded を false に変更 |

## テスト
- [x] 既存テスト通過 (pre-commit hook)
- [x] 型チェック通過 (pre-commit hook)

## セルフレビュー
- [x] console.log 残していない
- [x] any 使っていない
- [x] 責務分離を守っている
- [x] 600行ルール違反なし

## 影響範囲
- /daily/table ページを表示した際の初期表示が変更されます。