### PR TITLE
feat(monthly-records): refine planned rows calculation

### DIFF
--- a/src/features/records/monthly/UserProgressChart.tsx
+++ b/src/features/records/monthly/UserProgressChart.tsx
@@ -4,6 +4,8 @@ import CardContent from '@mui/material/CardContent';
 import LinearProgress from '@mui/material/LinearProgress';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
+import Tooltip from '@mui/material/Tooltip';
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 import React from 'react';
 import type { MonthlySummary } from './types';
 
@@ -141,9 +143,14 @@ export const UserProgressChart: React.FC<UserProgressChartProps> = ({ summary })
                 {completionRate}%
               </Typography>
             </Stack>
-            <Typography variant="caption" color="text.secondary">
-              {kpi.completedRows} / {kpi.plannedRows} 行完了
-            </Typography>
+            <Stack direction="row" alignItems="center" spacing={0.5}>
+              <Typography variant="caption" color="text.secondary">
+                {kpi.completedRows} / {kpi.plannedRows} 行完了
+              </Typography>
+              <Tooltip title="予定行数：利用契約曜日、祝日、および承認済みの欠席連絡を考慮して自動計算された今月の目標記録行数です。" arrow>
+                <HelpOutlineIcon sx={{ fontSize: 14, color: 'text.disabled', cursor: 'help' }} />
+              </Tooltip>
+            </Stack>
           </Box>
         </Stack>
       </CardContent>

--- a/src/features/records/monthly/__tests__/plannedRowsCalculator.spec.ts
+++ b/src/features/records/monthly/__tests__/plannedRowsCalculator.spec.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { calculateDetailedPlannedRows } from '../plannedRowsCalculator';
+import { aggregateMonthlyKpi } from '../aggregate';
+import type { YearMonth, DailyRecord, IsoDate } from '../types';
+
+describe('calculateDetailedPlannedRows - 予定行数精密計算ヘルパー', () => {
+  it('デフォルト設定（後方互換性）: 2026年5月の営業日数は21日 (土日を除く月〜金)', () => {
+    // optionsが空の場合、土日を除く月〜金で計算される。2026年5月の営業日は21日
+    const result = calculateDetailedPlannedRows('2026-05' as YearMonth);
+    expect(result).toBe(21 * 17);
+  });
+
+  it('契約曜日の変更: 2026年5月において、月・水・金のみ契約（週3日）', () => {
+    // 2026年5月の月・水・金の日数は、月曜4日、水曜4日、金曜5日 = 計13日
+    const result = calculateDetailedPlannedRows('2026-05' as YearMonth, {
+      contractWeekdays: [1, 3, 5], // 月(1), 水(3), 金(5)
+      rowsPerDay: 17,
+    });
+    expect(result).toBe(13 * 17);
+  });
+
+  it('祝日がある場合: 2026年5月のゴールデンウィーク期間を祝日指定', () => {
+    // 2026-05-04 (月), 2026-05-05 (火), 2026-05-06 (水) を祝日に指定。
+    // 通常の月金営業日21日から3日引いて、18日になる。
+    const result = calculateDetailedPlannedRows('2026-05' as YearMonth, {
+      holidays: ['2026-05-04', '2026-05-05', '2026-05-06'],
+    });
+    expect(result).toBe(18 * 17);
+  });
+
+  it('欠席承認日がある場合: 2026年5月中に欠席連絡2回', () => {
+    // 通常の月金営業日21日から、2026-05-11 (月) と 2026-05-12 (火) の欠席2日を除外、19日。
+    const result = calculateDetailedPlannedRows('2026-05' as YearMonth, {
+      absences: ['2026-05-11', '2026-05-12'],
+    });
+    expect(result).toBe(19 * 17);
+  });
+
+  it('複合ケース: 契約曜日(月火水木金)、祝日あり、欠席日あり、rowsPerDay=10', () => {
+    // 2026年5月 (月金営業日21日)
+    // 祝日: 2026-05-04 (月 - 営業日、除外対象)
+    // 欠席: 2026-05-15 (金 - 営業日、除外対象), 2026-05-17 (日 - 契約曜日に含まれないため二重引算に影響しない)
+    // 実質開所予定日数: 21 - 1 (祝日) - 1 (欠席金曜) = 19日
+    const result = calculateDetailedPlannedRows('2026-05' as YearMonth, {
+      contractWeekdays: [1, 2, 3, 4, 5],
+      holidays: ['2026-05-04'],
+      absences: ['2026-05-15', '2026-05-17'],
+      rowsPerDay: 10,
+    });
+    expect(result).toBe(19 * 10);
+  });
+});
+
+describe('aggregateMonthlyKpi - 精密化予定行数の統合テスト', () => {
+  const createDailyRecord = (date: string, completed: boolean = true): DailyRecord => ({
+    id: `record_${date}`,
+    userId: 'USER001',
+    userName: 'テスト太郎',
+    recordDate: date as IsoDate,
+    completed,
+    hasSpecialNotes: false,
+    hasIncidents: false,
+    isEmpty: false,
+  });
+
+  it('詳細オプション指定ありの場合、aggregateMonthlyKpiで精密計算したplannedRowsが反映されること', () => {
+    const records: DailyRecord[] = [
+      createDailyRecord('2026-05-01', true),
+    ];
+
+    const result = aggregateMonthlyKpi(records, '2026-05' as YearMonth, {
+      contractWeekdays: [1, 2, 3, 4, 5],
+      holidays: ['2026-05-04', '2026-05-05'], // 営業日21日 - 2日 = 19日
+      absences: ['2026-05-08'], // 19日 - 1日 = 18日
+      rowsPerDay: 17,
+    });
+
+    expect(result.plannedRows).toBe(18 * 17);
+    expect(result.completedRows).toBe(1);
+    expect(result.emptyRows).toBe((18 * 17) - 1); // 進行中は0のため、plannedRows - completedRows - inProgressRows
+  });
+});

