### PR TITLE
feat(planning-sheet): define iceberg import provenance contract

### DIFF
--- a/src/features/planning-sheet/__tests__/icebergToPlanningBridge.spec.ts
+++ b/src/features/planning-sheet/__tests__/icebergToPlanningBridge.spec.ts
@@ -126,5 +126,92 @@ describe('icebergToPlanningBridge', () => {
         strategyCount: 2, // '予防A', '事後A'
       });
     });
+
+    it('should return empty provenance and null sourceRef when sessionRef is omitted (backward compat)', () => {
+      const result = buildIcebergImportResult(mockDrafts);
+      expect(result.provenance).toEqual([]);
+      expect(result.sourceRef).toBeNull();
+    });
+  });
+
+  describe('buildIcebergImportResult with sessionRef (provenance contract)', () => {
+    const sessionRef = { id: 'session-abc', updatedAt: '2026-05-15T10:00:00.000Z' };
+
+    const mockDrafts: BehaviorInterventionPlan[] = [
+      {
+        id: '1',
+        userId: 'user1',
+        targetBehavior: 'パニック',
+        targetBehaviorNodeId: 'node-b1',
+        triggerFactors: [
+          { label: '指示された', nodeId: 'f1' },
+          { label: '騒がしい部屋', nodeId: 'f2' },
+        ],
+        strategies: {
+          prevention: 'イヤーマフ装着',
+          alternative: '「静かにして」と伝える',
+          reactive: '静かな場所に移動',
+        },
+        createdAt: '',
+        updatedAt: '',
+      },
+    ];
+
+    it('should include session ID in sourceLabel of each provenance entry', () => {
+      const result = buildIcebergImportResult(mockDrafts, sessionRef);
+      expect(result.provenance.length).toBeGreaterThan(0);
+      result.provenance.forEach(entry => {
+        expect(entry.sourceLabel).toContain('session-abc');
+      });
+    });
+
+    it('should set source to iceberg_session for all provenance entries', () => {
+      const result = buildIcebergImportResult(mockDrafts, sessionRef);
+      result.provenance.forEach(entry => {
+        expect(entry.source).toBe('iceberg_session');
+      });
+    });
+
+    it('affectedFields in sourceRef should include fields present in formPatches', () => {
+      const result = buildIcebergImportResult(mockDrafts, sessionRef);
+      expect(result.sourceRef).not.toBeNull();
+      const affectedFields = result.sourceRef!.affectedFields;
+      // 空文字でないパッチキーのみ affectedFields に含まれることを確認
+      // （desiredBehavior: '' は手動入力プレースホルダーのため追跡対象外）
+      const nonEmptyPatchKeys = Object.entries(result.formPatches)
+        .filter(([, v]) => typeof v === 'string' && v.trim() !== '')
+        .map(([k]) => k);
+      nonEmptyPatchKeys.forEach(key => {
+        expect(affectedFields).toContain(key);
+      });
+    });
+
+
+    it('importedAt in each provenance entry should be ISO 8601', () => {
+      const result = buildIcebergImportResult(mockDrafts, sessionRef);
+      result.provenance.forEach(entry => {
+        expect(() => new Date(entry.importedAt).toISOString()).not.toThrow();
+        expect(new Date(entry.importedAt).toISOString()).toBe(entry.importedAt);
+      });
+    });
+
+    it('behaviorNodeIds in sourceRef should match draft targetBehaviorNodeIds', () => {
+      const result = buildIcebergImportResult(mockDrafts, sessionRef);
+      expect(result.sourceRef?.behaviorNodeIds).toEqual(['node-b1']);
+    });
+
+    it('sourceRef.sessionId should match the provided sessionRef.id', () => {
+      const result = buildIcebergImportResult(mockDrafts, sessionRef);
+      expect(result.sourceRef?.sessionId).toBe('session-abc');
+      expect(result.sourceRef?.sessionUpdatedAt).toBe('2026-05-15T10:00:00.000Z');
+    });
+
+    it('should return empty provenance and null sourceRef when draft list is empty with sessionRef', () => {
+      const result = buildIcebergImportResult([], sessionRef);
+      // 空 drafts では formPatches も空なので provenance エントリも生成されない
+      expect(result.provenance).toEqual([]);
+      expect(result.sourceRef?.affectedFields).toEqual([]);
+      expect(result.sourceRef?.behaviorNodeIds).toEqual([]);
+    });
   });
 });

