### PR TITLE
feat(planning-sheet): generate evaluation draft from ABC evidence

### DIFF
--- a/src/features/planning-sheet/logic/__tests__/abcRecordEvidenceBridge.spec.ts
+++ b/src/features/planning-sheet/logic/__tests__/abcRecordEvidenceBridge.spec.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildAbcEvidenceEvaluationDraft,
+  getAbcOriginLabel
+} from '../abcRecordEvidenceBridge';
+import type { AbcRecord } from '@/domain/abc/abcRecord';
+
+// テスト用モックレコード作成ヘルパー
+function createMockRecord(overrides: Partial<AbcRecord> = {}): AbcRecord {
+  return {
+    id: 'rec_1',
+    userId: 'user_abc',
+    userName: '山田 太郎',
+    occurredAt: '2026-05-15T10:00:00Z',
+    setting: 'デイルーム',
+    antecedent: '他利用者が大声を出した',
+    behavior: '耳を塞いで大声を出す',
+    consequence: '静かな個室へ移動して落ち着く',
+    intensity: 'medium',
+    durationMinutes: 5,
+    riskFlag: false,
+    recorderName: '支援員A',
+    tags: ['大声'],
+    notes: 'テスト用のメモです',
+    createdAt: '2026-05-15T10:05:00Z',
+    ...overrides
+  };
+}
+
+describe('abcRecordEvidenceBridge', () => {
+  describe('getAbcOriginLabel', () => {
+    it('should resolve daily-support correctly', () => {
+      const rec = createMockRecord({
+        sourceContext: { source: 'daily-support', slotId: '09:30|朝の準備' }
+      });
+      expect(getAbcOriginLabel(rec)).toBe('支援手順起点');
+    });
+
+    it('should resolve kiosk support standalone correctly', () => {
+      const rec = createMockRecord({
+        sourceContext: { source: 'standalone', returnUrl: '/kiosk?user=1' }
+      });
+      expect(getAbcOriginLabel(rec)).toBe('キオスク・支援手順起点');
+    });
+
+    it('should resolve standard standalone correctly', () => {
+      const rec = createMockRecord({
+        sourceContext: { source: 'standalone', returnUrl: '/abc-list' }
+      });
+      expect(getAbcOriginLabel(rec)).toBe('専用ABC画面起点');
+    });
+
+    it('should resolve missing sourceContext as unidentified correctly', () => {
+      const rec = createMockRecord();
+      expect(getAbcOriginLabel(rec)).toBe('由来不明/旧データ');
+    });
+  });
+
+  describe('buildAbcEvidenceEvaluationDraft', () => {
+    const period = { from: '2026-05-01', to: '2026-07-30' };
+
+    it('should safely return draft when records is empty', () => {
+      const draft = buildAbcEvidenceEvaluationDraft({ records: [], period });
+      expect(draft.metadata.totalRecords).toBe(0);
+      expect(draft.evaluationMethod).toContain('対象期間内に評価ドラフト生成に利用できるDedicated ABC記録は確認されていない。');
+      expect(draft.improvementResult).toContain('対象期間内にDedicated ABC記録は確認されていないため');
+      expect(draft.nextSupport).toContain('必要に応じて、今後の支援場面でABC記録を継続的に蓄積');
+    });
+
+    it('should exclude records where isDeleted is true', () => {
+      const records = [
+        createMockRecord({ id: '1', isDeleted: true }),
+        createMockRecord({ id: '2', isDeleted: false })
+      ];
+      const draft = buildAbcEvidenceEvaluationDraft({ records, period });
+      expect(draft.metadata.totalRecords).toBe(1);
+    });
+
+    it('should include from and to dates and total counts in evaluationMethod', () => {
+      const records = [
+        createMockRecord({
+          id: '1',
+          sourceContext: { source: 'daily-support' }
+        })
+      ];
+      const draft = buildAbcEvidenceEvaluationDraft({ records, period });
+      expect(draft.evaluationMethod).toContain('2026-05-01');
+      expect(draft.evaluationMethod).toContain('2026-07-30');
+      expect(draft.evaluationMethod).toContain('総数1件');
+      expect(draft.evaluationMethod).toContain('支援手順起点 1件');
+    });
+
+    it('should add provisional warning to evaluationMethod when isProvisional is true', () => {
+      const draft = buildAbcEvidenceEvaluationDraft({
+        records: [],
+        period: { ...period, isProvisional: true }
+      });
+      expect(draft.evaluationMethod).toContain('なお、本評価期間は支援開始日が未確定のため、適用開始日をもとに暫定算出している。');
+    });
+
+    it('should extract correct metadata and draft summaries with a mix of records', () => {
+      const records = [
+        createMockRecord({
+          id: '1',
+          intensity: 'high',
+          riskFlag: true,
+          antecedent: '他利用者が大声を出した',
+          behavior: '耳を塞いで大声を出す',
+          consequence: '個室移動',
+          sourceContext: { source: 'daily-support', slotLabel: '朝の会' }
+        }),
+        createMockRecord({
+          id: '2',
+          intensity: 'medium',
+          antecedent: '他利用者が大声を出した',
+          behavior: '耳を塞いで大声を出す',
+          consequence: '個室移動',
+          sourceContext: { source: 'daily-support', slotLabel: '朝の会' }
+        }),
+        createMockRecord({
+          id: '3',
+          intensity: 'low',
+          antecedent: '活動の切り替え',
+          behavior: '自傷行動',
+          consequence: '声かけで落ち着く',
+          sourceContext: { source: 'standalone', returnUrl: '/kiosk' }
+        })
+      ];
+
+      const draft = buildAbcEvidenceEvaluationDraft({ records, period });
+
+      // メタデータ確認
+      expect(draft.metadata.totalRecords).toBe(3);
+      expect(draft.metadata.riskRecordsCount).toBe(1);
+      expect(draft.metadata.byIntensity).toEqual([
+        { label: '重度', count: 1 },
+        { label: '中度', count: 1 },
+        { label: '軽度', count: 1 }
+      ]);
+      expect(draft.metadata.topBehaviors[0].text).toBe('耳を塞いで大声を出す');
+      expect(draft.metadata.topBehaviors[0].count).toBe(2);
+      expect(draft.metadata.topSlots[0].slotLabel).toBe('朝の会');
+      expect(draft.metadata.topSlots[0].count).toBe(2);
+
+      // ドラフト文面確認 (断定禁止 & 客観表現)
+      expect(draft.improvementResult).toContain('耳を塞いで大声を出す');
+      expect(draft.improvementResult).toContain('朝の会');
+      expect(draft.improvementResult).toContain('可能性が示唆されるため');
+      expect(draft.improvementResult).not.toContain('著しく有効');
+      expect(draft.improvementResult).not.toContain('証明された');
+
+      // 優先支援文面の確認
+      expect(draft.nextSupport).toContain('重度の行動や危険を伴う行動が確認されているため');
+      expect(draft.nextSupport).toContain('朝の会');
+    });
+
+    it('should aggregate slotId without slotLabel as slotId split value or fallback correctly', () => {
+      const records = [
+        createMockRecord({
+          id: '1',
+          sourceContext: { source: 'daily-support', slotId: '13:00|午後の活動' }
+        })
+      ];
+      const draft = buildAbcEvidenceEvaluationDraft({ records, period });
+      expect(draft.metadata.topSlots[0].slotLabel).toBe('午後の活動');
+    });
+
+    it('should group records without slotId under "その他のABC記録（時間枠なし）"', () => {
+      const records = [
+        createMockRecord({
+          id: '1' // sourceContextなし
+        })
+      ];
+      const draft = buildAbcEvidenceEvaluationDraft({ records, period });
+      expect(draft.metadata.topSlots[0].slotLabel).toBe('その他のABC記録（時間枠なし）');
+    });
+
+    it('should strictly avoid assertive/banned words in draft texts', () => {
+      const records = [
+        createMockRecord({ intensity: 'medium', antecedent: 'A', behavior: 'B', consequence: 'C' })
+      ];
+      const draft = buildAbcEvidenceEvaluationDraft({ records, period });
+
+      const bannedWords = [
+        '著しく有効',
+        '証明された',
+        '改善した',
+        '原因は',
+        '必ず'
+      ];
+
+      for (const word of bannedWords) {
+        expect(draft.improvementResult).not.toContain(word);
+        expect(draft.nextSupport).not.toContain(word);
+      }
+
+      // 許容・推奨されている表現が含まれることを確認
+      expect(draft.improvementResult).toContain('可能性が示唆される');
+      expect(draft.improvementResult).toContain('確認する');
+    });
+  });
+});

