### PR TITLE
fix(health): gate admin diagnostics on SharePoint token readiness

### DIFF
--- a/src/app/components/ConnectionStatus.spec.tsx
+++ b/src/app/components/ConnectionStatus.spec.tsx
@@ -1,0 +1,56 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { ConnectionStatus } from './ConnectionStatus';
+
+vi.mock('@/auth/useAuth', () => ({
+  useAuth: vi.fn(),
+}));
+vi.mock('@/auth/MsalProvider', () => ({
+  useMsalContext: vi.fn(),
+}));
+vi.mock('@/lib/spClient', () => ({
+  useSP: vi.fn(),
+}));
+vi.mock('@/lib/env', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/env')>();
+  return {
+    ...actual,
+    isDemoModeEnabled: vi.fn(() => false),
+    isE2eMsalMockEnabled: vi.fn(() => false),
+    shouldSkipLogin: vi.fn(() => false),
+    readBool: vi.fn((key: string, fallback: boolean) => fallback),
+    getAppConfig: vi.fn(() => ({ isDev: true })),
+  };
+});
+
+import { useAuth } from '@/auth/useAuth';
+import { useMsalContext } from '@/auth/MsalProvider';
+import { useSP } from '@/lib/spClient';
+
+describe('ConnectionStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('accountあり/tokenなしのとき SP Connected を表示しない', async () => {
+    vi.mocked(useAuth).mockReturnValue({
+      tokenReady: false,
+      loading: false,
+    } as never);
+    vi.mocked(useMsalContext).mockReturnValue({
+      accounts: [{ homeAccountId: 'acc-1' }],
+    } as never);
+    vi.mocked(useSP).mockReturnValue({
+      spFetch: vi.fn().mockResolvedValue({ ok: true }),
+    } as never);
+
+    render(<ConnectionStatus />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('sp-connection-status')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('SP Connected')).not.toBeInTheDocument();
+    expect(screen.getByText('SP Sign-In')).toBeInTheDocument();
+  });
+});

--- a/src/app/components/ConnectionStatus.tsx
+++ b/src/app/components/ConnectionStatus.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useMsalContext } from '@/auth/MsalProvider';
+import { useAuth } from '@/auth/useAuth';
 import { getAppConfig, isDemoModeEnabled, isE2eMsalMockEnabled, readBool, shouldSkipLogin } from '@/lib/env';
 import { useSP } from '@/lib/spClient';
 import Box from '@mui/material/Box';
