### PR TITLE
feat(monthly-records): align monthly aggregation with kiosk execution evidence

### DIFF
--- a/src/features/records/monthly/MonthlySummaryTable.tsx
+++ b/src/features/records/monthly/MonthlySummaryTable.tsx
@@ -1,3 +1,4 @@
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import SearchIcon from '@mui/icons-material/Search';
 import TrendingUpIcon from '@mui/icons-material/TrendingUp';
@@ -343,9 +344,30 @@ export const MonthlySummaryTable: React.FC<MonthlySummaryTableProps> = ({
                   完了率
                 </TableSortLabel>
               </TableCell>
-              <TableCell align="right">完了</TableCell>
-              <TableCell align="right">進行中</TableCell>
-              <TableCell align="right">未入力</TableCell>
+              <TableCell align="right">
+                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 0.5 }}>
+                  完了
+                  <Tooltip title="支援が提供され、完了チェックされた項目数（キオスク集計時: completed ステータス）">
+                    <HelpOutlineIcon sx={{ fontSize: 16, color: 'text.secondary', cursor: 'help' }} />
+                  </Tooltip>
+                </Box>
+              </TableCell>
+              <TableCell align="right">
+                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 0.5 }}>
+                  進行中
+                  <Tooltip title="入力開始されているが、未完了の項目数。キオスク集計時、スキップや行動発生（トリガー）の行はここに計上されます。">
+                    <HelpOutlineIcon sx={{ fontSize: 16, color: 'text.secondary', cursor: 'help' }} />
+                  </Tooltip>
+                </Box>
+              </TableCell>
+              <TableCell align="right">
+                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 0.5 }}>
+                  未入力
+                  <Tooltip title="計画（営業日×17行）に対して、記録が全く存在しない項目数。二重計上を防ぐ不変ロジックで計算されています。">
+                    <HelpOutlineIcon sx={{ fontSize: 16, color: 'text.secondary', cursor: 'help' }} />
+                  </Tooltip>
+                </Box>
+              </TableCell>
               <TableCell align="center">特記事項</TableCell>
               <TableCell>
                 <TableSortLabel
@@ -378,7 +400,71 @@ export const MonthlySummaryTable: React.FC<MonthlySummaryTableProps> = ({
                       </Typography>
                     </Box>
                   </TableCell>
-                  <TableCell>{summary.yearMonth}</TableCell>
+                  <TableCell>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                      {summary.yearMonth}
+                      {summary.kpi.source === 'kiosk-execution' ? (
+                        <Tooltip title={
+                          <Box sx={{ p: 0.5 }}>
+                            <Typography variant="caption" sx={{ fontWeight: 'bold', display: 'block', mb: 0.5 }}>
+                              集計根拠: キオスク実施記録
+                            </Typography>
+                            <Typography variant="caption" sx={{ display: 'block' }}>
+                              ・完了: {summary.kpi.completedRows} 件
+                            </Typography>
+                            <Typography variant="caption" sx={{ display: 'block' }}>
+                              ・トリガー(行動発生): {summary.kpi.triggeredRows ?? 0} 件
+                            </Typography>
+                            <Typography variant="caption" sx={{ display: 'block' }}>
+                              ・スキップ: {summary.kpi.skippedRows ?? 0} 件
+                            </Typography>
+                            <Typography variant="caption" sx={{ display: 'block' }}>
+                              ・未入力: {summary.kpi.emptyRows} 件
+                            </Typography>
+                            <Typography variant="caption" sx={{ display: 'block' }}>
+                              ・メモ記載: {summary.kpi.memoRows ?? 0} 件
+                            </Typography>
+                          </Box>
+                        }>
+                          <Chip
+                            label="キオスク"
+                            size="small"
+                            color="primary"
+                            variant="outlined"
+                            sx={{ fontSize: '0.75rem', height: 20 }}
+                          />
+                        </Tooltip>
+                      ) : (
+                        <Tooltip title={
+                          <Box sx={{ p: 0.5 }}>
+                            <Typography variant="caption" sx={{ fontWeight: 'bold', display: 'block', mb: 0.5 }}>
+                              集計根拠: 日次手動入力
+                            </Typography>
+                            <Typography variant="caption" sx={{ display: 'block' }}>
+                              ・完了: {summary.kpi.completedRows} 件
+                            </Typography>
+                            <Typography variant="caption" sx={{ display: 'block' }}>
+                              ・進行中: {summary.kpi.inProgressRows} 件
+                            </Typography>
+                            <Typography variant="caption" sx={{ display: 'block' }}>
+                              ・未入力: {summary.kpi.emptyRows} 件
+                            </Typography>
+                            <Typography variant="caption" sx={{ display: 'block' }}>
+                              ・特記事項: {summary.kpi.specialNotes} 件
+                            </Typography>
+                          </Box>
+                        }>
+                          <Chip
+                            label="手動"
+                            size="small"
+                            color="default"
+                            variant="outlined"
+                            sx={{ fontSize: '0.75rem', height: 20 }}
+                          />
+                        </Tooltip>
+                      )}
+                    </Box>
+                  </TableCell>
                   <TableCell align="right">
                     <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 1 }}>
                       <Chip

