### PR TITLE
fix(kiosk): clarify support start date label on procedure list

### DIFF
--- a/src/features/daily/hooks/useHistoricalRecords.ts
+++ b/src/features/daily/hooks/useHistoricalRecords.ts
@@ -1,14 +1,23 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useExecutionData } from './useExecutionData';
 import type { ExecutionRecord } from '../domain/legacy/executionRecordTypes';
+import { normalizeScheduleItemId } from '../utils/normalizeScheduleItemId';
+import { normalizeExecutionUserId } from '../utils/normalizeExecutionLookup';
 
-export function useHistoricalRecords(userId: string, scheduleItemId: string) {
-  const { getHistoricalRecords } = useExecutionData();
+export function useHistoricalRecords(
+  userId: string,
+  scheduleItemId: string,
+  fallbackScheduleItemIds: string[] = [],
+  fallbackUserIds: string[] = [],
+) {
+  const { getHistoricalRecords, getRecordsInRange } = useExecutionData();
   const getHistoricalRecordsRef = useRef(getHistoricalRecords);
+  const getRecordsInRangeRef = useRef(getRecordsInRange);
 
   useEffect(() => {
     getHistoricalRecordsRef.current = getHistoricalRecords;
-  }, [getHistoricalRecords]);
+    getRecordsInRangeRef.current = getRecordsInRange;
+  }, [getHistoricalRecords, getRecordsInRange]);
 
   const [records, setRecords] = useState<ExecutionRecord[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -20,7 +29,56 @@ export function useHistoricalRecords(userId: string, scheduleItemId: string) {
     setIsLoading(true);
     setError(null);
     try {
-      const history = await getHistoricalRecordsRef.current(userId, scheduleItemId, 150);
+      const primaryUserId = normalizeExecutionUserId(userId);
+      const normalizedFallbackUserIds = fallbackUserIds
+        .map((id) => normalizeExecutionUserId(id))
+        .filter((id) => Boolean(id) && id !== primaryUserId);
+      const userCandidates = [primaryUserId, ...normalizedFallbackUserIds];
+
+      const primaryId = normalizeScheduleItemId(scheduleItemId);
+      const fallbackIds = fallbackScheduleItemIds
+        .map((id) => normalizeScheduleItemId(id))
+        .filter((id) => Boolean(id) && id !== primaryId);
+      const scheduleCandidates = [primaryId, ...fallbackIds];
+
+      let history: ExecutionRecord[] = [];
+      for (const candidateUserId of userCandidates) {
+        for (const candidateScheduleId of scheduleCandidates) {
+          history = await getHistoricalRecordsRef.current(candidateUserId, candidateScheduleId, 150);
+          if (history.length > 0) break;
+        }
+        if (history.length > 0) break;
+      }
+
+      // Second fallback: pull recent range and filter in-app.
+      if (history.length === 0) {
+        const to = new Date();
+        const from = new Date();
+        from.setDate(from.getDate() - 95);
+        const toStr = to.toISOString().slice(0, 10);
+        const fromStr = from.toISOString().slice(0, 10);
+        const scheduleSet = new Set(scheduleCandidates.map((id) => normalizeScheduleItemId(id)));
+
+        const isScheduleMatch = (value: unknown): boolean => {
+          const normalized = normalizeScheduleItemId(value);
+          if (!normalized) return false;
+          if (scheduleSet.has(normalized)) return true;
+          const trailing = normalized.match(/\d+$/)?.[0];
+          return Boolean(trailing && scheduleSet.has(trailing));
+        };
+
+        for (const candidateUserId of userCandidates) {
+          const rangeRecords = await getRecordsInRangeRef.current(candidateUserId, fromStr, toStr);
+          const matched = rangeRecords
+            .filter((record) => isScheduleMatch(record.scheduleItemId))
+            .sort((a, b) => (b.recordedAt || b.id).localeCompare(a.recordedAt || a.id))
+            .slice(0, 150);
+          if (matched.length > 0) {
+            history = matched;
+            break;
+          }
+        }
+      }
       setRecords(history);
     } catch (err) {
       console.error('[useHistoricalRecords] Failed to fetch history:', err);
@@ -28,7 +86,7 @@ export function useHistoricalRecords(userId: string, scheduleItemId: string) {
     } finally {
       setIsLoading(false);
     }
-  }, [userId, scheduleItemId]);
+  }, [userId, scheduleItemId, fallbackScheduleItemIds, fallbackUserIds]);
 
   useEffect(() => {
     void fetchHistory();
@@ -36,4 +94,3 @@ export function useHistoricalRecords(userId: string, scheduleItemId: string) {
 
   return { records, isLoading, error, refresh: fetchHistory };
 }
-

--- a/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
+++ b/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
@@ -141,7 +141,8 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
 
   private async ensureParentRecord(dailyKey: string, date: string, _userId: string): Promise<number> {
     await this.getResolvedFields(); // Ensure paths resolved
-    const filter = `${DAILY_RECORD_FIELDS.title} eq '${dailyKey}'`;
+    const escapedDailyKey = dailyKey.replace(/'/g, "''");
+    const filter = `${DAILY_RECORD_FIELDS.title} eq '${escapedDailyKey}'`;
     const url = `${this.resolvedParentPath}/items?$filter=${encodeURIComponent(filter)}&$select=Id`;
     
     const response = await this.spFetch(url, { method: 'GET' });
@@ -193,7 +194,8 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
     // rowKey format: YYYY-MM-DD-userId-scheduleItemId
     // We filter by userId and date range in rowKey.
     // rowKey >= from and rowKey <= to + 'z' ensures we get all items for those dates.
-    const filter = `(${rf.userId} eq '${normalizedUserId}') and (${rf.rowKey} ge '${normalizedFrom}') and (${rf.rowKey} le '${normalizedTo}z')`;
+    const escapedUserId = normalizedUserId.replace(/'/g, "''");
+    const filter = `(${rf.userId} eq '${escapedUserId}') and (${rf.rowKey} ge '${normalizedFrom}') and (${rf.rowKey} le '${normalizedTo}z')`;
     const url = `${this.resolvedChildPath}/items?$filter=${encodeURIComponent(filter)}&$top=5000`;
 
     const response = await this.spFetch(url);
@@ -217,7 +219,8 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
     // Safety check: if rf.rowKey is RowKey but was resolved without actual presence, OData will fail.
     // However, resolveInternalNames is supposed to be accurate. 
     // We lowercase startswith for maximum compatibility.
-    const filter = `startswith(${rf.rowKey}, '${rowKeyPrefix}')`;
+    const escapedPrefix = rowKeyPrefix.replace(/'/g, "''");
+    const filter = `startswith(${rf.rowKey}, '${escapedPrefix}')`;
     const url = `${this.resolvedChildPath}/items?$filter=${encodeURIComponent(filter)}`;
 
     const response = await this.spFetch(url);
@@ -244,7 +247,8 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
     const normalizedScheduleItemId = normalizeScheduleItemId(scheduleItemId);
     const rf = await this.getResolvedFields();
     const rowKey = `${normalizedDate}-${normalizedUserId}-${normalizedScheduleItemId}`;
-    const filter = `${rf.rowKey} eq '${rowKey}'`;
+    const escapedRowKey = rowKey.replace(/'/g, "''");
+    const filter = `${rf.rowKey} eq '${escapedRowKey}'`;
     const url = `${this.resolvedChildPath}/items?$filter=${encodeURIComponent(filter)}`;
 
     const response = await this.spFetch(url);
@@ -378,15 +382,43 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
     
     const uniqueSelect = [...new Set(selectFields.filter((f): f is string => Boolean(f)))];
 
+    const escapedUserId = normalizedUserId.replace(/'/g, "''");
+    const escapedScheduleItemId = normalizedScheduleItemId.replace(/'/g, "''");
+
     // 1. Primary query: Try direct filtering ONLY if rowNo is physically resolved
     if (rf.rowNo) {
-      const filter = `${rf.userId} eq '${normalizedUserId}' and ${rf.rowNo} eq '${normalizedScheduleItemId}' and ${rf.recordedAt} ge '${thresholdStr}'`;
-      const url = `${this.resolvedChildPath}/items?$select=${uniqueSelect.join(',')}&$filter=${encodeURIComponent(filter)}&$orderby=${rf.recordedAt} desc${limit ? `&$top=${limit}` : ''}`;
+      const isNumeric = /^\d+$/.test(normalizedScheduleItemId);
+      
+      const buildUrl = (useQuotes: boolean) => {
+        const rowNoPart = useQuotes 
+          ? `${rf.rowNo} eq '${escapedScheduleItemId}'` 
+          : `${rf.rowNo} eq ${normalizedScheduleItemId}`;
+        const filter = `${rf.userId} eq '${escapedUserId}' and ${rowNoPart} and ${rf.recordedAt} ge '${thresholdStr}'`;
+        return `${this.resolvedChildPath}/items?$select=${uniqueSelect.join(',')}&$filter=${encodeURIComponent(filter)}&$orderby=${rf.recordedAt} desc${limit ? `&$top=${limit}` : ''}`;
+      };
 
-      const response = await this.spFetch(url);
-      if (response.ok) {
-        const data: SharePointResponse<JsonRecord> = await response.json();
-        return (data.value || []).map((item: JsonRecord) => this.mapToDomain(item, rf));
+      // Try with quotes first (Text field is our default schema expectation)
+      const response = await this.spFetch(buildUrl(true));
+      const data = response.ok ? ((await response.json()) as SharePointResponse<JsonRecord>) : null;
+
+      // Fallback to numeric filtering if:
+      // 1. The value is numeric
+      // 2. AND (the first request failed with 400 OR returned no results)
+      // Some strict SharePoint environments return 400 for type mismatch, 
+      // while others return 0 results silently.
+      if (isNumeric && (!response.ok || (data && (data.value || []).length === 0))) {
+        const altRes = await this.spFetch(buildUrl(false));
+        if (altRes.ok) {
+          const altData = (await altRes.json()) as SharePointResponse<JsonRecord>;
+          // If fallback returns results, use them. Otherwise stick with the first response.
+          if ((altData.value || []).length > 0) {
+            return altData.value!.map(item => this.mapToDomain(item, rf));
+          }
+        }
+      }
+
+      if (data && data.value) {
+        return data.value.map(item => this.mapToDomain(item, rf));
       }
       console.warn(`[ExecutionRepo] Primary history query failed (status: ${response.status}), falling back...`);
     }
@@ -394,7 +426,7 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
     // 2. Fallback query: Filter by UserID + Date range and filter rows in-app
     // This is used when rowNo is missing or primary query fails.
     const fallbackSelect = uniqueSelect.filter(f => f !== rf.rowNo);
-    const fallbackFilter = `${rf.userId} eq '${normalizedUserId}' and (Created ge '${thresholdStr}' or ${rf.recordedAt} ge '${thresholdStr}')`;
+    const fallbackFilter = `${rf.userId} eq '${escapedUserId}' and (Created ge '${thresholdStr}' or ${rf.recordedAt} ge '${thresholdStr}')`;
     const fallbackUrl = `${this.resolvedChildPath}/items?$select=${fallbackSelect.join(',')}&$filter=${encodeURIComponent(fallbackFilter)}&$top=1000`;
     
     const fallbackRes = await this.spFetch(fallbackUrl);

--- a/src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts
+++ b/src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts
@@ -455,4 +455,65 @@ describe('SharePointExecutionRecordRepository', () => {
       expect(body.StaffName).toBeUndefined();
     });
   });
+
+  describe('OData Filter Robustness', () => {
+    it('escapes single quotes in userId and scheduleItemId in historical query', async () => {
+      mockSpFetch.mockReset();
+      mockSpFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ value: [] }),
+      });
+
+      // userId with quote
+      await repo.getHistoricalRecords("O'Connor", "Slot'1");
+
+      const call = mockSpFetch.mock.calls.find(c => c[0].includes('$filter'));
+      const url = decodeURIComponent(call![0]);
+      
+      expect(url).toContain("UserId eq 'O''Connor'"); // Match mock schema casing
+      expect(url).toContain("RowNo eq 'Slot''1'");
+    });
+
+    it('falls back to numeric filtering if quoted RowNo returns no results', async () => {
+      mockSpFetch.mockReset();
+      // First call (quoted) returns empty
+      mockSpFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ value: [] }),
+      });
+      // Second call (numeric) returns data
+      mockSpFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ value: [{ Id: 123, Title: 'Matched', User_x0020_ID: 'U001', RowNo: 123 }] }),
+      });
+
+      const results = await repo.getHistoricalRecords("U001", "123");
+
+      expect(mockSpFetch).toHaveBeenCalledTimes(2);
+      
+      const firstCall = decodeURIComponent(mockSpFetch.mock.calls[0][0]);
+      expect(firstCall).toContain("RowNo eq '123'");
+      
+      const secondCall = decodeURIComponent(mockSpFetch.mock.calls[1][0]);
+      expect(secondCall).toContain("RowNo eq 123");
+      
+      expect(results.length).toBe(1);
+    });
+
+    it('escapes single quotes in startswith query', async () => {
+      mockSpFetch.mockReset();
+      mockSpFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ value: [] }),
+      });
+
+      // userId with quote in rowKey prefix
+      await repo.getRecords('2024-01-01', "O'Connor");
+
+      const call = mockSpFetch.mock.calls.find(c => c[0].includes('startswith'));
+      const url = decodeURIComponent(call![0]);
+      
+      expect(url).toContain("startswith(Title, '2024-01-01-O''Connor')");
+    });
+  });
 });

