### PR TITLE
feat(monthly): add kiosk aggregation use case

### DIFF
--- a/src/features/records/monthly/index.ts
+++ b/src/features/records/monthly/index.ts
@@ -51,3 +51,9 @@ export {
 	buildMonthlyDailyRecordsFromKioskEvidence,
 	toMonthlyDailyRecordFromKioskEvidence,
 } from './kioskEvidence';
+
+export {
+	executeKioskMonthlyAggregation,
+	type KioskMonthlyAggregationParams,
+} from './kioskMonthlyAggregationUseCase';
+

--- a/src/features/records/monthly/kioskMonthlyAggregationUseCase.test.ts
+++ b/src/features/records/monthly/kioskMonthlyAggregationUseCase.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ExecutionRecord } from '@/features/daily/domain/executionRecordTypes';
+import type { ExecutionRecordRepository } from '@/features/daily/domain/ExecutionRecordRepository';
+import { executeKioskMonthlyAggregation } from './kioskMonthlyAggregationUseCase';
+
+function createMockRecord(overrides: Partial<ExecutionRecord>): ExecutionRecord {
+  return {
+    id: 'test-id',
+    date: '2026-05-01',
+    userId: 'I001',
+    scheduleItemId: 'row-1',
+    status: 'completed',
+    triggeredBipIds: [],
+    memo: '',
+    recordedBy: 'staff-1',
+    recordedAt: '2026-05-01T09:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('executeKioskMonthlyAggregation use case', () => {
+  it('correctly calculates monthly bounds and calls getRecordsInRange with calculated bounds', async () => {
+    const records: ExecutionRecord[] = [
+      createMockRecord({ id: 'rec-1', date: '2026-05-01', status: 'completed' }),
+      createMockRecord({ id: 'rec-2', date: '2026-05-15', status: 'completed' }),
+      createMockRecord({ id: 'rec-3', date: '2026-05-31', status: 'triggered', memo: 'some incident' }),
+    ];
+
+    const mockRepository = {
+      getRecords: vi.fn(),
+      getRecord: vi.fn(),
+      upsertRecord: vi.fn(),
+      getCompletionRate: vi.fn(),
+      getHistoricalRecords: vi.fn(),
+      getRecordsInRange: vi.fn().mockResolvedValue(records),
+    } satisfies ExecutionRecordRepository;
+
+    const result = await executeKioskMonthlyAggregation(mockRepository, {
+      userId: 'I001',
+      displayName: 'Test User',
+      yearMonth: '2026-05',
+      useWorkingDays: false,
+      rowsPerDay: 1,
+    });
+
+    // 1. Verify bounds computed from YearMonth (2026-05 has 31 days)
+    expect(mockRepository.getRecordsInRange).toHaveBeenCalledWith('I001', '2026-05-01', '2026-05-31');
+
+    // 2. Verify aggregation results are mapped correctly
+    expect(result.source).toBe('kiosk-execution');
+    expect(result.processedRecords).toBe(3);
+    expect(result.summary.userId).toBe('I001');
+    expect(result.summary.displayName).toBe('Test User');
+    expect(result.summary.yearMonth).toBe('2026-05');
+    
+    // 3. Verify KPI and Evidence alignment
+    expect(result.summary.kpi).toEqual({
+      totalDays: 31,
+      plannedRows: 31,
+      completedRows: 2,
+      inProgressRows: 1,
+      emptyRows: 28,
+      specialNotes: 1,
+      incidents: 1,
+    });
+
+    expect(result.evidence).toEqual({
+      source: 'kiosk-execution',
+      userId: 'I001',
+      yearMonth: '2026-05',
+      sourceRows: 3,
+      recordedRows: 3,
+      completedRows: 2,
+      triggeredRows: 1,
+      skippedRows: 0,
+      unrecordedRows: 0,
+      memoRows: 1,
+      incidentRows: 1,
+      recordedDays: 3,
+      firstEntryDate: '2026-05-01',
+      lastEntryDate: '2026-05-31',
+    });
+  });
+
+  it('computes correct bounds for 30-day months (e.g. November)', async () => {
+    const mockRepository = {
+      getRecords: vi.fn(),
+      getRecord: vi.fn(),
+      upsertRecord: vi.fn(),
+      getCompletionRate: vi.fn(),
+      getHistoricalRecords: vi.fn(),
+      getRecordsInRange: vi.fn().mockResolvedValue([]),
+    } satisfies ExecutionRecordRepository;
+
+    await executeKioskMonthlyAggregation(mockRepository, {
+      userId: 'I001',
+      displayName: 'Test User',
+      yearMonth: '2025-11', // November has 30 days
+    });
+
+    expect(mockRepository.getRecordsInRange).toHaveBeenCalledWith('I001', '2025-11-01', '2025-11-30');
+  });
+
+  it('computes correct bounds for February in leap years and non-leap years', async () => {
+    const mockRepository = {
+      getRecords: vi.fn(),
+      getRecord: vi.fn(),
+      upsertRecord: vi.fn(),
+      getCompletionRate: vi.fn(),
+      getHistoricalRecords: vi.fn(),
+      getRecordsInRange: vi.fn().mockResolvedValue([]),
+    } satisfies ExecutionRecordRepository;
+
+    // 2024 is a leap year (29 days)
+    await executeKioskMonthlyAggregation(mockRepository, {
+      userId: 'I001',
+      displayName: 'Test User',
+      yearMonth: '2024-02',
+    });
+    expect(mockRepository.getRecordsInRange).toHaveBeenCalledWith('I001', '2024-02-01', '2024-02-29');
+
+    // 2025 is not a leap year (28 days)
+    await executeKioskMonthlyAggregation(mockRepository, {
+      userId: 'I001',
+      displayName: 'Test User',
+      yearMonth: '2025-02',
+    });
+    expect(mockRepository.getRecordsInRange).toHaveBeenCalledWith('I001', '2025-02-01', '2025-02-28');
+  });
+
+  it('handles database/repository exceptions gracefully', async () => {
+    const mockRepository = {
+      getRecords: vi.fn(),
+      getRecord: vi.fn(),
+      upsertRecord: vi.fn(),
+      getCompletionRate: vi.fn(),
+      getHistoricalRecords: vi.fn(),
+      getRecordsInRange: vi.fn().mockRejectedValue(new Error('Connection timeout to SharePoint')),
+    } satisfies ExecutionRecordRepository;
+
+    const result = await executeKioskMonthlyAggregation(mockRepository, {
+      userId: 'I001',
+      displayName: 'Test User',
+      yearMonth: '2026-05',
+    });
+
+    expect(result.source).toBe('kiosk-execution');
+    expect(result.processedRecords).toBe(0);
+    expect(result.errors).toEqual(['Connection timeout to SharePoint']);
+    expect(result.summary.userId).toBe('I001');
+    expect(result.summary.displayName).toBe('Test User');
+    expect(result.summary.kpi.plannedRows).toBe(0);
+    expect(result.evidence.sourceRows).toBe(0);
+  });
+});

