### PR TITLE
fix(monthly-records): reconcile kiosk status priority after #1881

### DIFF
--- a/src/features/daily/domain/executionRecordReconciliation.ts
+++ b/src/features/daily/domain/executionRecordReconciliation.ts
@@ -1,0 +1,40 @@
+import type { ExecutionRecord } from './executionRecordTypes';
+
+/**
+ * 整合化された排他的な集計ステータス
+ * - completed: 完了（予定通り完了）
+ * - triggered: 行動発生（BIP発動または明示的トリガー）
+ * - skipped: スキップ（実施なし）
+ * - in-progress: 進行中（未完了だが、メモや一時記録あり）
+ * - empty: 未記入（記録が一切なし）
+ */
+export type ReconciledStatus = 'completed' | 'triggered' | 'skipped' | 'in-progress' | 'empty';
+
+/**
+ * 1件の ExecutionRecord から、排他ルールに基づいて整合化されたステータスを導出する。
+ *
+ * 【排他優先度】
+ * 1. record.status === 'completed' -> 'completed'
+ * 2. record.status === 'triggered' || (record.triggeredBipIds ?? []).length > 0 -> 'triggered'
+ * 3. record.status === 'skipped' -> 'skipped'
+ * 4. record.memo が空文字列以外 -> 'in-progress'
+ * 5. それ以外 (status === 'unrecorded' でメモ等なし) -> 'empty'
+ */
+export function reconcileRecordStatus(record: ExecutionRecord): ReconciledStatus {
+  const status = record.status;
+  const hasMemo = typeof record.memo === 'string' && record.memo.trim().length > 0;
+  const hasBips = Array.isArray(record.triggeredBipIds) && record.triggeredBipIds.length > 0;
+
+  if (status === 'completed') return 'completed';
+  if (status === 'triggered' || hasBips) return 'triggered';
+  if (status === 'skipped') return 'skipped';
+  if (hasMemo) return 'in-progress';
+  return 'empty';
+}
+
+/**
+ * レコードに有効なメモが記入されているか判定する（重複属性）
+ */
+export function hasRecordMemo(record: ExecutionRecord): boolean {
+  return typeof record.memo === 'string' && record.memo.trim().length > 0;
+}

--- a/src/features/monitoring/domain/monitoringKioskAnalytics.ts
+++ b/src/features/monitoring/domain/monitoringKioskAnalytics.ts
@@ -5,6 +5,10 @@
  */
 
 import type { ExecutionRecord } from '@/features/daily/domain/executionRecordTypes';
