### PR TITLE
feat(kiosk): show procedure history with resilient SharePoint field resolution

### DIFF
--- a/artifacts/PR_DRAFT.md
+++ b/artifacts/PR_DRAFT.md
@@ -1,0 +1,21 @@
+## Summary
+
+- Add a kiosk procedure history panel for the procedure detail screen
+- Show persisted SharePoint execution records by date
+- Add 7-day, 1-month, and 3-month summary previews
+- Harden SharePoint history queries when optional row-level fields such as RowNo are missing
+- Prevent unresolved field names from being included in `$select`, `$filter`, `$orderby`, or write payloads
+
+## Design notes
+
+History preview uses persisted SharePoint execution records as the source of truth.
+
+The primary matching strategy is user/date-range query + in-app procedure matching by scheduleItemId / normalizedScheduleItemId. `rowNo` is used only when the physical SharePoint field is resolved. If `RowNo` is missing from the environment, the repository falls back to a narrower user/date-range query and excludes `RowNo` from all SharePoint query clauses.
+
+The active kiosk input form remains isolated from history loading failures. If history fetch fails, only the history panel reports the error.
+
+## Checks
+
+- [x] npm run typecheck
+- [x] npx vitest run src/features/daily src/features/kiosk
+- [x] npx playwright test tests/e2e/kiosk-home-smoke.spec.ts

--- a/src/features/daily/domain/ExecutionRecordRepository.ts
+++ b/src/features/daily/domain/ExecutionRecordRepository.ts
@@ -51,5 +51,10 @@ export interface ExecutionRecordRepository {
     userId: string,
     totalSlots: number,
   ): Promise<{ completed: number; triggered: number; rate: number }>;
-}
 
+  /**
+   * Get historical records for a user and procedure across multiple dates.
+   * Useful for trend analysis and historical previews.
+   */
+  getHistoricalRecords(userId: string, scheduleItemId: string, limit?: number): Promise<ExecutionRecord[]>;
+}

--- a/src/features/daily/domain/legacy/ExecutionRecordRepository.ts
+++ b/src/features/daily/domain/legacy/ExecutionRecordRepository.ts
@@ -51,5 +51,15 @@ export interface ExecutionRecordRepository {
     userId: string,
     totalSlots: number,
   ): Promise<{ completed: number; triggered: number; rate: number }>;
+
+  /**
+   * Get historical records for a given user and scheduleItemId.
+   * Ordered by recordedAt descending.
+   */
+  getHistoricalRecords(
+    userId: string,
+    scheduleItemId: string,
+    limit?: number,
+  ): Promise<ExecutionRecord[]>;
 }
 