--- a/src/features/records/monthly/kioskMonthlyAggregationUseCase.ts
+++ b/src/features/records/monthly/kioskMonthlyAggregationUseCase.ts
@@ -1,0 +1,87 @@
+import type { ExecutionRecordRepository } from '@/features/daily/domain/ExecutionRecordRepository';
+import { getTotalDaysInMonth } from './aggregate';
+import {
+  aggregateMonthlySummaryFromKioskEvidence,
+  type KioskMonthlyAggregationResult,
+} from './kioskEvidence';
+import type { YearMonth } from './types';
+
+export interface KioskMonthlyAggregationParams {
+  userId: string;
+  displayName: string;
+  yearMonth: YearMonth;
+  useWorkingDays?: boolean;
+  rowsPerDay?: number;
+}
+
+/**
+ * Use case to aggregate kiosk execution evidence into a monthly record summary.
+ *
+ * This coordinates retrieving raw kiosk evidence from the repository for the target
+ * month range and passing it to the pure alignment layer to generate the MonthlySummary.
+ */
+export async function executeKioskMonthlyAggregation(
+  repository: ExecutionRecordRepository,
+  params: KioskMonthlyAggregationParams
+): Promise<KioskMonthlyAggregationResult> {
+  const { userId, displayName, yearMonth, useWorkingDays, rowsPerDay } = params;
+
+  // 1. Calculate from/to date range for the target YearMonth (inclusive)
+  const totalDays = getTotalDaysInMonth(yearMonth);
+  const from = `${yearMonth}-01`;
+  const to = `${yearMonth}-${totalDays}`;
+
+  try {
+    // 2. Fetch all execution records within the date range
+    const records = await repository.getRecordsInRange(userId, from, to);
+
+    // 3. Delegate to the pure alignment layer to produce the reconciled monthly summary
+    return aggregateMonthlySummaryFromKioskEvidence(records, {
+      userId,
+      yearMonth,
+      displayName,
+      useWorkingDays,
+      rowsPerDay,
+    });
+  } catch (error) {
+    // Return a graceful failure result in case of repository or system errors
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      source: 'kiosk-execution',
+      summary: {
+        userId,
+        yearMonth,
+        displayName,
+        lastUpdatedUtc: new Date().toISOString(),
+        kpi: {
+          totalDays: 0,
+          plannedRows: 0,
+          completedRows: 0,
+          inProgressRows: 0,
+          emptyRows: 0,
+          specialNotes: 0,
+          incidents: 0,
+        },
+        completionRate: 0,
+      },
+      processedRecords: 0,
+      skippedRecords: 0,
+      errors: [errorMessage],
+      dailyRecords: [],
+      evidence: {
+        source: 'kiosk-execution',
+        userId,
+        yearMonth,
+        sourceRows: 0,
+        recordedRows: 0,
+        completedRows: 0,
+        triggeredRows: 0,
+        skippedRows: 0,
+        unrecordedRows: 0,
+        memoRows: 0,
+        incidentRows: 0,
+        recordedDays: 0,
+      },
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- Add a use case for generating MonthlySummary from kiosk execution evidence
- Connect ExecutionRecordRepository.getRecordsInRange to aggregateMonthlySummaryFromKioskEvidence
- Compute inclusive month ranges from YearMonth
- Return graceful degraded aggregation results when repository access fails
- Export the use case from monthly records public API

## Design notes
This PR intentionally does not write to SharePoint. It only implements the non-destructive path:
ExecutionRecordRepository → kiosk evidence bridge → MonthlySummary.

This keeps monthly generation testable before connecting MonthlyRecord_Summary upsert in the next PR.

## Checks
- [x] npm run typecheck
- [x] npx vitest run src/features/records/monthly