### PR TITLE
fix(kiosk): prevent abc deep-link return loops after PR #1896

### DIFF
--- a/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
@@ -87,6 +87,7 @@ export const KioskProcedureDetailScreen: React.FC = () => {
       source: 'daily-support',
       date: selectedDateIso,
       slotId: abcSlotId,
+      kiosk: '1',
       returnUrl: `/kiosk/users/${encodeURIComponent(returnRouteUserId)}/procedures/${encodeURIComponent(String(slotKey ?? ''))}?${returnParams.toString()}`,
     });
     return `/abc-record?${params.toString()}`;

--- a/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
@@ -31,6 +31,11 @@ export const KioskProcedureDetailScreen: React.FC = () => {
     if (canonical) return canonical;
     return String(userId ?? '').trim();
   }, [user?.UserID, userId]);
+  const returnRouteUserId = React.useMemo(() => {
+    const routeId = String(userId ?? '').trim();
+    if (routeId) return routeId;
+    return deepLinkUserId;
+  }, [deepLinkUserId, userId]);
   
   const procedure = React.useMemo(() => {
     if (!userId || slotKey === undefined) return null;
@@ -82,10 +87,10 @@ export const KioskProcedureDetailScreen: React.FC = () => {
       source: 'daily-support',
       date: selectedDateIso,
       slotId: abcSlotId,
-      returnUrl: `/kiosk/users/${encodeURIComponent(deepLinkUserId)}/procedures/${encodeURIComponent(String(slotKey ?? ''))}?${returnParams.toString()}`,
+      returnUrl: `/kiosk/users/${encodeURIComponent(returnRouteUserId)}/procedures/${encodeURIComponent(String(slotKey ?? ''))}?${returnParams.toString()}`,
     });
     return `/abc-record?${params.toString()}`;
-  }, [abcSlotId, deepLinkUserId, selectedDateIso, slotKey, userId]);
+  }, [abcSlotId, deepLinkUserId, returnRouteUserId, selectedDateIso, slotKey]);
   const { record, saveRecord, isLoading } = useExecutionRecord(
     selectedDateIso,
     userId || '',

--- a/src/features/kiosk/components/KioskProcedureListScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureListScreen.tsx
@@ -89,6 +89,7 @@ export const KioskProcedureListScreen: React.FC = () => {
       source: 'daily-support',
       date: selectedDateIso,
       slotId,
+      kiosk: '1',
       returnUrl: `/kiosk/users/${encodeURIComponent(returnRouteUserId)}/procedures?${returnParams.toString()}`,
     });
     return `/abc-record?${params.toString()}`;

--- a/src/features/kiosk/components/KioskProcedureListScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureListScreen.tsx
@@ -34,6 +34,11 @@ export const KioskProcedureListScreen: React.FC = () => {
     if (canonical) return canonical;
     return String(userId ?? '').trim();
   }, [user?.UserID, userId]);
