### PR TITLE
feat(planning-sheet): apply kiosk monitoring evidence to section 9 draft

### DIFF
--- a/src/features/planning-sheet/components/new-form/FormSections.tsx
+++ b/src/features/planning-sheet/components/new-form/FormSections.tsx
@@ -32,6 +32,8 @@ import type { FormState } from './types';
 import { BEHAVIOR_FUNCTIONS, TRAINING_LEVELS, ICEBERG_FACTORS } from './constants';
 import { calculateMonitoringSchedule } from '@/features/planning-sheet/monitoringSchedule';
 import { useReverseBridge } from '../../hooks/useReverseBridge';
+import KioskMonitoringEvidencePanel from '@/features/monitoring/components/KioskMonitoringEvidencePanel';
+
 
 // ─────────────────────────────────────────────
 // SectionTitle — 共通ヘッダー
@@ -221,13 +223,14 @@ interface FormSectionsProps {
   updateField: <K extends keyof FormState>(key: K, value: FormState[K]) => void;
   renderProvenanceBadge: (fieldKey: string) => React.ReactNode;
   userId?: string;
+  isAdmin?: boolean;
 }
 
 // ─────────────────────────────────────────────
 // Component
 // ─────────────────────────────────────────────
 
-const FormSections: React.FC<FormSectionsProps> = ({ step, form, updateField, renderProvenanceBadge, userId }) => {
+const FormSections: React.FC<FormSectionsProps> = ({ step, form, updateField, renderProvenanceBadge, userId, isAdmin = true }) => {
   const { suggestions, isLoading: isBridgeLoading, error: bridgeError } = useReverseBridge(userId, form.supportStartDate);
 
   const schedule = React.useMemo(() => {
@@ -464,6 +467,18 @@ const FormSections: React.FC<FormSectionsProps> = ({ step, form, updateField, re
           {schedulePreview}
           <TextField label="評価方法" value={form.evaluationMethod} onChange={e => updateField('evaluationMethod', e.target.value)} fullWidth multiline minRows={2}
             placeholder="ABC記録集計、グラフ化、カンファレンス" />
+
+          {/* キオスク記録（17手順）統計ドラフト (Issue #1873) */}
+          {userId && (
+            <KioskMonitoringEvidencePanel
+              userId={userId}
+              onAppendInsight={(text) => {
+                const current = form.improvementResult || '';
+                updateField('improvementResult', current ? `${current}\n\n${text}` : text);
+              }}
+              isAdmin={isAdmin}
+            />
+          )}
 
           {/* L3-to-L2 Reverse-Bridge 自動提案 */}
           {userId && (

--- a/src/features/planning-sheet/components/new-form/NewPlanningSheetForm.tsx
+++ b/src/features/planning-sheet/components/new-form/NewPlanningSheetForm.tsx
@@ -50,6 +50,7 @@ import { useTokuseiSurveyResponses } from '@/features/assessment/hooks/useTokuse
 import { filterActiveUsers } from '@/features/users/domain/userLifecycle';
 import { useUsers } from '@/features/users/useUsers';
 import { useAuth } from '@/auth/useAuth';
+import { useUserAuthz } from '@/auth/useUserAuthz';
 import { tokuseiToPlanningBridge } from '../../tokuseiToPlanningBridge';
 import { buildImportPreview } from '../../buildImportPreview';
 import type { ImportPreviewResult } from '../../buildImportPreview';
@@ -83,6 +84,8 @@ export const NewPlanningSheetForm: React.FC<NewPlanningSheetFormProps> = ({
   const navigate = useNavigate();
   const { data: users } = useUsers();
   const { account } = useAuth();
+  const { role } = useUserAuthz();
+  const isAdmin = role === 'admin';
 
   // ── User selection state ──
   const [selectedUser, setSelectedUser] = React.useState<UserOption | null>(null);
@@ -695,6 +698,7 @@ export const NewPlanningSheetForm: React.FC<NewPlanningSheetFormProps> = ({
                 updateField={updateField}
                 renderProvenanceBadge={renderProvenanceBadge}
                 userId={selectedUser?.id}
+                isAdmin={isAdmin}
               />
             </Paper>
 


### PR DESCRIPTION
## Summary

- Add kiosk monitoring evidence support to planning sheet section 9
- Show `KioskMonitoringEvidencePanel` inside the monitoring evaluation section
- Allow staff to quote 90-day kiosk evidence into the improvement result draft
- Pass admin/manager authorization from `NewPlanningSheetForm` to `FormSections`
- Keep meeting-minutes block editor integration out of this PR

## Design notes

This PR focuses on planning-sheet monitoring evaluation support. Generated evidence text is treated as a staff-reviewed draft and is not automatically saved or finalized.

Existing section 9 content is not silently overwritten. Kiosk evidence is used as a draft aid for monitoring evaluation.

## Checks

- [x] npm run typecheck
- [x] npm run test:ci:required