--- a/src/features/daily/repositories/sharepoint/__tests__/executionRepositoryFactory.spec.ts
+++ b/src/features/daily/repositories/sharepoint/__tests__/executionRepositoryFactory.spec.ts
@@ -41,6 +41,14 @@ describe('executionRepositoryFactory', () => {
     expect(getCurrentExecutionRepositoryKind()).toBe('sharepoint');
   });
 
+  it('forces sharepoint in kiosk runtime even during dev', () => {
+    envState.isDev = true;
+    envState.dataProvider = 'local';
+    window.history.pushState({}, '', '/kiosk/users/10/procedures/0');
+
+    expect(getCurrentExecutionRepositoryKind()).toBe('sharepoint');
+  });
+
   it('respects local provider hint outside kiosk runtime', () => {
     envState.dataProvider = 'local';
     window.history.pushState({}, '', '/daily/activity');
@@ -55,4 +63,3 @@ describe('executionRepositoryFactory', () => {
     expect(getCurrentExecutionRepositoryKind()).toBe('sharepoint');
   });
 });
-

--- a/src/features/daily/repositories/sharepoint/executionRepositoryFactory.ts
+++ b/src/features/daily/repositories/sharepoint/executionRepositoryFactory.ts
@@ -55,9 +55,9 @@ const shouldUseLocalRepository = (): boolean => {
   const isKioskRuntime =
     typeof window !== 'undefined' && window.location.pathname.startsWith('/kiosk');
 
-  // Kiosk in non-dev runtime must never rely on local-only records.
-  // Even when demo/skip flags are accidentally enabled, prefer SharePoint.
-  if (isKioskRuntime && !isDev && !isTest) {
+  // Kiosk must rely on SharePoint so history and cross-device consistency work.
+  // Keep tests isolated by allowing local mode only while running test runtime.
+  if (isKioskRuntime && !isTest) {
     if (providerHint === 'local' || providerHint === 'memory' || shouldSkipLogin()) {
       console.warn(
         '[ExecutionRepositoryFactory] local/memory hint detected in kiosk runtime; forcing SharePoint adapter.',

--- a/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
@@ -39,6 +39,24 @@ export const KioskProcedureDetailScreen: React.FC = () => {
   const scheduleItemId = normalizeScheduleItemId(procedure?.rowNo) ||
     normalizeScheduleItemId(procedure?.id) ||
     normalizeScheduleItemId(slotKey);
+  const historyScheduleItemIds = React.useMemo(() => {
+    const indexValue = Number.parseInt(String(slotKey ?? ''), 10);
+    const indexPlusOne = Number.isNaN(indexValue) ? '' : normalizeScheduleItemId(indexValue + 1);
+    return [
+      normalizeScheduleItemId(procedure?.rowNo),
+      normalizeScheduleItemId(procedure?.id),
+      normalizeScheduleItemId(slotKey),
+      indexPlusOne,
+    ].filter((value, idx, arr): value is string => Boolean(value) && arr.indexOf(value) === idx);
+  }, [procedure?.id, procedure?.rowNo, slotKey]);
+  const historyUserIds = React.useMemo(() => {
+    const rawUserId = String(userId ?? '').trim();
+    const masterUserId = String(user?.UserID ?? '').trim();
+    const compactMasterUserId = masterUserId.replace(/-/g, '');
+    return [rawUserId, masterUserId, compactMasterUserId].filter(
+      (value, idx, arr): value is string => Boolean(value) && arr.indexOf(value) === idx,
+    );
+  }, [user?.UserID, userId]);
   const fallbackScheduleItemIds = React.useMemo(
     () => [normalizeScheduleItemId(slotKey)].filter((value): value is string => Boolean(value)),
     [slotKey],
@@ -437,7 +455,9 @@ export const KioskProcedureDetailScreen: React.FC = () => {
       >
         <KioskProcedureHistoryPanel
           userId={userId || ''}
+          fallbackUserIds={historyUserIds}
           scheduleItemId={scheduleItemId}
+          fallbackScheduleItemIds={historyScheduleItemIds}
           userName={user.FullName}
           procedureName={procedure.activity}
           onClose={() => setShowHistory(false)}

--- a/src/features/kiosk/components/KioskProcedureHistoryPanel.tsx
+++ b/src/features/kiosk/components/KioskProcedureHistoryPanel.tsx
@@ -25,7 +25,9 @@ import { KioskDailyProcedureFlowPreview } from './KioskDailyProcedureFlowPreview
 
 interface KioskProcedureHistoryPanelProps {
   userId: string;
+  fallbackUserIds?: string[];
   scheduleItemId: string;
+  fallbackScheduleItemIds?: string[];
   userName: string;
   procedureName: string;
   onClose: () => void;
@@ -35,14 +37,21 @@ type ViewMode = 'daily' | '7d' | '1m' | '3m';
 
 export const KioskProcedureHistoryPanel: React.FC<KioskProcedureHistoryPanelProps> = ({
   userId,
+  fallbackUserIds = [],
   scheduleItemId,
+  fallbackScheduleItemIds = [],
   userName,
   procedureName,
   onClose,
 }) => {
   const [viewMode, setViewMode] = useState<ViewMode>('daily');
   const [selectedFlowDate, setSelectedFlowDate] = useState<string | null>(null);
-  const { records, isLoading, error } = useHistoricalRecords(userId, scheduleItemId);
+  const { records, isLoading, error } = useHistoricalRecords(
+    userId,
+    scheduleItemId,
+    fallbackScheduleItemIds,
+    fallbackUserIds,
+  );
 
   const handleViewChange = (
     _event: React.MouseEvent<HTMLElement>,
@@ -289,4 +298,3 @@ export const KioskProcedureHistoryPanel: React.FC<KioskProcedureHistoryPanelProp
     </Box>
   );
 };
-

--- a/src/features/kiosk/components/KioskProcedureListScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureListScreen.tsx
@@ -189,21 +189,21 @@ export const KioskProcedureListScreen: React.FC = () => {
 
                   if (!date || source === 'none') {
                     return targetPlanningSheetId && isLoadingPlanningSheet
-                      ? '支援手順兼記録開始日: 確認中（90日参考）'
-                      : '支援手順兼記録開始日: 未設定（90日参考）';
+                      ? '支援開始日: 確認中（90日参考）'
+                      : '支援開始日: 未設定（90日参考）';
                   }
 
                   const dateStr = formatDateJapanese(date);
 
                   switch (source) {
                     case 'planning':
-                      return `支援手順兼記録開始日: ${dateStr}（90日参考・支援計画）`;
+                      return `支援開始日: ${dateStr}（90日参考・支援計画）`;
                     case 'master':
-                      return `支援手順兼記録開始日: ${dateStr}（90日参考・利用者マスタ）`;
+                      return `支援開始日: ${dateStr}（90日参考・利用者マスタ）`;
                     case 'fallback':
-                      return `[暫定] 支援手順兼記録開始日: ${dateStr}（90日参考・計画適用日）`;
+                      return `[暫定] 支援開始日: ${dateStr}（90日参考・計画適用日）`;
                     default:
-                      return `支援手順兼記録開始日: ${dateStr}（90日参考）`;
+                      return `支援開始日: ${dateStr}（90日参考）`;
                   }
                 })()}
               </Typography>

--- a/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
@@ -396,7 +396,7 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
     );
 
     await waitFor(() => {
-      expect(screen.getByText(/支援手順兼記録開始日: 2026年5月1日（90日参考・支援計画）/)).toBeInTheDocument();
+      expect(screen.getByText(/支援開始日: 2026年5月1日（90日参考・支援計画）/)).toBeInTheDocument();
     });
   });
 
@@ -417,7 +417,7 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
     );
 
     await waitFor(() => {
-      expect(screen.getByText(/支援手順兼記録開始日: 2026年4月1日（90日参考・利用者マスタ）/)).toBeInTheDocument();
+      expect(screen.getByText(/支援開始日: 2026年4月1日（90日参考・利用者マスタ）/)).toBeInTheDocument();
     });
   });
 
@@ -438,7 +438,7 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
     );
 
     await waitFor(() => {
-      expect(screen.getByText(/\[暫定\] 支援手順兼記録開始日: 2026年3月1日（90日参考・計画適用日）/)).toBeInTheDocument();
+      expect(screen.getByText(/\[暫定\] 支援開始日: 2026年3月1日（90日参考・計画適用日）/)).toBeInTheDocument();
     });
   });
 