--- a/src/features/planning-sheet/logic/abcRecordEvidenceBridge.ts
+++ b/src/features/planning-sheet/logic/abcRecordEvidenceBridge.ts
@@ -1,0 +1,219 @@
+import type { AbcRecord } from '@/domain/abc/abcRecord';
+
+export type BuildAbcEvidenceDraftInput = {
+  records: AbcRecord[];
+  period: {
+    from: string;
+    to: string;
+    isProvisional?: boolean;
+  };
+};
+
+export type AbcEvidenceEvaluationDraft = {
+  evaluationMethod: string;
+  improvementResult: string;
+  nextSupport: string;
+  metadata: {
+    totalRecords: number;
+    byOrigin: Array<{ label: string; count: number }>;
+    byIntensity: Array<{ label: string; count: number }>;
+    topAntecedents: Array<{ text: string; count: number }>;
+    topBehaviors: Array<{ text: string; count: number }>;
+    topConsequences: Array<{ text: string; count: number }>;
+    topSlots: Array<{ slotLabel: string; count: number }>;
+    riskRecordsCount: number;
+  };
+};
+
+/**
+ * ABC記録の作成元を分かりやすい由来ラベルに変換する
+ */
+export function getAbcOriginLabel(record: AbcRecord): string {
+  const sourceContext = record.sourceContext;
+  const source = sourceContext?.source;
+  const isKiosk = source === 'standalone' && sourceContext?.returnUrl?.includes('kiosk');
+
+  if (source === 'daily-support') {
+    return '支援手順起点';
+  } else if (source === 'standalone') {
+    if (isKiosk) {
+      return 'キオスク・支援手順起点';
+    } else {
+      return '専用ABC画面起点';
+    }
+  }
+  return '由来不明/旧データ';
+}
+
+/**
+ * 出現頻度順に集計してソートする汎用ヘルパー
+ */
+function getTopItems(items: string[], maxCount = 3): Array<{ text: string; count: number }> {
+  const counts: Record<string, number> = {};
+  for (const item of items) {
+    const trimmed = item ? item.trim() : '';
+    if (!trimmed) continue;
+    counts[trimmed] = (counts[trimmed] || 0) + 1;
+  }
+  return Object.entries(counts)
+    .map(([text, count]) => ({ text, count }))
+    .sort((a, b) => b.count - a.count || a.text.localeCompare(b.text))
+    .slice(0, maxCount);
+}
+
+/**
+ * 時間帯スロットを出現頻度順にソートするヘルパー
+ */
+function getTopSlots(records: AbcRecord[], maxCount = 3): Array<{ slotLabel: string; count: number }> {
+  const counts: Record<string, number> = {};
+  for (const rec of records) {
+    const sourceContext = rec.sourceContext;
+    let label = 'その他のABC記録（時間枠なし）';
+    if (sourceContext && sourceContext.slotLabel) {
+      label = sourceContext.slotLabel;
+    } else if (sourceContext && sourceContext.slotId) {
+      const parts = sourceContext.slotId.split('|');
+      label = parts[1] || parts[0];
+    }
+    counts[label] = (counts[label] || 0) + 1;
+  }
+  return Object.entries(counts)
+    .map(([slotLabel, count]) => ({ slotLabel, count }))
+    .sort((a, b) => b.count - a.count || a.slotLabel.localeCompare(b.slotLabel))
+    .slice(0, maxCount);
+}
+
+/**
+ * 期間内のDedicated ABC記録から、支援計画§9評価欄向けの評価ドラフトテキストを自動生成する（Pure Function）
+ */
+export function buildAbcEvidenceEvaluationDraft(input: BuildAbcEvidenceDraftInput): AbcEvidenceEvaluationDraft {
+  const { records, period } = input;
+
+  // 論理削除されているものを除外する
+  const validRecords = records.filter(rec => rec.isDeleted !== true);
+
+  // 0件の場合のフォールバック
+  if (validRecords.length === 0) {
+    const suffixProvisional = period.isProvisional
+      ? '\nなお、本評価期間は支援開始日が未確定のため、適用開始日をもとに暫定算出している。'
+      : '';
+
+    return {
+      evaluationMethod: `対象期間内に評価ドラフト生成に利用できるDedicated ABC記録は確認されていない。${suffixProvisional}`,
+      improvementResult: '対象期間内にDedicated ABC記録は確認されていないため、本項目では日々の支援記録や職員の観察を併せて評価する。',
+      nextSupport: '必要に応じて、今後の支援場面でABC記録を継続的に蓄積し、次回モニタリング時の評価材料とする。',
+      metadata: {
+        totalRecords: 0,
+        byOrigin: [],
+        byIntensity: [
+          { label: '重度', count: 0 },
+          { label: '中度', count: 0 },
+          { label: '軽度', count: 0 }
+        ],
+        topAntecedents: [],
+        topBehaviors: [],
+        topConsequences: [],
+        topSlots: [],
+        riskRecordsCount: 0
+      }
+    };
+  }
+
+  // 1. 各集計処理 (Metadataの生成)
+  const totalCount = validRecords.length;
+
+  // 由来別集計
+  const originCounts: Record<string, number> = {};
+  validRecords.forEach(rec => {
+    const label = getAbcOriginLabel(rec);
+    originCounts[label] = (originCounts[label] || 0) + 1;
+  });
+  const byOrigin = Object.entries(originCounts)
+    .map(([label, count]) => ({ label, count }))
+    .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+
+  // 強度別集計
+  const intensityCounts = { high: 0, medium: 0, low: 0 };
+  validRecords.forEach(rec => {
+    if (rec.intensity === 'high') intensityCounts.high++;
+    else if (rec.intensity === 'medium') intensityCounts.medium++;
+    else if (rec.intensity === 'low') intensityCounts.low++;
+  });
+  const byIntensity = [
+    { label: '重度', count: intensityCounts.high },
+    { label: '中度', count: intensityCounts.medium },
+    { label: '軽度', count: intensityCounts.low }
+  ];
+
+  // 頻出項目
+  const topAntecedents = getTopItems(validRecords.map(r => r.antecedent));
+  const topBehaviors = getTopItems(validRecords.map(r => r.behavior));
+  const topConsequences = getTopItems(validRecords.map(r => r.consequence));
+  const topSlots = getTopSlots(validRecords);
+
+  // 危険行動
+  const riskRecordsCount = validRecords.filter(r => r.riskFlag === true).length;
+
+  // 2. evaluationMethod の生成
+  const originBreakdown = byOrigin.map(o => `${o.label} ${o.count}件`).join('、');
+  const methodText = `評価期間中（${period.from}〜${period.to}）に記録されたDedicated ABC記録（総数${totalCount}件：${originBreakdown}）をもとに、発生場面、行動、先行事象、結果、および強度の推移傾向を確認し、行動変容の量的・質的評価を実施した。`;
+  const suffixProvisional = period.isProvisional
+    ? '\nなお、本評価期間は支援開始日が未確定のため、適用開始日をもとに暫定算出している。'
+    : '';
+  const evaluationMethod = `${methodText}${suffixProvisional}`;
+
+  // 3. improvementResult の生成
+  const intensityBreakdown = byIntensity.map(i => `${i.label}が${i.count}件`).join('、');
+  const primaryBehaviorText = topBehaviors.length > 0
+    ? `そのうち、特に確認頻度の高い行動は「${topBehaviors[0].text}」（期間中${topBehaviors[0].count}回）である。`
+    : '';
+  
+  const slotBiasText = topSlots.length > 0
+    ? `場面別の記録状況としては、主に「${topSlots[0].slotLabel}」（${topSlots[0].count}件）において記録が多く蓄積されている。`
+    : '';
+
+  const riskText = riskRecordsCount > 0
+    ? `なお、職員による特別な配慮や注視を要する危険行動（riskFlag）を伴う記録が期間中に${riskRecordsCount}件確認されている。`
+    : '';
+
+  const improvementResult = `対象期間中、合計${totalCount}件のDedicated ABC記録が蓄積された。記録の強度分布は${intensityBreakdown}となっている。${primaryBehaviorText}${slotBiasText}
+これらの客観的な記録傾向から、支援介入にともなう一時的な行動パターンの偏りや推移が示唆される。記述された先行事象および結果の客観分析により、特定の環境や契機（トリガー）が行動に影響を与えている可能性が示唆されるため、支援方法の有効性を継続して確認する。${riskText}`;
+
+  // 4. nextSupport の生成
+  const primaryAntecedent = topAntecedents.length > 0 ? topAntecedents[0].text : '';
+  const primaryConsequence = topConsequences.length > 0 ? topConsequences[0].text : '';
+  
+  let suggestionText = '';
+  if (primaryAntecedent || primaryConsequence) {
+    const antecedentPart = primaryAntecedent ? `「${primaryAntecedent}」といった先行事象（トリガー）の発生状況や` : '';
+    const consequencePart = primaryConsequence ? `行動後の「${primaryConsequence}」におけるかかわり方` : '';
+    suggestionText = `今後は、頻出している${antecedentPart}${consequencePart}に着目し、刺激の緩和や一貫したアプローチ手順を整理することが推奨される。`;
+  }
+
+  const primarySlot = topSlots.length > 0 ? topSlots[0].slotLabel : '';
+  const slotSuggestion = primarySlot && primarySlot !== 'その他のABC記録（時間枠なし）'
+    ? `特に記録件数の多い「${primarySlot}」の時間帯においては、先行事象の整理と個別支援手順の適合度合を継続して確認することが望ましい。`
+    : '各支援場面において、先行事象（トリガー）の確実な記録および整理を継続する。';
+
+  const riskPrioritySuggestion = (intensityCounts.high > 0 || riskRecordsCount > 0)
+    ? '\nまた、重度の行動や危険を伴う行動が確認されているため、該当する時間枠や状況における職員間の初期対応手順（速やかな安全確保・指示出し）の優先確認、および環境調整や介入声かけの見直しを最優先で検討する。'
+    : '';
+
+  const nextSupport = `これまでに蓄積された行動観察結果をもとに、特定の時間枠や場面における個別支援手順を継続確認する。${suggestionText}${slotSuggestion}${riskPrioritySuggestion}`;
+
+  return {
+    evaluationMethod,
+    improvementResult,
+    nextSupport,
+    metadata: {
+      totalRecords: totalCount,
+      byOrigin,
+      byIntensity,
+      topAntecedents,
+      topBehaviors,
+      topConsequences,
+      topSlots,
+      riskRecordsCount
+    }
+  };
+}


