### PR TITLE
fix(planning-sheet): resolve origin status rendering and finalize deletion workflow

### DIFF
--- a/src/app/config/navigationConfig.ts
+++ b/src/app/config/navigationConfig.ts
@@ -140,6 +140,7 @@ export function createNavItems(config: CreateNavItemsConfig): NavItem[] {
     }),
     PLANNING_ROUTES.SUPPORT_PLAN_GUIDE(isFieldStaffShell),
     PLANNING_ROUTES.ISP_EDITOR(isFieldStaffShell),
+    PLANNING_ROUTES.PLANNING_SHEET_LIST(isFieldStaffShell),
     
     SEVERE_ROUTES.SUPPORT_REVIEW_HUB(isFieldStaffShell),
 

--- a/src/app/config/routeGroups/planningRoutes.ts
+++ b/src/app/config/routeGroups/planningRoutes.ts
@@ -27,4 +27,15 @@ export const PLANNING_ROUTES = {
     audience: NAV_AUDIENCE.admin as NavAudience,
     group: 'planning' as NavGroupKey,
   }),
-} as const;
+
+  PLANNING_SHEET_LIST: (_isFieldStaffShell: boolean) => ({
+    label: '支援計画シート一覧',
+    to: '/planning-sheet-list',
+    isActive: (pathname: string) => pathname.startsWith('/planning-sheet-list') || pathname.startsWith('/support-planning-sheet'),
+    icon: undefined,
+    testId: TESTIDS.nav.planningSheet,
+    audience: NAV_AUDIENCE.staff as NavAudience,
+    group: 'planning' as NavGroupKey,
+    tier: 'more' as const,
+  }),
+};

--- a/src/data/isp/infra/DataProviderPlanningSheetRepository.ts
+++ b/src/data/isp/infra/DataProviderPlanningSheetRepository.ts
@@ -64,6 +64,13 @@ function adjustPayloadWithResolvedFields(
     PlanningJson: 'planningJson',
     SupportStartDate: 'supportStartDate',
     MonitoringCycleDays: 'monitoringCycleDays',
+    AppliedFrom: 'appliedFrom',
+    NextReviewAt: 'nextReviewAt',
+    TargetDomain: 'targetDomain',
+    CollectedInformation: 'collectedInformation',
+    EnvironmentalAdjustments: 'environmentalAdjustments',
+    AuthoredByStaffId: 'authoredByStaffId',
+    ApplicableServiceType: 'applicableServiceType',
     // Logical -> Logical
     title: 'title',
     userCode: 'userCode',
@@ -79,6 +86,12 @@ function adjustPayloadWithResolvedFields(
     planningJson: 'planningJson',
     supportStartDate: 'supportStartDate',
     monitoringCycleDays: 'monitoringCycleDays',
+    appliedFrom: 'appliedFrom',
+    nextReviewAt: 'nextReviewAt',
+    collectedInformation: 'collectedInformation',
+    environmentalAdjustments: 'environmentalAdjustments',
+    authoredByStaffId: 'authoredByStaffId',
+    applicableServiceType: 'applicableServiceType',
   };
 
   for (const [key, value] of Object.entries(payload)) {
@@ -279,5 +292,13 @@ export class DataProviderPlanningSheetRepository implements PlanningSheetReposit
     const updated = await this.getById(id);
     if (!updated) throw new Error(`[PlanningSheetRepository] Failed to reload updated item: ${id}`);
     return updated;
+  }
+  
+  async deleteItem(id: string): Promise<void> {
+    const numericId = extractSpId(id);
+    if (numericId === null) throw new Error(`Invalid ID: ${id}`);
+    
+    const { title } = await this.resolveSource();
+    await this.provider.deleteItem(title, numericId);
   }
 }

--- a/src/domain/isp/port.ts
+++ b/src/domain/isp/port.ts
@@ -125,6 +125,8 @@ export interface PlanningSheetRepository {
   create(input: PlanningSheetCreateInput): Promise<SupportPlanningSheet>;
   /** 支援計画シート更新 */
   update(id: string, input: PlanningSheetUpdateInput): Promise<SupportPlanningSheet>;
+  /** 支援計画シート削除 */
+  deleteItem(id: string): Promise<void>;
 }
 
 // ─────────────────────────────────────────────

--- a/src/pages/planning-sheet-list/PlanningSheetListView.tsx
+++ b/src/pages/planning-sheet-list/PlanningSheetListView.tsx
@@ -3,6 +3,7 @@ import AddRoundedIcon from '@mui/icons-material/AddRounded';
 import ArrowBackRoundedIcon from '@mui/icons-material/ArrowBackRounded';
 import AutoAwesomeRoundedIcon from '@mui/icons-material/AutoAwesomeRounded';
 import CheckCircleRoundedIcon from '@mui/icons-material/CheckCircleRounded';
+import DeleteRoundedIcon from '@mui/icons-material/DeleteRounded';
 import DescriptionRoundedIcon from '@mui/icons-material/DescriptionRounded';
 import InsightsRoundedIcon from '@mui/icons-material/InsightsRounded';
 import Alert from '@mui/material/Alert';