@@ -462,7 +462,7 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
     );
 
     await waitFor(() => {
-      expect(screen.getByText(/支援手順兼記録開始日: 未設定（90日参考）/)).toBeInTheDocument();
+      expect(screen.getByText(/支援開始日: 未設定（90日参考）/)).toBeInTheDocument();
     });
   });
 
@@ -483,7 +483,7 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
     );
 
     await waitFor(() => {
-      expect(screen.getByText(/支援手順兼記録開始日: 確認中（90日参考）/)).toBeInTheDocument();
+      expect(screen.getByText(/支援開始日: 確認中（90日参考）/)).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Summary

- Clarify the kiosk procedure list support start date label
- Rename `支援手順兼記録開始日` to `支援開始日`
- Keep existing Support Date Governance resolution unchanged
- Update regression tests for planning / master / fallback / none / loading states

## Additional fix

- Improve historical record fallback resolution for kiosk procedure history
- Try multiple schedule item identifiers when loading historical records
- Pass fallback candidate IDs from the detail screen to the history panel

## Design notes

This PR does not change the support start date resolution order.

The existing priority remains:

1. Planning Sheet `supportStartDate`
2. User Master `ServiceStartDate`
3. Planning Sheet `appliedFrom` provisional fallback
4. unset / loading state

The change is limited to display wording and test expectations, plus history lookup fallback hardening.

## Checks

- [x] npm run typecheck
- [x] npx vitest run src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
- [x] npx vitest run src/features/kiosk/components/__tests__/KioskProcedureHistoryPanel.spec.tsx src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx
