### PR TITLE
fix(isp): resolve created SharePoint item IDs case-insensitively

### DIFF
--- a/src/data/isp/infra/DataProviderIspRepository.ts
+++ b/src/data/isp/infra/DataProviderIspRepository.ts
@@ -28,7 +28,8 @@ import {
   mapIspRowToListItem, 
   mapIspCreateInputToPayload, 
   mapIspUpdateInputToPayload,
-  extractSpId
+  extractSpId,
+  extractCreatedItemId
 } from '@/data/isp/mapper';
 import { SP_QUERY_LIMITS } from '@/shared/api/spQueryLimits';
 
@@ -189,7 +190,8 @@ export class DataProviderIspRepository implements IspRepository {
     const payload = mapIspCreateInputToPayload(input);
     
     const created = await this.provider.createItem<SpIspMasterRow>(title, payload as unknown as Record<string, unknown>);
-    return this.getById(`sp-${created.id}`) as Promise<IndividualSupportPlan>;
+    const createdId = extractCreatedItemId(created);
+    return this.getById(`sp-${createdId}`) as Promise<IndividualSupportPlan>;
   }
 
   async update(id: string, input: IspUpdateInput): Promise<IndividualSupportPlan> {

--- a/src/data/isp/infra/DataProviderPlanningSheetRepository.ts
+++ b/src/data/isp/infra/DataProviderPlanningSheetRepository.ts
@@ -26,7 +26,8 @@ import {
   mapPlanningSheetRowToListItem, 
   mapPlanningSheetCreateInputToPayload, 
   mapPlanningSheetUpdateInputToPayload,
-  extractSpId
+  extractSpId,
+  extractCreatedItemId
 } from '@/data/isp/mapper';
 import { SP_QUERY_LIMITS } from '@/shared/api/spQueryLimits';
 
@@ -258,7 +259,8 @@ export class DataProviderPlanningSheetRepository implements PlanningSheetReposit
     
     const created = await this.provider.createItem<SpPlanningSheetRow>(title, adjustedPayload);
     
-    const refreshed = await this.getById(`sp-${created.id}`);
+    const createdId = extractCreatedItemId(created);
+    const refreshed = await this.getById(`sp-${createdId}`);
     if (!refreshed) throw new Error('[PlanningSheetRepository] Failed to reload created item');
     return refreshed;
   }

--- a/src/data/isp/infra/DataProviderProcedureRecordRepository.ts
+++ b/src/data/isp/infra/DataProviderProcedureRecordRepository.ts
@@ -26,7 +26,8 @@ import {
   mapProcedureRecordRowToListItem, 
   mapProcedureRecordCreateInputToPayload, 
   mapProcedureRecordUpdateInputToPayload,
-  extractSpId
+  extractSpId,
+  extractCreatedItemId
 } from '@/data/isp/mapper';
 import { SP_QUERY_LIMITS } from '@/shared/api/spQueryLimits';
 
@@ -147,7 +148,8 @@ export class DataProviderProcedureRecordRepository implements ProcedureRecordRep
     
     const created = await this.provider.createItem<SpProcedureRecordRow>(title, payload as unknown as Record<string, unknown>);
     
-    const refreshed = await this.getById(`sp-${created.id}`);
+    const createdId = extractCreatedItemId(created);
+    const refreshed = await this.getById(`sp-${createdId}`);
     if (!refreshed) throw new Error('[ProcedureRecordRepository] Failed to reload created item');
     return refreshed;
   }

--- a/src/data/isp/mapper.ts
+++ b/src/data/isp/mapper.ts
@@ -510,3 +510,22 @@ export function extractSpId(id: string): number | null {
   const num = id.startsWith('sp-') ? Number(id.slice(3)) : Number(id);
   return Number.isFinite(num) && num > 0 ? num : null;
 }
+
+/**
+ * DataProvider (SharePoint / InMemory) の作成応答から ID を型安全かつ大文字小文字無視で抽出する。
+ * sp-undefined を防ぐためのゲートウェイ関数。
+ */
+export function extractCreatedItemId(created: unknown): string {
+  if (!created || typeof created !== 'object') {
+    throw new Error('[DataProvider] createItem did not return an item object');
+  }
+
+  const row = created as Record<string, unknown>;
+  const rawId = row.id ?? row.Id ?? row.ID;
+
+  if (rawId == null || rawId === '') {
+    throw new Error('[DataProvider] createItem response did not include id / Id / ID');
+  }
+
+  return String(rawId);
+}


### PR DESCRIPTION
## PR Title

fix(isp): resolve created SharePoint item IDs case-insensitively

## Summary

- Add shared `extractCreatedItemId` helper to safely resolve created item IDs from DataProvider create responses.
  - Supports `id`, `Id`, and `ID`.
  - Throws an explicit error when the provider response does not contain a usable ID.
- Apply the helper across the three ISP layer repositories:
  - `DataProviderPlanningSheetRepository.ts`
  - `DataProviderIspRepository.ts`
  - `DataProviderProcedureRecordRepository.ts`
- Prevent invalid reload IDs such as `sp-undefined` after create operations.
- Improve robustness of create-after-reload flows across SharePoint and InMemory providers.

## Root Cause

`createItem` responses from SharePoint / InMemory providers may expose the created item ID as `Id` or `ID`, while the repository layer was reading `created.id` directly.

As a result, `created.id` became `undefined`, causing the repository to call:

```ts
getById("sp-undefined")
```

This eventually failed ID extraction, returned `NaN`, and caused the create-after-reload flow to throw:

```txt
[PlanningSheetRepository] Failed to reload created item
```

## Changes

* Added `extractCreatedItemId` as the single gateway for resolving created item IDs.
* Replaced direct `created.id` access in ISP-related repositories.
* Added explicit failure behavior for malformed provider responses.
* Preserved existing create/reload behavior when valid IDs are returned.

> [!NOTE]
> `extractCreatedItemId` is placed next to `extractSpId` in `mapper.ts` because both helpers handle ID normalization at the domain/DataProvider boundary. If more repository-level utilities are introduced later, these ID helpers can be moved together into an infra helper module.

## Checks

* [x] `npm run typecheck` — Passed, 0 errors
* [x] `npx vitest run src/data/isp` — 11/11 tests passed