--- a/src/features/planning-sheet/assessmentBridge.ts
+++ b/src/features/planning-sheet/assessmentBridge.ts
@@ -27,7 +27,8 @@ export type ProvenanceSource =
   | 'planning_sheet'       // 支援計画シート（→手順書兼記録へのブリッジ）
   | 'monitoring'           // モニタリング: 総合所見・意向
   | 'monitoring_goal'      // モニタリング: 目標達成評価
-  | 'monitoring_decision'; // モニタリング: 決定事項
+  | 'monitoring_decision'  // モニタリング: 決定事項
+  | 'iceberg_session';     // 氷山分析セッション（BIP → 支援計画シートへのブリッジ）
 
 /** 変換根拠の1エントリ */
 export interface ProvenanceEntry {

--- a/src/features/planning-sheet/components/ProvenanceBadge.tsx
+++ b/src/features/planning-sheet/components/ProvenanceBadge.tsx
@@ -32,6 +32,7 @@ const SOURCE_COLORS: Record<ProvenanceSource, 'primary' | 'secondary' | 'success
   monitoring: 'warning',
   monitoring_goal: 'warning',
   monitoring_decision: 'warning',
+  iceberg_session: 'info',
 };
 
 const SOURCE_ICON_LABEL: Record<ProvenanceSource, string> = {
@@ -43,6 +44,7 @@ const SOURCE_ICON_LABEL: Record<ProvenanceSource, string> = {
   monitoring: 'モニタ',
   monitoring_goal: '目標評価',
   monitoring_decision: '決定事項',
+  iceberg_session: '氷山',
 };
 
 // ---------------------------------------------------------------------------

--- a/src/features/planning-sheet/icebergToPlanningBridge.ts
+++ b/src/features/planning-sheet/icebergToPlanningBridge.ts
@@ -1,4 +1,5 @@
 import type { BehaviorInterventionPlan } from '@/features/analysis/domain/interventionTypes';
+import type { ProvenanceEntry } from '@/features/planning-sheet/assessmentBridge';
 import type { FormState } from './components/new-form/types';
 
 /**
@@ -74,6 +75,23 @@ export function icebergToPlanningBridge(drafts: BehaviorInterventionPlan[]): Par
   };
 }
 
+/**
+ * Iceberg import の出典参照（pure data、副作用なし）。
+ * importAuditStore へ渡すための取込メタデータを保持する。
+ */
+export interface IcebergSourceRef {
+  /** 氷山セッション ID */
+  sessionId: string;
+  /** セッション最終更新日時（ISO 8601） */
+  sessionUpdatedAt: string;
+  /** 取込実行日時（ISO 8601） */
+  importedAt: string;
+  /** 抽出した行動ノード ID 一覧 */
+  behaviorNodeIds: string[];
+  /** 反映先フィールド一覧（importAuditRecord.affectedFields に使用） */
+  affectedFields: string[];
+}
+
 export interface IcebergImportResult {
   formPatches: Partial<FormState>;
   summary: {
@@ -82,11 +100,33 @@ export interface IcebergImportResult {
     environmentFactorCount: number;
     strategyCount: number;
   };
+  /**
+   * フィールド変換の根拠一覧（assessmentBridge と同形式）。
+   * sessionRef を渡した場合に生成される。省略時は空配列。
+   */
+  provenance: ProvenanceEntry[];
+  /**
+   * 取込元の Iceberg セッション参照情報。
+   * sessionRef を渡した場合に生成される。省略時は null。
+   */
+  sourceRef: IcebergSourceRef | null;
 }
 
-export function buildIcebergImportResult(drafts: BehaviorInterventionPlan[]): IcebergImportResult {
+/**
+ * BehaviorInterventionPlan[] を IcebergImportResult に変換する。
+ *
+ * @param drafts - icebergToInterventionDrafts() が返す BIP Draft 群
+ * @param sessionRef - 取込元の Iceberg セッション参照（任意）。
+ *   指定した場合のみ provenance と sourceRef が生成される。
+ *   省略時は後方互換（provenance: [], sourceRef: null）。
+ */
+export function buildIcebergImportResult(
+  drafts: BehaviorInterventionPlan[],
+  sessionRef?: Pick<{ id: string; updatedAt: string }, 'id' | 'updatedAt'>,
+): IcebergImportResult {
   const patches = icebergToPlanningBridge(drafts);
-  
+  const now = new Date().toISOString();
+
   const allFactorLabels = drafts.flatMap(d => d.triggerFactors.map(t => t.label));
   const triggers = allFactorLabels.filter(l => classifyTriggerFactor(l) === 'trigger');
   const environments = allFactorLabels.filter(l => classifyTriggerFactor(l) === 'environment');
@@ -94,16 +134,139 @@ export function buildIcebergImportResult(drafts: BehaviorInterventionPlan[]): Ic
   const strategyInputs = drafts.flatMap(d => [
     d.strategies.prevention,
     d.strategies.alternative,
-    d.strategies.reactive
+    d.strategies.reactive,
   ]).filter(Boolean);
 
-  return {
-    formPatches: patches,
-    summary: {
-      behaviorCount: drafts.length,
-      triggerCount: uniqueLabels(triggers).length,
-      environmentFactorCount: uniqueLabels(environments).length,
-      strategyCount: uniqueLabels(strategyInputs).length,
-    }
+  const summary = {
+    behaviorCount: drafts.length,
+    triggerCount: uniqueLabels(triggers).length,
+    environmentFactorCount: uniqueLabels(environments).length,
+    strategyCount: uniqueLabels(strategyInputs).length,
   };
+
+  // sessionRef が省略された場合は後方互換の最小値を返す
+  if (!sessionRef) {
+    return { formPatches: patches, summary, provenance: [], sourceRef: null };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Provenance 生成（sessionRef あり）
+  // ---------------------------------------------------------------------------
+
+  const provenance: ProvenanceEntry[] = [];
+  const affectedFields: string[] = [];
+  const sessionLabel = `氷山分析セッション（${sessionRef.id}）`;
+
+  const firstDraft = drafts[0];
+
+  // targetBehavior / icebergSurface
+  if (firstDraft && firstDraft.targetBehavior) {
+    provenance.push({
+      field: 'targetBehavior',
+      source: 'iceberg_session',
+      sourceLabel: sessionLabel,
+      reason: `行動ノード「${firstDraft.targetBehavior}」を targetBehavior にマッピング`,
+      value: firstDraft.targetBehavior,
+      importedAt: now,
+    });
+    provenance.push({
+      field: 'icebergSurface',
+      source: 'iceberg_session',
+      sourceLabel: sessionLabel,
+      reason: `行動ノード「${firstDraft.targetBehavior}」を icebergSurface にマッピング`,
+      value: firstDraft.targetBehavior,
+      importedAt: now,
+    });
+    affectedFields.push('targetBehavior', 'icebergSurface');
+  }
+
+  // triggers
+  const dedupedTriggers = uniqueLabels(triggers);
+  if (dedupedTriggers.length > 0) {
+    provenance.push({
+      field: 'triggers',
+      source: 'iceberg_session',
+      sourceLabel: sessionLabel,
+      reason: `行動トリガー ${dedupedTriggers.length}件を triggers にマッピング`,
+      value: dedupedTriggers.join(', '),
+      importedAt: now,
+    });
+    affectedFields.push('triggers');
+  }
+
+  // environmentFactors
+  const dedupedEnvs = uniqueLabels(environments);
+  if (dedupedEnvs.length > 0) {
+    provenance.push({
+      field: 'environmentFactors',
+      source: 'iceberg_session',
+      sourceLabel: sessionLabel,
+      reason: `環境因子 ${dedupedEnvs.length}件を environmentFactors にマッピング`,
+      value: dedupedEnvs.join(', '),
+      importedAt: now,
+    });
+    affectedFields.push('environmentFactors');
+  }
+
+  // environmentalAdjustment（§5 予防的支援）
+  const dedupedPrevention = uniqueLabels(drafts.map(d => d.strategies.prevention).filter(Boolean));
+  if (dedupedPrevention.length > 0) {
+    provenance.push({
+      field: 'environmentalAdjustment',
+      source: 'iceberg_session',
+      sourceLabel: sessionLabel,
+      reason: `予防戦略 ${dedupedPrevention.length}件を environmentalAdjustment にマッピング`,
+      value: dedupedPrevention.join(', '),
+      importedAt: now,
+    });
+    affectedFields.push('environmentalAdjustment');
+  }
+
+  // teachingMethod（§6 代替行動）
+  const dedupedAlternative = uniqueLabels(drafts.map(d => d.strategies.alternative).filter(Boolean));
+  if (dedupedAlternative.length > 0) {
+    provenance.push({
+      field: 'teachingMethod',
+      source: 'iceberg_session',
+      sourceLabel: sessionLabel,
+      reason: `代替行動戦略 ${dedupedAlternative.length}件を teachingMethod にマッピング`,
+      value: dedupedAlternative.join(', '),
+      importedAt: now,
+    });
+    affectedFields.push('teachingMethod');
+  }
+
+  // initialResponse / staffResponse（§7 問題行動時対応）
+  const dedupedReactive = uniqueLabels(drafts.map(d => d.strategies.reactive).filter(Boolean));
+  if (dedupedReactive.length > 0) {
+    provenance.push(
+      {
+        field: 'initialResponse',
+        source: 'iceberg_session',
+        sourceLabel: sessionLabel,
+        reason: `事後対応戦略 ${dedupedReactive.length}件を initialResponse にマッピング`,
+        value: dedupedReactive.join(', '),
+        importedAt: now,
+      },
+      {
+        field: 'staffResponse',
+        source: 'iceberg_session',
+        sourceLabel: sessionLabel,
+        reason: `事後対応戦略 ${dedupedReactive.length}件を staffResponse にマッピング（initialResponse と同値）`,
+        value: dedupedReactive.join(', '),
+        importedAt: now,
+      },
+    );
+    affectedFields.push('initialResponse', 'staffResponse');
+  }
+
+  const sourceRef: IcebergSourceRef = {
+    sessionId: sessionRef.id,
+    sessionUpdatedAt: sessionRef.updatedAt,
+    importedAt: now,
+    behaviorNodeIds: drafts.map(d => d.targetBehaviorNodeId),
+    affectedFields,
+  };
+
+  return { formPatches: patches, summary, provenance, sourceRef };
 }


### PR DESCRIPTION
## Summary

- Add `iceberg_session` to `ProvenanceSource` union
- Define `IcebergSourceRef` type for audit trail metadata
- Extend `IcebergImportResult` with `provenance[]` and `sourceRef`
- Add optional `sessionRef` param to `buildIcebergImportResult()`
- Generate field-level `ProvenanceEntry` records per mapped patch
- Add `iceberg_session` to `ProvenanceBadge` color/label maps
- Add 7 new test cases for provenance contract (15/15 passing)

## Why

#1859 aims to make Iceberg → Planning Sheet imports fully auditable.
This Phase 1 PR defines the **pure contract** for Iceberg import provenance without changing save behavior or SharePoint schema.

## Scope

This PR only defines the provenance payload contract.
`buildIcebergImportResult(drafts, sessionRef?)` is now backward-compatible:
- `sessionRef` omitted → `provenance: []`, `sourceRef: null` (existing callers unchanged)
- `sessionRef` provided → full provenance + sourceRef generated

## Non-goals

- No `saveAuditRecord` wiring yet (Phase 2)
- No SharePoint schema changes
- No UI flow changes beyond existing `ProvenanceBadge` source support
- No Iceberg mapping logic redesign
- No Planning Sheet save flow redesign

## Checks

```
git diff --check          ✅ no whitespace errors
npm run typecheck         ✅ 0 errors
npx vitest run ...spec.ts ✅ 15/15 passed
```

Addresses #1859 (Phase 1 of 2)
Phase 2 remains: wire `saveAuditRecord` in `handlePreviewConfirm` when `importSource === 'iceberg'`