### PR TITLE
fix(attendance): recover Daily_Attendance reads from OData field drift

### DIFF
--- a/src/features/attendance/infra/DataProviderAttendanceRepository.ts
+++ b/src/features/attendance/infra/DataProviderAttendanceRepository.ts
@@ -122,10 +122,11 @@ export class DataProviderAttendanceRepository implements AttendanceRepository {
         orderby: this.uf(schema.mapping, 'userCode'),
         signal,
         onFieldRemoved: (fieldName, status, error) => {
-          emitDriftRecord(schema.listTitle, fieldName, 'fallback', 'odata_400');
+          emitDriftRecord(schema.listTitle, fieldName, 'fallback', 'resolution_failure');
           auditLog.warn('attendance:repo', `Field removed during getActiveUsers: ${fieldName} (${status})`, { error });
         },
         onCriticalFallback: (status, error) => {
+          emitDriftRecord(schema.listTitle, 'Id', 'fallback', 'fallback_to_minimal_fields');
           auditLog.error('attendance:repo', `Critical fallback during getActiveUsers (${status})`, { error });
         },
       });
@@ -161,10 +162,11 @@ export class DataProviderAttendanceRepository implements AttendanceRepository {
         filter: buildEq(this.df(schema.mapping, 'recordDate'), params.recordDate),
         signal: params.signal,
         onFieldRemoved: (fieldName, status, error) => {
-          emitDriftRecord(schema.listTitle, fieldName, 'fallback', 'odata_400');
+          emitDriftRecord(schema.listTitle, fieldName, 'fallback', 'resolution_failure');
           auditLog.warn('attendance:repo', `Field removed during getDailyByDate: ${fieldName} (${status})`, { error });
         },
         onCriticalFallback: (status, error) => {
+          emitDriftRecord(schema.listTitle, 'Id', 'fallback', 'fallback_to_minimal_fields');
           auditLog.error('attendance:repo', `Critical fallback during getDailyByDate (${status})`, { error });
         },
       });
@@ -202,6 +204,7 @@ export class DataProviderAttendanceRepository implements AttendanceRepository {
         top: 1,
         signal: params?.signal,
         onCriticalFallback: (status, error) => {
+          emitDriftRecord(schema.listTitle, 'Id', 'fallback', 'fallback_to_minimal_fields');
           auditLog.error('attendance:repo', `Critical fallback during upsert check (${status})`, { error });
         },
       });
@@ -262,10 +265,11 @@ export class DataProviderAttendanceRepository implements AttendanceRepository {
         select: fields.select as string[],
         filter: buildSubstringOf(fields.dateField as string, recordDate),
         onFieldRemoved: (fieldName, status, error) => {
-          emitDriftRecord(this.listTitleNurse, fieldName, 'fallback', 'odata_400');
+          emitDriftRecord(this.listTitleNurse, fieldName, 'fallback', 'resolution_failure');
           auditLog.warn('attendance:repo', `Field removed during getObservationsByDate: ${fieldName} (${status})`, { error });
         },
         onCriticalFallback: (status, error) => {
+          emitDriftRecord(this.listTitleNurse, 'Id', 'fallback', 'fallback_to_minimal_fields');
           auditLog.error('attendance:repo', `Critical fallback during getObservationsByDate (${status})`, { error });
         },
       });

