### PR TITLE
feat(planning-sheet): expose dedicated ABC evidence for evaluation

### DIFF
--- a/src/domain/abc/abcRecord.ts
+++ b/src/domain/abc/abcRecord.ts
@@ -112,6 +112,12 @@ export interface AbcRecordRepository {
   getAll(): Promise<AbcRecord[]>;
   /** 利用者 ID で絞り込み */
   getByUserId(userId: string): Promise<AbcRecord[]>;
+  /** 利用者 ID と日付範囲で絞り込み (IsDeleted=true除外、期間境界値含む) */
+  findByUserIdAndDateRange(input: {
+    userId: string;
+    from: string;
+    to: string;
+  }): Promise<AbcRecord[]>;
   /** ID で1件取得 */
   getById(id: string): Promise<AbcRecord | null>;
   /** 削除 */

--- a/src/features/monitoring/components/AbcEvidenceListPanel.tsx
+++ b/src/features/monitoring/components/AbcEvidenceListPanel.tsx
@@ -1,0 +1,224 @@
+import React from 'react';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Chip from '@mui/material/Chip';
+import Divider from '@mui/material/Divider';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemText from '@mui/material/ListItemText';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import CircularProgress from '@mui/material/CircularProgress';
+import Alert from '@mui/material/Alert';
+import AssessmentRoundedIcon from '@mui/icons-material/AssessmentRounded';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import type { AbcRecord } from '@/domain/abc/abcRecord';
+
+export interface AbcEvidenceListPanelProps {
+  records: AbcRecord[];
+  loading: boolean;
+  error: Error | null;
+  period: {
+    from: string;
+    to: string;
+    isProvisional: boolean;
+    source: 'planning' | 'master' | 'fallback' | 'none';
+  } | null;
+}
+
+export const AbcEvidenceListPanel: React.FC<AbcEvidenceListPanelProps> = ({
+  records,
+  loading,
+  error,
+  period,
+}) => {
+  if (loading) {
+    return (
+      <Card variant="outlined" sx={{ borderStyle: 'dashed', bgcolor: '#fbfcfe' }}>
+        <CardContent>
+          <Stack direction="row" spacing={2} alignItems="center" justifyContent="center" py={1}>
+            <CircularProgress size={20} color="primary" />
+            <Typography variant="body2" color="text.secondary" fontWeight={600}>
+              Dedicated ABC 根拠候補を取得中...
+            </Typography>
+          </Stack>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Alert severity="warning" variant="outlined" sx={{ borderRadius: 3 }}>
+        Dedicated ABC 記録の取得に失敗しました: {error.message}
+      </Alert>
+    );
+  }
+
+  if (!period) {
+    return null;
+  }
+
+  return (
+    <Card
+      variant="outlined"
+      sx={{
+        borderRadius: 3,
+        borderColor: '#93c5fd',
+        bgcolor: '#f0f9ff',
+        boxShadow: '0 2px 10px rgba(147, 197, 253, 0.08)',
+        overflow: 'visible',
+      }}
+    >
+      <CardContent sx={{ p: 2.5, '&:last-child': { pb: 2.5 } }}>
+        {/* ヘッダー */}
+        <Stack spacing={1}>
+          <Stack direction="row" alignItems="center" justifyContent="space-between" flexWrap="wrap" useFlexGap>
+            <Stack direction="row" spacing={1} alignItems="center">
+              <AssessmentRoundedIcon color="primary" />
+              <Typography variant="subtitle2" fontWeight={800} color="primary.dark">
+                評価対象期間の Dedicated ABC 記録（評価根拠候補）
+              </Typography>
+            </Stack>
+
+            <Stack direction="row" spacing={1} alignItems="center">
+              {period.isProvisional && (
+                <Chip
+                  label="暫定期間"
+                  size="small"
+                  color="warning"
+                  variant="filled"
+                  sx={{ fontWeight: 700, fontSize: '0.65rem', height: 20 }}
+                />
+              )}
+              <Chip
+                label={`期間: ${period.from} 〜 ${period.to}`}
+                size="small"
+                variant="outlined"
+                color="primary"
+                sx={{ fontWeight: 600, fontSize: '0.7rem', height: 20 }}
+              />
+            </Stack>
+          </Stack>
+
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+            <InfoOutlinedIcon sx={{ fontSize: 14 }} />
+            {period.source === 'planning' && '支援開始日（モニタリング起点）から算出された評価期間内の記録です。'}
+            {period.source === 'master' && '支援計画に開始日がないため、利用者マスタの支援開始日から算出された評価期間内の記録です。'}
+            {period.source === 'fallback' && '適用開始日仮設定に基づく、暫定的な評価期間内の記録です（監査エビデンスとしては確認が必要です）。'}
+          </Typography>
+        </Stack>
+
+        <Divider sx={{ my: 1.5, borderColor: '#bfdbfe' }} />
+
+        {records.length === 0 ? (
+          <Typography variant="body2" color="text.secondary" align="center" py={2} sx={{ fontStyle: 'italic' }}>
+            この期間内に登録された Dedicated ABC 記録はありません。
+          </Typography>
+        ) : (
+          <Stack spacing={1.5}>
+            <Typography variant="caption" fontWeight={700} color="text.secondary">
+              登録済みの ABC 記録（全 {records.length} 件）:
+            </Typography>
+
+            <List disablePadding sx={{ maxHeight: 260, overflowY: 'auto', pr: 1 }}>
+              {records.map((rec) => {
+                const sourceContext = rec.sourceContext;
+                const dateText = sourceContext?.date || rec.occurredAt.slice(0, 10);
+                const slotId = sourceContext?.slotId;
+                const slotText = slotId ? slotId.split('|')[1] || slotId : '（スロットなし）';
+
+                const source = sourceContext?.source;
+                const isKiosk = source === 'standalone' && sourceContext?.returnUrl?.includes('kiosk');
+
+                let sourceLabel = '由来不明/旧データ';
+                let sourceColor: 'default' | 'primary' | 'secondary' = 'default';
+
+                if (source === 'daily-support') {
+                  sourceLabel = '支援手順起点';
+                  sourceColor = 'primary';
+                } else if (source === 'standalone') {
+                  if (isKiosk) {
+                    sourceLabel = 'キオスク・支援手順起点';
+                    sourceColor = 'secondary';
+                  } else {
+                    sourceLabel = '専用ABC画面起点';
+                    sourceColor = 'secondary';
+                  }
+                }
+
+                let intensityColor: 'default' | 'primary' | 'warning' | 'error' = 'default';
+                let intensityText = '未入力';
+
+                if (rec.intensity === 'high') {
+                  intensityColor = 'error';
+                  intensityText = '重度';
+                } else if (rec.intensity === 'medium') {
+                  intensityColor = 'warning';
+                  intensityText = '中度';
+                } else if (rec.intensity === 'low') {
+                  intensityColor = 'primary';
+                  intensityText = '軽度';
+                }
+
+                return (
+                  <ListItem
+                    key={rec.id}
+                    divider
+                    disableGutters
+                    sx={{
+                      py: 1,
+                      alignItems: 'flex-start',
+                      '&:last-child': { borderBottom: 'none' },
+                    }}
+                  >
+                    <ListItemText
+                      primary={
+                        <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap sx={{ mb: 0.5 }}>
+                          <Typography variant="caption" fontWeight={700} color="text.primary">
+                            {dateText}
+                          </Typography>
+                          <Typography variant="caption" color="text.secondary">
+                            {slotText}
+                          </Typography>
+                          <Chip
+                            label={sourceLabel}
+                            size="small"
+                            color={sourceColor}
+                            variant="outlined"
+                            sx={{ height: 16, fontSize: '0.6rem', px: 0.5, '& .MuiChip-label': { px: 0.5 } }}
+                          />
+                          <Chip
+                            label={`強度: ${intensityText}`}
+                            size="small"
+                            color={intensityColor}
+                            sx={{ height: 16, fontSize: '0.6rem', px: 0.5, '& .MuiChip-label': { px: 0.5 } }}
+                          />
+                        </Stack>
+                      }
+                      secondary={
+                        <Stack spacing={0.25} sx={{ pl: 1, borderLeft: '2px solid #cbd5e1' }}>
+                          <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+                            <strong style={{ color: '#1e40af' }}>先行(A):</strong> {rec.antecedent || '未入力'}
+                          </Typography>
+                          <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+                            <strong style={{ color: '#b91c1c' }}>行動(B):</strong> {rec.behavior || '未入力'}
+                          </Typography>
+                          <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+                            <strong style={{ color: '#15803d' }}>結果(C):</strong> {rec.consequence || '未入力'}
+                          </Typography>
+                        </Stack>
+                      }
+                    />
+                  </ListItem>
+                );
+              })}
+            </List>
+          </Stack>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default AbcEvidenceListPanel;

--- a/src/features/monitoring/components/__tests__/AbcEvidenceListPanel.spec.tsx
+++ b/src/features/monitoring/components/__tests__/AbcEvidenceListPanel.spec.tsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { AbcEvidenceListPanel } from '../AbcEvidenceListPanel';
+import type { AbcRecord } from '@/domain/abc/abcRecord';
+
+describe('AbcEvidenceListPanel', () => {
+  const mockPeriod = {
+    from: '2026-05-01',
+    to: '2026-07-30',
+    isProvisional: false,
+    source: 'planning' as const,
+  };
+
+  const mockRecords: AbcRecord[] = [
+    {
+      id: 'rec_1',
+      userId: 'I009',
+      userName: '利用者A',
+      occurredAt: '2026-05-13T09:30:00.000Z',
+      setting: '通所',
+      antecedent: '朝の準備で名前を呼ばれた',
+      behavior: '机を叩いた',
+      consequence: '職員が別の場所に誘導した',
+      intensity: 'medium',
+      durationMinutes: 5,
+      riskFlag: false,
+      recorderName: '職員A',
+      tags: [],
+      notes: '',
+      createdAt: '2026-05-13T09:31:00.000Z',
+      sourceContext: {
+        source: 'daily-support',
+        date: '2026-05-13',
+        slotId: '9:30頃|通所・朝の準備',
+      },
+    },
+    {
+      id: 'rec_2',
+      userId: 'I009',
+      userName: '利用者A',
+      occurredAt: '2026-05-15T15:00:00.000Z',
+      setting: '食堂',
+      antecedent: 'おやつを待っている間',
+      behavior: '大声をあげた',
+      consequence: 'おやつを渡した',
+      intensity: 'high',
+      durationMinutes: 10,
+      riskFlag: true,
+      recorderName: '職員B',
+      tags: [],
+      notes: '',
+      createdAt: '2026-05-15T15:01:00.000Z',
+      sourceContext: {
+        source: 'standalone',
+        date: '2026-05-15',
+        returnUrl: '/kiosk/users/10',
+      },
+    },
+  ];
+
+  it('ローディング中は読込中メッセージが表示されること', () => {
+    render(
+      <AbcEvidenceListPanel
+        records={[]}
+        loading={true}
+        error={null}
+        period={null}
+      />
+    );
+
+    expect(screen.getByText('Dedicated ABC 根拠候補を取得中...')).toBeInTheDocument();
+  });
+
+  it('エラー時はエラーメッセージが表示されること', () => {
+    const error = new Error('SharePoint接続エラー');
+    render(
+      <AbcEvidenceListPanel
+        records={[]}
+        loading={false}
+        error={error}
+        period={null}
+      />
+    );
+
+    expect(screen.getByText('Dedicated ABC 記録の取得に失敗しました: SharePoint接続エラー')).toBeInTheDocument();
+  });
+
+  it('期間情報がない場合は何も表示されないこと', () => {
+    const { container } = render(
+      <AbcEvidenceListPanel
+        records={[]}
+        loading={false}
+        error={null}
+        period={null}
+      />
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('データが0件の場合は空のメッセージが表示されること', () => {
+    render(
+      <AbcEvidenceListPanel
+        records={[]}
+        loading={false}
+        error={null}
+        period={mockPeriod}
+      />
+    );
+
+    expect(screen.getByText('この期間内に登録された Dedicated ABC 記録はありません。')).toBeInTheDocument();
+    expect(screen.getByText('期間: 2026-05-01 〜 2026-07-30')).toBeInTheDocument();
+  });
+
+  it('暫定期間フラグがある場合は【暫定期間】バッジが表示されること', () => {
+    const provisionalPeriod = {
+      ...mockPeriod,
+      isProvisional: true,
+      source: 'fallback' as const,
+    };
+
+    render(
+      <AbcEvidenceListPanel
+        records={[]}
+        loading={false}
+        error={null}
+        period={provisionalPeriod}
+      />
+    );
+
+    expect(screen.getByText('暫定期間')).toBeInTheDocument();
+  });
+
+  it('データがある場合は日付、スロット、先行・行動・結果が正しくレンダリングされること', () => {
+    render(
+      <AbcEvidenceListPanel
+        records={mockRecords}
+        loading={false}
+        error={null}
+        period={mockPeriod}
+      />
+    );
+
+    // 1件目のテスト
+    expect(screen.getByText('2026-05-13')).toBeInTheDocument();
+    expect(screen.getByText('通所・朝の準備')).toBeInTheDocument();
+    expect(screen.getByText('支援手順起点')).toBeInTheDocument();
+    expect(screen.getByText('強度: 中度')).toBeInTheDocument();
+    expect(screen.getByText('朝の準備で名前を呼ばれた')).toBeInTheDocument();
+    expect(screen.getByText('机を叩いた')).toBeInTheDocument();
+    expect(screen.getByText('職員が別の場所に誘導した')).toBeInTheDocument();
+
+    // 2件目のテスト (キオスク判定)
+    expect(screen.getByText('2026-05-15')).toBeInTheDocument();
+    expect(screen.getByText('キオスク・支援手順起点')).toBeInTheDocument();
+    expect(screen.getByText('強度: 重度')).toBeInTheDocument();
+    expect(screen.getByText('おやつを待っている間')).toBeInTheDocument();
+    expect(screen.getByText('大声をあげた')).toBeInTheDocument();
+    expect(screen.getByText('おやつを渡した')).toBeInTheDocument();
+  });
+});

--- a/src/features/monitoring/hooks/__tests__/useMonitoringAbcEvidence.spec.tsx
+++ b/src/features/monitoring/hooks/__tests__/useMonitoringAbcEvidence.spec.tsx
@@ -1,10 +1,8 @@
-import React from 'react';
 import { renderHook, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useMonitoringAbcEvidence } from '../useMonitoringAbcEvidence';
 import { useUser } from '@/features/users/useUsers';
 import { useDataProvider } from '@/lib/data/useDataProvider';
-import { SharePointAbcRecordRepository } from '@/infra/sharepoint/repos/SharePointAbcRecordRepository';
 import type { AbcRecord } from '@/domain/abc/abcRecord';
 
 // ── モックセットアップ ──────────────────────────────────────
@@ -18,6 +16,7 @@ vi.mock('@/lib/data/useDataProvider', () => ({
   useDataProvider: vi.fn(),
 }));
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockFindByUserIdAndDateRange = vi.fn<any>();
 
 vi.mock('@/infra/sharepoint/repos/SharePointAbcRecordRepository', () => {
@@ -31,8 +30,10 @@ vi.mock('@/infra/sharepoint/repos/SharePointAbcRecordRepository', () => {
 describe('useMonitoringAbcEvidence', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (useDataProvider as any).mockReturnValue({ provider: {} });
-    (useUser as any).mockReturnValue({ data: null, isLoading: false });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (useUser as any).mockReturnValue({ data: null, status: 'idle' });
     mockFindByUserIdAndDateRange.mockResolvedValue([]);
   });
 
@@ -50,15 +51,25 @@ describe('useMonitoringAbcEvidence', () => {
       {
         id: '1',
         userId: 'U001',
-        date: '2026-05-10',
-        slotId: '9:30頃|通所・朝の準備',
-        isDeleted: false,
+        userName: 'User 1',
+        occurredAt: '2026-05-10T09:30:00.000Z',
+        setting: '通所',
         antecedent: 'Antecedent 1',
         behavior: 'Behavior 1',
         consequence: 'Consequence 1',
-        intensity: 3,
-        source: 'daily-support',
-      } as any,
+        intensity: 'medium',
+        durationMinutes: 5,
+        riskFlag: false,
+        recorderName: 'Staff 1',
+        tags: [],
+        notes: '',
+        createdAt: '2026-05-10T09:30:00.000Z',
+        sourceContext: {
+          source: 'daily-support',
+          date: '2026-05-10',
+          slotId: '9:30頃|通所・朝の準備',
+        },
+      },
     ];
     mockFindByUserIdAndDateRange.mockResolvedValue(mockRecords);
 
@@ -102,9 +113,10 @@ describe('useMonitoringAbcEvidence', () => {
   });
 
   it('supportStartDate がなく、UserMaster.ServiceStartDate がある場合はそれを使用する', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (useUser as any).mockReturnValue({
       data: { ServiceStartDate: '2026-04-01' },
-      isLoading: false,
+      status: 'success',
     });
 
     const { result } = renderHook(() =>
@@ -125,9 +137,10 @@ describe('useMonitoringAbcEvidence', () => {
   });
 
   it('supportStartDate も ServiceStartDate もなく、appliedFrom がある場合は provisional fallback とする', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (useUser as any).mockReturnValue({
       data: null,
-      isLoading: false,
+      status: 'success',
     });
 
     const { result } = renderHook(() =>

--- a/src/features/monitoring/hooks/__tests__/useMonitoringAbcEvidence.spec.tsx
+++ b/src/features/monitoring/hooks/__tests__/useMonitoringAbcEvidence.spec.tsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useMonitoringAbcEvidence } from '../useMonitoringAbcEvidence';
+import { useUser } from '@/features/users/useUsers';
+import { useDataProvider } from '@/lib/data/useDataProvider';
+import { SharePointAbcRecordRepository } from '@/infra/sharepoint/repos/SharePointAbcRecordRepository';
+import type { AbcRecord } from '@/domain/abc/abcRecord';
+
+// ── モックセットアップ ──────────────────────────────────────
+
+vi.mock('@/features/users/useUsers', () => ({
+  useUser: vi.fn(),
+  useUsers: vi.fn(),
+}));
+
+vi.mock('@/lib/data/useDataProvider', () => ({
+  useDataProvider: vi.fn(),
+}));
+
+const mockFindByUserIdAndDateRange = vi.fn<any>();
+
+vi.mock('@/infra/sharepoint/repos/SharePointAbcRecordRepository', () => {
+  return {
+    SharePointAbcRecordRepository: class {
+      findByUserIdAndDateRange = mockFindByUserIdAndDateRange;
+    },
+  };
+});
+
+describe('useMonitoringAbcEvidence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useDataProvider as any).mockReturnValue({ provider: {} });
+    (useUser as any).mockReturnValue({ data: null, isLoading: false });
+    mockFindByUserIdAndDateRange.mockResolvedValue([]);
+  });
+
+  it('userId が空、または null の場合はリポジトリを呼ばず、空配列を返す', async () => {
+    const { result } = renderHook(() =>
+      useMonitoringAbcEvidence(null, '2026-05-01', 90),
+    );
+
+    expect(result.current.records).toEqual([]);
+    expect(mockFindByUserIdAndDateRange).not.toHaveBeenCalled();
+  });
+
+  it('userId, supportStartDate, monitoringCycleDays がある場合、正しい期間でリポジトリを呼び出す', async () => {
+    const mockRecords: AbcRecord[] = [
+      {
+        id: '1',
+        userId: 'U001',
+        date: '2026-05-10',
+        slotId: '9:30頃|通所・朝の準備',
+        isDeleted: false,
+        antecedent: 'Antecedent 1',
+        behavior: 'Behavior 1',
+        consequence: 'Consequence 1',
+        intensity: 3,
+        source: 'daily-support',
+      } as any,
+    ];
+    mockFindByUserIdAndDateRange.mockResolvedValue(mockRecords);
+
+    const { result } = renderHook(() =>
+      useMonitoringAbcEvidence('U001', '2026-05-01', 90),
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(mockFindByUserIdAndDateRange).toHaveBeenCalledWith({
+      userId: 'U001',
+      from: '2026-05-01',
+      to: '2026-07-30', // 2026-05-01 + 90 days
+    });
+
+    expect(result.current.records).toEqual(mockRecords);
+    expect(result.current.period).toEqual({
+      from: '2026-05-01',
+      to: '2026-07-30',
+      isProvisional: false,
+      source: 'planning',
+    });
+  });
+
+  it('monitoringCycleDays が未設定の場合はデフォルトで 90 日として計算する', async () => {
+    const { result } = renderHook(() =>
+      useMonitoringAbcEvidence('U001', '2026-05-01', undefined),
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(mockFindByUserIdAndDateRange).toHaveBeenCalledWith({
+      userId: 'U001',
+      from: '2026-05-01',
+      to: '2026-07-30', // Default 90 days
+    });
+  });
+
+  it('supportStartDate がなく、UserMaster.ServiceStartDate がある場合はそれを使用する', async () => {
+    (useUser as any).mockReturnValue({
+      data: { ServiceStartDate: '2026-04-01' },
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() =>
+      useMonitoringAbcEvidence('U001', null, 90),
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(mockFindByUserIdAndDateRange).toHaveBeenCalledWith({
+      userId: 'U001',
+      from: '2026-04-01',
+      to: '2026-06-30', // 2026-04-01 + 90 days
+    });
+
+    expect(result.current.period?.source).toBe('master');
+  });
+
+  it('supportStartDate も ServiceStartDate もなく、appliedFrom がある場合は provisional fallback とする', async () => {
+    (useUser as any).mockReturnValue({
+      data: null,
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() =>
+      useMonitoringAbcEvidence('U001', null, 90, '2026-03-15'),
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(mockFindByUserIdAndDateRange).toHaveBeenCalledWith({
+      userId: 'U001',
+      from: '2026-03-15',
+      to: '2026-06-13', // 2026-03-15 + 90 days
+    });
+
+    expect(result.current.period?.isProvisional).toBe(true);
+    expect(result.current.period?.source).toBe('fallback');
+  });
+});

--- a/src/features/monitoring/hooks/useMonitoringAbcEvidence.ts
+++ b/src/features/monitoring/hooks/useMonitoringAbcEvidence.ts
@@ -1,0 +1,107 @@
+import React from 'react';
+import { useUser } from '@/features/users/useUsers';
+import { resolveSupportStartDateDetailed } from '@/features/planning-sheet/monitoringSchedule';
+import { useDataProvider } from '@/lib/data/useDataProvider';
+import { SharePointAbcRecordRepository } from '@/infra/sharepoint/repos/SharePointAbcRecordRepository';
+import type { AbcRecord } from '@/domain/abc/abcRecord';
+
+export interface UseMonitoringAbcEvidenceResult {
+  records: AbcRecord[];
+  loading: boolean;
+  error: Error | null;
+  period: {
+    from: string;
+    to: string;
+    isProvisional: boolean;
+    source: 'planning' | 'master' | 'fallback' | 'none';
+  } | null;
+}
+
+/**
+ * 評価期間内の AbcBehaviorRecords を取得するカスタムフック
+ */
+export function useMonitoringAbcEvidence(
+  userId: string | null | undefined,
+  supportStartDate: string | null | undefined,
+  monitoringCycleDays: number = 90,
+  appliedFrom?: string | null | undefined,
+): UseMonitoringAbcEvidenceResult {
+  const [records, setRecords] = React.useState<AbcRecord[]>([]);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<Error | null>(null);
+
+  const { data: userMaster, status: userStatus } = useUser(userId ?? undefined);
+  const { provider } = useDataProvider();
+  
+  const repository = React.useMemo(() => {
+    return provider ? new SharePointAbcRecordRepository(provider) : null;
+  }, [provider]);
+
+  const resolvedBase = React.useMemo(() => {
+    return resolveSupportStartDateDetailed(
+      supportStartDate,
+      userMaster?.ServiceStartDate,
+      appliedFrom,
+    );
+  }, [supportStartDate, userMaster?.ServiceStartDate, appliedFrom]);
+
+  // 評価期間の計算
+  const period = React.useMemo(() => {
+    if (!resolvedBase.date) return null;
+    const fromDate = new Date(resolvedBase.date);
+    if (isNaN(fromDate.getTime())) return null;
+
+    const days = monitoringCycleDays || 90;
+    // ミリ秒加算
+    const toDate = new Date(fromDate.getTime() + days * 24 * 60 * 60 * 1000);
+    if (isNaN(toDate.getTime())) return null;
+
+    return {
+      from: resolvedBase.date,
+      to: toDate.toISOString().slice(0, 10),
+      isProvisional: resolvedBase.source === 'fallback',
+      source: resolvedBase.source,
+    };
+  }, [resolvedBase, monitoringCycleDays]);
+
+  React.useEffect(() => {
+    if (!userId || !repository || !period) {
+      setRecords([]);
+      return;
+    }
+
+    let isMounted = true;
+    setLoading(true);
+    setError(null);
+
+    repository
+      .findByUserIdAndDateRange({
+        userId,
+        from: period.from,
+        to: period.to,
+      })
+      .then((data) => {
+        if (!isMounted) return;
+        setRecords(data);
+        setLoading(false);
+      })
+      .catch((err) => {
+        if (!isMounted) return;
+        setError(err instanceof Error ? err : new Error(String(err)));
+        setLoading(false);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [userId, repository, period?.from, period?.to]);
+
+  const isActuallyLoading = loading || (!!userId && userStatus === 'loading');
+
+  return {
+    records,
+    loading: isActuallyLoading,
+    error,
+    period,
+  };
+}

--- a/src/features/planning-sheet/components/new-form/FormSections.tsx
+++ b/src/features/planning-sheet/components/new-form/FormSections.tsx
@@ -33,6 +33,8 @@ import { BEHAVIOR_FUNCTIONS, TRAINING_LEVELS, ICEBERG_FACTORS } from './constant
 import { calculateMonitoringSchedule } from '@/features/planning-sheet/monitoringSchedule';
 import { useReverseBridge } from '../../hooks/useReverseBridge';
 import KioskMonitoringEvidencePanel from '@/features/monitoring/components/KioskMonitoringEvidencePanel';
+import { AbcEvidenceListPanel, type AbcEvidenceListPanelProps } from '@/features/monitoring/components/AbcEvidenceListPanel';
+import type { AbcRecord } from '@/domain/abc/abcRecord';
 
 
 // ─────────────────────────────────────────────
@@ -224,13 +226,28 @@ interface FormSectionsProps {
   renderProvenanceBadge: (fieldKey: string) => React.ReactNode;
   userId?: string;
   isAdmin?: boolean;
+  abcEvidenceRecords?: AbcRecord[];
+  abcEvidenceLoading?: boolean;
+  abcEvidencePeriod?: AbcEvidenceListPanelProps['period'];
+  abcEvidenceError?: Error | null;
 }
 
 // ─────────────────────────────────────────────
 // Component
 // ─────────────────────────────────────────────
 
-const FormSections: React.FC<FormSectionsProps> = ({ step, form, updateField, renderProvenanceBadge, userId, isAdmin = true }) => {
+const FormSections: React.FC<FormSectionsProps> = ({
+  step,
+  form,
+  updateField,
+  renderProvenanceBadge,
+  userId,
+  isAdmin = true,
+  abcEvidenceRecords = [],
+  abcEvidenceLoading = false,
+  abcEvidencePeriod = null,
+  abcEvidenceError = null,
+}) => {
   const { suggestions, isLoading: isBridgeLoading, error: bridgeError } = useReverseBridge(userId, form.supportStartDate);
 
   const schedule = React.useMemo(() => {
@@ -467,6 +484,16 @@ const FormSections: React.FC<FormSectionsProps> = ({ step, form, updateField, re
           {schedulePreview}
           <TextField label="評価方法" value={form.evaluationMethod} onChange={e => updateField('evaluationMethod', e.target.value)} fullWidth multiline minRows={2}
             placeholder="ABC記録集計、グラフ化、カンファレンス" />
+
+          {/* Dedicated ABC 記録 (評価根拠候補) */}
+          {userId && (
+            <AbcEvidenceListPanel
+              records={abcEvidenceRecords}
+              loading={abcEvidenceLoading}
+              error={abcEvidenceError}
+              period={abcEvidencePeriod}
+            />
+          )}
 
           {/* キオスク記録（17手順）統計ドラフト (Issue #1873) */}
           {userId && (

--- a/src/features/planning-sheet/components/new-form/NewPlanningSheetForm.tsx
+++ b/src/features/planning-sheet/components/new-form/NewPlanningSheetForm.tsx
@@ -63,6 +63,7 @@ import { icebergToInterventionDrafts } from '@/features/ibd/analysis/iceberg/ice
 import { buildIcebergImportResult } from '../../icebergToPlanningBridge';
 import { useImportAuditStore } from '../../stores/importAuditStore';
 import type { IcebergSession, IcebergSnapshot } from '@/features/ibd/analysis/iceberg/icebergTypes';
+import { useMonitoringAbcEvidence } from '@/features/monitoring/hooks/useMonitoringAbcEvidence';
 
 // ── Local (split) ──
 import type { NewPlanningSheetFormProps, UserOption, FormState } from './types';
@@ -140,6 +141,18 @@ export const NewPlanningSheetForm: React.FC<NewPlanningSheetFormProps> = ({
   });
   const [monitoringDialogOpen, setMonitoringDialogOpen] = React.useState(false);
   const [monitoringImported, setMonitoringImported] = React.useState(false);
+
+  // ── Dedicated ABC エビデンス取得 ──
+  const {
+    records: abcEvidenceRecords,
+    loading: abcEvidenceLoading,
+    error: abcEvidenceError,
+    period: abcEvidencePeriod,
+  } = useMonitoringAbcEvidence(
+    selectedUser?.id,
+    form.supportStartDate,
+    form.monitoringCycleDays,
+  );
 
   // ── Helpers ──
   const userOptions = React.useMemo<UserOption[]>(
@@ -699,6 +712,10 @@ export const NewPlanningSheetForm: React.FC<NewPlanningSheetFormProps> = ({
                 renderProvenanceBadge={renderProvenanceBadge}
                 userId={selectedUser?.id}
                 isAdmin={isAdmin}
+                abcEvidenceRecords={abcEvidenceRecords}
+                abcEvidenceLoading={abcEvidenceLoading}
+                abcEvidencePeriod={abcEvidencePeriod}
+                abcEvidenceError={abcEvidenceError}
               />
             </Paper>
 

--- a/src/infra/localStorage/localAbcRecordRepository.ts
+++ b/src/infra/localStorage/localAbcRecordRepository.ts
@@ -132,4 +132,21 @@ export const localAbcRecordRepository: AbcRecordRepository = {
       writeAll(records);
     }
   },
+
+  async findByUserIdAndDateRange(input: {
+    userId: string;
+    from: string;
+    to: string;
+  }): Promise<AbcRecord[]> {
+    const fromDate = new Date(input.from);
+    const toDate = new Date(input.to);
+
+    return readAll()
+      .filter((r) => r.userId === input.userId)
+      .filter((r) => r.isDeleted !== true)
+      .filter((r) => {
+        const d = new Date(r.occurredAt.slice(0, 10));
+        return d >= fromDate && d <= toDate;
+      });
+  },
 };

--- a/src/infra/sharepoint/repos/SharePointAbcRecordRepository.ts
+++ b/src/infra/sharepoint/repos/SharePointAbcRecordRepository.ts
@@ -9,7 +9,7 @@
  */
 
 import type { IDataProvider } from '@/lib/data/dataProvider.interface';
-import { buildEq, buildNe, joinAnd } from '@/sharepoint/query/builders';
+import { buildEq, buildNe, buildGe, buildLe, joinAnd } from '@/sharepoint/query/builders';
 import { LIST_CONFIG, ListKeys } from '@/sharepoint/fields/listRegistry';
 import { buildAbcRecordSelectFields } from '@/sharepoint/fields/abcRecordFields';
 import type {
@@ -279,6 +279,34 @@ export class SharePointAbcRecordRepository implements AbcRecordRepository {
     const filter = joinAnd([
       buildEq('UserId', userId),
       buildNe('IsDeleted', true),
+    ]);
+
+    const rows = await this.client.listItems<SpAbcRecordRow>(this.listName, {
+      select,
+      filter,
+      orderby: 'RecordDate desc, OccurredAt desc',
+    });
+
+    return rows
+      .map((row) => this.mapSpToDomain(row))
+      .filter((record) => record.isDeleted !== true);
+  }
+
+  /**
+   * 利用者 ID と日付範囲で絞り込み (IsDeleted=true除外、期間境界値含む)
+   */
+  async findByUserIdAndDateRange(input: {
+    userId: string;
+    from: string;
+    to: string;
+  }): Promise<AbcRecord[]> {
+    const { userId, from, to } = input;
+    const select = [...buildAbcRecordSelectFields()];
+    const filter = joinAnd([
+      buildEq('UserId', userId),
+      buildNe('IsDeleted', true),
+      buildGe('RecordDate', from),
+      buildLe('RecordDate', to),
     ]);
 
     const rows = await this.client.listItems<SpAbcRecordRow>(this.listName, {

--- a/src/infra/sharepoint/repos/__tests__/SharePointAbcRecordRepository.spec.ts
+++ b/src/infra/sharepoint/repos/__tests__/SharePointAbcRecordRepository.spec.ts
@@ -235,5 +235,38 @@ describe('SharePointAbcRecordRepository', () => {
       const record = await repository.getById('505');
       expect(record).toBeNull();
     });
+
+    it('findByUserIdAndDateRange で指定期間内かつ論理削除されていないデータを取得できること', async () => {
+      mockDataProvider.listItems.mockResolvedValue([
+        {
+          Id: 601,
+          UserId: 'user-01',
+          RecordDate: '2026-05-10',
+          IsDeleted: false,
+        },
+        {
+          Id: 602,
+          UserId: 'user-01',
+          RecordDate: '2026-05-12',
+          IsDeleted: false,
+        },
+      ]);
+
+      const records = await repository.findByUserIdAndDateRange({
+        userId: 'user-01',
+        from: '2026-05-10',
+        to: '2026-05-12',
+      });
+
+      const listOptions = mockDataProvider.listItems.mock.calls[0][1];
+      expect(listOptions.filter).toContain("UserId eq 'user-01'");
+      expect(listOptions.filter).toContain("IsDeleted ne true");
+      expect(listOptions.filter).toContain("RecordDate ge '2026-05-10'");
+      expect(listOptions.filter).toContain("RecordDate le '2026-05-12'");
+
+      expect(records).toHaveLength(2);
+      expect(records[0].id).toBe('601');
+      expect(records[1].id).toBe('602');
+    });
   });
 });


### PR DESCRIPTION
# Description

本PRは、**Dedicated ABC 記録（`AbcBehaviorRecords`）**を、L2 支援計画シートの **「§9 評価欄（モニタリング欄）」** において、職員が評価を決定するための客観的な根拠候補として画面上に表示する機能（PR 1）を実装するものです。

北極星（プロダクト原則）に従い、この機能は職員が確認した上で引用・修正されるためのものであり、直接的・自動的に個別支援計画（L1）に反映されるものではありません。

---

## 🎯 今回のスコープ (PR 1)
- [x] 評価期間（モニタリング開始日起点〜サイクル日数分）内の `AbcBehaviorRecords` を取得するカスタムフック `useMonitoringAbcEvidence` の実装。
- [x] 表示用コンポーネント `AbcEvidenceListPanel` の実装（MUI Card ベースの美しく客観的なエビデンスリスト）。
- [x] 支援計画新規作成/編集画面への表示統合。
- [x] 期間内の `IsDeleted=true` である記録の完全除外。
- [x] `slotId` が未定義の記録も、その他の記録として綺麗にフォールバックして表示し、データの漏れを防止。
- [x] 由来コンテキスト (`sourceContext`) の厳格な識別と、`DailyActivityRecords` と混同させないラベル表現の実装。
- [x] `Support Date Governance` と `MonitoringCycleDays` の尊重、および `appliedFrom provisional fallback` に基づく「暫定期間」表示の実装。

⚠️ **本PRのスコープ外（PR 2 / PR 3 で実施予定）**:
- 評価欄への自動転記、ドラフト（下書き）テキスト生成。
- `PlanningJson.monitoringEvidenceLinks[]` への引用元リンクの保存。
- `DailyActivityRecords` への同期・参照・結合。
- 個別支援計画（L1）への直接的な書き込み。

---

## 🛣️ 今後のロードマップ
- **PR 1 (本PR)**: Dedicated ABC 記録を、L2 支援計画シート §9 評価欄の客観的根拠候補として画面上に「表示」する。
- **PR 2**: `AbcRecordEvidenceBridge.ts` の pure function を構築し、`improvementResult` / `nextSupport` / `evaluationMethod` 用の評価ドラフトを自動生成する。
- **PR 3**: 「評価欄へ引用」ボタンと、`PlanningJson.monitoringEvidenceLinks[]` への `evidenceLink` 保存を実装する。

---

## 🛡️ ガードレール & コンプライアンス遵守チェック
- **読み取り専用**: 評価欄（`evaluationIndicator`, `evaluationMethod`, `improvementResult`, `nextSupport`）への書き込みや自動マージは一切おこないません。
- **データ分離の維持**: `DailyActivityRecords` への同期・参照・結合は一切おこなっていません。
- **スキーマ変更なし**: SharePoint リストへの列追加やプロビジョニング設定の変更はありません。
- **確実な監査性**: 削除済みレコードを確実に除外し、`appliedFrom fallback` を利用している場合は暫定期間（監査上の確認が必要）であることをUI上で明示します。
- **表記の厳格性**: `DailyActivityRecords` ととの混同を完全に避けるため、「日次支援由来」といった不適切な文言を排除し、**「支援手順起点」「キオスク・支援手順起点」「専用ABC画面起点」「由来不明/旧データ」** に統一しました。

---

## 🧪 テスト・検証状況
### 1. ユニットテスト
新設したカスタムフックおよびUIコンポーネントに対する網羅的な単体テストを記述し、完全に合格しています。

- **カスタムフックテスト**: `useMonitoringAbcEvidence.spec.tsx`（日付境界条件、fallback 優先度、userId による早期リターン、サイクル日数（デフォルト90日）の計算を検証）
- **コンポーネントテスト**: `AbcEvidenceListPanel.spec.tsx`（空のメッセージ、暫定期間バッジ、由来ラベルの厳密なテキストマッピング、強度別カラースキーマのレンダリングを検証）

```bash
Test Files  39 passed (39)
     Tests  533 passed (533)
  Duration  6.18s
```
- `src/features/monitoring` 配下の全テスト、SharePoint リポジトリのテスト、`src/features/planning-sheet` 配下の全テストが完全に合格しています。

### 2. 静的解析
- `npm run typecheck`: コンパイルエラーなし。
- `npm run lint`: 変更ファイル（`AbcEvidenceListPanel.tsx`, `useMonitoringAbcEvidence.ts`, `FormSections.tsx`, `NewPlanningSheetForm.tsx`）における ESLint エラー・警告は完全に 0 です。