+  const returnRouteUserId = React.useMemo(() => {
+    const routeId = String(userId ?? '').trim();
+    if (routeId) return routeId;
+    return deepLinkUserId;
+  }, [deepLinkUserId, userId]);
 
   const procedures = React.useMemo(() => {
     if (!userId) return [];
@@ -84,10 +89,10 @@ export const KioskProcedureListScreen: React.FC = () => {
       source: 'daily-support',
       date: selectedDateIso,
       slotId,
-      returnUrl: `/kiosk/users/${encodeURIComponent(deepLinkUserId)}/procedures?${returnParams.toString()}`,
+      returnUrl: `/kiosk/users/${encodeURIComponent(returnRouteUserId)}/procedures?${returnParams.toString()}`,
     });
     return `/abc-record?${params.toString()}`;
-  }, [deepLinkUserId, selectedDateIso]);
+  }, [deepLinkUserId, returnRouteUserId, selectedDateIso]);
 
   // 実施記録の取得
   useEffect(() => {

--- a/src/pages/abc-record/AbcRecordPage.tsx
+++ b/src/pages/abc-record/AbcRecordPage.tsx
@@ -61,6 +61,8 @@ const AbcRecordPage: React.FC = () => {
   const [deepLinkProcessed, setDeepLinkProcessed] = useState(false);
   const [deepLinkBanner, setDeepLinkBanner] = useState(false);
 
+  const currentPathWithSearch = `${location.pathname}${location.search}`;
+
   const safeReturnUrl = useMemo(() => {
     if (!urlReturnUrl) return null;
     try {
@@ -74,15 +76,28 @@ const AbcRecordPage: React.FC = () => {
         const date = parsed.searchParams.get('date');
         if (date) params.set('date', date);
         const query = params.toString();
-        return `${parsed.pathname}${query ? `?${query}` : ''}`;
+        const sanitized = `${parsed.pathname}${query ? `?${query}` : ''}`;
+        if (sanitized === currentPathWithSearch) return null;
+        return sanitized;
       }
 
-      return `${parsed.pathname}${parsed.search}`;
+      const direct = `${parsed.pathname}${parsed.search}`;
+      if (direct === currentPathWithSearch) return null;
+      return direct;
     } catch {
       if (urlReturnUrl.startsWith('/abc-record')) return null;
+      if (urlReturnUrl === currentPathWithSearch) return null;
       return urlReturnUrl;
     }
-  }, [urlReturnUrl]);
+  }, [currentPathWithSearch, urlReturnUrl]);
+
+  const fallbackKioskReturnUrl = useMemo(() => {
+    if (source !== 'daily-support' || !urlUserId) return null;
+    const params = new URLSearchParams();
+    if (urlDate) params.set('date', urlDate);
+    const query = params.toString();
+    return `/kiosk/users/${encodeURIComponent(urlUserId)}/procedures${query ? `?${query}` : ''}`;
+  }, [source, urlDate, urlUserId]);
 
   // ── daily-support からの遷移コンテキスト ──
   const supportContext = useMemo(() => {
@@ -161,15 +176,18 @@ const AbcRecordPage: React.FC = () => {
   const handleBack = useCallback(() => {
     if (source === 'support-planning') {
       navigate(-1);
-    } else if (source === 'daily-support' && safeReturnUrl) {
-      // 支援手順の元のユーザー・ステップへ正確に戻る
-      navigate(safeReturnUrl, { replace: true });
     } else if (source === 'daily-support') {
-      navigate(-1);
+      // returnUrl が自己参照/壊れていても、kiosk 側へ戻す
+      const backTarget = safeReturnUrl ?? fallbackKioskReturnUrl;
+      if (backTarget) {
+        navigate(backTarget, { replace: true });
+      } else {
+        navigate(-1);
+      }
     } else {
       navigate('/daily/support');
     }
-  }, [source, navigate, safeReturnUrl]);
+  }, [source, navigate, safeReturnUrl, fallbackKioskReturnUrl]);
 
   return (
     <Box sx={{ p: { xs: 2, md: 3 }, pb: 4, maxWidth: 800, mx: 'auto' }}>

--- a/src/pages/abc-record/AbcRecordPage.tsx
+++ b/src/pages/abc-record/AbcRecordPage.tsx
@@ -92,12 +92,25 @@ const AbcRecordPage: React.FC = () => {
   }, [currentPathWithSearch, urlReturnUrl]);
 
   const fallbackKioskReturnUrl = useMemo(() => {
-    if (source !== 'daily-support' || !urlUserId) return null;
+    if (source !== 'daily-support') return null;
+    let fallbackUserId = urlUserId ?? '';
+    if (urlReturnUrl) {
+      try {
+        const parsed = new URL(urlReturnUrl, window.location.origin);
+        const matched = parsed.pathname.match(/^\/kiosk\/users\/([^/]+)\/procedures(?:\/.*)?$/);
+        if (matched?.[1]) {
+          fallbackUserId = decodeURIComponent(matched[1]);
+        }
+      } catch {
+        // no-op
+      }
+    }
+    if (!fallbackUserId) return null;
     const params = new URLSearchParams();
     if (urlDate) params.set('date', urlDate);
     const query = params.toString();
-    return `/kiosk/users/${encodeURIComponent(urlUserId)}/procedures${query ? `?${query}` : ''}`;
-  }, [source, urlDate, urlUserId]);
+    return `/kiosk/users/${encodeURIComponent(fallbackUserId)}/procedures${query ? `?${query}` : ''}`;
+  }, [source, urlDate, urlReturnUrl, urlUserId]);
 
   // ── daily-support からの遷移コンテキスト ──
   const supportContext = useMemo(() => {


### PR DESCRIPTION
## Summary
- guard /abc-record returnUrl against self-referential navigation loops
- stabilize kiosk return navigation using route user id for returnUrl path
- keep kiosk mode on Kiosk -> /abc-record deep links via kiosk=1

## Why
Production at /kiosk showed return-loop/loading issues because these post-merge fixes were not included in merged PR #1896.

## Scope
- deep link safety only
- no sync changes
- save destination remains AbcBehaviorRecords

## Acceptance Criteria
- \/abc-record does not navigate back to itself via returnUrl
- Kiosk back navigation returns to kiosk procedures for the same route user id
- Kiosk-originated /abc-record opens in kiosk mode
