### PR TITLE
feat(tokusei): define import audit payload builder

### DIFF
--- a/src/features/planning-sheet/__tests__/tokuseiImportAuditBuilder.spec.ts
+++ b/src/features/planning-sheet/__tests__/tokuseiImportAuditBuilder.spec.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import type { ImportAuditRecord } from '../stores/importAuditStore';
+import { emptyBridgeResult } from '../tokuseiToPlanningBridge';
+import {
+  buildTokuseiImportAuditPayload,
+  hasAlreadyImportedTokusei,
+} from '../tokuseiImportAuditBuilder';
+
+describe('tokuseiImportAuditBuilder', () => {
+  describe('buildTokuseiImportAuditPayload', () => {
+    it('should build payload with correct structure and summary for empty result', () => {
+      const bridgeResult = emptyBridgeResult('tokusei-abc');
+      
+      const payload = buildTokuseiImportAuditPayload({
+        planningSheetId: 'sheet-1',
+        importedBy: 'Test User',
+        tokuseiResponseId: 'tokusei-abc',
+        bridgeResult,
+        now: '2026-05-17T00:00:00Z',
+      });
+
+      expect(payload).toEqual({
+        planningSheetId: 'sheet-1',
+        importedAt: '2026-05-17T00:00:00Z',
+        importedBy: 'Test User',
+        assessmentId: null,
+        tokuseiResponseId: 'tokusei-abc',
+        mode: 'with-tokusei',
+        affectedFields: [],
+        provenance: [],
+        summaryText: '特性アンケート取込 (反映データなし)',
+      });
+    });
+
+    it('should build payload with provenance and summary texts when result has items', () => {
+      const bridgeResult = emptyBridgeResult('tokusei-def');
+      bridgeResult.audit.fieldsTouched = ['formPatches.observationFacts', 'intakePatches.sensoryTriggers'];
+      bridgeResult.summary.sensoryTriggersAdded = 2;
+      bridgeResult.summary.icebergFieldsFilled = 1;
+      
+      bridgeResult.provenance = [
+        {
+          field: 'intakePatches.sensoryTriggers',
+          source: 'tokusei_survey',
+          sourceLabel: '特性アンケート',
+          reason: 'テスト理由',
+          value: '視覚過敏',
+          confidence: 'high',
+          importedAt: '2026-05-17T00:00:00Z',
+        }
+      ];
+
+      const payload = buildTokuseiImportAuditPayload({
+        planningSheetId: 'sheet-2',
+        importedBy: 'Test User 2',
+        tokuseiResponseId: 'tokusei-def',
+        bridgeResult,
+        now: '2026-05-17T00:00:01Z',
+      });
+
+      expect(payload.mode).toBe('with-tokusei');
+      expect(payload.affectedFields).toEqual(['formPatches.observationFacts', 'intakePatches.sensoryTriggers']);
+      expect(payload.summaryText).toBe('特性アンケート取込 (氷山分析: 1件 / 感覚トリガー: 2件)');
+      
+      // ProvenanceEntry に confidence は含まれないこと（型上 Omit されている想定、ランタイムでも含まれてよいが、一応形式を確認）
+      expect(payload.provenance[0]).toEqual({
+        field: 'intakePatches.sensoryTriggers',
+        source: 'tokusei_survey',
+        sourceLabel: '特性アンケート',
+        reason: 'テスト理由',
+        value: '視覚過敏',
+        importedAt: '2026-05-17T00:00:00Z',
+      });
+    });
+  });
+
+  describe('hasAlreadyImportedTokusei', () => {
+    it('should return true if the response id has already been imported', () => {
+      const records: ImportAuditRecord[] = [
+        {
+          id: '1',
+          planningSheetId: 'sheet-1',
+          importedAt: '2026-05-17T00:00:00Z',
+          importedBy: 'User',
+          assessmentId: null,
+          tokuseiResponseId: 'tokusei-xyz',
+          mode: 'with-tokusei',
+          affectedFields: [],
+          provenance: [],
+          summaryText: '',
+        }
+      ];
+
+      expect(hasAlreadyImportedTokusei(records, 'tokusei-xyz')).toBe(true);
+      expect(hasAlreadyImportedTokusei(records, 'tokusei-other')).toBe(false);
+    });
+
+    it('should ignore iceberg or other modes even with same id (conceptually)', () => {
+      const records: ImportAuditRecord[] = [
+        {
+          id: '2',
+          planningSheetId: 'sheet-1',
+          importedAt: '2026-05-17T00:00:00Z',
+          importedBy: 'User',
+          assessmentId: null,
+          tokuseiResponseId: 'tokusei-xyz', // Technically tokuseiResponseId is normally null for iceberg, but just in case
+          mode: 'iceberg',
+          affectedFields: [],
+          provenance: [],
+          summaryText: '',
+        }
+      ];
+
+      expect(hasAlreadyImportedTokusei(records, 'tokusei-xyz')).toBe(false);
+    });
+  });
+});