--- a/src/features/records/monthly/aggregate.ts
+++ b/src/features/records/monthly/aggregate.ts
@@ -10,6 +10,8 @@ import type {
     YearMonth
 } from './types';
 
+import { calculateDetailedPlannedRows } from './plannedRowsCalculator';
+
 /**
  * 日付から YearMonth 形式に変換
  */
@@ -55,9 +57,19 @@ export function aggregateMonthlyKpi(
     useWorkingDays?: boolean;
     rowsPerDay?: number;
     source?: 'daily-manual' | 'kiosk-execution' | 'hybrid' | string;
+    contractWeekdays?: number[];
+    holidays?: string[];
+    absences?: string[];
   } = {}
 ): MonthlyKpi {
-  const { useWorkingDays = true, rowsPerDay = 17, source = 'daily-manual' } = options;
+  const {
+    useWorkingDays = true,
+    rowsPerDay = 17,
+    source = 'daily-manual',
+    contractWeekdays,
+    holidays,
+    absences,
+  } = options;
 
   // 月内の基準日数
   const totalDays = useWorkingDays
@@ -65,7 +77,19 @@ export function aggregateMonthlyKpi(
     : getTotalDaysInMonth(yearMonth);
 
   // 計画行数 = 基準日数 × 1日あたりの行数
-  const plannedRows = totalDays * rowsPerDay;
+  const hasDetailedOptions =
+    contractWeekdays !== undefined ||
+    holidays !== undefined ||
+    absences !== undefined;
+
+  const plannedRows = hasDetailedOptions
+    ? calculateDetailedPlannedRows(yearMonth, {
+        contractWeekdays,
+        holidays,
+        absences,
+        rowsPerDay,
+      })
+    : totalDays * rowsPerDay;
 
   // 実績の集計
   const completedRows = dailyRecords.filter(r => r.completed).length;
@@ -138,6 +162,9 @@ export function aggregateMonthlySummary(
     useWorkingDays?: boolean;
     rowsPerDay?: number;
     source?: 'daily-manual' | 'kiosk-execution' | 'hybrid' | string;
+    contractWeekdays?: number[];
+    holidays?: string[];
+    absences?: string[];
   }
 ): MonthlySummary {
   // KPI集計
@@ -174,6 +201,9 @@ export function aggregateMultipleUsers(
   options?: {
     useWorkingDays?: boolean;
     rowsPerDay?: number;
+    contractWeekdays?: number[];
+    holidays?: string[];
+    absences?: string[];
   }
 ): MonthlyAggregationResult[] {
   return userRecords.map(({ userId, displayName, dailyRecords }) => {

--- a/src/features/records/monthly/plannedRowsCalculator.ts
+++ b/src/features/records/monthly/plannedRowsCalculator.ts
@@ -1,0 +1,62 @@
+import type { YearMonth } from './types';
+
+export interface PlannedRowsOptions {
+  /** 契約曜日: 0 (日) から 6 (土) の配列。未指定の場合は [1, 2, 3, 4, 5] (月〜金) */
+  contractWeekdays?: number[];
+  /** 祝日日付リスト: "YYYY-MM-DD" 形式の文字列配列 */
+  holidays?: string[];
+  /** 欠席承認済み日付リスト: "YYYY-MM-DD" 形式の文字列配列 */
+  absences?: string[];
+  /** 1日あたりの標準手順行数 (デフォルト: 17) */
+  rowsPerDay?: number;
+}
+
+/**
+ * 契約曜日、祝日、欠席日付を考慮して、対象月の正確な予定行数を計算する。
+ * 後方互換性のため、オプションが未指定の場合は従来の「土日を除く全日数」での計算結果と一致させる。
+ */
+export function calculateDetailedPlannedRows(
+  yearMonth: YearMonth,
+  options: PlannedRowsOptions = {}
+): number {
+  const {
+    contractWeekdays = [1, 2, 3, 4, 5],
+    holidays = [],
+    absences = [],
+    rowsPerDay = 17,
+  } = options;
+
+  const [year, month] = yearMonth.split('-').map(Number);
+  const totalDays = new Date(year, month, 0).getDate();
+
+  let plannedDays = 0;
+
+  for (let day = 1; day <= totalDays; day++) {
+    const y = String(year);
+    const m = String(month).padStart(2, '0');
+    const d = String(day).padStart(2, '0');
+    const dateStr = `${y}-${m}-${d}`;
+
+    const dateObj = new Date(year, month - 1, day);
+    const dayOfWeek = dateObj.getDay();
+
+    // 1. 契約曜日に入っているか
+    if (!contractWeekdays.includes(dayOfWeek)) {
+      continue;
+    }
+
+    // 2. 祝日に含まれるか
+    if (holidays.includes(dateStr)) {
+      continue;
+    }
+
+    // 3. 欠席日に含まれるか
+    if (absences.includes(dateStr)) {
+      continue;
+    }
+
+    plannedDays++;
+  }
+
+  return plannedDays * rowsPerDay;
+}


### PR DESCRIPTION
## 🎯 概要
本 PR は、月次 KPI および月次集計レポートにおける予定行数（`plannedRows`）の精度を向上させる **Phase 1-A 「plannedRows の精密化」** の実装です。

これまで簡易計算（`営業日数 * 17行` 等の固定計算）で行われていた分母算出ロジックを、利用予定曜日、祝日、および事前に承認された欠席申請日程を安全に考慮した「真の個別予定行数」へと段階的に改善するための基盤を新設しました。

---

## 🛠️ 主な変更内容

1. **精密計算用ヘルパー関数の新規作成 (`src/features/records/monthly/plannedRowsCalculator.ts`)**
   - 契約曜日（`contractWeekdays`）、祝日（`holidays`）、欠席日（`absences`）を安全に考慮する純粋関数 `calculateDetailedPlannedRows` を実装。
   - `new Date(year, month - 1, day)` を使用し、タイムゾーンのズレやローカル環境による日付判定のバグを完全に回避。
   - 祝日と欠席日が同じ日に重なったり、契約外曜日に祝日や欠席が発生した場合の二重減算や余計な減算を正しく排除するロジックを担保。

2. **集計コアエンジンへの統合 ＆ 100% 後方互換性の確保 (`src/features/records/monthly/aggregate.ts`)**
   - `aggregateMonthlyKpi`、`aggregateMonthlySummary`、`aggregateMultipleUsers` に新しい詳細オプション（`contractWeekdays`、`holidays`、`absences`）を追加。
   - オプションが渡されない既存の呼び出し元については、従来の「土日を除く営業日 * 17行」の簡易ロジックへ安全にフォールバック。

3. **網羅的なテストケースの追加 (`src/features/records/monthly/__tests__/plannedRowsCalculator.spec.ts`)**
   - 新規ヘルパーおよび集計関数の統合について、単体および統合テストケースを記述し、100% の動作検証を完了しました。

4. **UI（進捗チャート）への補足説明 Tooltip 追加 (`src/features/records/monthly/UserProgressChart.tsx`)**
   - 総合完了率表示の「`XX / XX 行完了`」の横に `Mui Tooltip` とヘルプアイコンを配置。
   - *「予定行数：利用契約曜日、祝日、および承認済みの欠席連絡を考慮して自動計算された今月の目標記録行数です。」* という日本語の説明を表示。

---

## 🔒 安全性・スコープ外の保証 (後方互換性)

- **既存保存スキーマの変更なし**: JSON 構造や DB インスタンススキーマは変更していません。
- **SharePoint 物理列追加なし**: 新規の物理列を SharePoint リストに追加していません。
- **他サブシステムへの影響なし**: PDF / Word エクスポート、国保連請求計算、Power Automate フロー等への変更・干渉は一切ありません。
- **既存の 17 行前提の維持**: `rowsPerDay` のデフォルト値は引き続き `17` を維持。

---

## ✅ テスト・検証状況

- **TypeScript 型チェック**: `npm run typecheck` をパス (エラー：0)
- **単体テスト**: `npx vitest run src/features/records/monthly` ですべてのテスト（計 65 ケース）が完全パス。
- **ESLint**: `npm run lint` が警告上限数（200）以下で問題なく完了（0 エラー）。
