### PR TITLE
feat(kiosk): show support procedure start date on procedure list

### DIFF
--- a/src/features/kiosk/components/KioskProcedureListScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureListScreen.tsx
@@ -157,9 +157,20 @@ export const KioskProcedureListScreen: React.FC = () => {
             <Typography variant="h4" component="h1" sx={{ fontWeight: 'bold' }}>
               {user.FullName} 様
             </Typography>
-            <Typography variant="subtitle1" color="text.secondary">
-              {selectedDateStr} の支援手順
-            </Typography>
+            <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', mt: 0.5 }}>
+              <Typography variant="subtitle1" color="text.secondary">
+                {selectedDateStr} の支援手順
+              </Typography>
+              {user.ServiceStartDate ? (
+                <Typography variant="subtitle1" color="text.secondary" sx={{ fontWeight: 'medium' }}>
+                  • 支援手順兼記録開始日: {formatDateJapanese(user.ServiceStartDate)}（90日参考・利用者マスタ）
+                </Typography>
+              ) : (
+                <Typography variant="subtitle1" color="text.secondary" sx={{ fontWeight: 'medium' }}>
+                  • 支援手順兼記録開始日: 未設定（90日参考）
+                </Typography>
+              )}
+            </Box>
           </Box>
         </Box>
 

--- a/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
@@ -14,8 +14,9 @@ vi.mock('react-router-dom', async () => {
   };
 });
 
+const mockUseUser = vi.fn(() => ({ data: { FullName: '田中 太郎', ServiceStartDate: undefined as string | undefined } as unknown as Record<string, unknown>, status: 'success' }));
 vi.mock('@/features/users/useUsers', () => ({
-  useUser: () => ({ data: { FullName: '田中 太郎' }, status: 'success' }),
+  useUser: () => mockUseUser(),
 }));
 
 const mockProcedures = [
@@ -54,6 +55,7 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
     vi.useFakeTimers({ toFake: ['Date'] });
     vi.setSystemTime(new Date(2026, 4, 8));
     vi.clearAllMocks();
+    mockUseUser.mockReturnValue({ data: { FullName: '田中 太郎' }, status: 'success' });
     mockGetCurrentExecutionRepositoryKind.mockReturnValue('local');
     mockGetStoreRecords.mockReturnValue([]);
     mockGetRecords.mockResolvedValue([]);
@@ -361,6 +363,40 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
 
     await waitFor(() => {
       expect(screen.getByText('記録の取得に失敗しました。再読み込みしてください。')).toBeInTheDocument();
+    });
+  });
+
+  it('renders service start date when user has ServiceStartDate', async () => {
+    mockUseUser.mockReturnValue({
+      data: { FullName: '田中 太郎', ServiceStartDate: '2026-04-01' },
+      status: 'success',
+    });
+
+    render(
+      <MemoryRouter>
+        <KioskProcedureListScreen />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/支援手順兼記録開始日: 2026年4月1日（90日参考・利用者マスタ）/)).toBeInTheDocument();
+    });
+  });
+
+  it('renders unset message when user does not have ServiceStartDate', async () => {
+    mockUseUser.mockReturnValue({
+      data: { FullName: '田中 太郎', ServiceStartDate: undefined },
+      status: 'success',
+    });
+
+    render(
+      <MemoryRouter>
+        <KioskProcedureListScreen />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/支援手順兼記録開始日: 未設定（90日参考）/)).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Display the support procedure start date (支援手順兼記録開始日 - 90日参考) on the kiosk procedure list screen.
- Formatted utilizing existing `formatDateJapanese` helper.
- Added a fallback label for 'unset' (未設定) and source labeling (90日参考・利用者マスタ) to avoid user confusion.
- Added unit tests checking both the populated `ServiceStartDate` case and the `unset` case.
- Completely type-safe with zero extra database or network overhead.

This completes **PR1** of the newly revised implementation strategy. PR2 will follow to fetch `SupportStartDate` using the procedure's `planningSheetId`.