--- a/src/features/planning-sheet/tokuseiImportAuditBuilder.ts
+++ b/src/features/planning-sheet/tokuseiImportAuditBuilder.ts
@@ -1,0 +1,88 @@
+import type { ImportAuditRecord } from './stores/importAuditStore';
+import type { TokuseiBridgeResult } from './tokuseiToPlanningBridge';
+
+/**
+ * Tokusei 取込の監査情報を生成するためのペイロード。
+ * ImportAuditStore.saveAuditRecord の引数となる。
+ */
+export type TokuseiImportAuditPayload = Omit<ImportAuditRecord, 'id'>;
+
+export interface TokuseiAuditBuilderOptions {
+  planningSheetId: string;
+  importedBy: string;
+  tokuseiResponseId: string;
+  bridgeResult: TokuseiBridgeResult;
+  /**
+   * 取込日時（省略時は現在時刻）
+   */
+  now?: string;
+}
+
+/**
+ * TokuseiBridgeResult から ImportAuditRecord の保存用ペイロードを構築する pure function。
+ * Iceberg audit trail とは別 mode ('with-tokusei') として責務を分離する。
+ *
+ * @param options - 構築に必要なオプション
+ * @returns 監査用ペイロード
+ */
+export function buildTokuseiImportAuditPayload(
+  options: TokuseiAuditBuilderOptions,
+): TokuseiImportAuditPayload {
+  const { planningSheetId, importedBy, tokuseiResponseId, bridgeResult, now } = options;
+  const importedAt = now || new Date().toISOString();
+
+  // audit.fieldsTouched を対象フィールドとして記録
+  const affectedFields = [...bridgeResult.audit.fieldsTouched];
+
+  // サマリーテキストの生成
+  const { summary } = bridgeResult;
+  const summaryParts: string[] = [];
+  if (summary.icebergFieldsFilled > 0) summaryParts.push(`氷山分析: ${summary.icebergFieldsFilled}件`);
+  if (summary.sensoryTriggersAdded > 0) summaryParts.push(`感覚トリガー: ${summary.sensoryTriggersAdded}件`);
+  if (summary.targetBehaviorCandidates > 0) summaryParts.push(`対象行動候補: ${summary.targetBehaviorCandidates}件`);
+  if (summary.hypothesesGenerated > 0) summaryParts.push(`機能仮説候補: ${summary.hypothesesGenerated}件`);
+
+  const summaryText = summaryParts.length > 0
+    ? `特性アンケート取込 (${summaryParts.join(' / ')})`
+    : '特性アンケート取込 (反映データなし)';
+
+  // TokuseiProvenanceEntry -> ProvenanceEntry (confidenceは落とす)
+  const provenance = bridgeResult.provenance.map((p) => ({
+    field: p.field,
+    source: p.source,
+    sourceLabel: p.sourceLabel,
+    reason: p.reason,
+    value: p.value,
+    importedAt: p.importedAt || importedAt,
+  }));
+
+  return {
+    planningSheetId,
+    importedAt,
+    importedBy,
+    assessmentId: null, // Tokusei 単独取込の場合は null
+    tokuseiResponseId,
+    mode: 'with-tokusei', // Iceberg (iceberg) とは別モード
+    affectedFields,
+    provenance,
+    summaryText,
+  };
+}
+
+/**
+ * 既に同じ TokuseiResponseId が取り込まれているか（二重記録防止用）を判定する。
+ * 
+ * @param existingRecords - シートに紐づく既存の監査レコード一覧
+ * @param tokuseiResponseId - 取込対象のアンケート回答ID
+ * @returns すでに取込済みであれば true
+ */
+export function hasAlreadyImportedTokusei(
+  existingRecords: ImportAuditRecord[],
+  tokuseiResponseId: string,
+): boolean {
+  return existingRecords.some(
+    (record) => 
+      record.mode === 'with-tokusei' && 
+      record.tokuseiResponseId === tokuseiResponseId
+  );
+}


### PR DESCRIPTION
## 概要
#1934 の Phase 0/1 として、特性アンケートのインポート証跡（Tokusei provenance）を `ImportAuditStore` に適合するペイロードへ変換する純粋関数を定義しました。

## 変更内容
- `tokuseiImportAuditBuilder.ts` を新設し、`buildTokuseiImportAuditPayload` および `hasAlreadyImportedTokusei` を実装。
- 既存の Iceberg Audit と責務を分けるため、`mode` を `'with-tokusei'` として扱い、単体テストで重複防止などの挙動を保証しました。
- UI (`NewPlanningSheetForm.tsx`) には変更を含めておらず、安全に基盤の型と変換ロジックのみを定義しています。

## Issue
- ref #1934