--- a/src/features/records/monthly/aggregate.ts
+++ b/src/features/records/monthly/aggregate.ts
@@ -48,19 +48,16 @@ export function getTotalDaysInMonth(yearMonth: YearMonth): number {
   return new Date(year, month, 0).getDate();
 }
 
-/**
- * 日次記録から月次KPIを集計
- * emptyRows は整合性を保つため、plannedRows - completedRows - inProgressRows で計算
- */
 export function aggregateMonthlyKpi(
   dailyRecords: DailyRecord[],
   yearMonth: YearMonth,
   options: {
     useWorkingDays?: boolean;
     rowsPerDay?: number;
+    source?: 'daily-manual' | 'kiosk-execution' | 'hybrid' | string;
   } = {}
 ): MonthlyKpi {
-  const { useWorkingDays = true, rowsPerDay = 17 } = options;
+  const { useWorkingDays = true, rowsPerDay = 17, source = 'daily-manual' } = options;
 
   // 月内の基準日数
   const totalDays = useWorkingDays
@@ -72,12 +69,27 @@ export function aggregateMonthlyKpi(
 
   // 実績の集計
   const completedRows = dailyRecords.filter(r => r.completed).length;
-  const inProgressRows = dailyRecords.filter(r => !r.completed && !r.isEmpty).length;
   const specialNotes = dailyRecords.filter(r => r.hasSpecialNotes).length;
   const incidents = dailyRecords.filter(r => r.hasIncidents).length;
 
-  // emptyRows は整合性保証: plannedRows - completedRows - inProgressRows（負にならない）
-  const emptyRows = Math.max(0, plannedRows - completedRows - inProgressRows);
+  // 詳細集計（拡張項目）
+  const skippedRows = dailyRecords.filter(r => r.isSkipped).length;
+  const triggeredRows = dailyRecords.filter(r => r.isTriggered).length;
+  const memoRows = dailyRecords.filter(r => r.hasMemo).length;
+
+  // inProgressRows は完了でも空でもない行。
+  // 二重計上を防ぐため、isSkipped もしくは isTriggered の拡張項目が true の場合は inProgressRows から除外する。
+  const inProgressRows = dailyRecords.filter(
+    r => !r.completed && !r.isEmpty && !r.isSkipped && !r.isTriggered
+  ).length;
+
+  // emptyRows は整合性保証：計画行数から、実際に何かしらの記録があった行数を引く。
+  // completed, inProgress, skipped, triggered は互いに排他であるため、単純に引いてよい。
+  // memoRows は独立した属性（completed や triggered と重複しうる）なので、ここでは引かない。
+  const emptyRows = Math.max(
+    0,
+    plannedRows - completedRows - inProgressRows - skippedRows - triggeredRows
+  );
 
   return {
     totalDays,
@@ -87,6 +99,10 @@ export function aggregateMonthlyKpi(
     emptyRows,
     specialNotes,
     incidents,
+    skippedRows,
+    triggeredRows,
+    memoRows,
+    source,
   };
 }
 
@@ -127,6 +143,7 @@ export function aggregateMonthlySummary(
   options?: {
     useWorkingDays?: boolean;
     rowsPerDay?: number;
+    source?: 'daily-manual' | 'kiosk-execution' | 'hybrid' | string;
   }
 ): MonthlySummary {
   // KPI集計

--- a/src/features/records/monthly/kioskEvidence.test.ts
+++ b/src/features/records/monthly/kioskEvidence.test.ts
@@ -79,10 +79,14 @@ describe('monthly kiosk evidence bridge', () => {
       totalDays: 31,
       plannedRows: 31,
       completedRows: 1,
-      inProgressRows: 2,
+      inProgressRows: 0,
       emptyRows: 28,
       specialNotes: 2,
       incidents: 1,
+      skippedRows: 1,
+      triggeredRows: 1,
+      memoRows: 2,
+      source: 'kiosk-execution',
     });
 
     expect(result.evidence).toEqual({
@@ -105,9 +109,9 @@ describe('monthly kiosk evidence bridge', () => {
     expect(result.summary.firstEntryDate).toBe(result.evidence.firstEntryDate);
     expect(result.summary.lastEntryDate).toBe(result.evidence.lastEntryDate);
     expect(result.summary.kpi.completedRows).toBe(result.evidence.completedRows);
-    expect(result.summary.kpi.inProgressRows).toBe(
-      result.evidence.triggeredRows + result.evidence.skippedRows
-    );
+    expect(result.summary.kpi.skippedRows).toBe(result.evidence.skippedRows);
+    expect(result.summary.kpi.triggeredRows).toBe(result.evidence.triggeredRows);
+    expect(result.summary.kpi.memoRows).toBe(result.evidence.memoRows);
     expect(result.summary.kpi.incidents).toBe(result.evidence.incidentRows);
   });
 });

--- a/src/features/records/monthly/kioskEvidence.ts
+++ b/src/features/records/monthly/kioskEvidence.ts
@@ -109,6 +109,9 @@ export function toMonthlyDailyRecordFromKioskEvidence(record: ExecutionRecord): 
     hasSpecialNotes: hasMemo(record),
     hasIncidents: hasIncidentEvidence(record, status),
     isEmpty,
+    isSkipped: status === 'skipped',
+    isTriggered: status === 'triggered',
+    hasMemo: hasMemo(record),
   };
 }
 
@@ -204,6 +207,7 @@ export function aggregateMonthlySummaryFromKioskEvidence(
   const summary = aggregateMonthlySummary(userId, displayName, dailyRecords, yearMonth, {
     useWorkingDays,
     rowsPerDay,
+    source: 'kiosk-execution',
   });
 
   return {

--- a/src/features/records/monthly/kioskMonthlyAggregationUseCase.test.ts
+++ b/src/features/records/monthly/kioskMonthlyAggregationUseCase.test.ts
@@ -59,10 +59,14 @@ describe('executeKioskMonthlyAggregation use case', () => {
       totalDays: 31,
       plannedRows: 31,
       completedRows: 2,
-      inProgressRows: 1,
+      inProgressRows: 0,
       emptyRows: 28,
       specialNotes: 1,
       incidents: 1,
+      skippedRows: 0,
+      triggeredRows: 1,
+      memoRows: 1,
+      source: 'kiosk-execution',
     });
 
     expect(result.evidence).toEqual({

--- a/src/features/records/monthly/types.ts
+++ b/src/features/records/monthly/types.ts
@@ -24,6 +24,10 @@ export interface MonthlyKpi {
   emptyRows: number;        // 未入力（生成時に invariant 保証: emptyRows = max(0, plannedRows - completedRows - inProgressRows)）
   specialNotes: number;     // 特記事項あり件数
   incidents: number;        // 事故/ヒヤリ等のタグ件数（拡張）
+  skippedRows?: number;     // スキップされた行数（拡張）
+  triggeredRows?: number;   // トリガー（行動発生）された行数（拡張）
+  memoRows?: number;        // メモが記入された行数（拡張）
+  source?: 'daily-manual' | 'kiosk-execution' | 'hybrid' | string; // 集計ソース
 }
 
 export interface MonthlySummary extends MonthlyRecordKey {
@@ -47,6 +51,9 @@ export interface DailyRecord {
   hasSpecialNotes: boolean;
   hasIncidents: boolean;
   isEmpty: boolean;         // 全フィールドが空の場合
+  isSkipped?: boolean;      // スキップされた行（拡張）
+  isTriggered?: boolean;    // トリガーされた行（拡張）
+  hasMemo?: boolean;        // 個別メモがある行（拡張）
 }
 
 // 月次サマリー操作の結果


### PR DESCRIPTION
## Summary

- Align monthly aggregation definitions with kiosk execution evidence
- Add optional MonthlyKpi fields for skipped / triggered / memo rows and source
- Map kiosk execution records into monthly DailyRecord fields
- Strengthen emptyRows invariant to avoid double counting completed / in-progress / skipped / triggered rows
- Add source badges and tooltips to MonthlySummaryTable to explain aggregation basis

## Design notes

This PR focuses on definition alignment only.

Monthly records and kiosk monitoring evidence now share clearer semantics for completed, triggered, skipped, memo, and empty/unrecorded rows.

`memoRows` is intentionally non-exclusive and is not subtracted from `emptyRows`, because memo can coexist with completed, triggered, skipped, or in-progress states.

This PR does not add PDF / Word output, printing, billing lock behavior, or SharePoint schema changes.

## Compatibility

New MonthlyKpi fields are optional to avoid breaking existing saved summaries and UI consumers.

## Checks

- [x] npm run typecheck
- [x] npx vitest run src/features/records/monthly
- [x] npx vitest run src/features/monitoring/domain/__tests__/monitoringKioskAnalytics.spec.ts