### PR TITLE
fix(kiosk): stabilize historical records retrieval for user-specific fallback

### DIFF
--- a/src/features/daily/hooks/__tests__/useHistoricalRecords.spec.ts
+++ b/src/features/daily/hooks/__tests__/useHistoricalRecords.spec.ts
@@ -1,0 +1,82 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { useHistoricalRecords } from '../useHistoricalRecords';
+import type { ExecutionRecord } from '../../domain/legacy/executionRecordTypes';
+
+const mockGetHistoricalRecords = vi.fn<(...args: unknown[]) => Promise<ExecutionRecord[]>>();
+const mockGetRecordsInRange = vi.fn<(...args: unknown[]) => Promise<ExecutionRecord[]>>();
+
+vi.mock('../useExecutionData', () => ({
+  useExecutionData: () => ({
+    getHistoricalRecords: mockGetHistoricalRecords,
+    getRecordsInRange: mockGetRecordsInRange,
+  }),
+}));
+
+const record = (id: string, date: string, scheduleItemId: string): ExecutionRecord => ({
+  id,
+  date,
+  userId: 'U001',
+  scheduleItemId,
+  status: 'completed',
+  triggeredBipIds: [],
+  memo: '',
+  recordedBy: '',
+  recordedAt: `${date}T09:00:00.000Z`,
+});
+
+describe('useHistoricalRecords', () => {
+  beforeEach(() => {
+    mockGetHistoricalRecords.mockReset();
+    mockGetRecordsInRange.mockReset();
+    mockGetRecordsInRange.mockResolvedValue([]);
+  });
+
+  it('merges results across schedule candidates instead of stopping at first hit', async () => {
+    mockGetHistoricalRecords.mockImplementation(async (_userId, scheduleItemId) => {
+      if (scheduleItemId === '0') return [record('r-2026-05-13', '2026-05-13', '0')];
+      if (scheduleItemId === '1') return [record('r-2026-05-10', '2026-05-10', '1')];
+      return [];
+    });
+
+    const scheduleFallbackIds = ['1'];
+    const fallbackUserIds: string[] = [];
+    const { result } = renderHook(() =>
+      useHistoricalRecords('U001', '0', scheduleFallbackIds, fallbackUserIds),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.records.map((r) => r.id)).toEqual(['r-2026-05-13', 'r-2026-05-10']);
+  });
+
+  it('backfills from range query even when primary history already has hits', async () => {
+    mockGetHistoricalRecords.mockResolvedValue([
+      record('r-2026-05-13', '2026-05-13', '1'),
+      record('r-2026-05-08', '2026-05-08', '1'),
+    ]);
+    mockGetRecordsInRange.mockResolvedValue([
+      record('r-2026-05-06', '2026-05-06', '1'),
+      record('r-2026-05-05', '2026-05-05', '1'),
+    ]);
+
+    const scheduleFallbackIds = ['1'];
+    const fallbackUserIds: string[] = [];
+    const { result } = renderHook(() =>
+      useHistoricalRecords('U001', '1', scheduleFallbackIds, fallbackUserIds),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.records.map((r) => r.id)).toEqual([
+      'r-2026-05-13',
+      'r-2026-05-08',
+      'r-2026-05-06',
+      'r-2026-05-05',
+    ]);
+  });
+});

--- a/src/features/daily/hooks/useHistoricalRecords.ts
+++ b/src/features/daily/hooks/useHistoricalRecords.ts
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { useExecutionData } from './useExecutionData';
 import type { ExecutionRecord } from '../domain/legacy/executionRecordTypes';
 import { normalizeScheduleItemId } from '../utils/normalizeScheduleItemId';