### PR DESCRIPTION
## 🚀 PR 2 概要

本PRでは、PR 1（Dedicated ABC記録の期間内自動取得と一覧表示）に続き、取得した `AbcRecord[]` を入力として、L2 支援計画シート §9 評価欄向けのドラフト評価文言を安全に自動生成する **Pure Function（純粋関数）** ロジックを実装します。

### 🛡️ 最重要ガードレール（PR 2 スコープ徹底）
* **UI変更なし**: 今回のPRではUIコンポーネントの変更や追加は一切おこなっていません。
* **書き込み・保存なし**: 実際の計画フォームの `evaluation` 各フィールド（`improvementResult` や `nextSupport` など）への自動書き込み、転記、`PlanningJson.monitoringEvidenceLinks[]` への保存は行いません。
* **引用ボタンなし**: 「評価欄へ引用」ボタンの設置はPR 3で行うため、本PRでは非対象です。
* **他システム非結合**: `DailyActivityRecords` への同期、参照、統合、および `L1 個別支援計画` への反映ロジックは一切ありません。
* **断定表現の徹底排除**: 自動生成される文言は、「確認された」「可能性が示唆される」「検討を継続する」など、職員の最終的な意思決定を支援する客観表現に限定。

---

## 🛠️ 変更内容

### 1. Pure Function の実装：[abcRecordEvidenceBridge.ts](file:///Users/yasutakesougo/audit-management-system-mvp/src/features/planning-sheet/logic/abcRecordEvidenceBridge.ts)
* `buildAbcEvidenceEvaluationDraft(input: BuildAbcEvidenceDraftInput): AbcEvidenceEvaluationDraft` の実装。
* `evaluationMethod` / `improvementResult` / `nextSupport` の3つの評価欄用テキストおよび集計用メタデータ（出現頻度別 topAntecedents / topBehaviors / topConsequences / topSlots 等）を出力。
* **集計・算出ルール**:
  * `isDeleted === true` のレコードは確実に除外。
  * `slotId`（時間枠）がないデータは「その他のABC記録（時間枠なし）」に集約。
  * `sourceContext` 未設定データは「由来不明/旧データ」として判別。
  * 適用開始日ベースの暫定期間（`isProvisional: true`）の場合は、警告文言を自動付記。
  * 高強度記録（high intensity）や危険行動フラグ（`riskFlag === true`）が1件でもある場合は、安全配慮および初期手順確認の優先度の高いアドバイスを出力。

