### PR TITLE
fix(types): remove nightly patrol any regressions

### DIFF
--- a/src/features/meeting-minutes/components/MeetingMinutesForm.tsx
+++ b/src/features/meeting-minutes/components/MeetingMinutesForm.tsx
@@ -131,6 +131,7 @@ export function MeetingMinutesForm(props: {
   errorMessage?: string;
 }) {
   const { mode, value, onChange, onSave, onCancel, isSaving, errorMessage } = props;
+  type InsertBlocksInput = Parameters<MeetingMinutesEditor['insertBlocks']>[0];
 
   const set = <K extends keyof MeetingMinutesDraft>(key: K, v: MeetingMinutesDraft[K]) =>
     onChange({ ...value, [key]: v });
@@ -157,8 +158,7 @@ export function MeetingMinutesForm(props: {
     }));
 
     editor.insertBlocks(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      blocks as any,
+      blocks as InsertBlocksInput,
       editor.getTextCursorPosition().block,
       'after'
     );

--- a/src/features/monitoring/components/MonitoringMeetingForm.tsx
+++ b/src/features/monitoring/components/MonitoringMeetingForm.tsx
@@ -79,6 +79,7 @@ export const MonitoringMeetingForm: React.FC<MonitoringMeetingFormProps> = ({
   improvementInput,
   onImprovementInputChange,
 }) => {
+  type InsertBlocksInput = Parameters<MeetingMinutesEditor['insertBlocks']>[0];
   const [validationErrors, setValidationErrors] = useState<string[]>([]);
   const [validationWarnings, setValidationWarnings] = useState<string[]>([]);
   const { data: staffMaster = [] } = useStaff();
@@ -183,8 +184,7 @@ export const MonitoringMeetingForm: React.FC<MonitoringMeetingFormProps> = ({
     }));
 
     editor.insertBlocks(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      blocks as any,
+      blocks as InsertBlocksInput,
       editor.getTextCursorPosition().block,
       'after'
     );

--- a/src/infra/sharepoint/repos/SharePointAbcRecordRepository.ts
+++ b/src/infra/sharepoint/repos/SharePointAbcRecordRepository.ts
@@ -65,6 +65,12 @@ interface SpAbcRecordRow {
   Modified?: string;
 }
 
+type SpCreateItemResponse = {
+  Id?: number;
+  d?: { Id?: number };
+  data?: { Id?: number };
+};
+
 export class SharePointAbcRecordRepository implements AbcRecordRepository {
   private listName = LIST_CONFIG[ListKeys.AbcBehaviorRecords].title;
 
@@ -163,8 +169,10 @@ export class SharePointAbcRecordRepository implements AbcRecordRepository {
     };
 
     // SharePoint への新規作成 POST
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const created = await this.client.createItem<any>(this.listName, payload as any);
+    const created = await this.client.createItem<SpCreateItemResponse>(
+      this.listName,
+      payload as Record<string, unknown>
+    );
     const createdId = Number(created?.Id ?? created?.d?.Id ?? created?.data?.Id);
 
     if (!createdId || !Number.isFinite(createdId)) {


### PR DESCRIPTION
## Summary

- Removed the 3 `any-regression` hits reported by Nightly Patrol
- Replaced `blocks as any` in meeting/monitoring forms with the inferred `insertBlocks` parameter type
- Replaced `createItem<any>(..., payload as any)` in the ABC SharePoint repository with `SpCreateItemResponse` and `Record<string, unknown>`

## Scope

- This PR only addresses the Nightly Patrol `any-regression` findings
- Large-file monitor/log-only findings are intentionally left untouched and should be handled in a separate refactor issue/PR

## Checks

- `npm run typecheck`
- `npm run lint`
- `npm run patrol`

## Patrol result

- `any hits: 0`
- `Issue drafts: 0`
- `classification status: monitor`
- Remaining monitor classification is caused only by large-file log-only findings