+import {
+  reconcileRecordStatus,
+  hasRecordMemo,
+} from '@/features/daily/domain/executionRecordReconciliation';
 
 export interface KioskProcedureSummary {
   scheduleItemId: string;
@@ -43,7 +47,8 @@ export function aggregateKioskRecords(
   const recordedDates = new Set<string>();
 
   for (const record of records) {
-    if (record.status === 'unrecorded') continue;
+    const reconciled = reconcileRecordStatus(record);
+    if (reconciled === 'empty') continue;
     
     recordedDates.add(record.date);
     
@@ -64,11 +69,11 @@ export function aggregateKioskRecords(
     }
 
     summary.totalCount++;
-    if (record.status === 'completed') summary.completedCount++;
-    else if (record.status === 'triggered') summary.triggeredCount++;
-    else if (record.status === 'skipped') summary.skippedCount++;
+    if (reconciled === 'completed') summary.completedCount++;
+    else if (reconciled === 'triggered') summary.triggeredCount++;
+    else if (reconciled === 'skipped') summary.skippedCount++;
 
-    if (record.memo && record.memo.trim()) {
+    if (hasRecordMemo(record)) {
       summary.memoCount++;
       if (summary.representativeMemos.length < 5) {
         summary.representativeMemos.push(record.memo);

--- a/src/features/records/monthly/UserKpiCards.tsx
+++ b/src/features/records/monthly/UserKpiCards.tsx
@@ -1,5 +1,6 @@
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import ErrorIcon from '@mui/icons-material/Error';
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 import ScheduleIcon from '@mui/icons-material/Schedule';
 import TrendingUpIcon from '@mui/icons-material/TrendingUp';
 import WarningIcon from '@mui/icons-material/Warning';
@@ -10,6 +11,7 @@ import Chip from '@mui/material/Chip';
 import Grid from '@mui/material/Grid';
 import LinearProgress from '@mui/material/LinearProgress';
 import Stack from '@mui/material/Stack';
+import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import React from 'react';
 import type { MonthlySummary } from './types';
@@ -116,22 +118,37 @@ export const UserKpiCards: React.FC<UserKpiCardsProps> = ({
               </Typography>
 
               <Stack spacing={1}>
-                <Stack direction="row" justifyContent="space-between">
-                  <Typography variant="body2">完了</Typography>
+                <Stack direction="row" justifyContent="space-between" alignItems="center">
+                  <Stack direction="row" spacing={0.5} alignItems="center">
+                    <Typography variant="body2">完了</Typography>
+                    <Tooltip title="予定通り「完了」と記録された手順の総数です。">
+                      <HelpOutlineIcon sx={{ fontSize: 16, color: 'text.secondary', cursor: 'help' }} />
+                    </Tooltip>
+                  </Stack>
                   <Typography variant="body1" color="success.main">
                     {kpi.completedRows} / {kpi.plannedRows}
                   </Typography>
                 </Stack>
 
-                <Stack direction="row" justifyContent="space-between">
-                  <Typography variant="body2">進行中</Typography>
+                <Stack direction="row" justifyContent="space-between" alignItems="center">
+                  <Stack direction="row" spacing={0.5} alignItems="center">
+                    <Typography variant="body2">進行中</Typography>
+                    <Tooltip title="行動発生(triggered)、スキップ(skipped)、または未完了だがメモ記入がある手順の総数です。">
+                      <HelpOutlineIcon sx={{ fontSize: 16, color: 'text.secondary', cursor: 'help' }} />
+                    </Tooltip>
+                  </Stack>
                   <Typography variant="body1" color="warning.main">
                     {kpi.inProgressRows}
                   </Typography>
                 </Stack>
 
-                <Stack direction="row" justifyContent="space-between">
-                  <Typography variant="body2">未記入</Typography>
+                <Stack direction="row" justifyContent="space-between" alignItems="center">
+                  <Stack direction="row" spacing={0.5} alignItems="center">
+                    <Typography variant="body2">未記入</Typography>
+                    <Tooltip title="記録が一切ない手順枠の総数です。(計算式: 計画行数 - 完了 - 進行中)">
+                      <HelpOutlineIcon sx={{ fontSize: 16, color: 'text.secondary', cursor: 'help' }} />
+                    </Tooltip>
+                  </Stack>
                   <Typography variant="body1" color="error.main">
                     {kpi.emptyRows}
                   </Typography>
@@ -148,9 +165,14 @@ export const UserKpiCards: React.FC<UserKpiCardsProps> = ({
               <Stack direction="row" spacing={2} alignItems="center">
                 <ScheduleIcon color="info" />
                 <Box sx={{ flex: 1 }}>
-                  <Typography variant="h6" color="text.secondary">
-                    特記事項
-                  </Typography>
+                  <Stack direction="row" spacing={0.5} alignItems="center">
+                    <Typography variant="h6" color="text.secondary">
+                      特記事項
+                    </Typography>
+                    <Tooltip title="手順に「メモ」が記入された総数です。完了や行動発生などのステータスに関わらず、重複してカウントされます。">
+                      <HelpOutlineIcon sx={{ fontSize: 16, color: 'text.secondary', cursor: 'help' }} />
+                    </Tooltip>
+                  </Stack>
                   <Typography variant="h4" color="info.main">
                     {kpi.specialNotes}
                   </Typography>
@@ -170,9 +192,14 @@ export const UserKpiCards: React.FC<UserKpiCardsProps> = ({
               <Stack direction="row" spacing={2} alignItems="center">
                 <ErrorIcon color={incidentSeverity.color} />
                 <Box sx={{ flex: 1 }}>
-                  <Typography variant="h6" color="text.secondary">
-                    インシデント
-                  </Typography>
+                  <Stack direction="row" spacing={0.5} alignItems="center">
+                    <Typography variant="h6" color="text.secondary">
+                      インシデント
+                    </Typography>
+                    <Tooltip title="「行動発生」(triggered)と判定された手順の総数です。">
+                      <HelpOutlineIcon sx={{ fontSize: 16, color: 'text.secondary', cursor: 'help' }} />
+                    </Tooltip>
+                  </Stack>
                   <Stack direction="row" spacing={1} alignItems="baseline">
                     <Typography variant="h4" color={`${incidentSeverity.color}.main`}>
                       {kpi.incidents}

--- a/src/features/records/monthly/aggregate.ts
+++ b/src/features/records/monthly/aggregate.ts
@@ -77,19 +77,13 @@ export function aggregateMonthlyKpi(
   const triggeredRows = dailyRecords.filter(r => r.isTriggered).length;
   const memoRows = dailyRecords.filter(r => r.hasMemo).length;
 
-  // inProgressRows は完了でも空でもない行。
-  // 二重計上を防ぐため、isSkipped もしくは isTriggered の拡張項目が true の場合は inProgressRows から除外する。
-  const inProgressRows = dailyRecords.filter(
-    r => !r.completed && !r.isEmpty && !r.isSkipped && !r.isTriggered
-  ).length;
+  // inProgressRows は完了でも空でもないすべての行（進行中）。
+  // skippedRows, triggeredRows, および「未完了だがメモ記入ありの行」がすべて含まれます。
+  const inProgressRows = dailyRecords.filter(r => !r.completed && !r.isEmpty).length;
 
-  // emptyRows は整合性保証：計画行数から、実際に何かしらの記録があった行数を引く。
-  // completed, inProgress, skipped, triggered は互いに排他であるため、単純に引いてよい。
-  // memoRows は独立した属性（completed や triggered と重複しうる）なので、ここでは引かない。
-  const emptyRows = Math.max(
-    0,
-    plannedRows - completedRows - inProgressRows - skippedRows - triggeredRows
-  );
+  // emptyRows は整合性保証：計画行数から、実際に記録があった行（完了、進行中）を引きます。
+  // memoRows は重複属性のため、ここでは引かない。
+  const emptyRows = Math.max(0, plannedRows - completedRows - inProgressRows);
 
   return {
     totalDays,

--- a/src/features/records/monthly/kioskEvidence.test.ts
+++ b/src/features/records/monthly/kioskEvidence.test.ts
@@ -7,6 +7,7 @@ import {
   buildMonthlyDailyRecordsFromKioskEvidence,
   toMonthlyDailyRecordFromKioskEvidence,
 } from './kioskEvidence';
+import { aggregateKioskRecords } from '@/features/monitoring/domain/monitoringKioskAnalytics';
 
 function record(overrides: Partial<ExecutionRecord>): ExecutionRecord {
   return {
@@ -79,7 +80,7 @@ describe('monthly kiosk evidence bridge', () => {
       totalDays: 31,
       plannedRows: 31,
       completedRows: 1,
-      inProgressRows: 0,
+      inProgressRows: 2,
       emptyRows: 28,
       specialNotes: 2,
       incidents: 1,
@@ -113,5 +114,55 @@ describe('monthly kiosk evidence bridge', () => {
     expect(result.summary.kpi.triggeredRows).toBe(result.evidence.triggeredRows);
     expect(result.summary.kpi.memoRows).toBe(result.evidence.memoRows);
     expect(result.summary.kpi.incidents).toBe(result.evidence.incidentRows);
+  });
+
+  it('guarantees SSOT reconciliation: monthly KPI/evidence counts align perfectly with monitoring digest summary', () => {
+    const rawRecords = [
+      record({ id: 'r1', date: '2026-05-01', scheduleItemId: 'row-1', status: 'completed', memo: '順調' }),
+      record({ id: 'r2', date: '2026-05-01', scheduleItemId: 'row-2', status: 'triggered', triggeredBipIds: ['bip-1'] }),
+      record({ id: 'r3', date: '2026-05-02', scheduleItemId: 'row-3', status: 'skipped', memo: '本人拒否' }),
+      record({ id: 'r4', date: '2026-05-03', scheduleItemId: 'row-1', status: 'unrecorded', memo: 'スタッフ代行' }), // unrecorded but has memo
+      record({ id: 'r5', date: '2026-05-04', scheduleItemId: 'row-2', status: 'unrecorded', memo: '' }), // empty
+    ];
+
+    // 1. Calculate Monthly summary & evidence
+    const monthlyResult = aggregateMonthlySummaryFromKioskEvidence(rawRecords, {
+      userId: 'I001',
+      displayName: '利用者A',
+      yearMonth: '2026-05',
+      useWorkingDays: false,
+      rowsPerDay: 1,
+    });
+
+    // 2. Calculate Monitoring summary
+    const monitoringResult = aggregateKioskRecords(rawRecords, {
+      userId: 'I001',
+      from: '2026-05-01',
+      to: '2026-05-31',
+    });
+
+    // 3. Sum up counts from monitoring procedures
+    let totalCompleted = 0;
+    let totalTriggered = 0;
+    let totalSkipped = 0;
+    let totalMemo = 0;
+
+    for (const p of monitoringResult.procedures) {
+      totalCompleted += p.completedCount;
+      totalTriggered += p.triggeredCount;
+      totalSkipped += p.skippedCount;
+      totalMemo += p.memoCount;
+    }
+
+    // 4. Assert perfect alignment
+    expect(monthlyResult.evidence.completedRows).toBe(totalCompleted);
+    expect(monthlyResult.evidence.triggeredRows).toBe(totalTriggered);
+    expect(monthlyResult.evidence.skippedRows).toBe(totalSkipped);
+    expect(monthlyResult.evidence.memoRows).toBe(totalMemo);
+
+    expect(monthlyResult.summary.kpi.completedRows).toBe(totalCompleted);
+    expect(monthlyResult.summary.kpi.triggeredRows).toBe(totalTriggered);
+    expect(monthlyResult.summary.kpi.skippedRows).toBe(totalSkipped);
+    expect(monthlyResult.summary.kpi.memoRows).toBe(totalMemo);
   });
 });

--- a/src/features/records/monthly/kioskEvidence.ts
+++ b/src/features/records/monthly/kioskEvidence.ts
@@ -1,4 +1,8 @@
 import type { ExecutionRecord, RecordStatus } from '@/features/daily/domain/executionRecordTypes';
+import {
+  reconcileRecordStatus,
+  hasRecordMemo,
+} from '@/features/daily/domain/executionRecordReconciliation';
 
 import { aggregateMonthlySummary } from './aggregate';
 import type {
@@ -73,18 +77,6 @@ function getEvidenceYearMonth(date: IsoDate): YearMonth {
   return date.slice(0, 7) as YearMonth;
 }
 
-function hasMemo(record: ExecutionRecord): boolean {
-  return typeof record.memo === 'string' && record.memo.trim().length > 0;
-}
-
-function hasIncidentEvidence(record: ExecutionRecord, status: RecordStatus): boolean {
-  return status === 'triggered' || (record.triggeredBipIds ?? []).length > 0;
-}
-
-function isEmptyKioskEvidence(record: ExecutionRecord, status: RecordStatus): boolean {
-  return status === 'unrecorded' && !hasMemo(record) && !hasIncidentEvidence(record, status);
-}
-
 /**
  * Convert one kiosk ExecutionRecord into the Monthly DailyRecord contract.
  *
@@ -97,21 +89,20 @@ export function toMonthlyDailyRecordFromKioskEvidence(record: ExecutionRecord): 
   const recordDate = parseEvidenceIsoDate(record.date);
   if (!recordDate) return null;
 
-  const status = normalizeStatus(record.status);
-  const isEmpty = isEmptyKioskEvidence(record, status);
+  const reconciled = reconcileRecordStatus(record);
 
   return {
     id: record.id,
     userId: record.userId,
     userName: '',
     recordDate,
-    completed: status === 'completed',
-    hasSpecialNotes: hasMemo(record),
-    hasIncidents: hasIncidentEvidence(record, status),
-    isEmpty,
-    isSkipped: status === 'skipped',
-    isTriggered: status === 'triggered',
-    hasMemo: hasMemo(record),
+    completed: reconciled === 'completed',
+    hasSpecialNotes: hasRecordMemo(record),
+    hasIncidents: reconciled === 'triggered',
+    isEmpty: reconciled === 'empty',
+    isSkipped: reconciled === 'skipped',
+    isTriggered: reconciled === 'triggered',
+    hasMemo: hasRecordMemo(record),
   };
 }
 
@@ -168,18 +159,20 @@ function summarizeKioskMonthlyEvidence(
   const nonEmptyRecords = included.filter(({ dailyRecord }) => !dailyRecord.isEmpty);
   const nonEmptyDates = [...new Set(nonEmptyRecords.map(({ dailyRecord }) => dailyRecord.recordDate))].sort();
 
+  const reconciledStats = included.map(({ sourceRecord }) => reconcileRecordStatus(sourceRecord));
+
   return {
     source: 'kiosk-execution',
     userId: target.userId,
     yearMonth: target.yearMonth,
     sourceRows: included.length,
     recordedRows: nonEmptyRecords.length,
-    completedRows: included.filter(({ status }) => status === 'completed').length,
-    triggeredRows: included.filter(({ status }) => status === 'triggered').length,
-    skippedRows: included.filter(({ status }) => status === 'skipped').length,
-    unrecordedRows: included.filter(({ dailyRecord }) => dailyRecord.isEmpty).length,
-    memoRows: included.filter(({ dailyRecord }) => dailyRecord.hasSpecialNotes).length,
-    incidentRows: included.filter(({ dailyRecord }) => dailyRecord.hasIncidents).length,
+    completedRows: reconciledStats.filter(s => s === 'completed').length,
+    triggeredRows: reconciledStats.filter(s => s === 'triggered').length,
+    skippedRows: reconciledStats.filter(s => s === 'skipped').length,
+    unrecordedRows: reconciledStats.filter(s => s === 'empty').length,
+    memoRows: included.filter(({ sourceRecord }) => hasRecordMemo(sourceRecord)).length,
+    incidentRows: reconciledStats.filter(s => s === 'triggered').length,
     recordedDays: nonEmptyDates.length,
     firstEntryDate: nonEmptyDates[0],
     lastEntryDate: nonEmptyDates[nonEmptyDates.length - 1],

--- a/src/features/records/monthly/kioskMonthlyAggregationUseCase.test.ts
+++ b/src/features/records/monthly/kioskMonthlyAggregationUseCase.test.ts
@@ -59,7 +59,7 @@ describe('executeKioskMonthlyAggregation use case', () => {
       totalDays: 31,
       plannedRows: 31,
       completedRows: 2,
-      inProgressRows: 0,
+      inProgressRows: 1,
       emptyRows: 28,
       specialNotes: 1,
       incidents: 1,


### PR DESCRIPTION
# PR本文ドラフト

**PRタイトル候補**: `fix(monthly-records): reconcile kiosk status priority after #1881`

---

## 概要
PR #1881 のマージ後に残存していた月次KPI、エビデンス集計、および90日モニタリング統計の間のステータス判定とカウンタ不整合を完全に解消するための follow-up PR です。

Closes #1880
(Follow-up to #1881)

## 変更内容

### 追加
- **ステータス整合化ヘルパーの創設** (`src/features/daily/domain/executionRecordReconciliation.ts`)
  - キオスク実施エビデンス（ExecutionRecord）から、指定された優先度ルール（完了 ➔ トリガー ➔ スキップ ➔ 進行中 ➔ 空）に基づき、排他的な整合化ステータス `ReconciledStatus` を導出するピュア関数 `reconcileRecordStatus` および重複属性用の `hasRecordMemo` を新設しました。
- **SSOT整合性保証テストの追加** (`src/features/records/monthly/kioskEvidence.test.ts`)
  - 同一のキオスク実施記録から「月次KPI」「月次エビデンスカウンタ」「90日モニタリング集計」を算出したとき、完了・トリガー・スキップ・メモ件数が **1件のズレもなく完全に一致すること** を保証する強力な結合テストケースを追加しました。

### 変更
- **90日モニタリング会議統計漏れバグの修正** (`src/features/monitoring/domain/monitoringKioskAnalytics.ts`)
  - 従来 `unrecorded` 状態のレコードが一律スキップされていたため、「未完了だが現場スタッフがメモを記入していた進行中レコード」が会議統計から漏れる不具合がありました。今回、共通ヘルパーに則り「本当に空のレコードのみスキップ」するよう修正しました。
- **計算式の安全化・簡略化（二重計上の排除）** (`src/features/records/monthly/aggregate.ts`)
  - `inProgressRows`（進行中）を「完了でも空でもないすべての行（トリガー、スキップ、メモあり未完了を含む）」に再定義し、`emptyRows`（未記入）の計算式を `max(0, plannedRows - completedRows - inProgressRows)` へと安全化しました。
- **キオスク集計変換処理の共通化** (`src/features/records/monthly/kioskEvidence.ts`)
  - 以前は局所的に重複実装されていた `hasMemo`, `isEmptyKioskEvidence` 等を撤廃し、新設した `executionRecordReconciliation.ts` の共通ロジックに一本化しました。
- **UI Tooltip による透明性向上** (`src/features/records/monthly/UserKpiCards.tsx`)
  - MUI の `Tooltip` と `HelpOutlineIcon` を新規配置し、完了・進行中・未記入・特記事項・インシデントの定義および計算ロジック（予定行数からの控除など）が現場で一目で分かるようにしました。

---

## 変更ファイル一覧
| ファイル | 変更種別 | 変更内容 |
|---------|---------|---------|
| `src/features/daily/domain/executionRecordReconciliation.ts` | **追加** | 共通の整合化ステータス判定ヘルパー |
| `src/features/records/monthly/aggregate.ts` | **変更** | `inProgressRows` & `emptyRows` 計算式の安全化 |
| `src/features/records/monthly/kioskEvidence.ts` | **変更** | 共通ヘルパーの適用、集計カウンタの整合化 |
| `src/features/monitoring/domain/monitoringKioskAnalytics.ts` | **変更** | 未完了メモありレコードのモニタリング集計漏れバグの修正 |
| `src/features/records/monthly/UserKpiCards.tsx` | **変更** | MUI Tooltip + HelpOutlineIcon による集計定義の可視化 |
| `src/features/records/monthly/kioskEvidence.test.ts` | **変更** | 既存アサーションの修正 ＋ SSOT完全一致テストの増強 |
| `src/features/records/monthly/kioskMonthlyAggregationUseCase.test.ts` | **変更** | 新仕様アライメントに合わせた期待値の修正 |

---

## テスト
- [x] 既存テスト通過 (`npx vitest run` -> 331テスト全件グリーン)
- [x] 型チェック通過 (`npm run typecheck` -> エラーなし)
- [x] 新規テスト追加 (月次・エビデンス・モニタリングのSSOT不整合防止テストを追加)

## セルフレビュー
- [x] `console.log` 残していない
- [x] `any` 使っていない
- [x] 責務分離を守っている
- [x] 600行ルール違反なし

## 影響範囲
- 月次のキオスクエビデンスアライメント集計、および90日モニタリング会議統計。
- データの物理保存スキーマや PDF/Word、請求への影響 is ありません（計算式の純粋な整合化とUI表示の改善のみ）。
