### PR TITLE
feat(monthly): aggregate monthly records from SharePoint execution data

### DIFF
--- a/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
+++ b/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
@@ -143,6 +143,21 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
     return activePayload;
   }
 
+  private getSelectFields(rf: ResolvedRowsFields): string {
+    const fields = new Set<string>(['Id', 'Title', 'Created', 'Modified']);
+    fields.add(rf.parentId);
+    fields.add(rf.userId);
+    fields.add(rf.status);
+    fields.add(rf.payload);
+    fields.add(rf.recordedAt);
+    fields.add(rf.rowKey);
+    if (rf.rowNo) fields.add(rf.rowNo);
+    if (rf.memo) fields.add(rf.memo);
+    if (rf.staffName) fields.add(rf.staffName);
+    if (rf.bipsJSON) fields.add(rf.bipsJSON);
+    return Array.from(fields).join(',');
+  }
+
   private async ensureParentRecord(dailyKey: string, date: string, _userId: string): Promise<number> {
     await this.getResolvedFields(); // Ensure paths resolved
     const filter = `${DAILY_RECORD_FIELDS.title} eq '${dailyKey}'`;
@@ -198,7 +213,8 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
     // We filter by userId and date range in rowKey.
     // rowKey >= from and rowKey <= to + 'z' ensures we get all items for those dates.
     const filter = `(${rf.userId} eq '${normalizedUserId}') and (${rf.rowKey} ge '${normalizedFrom}') and (${rf.rowKey} le '${normalizedTo}z')`;
-    const url = `${this.resolvedChildPath}/items?$filter=${encodeURIComponent(filter)}&$top=5000`;
+    const select = this.getSelectFields(rf);
+    const url = `${this.resolvedChildPath}/items?$filter=${encodeURIComponent(filter)}&$select=${select}&$top=5000`;
 
     const response = await this.spFetch(url);
     if (!response.ok) {
@@ -222,7 +238,8 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
     // However, resolveInternalNames is supposed to be accurate. 
     // We lowercase startswith for maximum compatibility.
     const filter = `startswith(${rf.rowKey}, '${rowKeyPrefix}')`;
-    const url = `${this.resolvedChildPath}/items?$filter=${encodeURIComponent(filter)}`;
+    const select = this.getSelectFields(rf);
+    const url = `${this.resolvedChildPath}/items?$filter=${encodeURIComponent(filter)}&$select=${select}`;
 
     const response = await this.spFetch(url);
     if (!response.ok) {
@@ -249,7 +266,8 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
     const rf = await this.getResolvedFields();
     const rowKey = `${normalizedDate}-${normalizedUserId}-${normalizedScheduleItemId}`;
     const filter = `${rf.rowKey} eq '${rowKey}'`;
-    const url = `${this.resolvedChildPath}/items?$filter=${encodeURIComponent(filter)}`;
+    const select = this.getSelectFields(rf);
+    const url = `${this.resolvedChildPath}/items?$filter=${encodeURIComponent(filter)}&$select=${select}`;
 
     const response = await this.spFetch(url);
     if (!response.ok) return undefined;

--- a/src/features/records/monthly/hooks/useMonthlySummaries.ts
+++ b/src/features/records/monthly/hooks/useMonthlySummaries.ts
@@ -1,0 +1,80 @@
+import { useState, useCallback, useEffect } from 'react';
+import { useUsers } from '@/features/users/useUsers';
+import { useExecutionData } from '@/features/daily/hooks/useExecutionData';
+import { isDemoModeEnabled } from '@/lib/env';
+import { mockMonthlySummaries } from '../monthlyRecordSeedData';
+import { executeKioskMonthlyAggregation } from '../kioskMonthlyAggregationUseCase';
+import type { MonthlySummary, YearMonth } from '../types';
+
+/**
+ * Hook to fetch and aggregate monthly summaries for all active users.
+ * Supports both demo (mock) and production (SharePoint) data sources.
+ */
+export function useMonthlySummaries(yearMonth: YearMonth) {
+  const { users, isLoading: loadingUsers } = useUsers();
+  const repository = useExecutionData();
+  const [summaries, setSummaries] = useState<MonthlySummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    // 1. Handle Demo Mode
+    if (isDemoModeEnabled()) {
+      // Filter mocks by yearMonth if needed, but for now we just return them
+      // as they are primarily for UI demonstration.
+      setSummaries(mockMonthlySummaries);
+      setLoading(false);
+      return;
+    }
+
+    // 2. Handle Production Mode (requires repository and users)
+    if (loadingUsers) return;
+    
+    if (!repository) {
+      setError('Repository not initialized');
+      setLoading(false);
+      return;
+    }
+
+    if (users.length === 0) {
+      setSummaries([]);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    try {
+      // Aggregate data for each user in parallel
+      const results = await Promise.all(
+        users.map((user) =>
+          executeKioskMonthlyAggregation(repository, {
+            userId: user.UserID,
+            displayName: user.FullName,
+            yearMonth,
+          })
+        )
+      );
+      
+      setSummaries(results.map((r) => r.summary));
+      setError(null);
+    } catch (err) {
+      console.error('[useMonthlySummaries] Aggregation failed:', err);
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [repository, users, yearMonth, loadingUsers]);
+
+  // Initial load and re-fetch when month changes
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return {
+    summaries,
+    loading: loading || loadingUsers,
+    error,
+    refresh,
+    isDemo: isDemoModeEnabled()
+  };
+}

--- a/src/pages/MonthlyRecordPage.tsx
+++ b/src/pages/MonthlyRecordPage.tsx
@@ -27,9 +27,14 @@ import RequireAudience from '../components/RequireAudience';
 import { MonthlySummaryTable } from '../features/records/monthly/MonthlySummaryTable';
 import { UserKpiCards } from '../features/records/monthly/UserKpiCards';
 import { UserProgressChart } from '../features/records/monthly/UserProgressChart';
-import { DEFAULT_MONTH, useDemoSummaries, type E2ESeedWindow } from '../features/records/monthly/monthlyRecordSeedData';
-import type { MonthlySummary, YearMonth } from '../features/records/monthly/types';
+import { DEFAULT_MONTH, type E2ESeedWindow } from '../features/records/monthly/monthlyRecordSeedData';
+import type { YearMonth } from '../features/records/monthly/types';
+import { useMonthlySummaries } from '../features/records/monthly/hooks/useMonthlySummaries';
 import { TESTIDS } from '../testids';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import Chip from '@mui/material/Chip';
+import CircularProgress from '@mui/material/CircularProgress';
+import Alert from '@mui/material/Alert';
 
 const srOnly = {
   border: 0,
@@ -48,20 +53,27 @@ type TabKey = 'summary' | 'user-detail' | 'pdf';
 export default function MonthlyRecordPage() {
   const [params, setParams] = useSearchParams();
   const { role } = useUserAuthz();
-  const [summaries] = React.useState<MonthlySummary[]>(useDemoSummaries());
-  const [loading] = React.useState(false);
+  const [selectedMonth, setSelectedMonth] = React.useState<YearMonth>(DEFAULT_MONTH);
+  const { summaries, loading, error, refresh, isDemo } = useMonthlySummaries(selectedMonth);
+  const [keyword, setKeyword] = React.useState('');
 
   const e2e = isE2E();
   const w = (typeof window !== 'undefined' ? window : {}) as E2ESeedWindow;
   const debugSeed = e2e ? w.__E2E_SEED__ : 'none';
 
-  const [selectedMonth, setSelectedMonth] = React.useState<YearMonth>(DEFAULT_MONTH);
-  const [keyword, setKeyword] = React.useState('');
-
-  const monthOptions = React.useMemo<YearMonth[]>(
-    () => Array.from(new Set(summaries.map((s) => s.yearMonth))) as YearMonth[],
-    [summaries],
-  );
+  const monthOptions = React.useMemo<YearMonth[]>(() => {
+    // 過去12ヶ月分をデフォルトの選択肢とする
+    const options: YearMonth[] = [];
+    const now = new Date();
+    for (let i = 0; i < 12; i++) {
+      const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
+      const ym = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}` as YearMonth;
+      options.push(ym);
+    }
+    // データがある月も追加して重複排除
+    const dataMonths = summaries.map(s => s.yearMonth);
+    return Array.from(new Set([...options, ...dataMonths])).sort().reverse() as YearMonth[];
+  }, [summaries]);
 
   const filteredSummaries = React.useMemo(
     () =>
@@ -229,13 +241,40 @@ export default function MonthlyRecordPage() {
       <Box sx={{ py: 3 }}>
         {/* ヘッダー */}
         <Box sx={{ mb: 3 }}>
-          <Typography variant="h4" component="h1">
-            月次記録
-          </Typography>
-          <Typography variant="body1" color="text.secondary">
-            利用者の月次活動記録を集計・分析し、完了率や進捗状況を管理します
-          </Typography>
+          <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
+            <Box>
+              <Typography variant="h4" component="h1">
+                月次記録
+              </Typography>
+              <Typography variant="body1" color="text.secondary">
+                利用者の月次活動記録を集計・分析し、完了率や進捗状況を管理します
+              </Typography>
+            </Box>
+            <Stack direction="row" spacing={1} alignItems="center">
+              <Chip
+                label={isDemo ? 'デモモード' : '本番データ'}
+                color={isDemo ? 'warning' : 'success'}
+                variant="outlined"
+                size="small"
+              />
+              <Button
+                variant="outlined"
+                size="small"
+                startIcon={loading ? <CircularProgress size={16} /> : <RefreshIcon />}
+                onClick={() => refresh()}
+                disabled={loading}
+              >
+                再集計
+              </Button>
+            </Stack>
+          </Stack>
         </Box>
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 3 }}>
+            データの取得に失敗しました: {error}
+          </Alert>
+        )}
 
         {/* フィルターバー */}
         <Box sx={{ mb: 2 }}>


### PR DESCRIPTION
## Summary
- Replace demo-only monthly summaries with useMonthlySummaries
- Aggregate monthly KPIs from SharePoint execution records in production mode
- Keep demo summaries available in demo mode
- Add production/demo status chip and manual re-aggregation button
- Keep last 12 months selectable even before summary data exists

## Scope
- Monthly record page only
- No Business Journal Preview wiring in this PR
- No SharePoint schema changes

## Checks
- Verify production mode shows 本番データ
- Verify users are loaded from Users_Master
- Verify 再集計 refreshes aggregation from SupportRecord_Daily
- Verify demo mode still uses seed data
