### PR TITLE
feat(monthly): add weekday converter for planned rows

### DIFF
--- a/src/features/records/monthly/utils/__tests__/weekdayConverter.spec.ts
+++ b/src/features/records/monthly/utils/__tests__/weekdayConverter.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { convertJapaneseWeekdaysToNumbers } from '../weekdayConverter';
+
+describe('convertJapaneseWeekdaysToNumbers', () => {
+  it('correctly maps standard Japanese single character weekdays', () => {
+    expect(convertJapaneseWeekdaysToNumbers(['月', '水', '金'])).toEqual([1, 3, 5]);
+    expect(convertJapaneseWeekdaysToNumbers(['日', '火', '木', '土'])).toEqual([0, 2, 4, 6]);
+  });
+
+  it('correctly extracts leading character from full weekday name', () => {
+    expect(convertJapaneseWeekdaysToNumbers(['月曜日', '水曜日', '金曜日'])).toEqual([1, 3, 5]);
+    expect(convertJapaneseWeekdaysToNumbers([' 日曜 ', '木曜'])).toEqual([0, 4]);
+  });
+
+  it('handles invalid inputs gracefully by filtering them out', () => {
+    // Non-existent weekdays should be ignored
+    expect(convertJapaneseWeekdaysToNumbers(['祝', '月', 'None'])).toEqual([1]);
+  });
+
+  it('returns empty array when input is empty or invalid type', () => {
+    expect(convertJapaneseWeekdaysToNumbers([])).toEqual([]);
+    expect(convertJapaneseWeekdaysToNumbers(null as unknown as string[])).toEqual([]);
+    expect(convertJapaneseWeekdaysToNumbers(undefined as unknown as string[])).toEqual([]);
+  });
+});

--- a/src/features/records/monthly/utils/weekdayConverter.ts
+++ b/src/features/records/monthly/utils/weekdayConverter.ts
@@ -1,0 +1,24 @@
+const WEEKDAY_MAP: Record<string, number> = {
+  '日': 0,
+  '月': 1,
+  '火': 2,
+  '水': 3,
+  '木': 4,
+  '金': 5,
+  '土': 6,
+};
+
+/**
+ * 日本語曜日文字列の配列を、0（日）〜 6（土）の数値配列に変換する
+ */
+export function convertJapaneseWeekdaysToNumbers(days: string[]): number[] {
+  if (!days || !Array.isArray(days)) return [];
+  
+  return days
+    .map(day => {
+      // "月曜日" などの表記に対応するため、先頭の1文字を抽出
+      const char = day.trim().charAt(0);
+      return WEEKDAY_MAP[char];
+    })
+    .filter((val): val is number => val !== undefined);
+}


### PR DESCRIPTION
## Summary
- Add weekday conversion helper for monthly plannedRows calculation
- Support Japanese weekday labels and canonical weekday keys
- Add unit tests for valid and invalid conversions

## Scope
- Utility/helper only
- No SharePoint schema changes
- No persistence changes
- No aggregation behavior changes by itself

## Checks
- npm run typecheck
- npx vitest run src/features/records/monthly/__tests__/plannedRowsCalculator.spec.ts src/features/records/monthly/utils/__tests__/weekdayConverter.spec.ts