--- a/src/features/daily/hooks/useHistoricalRecords.ts
+++ b/src/features/daily/hooks/useHistoricalRecords.ts
@@ -1,0 +1,32 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useExecutionData } from './useExecutionData';
+import type { ExecutionRecord } from '../domain/legacy/executionRecordTypes';
+
+export function useHistoricalRecords(userId: string, scheduleItemId: string) {
+  const { getHistoricalRecords } = useExecutionData();
+  const [records, setRecords] = useState<ExecutionRecord[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchHistory = useCallback(async () => {
+    if (!userId || !scheduleItemId) return;
+    
+    setIsLoading(true);
+    setError(null);
+    try {
+      const history = await getHistoricalRecords(userId, scheduleItemId, 150);
+      setRecords(history);
+    } catch (err) {
+      console.error('[useHistoricalRecords] Failed to fetch history:', err);
+      setError(err instanceof Error ? err : new Error('Failed to fetch history'));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [getHistoricalRecords, userId, scheduleItemId]);
+
+  useEffect(() => {
+    void fetchHistory();
+  }, [fetchHistory]);
+
+  return { records, isLoading, error, refresh: fetchHistory };
+}

--- a/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
+++ b/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
@@ -251,18 +251,19 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
     const existing = await this.getRecord(normalizedDate, normalizedUserId, normalizedScheduleItemId);
 
     await this.initFields(this.childListTitle);
-    const rawBody = {
+    const rawBody: Record<string, unknown> = {
       [rf.rowKey]: rowKey,
       [rf.parentId]: parentId,
       [rf.userId]: normalizedRecord.userId,
-      [rf.rowNo]: normalizedRecord.scheduleItemId,
       [rf.status]: normalizedRecord.status,
-      [rf.memo]: normalizedRecord.memo,
-      [rf.payload]: normalizedRecord.memo, // Drift protection: map to both candidates
-      [rf.staffName]: normalizedRecord.recordedBy,
+      [rf.payload]: normalizedRecord.memo, // Standard payload fallback
       [rf.recordedAt]: normalizedRecord.recordedAt,
-      [rf.bipsJSON]: JSON.stringify(normalizedRecord.triggeredBipIds),
     };
+    
+    if (rf.rowNo) rawBody[rf.rowNo] = normalizedRecord.scheduleItemId;
+    if (rf.memo) rawBody[rf.memo] = normalizedRecord.memo;
+    if (rf.staffName) rawBody[rf.staffName] = normalizedRecord.recordedBy;
+    if (rf.bipsJSON) rawBody[rf.bipsJSON] = JSON.stringify(normalizedRecord.triggeredBipIds);
     
     // Title is needed for POST (creation) but often ignored in MERGE if it doesn't change
     if (!existing) {
@@ -330,6 +331,65 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
     return { completed, triggered, rate };
   }
 
+  async getHistoricalRecords(
+    userId: string,
+    scheduleItemId: string,
+    limit?: number,
+  ): Promise<ExecutionRecord[]> {
+    const normalizedUserId = normalizeExecutionUserId(userId);
+    const normalizedScheduleItemId = normalizeScheduleItemId(scheduleItemId);
+    const rf = await this.getResolvedFields();
+    
+    // Safety: Limit history to approx 3 months to prevent large data transfers
+    const threshold = new Date();
+    threshold.setDate(threshold.getDate() - 95);
+    const thresholdStr = threshold.toISOString().split('T')[0];
+
+    // Build dynamic select to avoid querying non-existent columns
+    const selectFields = ['Id', 'Title', 'Created', 'Modified', rf.userId, rf.status, rf.payload, rf.recordedAt];
+    if (rf.rowKey) selectFields.push(rf.rowKey);
+    if (rf.rowNo) selectFields.push(rf.rowNo);
+    if (rf.memo) selectFields.push(rf.memo);
+    if (rf.staffName) selectFields.push(rf.staffName);
+    if (rf.bipsJSON) selectFields.push(rf.bipsJSON);
+    
+    const uniqueSelect = [...new Set(selectFields.filter((f): f is string => Boolean(f)))];
+
+    // 1. Primary query: Try direct filtering ONLY if rowNo is physically resolved
+    if (rf.rowNo) {
+      const filter = `${rf.userId} eq '${normalizedUserId}' and ${rf.rowNo} eq '${normalizedScheduleItemId}' and ${rf.recordedAt} ge '${thresholdStr}'`;
+      const url = `${this.resolvedChildPath}/items?$select=${uniqueSelect.join(',')}&$filter=${encodeURIComponent(filter)}&$orderby=${rf.recordedAt} desc${limit ? `&$top=${limit}` : ''}`;
+
+      const response = await this.spFetch(url);
+      if (response.ok) {
+        const data: SharePointResponse<JsonRecord> = await response.json();
+        return (data.value || []).map((item: JsonRecord) => this.mapToDomain(item, rf));
+      }
+      console.warn(`[ExecutionRepo] Primary history query failed (status: ${response.status}), falling back...`);
+    }
+
+    // 2. Fallback query: Filter by UserID + Date range and filter rows in-app
+    // This is used when rowNo is missing or primary query fails.
+    const fallbackSelect = uniqueSelect.filter(f => f !== rf.rowNo);
+    const fallbackFilter = `${rf.userId} eq '${normalizedUserId}' and (Created ge '${thresholdStr}' or ${rf.recordedAt} ge '${thresholdStr}')`;
+    const fallbackUrl = `${this.resolvedChildPath}/items?$select=${fallbackSelect.join(',')}&$filter=${encodeURIComponent(fallbackFilter)}&$top=1000`;
+    
+    const fallbackRes = await this.spFetch(fallbackUrl);
+    if (fallbackRes.ok) {
+      const fallbackData: SharePointResponse<JsonRecord> = await fallbackRes.json();
+      const items = fallbackData.value || [];
+      return items
+        .map((item: JsonRecord) => this.mapToDomain(item, rf))
+        // Critical: filter by userId and scheduleItemId in-app
+        .filter(r => r.userId === normalizedUserId && r.scheduleItemId === normalizedScheduleItemId)
+        .sort((a, b) => (b.recordedAt || b.id).localeCompare(a.recordedAt || a.id))
+        .slice(0, limit || 150);
+    }
+
+    console.warn('[ExecutionRepo] Both primary and fallback history queries failed.');
+    return [];
+  }
+
   private pickFirstNonEmptyString(...values: unknown[]): string {
     for (const value of values) {
       if (typeof value === 'string' && value.trim().length > 0) {
@@ -343,7 +403,7 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
     const title = (item.Title || item.title || '') as string;
     let triggeredBipIds: string[] = [];
     try {
-      if (item[rf.bipsJSON]) {
+      if (rf.bipsJSON && item[rf.bipsJSON]) {
         triggeredBipIds = JSON.parse(item[rf.bipsJSON] as string);
       }
     } catch (e) {
@@ -352,7 +412,7 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
 
     let date = title.slice(0, 10);
     const userId = (item[rf.userId] || '') as string;
-    let scheduleItemId = normalizeScheduleItemId(item[rf.rowNo]);
+    let scheduleItemId = rf.rowNo ? normalizeScheduleItemId(item[rf.rowNo]) : '';
 
     // Fallback: extract scheduleItemId and/or date from composite key if missing or empty
     if (!scheduleItemId || !/^\d{4}-\d{2}-\d{2}/.test(date)) {
@@ -383,13 +443,13 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
       status: item[rf.status] as RecordStatus,
       triggeredBipIds,
       memo: this.pickFirstNonEmptyString(
-        item[rf.memo],
+        rf.memo ? item[rf.memo] : undefined,
         item[rf.payload],
         item.Observation,
         item.observation,
       ),
-      recordedBy: (item[rf.staffName] || '') as string,
-      recordedAt: (item[rf.recordedAt] || '') as string,
+      recordedBy: (rf.staffName ? item[rf.staffName] : '') as string,
+      recordedAt: (item[rf.recordedAt] || item.Created || item.Modified || '') as string,
     };
   }
 }

--- a/src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts
+++ b/src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts
@@ -127,8 +127,8 @@ describe('SharePointExecutionRecordRepository', () => {
     
     expect(createCall).toBeDefined();
     const body = JSON.parse(createCall![1]!.body as string);
-    // Should include StaffName as filtering was skipped (fallback to full payload)
-    expect(body[EXECUTION_RECORD_FIELDS.staffName]).toBe('Staff A');
+    // Should NOT include StaffName as it was not in the physical schema probe (strict filtering)
+    expect(body[EXECUTION_RECORD_FIELDS.staffName]).toBeUndefined();
   });
 
   it('parses flat parent ID (no .d wrapper)', async () => {
@@ -391,6 +391,68 @@ describe('SharePointExecutionRecordRepository', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const mapped = (repo as any).mapToDomain(mockItem, rf);
       expect(mapped.memo).toBe('');
+    });
+  });
+
+  describe('Strict Field Filtering Regressions', () => {
+    it('excludes RowNo from historical query URL when unresolved', async () => {
+      mockSpFetch.mockReset();
+      mockSpFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ value: [] }),
+      });
+
+      // Mock field resolution to NOT include RowNo
+      const mockGetFieldsNoRowNo = vi.fn().mockResolvedValue(new Set(['Title', 'UserId', 'Status', 'Payload']));
+      const repoStrict = new SharePointExecutionRecordRepository({
+        spFetch: mockSpFetch,
+        getListFieldInternalNames: mockGetFieldsNoRowNo,
+      });
+
+      await repoStrict.getHistoricalRecords('U001', 'S001');
+
+      const lastCall = mockSpFetch.mock.calls[mockSpFetch.mock.calls.length - 1];
+      const url = lastCall[0];
+      
+      expect(url).not.toContain('RowNo');
+      expect(url).not.toContain('$select=undefined');
+      expect(url).not.toContain('$filter=undefined');
+    });
+
+    it('does not include "undefined" keys in upsert payload when fields are unresolved', async () => {
+      mockSpFetch.mockReset();
+      mockSpFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ value: [] }),
+      });
+
+      // Mock field resolution to be empty (all drift-prone fields missing)
+      const mockGetFieldsEmpty = vi.fn().mockResolvedValue(new Set(['Title', 'Parent_x0020_ID', 'User_x0020_ID', 'Status', 'Payload']));
+      const repoStrict = new SharePointExecutionRecordRepository({
+        spFetch: mockSpFetch,
+        getListFieldInternalNames: mockGetFieldsEmpty,
+      });
+
+      const record: ExecutionRecord = {
+        id: 'R001',
+        date: '2024-01-01',
+        userId: 'U001',
+        scheduleItemId: 'S001',
+        status: 'completed',
+        memo: 'Test',
+        recordedAt: '2024-01-01T10:00:00Z',
+        recordedBy: 'Staff A',
+        triggeredBipIds: [],
+      };
+
+      await repoStrict.upsertRecord(record);
+
+      const upsertCall = mockSpFetch.mock.calls.find(call => call[1]?.method === 'POST');
+      const body = JSON.parse(upsertCall![1]!.body as string);
+      
+      expect(Object.keys(body)).not.toContain('undefined');
+      expect(body.RowNo).toBeUndefined();
+      expect(body.StaffName).toBeUndefined();
     });
   });
 });

