### PR TITLE
fix(nav): clarify today lite nav flag behavior

### DIFF
--- a/src/app/config/__tests__/navigationConfig.helpers.spec.ts
+++ b/src/app/config/__tests__/navigationConfig.helpers.spec.ts
@@ -38,7 +38,7 @@ const items: NavItem[] = [
 ];
 
 describe('buildVisibleNavItems', () => {
-  it('returns all items when feature flag is off', () => {
+  it('does not apply tier-based collapsing when todayLiteNavV2 is off', () => {
     const result = buildVisibleNavItems(items, 'staff', {
       showMore: false,
       todayLiteNavV2: false,
@@ -55,7 +55,7 @@ describe('buildVisibleNavItems', () => {
     ]);
   });
 
-  it('viewer sees only core when showMore is false', () => {
+  it('applies lite-nav collapsing when todayLiteNavV2 is on and showMore is false', () => {
     const result = buildVisibleNavItems(items, 'staff', {
       showMore: false,
       todayLiteNavV2: true,
@@ -67,7 +67,7 @@ describe('buildVisibleNavItems', () => {
     expect(result.map((x) => x.label)).toEqual(['Today', 'Daily Table']);
   });
 
-  it('viewer sees more items when showMore is true', () => {
+  it('reveals tier=more items when todayLiteNavV2 is on and showMore is true', () => {
     const result = buildVisibleNavItems(items, 'staff', {
       showMore: true,
       todayLiteNavV2: true,
@@ -83,7 +83,7 @@ describe('buildVisibleNavItems', () => {
     ]);
   });
 
-  it('admin can see admin tier items', () => {
+  it('keeps tier=admin visible only for admin when todayLiteNavV2 is on', () => {
     const result = buildVisibleNavItems(items, 'admin', {
       showMore: true,
       todayLiteNavV2: true,
@@ -93,6 +93,26 @@ describe('buildVisibleNavItems', () => {
     });
 
     expect(result.some((x) => x.label === 'Analysis')).toBe(true);
+  });
+
+  it('treats tier=more as collapsed-by-default, not removed', () => {
+    const collapsed = buildVisibleNavItems(items, 'staff', {
+      showMore: false,
+      todayLiteNavV2: true,
+      isKiosk: false,
+      hiddenGroups: [],
+      hiddenItems: [],
+    });
+    const expanded = buildVisibleNavItems(items, 'staff', {
+      showMore: true,
+      todayLiteNavV2: true,
+      isKiosk: false,
+      hiddenGroups: [],
+      hiddenItems: [],
+    });
+
+    expect(collapsed.some((x) => x.label === 'Meeting Minutes')).toBe(false);
+    expect(expanded.some((x) => x.label === 'Meeting Minutes')).toBe(true);
   });
 });
 
@@ -105,4 +125,3 @@ describe('splitNavItemsByTier', () => {
     expect(result.admin.map((x) => x.label)).toEqual(['Analysis']);
   });
 });
-

--- a/src/app/config/navigationConfig.helpers.ts
+++ b/src/app/config/navigationConfig.helpers.ts
@@ -58,6 +58,14 @@ export function isNavVisible(item: NavItem, navAudience: NavAudience): boolean {
 
 export type BuildVisibleNavItemsOptions = {
   showMore: boolean;
+  /**
+   * Navigation display-mode flag.
+   *
+   * Note: this flag does NOT enable/disable page features themselves.
+   * It only enables tier-based sidebar behavior:
+   * - tier=more is collapsed unless showMore=true
+   * - tier=admin is hidden for non-admin
+   */
   todayLiteNavV2: boolean;
   isKiosk: boolean;
   hiddenGroups: string[];
@@ -94,7 +102,7 @@ export function buildVisibleNavItems(
     const FORCED_PILLARS = ['/records/monthly', '/support-plan-guide', '/planning-sheet-list', '/assessment'];
     if (FORCED_PILLARS.includes(item.to)) return true;
 
-    // 1. Feature Tier/Lite Nav filtering
+    // 1. Lite Nav display-mode filtering (tier behavior only)
     if (opts.todayLiteNavV2) {
       const tier = item.tier ?? DEFAULT_TIER;
       if (tier === 'admin' && role !== 'admin') return false;


### PR DESCRIPTION
## Summary
- clarify that `todayLiteNavV2` is a sidebar display-mode flag (tier behavior), not a page feature toggle
- make ON/OFF expectations explicit in nav visibility helper tests
- codify that tier=`more` items are collapsed by default and reappear when `showMore=true`

## Scope
- small semantics-fix PR only
- no feature-flag removal/rename
- no nav structure rewrite
- no production feature behavior change

## Files
- `src/app/config/navigationConfig.helpers.ts`
- `src/app/config/__tests__/navigationConfig.helpers.spec.ts`

## Verification
- `npx vitest run src/app/config/__tests__/navigationConfig.helpers.spec.ts --reporter=verbose`

## Issue
- #1490
