### PR TITLE
refactor(planning-sheet): split new planning sheet form into hook and sections

### DIFF
--- a/src/features/planning-sheet/components/new-form/FormSections.tsx
+++ b/src/features/planning-sheet/components/new-form/FormSections.tsx
@@ -1,224 +1,13 @@
-/**
- * FormSections — 10セクションの描画コンポーネント
- *
- * renderSection(step) で各セクションの JSX を返す。
- * 親から form / updateField / renderProvenanceBadge を受け取る。
- */
 import React from 'react';
-
-// ── MUI ──
-import Alert from '@mui/material/Alert';
-import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
-import Checkbox from '@mui/material/Checkbox';
-import Chip from '@mui/material/Chip';
-import CircularProgress from '@mui/material/CircularProgress';
-import Divider from '@mui/material/Divider';
-import FormControlLabel from '@mui/material/FormControlLabel';
-import MenuItem from '@mui/material/MenuItem';
-import Paper from '@mui/material/Paper';
-import Stack from '@mui/material/Stack';
-import TextField from '@mui/material/TextField';
-import Typography from '@mui/material/Typography';
-
-// ── Icons ──
-import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
-import CheckIcon from '@mui/icons-material/Check';
-import KeyboardDoubleArrowDownIcon from '@mui/icons-material/KeyboardDoubleArrowDown';
-import EqualizerIcon from '@mui/icons-material/Equalizer';
-
-// ── Local ──
 import type { FormState } from './types';
-import { BEHAVIOR_FUNCTIONS, TRAINING_LEVELS, ICEBERG_FACTORS } from './constants';
-import { calculateMonitoringSchedule } from '@/features/planning-sheet/monitoringSchedule';
-import { useReverseBridge } from '../../hooks/useReverseBridge';
-import KioskMonitoringEvidencePanel from '@/features/monitoring/components/KioskMonitoringEvidencePanel';
-import { AbcEvidenceListPanel, type AbcEvidenceListPanelProps } from '@/features/monitoring/components/AbcEvidenceListPanel';
 import type { AbcRecord } from '@/domain/abc/abcRecord';
-import type { MonitoringEvidenceLink } from '@/domain/isp/schema/ispPlanningSheetSchema';
+import type { AbcEvidenceListPanelProps } from '@/features/monitoring/components/AbcEvidenceListPanel';
 