-import { normalizeExecutionUserId } from '../utils/normalizeExecutionLookup';
+import { buildExecutionUserIdCandidates } from '../utils/normalizeExecutionLookup';
 
 export function useHistoricalRecords(
   userId: string,
@@ -29,11 +29,7 @@ export function useHistoricalRecords(
     setIsLoading(true);
     setError(null);
     try {
-      const primaryUserId = normalizeExecutionUserId(userId);
-      const normalizedFallbackUserIds = fallbackUserIds
-        .map((id) => normalizeExecutionUserId(id))
-        .filter((id) => Boolean(id) && id !== primaryUserId);
-      const userCandidates = [primaryUserId, ...normalizedFallbackUserIds];
+      const userCandidates = buildExecutionUserIdCandidates(userId, ...fallbackUserIds);
 
       const primaryId = normalizeScheduleItemId(scheduleItemId);
       const fallbackIds = fallbackScheduleItemIds
@@ -41,44 +37,73 @@ export function useHistoricalRecords(
         .filter((id) => Boolean(id) && id !== primaryId);
       const scheduleCandidates = [primaryId, ...fallbackIds];
 
+      const byId = new Map<string, ExecutionRecord>();
+      const buildStableKey = (item: ExecutionRecord): string => {
+        const explicitId = String(item.id ?? '').trim();
+        if (explicitId) return explicitId;
+        const date = String(item.date ?? '').trim();
+        const uid = String(item.userId ?? '').trim();
+        const sid = String(item.scheduleItemId ?? '').trim();
+        const recordedAt = String(item.recordedAt ?? '').trim();
+        return `${date}::${uid}::${sid}::${recordedAt}`;
+      };
+      const merge = (items: ExecutionRecord[]) => {
+        for (const item of items) {
+          const key = buildStableKey(item);
+          if (!key || key === '::::') continue;
+          const existing = byId.get(key);
+          if (!existing) {
+            byId.set(key, item);
+            continue;
+          }
+          const existingKey = existing.recordedAt || existing.id;
+          const nextKey = item.recordedAt || item.id;
+          if (nextKey > existingKey) {
+            byId.set(key, item);
+          }
+        }
+      };
+
       let history: ExecutionRecord[] = [];
       for (const candidateUserId of userCandidates) {
         for (const candidateScheduleId of scheduleCandidates) {
-          history = await getHistoricalRecordsRef.current(candidateUserId, candidateScheduleId, 150);
-          if (history.length > 0) break;
-        }
-        if (history.length > 0) break;
-      }
-
-      // Second fallback: pull recent range and filter in-app.
-      if (history.length === 0) {
-        const to = new Date();
-        const from = new Date();
-        from.setDate(from.getDate() - 95);
-        const toStr = to.toISOString().slice(0, 10);
-        const fromStr = from.toISOString().slice(0, 10);
-        const scheduleSet = new Set(scheduleCandidates.map((id) => normalizeScheduleItemId(id)));
-
-        const isScheduleMatch = (value: unknown): boolean => {
-          const normalized = normalizeScheduleItemId(value);
-          if (!normalized) return false;
-          if (scheduleSet.has(normalized)) return true;
-          const trailing = normalized.match(/\d+$/)?.[0];
-          return Boolean(trailing && scheduleSet.has(trailing));
-        };
-
-        for (const candidateUserId of userCandidates) {
-          const rangeRecords = await getRecordsInRangeRef.current(candidateUserId, fromStr, toStr);
-          const matched = rangeRecords
-            .filter((record) => isScheduleMatch(record.scheduleItemId))
-            .sort((a, b) => (b.recordedAt || b.id).localeCompare(a.recordedAt || a.id))
-            .slice(0, 150);
-          if (matched.length > 0) {
-            history = matched;
-            break;
-          }
+          const result = await getHistoricalRecordsRef.current(candidateUserId, candidateScheduleId, 150);
+          merge(result);
         }
       }
+      history = Array.from(byId.values())
+        .sort((a, b) => (b.recordedAt || b.id).localeCompare(a.recordedAt || a.id))
+        .slice(0, 150);
+
+      // Range backfill: pull recent records and merge in-app matches.
+      // Do this even when primary has hits, because legacy/migrated rows can be missed by direct query.
+      const to = new Date();
+      const from = new Date();
+      from.setDate(from.getDate() - 95);
+      const toStr = to.toISOString().slice(0, 10);
+      const fromStr = from.toISOString().slice(0, 10);
+      const scheduleSet = new Set(scheduleCandidates.map((id) => normalizeScheduleItemId(id)));
+
+      const isScheduleMatch = (value: unknown): boolean => {
+        const normalized = normalizeScheduleItemId(value);
+        if (!normalized) return false;
+        if (scheduleSet.has(normalized)) return true;
+        const trailing = normalized.match(/\d+$/)?.[0];
+        return Boolean(trailing && scheduleSet.has(trailing));
+      };
+
+      for (const candidateUserId of userCandidates) {
+        const rangeRecords = await getRecordsInRangeRef.current(candidateUserId, fromStr, toStr);
+        const matched = rangeRecords
+          .filter((record) => isScheduleMatch(record.scheduleItemId))
+          .sort((a, b) => (b.recordedAt || b.id).localeCompare(a.recordedAt || a.id));
+        if (matched.length > 0) {
+          merge(matched);
+        }
+      }
+      history = Array.from(byId.values())
+        .sort((a, b) => (b.recordedAt || b.id).localeCompare(a.recordedAt || a.id))
+        .slice(0, 150);
       setRecords(history);
     } catch (err) {
       console.error('[useHistoricalRecords] Failed to fetch history:', err);

--- a/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
+++ b/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
@@ -44,6 +44,10 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
   private initPromises = new Map<string, Promise<void>>();
   private entityTypes = new Map<string, string>();
 
+  private escapeODataString(value: string): string {
+    return value.replace(/'/g, "''");
+  }
+
   constructor(options: SharePointExecutionRecordRepositoryOptions) {
     this.spFetch = options.spFetch;
     this.getListFieldInternalNames = options.getListFieldInternalNames;
@@ -361,6 +365,8 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
   ): Promise<ExecutionRecord[]> {
     const normalizedUserId = normalizeExecutionUserId(userId);
     const normalizedScheduleItemId = normalizeScheduleItemId(scheduleItemId);
+    const escapedUserId = this.escapeODataString(normalizedUserId);
+    const escapedScheduleItemId = this.escapeODataString(normalizedScheduleItemId);
     const rf = await this.getResolvedFields();
     
     // Safety: Limit history to approx 3 months to prevent large data transfers
@@ -380,21 +386,33 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
 
     // 1. Primary query: Try direct filtering ONLY if rowNo is physically resolved
     if (rf.rowNo) {
-      const filter = `${rf.userId} eq '${normalizedUserId}' and ${rf.rowNo} eq '${normalizedScheduleItemId}' and ${rf.recordedAt} ge '${thresholdStr}'`;
-      const url = `${this.resolvedChildPath}/items?$select=${uniqueSelect.join(',')}&$filter=${encodeURIComponent(filter)}&$orderby=${rf.recordedAt} desc${limit ? `&$top=${limit}` : ''}`;
-
-      const response = await this.spFetch(url);
-      if (response.ok) {
+      const runPrimary = async (rowNoExpr: string): Promise<ExecutionRecord[] | null> => {
+        const filter = `${rf.userId} eq '${escapedUserId}' and ${rf.rowNo} eq ${rowNoExpr} and ${rf.recordedAt} ge '${thresholdStr}'`;
+        const url = `${this.resolvedChildPath}/items?$select=${uniqueSelect.join(',')}&$filter=${encodeURIComponent(filter)}&$orderby=${rf.recordedAt} desc${limit ? `&$top=${limit}` : ''}`;
+        const response = await this.spFetch(url);
+        if (!response.ok) {
+          console.warn(`[ExecutionRepo] Primary history query failed (status: ${response.status}), fallback step next...`);
+          return null;
+        }
         const data: SharePointResponse<JsonRecord> = await response.json();
         return (data.value || []).map((item: JsonRecord) => this.mapToDomain(item, rf));
+      };
+
+      // Step 1: text comparison
+      const textPrimary = await runPrimary(`'${escapedScheduleItemId}'`);
+      if (textPrimary && textPrimary.length > 0) return textPrimary;
+
+      // Step 2: numeric fallback (for Number rowNo columns)
+      if (/^\d+$/.test(normalizedScheduleItemId)) {
+        const numberPrimary = await runPrimary(String(Number.parseInt(normalizedScheduleItemId, 10)));
+        if (numberPrimary && numberPrimary.length > 0) return numberPrimary;
       }
-      console.warn(`[ExecutionRepo] Primary history query failed (status: ${response.status}), falling back...`);
     }
 
     // 2. Fallback query: Filter by UserID + Date range and filter rows in-app
     // This is used when rowNo is missing or primary query fails.
     const fallbackSelect = uniqueSelect.filter(f => f !== rf.rowNo);
-    const fallbackFilter = `${rf.userId} eq '${normalizedUserId}' and (Created ge '${thresholdStr}' or ${rf.recordedAt} ge '${thresholdStr}')`;
+    const fallbackFilter = `${rf.userId} eq '${escapedUserId}' and (Created ge '${thresholdStr}' or ${rf.recordedAt} ge '${thresholdStr}')`;
     const fallbackUrl = `${this.resolvedChildPath}/items?$select=${fallbackSelect.join(',')}&$filter=${encodeURIComponent(fallbackFilter)}&$top=1000`;
     
     const fallbackRes = await this.spFetch(fallbackUrl);

--- a/src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts
+++ b/src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts
@@ -395,6 +395,45 @@ describe('SharePointExecutionRecordRepository', () => {
   });
 
   describe('Strict Field Filtering Regressions', () => {
+    it('retries historical query with numeric RowNo when text comparison returns empty', async () => {
+      mockSpFetch.mockReset();
+      mockSpFetch.mockImplementation(async (url: string) => {
+        if (url.includes('/items?$select=') && url.includes('$orderby=')) {
+          const decoded = decodeURIComponent(url);
+          if (decoded.includes("RowNo eq '1'")) {
+            return { ok: true, json: async () => ({ value: [] }) };
+          }
+          if (decoded.includes('RowNo eq 1')) {
+            return {
+              ok: true,
+              json: async () => ({
+                value: [
+                  {
+                    Id: 1,
+                    Title: '2026-05-10-U010-1',
+                    UserId: 'U010',
+                    RowNo: 1,
+                    Status: 'completed',
+                    Payload: 'memo',
+                    RecordedAt: '2026-05-10T09:00:00Z',
+                    Created: '2026-05-10T09:00:00Z',
+                  },
+                ],
+              }),
+            };
+          }
+        }
+        return { ok: true, json: async () => ({ value: [] }) };
+      });
+
+      const records = await repo.getHistoricalRecords('U010', '1');
+      expect(records.length).toBe(1);
+
+      const calls = mockSpFetch.mock.calls.map((call) => decodeURIComponent(String(call[0])));
+      expect(calls.some((u) => u.includes("RowNo eq '1'"))).toBe(true);
+      expect(calls.some((u) => u.includes('RowNo eq 1'))).toBe(true);
+    });
+
     it('excludes RowNo from historical query URL when unresolved', async () => {
       mockSpFetch.mockReset();
       mockSpFetch.mockResolvedValue({

--- a/src/features/daily/utils/__tests__/normalizeExecutionLookup.spec.ts
+++ b/src/features/daily/utils/__tests__/normalizeExecutionLookup.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { buildExecutionUserIdCandidates } from '../normalizeExecutionLookup';
+
+describe('buildExecutionUserIdCandidates', () => {
+  it('builds stable variants for numeric user id', () => {
+    const candidates = buildExecutionUserIdCandidates('10');
+    expect(candidates).toContain('10');
+    expect(candidates).toContain('U10');
+    expect(candidates).toContain('U010');
+    expect(candidates).toContain('U-010');
+  });
+
+  it('keeps unique candidates when mixed formats are provided', () => {
+    const candidates = buildExecutionUserIdCandidates('10', 'U-010', 'U010');
+    expect(new Set(candidates).size).toBe(candidates.length);
+  });
+});

--- a/src/features/daily/utils/normalizeExecutionLookup.ts
+++ b/src/features/daily/utils/normalizeExecutionLookup.ts
@@ -9,4 +9,37 @@ export const normalizeExecutionDate = (value: unknown): string => {
 
 export const normalizeExecutionUserId = (value: unknown): string => String(value ?? '').trim();
 
+export const buildExecutionUserIdCandidates = (...values: unknown[]): string[] => {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  const push = (value: string) => {
+    const normalized = normalizeExecutionUserId(value);
+    if (!normalized || seen.has(normalized)) return;
+    seen.add(normalized);
+    out.push(normalized);
+  };
+
+  for (const value of values) {
+    const raw = normalizeExecutionUserId(value);
+    if (!raw) continue;
+    push(raw);
+    push(raw.toUpperCase());
+    push(raw.replace(/-/g, ''));
+
+    const compact = raw.replace(/-/g, '').toUpperCase();
+    const digitMatch = compact.match(/^U?(\d+)$/);
+    if (!digitMatch) continue;
+
+    const digits = digitMatch[1];
+    const noPad = String(Number.parseInt(digits, 10));
+    const pad3 = digits.padStart(3, '0');
+    push(noPad);
+    push(`U${digits}`);
+    push(`U${pad3}`);
+    push(`U-${pad3}`);
+  }
+
+  return out;
+};
+
 export { normalizeScheduleItemId };

--- a/src/features/kiosk/components/KioskProcedureHistoryPanel.tsx
+++ b/src/features/kiosk/components/KioskProcedureHistoryPanel.tsx
@@ -150,6 +150,7 @@ export const KioskProcedureHistoryPanel: React.FC<KioskProcedureHistoryPanelProp
                       </Stack>
                     </Stack>
                   }
+                  secondaryTypographyProps={{ component: 'div' }}
                   secondary={
                     <Stack spacing={1.5} sx={{ mt: 1 }}>
                       <Typography variant="body2" color="text.primary" sx={{ whiteSpace: 'pre-wrap' }}>


### PR DESCRIPTION
## Summary

- Stabilize kiosk historical records retrieval by merging across user/schedule fallback candidates
- Add robust execution userId candidate generation (`10`, `U10`, `U010`, `U-010`)
- Add RowNo text-to-number fallback query in SharePoint execution history repository
- Always backfill with range query and merge results to avoid partial day-only history
- Fix history panel DOM nesting warning (`div` inside `p`) by rendering secondary content as `div`
- Add regression tests for historical merge/fallback paths and userId candidate normalization

## Scope

Kiosk history retrieval robustness + UI warning fix. No schema/list changes.

## Checks

- [x] npx vitest run src/features/daily/hooks/__tests__/useHistoricalRecords.spec.ts src/features/daily/utils/__tests__/normalizeExecutionLookup.spec.ts src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts src/features/kiosk/components/__tests__/KioskProcedureHistoryPanel.spec.tsx
