### PR TITLE
feat(monthly-records): thread planned rows options through kiosk aggregation

### DIFF
--- a/src/features/records/monthly/kioskEvidence.ts
+++ b/src/features/records/monthly/kioskEvidence.ts
@@ -191,9 +191,21 @@ export function aggregateMonthlySummaryFromKioskEvidence(
     displayName: string;
     useWorkingDays?: boolean;
     rowsPerDay?: number;
+    contractWeekdays?: number[];
+    holidays?: string[];
+    absences?: string[];
   }
 ): KioskMonthlyAggregationResult {
-  const { userId, yearMonth, displayName, useWorkingDays, rowsPerDay } = options;
+  const {
+    userId,
+    yearMonth,
+    displayName,
+    useWorkingDays,
+    rowsPerDay,
+    contractWeekdays,
+    holidays,
+    absences,
+  } = options;
   const target = { userId, yearMonth };
   const { included, skippedRecords, errors } = collectKioskEvidenceRecords(records, target);
   const dailyRecords = included.map(({ dailyRecord }) => dailyRecord);
@@ -201,6 +213,9 @@ export function aggregateMonthlySummaryFromKioskEvidence(
     useWorkingDays,
     rowsPerDay,
     source: 'kiosk-execution',
+    contractWeekdays,
+    holidays,
+    absences,
   });
 
   return {

--- a/src/features/records/monthly/kioskMonthlyAggregationUseCase.test.ts
+++ b/src/features/records/monthly/kioskMonthlyAggregationUseCase.test.ts
@@ -157,4 +157,34 @@ describe('executeKioskMonthlyAggregation use case', () => {
     expect(result.summary.kpi.plannedRows).toBe(0);
     expect(result.evidence.sourceRows).toBe(0);
   });
+
+  it('applies contractWeekdays, holidays, and absences to limit plannedRows calculation', async () => {
+    const mockRepository = {
+      getRecords: vi.fn(),
+      getRecord: vi.fn(),
+      upsertRecord: vi.fn(),
+      getCompletionRate: vi.fn(),
+      getHistoricalRecords: vi.fn(),
+      getRecordsInRange: vi.fn().mockResolvedValue([]), // No records found
+    } satisfies ExecutionRecordRepository;
+
+    // In May 2026:
+    // contractWeekdays: [1, 3, 5] (Mon, Wed, Fri) -> Usually 13 days (1, 4, 6, 8, 11, 13, 15, 18, 20, 22, 25, 27, 29)
+    // holidays: ['2026-05-04', '2026-05-05', '2026-05-06'] -> Mon (4), Tue (5), Wed (6). Overlapping on contract weekdays: 4 (Mon) and 6 (Wed)
+    // absences: ['2026-05-15'] -> 15 (Fri). Overlapping on contract weekdays: 15 (Fri)
+    // Net contract days = 13 total - 2 holidays - 1 absence = 10 days
+    const result = await executeKioskMonthlyAggregation(mockRepository, {
+      userId: 'I001',
+      displayName: 'Test User',
+      yearMonth: '2026-05',
+      useWorkingDays: true,
+      rowsPerDay: 10,
+      contractWeekdays: [1, 3, 5],
+      holidays: ['2026-05-04', '2026-05-05', '2026-05-06'],
+      absences: ['2026-05-15'],
+    });
+
+    // 10 contract days * 10 rows per day = 100 planned rows
+    expect(result.summary.kpi.plannedRows).toBe(100);
+  });
 });

--- a/src/features/records/monthly/kioskMonthlyAggregationUseCase.ts
+++ b/src/features/records/monthly/kioskMonthlyAggregationUseCase.ts
@@ -12,6 +12,9 @@ export interface KioskMonthlyAggregationParams {
   yearMonth: YearMonth;
   useWorkingDays?: boolean;
   rowsPerDay?: number;
+  contractWeekdays?: number[];
+  holidays?: string[];
+  absences?: string[];
 }
 
 /**
@@ -24,7 +27,16 @@ export async function executeKioskMonthlyAggregation(
   repository: ExecutionRecordRepository,
   params: KioskMonthlyAggregationParams
 ): Promise<KioskMonthlyAggregationResult> {
-  const { userId, displayName, yearMonth, useWorkingDays, rowsPerDay } = params;
+  const {
+    userId,
+    displayName,
+    yearMonth,
+    useWorkingDays,
+    rowsPerDay,
+    contractWeekdays,
+    holidays,
+    absences,
+  } = params;
 
   // 1. Calculate from/to date range for the target YearMonth (inclusive)
   const totalDays = getTotalDaysInMonth(yearMonth);
@@ -42,6 +54,9 @@ export async function executeKioskMonthlyAggregation(
       displayName,
       useWorkingDays,
       rowsPerDay,
+      contractWeekdays,
+      holidays,
+      absences,
     });
   } catch (error) {
     // Return a graceful failure result in case of repository or system errors


### PR DESCRIPTION
## Summary
- Follow-up to PR #1902
- Thread plannedRows precision options through the kiosk monthly aggregation path
- Pass contractWeekdays / holidays / absences into kiosk aggregation use case
- Add/adjust tests for the kiosk aggregation path

## Safety
- No SharePoint schema changes
- No persistence changes
- No PDF / Word / billing / Power Automate changes
- Keeps PR #1902 backward-compatible plannedRows behavior

## Checks
- npm run typecheck
- npx vitest run src/features/records/monthly