### PR TITLE
fix(kiosk): update support start date label for unset state

### DIFF
--- a/src/features/kiosk/components/KioskProcedureListScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureListScreen.tsx
@@ -189,21 +189,21 @@ export const KioskProcedureListScreen: React.FC = () => {
 
                   if (!date || source === 'none') {
                     return targetPlanningSheetId && isLoadingPlanningSheet
-                      ? '支援手順兼記録開始日: 確認中（90日参考）'
-                      : '支援手順兼記録開始日: 未設定（90日参考）';
+                      ? '支援開始日: 確認中（90日参考）'
+                      : '支援開始日: 未設定（90日参考）';
                   }
 
                   const dateStr = formatDateJapanese(date);
 
                   switch (source) {
                     case 'planning':
-                      return `支援手順兼記録開始日: ${dateStr}（90日参考・支援計画）`;
+                      return `支援開始日: ${dateStr}（90日参考・支援計画）`;
                     case 'master':
-                      return `支援手順兼記録開始日: ${dateStr}（90日参考・利用者マスタ）`;
+                      return `支援開始日: ${dateStr}（90日参考・利用者マスタ）`;
                     case 'fallback':
-                      return `[暫定] 支援手順兼記録開始日: ${dateStr}（90日参考・計画適用日）`;
+                      return `[暫定] 支援開始日: ${dateStr}（90日参考・計画適用日）`;
                     default:
-                      return `支援手順兼記録開始日: ${dateStr}（90日参考）`;
+                      return `支援開始日: ${dateStr}（90日参考）`;
                   }
                 })()}
               </Typography>

--- a/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
@@ -396,7 +396,7 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
     );
 
     await waitFor(() => {
-      expect(screen.getByText(/支援手順兼記録開始日: 2026年5月1日（90日参考・支援計画）/)).toBeInTheDocument();
+      expect(screen.getByText(/支援開始日: 2026年5月1日（90日参考・支援計画）/)).toBeInTheDocument();
     });
   });
 
@@ -417,7 +417,7 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
     );
 
     await waitFor(() => {
-      expect(screen.getByText(/支援手順兼記録開始日: 2026年4月1日（90日参考・利用者マスタ）/)).toBeInTheDocument();
+      expect(screen.getByText(/支援開始日: 2026年4月1日（90日参考・利用者マスタ）/)).toBeInTheDocument();
     });
   });
 
@@ -438,7 +438,7 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
     );
 
     await waitFor(() => {
-      expect(screen.getByText(/\[暫定\] 支援手順兼記録開始日: 2026年3月1日（90日参考・計画適用日）/)).toBeInTheDocument();
+      expect(screen.getByText(/\[暫定\] 支援開始日: 2026年3月1日（90日参考・計画適用日）/)).toBeInTheDocument();
     });
   });
 
@@ -462,7 +462,7 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
     );
 
     await waitFor(() => {
-      expect(screen.getByText(/支援手順兼記録開始日: 未設定（90日参考）/)).toBeInTheDocument();
+      expect(screen.getByText(/支援開始日: 未設定（90日参考）/)).toBeInTheDocument();
     });
   });
 
@@ -483,7 +483,7 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
     );
 
     await waitFor(() => {
-      expect(screen.getByText(/支援手順兼記録開始日: 確認中（90日参考）/)).toBeInTheDocument();
+      expect(screen.getByText(/支援開始日: 確認中（90日参考）/)).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Summary

- Rename kiosk procedure list support start date label to `支援開始日`
- Fix remaining unset/loading/date-source variants that still used `支援手順兼記録開始日`
- Update regression test expectations in `KioskProcedureListScreen.spec.tsx`

## Scope

UI label and test expectation updates only. No behavior/order changes to support start date resolution.

## Checks

- [x] npx vitest run src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
