### PR TITLE
feat(kiosk): resolve support start date dynamically from planning sheet

### DIFF
--- a/src/features/kiosk/components/KioskProcedureListScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureListScreen.tsx
@@ -14,6 +14,9 @@ import { ExecutionRecord } from '@/features/daily/domain/executionRecordTypes';
 import { normalizeScheduleItemId } from '@/features/daily/utils/normalizeScheduleItemId';
 import { useExecutionStore } from '@/features/daily/stores/executionStore';
 import { getCurrentExecutionRepositoryKind } from '@/features/daily/repositories/sharepoint/executionRepositoryFactory';
+import { usePlanningSheetRepositories } from '@/features/planning-sheet/hooks/usePlanningSheetRepositories';
+import { usePlanningSheetData } from '@/features/planning-sheet/hooks/usePlanningSheetData';
+import { resolveSupportStartDateDetailed } from '@/features/planning-sheet/monitoringSchedule';
 
 export const KioskProcedureListScreen: React.FC = () => {
   const navigate = useNavigate();
@@ -41,6 +44,25 @@ export const KioskProcedureListScreen: React.FC = () => {
     }
     return keys;
   }, [procedures]);
+
+  const targetPlanningSheetId = React.useMemo(() => {
+    return procedures?.find((procedure) => procedure.planningSheetId)?.planningSheetId;
+  }, [procedures]);
+
+  const planningRepo = usePlanningSheetRepositories();
+
+  const {
+    data: planningSheet,
+    isLoading: isLoadingPlanningSheet,
+  } = usePlanningSheetData(targetPlanningSheetId, planningRepo);
+
+  const resolvedStartDate = React.useMemo(() => {
+    return resolveSupportStartDateDetailed(
+      planningSheet?.supportStartDate,
+      user?.ServiceStartDate,
+      planningSheet?.appliedFrom
+    );
+  }, [planningSheet?.supportStartDate, planningSheet?.appliedFrom, user?.ServiceStartDate]);
 
   const { getRecords: getStoreRecords } = useExecutionStore();
   const storeRecords = getStoreRecords(selectedDateIso || '', userId || '');
@@ -161,15 +183,30 @@ export const KioskProcedureListScreen: React.FC = () => {
               <Typography variant="subtitle1" color="text.secondary">
                 {selectedDateStr} の支援手順
               </Typography>
-              {user.ServiceStartDate ? (
-                <Typography variant="subtitle1" color="text.secondary" sx={{ fontWeight: 'medium' }}>
-                  • 支援手順兼記録開始日: {formatDateJapanese(user.ServiceStartDate)}（90日参考・利用者マスタ）
-                </Typography>
-              ) : (
-                <Typography variant="subtitle1" color="text.secondary" sx={{ fontWeight: 'medium' }}>
-                  • 支援手順兼記録開始日: 未設定（90日参考）
-                </Typography>
-              )}
+              <Typography variant="subtitle1" color="text.secondary" sx={{ fontWeight: 'medium' }}>
+                • {(() => {
+                  const { date, source } = resolvedStartDate;
+
+                  if (!date || source === 'none') {
+                    return targetPlanningSheetId && isLoadingPlanningSheet
+                      ? '支援手順兼記録開始日: 確認中（90日参考）'
+                      : '支援手順兼記録開始日: 未設定（90日参考）';
+                  }
+
+                  const dateStr = formatDateJapanese(date);
+
+                  switch (source) {
+                    case 'planning':
+                      return `支援手順兼記録開始日: ${dateStr}（90日参考・支援計画）`;
+                    case 'master':
+                      return `支援手順兼記録開始日: ${dateStr}（90日参考・利用者マスタ）`;
+                    case 'fallback':
+                      return `[暫定] 支援手順兼記録開始日: ${dateStr}（90日参考・計画適用日）`;
+                    default:
+                      return `支援手順兼記録開始日: ${dateStr}（90日参考）`;
+                  }
+                })()}
+              </Typography>
             </Box>
           </Box>
         </Box>

--- a/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor, within } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { KioskProcedureListScreen } from '../KioskProcedureListScreen';
 import { MemoryRouter } from 'react-router-dom';