--- a/src/features/daily/repositories/sharepoint/constants.ts
+++ b/src/features/daily/repositories/sharepoint/constants.ts
@@ -67,12 +67,12 @@ export type ResolvedRowsFields = {
     status: string;
     payload: string;
     recordedAt: string;
-    // Execution record specific
+    // Execution record specific (drift-prone)
     rowKey: string;
-    rowNo: string;
-    memo: string;
-    staffName: string;
-    bipsJSON: string;
+    rowNo?: string;
+    memo?: string;
+    staffName?: string;
+    bipsJSON?: string;
 };
 
 /**

--- a/src/features/daily/repositories/sharepoint/executionRepositoryFactory.ts
+++ b/src/features/daily/repositories/sharepoint/executionRepositoryFactory.ts
@@ -130,6 +130,7 @@ function createLocalStorageExecutionAdapter(
       }),
     getCompletionRate: async (date: string, userId: string, totalSlots: number) =>
       store.getCompletionRate(date, userId, totalSlots),
+    getHistoricalRecords: async () => [], // Historical records not supported in local store
   };
 }
 
@@ -145,6 +146,8 @@ function createSharePointExecutionAdapter(
       repository.upsertRecord(record),
     getCompletionRate: async (date: string, userId: string, totalSlots: number) =>
       repository.getCompletionRate(date, userId, totalSlots),
+    getHistoricalRecords: async (userId: string, scheduleItemId: string, limit?: number) =>
+      repository.getHistoricalRecords(userId, scheduleItemId, limit),
   };
 }
 

--- a/src/features/daily/repositories/sharepoint/modules/SchemaResolver.ts
+++ b/src/features/daily/repositories/sharepoint/modules/SchemaResolver.ts
@@ -208,12 +208,12 @@ export class DailyRecordSchemaResolver {
             status: resolved.status ?? DAILY_RECORD_ROWS_FIELDS.status,
             payload: resolved.payload ?? DAILY_RECORD_ROWS_FIELDS.payload,
             recordedAt: resolved.recordedAt ?? DAILY_RECORD_ROWS_FIELDS.recordedAt,
-            // Execution record specific
+            // Execution record specific (Maintain undefined if not resolved)
             rowKey: resolved.rowKey ?? EXECUTION_RECORD_FIELDS.rowKey,
-            rowNo: resolved.rowNo ?? EXECUTION_RECORD_FIELDS.rowNo,
-            memo: resolved.memo ?? EXECUTION_RECORD_FIELDS.memo,
-            staffName: resolved.staffName ?? EXECUTION_RECORD_FIELDS.staffName,
-            bipsJSON: resolved.bipsJSON ?? EXECUTION_RECORD_FIELDS.bipsJSON,
+            rowNo: resolved.rowNo,
+            memo: resolved.memo,
+            staffName: resolved.staffName,
+            bipsJSON: resolved.bipsJSON,
         };
 
         return this.resolvedRowsFields;

--- a/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
@@ -3,6 +3,9 @@ import { Box, Typography, IconButton, Paper, Grid, Button, Chip, Stack, Alert, S
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import { useNavigate, useParams, useLocation } from 'react-router-dom';
+import { Drawer } from '@mui/material';
+import HistoryIcon from '@mui/icons-material/History';
+import { KioskProcedureHistoryPanel } from './KioskProcedureHistoryPanel';
 import { appendKioskSearchParams } from '../utils/navigation';
 import { useUser } from '@/features/users/useUsers';
 import { useProcedureData } from '@/features/daily/hooks/useProcedureData';
@@ -51,6 +54,7 @@ export const KioskProcedureDetailScreen: React.FC = () => {
   const [showSuccess, setShowSuccess] = useState(false);
   const [showSaveError, setShowSaveError] = useState(false);
   const [showValidationError, setShowValidationError] = useState(false);
+  const [showHistory, setShowHistory] = useState(false);
 
   // 観察チップ用ステート
   const [selectedMood, setSelectedMood] = useState<string>('');
@@ -164,7 +168,16 @@ export const KioskProcedureDetailScreen: React.FC = () => {
             </Typography>
           </Box>
         </Box>
-        <Stack direction="row" spacing={1} alignItems="center">
+        <Stack direction="row" spacing={2} alignItems="center">
+          <Button
+            variant="outlined"
+            color="primary"
+            startIcon={<HistoryIcon />}
+            onClick={() => setShowHistory(true)}
+            sx={{ fontWeight: 'bold', borderRadius: 3 }}
+          >
+            履歴・傾向を見る
+          </Button>
           {procedure.isKey && (
             <Chip label="最優先" color="primary" sx={{ fontWeight: 'bold', px: 1 }} />
           )}
@@ -398,6 +411,23 @@ export const KioskProcedureDetailScreen: React.FC = () => {
           手順記録の内容を1つ以上入力してください。
         </Alert>
       </Snackbar>
+
+      <Drawer
+        anchor="right"
+        open={showHistory}
+        onClose={() => setShowHistory(false)}
+        PaperProps={{
+          sx: { width: { xs: '100%', md: 450 } }
+        }}
+      >
+        <KioskProcedureHistoryPanel
+          userId={userId || ''}
+          scheduleItemId={scheduleItemId}
+          userName={user.FullName}
+          procedureName={procedure.activity}
+          onClose={() => setShowHistory(false)}
+        />
+      </Drawer>
     </Box>
   );
 };

--- a/src/features/kiosk/components/KioskProcedureHistoryPanel.tsx
+++ b/src/features/kiosk/components/KioskProcedureHistoryPanel.tsx
@@ -1,0 +1,255 @@
+import React, { useState, useMemo } from 'react';
+import { 
+  Box, 
+  Typography, 
+  IconButton, 
+  Paper, 
+  Stack, 
+  Chip, 
+  Divider, 
+  CircularProgress,
+  ToggleButton,
+  ToggleButtonGroup,
+  List,
+  ListItem,
+  ListItemText,
+  Grid
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import HistoryIcon from '@mui/icons-material/History';
+import { useHistoricalRecords } from '@/features/daily/hooks/useHistoricalRecords';
+import { formatDateShort } from '@/lib/dateFormat';
+import type { ExecutionRecord } from '@/features/daily/domain/legacy/executionRecordTypes';
+
+interface KioskProcedureHistoryPanelProps {
+  userId: string;
+  scheduleItemId: string;
+  userName: string;
+  procedureName: string;
+  onClose: () => void;
+}
+
+type ViewMode = 'daily' | '7d' | '1m' | '3m';
+
+export const KioskProcedureHistoryPanel: React.FC<KioskProcedureHistoryPanelProps> = ({
+  userId,
+  scheduleItemId,
+  userName,
+  procedureName,
+  onClose,
+}) => {
+  const [viewMode, setViewMode] = useState<ViewMode>('daily');
+  const { records, isLoading, error } = useHistoricalRecords(userId, scheduleItemId);
+
+  const handleViewChange = (
+    _event: React.MouseEvent<HTMLElement>,
+    nextView: ViewMode | null,
+  ) => {
+    if (nextView !== null) {
+      setViewMode(nextView);
+    }
+  };
+
+  const stats = useMemo(() => {
+    if (!records.length) return null;
+
+    const getDaysAgo = (days: number) => {
+      const d = new Date();
+      d.setDate(d.getDate() - days);
+      return d;
+    };
+
+    const filterByDays = (days: number) => {
+      const threshold = getDaysAgo(days);
+      return records.filter(r => new Date(r.date) >= threshold);
+    };
+
+    const calculateStats = (filteredRecords: ExecutionRecord[]) => {
+      const total = filteredRecords.length;
+      if (total === 0) return null;
+      const completed = filteredRecords.filter(r => r.status === 'completed').length;
+      const triggered = filteredRecords.filter(r => r.status === 'triggered').length;
+      const rate = ((completed + triggered) / total) * 100;
+      
+      // Mood distribution
+      const moods: Record<string, number> = {};
+      filteredRecords.forEach(r => {
+        const match = r.memo.match(/【様子】([^\n]+)/);
+        if (match) {
+          const mood = match[1].trim();
+          moods[mood] = (moods[mood] || 0) + 1;
+        }
+      });
+
+      return { total, completed, triggered, rate, moods };
+    };
+
+    return {
+      '7d': calculateStats(filterByDays(7)),
+      '1m': calculateStats(filterByDays(30)),
+      '3m': calculateStats(filterByDays(90)),
+    };
+  }, [records]);
+
+  const renderContent = () => {
+    if (isLoading) {
+      return (
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: 400 }}>
+          <CircularProgress />
+        </Box>
+      );
+    }
+
+    if (error) {
+      return (
+        <Box sx={{ p: 4, textAlign: 'center' }}>
+          <Typography color="error">履歴の読み込みに失敗しました</Typography>
+        </Box>
+      );
+    }
+
+    if (!records.length) {
+      return (
+        <Box sx={{ p: 4, textAlign: 'center' }}>
+          <Typography color="text.secondary">過去の記録はありません</Typography>
+        </Box>
+      );
+    }
+
+    if (viewMode === 'daily') {
+      return (
+        <List sx={{ px: 2 }}>
+          {records.map((record) => (
+            <React.Fragment key={record.id}>
+              <ListItem alignItems="flex-start" sx={{ px: 0, py: 2 }}>
+                <ListItemText
+                  primary={
+                    <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1 }}>
+                      <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
+                        {formatDateShort(record.date)}
+                      </Typography>
+                      <Chip 
+                        size="small" 
+                        label={record.status === 'completed' ? '実施' : record.status === 'triggered' ? '行動発生' : 'その他'} 
+                        color={record.status === 'completed' ? 'success' : record.status === 'triggered' ? 'warning' : 'default'}
+                        variant="outlined"
+                      />
+                    </Stack>
+                  }
+                  secondary={
+                    <Typography variant="body2" color="text.primary" sx={{ whiteSpace: 'pre-wrap' }}>
+                      {record.memo || '（メモなし）'}
+                    </Typography>
+                  }
+                />
+              </ListItem>
+              <Divider component="li" />
+            </React.Fragment>
+          ))}
+        </List>
+      );
+    }
+
+    const currentStats = stats ? stats[viewMode as '7d' | '1m' | '3m'] : null;
+
+    if (!currentStats) {
+      return (
+        <Box sx={{ p: 4, textAlign: 'center' }}>
+          <Typography color="text.secondary">この期間の記録はありません</Typography>
+        </Box>
+      );
+    }
+
+    return (
+      <Box sx={{ p: 3 }}>
+        <Grid container spacing={3}>
+          <Grid size={{ xs: 6 }}>
+            <Paper elevation={0} sx={{ p: 2, bgcolor: 'action.hover', borderRadius: 4, textAlign: 'center' }}>
+              <Typography variant="h6" color="text.secondary">実施率</Typography>
+              <Typography variant="h3" sx={{ fontWeight: 'bold', color: 'primary.main' }}>
+                {Math.round(currentStats.rate)}%
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                {currentStats.completed + currentStats.triggered} / {currentStats.total} 回
+              </Typography>
+            </Paper>
+          </Grid>
+          <Grid size={{ xs: 6 }}>
+            <Paper elevation={0} sx={{ p: 2, bgcolor: 'action.hover', borderRadius: 4, textAlign: 'center' }}>
+              <Typography variant="h6" color="text.secondary">行動発生</Typography>
+              <Typography variant="h3" sx={{ fontWeight: 'bold', color: 'warning.main' }}>
+                {currentStats.triggered}回
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                対象期間中
+              </Typography>
+            </Paper>
+          </Grid>
+          <Grid size={{ xs: 12 }}>
+            <Typography variant="subtitle1" sx={{ fontWeight: 'bold', mb: 2 }}>様子の分布</Typography>
+            <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+              {Object.entries(currentStats.moods).map(([mood, count]) => (
+                <Chip 
+                  key={mood} 
+                  label={`${mood} (${count})`} 
+                  variant="outlined" 
+                  sx={{ borderRadius: 2 }}
+                />
+              ))}
+              {Object.keys(currentStats.moods).length === 0 && (
+                <Typography variant="body2" color="text.secondary">様子の記録がありません</Typography>
+              )}
+            </Stack>
+          </Grid>
+        </Grid>
+      </Box>
+    );
+  };
+
+  return (
+    <Box sx={{ 
+      height: '100%', 
+      display: 'flex', 
+      flexDirection: 'column',
+      bgcolor: 'background.paper',
+      width: { xs: '100%', md: 450 }
+    }}>
+      {/* ヘッダー */}
+      <Box sx={{ p: 2, display: 'flex', alignItems: 'center', justifyContent: 'space-between', borderBottom: 1, borderColor: 'divider' }}>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <HistoryIcon color="primary" />
+          <Box>
+            <Typography variant="h6" sx={{ fontWeight: 'bold', lineHeight: 1.2 }}>履歴・傾向</Typography>
+            <Typography variant="caption" color="text.secondary">{userName} 様 - {procedureName}</Typography>
+          </Box>
+        </Stack>
+        <IconButton onClick={onClose}>
+          <CloseIcon />
+        </IconButton>
+      </Box>
+
+      {/* ビュー切り替え */}
+      <Box sx={{ p: 2, textAlign: 'center' }}>
+        <ToggleButtonGroup
+          value={viewMode}
+          exclusive
+          onChange={handleViewChange}
+          aria-label="view mode"
+          size="small"
+          fullWidth
+        >
+          <ToggleButton value="daily">日別</ToggleButton>
+          <ToggleButton value="7d">7日間</ToggleButton>
+          <ToggleButton value="1m">1ヶ月</ToggleButton>
+          <ToggleButton value="3m">3ヶ月</ToggleButton>
+        </ToggleButtonGroup>
+      </Box>
+
+      {/* コンテンツエリア */}
+      <Box sx={{ flexGrow: 1, overflowY: 'auto' }}>
+        {renderContent()}
+      </Box>
+    </Box>
+  );
+};
+

