### PR TITLE
fix(nav): improve More button discoverability with labeled text and icons

### DIFF
--- a/src/app/AppShellSidebar.tsx
+++ b/src/app/AppShellSidebar.tsx
@@ -6,9 +6,12 @@ import { groupLabel, type NavGroupKey, type NavItem } from '@/app/config/navigat
 import NavLinkPrefetch from '@/components/NavLinkPrefetch';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import ExpandLessRoundedIcon from '@mui/icons-material/ExpandLessRounded';
+import ExpandMoreRoundedIcon from '@mui/icons-material/ExpandMoreRounded';
 import SearchIcon from '@mui/icons-material/Search';
 import Badge from '@mui/material/Badge';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
 import Divider from '@mui/material/Divider';
 import IconButton from '@mui/material/IconButton';
 import InputAdornment from '@mui/material/InputAdornment';
@@ -289,14 +292,23 @@ export const AppShellSidebar: React.FC<Props> = ({
       )}
       <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: navCollapsed ? 'center' : 'flex-end', px: 1, py: 0.5 }}>
         {todayLiteNavV2 && !navCollapsed && hasMoreNavItems && (
-          <Box sx={{ mr: 1 }}>
-            <IconButton
+          <Box sx={{ mr: 'auto', ml: 1 }}>
+            <Button
               onClick={onToggleMoreNavItems}
-              aria-label={showMoreNavItems ? 'Moreを閉じる' : 'Moreを開く'}
+              aria-label={showMoreNavItems ? 'その他のメニューを閉じる' : 'その他のメニューを開く'}
               size="small"
+              variant="text"
+              startIcon={showMoreNavItems ? <ExpandLessRoundedIcon /> : <ExpandMoreRoundedIcon />}
+              sx={{
+                fontSize: '0.75rem',
+                fontWeight: 600,
+                color: 'text.secondary',
+                textTransform: 'none',
+                '&:hover': { color: 'primary.main', bgcolor: 'action.hover' },
+              }}
             >
-              {showMoreNavItems ? '−' : '+'}
-            </IconButton>
+              {showMoreNavItems ? 'その他を閉じる' : 'その他のメニュー'}
+            </Button>
           </Box>
         )}
         <Tooltip title={navCollapsed ? 'ナビを展開' : 'ナビを折りたたみ'} placement="right" enterDelay={100}>
@@ -375,13 +387,22 @@ export const MobileNavContent: React.FC<{
       </Box>
       {todayLiteNavV2 && hasMoreNavItems && (
         <Box sx={{ px: 1.5, pb: 1 }}>
-          <IconButton
+          <Button
             onClick={onToggleMoreNavItems}
-            aria-label={showMoreNavItems ? 'Moreを閉じる' : 'Moreを開く'}
+            aria-label={showMoreNavItems ? 'その他のメニューを閉じる' : 'その他のメニューを開く'}
             size="small"
+            variant="text"
+            startIcon={showMoreNavItems ? <ExpandLessRoundedIcon /> : <ExpandMoreRoundedIcon />}
+            sx={{
+              fontSize: '0.75rem',
+              fontWeight: 600,
+              color: 'text.secondary',
+              textTransform: 'none',
+              '&:hover': { color: 'primary.main', bgcolor: 'action.hover' },
+            }}
           >
-            {showMoreNavItems ? '−' : '+'}
-          </IconButton>
+            {showMoreNavItems ? 'その他を閉じる' : 'その他のメニュー'}
+          </Button>
         </Box>
       )}
       <GroupedNavList

--- a/src/app/__tests__/AppShell.navigation.spec.tsx
+++ b/src/app/__tests__/AppShell.navigation.spec.tsx
@@ -96,7 +96,7 @@ describe('AppShell navigation exposure', () => {
     mockRole = 'viewer';
     renderShell();
 
-    const moreButton = screen.getByRole('button', { name: 'Moreを開く' });
+    const moreButton = screen.getByRole('button', { name: 'その他のメニューを開く' });
     expect(moreButton).toBeInTheDocument();
     fireEvent.click(moreButton);
 


### PR DESCRIPTION
## 概要
`todayLiteNavV2` フラグ ON 時の「More」トグルボタンの discoverability を改善します。

## 変更内容
- 裸の `+` / `−` IconButton → テキスト付き Button（「その他のメニュー」/「その他を閉じる」）に変更
- `ExpandMoreRoundedIcon` / `ExpandLessRoundedIcon` で視覚的に展開/折りたたみを示す
- Desktop / Mobile の両サイドバーで統一的に適用
- aria-label を日本語で明確化（「その他のメニューを開く/閉じる」）

## テスト
- `AppShell.navigation.spec.tsx`: aria-label の更新に追従 ✅
- `AppShell.kiosk-nav.spec.tsx`: 変更なし、パス ✅
- `navigationConfig.helpers.spec.ts`: 変更なし、パス ✅
- typecheck: パス ✅

## 対応 Issue
Partial fix for #1490 (Phase 2-B: More UX 改善)