### 2. 徹底した単体テスト：[abcRecordEvidenceBridge.spec.ts](file:///Users/yasutakesougo/audit-management-system-mvp/src/features/planning-sheet/logic/__tests__/abcRecordEvidenceBridge.spec.ts)
以下のケースを網羅する 12 件のテストを実装。
* records が空でも安全にフォールバックテキストを返すか
* 期間と件数が `evaluationMethod` に含まれているか
* 暫定期間（`isProvisional=true`）の暫定警告文が入るか
* `isDeleted=true` が除外されるか
* `slotId` なしを「その他のABC記録（時間枠なし）」として扱うか
* 危険行動・重度の行動がある場合に優先方針（安全確保）がアドバイスに差し込まれるか
* 断定表現（「著しく有効」「証明された」など）が一切含まれていないか
* `eslint` (未使用変数・未使用インポートの完全除去) の合格

---

## 💻 検証結果
* **`npm run typecheck`**: **PASS (グリーン)**
* **eslint**: **PASS (0 errors, 0 warnings on modified files)**
* **Vitest 関連スイート**: **PASS (12 tests passed)**
  * `src/features/planning-sheet/logic/__tests__/abcRecordEvidenceBridge.spec.ts`

---

## ⏭️ 次期ロードマップ (PR 3 予定)
PR 2 でロジックを確定させた後、**PR 3** にて：
1. 支援計画編集画面に「ドラフト生成（引用）」ボタンを配置。
2. クリック時に、今回の pure function で生成されたドラフトテキストを textarea へ安全に流し込む（転記）。
3. 引用時に `PlanningJson.monitoringEvidenceLinks[]` へ `evidenceLink` を自動保存し、監査時のエビデンス追跡（証跡リンク）を担保します。