### PR TITLE
fix(daily): normalize localized execution statuses

### DIFF
--- a/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
+++ b/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
@@ -497,10 +497,24 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
       }
     }
 
-    const rawStatus = item[rf.status];
-    const status = (rawStatus === 'done' || rawStatus === 'committed')
-      ? 'completed'
-      : (rawStatus as RecordStatus);
+    const rawStatus = String(item[rf.status] || '').trim();
+    let status: RecordStatus = 'unrecorded';
+    const s = rawStatus.toLowerCase();
+
+    // Normalization logic for English & Japanese statuses
+    if (s === 'completed' || s === 'done' || s === 'committed' || s === '完了' || s === '済') {
+      status = 'completed';
+    } else if (s === 'triggered' || s === '行動発生') {
+      status = 'triggered';
+    } else if (s === 'skipped' || s === 'スキップ' || s === '中止') {
+      status = 'skipped';
+    } else {
+      // Fallback to strict domain enum if it matches exactly (already handled by toLowerCase above for English)
+      if (['completed', 'triggered', 'skipped', 'unrecorded'].includes(s)) {
+        status = s as RecordStatus;
+      }
+    }
+
 
     return {
       id: title,

--- a/src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts
+++ b/src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts
@@ -427,7 +427,41 @@ describe('SharePointExecutionRecordRepository', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const mappedCommitted = (repo as any).mapToDomain(itemCommitted, rf);
       expect(mappedCommitted.status).toBe('completed');
+
+      // English case variations
+      const itemDoneUpper = { ...itemDone, Status: 'Done' };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mappedDoneUpper = (repo as any).mapToDomain(itemDoneUpper, rf);
+      expect(mappedDoneUpper.status).toBe('completed');
+
+      const itemCompletedUpper = { ...itemDone, Status: 'COMPLETED' };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mappedCompletedUpper = (repo as any).mapToDomain(itemCompletedUpper, rf);
+      expect(mappedCompletedUpper.status).toBe('completed');
+
+      // Japanese statuses
+      const itemKanryo = { ...itemDone, Status: '完了' };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mappedKanryo = (repo as any).mapToDomain(itemKanryo, rf);
+      expect(mappedKanryo.status).toBe('completed');
+
+      const itemSai = { ...itemDone, Status: '済' };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mappedSai = (repo as any).mapToDomain(itemSai, rf);
+      expect(mappedSai.status).toBe('completed');
+
+      const itemTriggeredJp = { ...itemDone, Status: '行動発生' };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mappedTriggeredJp = (repo as any).mapToDomain(itemTriggeredJp, rf);
+      expect(mappedTriggeredJp.status).toBe('triggered');
+
+      const itemSkippedJp = { ...itemDone, Status: 'スキップ' };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mappedSkippedJp = (repo as any).mapToDomain(itemSkippedJp, rf);
+      expect(mappedSkippedJp.status).toBe('skipped');
+
     });
+
   });
 
   describe('Strict Field Filtering Regressions', () => {


### PR DESCRIPTION
## Summary

- Normalize localized and case-insensitive SharePoint execution statuses
- Map 完了 / 済 / Done / done / committed / completed to completed
- Map 行動発生 / triggered to triggered
- Map スキップ / 中止 / skipped to skipped
- Fallback unknown values to unrecorded
- Add regression tests for localized status mapping

## Why

#1920 normalized legacy English status values such as done and committed.
This follow-up makes monthly evidence mapping robust for localized/manual SharePoint values while keeping the scope limited to status normalization.

## Checks

- npm run typecheck
- npx vitest src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts --run
- git diff --check

## Non-goals

- No monthly aggregation redesign
- No SharePoint schema/provision changes
- No auth/spFetch retry changes
- No Daily_Attendance 400/500 triage
- No spListRead fallback changes