### PR TITLE
fix(kiosk): keep daily flow preview open during background refresh

### DIFF
--- a/src/features/daily/hooks/useExecutionRecord.ts
+++ b/src/features/daily/hooks/useExecutionRecord.ts
@@ -3,7 +3,7 @@
 //
 // Storeへのアクセスを抽象化し、UI側が日付とタイムスタンプを意識せずに済む。
 // ---------------------------------------------------------------------------
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, useRef } from 'react';
 import { type RecordStatus, makeRecordId, type ExecutionRecord } from '../domain/executionRecordTypes';
 import { useExecutionData } from './useExecutionData';
 import { normalizeScheduleItemId } from '../utils/normalizeScheduleItemId';
@@ -18,15 +18,23 @@ export function useExecutionRecord(
   const [record, setRecord] = useState<ExecutionRecord | undefined>();
   const [isLoading, setIsLoading] = useState(true);
 
+  const getRecordRef = useRef(getRecord);
+  const upsertRecordRef = useRef(upsertRecord);
+
+  useEffect(() => {
+    getRecordRef.current = getRecord;
+    upsertRecordRef.current = upsertRecord;
+  }, [getRecord, upsertRecord]);
+
   const fetchRecord = useCallback(async () => {
     setIsLoading(true);
-    let resolved = await getRecord(date, userId, scheduleItemId);
+    let resolved = await getRecordRef.current(date, userId, scheduleItemId);
 
     if (!resolved && fallbackScheduleItemIds && fallbackScheduleItemIds.length > 0) {
       for (const fallbackId of fallbackScheduleItemIds) {
         const normalizedFallbackId = normalizeScheduleItemId(fallbackId);
         if (!normalizedFallbackId || normalizedFallbackId === scheduleItemId) continue;
-        const fallbackRecord = await getRecord(date, userId, normalizedFallbackId);
+        const fallbackRecord = await getRecordRef.current(date, userId, normalizedFallbackId);
         if (fallbackRecord) {
           resolved = fallbackRecord;
           break;
@@ -36,7 +44,7 @@ export function useExecutionRecord(
 
     setRecord(resolved);
     setIsLoading(false);
-  }, [getRecord, date, userId, scheduleItemId, fallbackScheduleItemIds]);
+  }, [date, userId, scheduleItemId, fallbackScheduleItemIds]);
 
   useEffect(() => {
     void fetchRecord();
@@ -56,9 +64,9 @@ export function useExecutionRecord(
         recordedAt: new Date().toISOString(),
       };
       setRecord(next);
-      await upsertRecord(next);
+      await upsertRecordRef.current(next);
     },
-    [date, userId, scheduleItemId, record, upsertRecord],
+    [date, userId, scheduleItemId, record],
   );
 
   const setMemo = useCallback(
@@ -70,9 +78,9 @@ export function useExecutionRecord(
         recordedAt: new Date().toISOString(),
       };
       setRecord(next);
-      await upsertRecord(next);
+      await upsertRecordRef.current(next);
     },
-    [record, upsertRecord],
+    [record],
   );
 
   const saveRecord = useCallback(
@@ -89,9 +97,9 @@ export function useExecutionRecord(
         recordedAt: new Date().toISOString(),
       };
       setRecord(next);
-      await upsertRecord(next);
+      await upsertRecordRef.current(next);
     },
-    [date, userId, scheduleItemId, record, upsertRecord],
+    [date, userId, scheduleItemId, record],
   );
 
   return { record, setStatus, setMemo, saveRecord, isLoading, refresh: fetchRecord } as const;

--- a/src/features/daily/hooks/useHistoricalRecords.ts
+++ b/src/features/daily/hooks/useHistoricalRecords.ts
@@ -1,9 +1,15 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useExecutionData } from './useExecutionData';
 import type { ExecutionRecord } from '../domain/legacy/executionRecordTypes';
 
 export function useHistoricalRecords(userId: string, scheduleItemId: string) {
   const { getHistoricalRecords } = useExecutionData();
+  const getHistoricalRecordsRef = useRef(getHistoricalRecords);
+
+  useEffect(() => {
+    getHistoricalRecordsRef.current = getHistoricalRecords;
+  }, [getHistoricalRecords]);
+
   const [records, setRecords] = useState<ExecutionRecord[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
@@ -14,7 +20,7 @@ export function useHistoricalRecords(userId: string, scheduleItemId: string) {
     setIsLoading(true);
     setError(null);
     try {
-      const history = await getHistoricalRecords(userId, scheduleItemId, 150);
+      const history = await getHistoricalRecordsRef.current(userId, scheduleItemId, 150);
       setRecords(history);
     } catch (err) {
       console.error('[useHistoricalRecords] Failed to fetch history:', err);
@@ -22,7 +28,7 @@ export function useHistoricalRecords(userId: string, scheduleItemId: string) {
     } finally {
       setIsLoading(false);
     }
-  }, [getHistoricalRecords, userId, scheduleItemId]);
+  }, [userId, scheduleItemId]);
 
   useEffect(() => {
     void fetchHistory();
@@ -30,3 +36,4 @@ export function useHistoricalRecords(userId: string, scheduleItemId: string) {
 
   return { records, isLoading, error, refresh: fetchHistory };
 }
+

--- a/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
@@ -66,24 +66,26 @@ export const KioskProcedureDetailScreen: React.FC = () => {
 
   // 以前の保存記録からステートを復元する（1回限り）
   React.useEffect(() => {
-    if (isLoading || isInitialized || !record) return;
+    if (isLoading || isInitialized) return;
     
-    const memoText = record.memo || '';
-    const moodMatch = memoText.match(/【様子】([^\n]+)/);
-    const actionMatch = memoText.match(/【対応】([^\n]+)/);
-    const resultMatch = memoText.match(/【変化】([^\n]+)/);
-    const textMatch = memoText.match(/【メモ】([\s\S]+)/);
-    
-    if (moodMatch) setSelectedMood(moodMatch[1].trim());
-    if (actionMatch) setSelectedAction(actionMatch[1].trim());
-    if (resultMatch) setSelectedResult(resultMatch[1].trim());
-    
-    if (textMatch) {
-      setTextMemo(textMatch[1].trim());
-    } else if (memoText.trim()) {
-      const hasLabels = memoText.includes('【様子】') || memoText.includes('【対応】') || memoText.includes('【変化】');
-      if (!hasLabels) {
-        setTextMemo(memoText.trim());
+    if (record) {
+      const memoText = record.memo || '';
+      const moodMatch = memoText.match(/【様子】([^\n]+)/);
+      const actionMatch = memoText.match(/【対応】([^\n]+)/);
+      const resultMatch = memoText.match(/【変化】([^\n]+)/);
+      const textMatch = memoText.match(/【メモ】([\s\S]+)/);
+      
+      if (moodMatch) setSelectedMood(moodMatch[1].trim());
+      if (actionMatch) setSelectedAction(actionMatch[1].trim());
+      if (resultMatch) setSelectedResult(resultMatch[1].trim());
+      
+      if (textMatch) {
+        setTextMemo(textMatch[1].trim());
+      } else if (memoText.trim()) {
+        const hasLabels = memoText.includes('【様子】') || memoText.includes('【対応】') || memoText.includes('【変化】');
+        if (!hasLabels) {
+          setTextMemo(memoText.trim());
+        }
       }
     }
     

--- a/src/features/kiosk/hooks/useDailyProcedureFlowPreview.ts
+++ b/src/features/kiosk/hooks/useDailyProcedureFlowPreview.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useExecutionData } from '@/features/daily/hooks/useExecutionData';
 import { useProcedureStore } from '@/features/daily/stores/procedureStore';
 import type { ExecutionRecord } from '@/features/daily/domain/legacy/executionRecordTypes';
@@ -19,6 +19,12 @@ export function useDailyProcedureFlowPreview(
   recordDate: string
 ): UseDailyProcedureFlowPreviewResult {
   const { getRecords } = useExecutionData();
+  const getRecordsRef = useRef(getRecords);
+  
+  useEffect(() => {
+    getRecordsRef.current = getRecords;
+  }, [getRecords]);
+
   const procedureStore = useProcedureStore();
   
   const [rawRecords, setRawRecords] = useState<ExecutionRecord[]>([]);
@@ -34,7 +40,7 @@ export function useDailyProcedureFlowPreview(
     setIsLoading(true);
     setError(null);
     try {
-      const records = await getRecords(recordDate, userId);
+      const records = await getRecordsRef.current(recordDate, userId);
       setRawRecords(records);
     } catch (err) {
       console.error('[useDailyProcedureFlowPreview] Failed to fetch daily records:', err);
@@ -42,7 +48,7 @@ export function useDailyProcedureFlowPreview(
     } finally {
       setIsLoading(false);
     }
-  }, [getRecords, userId, recordDate]);
+  }, [userId, recordDate]);
 
   useEffect(() => {
     void fetchDailyRecords();
@@ -65,3 +71,4 @@ export function useDailyProcedureFlowPreview(
     refresh: fetchDailyRecords,
   };
 }
+


### PR DESCRIPTION
## 概要
キオスク手順詳細画面（`KioskProcedureDetailScreen`）にて、履歴から「1日の流れプレビュー（Daily Flow Preview）」を開いた後に、バックグラウンドのリフレッシュがトリガーされるとDrawer全体が自動で閉じてしまう不具合を修正しました。

Closes #1878

## 変更内容
### 変更
- **KioskProcedureDetailScreen.tsx**:
  - `record`（手順の保存記録）が `undefined` の場合でも、初期フェッチが終了した時点で `isInitialized` が正しく `true` になるように修正。これにより、バックグラウンドフェッチ時の `isLoading` への切り替えで全画面ロード画面が再度マウントされ、Drawerがアンマウントされてしまう現象を防止。
- **useExecutionRecord.ts**:
  - `getRecord` / `upsertRecord` の関数参照を `useRef` を用いて透過的に固定。Zustand ストア更新時の不必要な再取得およびローディング状態の切り替え（`setIsLoading(true)`）を防止し、パフォーマンスと表示安定性を極限まで高めました。
- **useHistoricalRecords.ts** / **useDailyProcedureFlowPreview.ts**:
  - `getHistoricalRecords` と `getRecords` への参照をそれぞれ `useRef` で固定し、不要なエフェクトの再実行を防ぎ、キオスク履歴の無限フェッチ/マウントループを防ぎました。

## 変更ファイル一覧
| ファイル | 変更種別 | 変更内容 |
|---------|---------|---------|
| `src/features/kiosk/components/KioskProcedureDetailScreen.tsx` | 変更 | 未保存時の `isInitialized` 完了条件を修正、アンマウントバグを解消 |
| `src/features/daily/hooks/useExecutionRecord.ts` | 変更 | `useRef` を導入して関数参照の透過的固定とストア依存の再フェッチループを防止 |
| `src/features/daily/hooks/useHistoricalRecords.ts` | 変更 | `useRef` を用いたフェッチハンドラの安定化 |
| `src/features/kiosk/hooks/useDailyProcedureFlowPreview.ts` | 変更 | `useRef` を用いたフェッチハンドラの安定化 |

## テスト
- [x] 既存テスト通過 (`npx vitest src/features/kiosk/components/__tests__`)
- [x] 型チェック通過 (`npm run typecheck`)
- [ ] 新規テスト追加

## セルフレビュー
- [x] `console.log` 残していない
- [x] `any` 使っていない
- [x] 責務分離を守っている
- [x] 600行ルール違反なし

## 影響範囲
- キオスクモードの履歴パネル・1日の流れプレビュー
- 記録入力・保存処理（バックグラウンド更新時の安定性向上）