### PR TITLE
fix(auth): restore active account from MSAL cache fallback

### DIFF
--- a/src/auth/__tests__/useAuth.spec.ts
+++ b/src/auth/__tests__/useAuth.spec.ts
@@ -250,6 +250,57 @@ describe('useAuth', () => {
       expect(result.current.account).toBe(account);
     });
 
+    it('isAuthenticated=true when activeAccount/accounts are empty but getAllAccounts has cached account', () => {
+      const cached = makeAccount('cached@corp.com');
+      const instance = createMockMsalInstance({
+        getActiveAccount: vi.fn(() => null),
+        getAllAccounts: vi.fn(() => [cached]),
+      });
+      setupMsalContext({ instance, accounts: [] });
+
+      const { result } = renderHook(() => useAuth());
+
+      expect(result.current.isAuthenticated).toBe(true);
+      expect(result.current.account).toBe(cached);
+    });
+
+    it('sets fallback account as active when rawAccount is available', () => {
+      const cached = makeAccount('cache-only@corp.com');
+      const instance = createMockMsalInstance({
+        getActiveAccount: vi.fn(() => null),
+        getAllAccounts: vi.fn(() => [cached]),
+        setActiveAccount: vi.fn(),
+      });
+      setupMsalContext({ instance, accounts: [] });
+
+      renderHook(() => useAuth());
+
+      expect(instance.setActiveAccount).toHaveBeenCalledWith(cached);
+    });
+
+    it('does not authenticate from spToken only', () => {
+      const store = new Map<string, string>();
+      store.set('spToken', 'token-only');
+      vi.stubGlobal('sessionStorage', {
+        getItem: vi.fn((key: string) => store.get(key) ?? null),
+        setItem: vi.fn((key: string, val: string) => store.set(key, val)),
+        removeItem: vi.fn((key: string) => store.delete(key)),
+        clear: vi.fn(() => store.clear()),
+        get length() { return store.size; },
+        key: vi.fn(),
+      });
+      const instance = createMockMsalInstance({
+        getActiveAccount: vi.fn(() => null),
+        getAllAccounts: vi.fn(() => []),
+      });
+      setupMsalContext({ instance, accounts: [], inProgress: 'none' });
+
+      const { result } = renderHook(() => useAuth());
+
+      expect(result.current.isAuthenticated).toBe(false);
+      expect(result.current.tokenReady).toBe(false);
+    });
+
     it('tokenReady=true when authenticated and inProgress=none', () => {
       const account = makeAccount();
       const instance = createMockMsalInstance({
@@ -271,6 +322,20 @@ describe('useAuth', () => {
 
       const { result } = renderHook(() => useAuth());
 
+      expect(result.current.tokenReady).toBe(false);
+    });
+
+    it('keeps tokenReady contract: isAuthenticated && inProgress===none', () => {
+      const account = makeAccount('contract@corp.com');
+      const instance = createMockMsalInstance({
+        getActiveAccount: vi.fn(() => account),
+        getAllAccounts: vi.fn(() => [account]),
+      });
+      setupMsalContext({ instance, accounts: [account], inProgress: 'acquireToken' });
+
+      const { result } = renderHook(() => useAuth());
+
+      expect(result.current.isAuthenticated).toBe(true);
       expect(result.current.tokenReady).toBe(false);
     });
 

--- a/src/auth/useAuth.ts
+++ b/src/auth/useAuth.ts
@@ -119,7 +119,13 @@ export const useAuth = () => {
   // MSAL returns new object references for account on every context change (even if same user).
   // We stabilize by comparing homeAccountId so downstream useMemo deps don't thrash.
   const stableAccountRef = useRef<BasicAccountInfo | null>(null);
-  const rawAccount = (instance.getActiveAccount() ?? accounts[0] ?? null) as BasicAccountInfo | null;
+  const allAccounts = (instance.getAllAccounts() as BasicAccountInfo[]) ?? [];
+  const rawAccount = (
+    instance.getActiveAccount() ??
+    accounts[0] ??
+    allAccounts[0] ??
+    null
+  ) as BasicAccountInfo | null;
   const rawAccountId = rawAccount?.homeAccountId ?? rawAccount?.username ?? null;
   const prevAccountId = stableAccountRef.current?.homeAccountId ?? stableAccountRef.current?.username ?? null;
   if (rawAccountId !== prevAccountId) {
@@ -145,10 +151,10 @@ export const useAuth = () => {
   useEffect(() => {
     if (isE2eMock || skipLogin) return;
     const current = instance.getActiveAccount();
-    if (!current && accounts[0]) {
-      instance.setActiveAccount(accounts[0]);
+    if (!current && rawAccount) {
+      instance.setActiveAccount(rawAccount);
     }
-  }, [instance, accounts, isE2eMock, skipLogin]);
+  }, [instance, rawAccount, isE2eMock, skipLogin]);
 
   // Ensure active account is restored on initial load
   useEffect(() => {
@@ -469,6 +475,34 @@ export const useAuth = () => {
   const isInProgressNone = inProgress === InteractionStatus.None || inProgress === 'none';
   const tokenReady = isAuthenticated && isInProgressNone;
   const accountId = resolvedAccount?.homeAccountId ?? resolvedAccount?.username ?? null;
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const all = instance.getAllAccounts();
+    const active = instance.getActiveAccount();
+    const shouldExpose = authConfig.isDev || isE2eMock;
+    if (shouldExpose) {
+      (window as Window & {
+        __AUTH_STATE__?: {
+          isAuthenticated: boolean;
+          tokenReady: boolean;
+          accounts: number;
+          allAccounts: number;
+          active: boolean;
+          inProgress: string;
+        };
+      }).__AUTH_STATE__ = {
+        isAuthenticated,
+        tokenReady,
+        accounts: accounts.length,
+        allAccounts: all.length,
+        active: Boolean(active),
+        inProgress: String(inProgress),
+      };
+      return;
+    }
+    delete (window as Window & { __AUTH_STATE__?: unknown }).__AUTH_STATE__;
+  }, [instance, accounts.length, inProgress, isAuthenticated, tokenReady, isE2eMock]);
 
   const authFunctions = useMemo(() => ({
     signIn,

--- a/src/types/global-shims.d.ts
+++ b/src/types/global-shims.d.ts
@@ -49,6 +49,14 @@ declare module "@azure/msal-browser" {
 
 declare global {
   interface Window {
+    __AUTH_STATE__?: {
+      isAuthenticated: boolean;
+      tokenReady: boolean;
+      accounts: number;
+      allAccounts: number;
+      active: boolean;
+      inProgress: string;
+    };
     __AUDIT_BATCH_METRICS__?: {
       total: number;
       success: number;


### PR DESCRIPTION
## Summary

- Restore authenticated state from MSAL cache fallback when active account/accounts are temporarily empty
- Use `getActiveAccount() ?? accounts[0] ?? getAllAccounts()[0]`
- Set active account from fallback account when active account is missing
- Add DEV/E2E-only `window.__AUTH_STATE__` for diagnosis
- Keep `tokenReady = isAuthenticated && inProgress === 'none'`
- Do not treat `sessionStorage.spToken` alone as authenticated

## Non-goals

- No spFetch retry changes
- No AUTH_REQUIRED suppression
- No SharePoint schema/list/field changes
- No DailyRecordRows or monthly KPI logic changes
