### PR TITLE
feat(monthly): align kiosk execution evidence aggregation

### DIFF
--- a/src/features/records/monthly/index.ts
+++ b/src/features/records/monthly/index.ts
@@ -15,6 +15,11 @@ export type {
 	MonthlyRecordSortKey,
 } from './types';
 
+export type {
+	KioskMonthlyAggregationResult,
+	KioskMonthlyEvidenceStats,
+} from './kioskEvidence';
+
 // Map/boundary helpers（境界で使うものだけ公開）
 export {
 	getCurrentYearMonth,
@@ -39,3 +44,10 @@ export {
 	getWorkingDaysInMonth,
 	toYearMonth,
 } from './aggregate';
+
+// Kiosk evidence bridge（月次集計とキオスク実施証跡の整合境界）
+export {
+	aggregateMonthlySummaryFromKioskEvidence,
+	buildMonthlyDailyRecordsFromKioskEvidence,
+	toMonthlyDailyRecordFromKioskEvidence,
+} from './kioskEvidence';

--- a/src/features/records/monthly/kioskEvidence.test.ts
+++ b/src/features/records/monthly/kioskEvidence.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ExecutionRecord } from '@/features/daily/domain/executionRecordTypes';
+
+import {
+  aggregateMonthlySummaryFromKioskEvidence,
+  buildMonthlyDailyRecordsFromKioskEvidence,
+  toMonthlyDailyRecordFromKioskEvidence,
+} from './kioskEvidence';
+
+function record(overrides: Partial<ExecutionRecord>): ExecutionRecord {
+  return {
+    id: '2026-05-01-I001-row-1',
+    date: '2026-05-01',
+    userId: 'I001',
+    scheduleItemId: 'row-1',
+    status: 'completed',
+    triggeredBipIds: [],
+    memo: '',
+    recordedBy: 'staff-1',
+    recordedAt: '2026-05-01T09:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('monthly kiosk evidence bridge', () => {
+  it('converts kiosk execution status into the monthly DailyRecord contract', () => {
+    expect(toMonthlyDailyRecordFromKioskEvidence(record({ status: 'completed' }))).toEqual(
+      expect.objectContaining({ completed: true, isEmpty: false, hasIncidents: false })
+    );
+
+    expect(toMonthlyDailyRecordFromKioskEvidence(record({ status: 'triggered', triggeredBipIds: ['bip-1'] }))).toEqual(
+      expect.objectContaining({ completed: false, isEmpty: false, hasIncidents: true })
+    );
+
+    expect(toMonthlyDailyRecordFromKioskEvidence(record({ status: 'unrecorded', memo: '' }))).toEqual(
+      expect.objectContaining({ completed: false, isEmpty: true })
+    );
+
+    expect(toMonthlyDailyRecordFromKioskEvidence(record({ date: '2026-13-01' }))).toBeNull();
+  });
+
+  it('filters by target user and month before passing records to monthly aggregation', () => {
+    const dailyRecords = buildMonthlyDailyRecordsFromKioskEvidence([
+      record({ id: 'a', date: '2026-05-01', userId: 'I001' }),
+      record({ id: 'b', date: '2026-05-02', userId: 'I002' }),
+      record({ id: 'c', date: '2026-06-01', userId: 'I001' }),
+    ], {
+      userId: 'I001',
+      yearMonth: '2026-05',
+    });
+
+    expect(dailyRecords.map(r => r.id)).toEqual(['a']);
+  });
+
+  it('builds a monthly summary and evidence counters from the same kiosk records', () => {
+    const result = aggregateMonthlySummaryFromKioskEvidence([
+      record({ id: 'completed-1', date: '2026-05-01', scheduleItemId: 'row-1', status: 'completed', memo: '順調' }),
+      record({ id: 'triggered-1', date: '2026-05-01', scheduleItemId: 'row-2', status: 'triggered', triggeredBipIds: ['bip-1'] }),
+      record({ id: 'skipped-1', date: '2026-05-02', scheduleItemId: 'row-3', status: 'skipped', memo: '外出のため' }),
+      record({ id: 'empty-1', date: '2026-05-03', scheduleItemId: 'row-4', status: 'unrecorded', memo: '' }),
+      record({ id: 'other-user', date: '2026-05-01', userId: 'I002', status: 'completed' }),
+      record({ id: 'other-month', date: '2026-06-01', userId: 'I001', status: 'completed' }),
+      record({ id: 'bad-date', date: 'bad-date', userId: 'I001', status: 'completed' }),
+    ], {
+      userId: 'I001',
+      displayName: '利用者A',
+      yearMonth: '2026-05',
+      useWorkingDays: false,
+      rowsPerDay: 1,
+    });
+
+    expect(result.source).toBe('kiosk-execution');
+    expect(result.processedRecords).toBe(4);
+    expect(result.skippedRecords).toBe(3);
+    expect(result.errors).toEqual(['Invalid kiosk evidence date: record=bad-date, date=bad-date']);
+
+    expect(result.summary.kpi).toEqual({
+      totalDays: 31,
+      plannedRows: 31,
+      completedRows: 1,
+      inProgressRows: 2,
+      emptyRows: 28,
+      specialNotes: 2,
+      incidents: 1,
+    });
+
+    expect(result.evidence).toEqual({
+      source: 'kiosk-execution',
+      userId: 'I001',
+      yearMonth: '2026-05',
+      sourceRows: 4,
+      recordedRows: 3,
+      completedRows: 1,
+      triggeredRows: 1,
+      skippedRows: 1,
+      unrecordedRows: 1,
+      memoRows: 2,
+      incidentRows: 1,
+      recordedDays: 2,
+      firstEntryDate: '2026-05-01',
+      lastEntryDate: '2026-05-02',
+    });
+
+    expect(result.summary.firstEntryDate).toBe(result.evidence.firstEntryDate);
+    expect(result.summary.lastEntryDate).toBe(result.evidence.lastEntryDate);
+    expect(result.summary.kpi.completedRows).toBe(result.evidence.completedRows);
+    expect(result.summary.kpi.inProgressRows).toBe(
+      result.evidence.triggeredRows + result.evidence.skippedRows
+    );
+    expect(result.summary.kpi.incidents).toBe(result.evidence.incidentRows);
+  });
+});