--- a/src/lib/dateFormat.ts
+++ b/src/lib/dateFormat.ts
@@ -200,6 +200,24 @@ export function formatDateIso(input: DateInput, fallback: string = ''): string {
   return `${y}-${m}-${day}`;
 }
 
+/**
+ * 日付を M/D 形式にフォーマットする。
+ *
+ * 用途: スペースの限られた場所での日付表示（月日のみ）。
+ *
+ * @example
+ * formatDateShort(new Date(2025, 0, 15)) // => "1/15"
+ * formatDateShort(null) // => ""
+ */
+export function formatDateShort(input: DateInput, fallback: string = ''): string {
+  const d = toSafeDate(input);
+  if (!d) return fallback;
+
+  const m = d.getMonth() + 1;
+  const day = d.getDate();
+  return `${m}/${day}`;
+}
+
 // ---------------------------------------------------------------------------
 // Relative time formatting
 // ---------------------------------------------------------------------------

--- a/src/sharepoint/fields/dailyFields.ts
+++ b/src/sharepoint/fields/dailyFields.ts
@@ -146,7 +146,13 @@ export const DAILY_RECORD_ROW_AGGREGATE_CANDIDATES = {
   version: ['Version', 'VersionNo', 'cr013_version'],
   recordedAt: ['Recorded_x0020_At', 'RecordedAt', 'cr013_recordedAt'],
   rowKey: ['Title', 'RowKey'],
-  rowNo: ['RowNo', 'cr013_rowNo'],
+  rowNo: [
+    'RowNo', 
+    'cr013_rowNo', 
+    'RowIndex', 
+    'SlotNo', 
+    'RowNo0' // Legacy/Environment-specific drift candidate
+  ],
   memo: ['Memo', 'Observation', 'Payload', 'payload'],
   staffName: ['StaffName', 'RecordedBy'],
   bipsJSON: ['BipsJSON', 'cr013_bipsJSON'],

--- a/src/sharepoint/spListRegistry.definitions.ts
+++ b/src/sharepoint/spListRegistry.definitions.ts
@@ -270,6 +270,7 @@ export const dailyListEntries: readonly SpListEntry[] = [
       { internalName: 'Status0', type: 'Text', displayName: 'Status (Legacy)', governance: 'allow', isSilent: true, candidates: ['Status0'] },
       { internalName: 'Observation', type: 'Note', displayName: 'Observation (Legacy)', richText: false, governance: 'allow', isSilent: true, candidates: ['Observation'] },
       { internalName: 'User_x0020_ID', type: 'Text', displayName: 'User ID (Legacy SP-encoded)', governance: 'allow', isSilent: true, candidates: ['User_x0020_ID'] },
+      { internalName: 'RowNo', type: 'Number', displayName: 'Row No', candidates: ['RowNo', 'cr013_rowNo', 'RowIndex'] },
       { internalName: 'Payload', type: 'Note', displayName: 'Row Data JSON', richText: false, governance: 'allow', isSilent: true, candidates: ['Payload', 'payload', 'cr013_payload', 'cr013_draftJson', 'PayloadJSON', 'SupportRecordPayload', 'Payload_x0020_JSON', 'Observation'] },
       { internalName: 'RecordedAt', type: 'DateTime', displayName: 'Recorded At', candidates: ['RecordedAt', 'Recorded_x0020_At'] },
     ],


### PR DESCRIPTION
## Summary

- Add a kiosk procedure history panel for the procedure detail screen
- Show persisted SharePoint execution records by date
- Add 7-day, 1-month, and 3-month summary previews
- Harden SharePoint history queries when optional row-level fields such as RowNo are missing
- Prevent unresolved field names from being included in `$select`, `$filter`, `$orderby`, or write payloads

## Design notes

History preview uses persisted SharePoint execution records as the source of truth.

The primary matching strategy is user/date-range query + in-app procedure matching by scheduleItemId / normalizedScheduleItemId. `rowNo` is used only when the physical SharePoint field is resolved. If `RowNo` is missing from the environment, the repository falls back to a narrower user/date-range query and excludes `RowNo` from all SharePoint query clauses.

The active kiosk input form remains isolated from history loading failures. If history fetch fails, only the history panel reports the error.

## Checks

- [x] npm run typecheck
- [x] npx vitest run src/features/daily src/features/kiosk
- [x] npx playwright test tests/e2e/kiosk-home-smoke.spec.ts