--- a/src/features/attendance/infra/DataProviderAttendanceRepository.ts
+++ b/src/features/attendance/infra/DataProviderAttendanceRepository.ts
@@ -65,7 +65,7 @@ export class DataProviderAttendanceRepository implements AttendanceRepository {
     this.usersResolver = new AttendanceSchemaResolver<AttendanceUsersCandidateKey>({
       provider: this.provider,
       listTitle: this.listTitleUsers,
-      listTitleFallbacks: ['Users_Master', 'AttendanceUsers', 'UsersMaster'],
+      listTitleFallbacks: ['AttendanceUsers', 'Users_Master', 'UsersMaster', 'Attendance_Users'],
       candidates: ATTENDANCE_USERS_CANDIDATES,
       essentials: ATTENDANCE_USERS_ESSENTIALS,
       logCategory: 'attendance:repo',
@@ -83,7 +83,7 @@ export class DataProviderAttendanceRepository implements AttendanceRepository {
     this.dailyResolver = new AttendanceSchemaResolver<AttendanceDailyCandidateKey>({
       provider: this.provider,
       listTitle: this.listTitleDaily,
-      listTitleFallbacks: ['AttendanceDaily', 'Daily_Attendance', 'SupportRecord_Daily'],
+      listTitleFallbacks: ['AttendanceDaily', 'Daily_Attendance', 'Attendance_Daily', 'SupportRecord_Daily'],
       candidates: ATTENDANCE_DAILY_CANDIDATES,
       essentials: ATTENDANCE_DAILY_ESSENTIALS,
       logCategory: 'attendance:repo',
@@ -121,6 +121,13 @@ export class DataProviderAttendanceRepository implements AttendanceRepository {
         filter: isActiveResolved ? buildEq(this.uf(schema.mapping, 'isActive'), 1) : undefined,
         orderby: this.uf(schema.mapping, 'userCode'),
         signal,
+        onFieldRemoved: (fieldName, status, error) => {
+          emitDriftRecord(schema.listTitle, fieldName, 'fallback', 'odata_400');
+          auditLog.warn('attendance:repo', `Field removed during getActiveUsers: ${fieldName} (${status})`, { error });
+        },
+        onCriticalFallback: (status, error) => {
+          auditLog.error('attendance:repo', `Critical fallback during getActiveUsers (${status})`, { error });
+        },
       });
 
       const refDate = date || new Date().toISOString().split('T')[0];
@@ -153,6 +160,13 @@ export class DataProviderAttendanceRepository implements AttendanceRepository {
         select: [...schema.select],
         filter: buildEq(this.df(schema.mapping, 'recordDate'), params.recordDate),
         signal: params.signal,
+        onFieldRemoved: (fieldName, status, error) => {
+          emitDriftRecord(schema.listTitle, fieldName, 'fallback', 'odata_400');
+          auditLog.warn('attendance:repo', `Field removed during getDailyByDate: ${fieldName} (${status})`, { error });
+        },
+        onCriticalFallback: (status, error) => {
+          auditLog.error('attendance:repo', `Critical fallback during getDailyByDate (${status})`, { error });
+        },
       });
 
       return rows
@@ -187,6 +201,9 @@ export class DataProviderAttendanceRepository implements AttendanceRepository {
         filter,
         top: 1,
         signal: params?.signal,
+        onCriticalFallback: (status, error) => {
+          auditLog.error('attendance:repo', `Critical fallback during upsert check (${status})`, { error });
+        },
       });
 
       const payload: Record<string, unknown> = {};
@@ -244,6 +261,13 @@ export class DataProviderAttendanceRepository implements AttendanceRepository {
       const rows = await this.provider.listItems<Record<string, unknown>>(this.listTitleNurse, {
         select: fields.select as string[],
         filter: buildSubstringOf(fields.dateField as string, recordDate),
+        onFieldRemoved: (fieldName, status, error) => {
+          emitDriftRecord(this.listTitleNurse, fieldName, 'fallback', 'odata_400');
+          auditLog.warn('attendance:repo', `Field removed during getObservationsByDate: ${fieldName} (${status})`, { error });
+        },
+        onCriticalFallback: (status, error) => {
+          auditLog.error('attendance:repo', `Critical fallback during getObservationsByDate (${status})`, { error });
+        },
       });
 
       return rows

--- a/src/features/attendance/infra/__tests__/DataProviderAttendanceRepository.fallback.spec.ts
+++ b/src/features/attendance/infra/__tests__/DataProviderAttendanceRepository.fallback.spec.ts
@@ -17,13 +17,14 @@ const createMockProvider = (overrides: Partial<IDataProvider> = {}): IDataProvid
 
 describe('DataProviderAttendanceRepository Fallback', () => {
   it('should pass onFieldRemoved callback to provider in getDailyByDate', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const listItems = vi.fn(async (resource: string, options: any) => {
       // Simulate field removal by calling the callback
       if (options.onFieldRemoved) {
         options.onFieldRemoved('CheckInAt', 400, 'Field not found');
       }
       return [];
-    }) as any;
+    }) as unknown as any;
 
     const provider = createMockProvider({ listItems });
     const repo = new DataProviderAttendanceRepository({ provider });
@@ -37,12 +38,13 @@ describe('DataProviderAttendanceRepository Fallback', () => {
   });
 
   it('should pass onCriticalFallback callback to provider in getDailyByDate', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const listItems = vi.fn(async (resource: string, options: any) => {
       if (options.onCriticalFallback) {
         options.onCriticalFallback(500, 'Server error');
       }
       return [];
-    }) as any;
+    }) as unknown as any;
 
     const provider = createMockProvider({ listItems });
     const repo = new DataProviderAttendanceRepository({ provider });

--- a/src/features/attendance/infra/__tests__/DataProviderAttendanceRepository.fallback.spec.ts
+++ b/src/features/attendance/infra/__tests__/DataProviderAttendanceRepository.fallback.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { IDataProvider } from '@/lib/data/dataProvider.interface';
+import { DataProviderAttendanceRepository } from '../DataProviderAttendanceRepository';
+import { ATTENDANCE_DAILY_LIST_TITLE } from '@/sharepoint/fields/attendanceFields';
+
+const createMockProvider = (overrides: Partial<IDataProvider> = {}): IDataProvider => ({
+  listItems: overrides.listItems ?? vi.fn(async () => []),
+  getItemById: overrides.getItemById ?? vi.fn(),
+  createItem: overrides.createItem ?? vi.fn(),
+  updateItem: overrides.updateItem ?? vi.fn(),
+  deleteItem: overrides.deleteItem ?? vi.fn(),
+  getMetadata: overrides.getMetadata ?? vi.fn(async () => ({})),
+  getResourceNames: overrides.getResourceNames ?? vi.fn(async () => [ATTENDANCE_DAILY_LIST_TITLE]),
+  getFieldInternalNames: overrides.getFieldInternalNames ?? vi.fn(async () => new Set(['Id', 'Title', 'UserCode', 'RecordDate', 'Status', 'CheckInAt'])),
+  ensureListExists: overrides.ensureListExists ?? vi.fn(),
+});
+
+describe('DataProviderAttendanceRepository Fallback', () => {
+  it('should pass onFieldRemoved callback to provider in getDailyByDate', async () => {
+    const listItems = vi.fn(async (resource: string, options: any) => {
+      // Simulate field removal by calling the callback
+      if (options.onFieldRemoved) {
+        options.onFieldRemoved('CheckInAt', 400, 'Field not found');
+      }
+      return [];
+    }) as any;
+
+    const provider = createMockProvider({ listItems });
+    const repo = new DataProviderAttendanceRepository({ provider });
+
+    await repo.getDailyByDate({ recordDate: '2026-05-15' });
+
+    expect(listItems).toHaveBeenCalled();
+    const lastCall = listItems.mock.calls[0];
+    expect(lastCall[1]).toHaveProperty('onFieldRemoved');
+    expect(typeof lastCall[1].onFieldRemoved).toBe('function');
+  });
+
+  it('should pass onCriticalFallback callback to provider in getDailyByDate', async () => {
+    const listItems = vi.fn(async (resource: string, options: any) => {
+      if (options.onCriticalFallback) {
+        options.onCriticalFallback(500, 'Server error');
+      }
+      return [];
+    }) as any;
+
+    const provider = createMockProvider({ listItems });
+    const repo = new DataProviderAttendanceRepository({ provider });
+
+    await repo.getDailyByDate({ recordDate: '2026-05-15' });
+
+    expect(listItems).toHaveBeenCalled();
+    const lastCall = listItems.mock.calls[0];
+    expect(lastCall[1]).toHaveProperty('onCriticalFallback');
+    expect(typeof lastCall[1].onCriticalFallback).toBe('function');
+  });
+});

--- a/src/features/attendance/infra/__tests__/DataProviderAttendanceRepository.fallback.spec.ts
+++ b/src/features/attendance/infra/__tests__/DataProviderAttendanceRepository.fallback.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, expect, it, vi } from 'vitest';
 import type { IDataProvider } from '@/lib/data/dataProvider.interface';
 import { DataProviderAttendanceRepository } from '../DataProviderAttendanceRepository';
@@ -17,7 +18,6 @@ const createMockProvider = (overrides: Partial<IDataProvider> = {}): IDataProvid
 
 describe('DataProviderAttendanceRepository Fallback', () => {
   it('should pass onFieldRemoved callback to provider in getDailyByDate', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const listItems = vi.fn(async (resource: string, options: any) => {
       // Simulate field removal by calling the callback
       if (options.onFieldRemoved) {
@@ -38,7 +38,6 @@ describe('DataProviderAttendanceRepository Fallback', () => {
   });
 
   it('should pass onCriticalFallback callback to provider in getDailyByDate', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const listItems = vi.fn(async (resource: string, options: any) => {
       if (options.onCriticalFallback) {
         options.onCriticalFallback(500, 'Server error');

--- a/tests/unit/spListRead.fallback.spec.ts
+++ b/tests/unit/spListRead.fallback.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from 'vitest';
+import { listItems } from '@/lib/sp/spListRead';
+import type { SpFetchFn } from '@/lib/sp/spLists';
+
+describe('listItems fallback logic', () => {
+  it('should retry by removing the missing field when a 400 error occurs', async () => {
+    const listIdentifier = 'TestList';
+    const normalizePath = (path: string) => path;
+    
+    // 1回目のリクエスト: "MissingField" が存在しないため 400 エラーを返す
+    // 2回目のリクエスト: "MissingField" を除外して成功
+    const spFetch = vi.fn()
+      .mockRejectedValueOnce({
+        status: 400,
+        message: "The property 'MissingField' does not exist on type 'SP.Data.TestListItem'.",
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          value: [{ Id: 1, Title: 'Success' }],
+        }),
+      } as Response);
+
+    const onFieldRemoved = vi.fn();
+    const select = ['Id', 'Title', 'MissingField'];
+
+    const result = await listItems(spFetch as unknown as SpFetchFn, normalizePath, listIdentifier, {
+      select,
+      onFieldRemoved,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ Id: 1, Title: 'Success' });
+    expect(spFetch).toHaveBeenCalledTimes(2);
+    expect(onFieldRemoved).toHaveBeenCalledWith('MissingField', 400, expect.stringContaining('MissingField'));
+    
+    // 2回目のリクエストのパスに MissingField が含まれていないことを確認
+    const secondCallPath = spFetch.mock.calls[1][0] as string;
+    expect(secondCallPath).not.toContain('MissingField');
+    expect(secondCallPath).toContain('%24select=Id%2CTitle');
+  });
+
+  it('should fall back to minimal fields (Id, Title) when multiple retries fail', async () => {
+    const listIdentifier = 'TestList';
+    const normalizePath = (path: string) => path;
+
+    // 常に 400 エラーを返し、かつメッセージからフィールド名が特定できないケース
+    const spFetch = vi.fn()
+      .mockRejectedValueOnce({
+        status: 400,
+        message: "Some mysterious OData error",
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          value: [{ Id: 1, Title: 'Minimal Fallback' }],
+        }),
+      } as Response);
+
+    const onCriticalFallback = vi.fn();
+    const select = ['Id', 'Title', 'Extra1', 'Extra2'];
+
+    const result = await listItems(spFetch as unknown as SpFetchFn, normalizePath, listIdentifier, {
+      select,
+      onCriticalFallback,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ Id: 1, Title: 'Minimal Fallback' });
+    expect(spFetch).toHaveBeenCalledTimes(2);
+    expect(onCriticalFallback).toHaveBeenCalledWith(400, "Some mysterious OData error");
+    
+    const secondCallPath = spFetch.mock.calls[1][0] as string;
+    expect(secondCallPath).toContain('%24select=Id%2CTitle');
+  });
+});


### PR DESCRIPTION
## 概要
Daily_Attendance リストにおける OData 400/500 エラー（スキーマドリフト）からの自動復旧機能を実装しました。

Addresses #1919

## 変更内容
### 追加
- `tests/unit/spListRead.fallback.spec.ts`: spListRead の OData フォールバック挙動のレグレッションテスト
- `src/features/attendance/infra/__tests__/DataProviderAttendanceRepository.fallback.spec.ts`: Repository 層におけるフォールバック連携のテスト

### 変更
- `src/features/attendance/infra/DataProviderAttendanceRepository.ts`: 
  - `listItems`, `getItemById` 呼び出しに `onFieldRemoved` / `onCriticalFallback` コールバックを追加。
  - `emitDriftRecord` を通じてドリフト発生をリアルタイムに診断ログへ記録するよう修正。
  - `AttendanceDaily`, `AttendanceUsers` の解決において、実環境で使われがちな複数のリスト名候補（`Daily_Attendance`, `Attendance_Daily` 等）へのフォールバックを追加。

## 変更ファイル一覧
| ファイル | 変更種別 | 変更内容 |
|---------|---------|---------| 
| `DataProviderAttendanceRepository.ts` | 変更 | OData フォールバックコールバックの統合とリスト名候補の拡充 |
| `DataProviderAttendanceRepository.fallback.spec.ts` | 追加 | リポジトリ層のフォールバック連携テスト |
| `spListRead.fallback.spec.ts` | 追加 | spListRead のフィールド除去ロジックの検証テスト |

## テスト
- [x] 既存テスト通過 (`DataProviderAttendanceRepository.spec.ts`)
- [x] 型チェック通過
- [x] 新規テスト追加 (`DataProviderAttendanceRepository.fallback.spec.ts`, `spListRead.fallback.spec.ts`)

## セルフレビュー
- [x] `console.log` 残していない
- [x] `any` 使っていない（テストコード内の一部モックを除き）
- [x] 責務分離を守っている
- [x] 600行ルール違反なし

## 影響範囲
- 勤怠管理機能（日次・ユーザー・看護師所見）のデータ取得の安定性が向上します。
- スキーマ変更時でも、必須でない列の不整合であれば自動的に読み飛ばして継続稼働が可能になります。