@@ -54,6 +55,7 @@ const ConnectionStatusReal: React.FC<{ sharePointDisabled: boolean }> = ({ share
   const sharePointFeatureEnabled = readBool('VITE_FEATURE_SCHEDULES_SP', false);
   const { spFetch } = useSP();
   const { accounts } = useMsalContext();
+  const { tokenReady, loading: authLoading } = useAuth();
   const accountsCount = accounts.length;
   const [state, setState] = useState<'checking' | 'ok' | 'error' | 'signedOut'>('checking');
   const skipLogin = SKIP_LOGIN_RAW();
@@ -81,6 +83,12 @@ const ConnectionStatusReal: React.FC<{ sharePointDisabled: boolean }> = ({ share
     }
 
     if (!bypassAccountGate && accountsCount === 0) {
+      setState('signedOut');
+      return;
+    }
+
+    // Badge and diagnostics must share token readiness conditions.
+    if (!bypassAccountGate && (!tokenReady || authLoading)) {
       setState('signedOut');
       return;
     }
@@ -115,7 +123,7 @@ const ConnectionStatusReal: React.FC<{ sharePointDisabled: boolean }> = ({ share
       cancelled = true;
       controller.abort();
     };
-  }, [isDemoMode, accountsCount, bypassAccountGate, forceSharePoint, sharePointFeatureEnabled, sharePointDisabled]);
+  }, [isDemoMode, accountsCount, bypassAccountGate, forceSharePoint, sharePointFeatureEnabled, sharePointDisabled, tokenReady, authLoading]);
 
   const { label, background } = useMemo(() => {
     switch (state) {

--- a/src/features/diagnostics/health/__tests__/authGate.spec.ts
+++ b/src/features/diagnostics/health/__tests__/authGate.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest';
+import { runHealthChecks } from '../checks';
+import type { HealthContext } from '../types';
+import type { SpAdapter } from '../spAdapter';
+
+describe('Health Checks — Auth Gate', () => {
+  const baseCtx: HealthContext = {
+    env: {
+      VITE_SP_RESOURCE: 'https://tenant.sharepoint.com',
+      VITE_MSAL_CLIENT_ID: 'client-id',
+      VITE_MSAL_TENANT_ID: 'tenant-id',
+    },
+    siteUrl: 'https://tenant.sharepoint.com/sites/test',
+    listSpecs: () => [
+      {
+        key: 'users_master',
+        displayName: '利用者マスタ',
+        resolvedTitle: 'Users_Master',
+        requiredFields: [],
+        createItem: {},
+        updateItem: {},
+      },
+    ],
+    isProductionLike: true,
+    autonomyLevel: 'F',
+  };
+
+  it('token未準備時は list/schema/permission checks をスキップし大量FAIL化しない', async () => {
+    const sp: SpAdapter = {
+      getCurrentUser: vi.fn(),
+      getWebTitle: vi.fn(),
+      getListByTitle: vi.fn(),
+      getFields: vi.fn(),
+      getItemsTop1: vi.fn(),
+      createItem: vi.fn(),
+      updateItem: vi.fn(),
+      deleteItem: vi.fn(),
+    };
+
+    const results = await runHealthChecks(baseCtx, sp, {
+      hasActiveAccount: true,
+      tokenReady: false,
+      tokenPending: true,
+    });
+
+    expect(results.some((r) => r.key === 'auth.tokenReadiness')).toBe(true);
+    expect(results.some((r) => r.key === 'lists.authGate' && r.detail === 'SKIPPED_AUTH_REQUIRED')).toBe(true);
+    expect(results.some((r) => r.key.startsWith('lists.exists.'))).toBe(false);
+    expect(sp.getCurrentUser).not.toHaveBeenCalled();
+  });
+
+  it('currentUserがAUTH_REQUIREDなら後続list checksをスキップする', async () => {
+    const sp: SpAdapter = {
+      getCurrentUser: vi.fn().mockRejectedValue(new Error('AUTH_REQUIRED')),
+      getWebTitle: vi.fn().mockRejectedValue(new Error('AUTH_REQUIRED')),
+      getListByTitle: vi.fn(),
+      getFields: vi.fn(),
+      getItemsTop1: vi.fn(),
+      createItem: vi.fn(),
+      updateItem: vi.fn(),
+      deleteItem: vi.fn(),
+    };
+
+    const results = await runHealthChecks(baseCtx, sp, {
+      hasActiveAccount: true,
+      tokenReady: true,
+      tokenPending: false,
+    });
+
+    expect(results.find((r) => r.key === 'auth.currentUser')?.detail).toContain('AUTH_REQUIRED');
+    expect(results.some((r) => r.key === 'lists.authGate' && r.detail === 'SKIPPED_AUTH_REQUIRED')).toBe(true);
+    expect(results.some((r) => r.key.startsWith('lists.exists.'))).toBe(false);
+    expect(sp.getListByTitle).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/diagnostics/health/checks.ts
+++ b/src/features/diagnostics/health/checks.ts
@@ -3,6 +3,13 @@ import { SpAdapter } from "./spAdapter";
 import { runConfigChecks } from "./checks/configChecks";
 import { runAuthAndConnectivityChecks } from "./checks/authChecks";
 import { runAllListChecks } from "./checks/listChecks";
+import { warn } from "./checks/utils";
+
+export type HealthCheckAuthGate = {
+  hasActiveAccount: boolean;
+  tokenReady: boolean;
+  tokenPending: boolean;
+};
 
 /**
  * 統合 Health 診断実行。
@@ -10,7 +17,8 @@ import { runAllListChecks } from "./checks/listChecks";
  */
 export async function runHealthChecks(
   ctx: HealthContext,
-  sp: SpAdapter
+  sp: SpAdapter,
+  authGate?: HealthCheckAuthGate
 ): Promise<HealthCheckResult[]> {
   const results: HealthCheckResult[] = [];
 
@@ -22,8 +30,58 @@ export async function runHealthChecks(
     return results;
   }
 
+  if (authGate && (!authGate.hasActiveAccount || !authGate.tokenReady || authGate.tokenPending)) {
+    results.push(
+      warn({
+        key: "auth.tokenReadiness",
+        label: "認証トークン準備状態",
+        category: "auth",
+        summary: "診断を保留しました。認証トークンの準備が完了していません。",
+        detail: "AUTH_TOKEN_NOT_READY",
+        evidence: {
+          hasActiveAccount: authGate.hasActiveAccount,
+          tokenReady: authGate.tokenReady,
+          tokenPending: authGate.tokenPending,
+        },
+      })
+    );
+    results.push(
+      warn({
+        key: "lists.authGate",
+        label: "リスト/スキーマ診断の実行可否",
+        category: "lists",
+        summary: "認証準備待ちのため、リスト/スキーマ/権限チェックをスキップしました。",
+        detail: "SKIPPED_AUTH_REQUIRED",
+        evidence: {
+          skippedCategories: ["lists", "schema", "permissions"],
+        },
+      })
+    );
+    return results;
+  }
+
   // B) 認証・接続性チェック
-  await runAuthAndConnectivityChecks(ctx, sp, results);
+  const authSummary = await runAuthAndConnectivityChecks(ctx, sp, results);
+  if (
+    authSummary.currentUserStatus === "fail" &&
+    typeof authSummary.currentUserDetail === "string" &&
+    authSummary.currentUserDetail.includes("AUTH_REQUIRED")
+  ) {
+    results.push(
+      warn({
+        key: "lists.authGate",
+        label: "リスト/スキーマ診断の実行可否",
+        category: "lists",
+        summary: "AUTH_REQUIRED 検出のため、リスト/スキーマ/権限チェックをスキップしました。",
+        detail: "SKIPPED_AUTH_REQUIRED",
+        evidence: {
+          skippedCategories: ["lists", "schema", "permissions"],
+          blocker: "auth.currentUser",
+        },
+      })
+    );
+    return results;
+  }
 
   // D/E) リスト・スキーマ・権限チェック（全てのリストに対してループ実行）
   await runAllListChecks(ctx, sp, results);

--- a/src/features/diagnostics/health/checks/authChecks.ts
+++ b/src/features/diagnostics/health/checks/authChecks.ts
@@ -2,12 +2,23 @@ import { HealthCheckResult, HealthContext } from "../types";
 import { SpAdapter } from "../spAdapter";
 import { pass, fail, safe } from "./utils";
 
+export type AuthConnectivityCheckSummary = {
+  currentUserStatus: "pass" | "fail";
+  currentUserDetail?: string;
+  webStatus: "pass" | "fail";
+  webDetail?: string;
+};
+
 export async function runAuthAndConnectivityChecks(
   ctx: HealthContext,
   sp: SpAdapter,
   results: HealthCheckResult[]
-): Promise<void> {
+): Promise<AuthConnectivityCheckSummary> {
   const isSkipSharePoint = ctx.env["VITE_SKIP_SHAREPOINT"] === "1";
+  let currentUserStatus: "pass" | "fail" = "fail";
+  let currentUserDetail: string | undefined;
+  let webStatus: "pass" | "fail" = "fail";
+  let webDetail: string | undefined;
 
   // --- B) Auth / Connectivity ---
   const currentUser = isSkipSharePoint
@@ -32,6 +43,8 @@ export async function runAuthAndConnectivityChecks(
         ],
       })
     );
+    currentUserStatus = "fail";
+    currentUserDetail = currentUser.err;
   } else {
     results.push(
       pass({
@@ -42,6 +55,7 @@ export async function runAuthAndConnectivityChecks(
         evidence: currentUser.v,
       })
     );
+    currentUserStatus = "pass";
   }
 
   const webTitle = isSkipSharePoint
@@ -58,6 +72,8 @@ export async function runAuthAndConnectivityChecks(
         evidence: { siteUrl: ctx.siteUrl },
       })
     );
+    webStatus = "fail";
+    webDetail = webTitle.err;
   } else {
     results.push(
       pass({
@@ -68,5 +84,13 @@ export async function runAuthAndConnectivityChecks(
         evidence: { siteUrl: ctx.siteUrl, webTitle: webTitle.v },
       })
     );
+    webStatus = "pass";
   }
+
+  return {
+    currentUserStatus,
+    currentUserDetail,
+    webStatus,
+    webDetail,
+  };
 }

--- a/src/features/diagnostics/health/useHealthChecks.ts
+++ b/src/features/diagnostics/health/useHealthChecks.ts
@@ -44,7 +44,7 @@ export function useHealthChecks(ctx: HealthContext) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const { acquireToken } = useAuth();
+  const { acquireToken, isAuthenticated, tokenReady, loading: authLoading } = useAuth();
   const sp = useMemo(() => createSpAdapterWithAuth(acquireToken), [acquireToken]);
 
   const run = async () => {
@@ -54,7 +54,11 @@ export function useHealthChecks(ctx: HealthContext) {
     setError(null);
     try {
       console.log("=== RUNNING runHealthChecks ===");
-      const results = await runHealthChecks(ctx, sp);
+      const results = await runHealthChecks(ctx, sp, {
+        hasActiveAccount: isAuthenticated,
+        tokenReady,
+        tokenPending: authLoading,
+      });
       console.log("=== HEALTH CHECKS COMPLETED ===", results.length, "results");
       if (typeof window !== 'undefined') {
         (window as unknown as Record<string, unknown>).__HEALTH_CHECKS__ = results;


### PR DESCRIPTION
## 概要
/admin/status の診断で、MSAL token 未準備時に `AUTH_REQUIRED` が連鎖して `FAIL 50` に展開される誤判定を抑止。

## 変更内容
- auth gate を追加し、token 未準備時は診断を WARN で停止
  - `AUTH_TOKEN_NOT_READY`
  - `SKIPPED_AUTH_REQUIRED`
- `currentUser` が `AUTH_REQUIRED` の場合、後続 list/schema/permission checks を停止
- `SP Connected` 表示条件を token readiness と整合
  - account ありでも token 未準備時は `SP Sign-In` 表示

## 実環境確認結果

- token未準備時に旧挙動の `FAIL 50` 連鎖は再発しない
- `AUTH_TOKEN_NOT_READY` / `SKIPPED_AUTH_REQUIRED` の WARN で停止する
- list/schema/permission checks は実行されない
- token未準備時に `SP Connected` は表示されず、`SP Sign-In` 表示になる
- FAIL は 0

## 未確認

- token成立後に通常の full `/admin/status` 診断へ進むケースは今回未確認

## Non-goals

- SharePoint schema/list/field 変更なし
- spFetch retry 追加なし
- AUTH_REQUIRED の握りつぶしなし
- DailyRecordRows / 月次KPI ロジック変更なし

## テスト
- `git diff --check`
- `npm run typecheck`
- `npx vitest run src/features/diagnostics/health`
- `npx vitest run src/features/diagnostics`
- `npx vitest run src/app/components/ConnectionStatus.spec.tsx`
