### PR TITLE
feat(tokusei): wire import audit payload builder in NewPlanningSheetForm

### DIFF
--- a/src/features/planning-sheet/components/new-form/NewPlanningSheetForm.tsx
+++ b/src/features/planning-sheet/components/new-form/NewPlanningSheetForm.tsx
@@ -52,7 +52,7 @@ import { filterActiveUsers } from '@/features/users/domain/userLifecycle';
 import { useUsers } from '@/features/users/useUsers';
 import { useAuth } from '@/auth/useAuth';
 import { useUserAuthz } from '@/auth/useUserAuthz';
-import { tokuseiToPlanningBridge } from '../../tokuseiToPlanningBridge';
+import { tokuseiToPlanningBridge, type TokuseiBridgeResult } from '../../tokuseiToPlanningBridge';
 import { buildImportPreview } from '../../buildImportPreview';
 import type { ImportPreviewResult } from '../../buildImportPreview';
 import { ImportPreviewDialog } from '../ImportPreviewDialog';
@@ -63,6 +63,7 @@ import { useIcebergRepository } from '@/features/ibd/analysis/iceberg/SharePoint
 import { icebergToInterventionDrafts } from '@/features/ibd/analysis/iceberg/icebergToIntervention';
 import { buildIcebergImportResult, type IcebergImportResult } from '../../icebergToPlanningBridge';
 import { useImportAuditStore } from '../../stores/importAuditStore';
+import { buildTokuseiImportAuditPayload } from '../../tokuseiImportAuditBuilder';
 import type { IcebergSession } from '@/features/ibd/analysis/iceberg/icebergTypes';
 import { useMonitoringAbcEvidence } from '@/features/monitoring/hooks/useMonitoringAbcEvidence';
 
@@ -112,6 +113,7 @@ export const NewPlanningSheetForm: React.FC<NewPlanningSheetFormProps> = ({
   const [selectedTokusei, setSelectedTokusei] = React.useState<TokuseiSurveyResponse | null>(null);
   const [tokuseiImported, setTokuseiImported] = React.useState(false);
   const [previewDialogOpen, setPreviewDialogOpen] = React.useState(false);
+  const [tokuseiBridgeResult, setTokuseiBridgeResult] = React.useState<TokuseiBridgeResult | null>(null);
   const [lastBridgeResult, setLastBridgeResult] = React.useState<{ formPatches: Record<string, string> } | null>(null);
   const [tokuseiProvenance] = React.useState<Map<string, { name: string; relation?: string; fillDate?: string }>>(new Map());
   const [importPreview, setImportPreview] = React.useState<ImportPreviewResult | null>(null);
@@ -290,6 +292,7 @@ export const NewPlanningSheetForm: React.FC<NewPlanningSheetFormProps> = ({
     // プレビュー生成
     const preview = buildImportPreview(result.formPatches, form as unknown as Record<string, unknown>);
     setImportPreview(preview);
+    setTokuseiBridgeResult(result);
     setLastBridgeResult(result);
     setImportSource('tokusei');
     setPreviewDialogOpen(true);
@@ -470,6 +473,18 @@ export const NewPlanningSheetForm: React.FC<NewPlanningSheetFormProps> = ({
           provenance: icebergImportResult.provenance,
           summaryText: `氷山分析から取込完了: 行動${icebergImportResult.summary.behaviorCount}件, きっかけ${icebergImportResult.summary.triggerCount}件, 環境${icebergImportResult.summary.environmentFactorCount}件, 対応${icebergImportResult.summary.strategyCount}件`,
         });
+      }
+
+      // 特性アンケートからインポートした場合の監査記録
+      if (tokuseiImported && selectedTokusei && tokuseiBridgeResult) {
+        const payload = buildTokuseiImportAuditPayload({
+          planningSheetId: created.id,
+          importedBy: createdBy,
+          tokuseiResponseId: selectedTokusei.responseId,
+          bridgeResult: tokuseiBridgeResult,
+          now: new Date().toISOString()
+        });
+        saveAuditRecord(payload);
       }
 
 


### PR DESCRIPTION
## 概要
#1934 の Phase 2 として、特性アンケートのインポート証跡を `ImportAuditStore` に記録する処理を `NewPlanningSheetForm` の保存導線（`handleCreate`）に組み込みました。

## 変更内容
- `tokuseiToPlanningBridge` からの返り値である `TokuseiBridgeResult` を `tokuseiBridgeResult` State に保持するよう変更。
- `handleCreate` 内で、特性アンケートが取り込まれた場合にのみ `buildTokuseiImportAuditPayload` を呼び出し、`saveAuditRecord` を実行する処理を追加。
- `mode: 'with-tokusei'` により、Iceberg Audit (`mode: 'iceberg'`) との共有 State や Provenance のマージを完全に分離・禁止しました。
- 型推論の恩恵を受け、`any` や `unknown` キャストを必要としない安全な統合を実現しています。

## 依存関係
- PR #1935 (Phase 0/1) に依存しています。このPRは #1935 のブランチから派生しています。

## Issue
- ref #1934