@@ -10,6 +11,7 @@ import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
 import CircularProgress from '@mui/material/CircularProgress';
+import IconButton from '@mui/material/IconButton';
 import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
 import Table from '@mui/material/Table';
@@ -348,9 +350,30 @@ export const PlanningSheetListView: React.FC<PlanningSheetListViewProps> = ({
                       </Typography>
                     </TableCell>
                     <TableCell align="right">
-                      <Button size="small" variant="outlined">
-                        開く
-                      </Button>
+                      <Stack direction="row" spacing={1} justifyContent="flex-end">
+                        <Button 
+                          size="small" 
+                          variant="outlined"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handlers.onNavigateToSheet(sheet.id);
+                          }}
+                        >
+                          開く
+                        </Button>
+                        <Tooltip title="このシートを削除" arrow>
+                          <IconButton 
+                            size="small" 
+                            color="error"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handlers.onDeleteSheet(sheet.id);
+                            }}
+                          >
+                            <DeleteRoundedIcon fontSize="small" />
+                          </IconButton>
+                        </Tooltip>
+                      </Stack>
                     </TableCell>
                   </TableRow>
                 ))}

--- a/src/pages/planning-sheet-list/hooks/__tests__/usePlanningSheetListOrchestrator.spec.tsx
+++ b/src/pages/planning-sheet-list/hooks/__tests__/usePlanningSheetListOrchestrator.spec.tsx
@@ -18,8 +18,9 @@ vi.mock('react-router-dom', async () => {
 });
 
 const mockRepo = {
-  listCurrentByUser: vi.fn(),
+  listByUser: vi.fn(),
   getById: vi.fn(),
+  deleteItem: vi.fn(),
 };
 
 vi.mock('@/features/planning-sheet/hooks/usePlanningSheetRepositories', () => ({
@@ -57,7 +58,7 @@ describe('usePlanningSheetListOrchestrator', () => {
 
   it('userId 選択時、データフェッチが成功し viewModel が構築されること', async () => {
     mockSearchParams.set('userId', 'U001');
-    mockRepo.listCurrentByUser.mockResolvedValue([{ id: 's1', isCurrent: true }]);
+    mockRepo.listByUser.mockResolvedValue([{ id: 's1', isCurrent: true }]);
     mockRepo.getById.mockResolvedValue({ id: 's1', assessment: { targetBehaviors: [] } });
     mockIcebergRepo.getLatestByUser.mockResolvedValue(null);
 
@@ -71,7 +72,7 @@ describe('usePlanningSheetListOrchestrator', () => {
 
   it('フェッチエラー時に error 状態が更新されること', async () => {
     mockSearchParams.set('userId', 'U001');
-    mockRepo.listCurrentByUser.mockRejectedValue(new Error('Fetch failed'));
+    mockRepo.listByUser.mockRejectedValue(new Error('Fetch failed'));
 
     const { result } = renderHook(() => usePlanningSheetListOrchestrator(), { wrapper });
 
@@ -84,13 +85,13 @@ describe('usePlanningSheetListOrchestrator', () => {
   it('userId 切替時に古い fetch 結果が混入しないこと', async () => {
     // 最初のユーザー
     mockSearchParams.set('userId', 'U001');
-    mockRepo.listCurrentByUser.mockImplementation(() => new Promise(resolve => setTimeout(() => resolve([{ id: 's1' }]), 50)));
+    mockRepo.listByUser.mockImplementation(() => new Promise(resolve => setTimeout(() => resolve([{ id: 's1' }]), 50)));
     
     const { result, rerender } = renderHook(() => usePlanningSheetListOrchestrator(), { wrapper });
 
     // 完了前にユーザー切り替え
     mockSearchParams.set('userId', 'U002');
-    mockRepo.listCurrentByUser.mockResolvedValue([{ id: 's2' }]);
+    mockRepo.listByUser.mockResolvedValue([{ id: 's2' }]);
     rerender();
 
     await waitFor(() => {
@@ -101,7 +102,7 @@ describe('usePlanningSheetListOrchestrator', () => {
 
   it('current sheet がない場合、details フェッチが行われないこと', async () => {
     mockSearchParams.set('userId', 'U001');
-    mockRepo.listCurrentByUser.mockResolvedValue([{ id: 's1', isCurrent: false }]);
+    mockRepo.listByUser.mockResolvedValue([{ id: 's1', isCurrent: false }]);
     
     renderHook(() => usePlanningSheetListOrchestrator(), { wrapper });
 

--- a/src/pages/planning-sheet-list/hooks/usePlanningSheetListOrchestrator.ts
+++ b/src/pages/planning-sheet-list/hooks/usePlanningSheetListOrchestrator.ts
@@ -30,6 +30,9 @@ export function usePlanningSheetListOrchestrator(): {
   const [latestIcebergSnapshot, setLatestIcebergSnapshot] = useState<IcebergSnapshot | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [refreshTrigger, setRefreshTrigger] = useState(0);
+
+  const refresh = () => setRefreshTrigger(v => v + 1);
 
   useEffect(() => {
     let isCancelled = false;
@@ -47,7 +50,7 @@ export function usePlanningSheetListOrchestrator(): {
       try {
         // Parallel fetch
         const [items, iceberg] = await Promise.all([
-          repo.listCurrentByUser(userId),
+          repo.listByUser(userId),
           icebergRepo ? icebergRepo.getLatestByUser(userId) : Promise.resolve(null),
         ]);
 
@@ -70,7 +73,7 @@ export function usePlanningSheetListOrchestrator(): {
     return () => {
       isCancelled = true;
     };
-  }, [userId, repo, icebergRepo]);
+  }, [userId, repo, icebergRepo, refreshTrigger]);
 
   // 現行シートの詳細をフェッチ
   useEffect(() => {
@@ -116,6 +119,20 @@ export function usePlanningSheetListOrchestrator(): {
         .join(' / ');
       const diffQuery = diffSummary ? `&diffSummary=${encodeURIComponent(diffSummary)}` : '';
       navigate(`/support-planning-sheet/new?userId=${uid}&source=iceberg&baseSheetId=${sid}${diffQuery}`);
+    },
+    onDeleteSheet: async (id) => {
+      if (!window.confirm('この支援計画シートを削除してもよろしいですか？\n削除したデータは元に戻せません。')) {
+        return;
+      }
+      try {
+        setIsLoading(true);
+        await repo.deleteItem(id);
+        refresh();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setIsLoading(false);
+      }
     },
     onBackToIsp: () => navigate('/support-plan-guide'),
   };

--- a/src/pages/planning-sheet-list/types.tsx
+++ b/src/pages/planning-sheet-list/types.tsx
@@ -46,6 +46,7 @@ export interface PlanningSheetListActionHandlers {
   onOpenIceberg: (userId: string) => void;
   onCreateFromIceberg: (userId: string) => void;
   onReviseFromIceberg: (userId: string, currentSheetId: string) => void;
+  onDeleteSheet: (id: string) => void;
   onBackToIsp: () => void;
 }
 

--- a/src/sharepoint/fields/ispThreeLayerFields.ts
+++ b/src/sharepoint/fields/ispThreeLayerFields.ts
@@ -333,12 +333,19 @@ export const PLANNING_SHEET_CANDIDATES = {
   supportPolicy: ['SupportPolicy', 'cr013_supportPolicy'],
   concreteApproaches: ['ConcreteApproaches', 'cr013_concreteApproaches'],
   versionNo: ['VersionNo', 'Version', 'cr013_versionNo'],
+  appliedFrom: ['AppliedFrom', 'cr013_appliedFrom'],
+  nextReviewAt: ['NextReviewAt', 'cr013_nextReviewAt'],
+  targetDomain: ['TargetDomain', 'Domain', 'cr013_targetDomain'],
   supportStartDate: ['SupportStartDate', 'cr013_supportStartDate'],
   monitoringCycleDays: ['MonitoringCycleDays', 'cr013_monitoringCycleDays'],
+  collectedInformation: ['CollectedInformation', 'cr013_collectedInformation'],
+  environmentalAdjustments: ['EnvironmentalAdjustments', 'cr013_environmentalAdjustments'],
+  authoredByStaffId: ['AuthoredByStaffId', 'cr013_authoredByStaffId'],
+  applicableServiceType: ['ApplicableServiceType', 'cr013_applicableServiceType'],
 } as const;
 
 export const PLANNING_SHEET_ESSENTIALS: (keyof typeof PLANNING_SHEET_CANDIDATES)[] = [
-  'userCode', 'status'
+  'userCode', 'status', 'appliedFrom'
 ];
 
 // ═════════════════════════════════════════════


### PR DESCRIPTION
## 概要
支援計画シート一覧において、起点ステータス（確定/暫定）が正しく表示されない問題と、シートの削除機能が未実装だった問題を修正しました。

## 修正内容
1. **起点ステータス表示の修正**
   - `appliedFrom` (計画適用日) が SharePoint フィールド解決候補に含まれていなかったため追加
   - リポジトリの論理マッピングに不足していたフィールド (`appliedFrom`, `nextReviewAt`, `targetDomain` 等) を追加
   - `I005` など利用開始日が未設定のケースでも、計画適用日から「暫定」ステータスが正しく算出されることを確認

2. **削除機能の正式実装**
   - `PlanningSheetRepository` インターフェースに `deleteItem` を追加
   - `PlanningSheetListView` に削除ボタン（ゴミ箱アイコン）と確認ダイアログを統合
   - オーケストレーターの削除ハンドラーをクリーンアップ（型安全化）

3. **ナビゲーション追加**
   - メインメニューに「支援計画シート一覧」を追加し、アクセス性を改善

4. **テスト修正**
   - オーケストレーターのテストにおいて、メソッド名変更 (`listCurrentByUser` -> `listByUser`) に追随

## 検証結果
- `userId=I005` の一覧で、利用開始日がなくても「暫定」と表示されることを確認
- 削除ボタンクリック後のダイアログ承認で、SharePoint からデータが削除され一覧が更新されることを確認