+import type { SupportPlanningSheet } from '@/domain/isp/schema';
 
 // Mock dependencies
 vi.mock('react-router-dom', async () => {
@@ -20,13 +21,14 @@ vi.mock('@/features/users/useUsers', () => ({
 }));
 
 const mockProcedures = [
-  { id: '1', rowNo: 1, time: '10:00', activity: '朝のバイタルチェック', instruction: '体温と血圧を測ります' },
-  { id: 'P002', rowNo: 2, time: '12:00', activity: '昼食の介助', instruction: '見守りを行います' }
+  { id: '1', rowNo: 1, time: '10:00', activity: '朝のバイタルチェック', instruction: '体温と血圧を測ります', planningSheetId: 'S001' },
+  { id: 'P002', rowNo: 2, time: '12:00', activity: '昼食の介助', instruction: '見守りを行います', planningSheetId: 'S001' }
 ];
 
+const mockGetByUser = vi.fn(() => mockProcedures);
 vi.mock('@/features/daily/hooks/useProcedureData', () => ({
   useProcedureData: () => ({
-    getByUser: () => mockProcedures
+    getByUser: () => mockGetByUser()
   }),
 }));
 
@@ -50,6 +52,15 @@ vi.mock('@/features/daily/repositories/sharepoint/executionRepositoryFactory', (
   getCurrentExecutionRepositoryKind: () => mockGetCurrentExecutionRepositoryKind(),
 }));
 
+const mockUsePlanningSheetData = vi.fn(() => ({ data: null, isLoading: false }));
+vi.mock('@/features/planning-sheet/hooks/usePlanningSheetData', () => ({
+  usePlanningSheetData: () => mockUsePlanningSheetData(),
+}));
+
+vi.mock('@/features/planning-sheet/hooks/usePlanningSheetRepositories', () => ({
+  usePlanningSheetRepositories: () => ({}),
+}));
+
 describe('KioskProcedureListScreen (includes local/memory-style recorded-state checks)', () => {
   beforeEach(() => {
     vi.useFakeTimers({ toFake: ['Date'] });
@@ -58,6 +69,8 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
     mockUseUser.mockReturnValue({ data: { FullName: '田中 太郎' }, status: 'success' });
     mockGetCurrentExecutionRepositoryKind.mockReturnValue('local');
     mockGetStoreRecords.mockReturnValue([]);
+    mockGetByUser.mockReturnValue(mockProcedures);
+    mockUsePlanningSheetData.mockReturnValue({ data: null, isLoading: false });
     mockGetRecords.mockResolvedValue([]);
   });
 
@@ -366,10 +379,35 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
     });
   });
 
-  it('renders service start date when user has ServiceStartDate', async () => {
+  it('Case 1: renders supportStartDate from planningSheet when planningSheet.supportStartDate is present', async () => {
     mockUseUser.mockReturnValue({
       data: { FullName: '田中 太郎', ServiceStartDate: '2026-04-01' },
       status: 'success',
+    });
+    mockUsePlanningSheetData.mockReturnValue({
+      data: { supportStartDate: '2026-05-01' } as unknown as SupportPlanningSheet,
+      isLoading: false,
+    });
+
+    render(
+      <MemoryRouter>
+        <KioskProcedureListScreen />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/支援手順兼記録開始日: 2026年5月1日（90日参考・支援計画）/)).toBeInTheDocument();
+    });
+  });
+
+  it('Case 2: renders ServiceStartDate from user master when planningSheet.supportStartDate is not present', async () => {
+    mockUseUser.mockReturnValue({
+      data: { FullName: '田中 太郎', ServiceStartDate: '2026-04-01' },
+      status: 'success',
+    });
+    mockUsePlanningSheetData.mockReturnValue({
+      data: { supportStartDate: undefined } as unknown as SupportPlanningSheet,
+      isLoading: false,
     });
 
     render(
@@ -383,10 +421,38 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
     });
   });
 
