### PR TITLE
fix(daily): normalize completed status for monthly evidence

### DIFF
--- a/src/features/daily/domain/integrity/dailyIntegrityChecker.ts
+++ b/src/features/daily/domain/integrity/dailyIntegrityChecker.ts
@@ -107,7 +107,7 @@ export function scanDailyRecordIntegrity(
 
   // 3. stale_pending: 10分以上経っても committed にならない孤立行（全子レコードを直接走査）
   children.forEach(child => {
-    if (child.status !== 'committed' && child.status !== 'done') {
+    if (child.status !== 'committed' && child.status !== 'done' && child.status !== 'completed') {
       const recordedAtTime = new Date(child.recordedAt).getTime();
       if (now.getTime() - recordedAtTime > STALE_THRESHOLD_MS) {
         exceptions.push({

--- a/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
+++ b/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
@@ -497,12 +497,17 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
       }
     }
 
+    const rawStatus = item[rf.status];
+    const status = (rawStatus === 'done' || rawStatus === 'committed')
+      ? 'completed'
+      : (rawStatus as RecordStatus);
+
     return {
       id: title,
       date, 
       userId,
       scheduleItemId,
-      status: item[rf.status] as RecordStatus,
+      status: status,
       triggeredBipIds,
       memo: this.pickFirstNonEmptyString(
         rf.memo ? item[rf.memo] : undefined,

--- a/src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts
+++ b/src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts
@@ -392,6 +392,42 @@ describe('SharePointExecutionRecordRepository', () => {
       const mapped = (repo as any).mapToDomain(mockItem, rf);
       expect(mapped.memo).toBe('');
     });
+
+    it('maps "done" and "committed" to "completed"', () => {
+      const rf = {
+        parentId: 'Parent_x0020_ID',
+        userId: 'User_x0020_ID',
+        version: 'Version',
+        status: 'Status',
+        payload: 'Payload',
+        recordedAt: 'Recorded_x0020_At',
+        rowKey: 'Title',
+        rowNo: 'RowNo',
+        memo: 'Memo',
+        staffName: 'StaffName',
+        bipsJSON: 'BipsJSON',
+      };
+
+      const itemDone = {
+        Title: '2026-05-08-4-1',
+        User_x0020_ID: '4',
+        Status: 'done',
+        Recorded_x0020_At: '2026-05-08T12:00:00Z',
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mappedDone = (repo as any).mapToDomain(itemDone, rf);
+      expect(mappedDone.status).toBe('completed');
+
+      const itemCommitted = {
+        Title: '2026-05-08-4-1',
+        User_x0020_ID: '4',
+        Status: 'committed',
+        Recorded_x0020_At: '2026-05-08T12:00:00Z',
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mappedCommitted = (repo as any).mapToDomain(itemCommitted, rf);
+      expect(mappedCommitted.status).toBe('completed');
+    });
   });
 
   describe('Strict Field Filtering Regressions', () => {

--- a/src/features/daily/repositories/sharepoint/modules/Saver.ts
+++ b/src/features/daily/repositories/sharepoint/modules/Saver.ts
@@ -105,7 +105,7 @@ export class DailyRecordSaver {
                     Title: rowIdentityKey,
                     [resolvedRowsFields.parentId]: parentId,
                     [resolvedRowsFields.userId]: row.userId,
-                    [resolvedRowsFields.status]: 'done',
+                    [resolvedRowsFields.status]: 'completed',
                     [resolvedRowsFields.payload]: JSON.stringify(row),
                     [resolvedRowsFields.recordedAt]: new Date().toISOString(),
                     [resolvedRowsFields.rowKey]: rowIdentityKey,


### PR DESCRIPTION
## Summary

- Normalize SharePoint execution row status values in `mapToDomain`
  - `done` -> `completed`
  - `committed` -> `completed`
- Persist new DailyRecordRows with `Status='completed'`
- Treat `completed` as a valid terminal status in integrity checks
- Add regression coverage for legacy status normalization

## Why

Monthly KPI aggregation expects the domain-standard `completed` status.
Daily Table rows were saved as `done`, so rows with content were classified as `inProgress` instead of `completedRows`.

This PR aligns the persistence, repository mapping, and integrity layers so I005 monthly evidence can count as completed.

## Checks

- `npm run test src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts` (PASS)
- `npm run typecheck` (PASS)

## Non-goals

- No monthly aggregation redesign
- No SharePoint schema/provision changes
- No auth/spFetch retry changes
- No Daily_Attendance 400/500 triage