--- a/src/features/records/monthly/kioskEvidence.ts
+++ b/src/features/records/monthly/kioskEvidence.ts
@@ -1,0 +1,218 @@
+import type { ExecutionRecord, RecordStatus } from '@/features/daily/domain/executionRecordTypes';
+
+import { aggregateMonthlySummary } from './aggregate';
+import type {
+  DailyRecord,
+  IsoDate,
+  MonthlyAggregationResult,
+  MonthlySummary,
+  YearMonth,
+} from './types';
+
+const VALID_RECORD_STATUSES: readonly RecordStatus[] = [
+  'completed',
+  'triggered',
+  'skipped',
+  'unrecorded',
+] as const;
+
+export interface KioskMonthlyEvidenceStats {
+  source: 'kiosk-execution';
+  userId: string;
+  yearMonth: YearMonth;
+  /** Target-month kiosk rows resolved from execution evidence, including unrecorded rows. */
+  sourceRows: number;
+  /** Rows with actual evidence: completed / triggered / skipped / memo / BIP evidence. */
+  recordedRows: number;
+  completedRows: number;
+  triggeredRows: number;
+  skippedRows: number;
+  unrecordedRows: number;
+  memoRows: number;
+  incidentRows: number;
+  recordedDays: number;
+  firstEntryDate?: IsoDate;
+  lastEntryDate?: IsoDate;
+}
+
+export interface KioskMonthlyAggregationResult extends MonthlyAggregationResult {
+  source: 'kiosk-execution';
+  summary: MonthlySummary;
+  /** DailyRecord[] actually passed into monthly aggregation. */
+  dailyRecords: DailyRecord[];
+  /** Reconciliation counters derived from the same kiosk evidence as summary.kpi. */
+  evidence: KioskMonthlyEvidenceStats;
+}
+
+interface IncludedKioskRecord {
+  sourceRecord: ExecutionRecord;
+  dailyRecord: DailyRecord;
+  status: RecordStatus;
+}
+
+interface KioskEvidenceTarget {
+  userId: string;
+  yearMonth: YearMonth;
+}
+
+function normalizeStatus(status: unknown): RecordStatus {
+  return VALID_RECORD_STATUSES.includes(status as RecordStatus)
+    ? (status as RecordStatus)
+    : 'unrecorded';
+}
+
+function parseEvidenceIsoDate(value: unknown): IsoDate | null {
+  if (typeof value !== 'string') return null;
+  if (!/^(\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/.test(value)) {
+    return null;
+  }
+  return value as IsoDate;
+}
+
+function getEvidenceYearMonth(date: IsoDate): YearMonth {
+  return date.slice(0, 7) as YearMonth;
+}
+
+function hasMemo(record: ExecutionRecord): boolean {
+  return typeof record.memo === 'string' && record.memo.trim().length > 0;
+}
+
+function hasIncidentEvidence(record: ExecutionRecord, status: RecordStatus): boolean {
+  return status === 'triggered' || (record.triggeredBipIds ?? []).length > 0;
+}
+
+function isEmptyKioskEvidence(record: ExecutionRecord, status: RecordStatus): boolean {
+  return status === 'unrecorded' && !hasMemo(record) && !hasIncidentEvidence(record, status);
+}
+
+/**
+ * Convert one kiosk ExecutionRecord into the Monthly DailyRecord contract.
+ *
+ * Monthly aggregation treats kiosk statuses as follows:
+ * - completed  -> completedRows
+ * - triggered/skipped or memo-only rows -> inProgressRows (recorded, but not completed)
+ * - unrecorded with no memo/BIP evidence -> empty evidence row
+ */
+export function toMonthlyDailyRecordFromKioskEvidence(record: ExecutionRecord): DailyRecord | null {
+  const recordDate = parseEvidenceIsoDate(record.date);
+  if (!recordDate) return null;
+
+  const status = normalizeStatus(record.status);
+  const isEmpty = isEmptyKioskEvidence(record, status);
+
+  return {
+    id: record.id,
+    userId: record.userId,
+    userName: '',
+    recordDate,
+    completed: status === 'completed',
+    hasSpecialNotes: hasMemo(record),
+    hasIncidents: hasIncidentEvidence(record, status),
+    isEmpty,
+  };
+}
+
+function collectKioskEvidenceRecords(
+  records: ExecutionRecord[],
+  target: KioskEvidenceTarget
+): { included: IncludedKioskRecord[]; skippedRecords: number; errors: string[] } {
+  const included: IncludedKioskRecord[] = [];
+  const errors: string[] = [];
+  let skippedRecords = 0;
+
+  for (const record of records) {
+    if (record.userId !== target.userId) {
+      skippedRecords++;
+      continue;
+    }
+
+    const dailyRecord = toMonthlyDailyRecordFromKioskEvidence(record);
+    if (!dailyRecord) {
+      skippedRecords++;
+      errors.push(`Invalid kiosk evidence date: record=${record.id}, date=${record.date}`);
+      continue;
+    }
+
+    if (getEvidenceYearMonth(dailyRecord.recordDate) !== target.yearMonth) {
+      skippedRecords++;
+      continue;
+    }
+
+    included.push({
+      sourceRecord: record,
+      dailyRecord,
+      status: normalizeStatus(record.status),
+    });
+  }
+
+  return { included, skippedRecords, errors };
+}
+
+/**
+ * Build the exact DailyRecord[] input used by monthly aggregation from kiosk execution evidence.
+ */
+export function buildMonthlyDailyRecordsFromKioskEvidence(
+  records: ExecutionRecord[],
+  target: KioskEvidenceTarget
+): DailyRecord[] {
+  return collectKioskEvidenceRecords(records, target).included.map(({ dailyRecord }) => dailyRecord);
+}
+
+function summarizeKioskMonthlyEvidence(
+  included: IncludedKioskRecord[],
+  target: KioskEvidenceTarget
+): KioskMonthlyEvidenceStats {
+  const nonEmptyRecords = included.filter(({ dailyRecord }) => !dailyRecord.isEmpty);
+  const nonEmptyDates = [...new Set(nonEmptyRecords.map(({ dailyRecord }) => dailyRecord.recordDate))].sort();
+
+  return {
+    source: 'kiosk-execution',
+    userId: target.userId,
+    yearMonth: target.yearMonth,
+    sourceRows: included.length,
+    recordedRows: nonEmptyRecords.length,
+    completedRows: included.filter(({ status }) => status === 'completed').length,
+    triggeredRows: included.filter(({ status }) => status === 'triggered').length,
+    skippedRows: included.filter(({ status }) => status === 'skipped').length,
+    unrecordedRows: included.filter(({ dailyRecord }) => dailyRecord.isEmpty).length,
+    memoRows: included.filter(({ dailyRecord }) => dailyRecord.hasSpecialNotes).length,
+    incidentRows: included.filter(({ dailyRecord }) => dailyRecord.hasIncidents).length,
+    recordedDays: nonEmptyDates.length,
+    firstEntryDate: nonEmptyDates[0],
+    lastEntryDate: nonEmptyDates[nonEmptyDates.length - 1],
+  };
+}
+
+/**
+ * Reconcile kiosk execution evidence with MonthlyRecord_Summary aggregation.
+ *
+ * This is the SSOT bridge for monthly aggregation from kiosk records: the summary KPI and
+ * evidence counters are derived from the same filtered ExecutionRecord[] input.
+ */
+export function aggregateMonthlySummaryFromKioskEvidence(
+  records: ExecutionRecord[],
+  options: KioskEvidenceTarget & {
+    displayName: string;
+    useWorkingDays?: boolean;
+    rowsPerDay?: number;
+  }
+): KioskMonthlyAggregationResult {
+  const { userId, yearMonth, displayName, useWorkingDays, rowsPerDay } = options;
+  const target = { userId, yearMonth };
+  const { included, skippedRecords, errors } = collectKioskEvidenceRecords(records, target);
+  const dailyRecords = included.map(({ dailyRecord }) => dailyRecord);
+  const summary = aggregateMonthlySummary(userId, displayName, dailyRecords, yearMonth, {
+    useWorkingDays,
+    rowsPerDay,
+  });
+
+  return {
+    source: 'kiosk-execution',
+    summary,
+    processedRecords: dailyRecords.length,
+    skippedRecords,
+    errors,
+    dailyRecords,
+    evidence: summarizeKioskMonthlyEvidence(included, target),
+  };
+}


### PR DESCRIPTION
## Summary

- Add a monthly aggregation bridge from kiosk `ExecutionRecord[]` to the existing monthly `DailyRecord` contract
- Derive `MonthlySummary` and kiosk evidence counters from the same filtered source rows
- Treat kiosk statuses consistently:
  - `completed` → monthly completed rows
  - `triggered` / `skipped` / memo evidence → recorded but not completed (`inProgressRows`)
  - empty `unrecorded` → empty evidence row
- Export the bridge through `src/features/records/monthly/index.ts`
- Add unit coverage for conversion, target user/month filtering, and KPI/evidence reconciliation

## Design notes

This PR keeps the scope intentionally small. It does not add SharePoint writes or UI changes. The purpose is to establish a pure, testable boundary so `MonthlyRecord_Summary` can be reproduced from kiosk execution evidence without a second interpretation layer.

The monthly KPI and the evidence counters are computed from the same filtered `ExecutionRecord[]`, making mismatches visible in unit tests before repository/API integration.

## Checks

- [ ] npm run typecheck
- [ ] npx vitest run src/features/records/monthly
