### PR TITLE
fix(daily): persist row identity keys for monthly evidence

### DIFF
--- a/src/features/daily/repositories/sharepoint/__tests__/DailyRecordSchemaDrift.spec.ts
+++ b/src/features/daily/repositories/sharepoint/__tests__/DailyRecordSchemaDrift.spec.ts
@@ -124,8 +124,10 @@ describe('DailyRecord Schema Drift & Dynamic Resolution', () => {
       if (path.includes("lists/getbytitle('DailyRecordRows')/fields")) {
         return jsonResponse({
           value: [
+            { InternalName: 'Title' },
             { InternalName: 'ParentID' },
             { InternalName: 'UserID' },
+            { InternalName: 'RowNo' },
             { InternalName: 'Date' },
             { InternalName: 'Status' },
             { InternalName: 'Observation' },
@@ -184,7 +186,9 @@ describe('DailyRecord Schema Drift & Dynamic Resolution', () => {
     });
 
     expect(childBodies.length).toBeGreaterThan(0);
+    expect(childBodies[0].Title).toBe('2026-05-15-I005-1');
     expect(childBodies[0].Date).toContain('2026-05-15');
     expect(childBodies[0].UserID).toBe('I005');
+    expect(childBodies[0].RowNo).toBe(1);
   });
 });

--- a/src/features/daily/repositories/sharepoint/modules/Saver.ts
+++ b/src/features/daily/repositories/sharepoint/modules/Saver.ts
@@ -98,14 +98,21 @@ export class DailyRecordSaver {
             }
 
             // Save new children
-            for (const row of input.userRows) {
+            for (const [index, row] of input.userRows.entries()) {
+                const rowNo = index + 1;
+                const rowIdentityKey = `${input.date}-${row.userId}-${rowNo}`;
                 const rowPayload: Record<string, unknown> = {
+                    Title: rowIdentityKey,
                     [resolvedRowsFields.parentId]: parentId,
                     [resolvedRowsFields.userId]: row.userId,
                     [resolvedRowsFields.status]: 'done',
                     [resolvedRowsFields.payload]: JSON.stringify(row),
                     [resolvedRowsFields.recordedAt]: new Date().toISOString(),
+                    [resolvedRowsFields.rowKey]: rowIdentityKey,
                 };
+                if (resolvedRowsFields.rowNo) {
+                    rowPayload[resolvedRowsFields.rowNo] = rowNo;
+                }
                 if (resolvedRowsFields.recordDate) {
                     rowPayload[resolvedRowsFields.recordDate] = itemData.RecordDate;
                 }


### PR DESCRIPTION
## Summary

- Persist stable row identity keys on DailyRecordRows child payload
- Set `Title` to `YYYY-MM-DD-userId-rowNo`
- Persist `rowKey` and `RowNo` when resolved by DailyRecordSchemaResolver
- Keep existing ParentID / UserID / Status / Observation / Recorded_x0020_At / recordDate behavior
- Add regression coverage for monthly evidence keys

## Why

Monthly aggregation derives `ExecutionRecord.date` from `Title` or `rowKey`.
DailyRecordRows were being saved, but without `Title` / `rowKey` / `RowNo`, monthly completedRows could not reliably count the saved evidence.

## Checks

- npm run typecheck
- npx vitest run src/features/daily
- npx vitest run src/features/records/monthly

## Non-goals

- No monthly aggregation redesign
- No plannedRows formula changes
- No SharePoint provisioning
- No auth or spFetch retry changes
- No Dedicated ABC / DailyActivityRecords integration
