### PR TITLE
refactor(monitoring): standardize repository access

### DIFF
--- a/src/features/monitoring/repositories/__tests__/useMonitoringMeetingRepository.compat.spec.ts
+++ b/src/features/monitoring/repositories/__tests__/useMonitoringMeetingRepository.compat.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mockRepo = { listByUser: vi.fn() };
+
+vi.mock('@/features/monitoring/data/useMonitoringMeetingRepository', () => ({
+  useMonitoringMeetingRepository: vi.fn(() => mockRepo),
+}));
+
+import { useMonitoringMeetingRepository } from '@/features/monitoring/repositories/createMonitoringMeetingRepository';
+import { useMonitoringMeetingRepository as useMonitoringMeetingRepositoryFromData } from '@/features/monitoring/data/useMonitoringMeetingRepository';
+
+describe('createMonitoringMeetingRepository compat hook', () => {
+  it('delegates to data/useMonitoringMeetingRepository', () => {
+    const repo = useMonitoringMeetingRepository();
+    expect(repo).toBe(mockRepo);
+    expect(useMonitoringMeetingRepositoryFromData).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/monitoring/repositories/createMonitoringMeetingRepository.ts
+++ b/src/features/monitoring/repositories/createMonitoringMeetingRepository.ts
@@ -7,11 +7,10 @@
 
 import type { MonitoringMeetingRepository } from '@/domain/isp/monitoringMeetingRepository';
 import type { UseSP } from '@/lib/spClient';
-import { useMemo } from 'react';
-import { useDataProvider } from '@/lib/data/useDataProvider';
 import { localMonitoringMeetingRepository } from '@/infra/localStorage/localMonitoringMeetingRepository';
 import { SharePointDataProvider } from '@/lib/sp/spDataProvider';
 import { DataProviderMonitoringMeetingRepository } from '../data/DataProviderMonitoringMeetingRepository';
+export { useMonitoringMeetingRepository } from '../data/useMonitoringMeetingRepository';
 
 type Mode = 'local' | 'sharepoint';
 type Options = { spClient?: UseSP };
@@ -28,18 +27,5 @@ export function createMonitoringMeetingRepository(
   }
   const provider = new SharePointDataProvider(options.spClient);
   return new DataProviderMonitoringMeetingRepository(provider);
-}
-
-/**
- * React Hook: MonitoringMeetingRepository を取得する
- */
-export function useMonitoringMeetingRepository(): MonitoringMeetingRepository {
-  const { provider, type } = useDataProvider();
-  return useMemo(() => {
-    if (type !== 'sharepoint') {
-      return localMonitoringMeetingRepository;
-    }
-    return new DataProviderMonitoringMeetingRepository(provider);
-  }, [provider, type]);
 }
 

--- a/src/features/planning-sheet/components/new-form/NewPlanningSheetForm.tsx
+++ b/src/features/planning-sheet/components/new-form/NewPlanningSheetForm.tsx
@@ -57,7 +57,7 @@ import type { ImportPreviewResult } from '../../buildImportPreview';
 import { ImportPreviewDialog } from '../ImportPreviewDialog';
 import { ImportMonitoringDialog } from '../ImportMonitoringDialog';
 import { useLatestBehaviorMonitoring } from '../../hooks/useLatestBehaviorMonitoring';
-import { useMonitoringMeetingRepository } from '@/features/monitoring/repositories/createMonitoringMeetingRepository';
+import { useMonitoringMeetingRepository } from '@/features/monitoring/data/useMonitoringMeetingRepository';
 import { useIcebergRepository } from '@/features/ibd/analysis/iceberg/SharePointIcebergRepository';
 import { icebergToInterventionDrafts } from '@/features/ibd/analysis/iceberg/icebergToIntervention';
 import { buildIcebergImportResult } from '../../icebergToPlanningBridge';
@@ -128,9 +128,8 @@ export const NewPlanningSheetForm: React.FC<NewPlanningSheetFormProps> = ({
 
   // ── モニタリング読込 ──
   // NOTE:
-  // Repository is resolved via createMonitoringMeetingRepository factory.
+  // Repository is resolved by the monitoring data-layer hook.
   // Do not import localMonitoringMeetingRepository directly in UI components.
-  // SP_ENABLED のときは sharepoint モードで SP リストから取得する。
   const monitoringRepo = useMonitoringMeetingRepository();
   const {
     record: latestMonitoringRecord,

--- a/src/pages/support-planning-sheet/hooks/__tests__/useSupportPlanningSheetOrchestrator.spec.tsx
+++ b/src/pages/support-planning-sheet/hooks/__tests__/useSupportPlanningSheetOrchestrator.spec.tsx
@@ -112,7 +112,7 @@ vi.mock('@/features/planning-sheet/hooks/useStrategyUsageCounts', () => ({ useSt
 vi.mock('@/features/planning-sheet/hooks/useStrategyUsageTrend', () => ({ useStrategyUsageTrend: () => ({ result: null, days: 30, setDays: vi.fn(), loading: false }) }));
 vi.mock('@/features/assessment/stores/assessmentStore', () => ({ useAssessmentStore: () => ({ getByUserId: vi.fn() }) }));
 vi.mock('@/features/planning-sheet/hooks/useLatestBehaviorMonitoring', () => ({ useLatestBehaviorMonitoring: () => ({ record: null }) }));
-vi.mock('@/features/monitoring/repositories/createMonitoringMeetingRepository', () => ({ useMonitoringMeetingRepository: () => ({ listByUser: vi.fn(async () => []) }) }));
+vi.mock('@/features/monitoring/data/useMonitoringMeetingRepository', () => ({ useMonitoringMeetingRepository: () => ({ listByUser: vi.fn(async () => []) }) }));
 vi.mock('@/features/ibd/analysis/pdca/queries/usePdcaCycleState', () => ({ usePdcaCycleState: () => ({ state: {} }) }));
 vi.mock('@/app/services/bridgeProxy', () => ({
   getPlanningWorkflowPhaseForSheet: vi.fn(() => ({ phase: 'active_plan' })),

--- a/src/pages/support-planning-sheet/hooks/useSupportPlanningSheetOrchestrator.ts
+++ b/src/pages/support-planning-sheet/hooks/useSupportPlanningSheetOrchestrator.ts
@@ -10,7 +10,7 @@ import { useAssessmentStore } from '@/features/assessment/stores/assessmentStore
 import { useImportAuditStore } from '@/features/planning-sheet/stores/importAuditStore';
 import { filterAuditHistoryRecords } from '@/features/planning-sheet/domain/filterAuditHistory';
 import { useLatestBehaviorMonitoring } from '@/features/planning-sheet/hooks/useLatestBehaviorMonitoring';
-import { useMonitoringMeetingRepository } from '@/features/monitoring/repositories/createMonitoringMeetingRepository';
+import { useMonitoringMeetingRepository } from '@/features/monitoring/data/useMonitoringMeetingRepository';
 import { useStrategyUsageCounts } from '@/features/planning-sheet/hooks/useStrategyUsageCounts';
 import { useStrategyUsageTrend, type TrendDays } from '@/features/planning-sheet/hooks/useStrategyUsageTrend';
 import { useUsers } from '@/features/users/useUsers';


### PR DESCRIPTION
## 目的
MonitoringMeetingRepository の取得経路を `data/useMonitoringMeetingRepository.ts` 側へ正規化し、compat shim の位置づけを明確にしました。

## 非対象
- モニタリング周期計算の変更
- SupportStartDate / ServiceStartDate / appliedFrom の優先順位変更
- 90日モニタリング仕様の変更
- L2/L3責務境界の変更
- PlanningSheet / Daily / Kiosk の保存仕様変更
- SharePoint list / field 契約変更
- MonitoringMeeting の保存payload仕様変更

## 変更内容
- `repositories/createMonitoringMeetingRepository.ts` の hook 重複実装を削除し、`data/useMonitoringMeetingRepository.ts` へ委譲
- 安全に寄せられる利用箇所2件を正規 hook import へ変更
- 追従テストモックを更新
- compat shim 互換テストを追加

## 統合禁止境界チェック
- [x] L2のモニタリング起点責務を変更していない
- [x] L3 Daily画面の起点参照仕様を変更していない
- [x] 90日モニタリング周期計算を変更していない
- [x] SharePoint list / field 契約を変更していない
- [x] Daily / Kiosk の保存仕様を変更していない

## 実行したテスト
- `npx vitest run src/features/monitoring/repositories/__tests__/useMonitoringMeetingRepository.compat.spec.ts`
- `npx vitest run src/pages/support-planning-sheet/hooks/__tests__/useSupportPlanningSheetOrchestrator.spec.tsx`
- `npx vitest run src/features/planning-sheet/__tests__/monitoringSchedule.spec.ts`
- `npx vitest run src/features/daily/components/__tests__/MonitoringCountdown.spec.tsx`
- `npm run typecheck`
- `npm run lint` ※既存warningのみ、今回差分由来のerrorなし

## 補足
`npm run test -- monitoring` は差分外の `src/sharepoint/fields/__tests__/monitoringMeetingFields.drift.spec.ts` で1件失敗しています。  
失敗内容は `discussionSummaryBlocksJson` に関する既存失敗であり、今回の repository access / compat shim / planning-sheet hook 変更とは別件です。

## リスク
- import経路変更による既存利用箇所の取りこぼし
- compat shim の互換性漏れ

## ロールバック方針
問題があれば、このPRを revert して Monitoring repository の取得経路を元に戻します。
