### PR TITLE
fix(sp): stop retry storm on SharePoint throttling

### DIFF
--- a/src/lib/sp/__tests__/spFetch.retry-guard.spec.ts
+++ b/src/lib/sp/__tests__/spFetch.retry-guard.spec.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createSpFetch } from '../spFetch';
+import type { EnvRecord } from '@/lib/env';
+
+function createTestEnv(): EnvRecord {
+  return {
+    VITE_SKIP_LOGIN: '0',
+    VITE_SKIP_SHAREPOINT: '0',
+    VITE_E2E_MSAL_MOCK: '0',
+    VITE_AUDIT_DEBUG: '0',
+  } as unknown as EnvRecord;
+}
+
+function createFetcher() {
+  return createSpFetch({
+    acquireToken: async () => 'test-token',
+    baseUrl: 'https://example.sharepoint.com/sites/welfare',
+    config: createTestEnv(),
+    retrySettings: { maxAttempts: 4, baseDelay: 2000, capDelay: 30000 },
+    debugEnabled: false,
+    spSiteLegacy: '/sites/welfare',
+    throwOnError: false,
+  });
+}
+
+describe('spFetch retry guard for SharePoint throttle/cors', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('does not retry when redirected to Throttle.htm', async () => {
+    const throttled = new Response('', { status: 200 });
+    Object.defineProperty(throttled, 'url', {
+      value: 'https://example.sharepoint.com/_layouts/15/Throttle.htm#17',
+    });
+
+    const fetchMock = vi.fn().mockResolvedValue(throttled);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const spFetch = createFetcher();
+
+    await expect(spFetch('/_api/web/lists')).rejects.toThrow('Throttle.htm');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries 429/503 with exponential backoff and then succeeds', async () => {
+    const r503a = new Response('busy', { status: 503 });
+    const r503b = new Response('busy', { status: 503 });
+    const ok = new Response(JSON.stringify({ value: [] }), { status: 200 });
+    Object.defineProperty(r503a, 'url', { value: 'https://example.sharepoint.com/sites/welfare/_api/x' });
+    Object.defineProperty(r503b, 'url', { value: 'https://example.sharepoint.com/sites/welfare/_api/x' });
+    Object.defineProperty(ok, 'url', { value: 'https://example.sharepoint.com/sites/welfare/_api/x' });
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(r503a)
+      .mockResolvedValueOnce(r503b)
+      .mockResolvedValueOnce(ok);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+    const spFetch = createFetcher();
+
+    const req = spFetch('/_api/web/lists');
+    await vi.runAllTimersAsync();
+    const response = await req;
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const delays = setTimeoutSpy.mock.calls.map((call) => Number(call[1]));
+    expect(delays).toHaveLength(2);
+    expect(delays[0]).toBeGreaterThanOrEqual(1600);
+    expect(delays[0]).toBeLessThanOrEqual(2400);
+    expect(delays[1]).toBeGreaterThanOrEqual(3200);
+    expect(delays[1]).toBeLessThanOrEqual(4800);
+    expect(delays[1]).toBeGreaterThan(delays[0]);
+  });
+
+  it('does not keep retrying on Failed to fetch (CORS-like TypeError)', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const spFetch = createFetcher();
+
+    await expect(spFetch('/_api/web/lists')).rejects.toThrow('Failed to fetch');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/sp/spFetch.ts
+++ b/src/lib/sp/spFetch.ts
@@ -196,8 +196,8 @@ function isRetryableStatus(status: number): boolean {
   return status === 429 || status === 503;
 }
 
-function isThrottleRedirect(url: string): boolean {
-  return url.includes('/_layouts/15/Throttle.htm');
+function isThrottleRedirect(url: unknown): boolean {
+  return typeof url === 'string' && url.includes('/_layouts/15/Throttle.htm');
 }
 
 function isLikelyCorsOrRedirectFailure(error: unknown): boolean {
@@ -413,15 +413,16 @@ export function createSpFetch(deps: SpFetchDeps) {
           const response = await fetch(url, { ...init, headers, signal: mergedSignal });
 
           if (isThrottleRedirect(response.url)) {
+            const responseUrl = typeof response.url === 'string' ? response.url : '';
             if (!hasWarnedThrottleRedirect) {
               hasWarnedThrottleRedirect = true;
               auditLog.warn('sp:fetch', 'throttle_redirect_detected_retry_stopped', {
-                url: response.url.split('?')[0],
+                url: responseUrl.split('?')[0],
                 method,
                 lane,
               });
             }
-            throw new SpThrottleRedirectError(response.url);
+            throw new SpThrottleRedirectError(responseUrl);
           }
 
           const retryAfterMs = parseRetryAfterMs(response);

--- a/src/lib/sp/spFetch.ts
+++ b/src/lib/sp/spFetch.ts
@@ -193,8 +193,32 @@ function computeBackoffMs(
 }
 
 function isRetryableStatus(status: number): boolean {
-  return status === 429 || status === 500 || status === 502 || status === 503 || status === 504;
+  return status === 429 || status === 503;
 }
+
+function isThrottleRedirect(url: string): boolean {
+  return url.includes('/_layouts/15/Throttle.htm');
+}
+
+function isLikelyCorsOrRedirectFailure(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const message = error.message.toLowerCase();
+  return (
+    message.includes('failed to fetch') ||
+    message.includes('networkerror') ||
+    message.includes('cors')
+  );
+}
+
+class SpThrottleRedirectError extends Error {
+  constructor(public readonly responseUrl: string) {
+    super('[SharePoint] Throttled: redirected to Throttle.htm. Retry stopped to avoid request storm.');
+    this.name = 'SpThrottleRedirectError';
+  }
+}
+
+let hasWarnedThrottleRedirect = false;
+let hasWarnedCorsOrRedirectFailure = false;
 
 function sleep(ms: number, signal?: AbortSignal): Promise<void> {
   if (ms <= 0) return Promise.resolve();
@@ -387,6 +411,19 @@ export function createSpFetch(deps: SpFetchDeps) {
         try {
           // eslint-disable-next-line no-restricted-globals
           const response = await fetch(url, { ...init, headers, signal: mergedSignal });
+
+          if (isThrottleRedirect(response.url)) {
+            if (!hasWarnedThrottleRedirect) {
+              hasWarnedThrottleRedirect = true;
+              auditLog.warn('sp:fetch', 'throttle_redirect_detected_retry_stopped', {
+                url: response.url.split('?')[0],
+                method,
+                lane,
+              });
+            }
+            throw new SpThrottleRedirectError(response.url);
+          }
+
           const retryAfterMs = parseRetryAfterMs(response);
 
           if (response.ok) {
@@ -484,6 +521,19 @@ export function createSpFetch(deps: SpFetchDeps) {
             throw error;
           }
 
+          if (error instanceof SpThrottleRedirectError) {
+            recordTelemetry('sp:request_failed', {
+              url: url.split('?')[0],
+              method,
+              lane,
+              attempt,
+              durationMs: Date.now() - attemptStartedAt,
+              message: error.message,
+            });
+            span.error('SpThrottleRedirectError', attempt - 1);
+            throw error;
+          }
+
           if (isAbortError(error)) {
             recordTelemetry('sp:request_failed', {
               url: url.split('?')[0],
@@ -497,7 +547,17 @@ export function createSpFetch(deps: SpFetchDeps) {
             throw error;
           }
 
-          const retryable = !skipRetry && attempt <= maxRetries;
+          const retryableNetwork = !isLikelyCorsOrRedirectFailure(error);
+          if (!retryableNetwork && !hasWarnedCorsOrRedirectFailure) {
+            hasWarnedCorsOrRedirectFailure = true;
+            auditLog.warn('sp:fetch', 'cors_or_redirect_failure_retry_stopped', {
+              method,
+              lane,
+              message: error instanceof Error ? error.message : 'NetworkError',
+            });
+          }
+
+          const retryable = !skipRetry && attempt <= maxRetries && retryableNetwork;
           if (retryable) {
             const delayMs = computeBackoffMs(attempt, baseDelay, capDelay);
             recordTelemetry('sp:retry', {


### PR DESCRIPTION
## Summary
- Stop retrying when SharePoint redirects to `/_layouts/15/Throttle.htm`
- Limit retryable SharePoint responses to HTTP 429/503
- Do not retry browser-side `TypeError: Failed to fetch` errors such as CORS/redirect failures
- Suppress repeated throttle warnings with a module-level guard

## Why
When SharePoint throttles API requests, it may redirect REST calls to `/_layouts/15/Throttle.htm`.
That redirect target does not satisfy localhost CORS preflight, so browser clients see `No Access-Control-Allow-Origin` / `Failed to fetch`.

If `spFetch.ts` retries those failures aggressively, it can amplify the throttle condition and create a retry storm.

## Scope
This PR only hardens the frontend SharePoint fetch retry guard.

## Non-goals
- No BFF / Azure Functions migration
- No Graph API migration
- No SharePoint schema changes
- No repository-level refactor

## Checks
- `npx vitest run src/lib/sp/__tests__/spFetch.retry-guard.spec.ts`
- `npm run typecheck`