-  it('renders unset message when user does not have ServiceStartDate', async () => {
+  it('Case 3: renders appliedFrom from planningSheet when supportStartDate and ServiceStartDate are both absent', async () => {
     mockUseUser.mockReturnValue({
       data: { FullName: '田中 太郎', ServiceStartDate: undefined },
       status: 'success',
+    });
+    mockUsePlanningSheetData.mockReturnValue({
+      data: { supportStartDate: undefined, appliedFrom: '2026-03-01' } as unknown as SupportPlanningSheet,
+      isLoading: false,
+    });
+
+    render(
+      <MemoryRouter>
+        <KioskProcedureListScreen />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/\[暫定\] 支援手順兼記録開始日: 2026年3月1日（90日参考・計画適用日）/)).toBeInTheDocument();
+    });
+  });
+
+  it('Case 4: renders unset message when planningSheetId, supportStartDate, ServiceStartDate and appliedFrom are all absent', async () => {
+    mockUseUser.mockReturnValue({
+      data: { FullName: '田中 太郎', ServiceStartDate: undefined },
+      status: 'success',
+    });
+    mockGetByUser.mockReturnValue([
+      { id: '1', rowNo: 1, time: '10:00', activity: '朝のバイタルチェック', instruction: '体温と血圧を測ります' }
+    ]);
+    mockUsePlanningSheetData.mockReturnValue({
+      data: null,
+      isLoading: false,
     });
 
     render(
@@ -397,6 +463,27 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
 
     await waitFor(() => {
       expect(screen.getByText(/支援手順兼記録開始日: 未設定（90日参考）/)).toBeInTheDocument();
+    });
+  });
+
+  it('Loading case: renders confirmation message during loading when planningSheetId is present but data is not loaded yet', async () => {
+    mockUseUser.mockReturnValue({
+      data: { FullName: '田中 太郎', ServiceStartDate: undefined },
+      status: 'success',
+    });
+    mockUsePlanningSheetData.mockReturnValue({
+      data: null,
+      isLoading: true,
+    });
+
+    render(
+      <MemoryRouter>
+        <KioskProcedureListScreen />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/支援手順兼記録開始日: 確認中（90日参考）/)).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Summary

- Resolves the support start date dynamically from the user's `planningSheet` in KioskProcedureListScreen.
- Uses `usePlanningSheetRepositories` and `usePlanningSheetData` to perform lightweight, non-blocking asynchronous fetching of the target plan sheet.
- Restores the rigorous support date governance hierarchy via the existing `resolveSupportStartDateDetailed` utility:
  1. `supportStartDate` (Support plan sheet - lowercase)
  2. `ServiceStartDate` (User master - PascalCase)
  3. `appliedFrom` (Plan sheet fallback - lowercase)
- Improves loading UX by showing `支援手順兼記録開始日: 確認中（90日参考）` while the non-blocking fetch is in progress, preventing visual jumping or flashing.
- standardizes type safety with eslint/tsc, resolving type-assertion concerns by replacing raw `as any` with standard type casts in test specs.

## Verification & Tests

Added 5 comprehensive test cases in `KioskProcedureListScreen.spec.tsx` ensuring 100% test coverage for all source resolution conditions:
1. **Case 1**: `planningSheetId` and `supportStartDate` are present -> **支援計画**
2. **Case 2**: `supportStartDate` absent, `ServiceStartDate` present -> **利用者マスタ**
3. **Case 3**: `supportStartDate` and `ServiceStartDate` absent, `appliedFrom` present -> **計画適用日（暫定）**
4. **Case 4**: All dates absent -> **未設定**
5. **Loading Case**: `planningSheetId` present, but still fetching (`isLoading: true`) -> **確認中**

### Test Results

```txt
✓ Case 1: renders supportStartDate from planningSheet when planningSheet.supportStartDate is present 6ms
✓ Case 2: renders ServiceStartDate from user master when planningSheet.supportStartDate is not present 6ms
✓ Case 3: renders appliedFrom from planningSheet when supportStartDate and ServiceStartDate are both absent 8ms
✓ Case 4: renders unset message when planningSheetId, supportStartDate, ServiceStartDate and appliedFrom are all absent 5ms
✓ Loading case: renders confirmation message during loading when planningSheetId is present but data is not loaded yet 5ms
```

All 22 unit tests passed successfully with 0 lint errors or warnings.