-
-// ─────────────────────────────────────────────
-// SectionTitle — 共通ヘッダー
-// ─────────────────────────────────────────────
-
-const SectionTitle: React.FC<{ number: number; title: string; desc?: string }> = ({ number, title, desc }) => (
-  <Stack spacing={0.5} sx={{ mb: 1 }}>
-    <Stack direction="row" spacing={1} alignItems="center">
-      <Chip label={`§${number}`} size="small" color="primary" variant="outlined" />
-      <Typography variant="h6" fontWeight={700}>{title}</Typography>
-    </Stack>
-    {desc && <Typography variant="body2" color="text.secondary">{desc}</Typography>}
-  </Stack>
-);
-
-// ─────────────────────────────────────────────
-// IcebergIllustration — 氷山分析の視覚図
-// ─────────────────────────────────────────────
-
-// ─────────────────────────────────────────────
-// IcebergIllustration — 氷山分析の視覚図
-// ─────────────────────────────────────────────
-
-const IcebergIllustration: React.FC<{ surfaceValue?: string }> = ({ surfaceValue }) => (
-  <Box sx={{ width: '100%', display: 'flex', justifyContent: 'center', mb: 6 }}>
-    <Box sx={{
-      width: '100%',
-      maxWidth: 600,
-      bgcolor: '#f8fbff',
-      borderRadius: 4,
-      p: { xs: 2, sm: 4 },
-      pb: { xs: 3, sm: 5 },
-      border: '1px solid #e0f2fe',
-      boxShadow: '0 2px 12px rgba(0,0,0,0.02)',
-      display: 'flex',
-      flexDirection: 'column',
-      alignItems: 'center'
-    }}>
-      <svg
-        viewBox="0 0 520 400"
-        width="100%"
-        height="auto"
-        role="img"
-        aria-label="氷山分析の構造図"
-        style={{ display: 'block', maxWidth: '520px' }}
-      >
-        {/* タイトル (SVG内でも中央) */}
-        <text x="260" y="30" textAnchor="middle" fontSize="22" fontWeight="800" fill="#0c4a6e">氷山分析</text>
-
-        {/* 水面上：問題行動 (入力値があれば表示) */}
-        <rect x="100" y="50" width="320" height="56" rx="16" fill="#fde68a" stroke="#f59e0b" strokeWidth="1" />
-        <text x="260" y="86" textAnchor="middle" fontSize={surfaceValue && surfaceValue.length > 15 ? 14 : 18} fontWeight="700" fill="#78350f">
-          {surfaceValue 
-            ? (surfaceValue.length > 22 ? surfaceValue.substring(0, 20) + '...' : surfaceValue)
-            : '🏔️ 問題行動（水面上）'
-          }
-        </text>
-
-        {/* 水面ライン */}
-        <line x1="30" y1="130" x2="490" y2="130" stroke="#38bdf8" strokeWidth="4" strokeLinecap="round" />
-        <text x="490" y="122" textAnchor="end" fontSize="12" fontWeight="700" fill="#0369a1">水面</text>
-
-        {/* 氷山本体 (幅を広げて中央感を強調) */}
-        <path d="M120 150 L400 150 L460 380 L60 380 Z" fill="#eff6ff" stroke="#93c5fd" strokeWidth="2" />
-
-        {/* 層区切り */}
-        <line x1="105" y1="195" x2="415" y2="195" stroke="#bfdbfe" strokeWidth="1.5" />
-        <line x1="90" y1="240" x2="430" y2="240" stroke="#bfdbfe" strokeWidth="1.5" />
-        <line x1="75" y1="285" x2="445" y2="285" stroke="#bfdbfe" strokeWidth="1.5" />
-        <line x1="65" y1="330" x2="455" y2="330" stroke="#bfdbfe" strokeWidth="1.5" />
-
-        {/* ラベル — 260を軸に完全中央配置 */}
-        <text x="260" y="180" textAnchor="middle" fontSize="16" fontWeight="600" fill="#1e40af">{ICEBERG_FACTORS[1].icon} {ICEBERG_FACTORS[1].label}</text>
-        <text x="260" y="225" textAnchor="middle" fontSize="16" fontWeight="600" fill="#1e40af">{ICEBERG_FACTORS[2].icon} {ICEBERG_FACTORS[2].label}</text>
-        <text x="260" y="270" textAnchor="middle" fontSize="16" fontWeight="600" fill="#1e40af">{ICEBERG_FACTORS[3].icon} {ICEBERG_FACTORS[3].label}</text>
-        <text x="260" y="315" textAnchor="middle" fontSize="16" fontWeight="600" fill="#1e40af">{ICEBERG_FACTORS[4].icon} {ICEBERG_FACTORS[4].label}</text>
-        <text x="260" y="362" textAnchor="middle" fontSize="16" fontWeight="800" fill="#1d4ed8">{ICEBERG_FACTORS[5].icon} {ICEBERG_FACTORS[5].label}</text>
-      </svg>
-      <Typography variant="body2" sx={{ mt: 3, textAlign: 'center', color: 'text.secondary', fontStyle: 'italic', px: 2 }}>
-        表面に見える行動の下に、背景要因や本人の願いが重なっています。
-      </Typography>
-    </Box>
-  </Box>
-);
-
-// ─────────────────────────────────────────────
-// ABCIllustration — ABC分析の視覚図
-// ─────────────────────────────────────────────
-
-const ABCIllustration: React.FC<{ a?: string; b?: string; c?: string }> = ({ a, b, c }) => (
-  <Box sx={{ width: '100%', display: 'flex', justifyContent: 'center', mb: 4 }}>
-    <Box sx={{
-      width: '100%',
-      maxWidth: 700,
-      bgcolor: '#fff',
-      borderRadius: 4,
-      p: { xs: 2, sm: 3 },
-      border: '1px solid #e2e8f0',
-      boxShadow: '0 4px 12px rgba(0,0,0,0.03)',
-    }}>
-      <Stack direction="row" alignItems="center" spacing={1} justifyContent="center">
-        {/* A: Antecedent */}
-        <Box sx={{ flex: 1, minHeight: 120, p: 2, borderRadius: 3, border: '2px solid #93c5fd', bgcolor: '#f0f9ff', display: 'flex', flexDirection: 'column', alignItems: 'center', textAlign: 'center' }}>
-          <Typography variant="caption" fontWeight={800} color="primary.main" gutterBottom sx={{ fontSize: '0.65rem', borderBottom: '1px solid currentColor', mb: 1, px: 1 }}>A: 先行事象</Typography>
-          <Typography variant="body2" sx={{ fontSize: '0.75rem', color: '#1e3a8a', overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 4, WebkitBoxOrient: 'vertical', lineHeight: 1.4 }}>
-            {a || '（行動の直前の状況）'}
-          </Typography>
-        </Box>
-
-        <Box sx={{ color: '#cbd5e1', fontWeight: 900 }}>▶</Box>
-
-        {/* B: Behavior */}
-        <Box sx={{ flex: 1, minHeight: 120, p: 2, borderRadius: 3, border: '2px solid #fecaca', bgcolor: '#fef2f2', display: 'flex', flexDirection: 'column', alignItems: 'center', textAlign: 'center' }}>
-          <Typography variant="caption" fontWeight={800} color="error.main" gutterBottom sx={{ fontSize: '0.65rem', borderBottom: '1px solid currentColor', mb: 1, px: 1 }}>B: 行動</Typography>
-          <Typography variant="body2" sx={{ fontSize: '0.75rem', color: '#7f1d1d', overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 4, WebkitBoxOrient: 'vertical', lineHeight: 1.4 }}>
-            {b || '（具体的な行動の内容）'}
-          </Typography>
-        </Box>
-
-        <Box sx={{ color: '#cbd5e1', fontWeight: 900 }}>▶</Box>
-
-        {/* C: Consequence */}
-        <Box sx={{ flex: 1, minHeight: 120, p: 2, borderRadius: 3, border: '2px solid #bbf7d0', bgcolor: '#f0fdf4', display: 'flex', flexDirection: 'column', alignItems: 'center', textAlign: 'center' }}>
-          <Typography variant="caption" fontWeight={800} color="success.main" gutterBottom sx={{ fontSize: '0.65rem', borderBottom: '1px solid currentColor', mb: 1, px: 1 }}>C: 結果</Typography>
-          <Typography variant="body2" sx={{ fontSize: '0.75rem', color: '#064e3b', overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 4, WebkitBoxOrient: 'vertical', lineHeight: 1.4 }}>
-            {c || '（行動のあとの変化）'}
-          </Typography>
-        </Box>
-      </Stack>
-      <Typography variant="caption" sx={{ display: 'block', mt: 2, textAlign: 'center', color: 'text.secondary', fontWeight: 500 }}>
-        この連鎖（A→B→C）から、なぜその行動が繰り返されるのか（機能）を推測します。
-      </Typography>
-    </Box>
-  </Box>
-);
-
-// ─────────────────────────────────────────────
-// ResponseProtocolVisualizer — 現場対応プロトコル（Cフェーズ）
-// ─────────────────────────────────────────────
-
-const ResponseProtocolVisualizer: React.FC<{ phase: 'initial' | 'escalated' | 'crisis' }> = ({ phase }) => {
-  const config = {
-    initial: { label: '🟢 初期対応（前兆期）', color: '#10b981', bg: '#ecfdf5', dark: '#064e3b', desc: '落ち着きがなくなる、声が出る等' },
-    escalated: { label: '🟡 中期対応（行動発現期）', color: '#f59e0b', bg: '#fffbeb', dark: '#78350f', desc: '大声、座り込み、物への接触等' },
-    crisis: { label: '🔴 危機対応（極期）', color: '#ef4444', bg: '#fef2f2', dark: '#7f1d1d', desc: '自傷、他害、激しい破壊等' },
-  }[phase];
-
-  return (
-    <Box sx={{ width: '100%', mb: 4 }}>
-      <Paper variant="outlined" sx={{ p: 2, borderLeft: `6px solid ${config.color}`, bgcolor: config.bg, borderRadius: '8px 16px 16px 8px' }}>
-        <Stack direction="row" spacing={2} alignItems="center">
-          <Box sx={{ 
-            width: 48, height: 48, borderRadius: '50%', bgcolor: config.color, 
-            display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#fff' 
-          }}>
-            {phase === 'initial' && '🟢'}
-            {phase === 'escalated' && '🟡'}
-            {phase === 'crisis' && '🔴'}
-          </Box>
-          <Box>
-            <Typography variant="subtitle1" fontWeight={800} color={config.dark}>{config.label}</Typography>
-            <Typography variant="caption" color={config.dark} sx={{ opacity: 0.8 }}>{config.desc}</Typography>
-          </Box>
-        </Stack>
-      </Paper>
-      
-      {/* 迷わないための指示構造 */}
-      <Stack direction="row" spacing={1} sx={{ mt: 1 }}>
-        <Box sx={{ flex: 1, p: 1, bgcolor: '#f8fafc', borderRadius: 2, border: '1px dashed #cbd5e1', textAlign: 'center' }}>
-          <Typography variant="caption" fontWeight={700} color="text.secondary">判断せずに動く</Typography>
-        </Box>
-        <Box sx={{ flex: 1, p: 1, bgcolor: '#fef2f2', borderRadius: 2, border: '1px dashed #fecaca', textAlign: 'center' }}>
-          <Typography variant="caption" fontWeight={700} color="error.main">NG行動の徹底回避</Typography>
-        </Box>
-      </Stack>
-    </Box>
-  );
-};
-
-// ─────────────────────────────────────────────
-// Props
-// ─────────────────────────────────────────────
+import { SectionBasicAndTarget } from './sections/SectionBasicAndTarget';
+import { SectionAnalysisAndFba } from './sections/SectionAnalysisAndFba';
+import { SectionPBSStrategies } from './sections/SectionPBSStrategies';
+import { SectionMonitoring } from './sections/SectionMonitoring';
+import { SectionSharing } from './sections/SectionSharing';
 
 interface FormSectionsProps {
   step: number;
@@ -233,11 +22,7 @@ interface FormSectionsProps {
   abcEvidenceError?: Error | null;
 }
 
-// ─────────────────────────────────────────────
-// Component
-// ─────────────────────────────────────────────
-
-const FormSections: React.FC<FormSectionsProps> = ({
+export const FormSections: React.FC<FormSectionsProps> = ({
   step,
   form,
   updateField,
@@ -249,553 +34,62 @@ const FormSections: React.FC<FormSectionsProps> = ({
   abcEvidencePeriod = null,
   abcEvidenceError = null,
 }) => {
-  const { suggestions, isLoading: isBridgeLoading, error: bridgeError } = useReverseBridge(userId, form.supportStartDate);
-
-  const schedule = React.useMemo(() => {
-    if (!form.supportStartDate) return null;
-    return calculateMonitoringSchedule(form.supportStartDate, form.monitoringCycleDays);
-  }, [form.supportStartDate, form.monitoringCycleDays]);
-
-  const schedulePreview = schedule ? (
-    <Alert icon={false} severity="info" sx={{ mt: 1, py: 0.5, px: 2, border: '1px solid #93c5fd', bgcolor: '#eff6ff', borderRadius: 2 }}>
-      <Typography variant="caption" color="primary.main" fontWeight={800}>
-        🗓️ 次回予定日: {schedule.nextMonitoringDate} （{form.monitoringCycleDays}日周期）
-      </Typography>
-    </Alert>
-  ) : null;
-
   switch (step) {
     case 0: // §1 基本情報
-      return (
-        <Stack spacing={2}>
-          <SectionTitle number={1} title="基本情報" desc="利用者の基本情報と計画の概要" />
-          <TextField label="計画タイトル" value={form.title} onChange={e => updateField('title', e.target.value)} required fullWidth
-            placeholder="例: 外出活動場面における行動支援計画" />
-          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
-            <TextField label="支援区分" value={form.supportLevel} onChange={e => updateField('supportLevel', e.target.value)} fullWidth
-              placeholder="例: 区分5" />
-            <TextField label="行動関連項目点数" value={form.behaviorScore} onChange={e => updateField('behaviorScore', e.target.value)} fullWidth
-              placeholder="例: 18点" />
-          </Stack>
-          <TextField label="計画期間" value={form.planPeriod} onChange={e => updateField('planPeriod', e.target.value)} fullWidth
-            placeholder="例: 2026年4月1日 〜 2026年9月30日" />
-          <TextField
-            label="支援開始日（モニタリング起点）"
-            type="date"
-            value={form.supportStartDate}
-            onChange={e => updateField('supportStartDate', e.target.value)}
-            fullWidth
-            InputLabelProps={{ shrink: true }}
-            helperText="90日モニタリングの起点となる日付です。通常は利用開始日を設定します。"
-          />
-          {schedulePreview}
-          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
-            <TextField select label="関与研修" value={form.trainingLevel} onChange={e => updateField('trainingLevel', e.target.value)} fullWidth>
-              {TRAINING_LEVELS.map(t => <MenuItem key={t.value} value={t.value}>{t.label}</MenuItem>)}
-            </TextField>
-            <TextField label="関係機関" value={form.relatedOrganizations} onChange={e => updateField('relatedOrganizations', e.target.value)} fullWidth
-              placeholder="例: 相談支援センター、訪問看護" />
-          </Stack>
-          {form.trainingLevel !== 'なし' && (
-            <Alert severity="info" variant="outlined">
-              ✅ 強度行動障害支援者養成研修（{form.trainingLevel}）修了者が関与 — 加算算定要件を充足
-            </Alert>
-          )}
-        </Stack>
-      );
     case 1: // §2 対象行動
       return (
-        <Stack spacing={2}>
-          <SectionTitle number={2} title="対象行動（ターゲット行動）" desc="支援の対象となる行動を操作的に定義する" />
-          <TextField label="対象行動" value={form.targetBehavior} onChange={e => updateField('targetBehavior', e.target.value)} required fullWidth multiline minRows={2}
-            placeholder="例: 外出活動前に大声で拒否し床に座り込む" />
-          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
-            <TextField label="発生頻度" value={form.behaviorFrequency} onChange={e => updateField('behaviorFrequency', e.target.value)} fullWidth
-              placeholder="例: 週3〜4回" />
-            <TextField label="継続時間" value={form.behaviorDuration} onChange={e => updateField('behaviorDuration', e.target.value)} fullWidth
-              placeholder="例: 5〜20分" />
-          </Stack>
-          <TextField label="発生場面" value={form.behaviorSituation} onChange={e => updateField('behaviorSituation', e.target.value)} fullWidth multiline minRows={2}
-            placeholder="いつ・どこで・どのような状況で発生するか" />
-          <TextField label="強度" value={form.behaviorIntensity} onChange={e => updateField('behaviorIntensity', e.target.value)} fullWidth
-            placeholder="例: 大声（70dB程度）、床への座り込み" />
-          <TextField label="危険性" value={form.behaviorRisk} onChange={e => updateField('behaviorRisk', e.target.value)} fullWidth
-            placeholder="本人: / 他者:" />
-          <TextField label="影響" value={form.behaviorImpact} onChange={e => updateField('behaviorImpact', e.target.value)} fullWidth multiline minRows={2}
-            placeholder="他利用者・職員・環境への影響" />
-        </Stack>
+        <SectionBasicAndTarget
+          step={step}
+          form={form}
+          updateField={updateField}
+        />
       );
-    case 2: // §3 氷山分析
-      return (
-        <Stack spacing={2}>
-          <SectionTitle number={3} title="行動の背景（氷山分析）" desc="行動の水面下にある要因を構造化して分析する" />
-          <IcebergIllustration surfaceValue={form.icebergSurface} />
 
-          {ICEBERG_FACTORS.map(f => {
-            const fieldKey = f.key as keyof FormState;
-            return (
-              <Stack key={f.key} spacing={0.5}>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                  <Typography variant="subtitle2" fontWeight={600}>{f.icon} {f.label}</Typography>
-                  {renderProvenanceBadge(f.key)}
-                </Box>
-                <TextField
-                  value={String(form[fieldKey] || '')}
-                  onChange={e => updateField(fieldKey, e.target.value)}
-                  fullWidth
-                  multiline
-                  minRows={2}
-                  placeholder={f.placeholder}
-                />
-              </Stack>
-            );
-          })}
-        </Stack>
-      );
+    case 2: // §3 氷山分析
     case 3: // §4 FBA
       return (
-        <Stack spacing={2}>
-          <SectionTitle number={4} title="行動機能分析（FBA）" desc="行動の「機能（目的）」を特定し、ABC記録で裏付ける" />
-          
-          <ABCIllustration 
-            a={form.abcAntecedent} 
-            b={form.abcBehavior} 
-            c={form.abcConsequence} 
-          />
-
-          <Typography variant="subtitle2" fontWeight={600} sx={{ mt: 2 }}>行動の機能（複数選択可）</Typography>
-          <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
-            {BEHAVIOR_FUNCTIONS.map(bf => (
-              <FormControlLabel key={bf.value} control={
-                <Checkbox
-                  checked={form.behaviorFunctions.includes(bf.value)}
-                  onChange={e => {
-                    const next = e.target.checked
-                      ? [...form.behaviorFunctions, bf.value]
-                      : form.behaviorFunctions.filter(v => v !== bf.value);
-                    updateField('behaviorFunctions', next);
-                  }}
-                />
-              } label={bf.label} />
-            ))}
-          </Stack>
-          <TextField label="機能の詳細分析" value={form.behaviorFunctionDetail} onChange={e => updateField('behaviorFunctionDetail', e.target.value)} fullWidth multiline minRows={3}
-            placeholder="なぜこの機能と判断したか、根拠を記載" />
-
-          <Divider textAlign="left"><Chip label="ABC 記録" size="small" /></Divider>
-          <TextField label="A: 先行事象（Antecedent）" value={form.abcAntecedent} onChange={e => updateField('abcAntecedent', e.target.value)} fullWidth multiline minRows={2}
-            placeholder="行動の直前に何が起きたか" />
-          <TextField label="B: 行動（Behavior）" value={form.abcBehavior} onChange={e => updateField('abcBehavior', e.target.value)} fullWidth multiline minRows={2}
-            placeholder="具体的にどのような行動が見られたか" />
-          <TextField label="C: 結果（Consequence）" value={form.abcConsequence} onChange={e => updateField('abcConsequence', e.target.value)} fullWidth multiline minRows={2}
-            placeholder="行動の結果何が起きたか（環境がどう変化したか）" />
-        </Stack>
+        <SectionAnalysisAndFba
+          step={step}
+          form={form}
+          updateField={updateField}
+          renderProvenanceBadge={renderProvenanceBadge}
+        />
       );
+
     case 4: // §5 予防的支援
-      return (
-        <Stack spacing={2}>
-          <SectionTitle number={5} title="予防的支援（最重要）" desc="問題行動が起きる前に環境や関わり方を調整する" />
-          <Alert severity="info" variant="outlined" sx={{ mb: 1 }}>
-            💡 PBS では「問題行動を起こさせない環境づくり」が最も重要です
-          </Alert>
-          <TextField label="環境調整" value={form.environmentalAdjustment} onChange={e => updateField('environmentalAdjustment', e.target.value)} required fullWidth multiline minRows={2}
-            placeholder="物理的環境の変更（レイアウト、刺激の調整）" />
-          <TextField label="見通し支援" value={form.visualSupport} onChange={e => updateField('visualSupport', e.target.value)} required fullWidth multiline minRows={2}
-            placeholder="スケジュールカード、写真提示、タイマー" />
-          <TextField label="コミュニケーション支援" value={form.communicationSupport} onChange={e => updateField('communicationSupport', e.target.value)} fullWidth multiline minRows={2}
-            placeholder="絵カード、PECS、サイン" />
-          <TextField label="安心支援" value={form.safetySupport} onChange={e => updateField('safetySupport', e.target.value)} fullWidth multiline minRows={2}
-            placeholder="馴染みの職員配置、安心グッズ" />
-          <TextField label="事前支援" value={form.preSupport} onChange={e => updateField('preSupport', e.target.value)} fullWidth multiline minRows={2}
-            placeholder="前日の確認、当日朝の予告" />
-        </Stack>
-      );
     case 5: // §6 代替行動
-      return (
-        <Stack spacing={2}>
-          <SectionTitle number={6} title="代替行動（Replacement Behavior）" desc="問題行動と同じ機能を果たす適切な行動を教える" />
-          <TextField label="望ましい行動" value={form.desiredBehavior} onChange={e => updateField('desiredBehavior', e.target.value)} required fullWidth multiline minRows={2}
-            placeholder="問題行動の代わりに取ってほしい行動" />
-          <TextField label="教える方法" value={form.teachingMethod} onChange={e => updateField('teachingMethod', e.target.value)} fullWidth multiline minRows={2}
-            placeholder="モデリング、プロンプト、ロールプレイ" />
-          <TextField label="練習方法" value={form.practiceMethod} onChange={e => updateField('practiceMethod', e.target.value)} fullWidth multiline minRows={2}
-            placeholder="練習頻度、場面設定、般化計画" />
-          <TextField label="強化方法" value={form.reinforcementMethod} onChange={e => updateField('reinforcementMethod', e.target.value)} fullWidth multiline minRows={2}
-            placeholder="即時強化、トークンエコノミー、二次強化" />
-        </Stack>
-      );
-    case 6: // §7 問題行動時の対応
-      return (
-        <Stack spacing={3}>
-          <SectionTitle number={7} title="問題行動時対応" desc="行動が発生した瞬間に、チームで統一した動きをとるためのプロトコル" />
-          
-          <ResponseProtocolVisualizer phase="initial" />
-          <TextField label="① 初動対応（前兆へのアプローチ）" value={form.initialResponse} onChange={e => updateField('initialResponse', e.target.value)} fullWidth multiline minRows={2}
-            placeholder="例：穏やかに声をかける、特定の視覚提示を行う" />
-          
-          <ResponseProtocolVisualizer phase="escalated" />
-          <TextField label="② 現場環境の調整（中期対応）" value={form.responseEnvironment} onChange={e => updateField('responseEnvironment', e.target.value)} fullWidth multiline minRows={2}
-            placeholder="例：パーテーションを閉める、他利用者を誘導する" />
-          <TextField label="③ 職員の動き・NG行動" value={form.staffResponse} onChange={e => updateField('staffResponse', e.target.value)} fullWidth multiline minRows={3}
-            placeholder="迷わず動くための指示。やってはいけない（NG）行動も明記" />
-
-          <Divider />
-          <Typography variant="subtitle2" fontWeight={600}>安全確保と記録</Typography>
-          <TextField label="安全確保（セーフガーディング）" value={form.safeguarding} onChange={e => updateField('safeguarding', e.target.value)} fullWidth multiline minRows={2}
-            placeholder="距離の取り方、物品の撤去など" />
-          <TextField label="記録・報告の方法" value={form.recordMethod} onChange={e => updateField('recordMethod', e.target.value)} fullWidth multiline minRows={2}
-            placeholder="どのシートに、いつ記入するか" />
-        </Stack>
-      );
+    case 6: // §7 問題行動時対応
     case 7: // §8 危機対応
       return (
-        <Stack spacing={3}>
-          <SectionTitle number={8} title="危機対応（エスカレーション）" desc="自傷・他害等の生命に関わる危機状況への限定的・緊急的対応" />
-
-          <ResponseProtocolVisualizer phase="crisis" />
-          
-          <Alert severity="error" variant="outlined" sx={{ mb: 1, borderStyle: 'dashed' }}>
-              ※危機対応は最終手段です。身体拘束等の権利侵害を未然に防ぐことを優先してください。
-          </Alert>
-
-          <TextField label="危機的行動の定義" value={form.dangerousBehavior} onChange={e => updateField('dangerousBehavior', e.target.value)} fullWidth multiline minRows={2}
-            placeholder="「これが起きたら危機対応を開始する」という具体的な指標" />
-          <TextField label="緊急時の具体的対応（3ステップ）" value={form.emergencyResponse} onChange={e => updateField('emergencyResponse', e.target.value)} fullWidth multiline minRows={3}
-            placeholder="①〜③の順番で、迷わず行うべき緊急動作" />
-          
-          <Divider />
-          <Typography variant="subtitle2" fontWeight={600}>連絡・連携プロトコル</Typography>
-          <TextField label="医療連携（受診・主治医連絡）" value={form.medicalCoordination} onChange={e => updateField('medicalCoordination', e.target.value)} fullWidth multiline minRows={2} />
-          <TextField label="家族への連絡（緊急連絡先・タイミング）" value={form.familyContact} onChange={e => updateField('familyContact', e.target.value)} fullWidth multiline minRows={2} />
-          <TextField label="安全確保の具体的方法（ハード面）" value={form.safetyMethod} onChange={e => updateField('safetyMethod', e.target.value)} fullWidth multiline minRows={2} />
-        </Stack>
+        <SectionPBSStrategies
+          step={step}
+          form={form}
+          updateField={updateField}
+        />
       );
+
     case 8: // §9 モニタリング
       return (
-        <Stack spacing={2}>
-          <SectionTitle number={9} title="モニタリング" desc="支援の効果を定量的・定性的に評価する" />
-          <TextField label="評価指標" value={form.evaluationIndicator} onChange={e => updateField('evaluationIndicator', e.target.value)} required fullWidth multiline minRows={2}
-            placeholder="何を指標とするか（頻度、持続時間、代替行動の使用率など）" />
-          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
-            <TextField label="評価期間" value={form.evaluationPeriod} onChange={e => updateField('evaluationPeriod', e.target.value)} fullWidth
-              placeholder="例: 毎月末に月次評価" />
-            <TextField type="number" label="モニタリング周期（日）" value={form.monitoringCycleDays} onChange={e => updateField('monitoringCycleDays', Number(e.target.value) || 90)} fullWidth
-              inputProps={{ min: 1, max: 365 }} />
-          </Stack>
-          {schedulePreview}
-          <TextField label="評価方法" value={form.evaluationMethod} onChange={e => updateField('evaluationMethod', e.target.value)} fullWidth multiline minRows={2}
-            placeholder="ABC記録集計、グラフ化、カンファレンス" />
-
-          {/* Dedicated ABC 記録 (評価根拠候補) */}
-          {userId && (
-            <AbcEvidenceListPanel
-              records={abcEvidenceRecords || []}
-              loading={abcEvidenceLoading || false}
-              error={abcEvidenceError || null}
-              period={abcEvidencePeriod || null}
-              monitoringCycleDays={form.monitoringCycleDays || 90}
-              isCited={(form.monitoringEvidenceLinks || []).some(
-                (link: MonitoringEvidenceLink) => link.source === 'dedicated-abc' &&
-                               link.recordIds.some((id: string) => (abcEvidenceRecords || []).map((r: AbcRecord) => r.id).includes(id))
-              )}
-              onCiteDraft={(draft, recordIds) => {
-                const appendText = (current: string | undefined, append: string) => {
-                  const cur = (current || '').trim();
-                  if (!cur) return append;
-                  if (cur.includes(append.trim())) return cur;
-                  return `${cur}\n\n${append}`;
-                };
-
-                const nextEvaluationMethod = appendText(form.evaluationMethod, draft.evaluationMethod);
-                const nextImprovementResult = appendText(form.improvementResult, draft.improvementResult);
-                const nextNextSupport = appendText(form.nextSupport, draft.nextSupport);
-
-                const newLink = {
-                  source: 'dedicated-abc' as const,
-                  sourceList: 'AbcBehaviorRecords' as const,
-                  recordIds: recordIds,
-                  period: {
-                    from: abcEvidencePeriod?.from || '',
-                    to: abcEvidencePeriod?.to || '',
-                  },
-                  generatedAt: new Date().toISOString(),
-                  citedFields: ['evaluationMethod', 'improvementResult', 'nextSupport'] as ('evaluationMethod' | 'improvementResult' | 'nextSupport')[],
-                };
-
-                const nextLinks = [...(form.monitoringEvidenceLinks || []), newLink];
-
-                updateField('evaluationMethod', nextEvaluationMethod);
-                updateField('improvementResult', nextImprovementResult);
-                updateField('nextSupport', nextNextSupport);
-                updateField('monitoringEvidenceLinks', nextLinks);
-              }}
-            />
-          )}
-
-          {/* キオスク記録（17手順）統計ドラフト (Issue #1873) */}
-          {userId && (
-            <KioskMonitoringEvidencePanel
-              userId={userId}
-              onAppendInsight={(text) => {
-                const current = form.improvementResult || '';
-                updateField('improvementResult', current ? `${current}\n\n${text}` : text);
-              }}
-              isAdmin={isAdmin}
-            />
-          )}
-
-          {/* L3-to-L2 Reverse-Bridge 自動提案 */}
-          {userId && (
-            <Box sx={{ my: 1 }}>
-              {isBridgeLoading && (
-                <Paper variant="outlined" sx={{ p: 2, bgcolor: '#fafafc', borderColor: '#e2e8f0', borderStyle: 'dashed', borderRadius: 3 }}>
-                  <Stack direction="row" spacing={2} alignItems="center" justifyContent="center">
-                    <CircularProgress size={20} color="secondary" />
-                    <Typography variant="body2" color="text.secondary" fontWeight={600}>
-                      🤖 日々の記録実績（L3）から評価案を自動生成中...
-                    </Typography>
-                  </Stack>
-                </Paper>
-              )}
-
-              {bridgeError && (
-                <Alert severity="warning" sx={{ borderRadius: 3 }}>
-                  実績データの取得・分析に失敗しました。自動提案は一時的に利用できません: {bridgeError.message}
-                </Alert>
-              )}
-
-              {!isBridgeLoading && !bridgeError && suggestions && (
-                <Paper
-                  variant="outlined"
-                  sx={{
-                    p: 2.5,
-                    border: '1px dashed #c084fc',
-                    bgcolor: '#faf5ff',
-                    borderRadius: 3,
-                    transition: 'all 0.3s ease',
-                    boxShadow: '0 2px 12px rgba(168, 85, 247, 0.05)',
-                    '&:hover': {
-                      borderColor: '#a855f7',
-                      boxShadow: '0 4px 20px rgba(168, 85, 247, 0.12)',
-                    },
-                  }}
-                >
-                  <Stack spacing={2}>
-                    {/* ヘッダー */}
-                    <Stack direction="row" alignItems="center" justifyContent="space-between" flexWrap="wrap" useFlexGap>
-                      <Stack direction="row" spacing={1} alignItems="center">
-                        <AutoAwesomeIcon sx={{ color: '#a855f7' }} />
-                        <Typography variant="subtitle2" fontWeight={800} color="#7c3aed" sx={{ letterSpacing: 0.5 }}>
-                          L3支援実績からの評価提案（自動生成）
-                        </Typography>
-                      </Stack>
-                      
-                      <Stack direction="row" spacing={1} alignItems="center">
-                        {suggestions.confidence !== 'none' && (
-                          <Chip
-                            label={`確信度: ${
-                              suggestions.confidence === 'high' ? '高' :
-                              suggestions.confidence === 'medium' ? '中' : '低'
-                            }`}
-                            size="small"
-                            sx={{
-                              fontWeight: 700,
-                              bgcolor: 
-                                suggestions.confidence === 'high' ? '#dcfce7' :
-                                suggestions.confidence === 'medium' ? '#ffedd5' : '#f3e8ff',
-                              color:
-                                suggestions.confidence === 'high' ? '#15803d' :
-                                suggestions.confidence === 'medium' ? '#c2410c' : '#6b21a8',
-                              border: 'none',
-                            }}
-                          />
-                        )}
-                        <Chip label="Human-in-the-Loop" size="small" variant="outlined" sx={{ color: '#a855f7', borderColor: '#d8b4fe', fontWeight: 600 }} />
-                      </Stack>
-                    </Stack>
-
-                    {/* 説明 */}
-                    <Typography variant="caption" color="text.secondary">
-                      対象期間内の支援手順実施記録および週次観察記録（L3）を自動的に解析し、§9 モニタリングの改善結果・次の支援方針案を提案します。
-                    </Typography>
-
-                    {/* 定量的メトリクス */}
-                    <Paper variant="outlined" sx={{ p: 1.5, bgcolor: '#ffffff', borderRadius: 2, borderColor: '#f3e8ff' }}>
-                      <Stack direction="row" spacing={3} alignItems="center" justifyContent="space-around" flexWrap="wrap" useFlexGap>
-                        <Stack alignItems="center" spacing={0.5}>
-                          <Typography variant="caption" color="text.secondary">日次記録数</Typography>
-                          <Typography variant="body2" fontWeight={800} color="text.primary">
-                            {suggestions.stats.recordCount} 件
-                          </Typography>
-                        </Stack>
-                        <Divider orientation="vertical" flexItem />
-                        <Stack alignItems="center" spacing={0.5}>
-                          <Typography variant="caption" color="text.secondary">手順実施率</Typography>
-                          <Typography variant="body2" fontWeight={800} color="#15803d">
-                            {suggestions.stats.procedureCompletionRate !== null ? `${suggestions.stats.procedureCompletionRate}%` : '---'}
-                          </Typography>
-                        </Stack>
-                        <Divider orientation="vertical" flexItem />
-                        <Stack alignItems="center" spacing={0.5}>
-                          <Typography variant="caption" color="text.secondary">BIP誘発率</Typography>
-                          <Typography variant="body2" fontWeight={800} color="#b91c1c">
-                            {suggestions.stats.bipActivationRate !== null ? `${suggestions.stats.bipActivationRate}%` : '---'}
-                          </Typography>
-                        </Stack>
-                        <Divider orientation="vertical" flexItem />
-                        <Stack alignItems="center" spacing={0.5}>
-                          <Typography variant="caption" color="text.secondary">週次観察数</Typography>
-                          <Typography variant="body2" fontWeight={800} color="#0369a1">
-                            {suggestions.stats.observationCount} 件
-                          </Typography>
-                        </Stack>
-                      </Stack>
-                    </Paper>
-
-                    {suggestions.confidence === 'none' ? (
-                      <Alert severity="info" icon={false} sx={{ py: 1, bgcolor: '#f8fafc', border: '1px solid #e2e8f0', borderRadius: 2 }}>
-                        <Typography variant="body2" fontWeight={600} color="text.secondary">
-                          分析データが不足しています
-                        </Typography>
-                        <Typography variant="caption" color="text.secondary">
-                          指定された評価期間内にL3の支援実績記録が登録されていません。L3モードで記録を入力すると、自動的に評価提案が利用可能になります。
-                        </Typography>
-                      </Alert>
-                    ) : (
-                      <>
-                        {/* 提案コンテンツ */}
-                        <Stack spacing={1.5}>
-                          {/* 改善結果案 */}
-                          <Stack spacing={0.5}>
-                            <Typography variant="caption" fontWeight={700} color="#7c3aed">改善結果の提案（前回からの変化）</Typography>
-                            <Box sx={{ p: 1.5, bgcolor: '#ffffff', borderRadius: 2, border: '1px solid #e9d5ff', position: 'relative' }}>
-                              <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', pr: 12, fontSize: '0.825rem', lineHeight: 1.5 }}>
-                                {suggestions.improvementResult}
-                              </Typography>
-                              <Button
-                                size="small"
-                                variant="outlined"
-                                color="secondary"
-                                startIcon={<CheckIcon />}
-                                sx={{
-                                  position: 'absolute',
-                                  right: 8,
-                                  top: '50%',
-                                  transform: 'translateY(-50%)',
-                                  fontSize: '0.7rem',
-                                  py: 0.25,
-                                  px: 1,
-                                  borderRadius: 1.5,
-                                  borderColor: '#d8b4fe',
-                                  bgcolor: '#faf5ff',
-                                  '&:hover': { bgcolor: '#f3e8ff' }
-                                }}
-                                onClick={() => updateField('improvementResult', suggestions.improvementResult)}
-                              >
-                                適用
-                              </Button>
-                            </Box>
-                          </Stack>
-
-                          {/* 次の支援方針案 */}
-                          <Stack spacing={0.5}>
-                            <Typography variant="caption" fontWeight={700} color="#7c3aed">次の支援方針の提案（次回改善アクション）</Typography>
-                            <Box sx={{ p: 1.5, bgcolor: '#ffffff', borderRadius: 2, border: '1px solid #e9d5ff', position: 'relative' }}>
-                              <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', pr: 12, fontSize: '0.825rem', lineHeight: 1.5 }}>
-                                {suggestions.nextSupport}
-                              </Typography>
-                              <Button
-                                size="small"
-                                variant="outlined"
-                                color="secondary"
-                                startIcon={<CheckIcon />}
-                                sx={{
-                                  position: 'absolute',
-                                  right: 8,
-                                  top: '50%',
-                                  transform: 'translateY(-50%)',
-                                  fontSize: '0.7rem',
-                                  py: 0.25,
-                                  px: 1,
-                                  borderRadius: 1.5,
-                                  borderColor: '#d8b4fe',
-                                  bgcolor: '#faf5ff',
-                                  '&:hover': { bgcolor: '#f3e8ff' }
-                                }}
-                                onClick={() => updateField('nextSupport', suggestions.nextSupport)}
-                              >
-                                適用
-                              </Button>
-                            </Box>
-                          </Stack>
-                        </Stack>
-
-                        {/* 一括反映・根拠データ */}
-                        <Stack spacing={1.5}>
-                          <Button
-                            size="small"
-                            variant="contained"
-                            color="secondary"
-                            startIcon={<KeyboardDoubleArrowDownIcon />}
-                            sx={{
-                              alignSelf: 'flex-start',
-                              bgcolor: '#a855f7',
-                              fontWeight: 700,
-                              borderRadius: 2,
-                              px: 2,
-                              py: 0.75,
-                              boxShadow: '0 2px 6px rgba(168, 85, 247, 0.2)',
-                              '&:hover': { bgcolor: '#9333ea', boxShadow: '0 4px 12px rgba(168, 85, 247, 0.3)' }
-                            }}
-                            onClick={() => {
-                              updateField('improvementResult', suggestions.improvementResult);
-                              updateField('nextSupport', suggestions.nextSupport);
-                            }}
-                          >
-                            改善結果・支援方針に一括反映する
-                          </Button>
-
-                          {/* 根拠サマリー（詳細展開トグル） */}
-                          <Box sx={{ mt: 1, p: 1.5, bgcolor: '#fdfbfe', borderRadius: 2, border: '1px solid #f3e8ff' }}>
-                            <Typography variant="caption" fontWeight={700} color="text.secondary" sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mb: 0.5 }}>
-                              <EqualizerIcon sx={{ fontSize: 16, color: '#a855f7' }} />
-                              📌 提案根拠データサマリー:
-                            </Typography>
-                            <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.75rem', lineHeight: 1.4, display: 'block', whiteSpace: 'pre-wrap' }}>
-                              {suggestions.evidenceSummary}
-                            </Typography>
-                          </Box>
-                        </Stack>
-                      </>
-                    )}
-                  </Stack>
-                </Paper>
-              )}
-            </Box>
-          )}
-
-          <TextField label="改善結果" value={form.improvementResult} onChange={e => updateField('improvementResult', e.target.value)} fullWidth multiline minRows={2}
-            placeholder="（評価後に記入）前回からの変化" />
-          <TextField label="次の支援方針" value={form.nextSupport} onChange={e => updateField('nextSupport', e.target.value)} fullWidth multiline minRows={2}
-            placeholder="（評価後に記入）次の改善アクション" />
-        </Stack>
+        <SectionMonitoring
+          form={form}
+          updateField={updateField}
+          userId={userId}
+          isAdmin={isAdmin}
+          abcEvidenceRecords={abcEvidenceRecords}
+          abcEvidenceLoading={abcEvidenceLoading}
+          abcEvidencePeriod={abcEvidencePeriod}
+          abcEvidenceError={abcEvidenceError}
+        />
       );
+
     case 9: // §10 チーム共有
       return (
-        <Stack spacing={2}>
-          <SectionTitle number={10} title="チーム共有" desc="支援チーム全体で計画を共有し実行する体制" />
-          <TextField label="共有方法" value={form.sharingMethod} onChange={e => updateField('sharingMethod', e.target.value)} fullWidth multiline minRows={2}
-            placeholder="朝礼、週1回会議、計画掲示" />
-          <TextField label="研修計画" value={form.training} onChange={e => updateField('training', e.target.value)} fullWidth multiline minRows={2}
-            placeholder="OJT、事例検討会、外部研修" />
-          <TextField label="担当者" value={form.personInCharge} onChange={e => updateField('personInCharge', e.target.value)} fullWidth
-            placeholder="主担当 / 副担当" />
-          <TextField label="確認日" value={form.confirmationDate} onChange={e => updateField('confirmationDate', e.target.value)} fullWidth
-            placeholder="計画確認日" />
-          <TextField label="チーム合意事項" value={form.teamConsensusNote} onChange={e => updateField('teamConsensusNote', e.target.value)} fullWidth multiline minRows={3}
-            placeholder="チームで共有すべき方針・留意点" />
-        </Stack>
+        <SectionSharing
+          form={form}
+          updateField={updateField}
+        />
       );
+
     default:
       return null;
   }

--- a/src/features/planning-sheet/components/new-form/NewPlanningSheetForm.tsx
+++ b/src/features/planning-sheet/components/new-form/NewPlanningSheetForm.tsx
@@ -46,480 +46,90 @@ import RefreshRoundedIcon from '@mui/icons-material/RefreshRounded';
 // ── Domain ──
 import type { TokuseiSurveyResponse } from '@/domain/assessment/tokusei';
 import type { PlanningSheetFormValues } from '@/domain/isp/schema';
-import type { MonitoringToPlanningResult } from '../../monitoringToPlanningBridge';
-import { useTokuseiSurveyResponses } from '@/features/assessment/hooks/useTokuseiSurveyResponses';
-import { filterActiveUsers } from '@/features/users/domain/userLifecycle';
-import { useUsers } from '@/features/users/useUsers';
-import { useAuth } from '@/auth/useAuth';
-import { useUserAuthz } from '@/auth/useUserAuthz';
-import { tokuseiToPlanningBridge, type TokuseiBridgeResult } from '../../tokuseiToPlanningBridge';
-import { buildImportPreview } from '../../buildImportPreview';
-import type { ImportPreviewResult } from '../../buildImportPreview';
 import { ImportPreviewDialog } from '../ImportPreviewDialog';
 import { ImportMonitoringDialog } from '../ImportMonitoringDialog';
-import { useLatestBehaviorMonitoring } from '../../hooks/useLatestBehaviorMonitoring';
-import { useMonitoringMeetingRepository } from '@/features/monitoring/data/useMonitoringMeetingRepository';
-import { useIcebergRepository } from '@/features/ibd/analysis/iceberg/SharePointIcebergRepository';
-import { icebergToInterventionDrafts } from '@/features/ibd/analysis/iceberg/icebergToIntervention';
-import { buildIcebergImportResult, type IcebergImportResult } from '../../icebergToPlanningBridge';
-import { useImportAuditStore } from '../../stores/importAuditStore';
-import { buildTokuseiImportAuditPayload } from '../../tokuseiImportAuditBuilder';
-import type { IcebergSession } from '@/features/ibd/analysis/iceberg/icebergTypes';
-import { useMonitoringAbcEvidence } from '@/features/monitoring/hooks/useMonitoringAbcEvidence';
 
 // ── Local (split) ──
-import type { NewPlanningSheetFormProps, UserOption, FormState } from './types';
-import { SECTION_STEPS, INITIAL_FORM, SAMPLE_FORM } from './constants';
-import { buildCreateInput } from './helpers';
+import type { NewPlanningSheetFormProps } from './types';
+import { SECTION_STEPS } from './constants';
 import FormSections from './FormSections';
+import { useNewPlanningSheetForm } from './hooks/useNewPlanningSheetForm';
 
 // ─────────────────────────────────────────────
 // Component
 // ─────────────────────────────────────────────
 
-export const NewPlanningSheetForm: React.FC<NewPlanningSheetFormProps> = ({
-  planningSheetRepo,
-  ispRepo,
-  initialUserId,
-  initialSource,
-  diffSummary,
-}) => {
+export const NewPlanningSheetForm: React.FC<NewPlanningSheetFormProps> = (props) => {
   const navigate = useNavigate();
-  const { data: users } = useUsers();
-  const { account } = useAuth();
-  const { role } = useUserAuthz();
-  const isAdmin = role === 'admin';
+  const { diffSummary } = props;
 
-  // ── User selection state ──
-  const [selectedUser, setSelectedUser] = React.useState<UserOption | null>(null);
-  const [ispId, setIspId] = React.useState<string | null>(null);
-  const [ispLoading, setIspLoading] = React.useState(false);
-  const [ispWarning, setIspWarning] = React.useState<string | null>(null);
-
-  // ── Form state ──
-  const [form, setForm] = React.useState<FormState>(INITIAL_FORM);
-  const [activeStep, setActiveStep] = React.useState(0);
-
-  // ── Save state ──
-  const [isSaving, setIsSaving] = React.useState(false);
-  const [saveError, setSaveError] = React.useState<string | null>(null);
-
-  // ── 特性アンケート読込 ──
-  const { 
-    responses: tokuseiResponses, 
-    status: tokuseiStatus,
-    refresh: refreshTokusei
-  } = useTokuseiSurveyResponses();
-  const [selectedTokusei, setSelectedTokusei] = React.useState<TokuseiSurveyResponse | null>(null);
-  const [tokuseiImported, setTokuseiImported] = React.useState(false);
-  const [previewDialogOpen, setPreviewDialogOpen] = React.useState(false);
-  const [tokuseiBridgeResult, setTokuseiBridgeResult] = React.useState<TokuseiBridgeResult | null>(null);
-  const [lastBridgeResult, setLastBridgeResult] = React.useState<{ formPatches: Record<string, string> } | null>(null);
-  const [tokuseiProvenance] = React.useState<Map<string, { name: string; relation?: string; fillDate?: string }>>(new Map());
-  const [importPreview, setImportPreview] = React.useState<ImportPreviewResult | null>(null);
-  const [toast, setToast] = React.useState<{ open: boolean; message: string; severity: 'success' | 'info' | 'warning' }>({
-    open: false, message: '', severity: 'success',
-  });
-
-  // ── 氷山分析読込 ──
-  const icebergRepo = useIcebergRepository();
-  const [icebergImported, setIcebergImported] = React.useState(false);
-  const [icebergImportResult, setIcebergImportResult] = React.useState<IcebergImportResult | null>(null);
-  const [isIcebergLoading, setIsIcebergLoading] = React.useState(false);
-  const [importSource, setImportSource] = React.useState<'tokusei' | 'iceberg' | null>(null);
-  const autoIcebergHandledRef = React.useRef(false);
+  const {
+    selectedUser,
+    ispId,
+    ispLoading,
+    ispWarning,
+    form,
+    activeStep,
+    isSaving,
+    saveError,
+    tokuseiStatus,
+    selectedTokusei,
+    setSelectedTokusei,
+    tokuseiImported,
+    previewDialogOpen,
+    setPreviewDialogOpen,
+    importPreview,
+    toast,
+    setToast,
+    icebergImported,
+    isIcebergLoading,
+    monitoringDialogOpen,
+    setMonitoringDialogOpen,
+    monitoringImported,
+    latestMonitoringRecord,
+    isMonitoringLoading,
+    abcEvidenceRecords,
+    abcEvidenceLoading,
+    abcEvidenceError,
+    abcEvidencePeriod,
+    isAdmin,
+    userOptions,
+    matchedResponses,
+    hasExactMatch,
+    updateField,
+    handleUserSelect,
+    refreshTokusei,
+    handleTokuseiImport,
+    handleIcebergImport,
+    handlePreviewConfirm,
+    renderProvenanceBadge,
+    handleMonitoringImport,
+    handleFillSample,
+    handleCreate,
+    setActiveStep,
+  } = useNewPlanningSheetForm(props);
 
   // ── 特性アンケートセクション ref ──
   const tokuseiSectionRef = React.useRef<HTMLDivElement>(null);
 
-
-
-  // ── モニタリング読込 ──
-  // NOTE:
-  // Repository is resolved by the monitoring data-layer hook.
-  // Do not import localMonitoringMeetingRepository directly in UI components.
-  const monitoringRepo = useMonitoringMeetingRepository();
-  const {
-    record: latestMonitoringRecord,
-    isLoading: isMonitoringLoading,
-  } = useLatestBehaviorMonitoring(selectedUser?.id ?? null, {
-    repository: monitoringRepo,
-    planningSheetId: 'new',
-  });
-  const [monitoringDialogOpen, setMonitoringDialogOpen] = React.useState(false);
-  const [monitoringImported, setMonitoringImported] = React.useState(false);
-
-  // ── Dedicated ABC エビデンス取得 ──
-  const {
-    records: abcEvidenceRecords,
-    loading: abcEvidenceLoading,
-    error: abcEvidenceError,
-    period: abcEvidencePeriod,
-  } = useMonitoringAbcEvidence(
-    selectedUser?.id,
-    form.supportStartDate,
-    form.monitoringCycleDays,
-  );
-
-  // ── Helpers ──
-  const userOptions = React.useMemo<UserOption[]>(
-    () => filterActiveUsers(users).map(u => ({ id: u.UserID, label: `${u.FullName} (${u.UserID})` })),
-    [users],
-  );
-
-  const updateField = React.useCallback(<K extends keyof FormState>(key: K, value: FormState[K]) => {
-    setForm(prev => ({ ...prev, [key]: value }));
-  }, []);
-
-  // ── User selection handler ──
-  const handleUserSelect = React.useCallback(
-    async (_event: React.SyntheticEvent | null, value: UserOption | null) => {
-      setSelectedUser(value);
-      setIspId(null);
-      setIspWarning(null);
-      setSaveError(null);
-      if (!value) return;
-
-      setIspLoading(true);
-      try {
-        const currentIsp = await ispRepo.getCurrentByUser(value.id);
-        if (currentIsp) {
-          setIspId(currentIsp.id);
-        } else {
-          setIspId(`draft-isp-${value.id}-${Date.now()}`);
-          setIspWarning(`利用者「${value.label}」の現行個別支援計画が見つかりません。仮の紐付けで続行します。`);
-        }
-      } catch {
-        setIspId(`draft-isp-${value.id}-${Date.now()}`);
-        setIspWarning('個別支援計画の取得に失敗しました。仮の紐付けで続行します。');
-      } finally {
-        setIspLoading(false);
-      }
-    },
-    [ispRepo],
-  );
-
-  // ── Auto select initial user ──
-  React.useEffect(() => {
-    if (initialUserId && users && users.length > 0 && !selectedUser && !ispLoading) {
-      const u = userOptions.find(o => o.id === initialUserId);
-      if (u) {
-        handleUserSelect(null, u).catch(console.error);
-      }
-    }
-  }, [initialUserId, users, userOptions, selectedUser, handleUserSelect, ispLoading]);
-
-  // ── 特性アンケート: 利用者に紐づく回答をフィルタ ──
-  const { matchedResponses, hasExactMatch } = React.useMemo(() => {
-    if (!selectedUser || tokuseiResponses.length === 0) return { matchedResponses: [], hasExactMatch: false };
-    
-    const normalize = (val: string) => val
-      .normalize('NFKC')
-      .replace(/[\p{White_Space}\p{Cf}]+/gu, '')
-      .toLowerCase();
-    const normalizeName = (val: string) => normalize(val)
-      .replace(/[（(].*?[)）]/g, '')
-      .replace(/(さん|様|ちゃん|くん)$/u, '');
-    const userName = selectedUser.label.split(' (')[0]; 
-    const normalizedTarget = normalizeName(userName);
-
-    const matches = tokuseiResponses.filter(r => {
-      const normalizedSource = normalize(r.targetUserName || '');
-      const normalizedSourceName = normalizeName(r.targetUserName || '');
-      const targetId = normalize(selectedUser.id);
-      
-      const idMatch = normalizedSource === targetId || normalizedSource.includes(`(${targetId})`) || normalizedSource.includes(targetId);
-      const nameMatch =
-        normalizedSourceName === normalizedTarget ||
-        (normalizedTarget.length > 1 && normalizedSourceName.includes(normalizedTarget)) ||
-        (normalizedSourceName.length > 1 && normalizedTarget.includes(normalizedSourceName));
-
-      return idMatch || nameMatch;
-    });
-
-    const hasExactMatch = matches.some(r => {
-      const normalizedSource = normalize(r.targetUserName || '');
-      const targetId = normalize(selectedUser.id);
-      const idMatch = normalizedSource === targetId || normalizedSource.includes(`(${targetId})`) || normalizedSource.includes(targetId);
-
-      const normalizedSourceName = normalizeName(r.targetUserName || '');
-      const namePerfectMatch = normalizedSourceName === normalizedTarget;
-
-      return idMatch || namePerfectMatch;
-    });
-
-    // 優先度順にソート（ID一致 -> 名前完全一致 -> 名前部分一致）
-    matches.sort((a, b) => {
-      const aSource = normalize(a.targetUserName || '');
-      const bSource = normalize(b.targetUserName || '');
-      const targetId = normalize(selectedUser.id);
-      
-      const aIdMatch = aSource === targetId ? 2 : (aSource.includes(targetId) ? 1 : 0);
-      const bIdMatch = bSource === targetId ? 2 : (bSource.includes(targetId) ? 1 : 0);
-      
-      if (aIdMatch !== bIdMatch) return bIdMatch - aIdMatch;
-      
-      const aNameMatch = normalizeName(a.targetUserName || '') === normalizedTarget ? 1 : 0;
-      const bNameMatch = normalizeName(b.targetUserName || '') === normalizedTarget ? 1 : 0;
-      
-      return bNameMatch - aNameMatch;
-    });
-
-    return {
-      matchedResponses: matches,
-      hasExactMatch
-    };
-  }, [selectedUser, tokuseiResponses]);
-
-  // ── 特性アンケート: 自動選択 ──
-  React.useEffect(() => {
-    if (hasExactMatch && matchedResponses.length === 1 && !selectedTokusei) {
-      setSelectedTokusei(matchedResponses[0]);
-    }
-  }, [hasExactMatch, matchedResponses, selectedTokusei]);
-
-  // ── 特性アンケート: プレビュー表示 ──
-  const handleTokuseiImport = React.useCallback(() => {
-    if (!selectedTokusei) return;
-
-    const result = tokuseiToPlanningBridge({
-      kind: 'aggregated',
-      response: selectedTokusei,
-      responseId: selectedTokusei.responseId,
-      updatedAt: selectedTokusei.createdAt,
-    });
-
-    // プレビュー生成
-    const preview = buildImportPreview(result.formPatches, form as unknown as Record<string, unknown>);
-    setImportPreview(preview);
-    setTokuseiBridgeResult(result);
-    setLastBridgeResult(result);
-    setImportSource('tokusei');
-    setPreviewDialogOpen(true);
-  }, [selectedTokusei, form]);
-
-  // ── 氷山分析: インポート ──
-  const handleIcebergImport = React.useCallback(async () => {
-    if (!selectedUser || !icebergRepo) return;
-    
-    setIsIcebergLoading(true);
-    try {
-      const latest = await icebergRepo.getLatestByUser(selectedUser.id);
-      if (!latest) {
-        setToast({ open: true, message: 'この利用者の氷山分析データが見つかりません', severity: 'warning' });
-        return;
-      }
-
-      const sessionLike = { ...latest, id: latest.sessionId, targetUserId: latest.userId } as unknown as IcebergSession;
-      const drafts = icebergToInterventionDrafts(sessionLike);
-
-      const sessionRef = {
-        id: latest.sessionId,
-        updatedAt: latest.updatedAt,
-      };
-
-      const result = buildIcebergImportResult(drafts, sessionRef);
-      
-      const preview = buildImportPreview(result.formPatches as Record<string, string>, form as unknown as Record<string, unknown>, result.summary);
-      setImportPreview(preview);
-      // 特性アンケートのブリッジ結果と構造が同じなので再利用
-      setLastBridgeResult({ formPatches: result.formPatches } as unknown as { formPatches: Record<string, string> });
-      setIcebergImportResult(result);
-      setImportSource('iceberg');
-      setPreviewDialogOpen(true);
-    } catch (err) {
-      setToast({ open: true, message: `氷山分析の取得に失敗しました: ${err}`, severity: 'warning' });
-    } finally {
-      setIsIcebergLoading(false);
-    }
-  }, [selectedUser, icebergRepo, form]);
-
-  // ── 特性アンケート: プレビュー確定→反映 ──
-  const handlePreviewConfirm = React.useCallback(() => {
-    if (!lastBridgeResult) return;
-    if (importSource === 'tokusei' && !selectedTokusei) return;
-
-    const sourceLabel = importSource === 'tokusei' ? '特性アンケート' : '氷山分析';
-
-    // formPatches を FormState に反映
-    setForm(prev => {
-      const next = { ...prev };
-      for (const [key, value] of Object.entries(lastBridgeResult.formPatches)) {
-        if (key in next && typeof value === 'string') {
-          const k = key as keyof FormState;
-          const current = next[k];
-          if (typeof current === 'string' && !current.trim()) {
-            (next as Record<string, unknown>)[k] = value;
-          } else if (typeof current === 'string' && current.trim()) {
-            (next as Record<string, unknown>)[k] = `${current}\n\n【${sourceLabel}より】\n${value}`;
-          }
-        }
-      }
-      return next;
-    });
-
-    if (importSource === 'tokusei') {
-      setTokuseiImported(true);
-    } else if (importSource === 'iceberg') {
-      setIcebergImported(true);
-    }
-    
-    setPreviewDialogOpen(false);
-
-    // サマリーをトースト表示
-    const s = importPreview?.summary;
-    let summaryText = '取込完了';
-    if (importSource === 'tokusei') {
-      summaryText = s && s.totalAffected > 0
-        ? `特性アンケートから取込完了: 新規${s.newCount}項目 + 追記${s.appendCount}項目`
-        : '特性アンケートから取込完了（該当データなし）';
-    } else {
-      summaryText = s && s.totalAffected > 0
-        ? `氷山分析から取込完了: 新規${s.newCount}項目 + 追記${s.appendCount}項目`
-        : '氷山分析から取込完了';
-    }
-    setToast({ open: true, message: summaryText, severity: 'success' });
-  }, [lastBridgeResult, selectedTokusei, importPreview, importSource]);
-
-  // ── Provenance バッジヘルパー ──
-  const renderProvenanceBadge = React.useCallback((fieldKey: string) => {
-    const prov = tokuseiProvenance.get(fieldKey);
+  // ── Custom provenance badge inside view context ──
+  const customProvenanceBadge = React.useCallback((fieldKey: string) => {
+    const prov = renderProvenanceBadge(fieldKey);
     if (!prov) return null;
-    const dateStr = prov.fillDate ? new Date(prov.fillDate).toLocaleDateString('ja-JP', { month: 'numeric', day: 'numeric' }) : '';
+    const p = prov as { name: string; relation?: string; fillDate?: string };
+    const dateStr = p.fillDate ? new Date(p.fillDate).toLocaleDateString('ja-JP', { month: 'numeric', day: 'numeric' }) : '';
     return (
       <Chip
         size="small"
         variant="outlined"
         color="secondary"
         sx={{ height: 20, '& .MuiChip-label': { px: 0.8, fontSize: '0.65rem' } }}
-        label={`📋 特性アンケ ${prov.name}${prov.relation ? `(${prov.relation})` : ''} ${dateStr}`}
+        label={`📋 特性アンケ ${p.name}${p.relation ? `(${p.relation})` : ''} ${dateStr}`}
       />
     );
-  }, [tokuseiProvenance]);
+  }, [renderProvenanceBadge]);
 
-  // ── モニタリング反映 ──
-  const handleMonitoringImport = React.useCallback(
-    (result: MonitoringToPlanningResult, _selectedCandidateIds: string[]) => {
-      if (!result) return;
-
-      // autoPatches を FormState に反映（フィールド名が一致するもののみ）
-      setForm(prev => {
-        const next = { ...prev };
-        for (const [key, value] of Object.entries(result.autoPatches)) {
-          if (key in next && typeof value === 'string') {
-            const k = key as keyof FormState;
-            const current = next[k];
-            if (typeof current === 'string' && !current.trim()) {
-              (next as Record<string, unknown>)[k] = value;
-            } else if (typeof current === 'string' && current.trim()) {
-              (next as Record<string, unknown>)[k] = `${current}\n\n【モニタリングより】\n${value}`;
-            }
-          }
-        }
-        return next;
-      });
-
-      setMonitoringImported(true);
-      setMonitoringDialogOpen(false);
-
-      const s = result.summary;
-      const summaryText = (s.autoFieldCount + s.candidateCount) > 0
-        ? `モニタリングから取込完了: 自動${s.autoFieldCount}項目 + 候補${s.candidateCount}件`
-        : 'モニタリングから取込完了（該当データなし）';
-      setToast({ open: true, message: summaryText, severity: 'success' });
-    },
-    [],
-  );
-
-  // ── Fill sample data ──
-  const handleFillSample = React.useCallback(() => setForm(SAMPLE_FORM), []);
-
-  // ── Save ──
-  const { saveAuditRecord } = useImportAuditStore();
-  const handleCreate = React.useCallback(async () => {
-    if (!selectedUser || !ispId) return;
-    setIsSaving(true);
-    setSaveError(null);
-    try {
-      const createdBy = (account as { name?: string })?.name ?? '不明';
-      const input = buildCreateInput(form, selectedUser.id, ispId, createdBy);
-      const created = await planningSheetRepo.create(input);
-      
-      // 差分基づく作成の確定をログに記録
-      if (diffSummary) {
-        saveAuditRecord({
-          planningSheetId: created.id,
-          importedAt: new Date().toISOString(),
-          importedBy: createdBy,
-          assessmentId: null,
-          tokuseiResponseId: null,
-          mode: 'behavior-monitoring',
-          affectedFields: ['iceberg_differential_completion'],
-          provenance: [],
-          summaryText: `氷山分析の差分基づき改訂を確定: ${diffSummary}`,
-        });
-      }
-
-      // 氷山分析からインポートした場合の監査記録
-      if (icebergImported && icebergImportResult && icebergImportResult.provenance.length > 0) {
-        saveAuditRecord({
-          planningSheetId: created.id,
-          importedAt: new Date().toISOString(),
-          importedBy: createdBy,
-          assessmentId: null,
-          tokuseiResponseId: null,
-          mode: 'iceberg',
-          affectedFields: icebergImportResult.formPatches ? Object.keys(icebergImportResult.formPatches) : [],
-          provenance: icebergImportResult.provenance,
-          summaryText: `氷山分析から取込完了: 行動${icebergImportResult.summary.behaviorCount}件, きっかけ${icebergImportResult.summary.triggerCount}件, 環境${icebergImportResult.summary.environmentFactorCount}件, 対応${icebergImportResult.summary.strategyCount}件`,
-        });
-      }
-
-      // 特性アンケートからインポートした場合の監査記録
-      if (tokuseiImported && selectedTokusei && tokuseiBridgeResult) {
-        const payload = buildTokuseiImportAuditPayload({
-          planningSheetId: created.id,
-          importedBy: createdBy,
-          tokuseiResponseId: selectedTokusei.responseId,
-          bridgeResult: tokuseiBridgeResult,
-          now: new Date().toISOString()
-        });
-        saveAuditRecord(payload);
-      }
-
-
-      navigate(`/support-planning-sheet/${created.id}`, { replace: true });
-    } catch (err) {
-      setSaveError(`作成に失敗しました: ${err instanceof Error ? err.message : String(err)}`);
-    } finally {
-      setIsSaving(false);
-    }
-  }, [selectedUser, ispId, account, form, planningSheetRepo, navigate]);
-
-  // ── Navigation ──
-  const canProceedToForm = !!(selectedUser && ispId);
-  const isPristineForm = React.useMemo(
-    () => JSON.stringify(form) === JSON.stringify(INITIAL_FORM),
-    [form],
-  );
-
-  React.useEffect(() => {
-    if (initialSource !== 'iceberg' || autoIcebergHandledRef.current) return;
-    if (!canProceedToForm || !selectedUser || isIcebergLoading) return;
-
-    autoIcebergHandledRef.current = true;
-
-    if (!isPristineForm) {
-      setToast({
-        open: true,
-        severity: 'info',
-        message: '下書きがあるため、氷山分析の自動読込はスキップしました。必要な場合は「氷山分析を読み込む」を押してください。',
-      });
-      return;
-    }
-
-    void handleIcebergImport();
-  }, [initialSource, canProceedToForm, selectedUser, isIcebergLoading, isPristineForm, handleIcebergImport]);
+  const canProceed = !!(selectedUser && ispId);
 
   return (
     <Box sx={{ p: { xs: 2, md: 3 }, pb: 4, maxWidth: 960, mx: 'auto' }}>
@@ -561,7 +171,7 @@ export const NewPlanningSheetForm: React.FC<NewPlanningSheetFormProps> = ({
                 variant="outlined"
                 color="primary"
                 startIcon={<QuizRoundedIcon />}
-                disabled={!canProceedToForm}
+                disabled={!canProceed}
                 onClick={() => tokuseiSectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })}
               >
                 特性アンケート
@@ -571,7 +181,7 @@ export const NewPlanningSheetForm: React.FC<NewPlanningSheetFormProps> = ({
                 variant="outlined"
                 color="primary"
                 startIcon={isIcebergLoading ? <CircularProgress size={16} /> : <WorkspacesIcon />}
-                disabled={!canProceedToForm || isIcebergLoading}
+                disabled={!canProceed || isIcebergLoading}
                 onClick={handleIcebergImport}
               >
                 {icebergImported ? '氷山分析を再読込' : '氷山分析を読み込む'}
@@ -581,12 +191,12 @@ export const NewPlanningSheetForm: React.FC<NewPlanningSheetFormProps> = ({
                 variant="outlined"
                 color="secondary"
                 startIcon={<TimelineRoundedIcon />}
-                disabled={!canProceedToForm || !latestMonitoringRecord || isMonitoringLoading}
+                disabled={!canProceed || !latestMonitoringRecord || isMonitoringLoading}
                 onClick={() => setMonitoringDialogOpen(true)}
               >
                 {isMonitoringLoading ? '読込中…' : monitoringImported ? 'モニタリングから再反映' : 'モニタリングから反映'}
               </Button>
-              <Button size="small" variant="outlined" color="secondary" startIcon={<AutoFixHighRoundedIcon />} onClick={handleFillSample} disabled={!canProceedToForm}>
+              <Button size="small" variant="outlined" color="secondary" startIcon={<AutoFixHighRoundedIcon />} onClick={handleFillSample} disabled={!canProceed}>
                 サンプルデータ
               </Button>
               <Button size="small" startIcon={<ArrowBackRoundedIcon />} onClick={() => navigate('/support-plan-guide')}>
@@ -621,7 +231,7 @@ export const NewPlanningSheetForm: React.FC<NewPlanningSheetFormProps> = ({
         </Paper>
 
         {/* ── 特性アンケート読込 ── */}
-        {canProceedToForm && (
+        {canProceed && (
           <Paper ref={tokuseiSectionRef} variant="outlined" sx={{ p: { xs: 2, md: 3 }, borderColor: tokuseiImported ? 'success.main' : 'divider' }}>
             <Stack spacing={2}>
               <Stack direction="row" spacing={1} alignItems="center">
@@ -630,12 +240,12 @@ export const NewPlanningSheetForm: React.FC<NewPlanningSheetFormProps> = ({
                   特性アンケートから読込
                 </Typography>
                 <Button 
-                  size="small" 
-                  variant="text" 
-                  startIcon={tokuseiStatus === 'loading' ? <CircularProgress size={14} /> : <RefreshRoundedIcon />}
-                  onClick={() => refreshTokusei()}
-                  disabled={tokuseiStatus === 'loading'}
-                  sx={{ ml: 1 }}
+                   size="small" 
+                   variant="text" 
+                   startIcon={tokuseiStatus === 'loading' ? <CircularProgress size={14} /> : <RefreshRoundedIcon />}
+                   onClick={() => refreshTokusei()}
+                   disabled={tokuseiStatus === 'loading'}
+                   sx={{ ml: 1 }}
                 >
                   最新に更新
                 </Button>
@@ -725,7 +335,7 @@ export const NewPlanningSheetForm: React.FC<NewPlanningSheetFormProps> = ({
         )}
 
         {/* ── Stepper + Form ── */}
-        {canProceedToForm && (
+        {canProceed && (
           <>
             <Paper 
               variant="outlined" 
@@ -739,7 +349,7 @@ export const NewPlanningSheetForm: React.FC<NewPlanningSheetFormProps> = ({
             >
               <Stepper 
                 activeStep={activeStep} 
-                alternativeLabel={false} // 横並びにして視認性を向上 
+                alternativeLabel={false}
                 sx={{ 
                   minWidth: 1000,
                   '& .MuiStepConnector-line': {
@@ -758,7 +368,7 @@ export const NewPlanningSheetForm: React.FC<NewPlanningSheetFormProps> = ({
                           fontWeight: index === activeStep ? 700 : 500,
                           color: index === activeStep ? 'primary.main' : 'text.secondary',
                           lineHeight: 1.2,
-                          maxWidth: '80px', // 折り返し制御
+                          maxWidth: '80px',
                           textAlign: 'center'
                         },
                         '& .MuiStepIcon-root': {
@@ -781,7 +391,7 @@ export const NewPlanningSheetForm: React.FC<NewPlanningSheetFormProps> = ({
                 step={activeStep}
                 form={form}
                 updateField={updateField}
-                renderProvenanceBadge={renderProvenanceBadge}
+                renderProvenanceBadge={customProvenanceBadge}
                 userId={selectedUser?.id}
                 isAdmin={isAdmin}
                 abcEvidenceRecords={abcEvidenceRecords}
@@ -874,3 +484,5 @@ export const NewPlanningSheetForm: React.FC<NewPlanningSheetFormProps> = ({
     </Box>
   );
 };
+
+export default NewPlanningSheetForm;

--- a/src/features/planning-sheet/components/new-form/components/SectionTitle.tsx
+++ b/src/features/planning-sheet/components/new-form/components/SectionTitle.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Stack from '@mui/material/Stack';
+import Chip from '@mui/material/Chip';
+import Typography from '@mui/material/Typography';
+
+interface SectionTitleProps {
+  number: number;
+  title: string;
+  desc?: string;
+}
+
+export const SectionTitle: React.FC<SectionTitleProps> = ({ number, title, desc }) => (
+  <Stack spacing={0.5} sx={{ mb: 1 }}>
+    <Stack direction="row" spacing={1} alignItems="center">
+      <Chip label={`§${number}`} size="small" color="primary" variant="outlined" />
+      <Typography variant="h6" fontWeight={700}>{title}</Typography>
+    </Stack>
+    {desc && <Typography variant="body2" color="text.secondary">{desc}</Typography>}
+  </Stack>
+);
+
+export default SectionTitle;

--- a/src/features/planning-sheet/components/new-form/components/illustrations/ABCIllustration.tsx
+++ b/src/features/planning-sheet/components/new-form/components/illustrations/ABCIllustration.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Stack from '@mui/material/Stack';
+
+interface ABCIllustrationProps {
+  a?: string;
+  b?: string;
+  c?: string;
+}
+
+export const ABCIllustration: React.FC<ABCIllustrationProps> = ({ a, b, c }) => (
+  <Box sx={{ width: '100%', display: 'flex', justifyContent: 'center', mb: 4 }}>
+    <Box sx={{
+      width: '100%',
+      maxWidth: 700,
+      bgcolor: '#fff',
+      borderRadius: 4,
+      p: { xs: 2, sm: 3 },
+      border: '1px solid #e2e8f0',
+      boxShadow: '0 4px 12px rgba(0,0,0,0.03)',
+    }}>
+      <Stack direction="row" alignItems="center" spacing={1} justifyContent="center">
+        {/* A: Antecedent */}
+        <Box sx={{ flex: 1, minHeight: 120, p: 2, borderRadius: 3, border: '2px solid #93c5fd', bgcolor: '#f0f9ff', display: 'flex', flexDirection: 'column', alignItems: 'center', textAlign: 'center' }}>
+          <Typography variant="caption" fontWeight={800} color="primary.main" gutterBottom sx={{ fontSize: '0.65rem', borderBottom: '1px solid currentColor', mb: 1, px: 1 }}>A: 先行事象</Typography>
+          <Typography variant="body2" sx={{ fontSize: '0.75rem', color: '#1e3a8a', overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 4, WebkitBoxOrient: 'vertical', lineHeight: 1.4 }}>
+            {a || '（行動の直前の状況）'}
+          </Typography>
+        </Box>
+
+        <Box sx={{ color: '#cbd5e1', fontWeight: 900 }}>▶</Box>
+
+        {/* B: Behavior */}
+        <Box sx={{ flex: 1, minHeight: 120, p: 2, borderRadius: 3, border: '2px solid #fecaca', bgcolor: '#fef2f2', display: 'flex', flexDirection: 'column', alignItems: 'center', textAlign: 'center' }}>
+          <Typography variant="caption" fontWeight={800} color="error.main" gutterBottom sx={{ fontSize: '0.65rem', borderBottom: '1px solid currentColor', mb: 1, px: 1 }}>B: 行動</Typography>
+          <Typography variant="body2" sx={{ fontSize: '0.75rem', color: '#7f1d1d', overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 4, WebkitBoxOrient: 'vertical', lineHeight: 1.4 }}>
+            {b || '（具体的な行動の内容）'}
+          </Typography>
+        </Box>
+
+        <Box sx={{ color: '#cbd5e1', fontWeight: 900 }}>▶</Box>
+
+        {/* C: Consequence */}
+        <Box sx={{ flex: 1, minHeight: 120, p: 2, borderRadius: 3, border: '2px solid #bbf7d0', bgcolor: '#f0fdf4', display: 'flex', flexDirection: 'column', alignItems: 'center', textAlign: 'center' }}>
+          <Typography variant="caption" fontWeight={800} color="success.main" gutterBottom sx={{ fontSize: '0.65rem', borderBottom: '1px solid currentColor', mb: 1, px: 1 }}>C: 結果</Typography>
+          <Typography variant="body2" sx={{ fontSize: '0.75rem', color: '#064e3b', overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 4, WebkitBoxOrient: 'vertical', lineHeight: 1.4 }}>
+            {c || '（行動のあとの変化）'}
+          </Typography>
+        </Box>
+      </Stack>
+      <Typography variant="caption" sx={{ display: 'block', mt: 2, textAlign: 'center', color: 'text.secondary', fontWeight: 500 }}>
+        この連鎖（A→B→C）から、なぜその行動が繰り返されるのか（機能）を推測します。
+      </Typography>
+    </Box>
+  </Box>
+);
+
+export default ABCIllustration;

--- a/src/features/planning-sheet/components/new-form/components/illustrations/IcebergIllustration.tsx
+++ b/src/features/planning-sheet/components/new-form/components/illustrations/IcebergIllustration.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { ICEBERG_FACTORS } from '../../constants';
+
+interface IcebergIllustrationProps {
+  surfaceValue?: string;
+}
+
+export const IcebergIllustration: React.FC<IcebergIllustrationProps> = ({ surfaceValue }) => (
+  <Box sx={{ width: '100%', display: 'flex', justifyContent: 'center', mb: 6 }}>
+    <Box sx={{
+      width: '100%',
+      maxWidth: 600,
+      bgcolor: '#f8fbff',
+      borderRadius: 4,
+      p: { xs: 2, sm: 4 },
+      pb: { xs: 3, sm: 5 },
+      border: '1px solid #e0f2fe',
+      boxShadow: '0 2px 12px rgba(0,0,0,0.02)',
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center'
+    }}>
+      <svg
+        viewBox="0 0 520 400"
+        width="100%"
+        height="auto"
+        role="img"
+        aria-label="氷山分析の構造図"
+        style={{ display: 'block', maxWidth: '520px' }}
+      >
+        {/* タイトル */}
+        <text x="260" y="30" textAnchor="middle" fontSize="22" fontWeight="800" fill="#0c4a6e">氷山分析</text>
+
+        {/* 水面上：問題行動 */}
+        <rect x="100" y="50" width="320" height="56" rx="16" fill="#fde68a" stroke="#f59e0b" strokeWidth="1" />
+        <text x="260" y="86" textAnchor="middle" fontSize={surfaceValue && surfaceValue.length > 15 ? 14 : 18} fontWeight="700" fill="#78350f">
+          {surfaceValue 
+            ? (surfaceValue.length > 22 ? surfaceValue.substring(0, 20) + '...' : surfaceValue)
+            : '🏔️ 問題行動（水面上）'
+          }
+        </text>
+
+        {/* 水面ライン */}
+        <line x1="30" y1="130" x2="490" y2="130" stroke="#38bdf8" strokeWidth="4" strokeLinecap="round" />
+        <text x="490" y="122" textAnchor="end" fontSize="12" fontWeight="700" fill="#0369a1">水面</text>
+
+        {/* 氷山本体 */}
+        <path d="M120 150 L400 150 L460 380 L60 380 Z" fill="#eff6ff" stroke="#93c5fd" strokeWidth="2" />
+
+        {/* 層区切り */}
+        <line x1="105" y1="195" x2="415" y2="195" stroke="#bfdbfe" strokeWidth="1.5" />
+        <line x1="90" y1="240" x2="430" y2="240" stroke="#bfdbfe" strokeWidth="1.5" />
+        <line x1="75" y1="285" x2="445" y2="285" stroke="#bfdbfe" strokeWidth="1.5" />
+        <line x1="65" y1="330" x2="455" y2="330" stroke="#bfdbfe" strokeWidth="1.5" />
+
+        {/* ラベル */}
+        <text x="260" y="180" textAnchor="middle" fontSize="16" fontWeight="600" fill="#1e40af">{ICEBERG_FACTORS[1].icon} {ICEBERG_FACTORS[1].label}</text>
+        <text x="260" y="225" textAnchor="middle" fontSize="16" fontWeight="600" fill="#1e40af">{ICEBERG_FACTORS[2].icon} {ICEBERG_FACTORS[2].label}</text>
+        <text x="260" y="270" textAnchor="middle" fontSize="16" fontWeight="600" fill="#1e40af">{ICEBERG_FACTORS[3].icon} {ICEBERG_FACTORS[3].label}</text>
+        <text x="260" y="315" textAnchor="middle" fontSize="16" fontWeight="600" fill="#1e40af">{ICEBERG_FACTORS[4].icon} {ICEBERG_FACTORS[4].label}</text>
+        <text x="260" y="362" textAnchor="middle" fontSize="16" fontWeight="800" fill="#1d4ed8">{ICEBERG_FACTORS[5].icon} {ICEBERG_FACTORS[5].label}</text>
+      </svg>
+      <Typography variant="body2" sx={{ mt: 3, textAlign: 'center', color: 'text.secondary', fontStyle: 'italic', px: 2 }}>
+        表面に見える行動の下に、背景要因や本人の願いが重なっています。
+      </Typography>
+    </Box>
+  </Box>
+);
+
+export default IcebergIllustration;

--- a/src/features/planning-sheet/components/new-form/components/illustrations/ResponseProtocolVisualizer.tsx
+++ b/src/features/planning-sheet/components/new-form/components/illustrations/ResponseProtocolVisualizer.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+
+interface ResponseProtocolVisualizerProps {
+  phase: 'initial' | 'escalated' | 'crisis';
+}
+
+export const ResponseProtocolVisualizer: React.FC<ResponseProtocolVisualizerProps> = ({ phase }) => {
+  const config = {
+    initial: { label: '🟢 初期対応（前兆期）', color: '#10b981', bg: '#ecfdf5', dark: '#064e3b', desc: '落ち着きがなくなる、声が出る等' },
+    escalated: { label: '🟡 中期対応（行動発現期）', color: '#f59e0b', bg: '#fffbeb', dark: '#78350f', desc: '大声、座り込み、物への接触等' },
+    crisis: { label: '🔴 危機対応（極期）', color: '#ef4444', bg: '#fef2f2', dark: '#7f1d1d', desc: '自傷、他害、激しい破壊等' },
+  }[phase];
+
+  return (
+    <Box sx={{ width: '100%', mb: 4 }}>
+      <Paper variant="outlined" sx={{ p: 2, borderLeft: `6px solid ${config.color}`, bgcolor: config.bg, borderRadius: '8px 16px 16px 8px' }}>
+        <Stack direction="row" spacing={2} alignItems="center">
+          <Box sx={{ 
+            width: 48, height: 48, borderRadius: '50%', bgcolor: config.color, 
+            display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#fff' 
+          }}>
+            {phase === 'initial' && '🟢'}
+            {phase === 'escalated' && '🟡'}
+            {phase === 'crisis' && '🔴'}
+          </Box>
+          <Box>
+            <Typography variant="subtitle1" fontWeight={800} color={config.dark}>{config.label}</Typography>
+            <Typography variant="caption" color={config.dark} sx={{ opacity: 0.8 }}>{config.desc}</Typography>
+          </Box>
+        </Stack>
+      </Paper>
+      
+      {/* 迷わないための指示構造 */}
+      <Stack direction="row" spacing={1} sx={{ mt: 1 }}>
+        <Box sx={{ flex: 1, p: 1, bgcolor: '#f8fafc', borderRadius: 2, border: '1px dashed #cbd5e1', textAlign: 'center' }}>
+          <Typography variant="caption" fontWeight={700} color="text.secondary">判断せずに動く</Typography>
+        </Box>
+        <Box sx={{ flex: 1, p: 1, bgcolor: '#fef2f2', borderRadius: 2, border: '1px dashed #fecaca', textAlign: 'center' }}>
+          <Typography variant="caption" fontWeight={700} color="error.main">NG行動の徹底回避</Typography>
+        </Box>
+      </Stack>
+    </Box>
+  );
+};
+
+export default ResponseProtocolVisualizer;

--- a/src/features/planning-sheet/components/new-form/hooks/useNewPlanningSheetForm.ts
+++ b/src/features/planning-sheet/components/new-form/hooks/useNewPlanningSheetForm.ts
@@ -1,0 +1,493 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import type { TokuseiSurveyResponse } from '@/domain/assessment/tokusei';
+import type { MonitoringToPlanningResult } from '@/features/planning-sheet/monitoringToPlanningBridge';
+import { useTokuseiSurveyResponses } from '@/features/assessment/hooks/useTokuseiSurveyResponses';
+import { filterActiveUsers } from '@/features/users/domain/userLifecycle';
+import { useUsers } from '@/features/users/useUsers';
+import { useAuth } from '@/auth/useAuth';
+import { useUserAuthz } from '@/auth/useUserAuthz';
+import { tokuseiToPlanningBridge, type TokuseiBridgeResult } from '@/features/planning-sheet/tokuseiToPlanningBridge';
+import { buildImportPreview } from '@/features/planning-sheet/buildImportPreview';
+import type { ImportPreviewResult } from '@/features/planning-sheet/buildImportPreview';
+import { useLatestBehaviorMonitoring } from '@/features/planning-sheet/hooks/useLatestBehaviorMonitoring';
+import { useMonitoringMeetingRepository } from '@/features/monitoring/data/useMonitoringMeetingRepository';
+import { useIcebergRepository } from '@/features/ibd/analysis/iceberg/SharePointIcebergRepository';
+import { icebergToInterventionDrafts } from '@/features/ibd/analysis/iceberg/icebergToIntervention';
+import { buildIcebergImportResult, type IcebergImportResult } from '@/features/planning-sheet/icebergToPlanningBridge';
+import { useImportAuditStore } from '@/features/planning-sheet/stores/importAuditStore';
+import { buildTokuseiImportAuditPayload } from '@/features/planning-sheet/tokuseiImportAuditBuilder';
+import type { IcebergSession } from '@/features/ibd/analysis/iceberg/icebergTypes';
+import { useMonitoringAbcEvidence } from '@/features/monitoring/hooks/useMonitoringAbcEvidence';
+
+import type { NewPlanningSheetFormProps, UserOption, FormState } from '../types';
+import { INITIAL_FORM, SAMPLE_FORM } from '../constants';
+import { buildCreateInput } from '../helpers';
+
+export const useNewPlanningSheetForm = (props: NewPlanningSheetFormProps) => {
+  const {
+    planningSheetRepo,
+    ispRepo,
+    initialUserId,
+    initialSource,
+    diffSummary,
+  } = props;
+
+  const navigate = useNavigate();
+  const { data: users } = useUsers();
+  const { account } = useAuth();
+  const { role } = useUserAuthz();
+  const isAdmin = role === 'admin';
+
+  // ── User selection state ──
+  const [selectedUser, setSelectedUser] = React.useState<UserOption | null>(null);
+  const [ispId, setIspId] = React.useState<string | null>(null);
+  const [ispLoading, setIspLoading] = React.useState(false);
+  const [ispWarning, setIspWarning] = React.useState<string | null>(null);
+
+  // ── Form state ──
+  const [form, setForm] = React.useState<FormState>(INITIAL_FORM);
+  const [activeStep, setActiveStep] = React.useState(0);
+
+  // ── Save state ──
+  const [isSaving, setIsSaving] = React.useState(false);
+  const [saveError, setSaveError] = React.useState<string | null>(null);
+
+  // ── 特性アンケート読込 ──
+  const { 
+    responses: tokuseiResponses, 
+    status: tokuseiStatus,
+    refresh: refreshTokusei
+  } = useTokuseiSurveyResponses();
+  const [selectedTokusei, setSelectedTokusei] = React.useState<TokuseiSurveyResponse | null>(null);
+  const [tokuseiImported, setTokuseiImported] = React.useState(false);
+  const [previewDialogOpen, setPreviewDialogOpen] = React.useState(false);
+  const [tokuseiBridgeResult, setTokuseiBridgeResult] = React.useState<TokuseiBridgeResult | null>(null);
+  const [lastBridgeResult, setLastBridgeResult] = React.useState<{ formPatches: Record<string, string> } | null>(null);
+  const [tokuseiProvenance] = React.useState<Map<string, { name: string; relation?: string; fillDate?: string }>>(new Map());
+  const [importPreview, setImportPreview] = React.useState<ImportPreviewResult | null>(null);
+  const [toast, setToast] = React.useState<{ open: boolean; message: string; severity: 'success' | 'info' | 'warning' }>({
+    open: false, message: '', severity: 'success',
+  });
+
+  // ── 氷山分析読込 ──
+  const icebergRepo = useIcebergRepository();
+  const [icebergImported, setIcebergImported] = React.useState(false);
+  const [icebergImportResult, setIcebergImportResult] = React.useState<IcebergImportResult | null>(null);
+  const [isIcebergLoading, setIsIcebergLoading] = React.useState(false);
+  const [importSource, setImportSource] = React.useState<'tokusei' | 'iceberg' | null>(null);
+  const autoIcebergHandledRef = React.useRef(false);
+
+  // ── モニタリング読込 ──
+  const monitoringRepo = useMonitoringMeetingRepository();
+  const {
+    record: latestMonitoringRecord,
+    isLoading: isMonitoringLoading,
+  } = useLatestBehaviorMonitoring(selectedUser?.id ?? null, {
+    repository: monitoringRepo,
+    planningSheetId: 'new',
+  });
+  const [monitoringDialogOpen, setMonitoringDialogOpen] = React.useState(false);
+  const [monitoringImported, setMonitoringImported] = React.useState(false);
+
+  // ── Dedicated ABC エビデンス取得 ──
+  const {
+    records: abcEvidenceRecords,
+    loading: abcEvidenceLoading,
+    error: abcEvidenceError,
+    period: abcEvidencePeriod,
+  } = useMonitoringAbcEvidence(
+    selectedUser?.id,
+    form.supportStartDate,
+    form.monitoringCycleDays,
+  );
+
+  // ── Helpers ──
+  const userOptions = React.useMemo<UserOption[]>(
+    () => filterActiveUsers(users).map(u => ({ id: u.UserID, label: `${u.FullName} (${u.UserID})` })),
+    [users],
+  );
+
+  const updateField = React.useCallback(<K extends keyof FormState>(key: K, value: FormState[K]) => {
+    setForm(prev => ({ ...prev, [key]: value }));
+  }, []);
+
+  // ── User selection handler ──
+  const handleUserSelect = React.useCallback(
+    async (_event: React.SyntheticEvent | null, value: UserOption | null) => {
+      setSelectedUser(value);
+      setIspId(null);
+      setIspWarning(null);
+      setSaveError(null);
+      if (!value) return;
+
+      setIspLoading(true);
+      try {
+        const currentIsp = await ispRepo.getCurrentByUser(value.id);
+        if (currentIsp) {
+          setIspId(currentIsp.id);
+        } else {
+          setIspId(`draft-isp-${value.id}-${Date.now()}`);
+          setIspWarning(`利用者「${value.label}」の現行個別支援計画が見つかりません。仮の紐付けで続行します。`);
+        }
+      } catch {
+        setIspId(`draft-isp-${value.id}-${Date.now()}`);
+        setIspWarning('個別支援計画の取得に失敗しました。仮の紐付けで続行します。');
+      } finally {
+        setIspLoading(false);
+      }
+    },
+    [ispRepo],
+  );
+
+  // ── Auto select initial user ──
+  React.useEffect(() => {
+    if (initialUserId && users && users.length > 0 && !selectedUser && !ispLoading) {
+      const u = userOptions.find(o => o.id === initialUserId);
+      if (u) {
+        handleUserSelect(null, u).catch(console.error);
+      }
+    }
+  }, [initialUserId, users, userOptions, selectedUser, handleUserSelect, ispLoading]);
+
+  // ── 特性アンケート: 利用者に紐づく回答をフィルタ ──
+  const { matchedResponses, hasExactMatch } = React.useMemo(() => {
+    if (!selectedUser || tokuseiResponses.length === 0) return { matchedResponses: [], hasExactMatch: false };
+    
+    const normalize = (val: string) => val
+      .normalize('NFKC')
+      .replace(/[\p{White_Space}\p{Cf}]+/gu, '')
+      .toLowerCase();
+    const normalizeName = (val: string) => normalize(val)
+      .replace(/[（(].*?[)）]/g, '')
+      .replace(/(さん|様|ちゃん|くん)$/u, '');
+    const userName = selectedUser.label.split(' (')[0]; 
+    const normalizedTarget = normalizeName(userName);
+
+    const matches = tokuseiResponses.filter(r => {
+      const normalizedSource = normalize(r.targetUserName || '');
+      const normalizedSourceName = normalizeName(r.targetUserName || '');
+      const targetId = normalize(selectedUser.id);
+      
+      const idMatch = normalizedSource === targetId || normalizedSource.includes(`(${targetId})`) || normalizedSource.includes(targetId);
+      const nameMatch =
+        normalizedSourceName === normalizedTarget ||
+        (normalizedTarget.length > 1 && normalizedSourceName.includes(normalizedTarget)) ||
+        (normalizedSourceName.length > 1 && normalizedTarget.includes(normalizedSourceName));
+
+      return idMatch || nameMatch;
+    });
+
+    const hasExactMatch = matches.some(r => {
+      const normalizedSource = normalize(r.targetUserName || '');
+      const targetId = normalize(selectedUser.id);
+      const idMatch = normalizedSource === targetId || normalizedSource.includes(`(${targetId})`) || normalizedSource.includes(targetId);
+
+      const normalizedSourceName = normalizeName(r.targetUserName || '');
+      const namePerfectMatch = normalizedSourceName === normalizedTarget;
+
+      return idMatch || namePerfectMatch;
+    });
+
+    // 優先度順にソート（ID一致 -> 名前完全一致 -> 名前部分一致）
+    matches.sort((a, b) => {
+      const aSource = normalize(a.targetUserName || '');
+      const bSource = normalize(b.targetUserName || '');
+      const targetId = normalize(selectedUser.id);
+      
+      const aIdMatch = aSource === targetId ? 2 : (aSource.includes(targetId) ? 1 : 0);
+      const bIdMatch = bSource === targetId ? 2 : (bSource.includes(targetId) ? 1 : 0);
+      
+      if (aIdMatch !== bIdMatch) return bIdMatch - aIdMatch;
+      
+      const aNameMatch = normalizeName(a.targetUserName || '') === normalizedTarget ? 1 : 0;
+      const bNameMatch = normalizeName(b.targetUserName || '') === normalizedTarget ? 1 : 0;
+      
+      return bNameMatch - aNameMatch;
+    });
+
+    return {
+      matchedResponses: matches,
+      hasExactMatch
+    };
+  }, [selectedUser, tokuseiResponses]);
+
+  // ── 特性アンケート: 自動選択 ──
+  React.useEffect(() => {
+    if (hasExactMatch && matchedResponses.length === 1 && !selectedTokusei) {
+      setSelectedTokusei(matchedResponses[0]);
+    }
+  }, [hasExactMatch, matchedResponses, selectedTokusei]);
+
+  // ── 特性アンケート: プレビュー表示 ──
+  const handleTokuseiImport = React.useCallback(() => {
+    if (!selectedTokusei) return;
+
+    const result = tokuseiToPlanningBridge({
+      kind: 'aggregated',
+      response: selectedTokusei,
+      responseId: selectedTokusei.responseId,
+      updatedAt: selectedTokusei.createdAt,
+    });
+
+    const preview = buildImportPreview(result.formPatches, form as unknown as Record<string, unknown>);
+    setImportPreview(preview);
+    setTokuseiBridgeResult(result);
+    setLastBridgeResult(result);
+    setImportSource('tokusei');
+    setPreviewDialogOpen(true);
+  }, [selectedTokusei, form]);
+
+  // ── 氷山分析: インポート ──
+  const handleIcebergImport = React.useCallback(async () => {
+    if (!selectedUser || !icebergRepo) return;
+    
+    setIsIcebergLoading(true);
+    try {
+      const latest = await icebergRepo.getLatestByUser(selectedUser.id);
+      if (!latest) {
+        setToast({ open: true, message: 'この利用者の氷山分析データが見つかりません', severity: 'warning' });
+        return;
+      }
+
+      const sessionLike = { ...latest, id: latest.sessionId, targetUserId: latest.userId } as unknown as IcebergSession;
+      const drafts = icebergToInterventionDrafts(sessionLike);
+
+      const sessionRef = {
+        id: latest.sessionId,
+        updatedAt: latest.updatedAt,
+      };
+
+      const result = buildIcebergImportResult(drafts, sessionRef);
+      
+      const preview = buildImportPreview(result.formPatches as Record<string, string>, form as unknown as Record<string, unknown>, result.summary);
+      setImportPreview(preview);
+      setLastBridgeResult({ formPatches: result.formPatches } as unknown as { formPatches: Record<string, string> });
+      setIcebergImportResult(result);
+      setImportSource('iceberg');
+      setPreviewDialogOpen(true);
+    } catch (err) {
+      setToast({ open: true, message: `氷山分析の取得に失敗しました: ${err}`, severity: 'warning' });
+    } finally {
+      setIsIcebergLoading(false);
+    }
+  }, [selectedUser, icebergRepo, form]);
+
+  // ── 特性アンケート: プレビュー確定→反映 ──
+  const handlePreviewConfirm = React.useCallback(() => {
+    if (!lastBridgeResult) return;
+    if (importSource === 'tokusei' && !selectedTokusei) return;
+
+    const sourceLabel = importSource === 'tokusei' ? '特性アンケート' : '氷山分析';
+
+    setForm(prev => {
+      const next = { ...prev };
+      for (const [key, value] of Object.entries(lastBridgeResult.formPatches)) {
+        if (key in next && typeof value === 'string') {
+          const k = key as keyof FormState;
+          const current = next[k];
+          if (typeof current === 'string' && !current.trim()) {
+            (next as Record<string, unknown>)[k] = value;
+          } else if (typeof current === 'string' && current.trim()) {
+            (next as Record<string, unknown>)[k] = `${current}\n\n【${sourceLabel}より】\n${value}`;
+          }
+        }
+      }
+      return next;
+    });
+
+    if (importSource === 'tokusei') {
+      setTokuseiImported(true);
+    } else if (importSource === 'iceberg') {
+      setIcebergImported(true);
+    }
+    
+    setPreviewDialogOpen(false);
+
+    const s = importPreview?.summary;
+    let summaryText = '取込完了';
+    if (importSource === 'tokusei') {
+      summaryText = s && s.totalAffected > 0
+        ? `特性アンケートから取込完了: 新規${s.newCount}項目 + 追記${s.appendCount}項目`
+        : '特性アンケートから取込完了（該当データなし）';
+    } else {
+      summaryText = s && s.totalAffected > 0
+        ? `氷山分析から取込完了: 新規${s.newCount}項目 + 追記${s.appendCount}項目`
+        : '氷山分析から取込完了';
+    }
+    setToast({ open: true, message: summaryText, severity: 'success' });
+  }, [lastBridgeResult, selectedTokusei, importPreview, importSource]);
+
+  // ── Provenance バッジヘルパー ──
+  const renderProvenanceBadge = React.useCallback((fieldKey: string) => {
+    const prov = tokuseiProvenance.get(fieldKey);
+    if (!prov) return null;
+    return prov;
+  }, [tokuseiProvenance]);
+
+  // ── モニタリング反映 ──
+  const handleMonitoringImport = React.useCallback(
+    (result: MonitoringToPlanningResult, _selectedCandidateIds: string[]) => {
+      if (!result) return;
+
+      setForm(prev => {
+        const next = { ...prev };
+        for (const [key, value] of Object.entries(result.autoPatches)) {
+          if (key in next && typeof value === 'string') {
+            const k = key as keyof FormState;
+            const current = next[k];
+            if (typeof current === 'string' && !current.trim()) {
+              (next as Record<string, unknown>)[k] = value;
+            } else if (typeof current === 'string' && current.trim()) {
+              (next as Record<string, unknown>)[k] = `${current}\n\n【モニタリングより】\n${value}`;
+            }
+          }
+        }
+        return next;
+      });
+
+      setMonitoringImported(true);
+      setMonitoringDialogOpen(false);
+
+      const s = result.summary;
+      const summaryText = (s.autoFieldCount + s.candidateCount) > 0
+        ? `モニタリングから取込完了: 自動${s.autoFieldCount}項目 + 候補${s.candidateCount}件`
+        : 'モニタリングから取込完了（該当データなし）';
+      setToast({ open: true, message: summaryText, severity: 'success' });
+    },
+    [],
+  );
+
+  // ── Fill sample data ──
+  const handleFillSample = React.useCallback(() => setForm(SAMPLE_FORM), []);
+
+  // ── Save ──
+  const { saveAuditRecord } = useImportAuditStore();
+  const handleCreate = React.useCallback(async () => {
+    if (!selectedUser || !ispId) return;
+    setIsSaving(true);
+    setSaveError(null);
+    try {
+      const createdBy = (account as { name?: string })?.name ?? '不明';
+      const input = buildCreateInput(form, selectedUser.id, ispId, createdBy);
+      const created = await planningSheetRepo.create(input);
+      
+      if (diffSummary) {
+        saveAuditRecord({
+          planningSheetId: created.id,
+          importedAt: new Date().toISOString(),
+          importedBy: createdBy,
+          assessmentId: null,
+          tokuseiResponseId: null,
+          mode: 'behavior-monitoring',
+          affectedFields: ['iceberg_differential_completion'],
+          provenance: [],
+          summaryText: `氷山分析の差分基づき改訂を確定: ${diffSummary}`,
+        });
+      }
+
+      if (icebergImported && icebergImportResult && icebergImportResult.provenance.length > 0) {
+        saveAuditRecord({
+          planningSheetId: created.id,
+          importedAt: new Date().toISOString(),
+          importedBy: createdBy,
+          assessmentId: null,
+          tokuseiResponseId: null,
+          mode: 'iceberg',
+          affectedFields: icebergImportResult.formPatches ? Object.keys(icebergImportResult.formPatches) : [],
+          provenance: icebergImportResult.provenance,
+          summaryText: `氷山分析から取込完了: 行動${icebergImportResult.summary.behaviorCount}件, きっかけ${icebergImportResult.summary.triggerCount}件, 環境${icebergImportResult.summary.environmentFactorCount}件, 対応${icebergImportResult.summary.strategyCount}件`,
+        });
+      }
+
+      if (tokuseiImported && selectedTokusei && tokuseiBridgeResult) {
+        const payload = buildTokuseiImportAuditPayload({
+          planningSheetId: created.id,
+          importedBy: createdBy,
+          tokuseiResponseId: selectedTokusei.responseId,
+          bridgeResult: tokuseiBridgeResult,
+          now: new Date().toISOString()
+        });
+        saveAuditRecord(payload);
+      }
+
+      navigate(`/support-planning-sheet/${created.id}`, { replace: true });
+    } catch (err) {
+      setSaveError(`作成に失敗しました: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setIsSaving(false);
+    }
+  }, [selectedUser, ispId, account, form, planningSheetRepo, navigate, diffSummary, icebergImported, icebergImportResult, tokuseiImported, selectedTokusei, tokuseiBridgeResult, saveAuditRecord]);
+
+  const canProceedToForm = !!(selectedUser && ispId);
+  const isPristineForm = React.useMemo(
+    () => JSON.stringify(form) === JSON.stringify(INITIAL_FORM),
+    [form],
+  );
+
+  React.useEffect(() => {
+    if (initialSource !== 'iceberg' || autoIcebergHandledRef.current) return;
+    if (!canProceedToForm || !selectedUser || isIcebergLoading) return;
+
+    autoIcebergHandledRef.current = true;
+
+    if (!isPristineForm) {
+      setToast({
+        open: true,
+        severity: 'info',
+        message: '下書きがあるため、氷山分析の自動読込はスキップしました。必要な場合は「氷山分析を読み込む」を押してください。',
+      });
+      return;
+    }
+
+    void handleIcebergImport();
+  }, [initialSource, canProceedToForm, selectedUser, isIcebergLoading, isPristineForm, handleIcebergImport]);
+
+  return {
+    selectedUser,
+    ispId,
+    ispLoading,
+    ispWarning,
+    form,
+    activeStep,
+    isSaving,
+    saveError,
+    tokuseiStatus,
+    selectedTokusei,
+    setSelectedTokusei,
+    tokuseiImported,
+    previewDialogOpen,
+    setPreviewDialogOpen,
+    importPreview,
+    toast,
+    setToast,
+    icebergImported,
+    isIcebergLoading,
+    monitoringDialogOpen,
+    setMonitoringDialogOpen,
+    monitoringImported,
+    latestMonitoringRecord,
+    isMonitoringLoading,
+    abcEvidenceRecords,
+    abcEvidenceLoading,
+    abcEvidenceError,
+    abcEvidencePeriod,
+    isAdmin,
+    userOptions,
+    matchedResponses,
+    hasExactMatch,
+    canProceedToForm,
+    updateField,
+    handleUserSelect,
+    refreshTokusei,
+    handleTokuseiImport,
+    handleIcebergImport,
+    handlePreviewConfirm,
+    renderProvenanceBadge,
+    handleMonitoringImport,
+    handleFillSample,
+    handleCreate,
+    setActiveStep,
+  };
+};

--- a/src/features/planning-sheet/components/new-form/sections/SectionAnalysisAndFba.tsx
+++ b/src/features/planning-sheet/components/new-form/sections/SectionAnalysisAndFba.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Checkbox from '@mui/material/Checkbox';
+import Divider from '@mui/material/Divider';
+import Chip from '@mui/material/Chip';
+import { SectionTitle } from '../components/SectionTitle';
+import { IcebergIllustration } from '../components/illustrations/IcebergIllustration';
+import { ABCIllustration } from '../components/illustrations/ABCIllustration';
+import type { FormState } from '../types';
+import { ICEBERG_FACTORS, BEHAVIOR_FUNCTIONS } from '../constants';
+
+interface SectionAnalysisAndFbaProps {
+  step: number;
+  form: FormState;
+  updateField: <K extends keyof FormState>(key: K, value: FormState[K]) => void;
+  renderProvenanceBadge: (fieldKey: string) => React.ReactNode;
+}
+
+export const SectionAnalysisAndFba: React.FC<SectionAnalysisAndFbaProps> = ({
+  step,
+  form,
+  updateField,
+  renderProvenanceBadge,
+}) => {
+  if (step === 2) {
+    // §3 氷山分析
+    return (
+      <Stack spacing={2}>
+        <SectionTitle number={3} title="行動の背景（氷山分析）" desc="行動の水面下にある要因を構造化して分析する" />
+        <IcebergIllustration surfaceValue={form.icebergSurface} />
+
+        {ICEBERG_FACTORS.map(f => {
+          const fieldKey = f.key as keyof FormState;
+          return (
+            <Stack key={f.key} spacing={0.5}>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                <Typography variant="subtitle2" fontWeight={600}>{f.icon} {f.label}</Typography>
+                {renderProvenanceBadge(f.key)}
+              </Box>
+              <TextField
+                value={String(form[fieldKey] || '')}
+                onChange={e => updateField(fieldKey, e.target.value)}
+                fullWidth
+                multiline
+                minRows={2}
+                placeholder={f.placeholder}
+              />
+            </Stack>
+          );
+        })}
+      </Stack>
+    );
+  }
+
+  // §4 FBA
+  return (
+    <Stack spacing={2}>
+      <SectionTitle number={4} title="行動機能分析（FBA）" desc="行動の「機能（目的）」を特定し、ABC記録で裏付ける" />
+      
+      <ABCIllustration 
+        a={form.abcAntecedent} 
+        b={form.abcBehavior} 
+        c={form.abcConsequence} 
+      />
+
+      <Typography variant="subtitle2" fontWeight={600} sx={{ mt: 2 }}>行動の機能（複数選択可）</Typography>
+      <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+        {BEHAVIOR_FUNCTIONS.map(bf => (
+          <FormControlLabel key={bf.value} control={
+            <Checkbox
+              checked={form.behaviorFunctions.includes(bf.value)}
+              onChange={e => {
+                const next = e.target.checked
+                  ? [...form.behaviorFunctions, bf.value]
+                  : form.behaviorFunctions.filter(v => v !== bf.value);
+                updateField('behaviorFunctions', next);
+              }}
+            />
+          } label={bf.label} />
+        ))}
+      </Stack>
+      <TextField label="機能の詳細分析" value={form.behaviorFunctionDetail} onChange={e => updateField('behaviorFunctionDetail', e.target.value)} fullWidth multiline minRows={3}
+        placeholder="なぜこの機能と判断したか、根拠を記載" />
+
+      <Divider textAlign="left"><Chip label="ABC 記録" size="small" /></Divider>
+      <TextField label="A: 先行事象（Antecedent）" value={form.abcAntecedent} onChange={e => updateField('abcAntecedent', e.target.value)} fullWidth multiline minRows={2}
+        placeholder="行動の直前に何が起きたか" />
+      <TextField label="B: 行動（Behavior）" value={form.abcBehavior} onChange={e => updateField('abcBehavior', e.target.value)} fullWidth multiline minRows={2}
+        placeholder="具体的にどのような行動が見られたか" />
+      <TextField label="C: 結果（Consequence）" value={form.abcConsequence} onChange={e => updateField('abcConsequence', e.target.value)} fullWidth multiline minRows={2}
+        placeholder="行動の結果何が起きたか（環境がどう変化したか）" />
+    </Stack>
+  );
+};

--- a/src/features/planning-sheet/components/new-form/sections/SectionBasicAndTarget.tsx
+++ b/src/features/planning-sheet/components/new-form/sections/SectionBasicAndTarget.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import MenuItem from '@mui/material/MenuItem';
+import Alert from '@mui/material/Alert';
+import Typography from '@mui/material/Typography';
+import { SectionTitle } from '../components/SectionTitle';
+import type { FormState } from '../types';
+import { TRAINING_LEVELS } from '../constants';
+import { calculateMonitoringSchedule } from '@/features/planning-sheet/monitoringSchedule';
+
+interface SectionBasicAndTargetProps {
+  step: number;
+  form: FormState;
+  updateField: <K extends keyof FormState>(key: K, value: FormState[K]) => void;
+}
+
+export const SectionBasicAndTarget: React.FC<SectionBasicAndTargetProps> = ({
+  step,
+  form,
+  updateField,
+}) => {
+  const schedule = React.useMemo(() => {
+    if (!form.supportStartDate) return null;
+    return calculateMonitoringSchedule(form.supportStartDate, form.monitoringCycleDays);
+  }, [form.supportStartDate, form.monitoringCycleDays]);
+
+  const schedulePreview = schedule ? (
+    <Alert icon={false} severity="info" sx={{ mt: 1, py: 0.5, px: 2, border: '1px solid #93c5fd', bgcolor: '#eff6ff', borderRadius: 2 }}>
+      <Typography variant="caption" color="primary.main" fontWeight={800}>
+        🗓️ 次回予定日: {schedule.nextMonitoringDate} （{form.monitoringCycleDays}日周期）
+      </Typography>
+    </Alert>
+  ) : null;
+
+  if (step === 0) {
+    // §1 基本情報
+    return (
+      <Stack spacing={2}>
+        <SectionTitle number={1} title="基本情報" desc="利用者の基本情報と計画の概要" />
+        <TextField label="計画タイトル" value={form.title} onChange={e => updateField('title', e.target.value)} required fullWidth
+          placeholder="例: 外出活動場面における行動支援計画" />
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+          <TextField label="支援区分" value={form.supportLevel} onChange={e => updateField('supportLevel', e.target.value)} fullWidth
+            placeholder="例: 区分5" />
+          <TextField label="行動関連項目点数" value={form.behaviorScore} onChange={e => updateField('behaviorScore', e.target.value)} fullWidth
+            placeholder="例: 18点" />
+        </Stack>
+        <TextField label="計画期間" value={form.planPeriod} onChange={e => updateField('planPeriod', e.target.value)} fullWidth
+          placeholder="例: 2026年4月1日 〜 2026年9月30日" />
+        <TextField
+          label="支援開始日（モニタリング起点）"
+          type="date"
+          value={form.supportStartDate}
+          onChange={e => updateField('supportStartDate', e.target.value)}
+          fullWidth
+          InputLabelProps={{ shrink: true }}
+          helperText="90日モニタリングの起点となる日付です。通常は利用開始日を設定します。"
+        />
+        {schedulePreview}
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+          <TextField select label="関与研修" value={form.trainingLevel} onChange={e => updateField('trainingLevel', e.target.value)} fullWidth>
+            {TRAINING_LEVELS.map(t => <MenuItem key={t.value} value={t.value}>{t.label}</MenuItem>)}
+          </TextField>
+          <TextField label="関係機関" value={form.relatedOrganizations} onChange={e => updateField('relatedOrganizations', e.target.value)} fullWidth
+            placeholder="例: 相談支援センター、訪問看護" />
+        </Stack>
+        {form.trainingLevel !== 'なし' && (
+          <Alert severity="info" variant="outlined">
+            ✅ 強度行動障害支援者養成研修（{form.trainingLevel}）修了者が関与 — 加算算定要件を充足
+          </Alert>
+        )}
+      </Stack>
+    );
+  }
+
+  // §2 対象行動
+  return (
+    <Stack spacing={2}>
+      <SectionTitle number={2} title="対象行動（ターゲット行動）" desc="支援の対象となる行動を操作的に定義する" />
+      <TextField label="対象行動" value={form.targetBehavior} onChange={e => updateField('targetBehavior', e.target.value)} required fullWidth multiline minRows={2}
+        placeholder="例: 外出活動前に大声で拒否し床に座り込む" />
+      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+        <TextField label="発生頻度" value={form.behaviorFrequency} onChange={e => updateField('behaviorFrequency', e.target.value)} fullWidth
+          placeholder="例: 週3〜4回" />
+        <TextField label="継続時間" value={form.behaviorDuration} onChange={e => updateField('behaviorDuration', e.target.value)} fullWidth
+          placeholder="例: 5〜20分" />
+      </Stack>
+      <TextField label="発生場面" value={form.behaviorSituation} onChange={e => updateField('behaviorSituation', e.target.value)} fullWidth multiline minRows={2}
+        placeholder="いつ・どこで・どのような状況で発生するか" />
+      <TextField label="強度" value={form.behaviorIntensity} onChange={e => updateField('behaviorIntensity', e.target.value)} fullWidth
+        placeholder="例: 大声（70dB程度）、床への座り込み" />
+      <TextField label="危険性" value={form.behaviorRisk} onChange={e => updateField('behaviorRisk', e.target.value)} fullWidth
+        placeholder="本人: / 他者:" />
+      <TextField label="影響" value={form.behaviorImpact} onChange={e => updateField('behaviorImpact', e.target.value)} fullWidth multiline minRows={2}
+        placeholder="他利用者・職員・環境への影響" />
+    </Stack>
+  );
+};

--- a/src/features/planning-sheet/components/new-form/sections/SectionMonitoring.tsx
+++ b/src/features/planning-sheet/components/new-form/sections/SectionMonitoring.tsx
@@ -1,0 +1,371 @@
+import React from 'react';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import CircularProgress from '@mui/material/CircularProgress';
+import Divider from '@mui/material/Divider';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+
+import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
+import CheckIcon from '@mui/icons-material/Check';
+import KeyboardDoubleArrowDownIcon from '@mui/icons-material/KeyboardDoubleArrowDown';
+import EqualizerIcon from '@mui/icons-material/Equalizer';
+
+import { SectionTitle } from '../components/SectionTitle';
+import type { FormState } from '../types';
+import { calculateMonitoringSchedule } from '@/features/planning-sheet/monitoringSchedule';
+import { useReverseBridge } from '@/features/planning-sheet/hooks/useReverseBridge';
+import KioskMonitoringEvidencePanel from '@/features/monitoring/components/KioskMonitoringEvidencePanel';
+import { AbcEvidenceListPanel, type AbcEvidenceListPanelProps } from '@/features/monitoring/components/AbcEvidenceListPanel';
+import type { AbcRecord } from '@/domain/abc/abcRecord';
+import type { MonitoringEvidenceLink } from '@/domain/isp/schema/ispPlanningSheetSchema';
+
+interface SectionMonitoringProps {
+  form: FormState;
+  updateField: <K extends keyof FormState>(key: K, value: FormState[K]) => void;
+  userId?: string;
+  isAdmin?: boolean;
+  abcEvidenceRecords?: AbcRecord[];
+  abcEvidenceLoading?: boolean;
+  abcEvidencePeriod?: AbcEvidenceListPanelProps['period'];
+  abcEvidenceError?: Error | null;
+}
+
+export const SectionMonitoring: React.FC<SectionMonitoringProps> = ({
+  form,
+  updateField,
+  userId,
+  isAdmin = true,
+  abcEvidenceRecords = [],
+  abcEvidenceLoading = false,
+  abcEvidencePeriod = null,
+  abcEvidenceError = null,
+}) => {
+  const { suggestions, isLoading: isBridgeLoading, error: bridgeError } = useReverseBridge(userId, form.supportStartDate);
+
+  const schedule = React.useMemo(() => {
+    if (!form.supportStartDate) return null;
+    return calculateMonitoringSchedule(form.supportStartDate, form.monitoringCycleDays);
+  }, [form.supportStartDate, form.monitoringCycleDays]);
+
+  const schedulePreview = schedule ? (
+    <Alert icon={false} severity="info" sx={{ mt: 1, py: 0.5, px: 2, border: '1px solid #93c5fd', bgcolor: '#eff6ff', borderRadius: 2 }}>
+      <Typography variant="caption" color="primary.main" fontWeight={800}>
+        🗓️ 次回予定日: {schedule.nextMonitoringDate} （{form.monitoringCycleDays}日周期）
+      </Typography>
+    </Alert>
+  ) : null;
+
+  return (
+    <Stack spacing={2}>
+      <SectionTitle number={9} title="モニタリング" desc="支援の効果を定量的・定性的に評価する" />
+      <TextField label="評価指標" value={form.evaluationIndicator} onChange={e => updateField('evaluationIndicator', e.target.value)} required fullWidth multiline minRows={2}
+        placeholder="何を指標とするか（頻度、持続時間、代替行動の使用率など）" />
+      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+        <TextField label="評価期間" value={form.evaluationPeriod} onChange={e => updateField('evaluationPeriod', e.target.value)} fullWidth
+          placeholder="例: 毎月末に月次評価" />
+        <TextField type="number" label="モニタリング周期（日）" value={form.monitoringCycleDays} onChange={e => updateField('monitoringCycleDays', Number(e.target.value) || 90)} fullWidth
+          inputProps={{ min: 1, max: 365 }} />
+      </Stack>
+      {schedulePreview}
+      <TextField label="評価方法" value={form.evaluationMethod} onChange={e => updateField('evaluationMethod', e.target.value)} fullWidth multiline minRows={2}
+        placeholder="ABC記録集計、グラフ化、カンファレンス" />
+
+      {/* Dedicated ABC 記録 (評価根拠候補) */}
+      {userId && (
+        <AbcEvidenceListPanel
+          records={abcEvidenceRecords}
+          loading={abcEvidenceLoading}
+          error={abcEvidenceError}
+          period={abcEvidencePeriod}
+          monitoringCycleDays={form.monitoringCycleDays || 90}
+          isCited={(form.monitoringEvidenceLinks || []).some(
+            (link: MonitoringEvidenceLink) => link.source === 'dedicated-abc' &&
+                           link.recordIds.some((id: string) => abcEvidenceRecords.map((r: AbcRecord) => r.id).includes(id))
+          )}
+          onCiteDraft={(draft, recordIds) => {
+            const appendText = (current: string | undefined, append: string) => {
+              const cur = (current || '').trim();
+              if (!cur) return append;
+              if (cur.includes(append.trim())) return cur;
+              return `${cur}\n\n${append}`;
+            };
+
+            const nextEvaluationMethod = appendText(form.evaluationMethod, draft.evaluationMethod);
+            const nextImprovementResult = appendText(form.improvementResult, draft.improvementResult);
+            const nextNextSupport = appendText(form.nextSupport, draft.nextSupport);
+
+            const newLink = {
+              source: 'dedicated-abc' as const,
+              sourceList: 'AbcBehaviorRecords' as const,
+              recordIds: recordIds,
+              period: {
+                from: abcEvidencePeriod?.from || '',
+                to: abcEvidencePeriod?.to || '',
+              },
+              generatedAt: new Date().toISOString(),
+              citedFields: ['evaluationMethod', 'improvementResult', 'nextSupport'] as ('evaluationMethod' | 'improvementResult' | 'nextSupport')[],
+            };
+
+            const nextLinks = [...(form.monitoringEvidenceLinks || []), newLink];
+
+            updateField('evaluationMethod', nextEvaluationMethod);
+            updateField('improvementResult', nextImprovementResult);
+            updateField('nextSupport', nextNextSupport);
+            updateField('monitoringEvidenceLinks', nextLinks);
+          }}
+        />
+      )}
+
+      {/* キオスク記録（17手順）統計ドラフト */}
+      {userId && (
+        <KioskMonitoringEvidencePanel
+          userId={userId}
+          onAppendInsight={(text) => {
+            const current = form.improvementResult || '';
+            updateField('improvementResult', current ? `${current}\n\n${text}` : text);
+          }}
+          isAdmin={isAdmin}
+        />
+      )}
+
+      {/* L3-to-L2 Reverse-Bridge 自動提案 */}
+      {userId && (
+        <Box sx={{ my: 1 }}>
+          {isBridgeLoading && (
+            <Paper variant="outlined" sx={{ p: 2, bgcolor: '#fafafc', borderColor: '#e2e8f0', borderStyle: 'dashed', borderRadius: 3 }}>
+              <Stack direction="row" spacing={2} alignItems="center" justifyContent="center">
+                <CircularProgress size={20} color="secondary" />
+                <Typography variant="body2" color="text.secondary" fontWeight={600}>
+                  🤖 日々の記録実績（L3）から評価案を自動生成中...
+                </Typography>
+              </Stack>
+            </Paper>
+          )}
+
+          {bridgeError && (
+            <Alert severity="warning" sx={{ borderRadius: 3 }}>
+              実績データの取得・分析に失敗しました。自動提案は一時的に利用できません: {bridgeError.message}
+            </Alert>
+          )}
+
+          {!isBridgeLoading && !bridgeError && suggestions && (
+            <Box
+              sx={{
+                p: 2.5,
+                border: '1px dashed #c084fc',
+                bgcolor: '#faf5ff',
+                borderRadius: 3,
+                transition: 'all 0.3s ease',
+                boxShadow: '0 2px 12px rgba(168, 85, 247, 0.05)',
+                '&:hover': {
+                  borderColor: '#a855f7',
+                  boxShadow: '0 4px 20px rgba(168, 85, 247, 0.12)',
+                },
+              }}
+            >
+              <Stack spacing={2}>
+                {/* ヘッダー */}
+                <Stack direction="row" alignItems="center" justifyContent="space-between" flexWrap="wrap" useFlexGap>
+                  <Stack direction="row" spacing={1} alignItems="center">
+                    <AutoAwesomeIcon sx={{ color: '#a855f7' }} />
+                    <Typography variant="subtitle2" fontWeight={800} color="#7c3aed" sx={{ letterSpacing: 0.5 }}>
+                      L3支援実績からの評価提案（自動生成）
+                    </Typography>
+                  </Stack>
+                  
+                  <Stack direction="row" spacing={1} alignItems="center">
+                    {suggestions.confidence !== 'none' && (
+                      <Chip
+                        label={`確信度: ${
+                          suggestions.confidence === 'high' ? '高' :
+                          suggestions.confidence === 'medium' ? '中' : '低'
+                        }`}
+                        size="small"
+                        sx={{
+                          fontWeight: 700,
+                          bgcolor: 
+                            suggestions.confidence === 'high' ? '#dcfce7' :
+                            suggestions.confidence === 'medium' ? '#ffedd5' : '#f3e8ff',
+                          color:
+                            suggestions.confidence === 'high' ? '#15803d' :
+                            suggestions.confidence === 'medium' ? '#c2410c' : '#6b21a8',
+                          border: 'none',
+                        }}
+                      />
+                    )}
+                    <Chip label="Human-in-the-Loop" size="small" variant="outlined" sx={{ color: '#a855f7', borderColor: '#d8b4fe', fontWeight: 600 }} />
+                  </Stack>
+                </Stack>
+
+                {/* 説明 */}
+                <Typography variant="caption" color="text.secondary">
+                  対象期間内の支援手順実施記録および週次観察記録（L3）を自動的に解析し、§9 モニタリングの改善結果・次の支援方針案を提案します。
+                </Typography>
+
+                {/* 定量的メトリクス */}
+                <Box sx={{ p: 1.5, bgcolor: '#ffffff', borderRadius: 2, border: '1px solid #f3e8ff' }}>
+                  <Stack direction="row" spacing={3} alignItems="center" justifyContent="space-around" flexWrap="wrap" useFlexGap>
+                    <Stack alignItems="center" spacing={0.5}>
+                      <Typography variant="caption" color="text.secondary">日次記録数</Typography>
+                      <Typography variant="body2" fontWeight={800} color="text.primary">
+                        {suggestions.stats.recordCount} 件
+                      </Typography>
+                    </Stack>
+                    <Divider orientation="vertical" flexItem />
+                    <Stack alignItems="center" spacing={0.5}>
+                      <Typography variant="caption" color="text.secondary">手順実施率</Typography>
+                      <Typography variant="body2" fontWeight={800} color="#15803d">
+                        {suggestions.stats.procedureCompletionRate !== null ? `${suggestions.stats.procedureCompletionRate}%` : '---'}
+                      </Typography>
+                    </Stack>
+                    <Divider orientation="vertical" flexItem />
+                    <Stack alignItems="center" spacing={0.5}>
+                      <Typography variant="caption" color="text.secondary">BIP誘発率</Typography>
+                      <Typography variant="body2" fontWeight={800} color="#b91c1c">
+                        {suggestions.stats.bipActivationRate !== null ? `${suggestions.stats.bipActivationRate}%` : '---'}
+                      </Typography>
+                    </Stack>
+                    <Divider orientation="vertical" flexItem />
+                    <Stack alignItems="center" spacing={0.5}>
+                      <Typography variant="caption" color="text.secondary">週次観察数</Typography>
+                      <Typography variant="body2" fontWeight={800} color="#0369a1">
+                        {suggestions.stats.observationCount} 件
+                      </Typography>
+                    </Stack>
+                  </Stack>
+                </Box>
+
+                {suggestions.confidence === 'none' ? (
+                  <Alert severity="info" icon={false} sx={{ py: 1, bgcolor: '#f8fafc', border: '1px solid #e2e8f0', borderRadius: 2 }}>
+                    <Typography variant="body2" fontWeight={600} color="text.secondary">
+                      分析データが不足しています
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      指定された評価期間内にL3の支援実績記録が登録されていません。L3モードで記録を入力すると、自動的に評価提案が利用可能になります。
+                    </Typography>
+                  </Alert>
+                ) : (
+                  <>
+                    {/* 提案コンテンツ */}
+                    <Stack spacing={1.5}>
+                      {/* 改善結果案 */}
+                      <Stack spacing={0.5}>
+                        <Typography variant="caption" fontWeight={700} color="#7c3aed">改善結果の提案（前回からの変化）</Typography>
+                        <Box sx={{ p: 1.5, bgcolor: '#ffffff', borderRadius: 2, border: '1px solid #e9d5ff', position: 'relative' }}>
+                          <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', pr: 12, fontSize: '0.825rem', lineHeight: 1.5 }}>
+                            {suggestions.improvementResult}
+                          </Typography>
+                          <Button
+                            size="small"
+                            variant="outlined"
+                            color="secondary"
+                            startIcon={<CheckIcon />}
+                            sx={{
+                              position: 'absolute',
+                              right: 8,
+                              top: '50%',
+                              transform: 'translateY(-50%)',
+                              fontSize: '0.7rem',
+                              py: 0.25,
+                              px: 1,
+                              borderRadius: 1.5,
+                              borderColor: '#d8b4fe',
+                              bgcolor: '#faf5ff',
+                              '&:hover': { bgcolor: '#f3e8ff' }
+                            }}
+                            onClick={() => updateField('improvementResult', suggestions.improvementResult)}
+                          >
+                            適用
+                          </Button>
+                        </Box>
+                      </Stack>
+
+                      {/* 次の支援方針案 */}
+                      <Stack spacing={0.5}>
+                        <Typography variant="caption" fontWeight={700} color="#7c3aed">次の支援方針の提案（次回改善アクション）</Typography>
+                        <Box sx={{ p: 1.5, bgcolor: '#ffffff', borderRadius: 2, border: '1px solid #e9d5ff', position: 'relative' }}>
+                          <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', pr: 12, fontSize: '0.825rem', lineHeight: 1.5 }}>
+                            {suggestions.nextSupport}
+                          </Typography>
+                          <Button
+                            size="small"
+                            variant="outlined"
+                            color="secondary"
+                            startIcon={<CheckIcon />}
+                            sx={{
+                              position: 'absolute',
+                              right: 8,
+                              top: '50%',
+                              transform: 'translateY(-50%)',
+                              fontSize: '0.7rem',
+                              py: 0.25,
+                              px: 1,
+                              borderRadius: 1.5,
+                              borderColor: '#d8b4fe',
+                              bgcolor: '#faf5ff',
+                              '&:hover': { bgcolor: '#f3e8ff' }
+                            }}
+                            onClick={() => updateField('nextSupport', suggestions.nextSupport)}
+                          >
+                            適用
+                          </Button>
+                        </Box>
+                      </Stack>
+                    </Stack>
+
+                    {/* 一括反映・根拠データ */}
+                    <Stack spacing={1.5}>
+                      <Button
+                        size="small"
+                        variant="contained"
+                        color="secondary"
+                        startIcon={<KeyboardDoubleArrowDownIcon />}
+                        sx={{
+                          alignSelf: 'flex-start',
+                          bgcolor: '#a855f7',
+                          fontWeight: 700,
+                          borderRadius: 2,
+                          px: 2,
+                          py: 0.75,
+                          boxShadow: '0 2px 6px rgba(168, 85, 247, 0.2)',
+                          '&:hover': { bgcolor: '#9333ea', boxShadow: '0 4px 12px rgba(168, 85, 247, 0.3)' }
+                        }}
+                        onClick={() => {
+                          updateField('improvementResult', suggestions.improvementResult);
+                          updateField('nextSupport', suggestions.nextSupport);
+                        }}
+                      >
+                        改善結果・支援方針に一括反映する
+                      </Button>
+
+                      {/* 根拠サマリー */}
+                      <Box sx={{ mt: 1, p: 1.5, bgcolor: '#fdfbfe', borderRadius: 2, border: '1px solid #f3e8ff' }}>
+                        <Typography variant="caption" fontWeight={700} color="text.secondary" sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mb: 0.5 }}>
+                          <EqualizerIcon sx={{ fontSize: 16, color: '#a855f7' }} />
+                          📌 提案根拠データサマリー:
+                        </Typography>
+                        <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.75rem', lineHeight: 1.4, display: 'block', whiteSpace: 'pre-wrap' }}>
+                          {suggestions.evidenceSummary}
+                        </Typography>
+                      </Box>
+                    </Stack>
+                  </>
+                )}
+              </Stack>
+            </Box>
+          )}
+        </Box>
+      )}
+
+      <TextField label="改善結果" value={form.improvementResult} onChange={e => updateField('improvementResult', e.target.value)} fullWidth multiline minRows={2}
+        placeholder="（評価後に記入）前回からの変化" />
+      <TextField label="次の支援方針" value={form.nextSupport} onChange={e => updateField('nextSupport', e.target.value)} fullWidth multiline minRows={2}
+        placeholder="（評価後に記入）次の改善アクション" />
+    </Stack>
+  );
+};

--- a/src/features/planning-sheet/components/new-form/sections/SectionPBSStrategies.tsx
+++ b/src/features/planning-sheet/components/new-form/sections/SectionPBSStrategies.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Alert from '@mui/material/Alert';
+import Divider from '@mui/material/Divider';
+import Typography from '@mui/material/Typography';
+import { SectionTitle } from '../components/SectionTitle';
+import { ResponseProtocolVisualizer } from '../components/illustrations/ResponseProtocolVisualizer';
+import type { FormState } from '../types';
+
+interface SectionPBSStrategiesProps {
+  step: number;
+  form: FormState;
+  updateField: <K extends keyof FormState>(key: K, value: FormState[K]) => void;
+}
+
+export const SectionPBSStrategies: React.FC<SectionPBSStrategiesProps> = ({
+  step,
+  form,
+  updateField,
+}) => {
+  if (step === 4) {
+    // §5 予防的支援
+    return (
+      <Stack spacing={2}>
+        <SectionTitle number={5} title="予防的支援（最重要）" desc="問題行動が起きる前に環境や関わり方を調整する" />
+        <Alert severity="info" variant="outlined" sx={{ mb: 1 }}>
+          💡 PBS では「問題行動を起こさせない環境づくり」が最も重要です
+        </Alert>
+        <TextField label="環境調整" value={form.environmentalAdjustment} onChange={e => updateField('environmentalAdjustment', e.target.value)} required fullWidth multiline minRows={2}
+          placeholder="物理的環境の変更（レイアウト、刺激の調整）" />
+        <TextField label="見通し支援" value={form.visualSupport} onChange={e => updateField('visualSupport', e.target.value)} required fullWidth multiline minRows={2}
+          placeholder="スケジュールカード、写真提示、タイマー" />
+        <TextField label="コミュニケーション支援" value={form.communicationSupport} onChange={e => updateField('communicationSupport', e.target.value)} fullWidth multiline minRows={2}
+          placeholder="絵カード、PECS、サイン" />
+        <TextField label="安心支援" value={form.safetySupport} onChange={e => updateField('safetySupport', e.target.value)} fullWidth multiline minRows={2}
+          placeholder="馴染みの職員配置、安心グッズ" />
+        <TextField label="事前支援" value={form.preSupport} onChange={e => updateField('preSupport', e.target.value)} fullWidth multiline minRows={2}
+          placeholder="前日の確認、当日朝の予告" />
+      </Stack>
+    );
+  }
+
+  if (step === 5) {
+    // §6 代替行動
+    return (
+      <Stack spacing={2}>
+        <SectionTitle number={6} title="代替行動（Replacement Behavior）" desc="問題行動と同じ機能を果たす適切な行動を教える" />
+        <TextField label="望ましい行動" value={form.desiredBehavior} onChange={e => updateField('desiredBehavior', e.target.value)} required fullWidth multiline minRows={2}
+          placeholder="問題行動の代わりに取ってほしい行動" />
+        <TextField label="教える方法" value={form.teachingMethod} onChange={e => updateField('teachingMethod', e.target.value)} fullWidth multiline minRows={2}
+          placeholder="モデリング、プロンプト、ロールプレイ" />
+        <TextField label="練習方法" value={form.practiceMethod} onChange={e => updateField('practiceMethod', e.target.value)} fullWidth multiline minRows={2}
+          placeholder="練習頻度、場面設定、般化計画" />
+        <TextField label="強化方法" value={form.reinforcementMethod} onChange={e => updateField('reinforcementMethod', e.target.value)} fullWidth multiline minRows={2}
+          placeholder="即時強化、トークンエコノミー、二次強化" />
+      </Stack>
+    );
+  }
+
+  if (step === 6) {
+    // §7 問題行動時の対応
+    return (
+      <Stack spacing={3}>
+        <SectionTitle number={7} title="問題行動時対応" desc="行動が発生した瞬間に、チームで統一した動きをとるためのプロトコル" />
+        
+        <ResponseProtocolVisualizer phase="initial" />
+        <TextField label="① 初動対応（前兆へのアプローチ）" value={form.initialResponse} onChange={e => updateField('initialResponse', e.target.value)} fullWidth multiline minRows={2}
+          placeholder="例：穏やかに声をかける、特定の視覚提示を行う" />
+        
+        <ResponseProtocolVisualizer phase="escalated" />
+        <TextField label="② 現場環境の調整（中期対応）" value={form.responseEnvironment} onChange={e => updateField('responseEnvironment', e.target.value)} fullWidth multiline minRows={2}
+          placeholder="例：パーテーションを閉める、他利用者を誘導する" />
+        <TextField label="③ 職員の動き・NG行動" value={form.staffResponse} onChange={e => updateField('staffResponse', e.target.value)} fullWidth multiline minRows={3}
+          placeholder="迷わず動くための指示。やってはいけない（NG）行動も明記" />
+
+        <Divider />
+        <Typography variant="subtitle2" fontWeight={600}>安全確保と記録</Typography>
+        <TextField label="安全確保（セーフガーディング）" value={form.safeguarding} onChange={e => updateField('safeguarding', e.target.value)} fullWidth multiline minRows={2}
+          placeholder="距離の取り方、物品の撤去など" />
+        <TextField label="記録・報告の方法" value={form.recordMethod} onChange={e => updateField('recordMethod', e.target.value)} fullWidth multiline minRows={2}
+          placeholder="どのシートに、いつ記入するか" />
+      </Stack>
+    );
+  }
+
+  // §8 危機対応
+  return (
+    <Stack spacing={3}>
+      <SectionTitle number={8} title="危機対応（エスカレーション）" desc="自傷・他害等の生命に関わる危機状況への限定的・緊急的対応" />
+
+      <ResponseProtocolVisualizer phase="crisis" />
+      
+      <Alert severity="error" variant="outlined" sx={{ mb: 1, borderStyle: 'dashed' }}>
+          ※危機対応は最終手段です。身体拘束等の権利侵害を未然に防ぐことを優先してください。
+      </Alert>
+
+      <TextField label="危機的行動の定義" value={form.dangerousBehavior} onChange={e => updateField('dangerousBehavior', e.target.value)} fullWidth multiline minRows={2}
+        placeholder="「これが起きたら危機対応を開始する」という具体的な指標" />
+      <TextField label="緊急時の具体的対応（3ステップ）" value={form.emergencyResponse} onChange={e => updateField('emergencyResponse', e.target.value)} fullWidth multiline minRows={3}
+        placeholder="①〜③の順番で、迷わず行うべき緊急動作" />
+      
+      <Divider />
+      <Typography variant="subtitle2" fontWeight={600}>連絡・連携プロトコル</Typography>
+      <TextField label="医療連携（受診・主治医連絡）" value={form.medicalCoordination} onChange={e => updateField('medicalCoordination', e.target.value)} fullWidth multiline minRows={2} />
+      <TextField label="家族への連絡（緊急連絡先・タイミング）" value={form.familyContact} onChange={e => updateField('familyContact', e.target.value)} fullWidth multiline minRows={2} />
+      <TextField label="安全確保の具体的方法（ハード面）" value={form.safetyMethod} onChange={e => updateField('safetyMethod', e.target.value)} fullWidth multiline minRows={2} />
+    </Stack>
+  );
+};

--- a/src/features/planning-sheet/components/new-form/sections/SectionSharing.tsx
+++ b/src/features/planning-sheet/components/new-form/sections/SectionSharing.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import { SectionTitle } from '../components/SectionTitle';
+import type { FormState } from '../types';
+
+interface SectionSharingProps {
+  form: FormState;
+  updateField: <K extends keyof FormState>(key: K, value: FormState[K]) => void;
+}
+
+export const SectionSharing: React.FC<SectionSharingProps> = ({
+  form,
+  updateField,
+}) => {
+  return (
+    <Stack spacing={2}>
+      <SectionTitle number={10} title="チーム共有" desc="支援チーム全体で計画を共有し実行する体制" />
+      <TextField label="共有方法" value={form.sharingMethod} onChange={e => updateField('sharingMethod', e.target.value)} fullWidth multiline minRows={2}
+        placeholder="朝礼、週1回会議、計画掲示" />
+      <TextField label="研修計画" value={form.training} onChange={e => updateField('training', e.target.value)} fullWidth multiline minRows={2}
+        placeholder="OJT、事例検討会、外部研修" />
+      <TextField label="担当者" value={form.personInCharge} onChange={e => updateField('personInCharge', e.target.value)} fullWidth
+        placeholder="主担当 / 副担当" />
+      <TextField label="確認日" value={form.confirmationDate} onChange={e => updateField('confirmationDate', e.target.value)} fullWidth
+        placeholder="計画確認日" />
+      <TextField label="チーム合意事項" value={form.teamConsensusNote} onChange={e => updateField('teamConsensusNote', e.target.value)} fullWidth multiline minRows={3}
+        placeholder="チームで共有すべき方針・留意点" />
+    </Stack>
+  );
+};

--- a/tests/unit/useNewPlanningSheetForm.spec.ts
+++ b/tests/unit/useNewPlanningSheetForm.spec.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import React from 'react';
+
+// Mock routing
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+// Mock hooks and auth
+vi.mock('@/features/assessment/hooks/useTokuseiSurveyResponses', () => ({
+  useTokuseiSurveyResponses: () => ({
+    responses: [],
+    status: 'success',
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock('@/features/users/useUsers', () => ({
+  useUsers: () => ({
+    data: [
+      { UserID: 'I005', FullName: '利用者 五郎', Status: 'active' },
+      { UserID: 'I006', FullName: '利用者 六郎', Status: 'active' },
+    ],
+  }),
+}));
+
+vi.mock('@/auth/useAuth', () => ({
+  useAuth: () => ({
+    account: { name: 'テスト職員' },
+  }),
+}));
+
+vi.mock('@/auth/useUserAuthz', () => ({
+  useUserAuthz: () => ({
+    role: 'staff',
+  }),
+}));
+
+vi.mock('@/features/planning-sheet/hooks/useLatestBehaviorMonitoring', () => ({
+  useLatestBehaviorMonitoring: () => ({
+    record: null,
+    isLoading: false,
+  }),
+}));
+
+vi.mock('@/features/monitoring/data/useMonitoringMeetingRepository', () => ({
+  useMonitoringMeetingRepository: () => ({}),
+}));
+
+vi.mock('@/features/ibd/analysis/iceberg/SharePointIcebergRepository', () => ({
+  useIcebergRepository: () => ({
+    getLatestByUser: vi.fn(),
+  }),
+}));
+
+vi.mock('@/features/monitoring/hooks/useMonitoringAbcEvidence', () => ({
+  useMonitoringAbcEvidence: () => ({
+    records: [],
+    loading: false,
+    error: null,
+    period: null,
+  }),
+}));
+
+vi.mock('@/features/planning-sheet/stores/importAuditStore', () => ({
+  useImportAuditStore: () => ({
+    saveAuditRecord: vi.fn(),
+  }),
+}));
+
+import { useNewPlanningSheetForm } from '@/features/planning-sheet/components/new-form/hooks/useNewPlanningSheetForm';
+import { INITIAL_FORM, SAMPLE_FORM } from '@/features/planning-sheet/components/new-form/constants';
+
+describe('useNewPlanningSheetForm', () => {
+  const mockPlanningSheetRepo = {
+    create: vi.fn().mockResolvedValue({ id: 'new-sheet-123' }),
+  } as any;
+
+  const mockIspRepo = {
+    getCurrentByUser: vi.fn().mockResolvedValue({ id: 'isp-current-123' }),
+  } as any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('初期状態が正しくセットアップされること', () => {
+    const { result } = renderHook(() => useNewPlanningSheetForm({
+      planningSheetRepo: mockPlanningSheetRepo,
+      ispRepo: mockIspRepo,
+    }));
+
+    expect(result.current.selectedUser).toBeNull();
+    expect(result.current.ispId).toBeNull();
+    expect(result.current.activeStep).toBe(0);
+    expect(result.current.form).toEqual(INITIAL_FORM);
+    expect(result.current.isSaving).toBe(false);
+  });
+
+  it('利用者を選択すると、現行個別支援計画を正しく取得して紐付けること', async () => {
+    const { result } = renderHook(() => useNewPlanningSheetForm({
+      planningSheetRepo: mockPlanningSheetRepo,
+      ispRepo: mockIspRepo,
+    }));
+
+    await act(async () => {
+      await result.current.handleUserSelect(null, { id: 'I005', label: '利用者 五郎 (I005)' });
+    });
+
+    expect(mockIspRepo.getCurrentByUser).toHaveBeenCalledWith('I005');
+    expect(result.current.selectedUser).toEqual({ id: 'I005', label: '利用者 五郎 (I005)' });
+    expect(result.current.ispId).toBe('isp-current-123');
+    expect(result.current.ispWarning).toBeNull();
+  });
+
+  it('updateField でフォームの各フィールドを更新できること', () => {
+    const { result } = renderHook(() => useNewPlanningSheetForm({
+      planningSheetRepo: mockPlanningSheetRepo,
+      ispRepo: mockIspRepo,
+    }));
+
+    act(() => {
+      result.current.updateField('title', 'テスト支援計画タイトル');
+    });
+
+    expect(result.current.form.title).toBe('テスト支援計画タイトル');
+  });
+
+  it('handleFillSample を呼ぶと、サンプルデータでフォームが埋まること', () => {
+    const { result } = renderHook(() => useNewPlanningSheetForm({
+      planningSheetRepo: mockPlanningSheetRepo,
+      ispRepo: mockIspRepo,
+    }));
+
+    act(() => {
+      result.current.handleFillSample();
+    });
+
+    expect(result.current.form).toEqual(SAMPLE_FORM);
+  });
+
+  it('ステップの切り替えができること', () => {
+    const { result } = renderHook(() => useNewPlanningSheetForm({
+      planningSheetRepo: mockPlanningSheetRepo,
+      ispRepo: mockIspRepo,
+    }));
+
+    act(() => {
+      result.current.setActiveStep(2);
+    });
+
+    expect(result.current.activeStep).toBe(2);
+  });
+});


### PR DESCRIPTION
## 概要

強度行動障害支援計画シートの新規作成フォーム (`NewPlanningSheetForm.tsx`) の保守性向上および肥大化防止（Nightly Patrol 600行ルール対応）を目的とし、状態管理・API連携・データ取込ロジックとマークアップの責務分離を行いました。

## 変更内容

- `NewPlanningSheetForm.tsx` を Presenter として整理
  - 約877行から約365行へ削減
- `useNewPlanningSheetForm.ts` を追加
  - 利用者選択、ISP紐付け、ステップ状態、各種取込、保存処理を集約
- `FormSections.tsx` をセクションルーティング担当へ整理
- `sections/` 配下に §1〜§10 のUIを分割
- `components/` 配下に共通UI部品を抽出
- `tests/unit/useNewPlanningSheetForm.spec.ts` を追加

## Safety

- Behavior change なし
- UI仕様変更なし
- Responsibility separation only
- SharePoint schema変更なし
- Tokusei / Iceberg / Monitoring の業務ロジック変更なし

## Checks

- `npm run typecheck`
- `npm run test:ci -- tests/unit/useNewPlanningSheetForm.spec.ts src/features/planning-sheet`
- `npm run build`

## Notes

This refactor addresses the Nightly Patrol large-file pressure around `NewPlanningSheetForm.tsx` and improves maintainability for future planning-sheet changes.