### PR TITLE
refactor(daily): split UserSelectionStep into presenter, sub-component, and hook

### DIFF
--- a/src/features/daily/components/__tests__/UserSelectionStep.spec.tsx
+++ b/src/features/daily/components/__tests__/UserSelectionStep.spec.tsx
@@ -1,0 +1,173 @@
+import type { SupportPlanningSheet } from '@/domain/isp/schema';
+import type { DailySupportUserFilter } from '@/features/daily/hooks/useDailySupportUserFilter';
+import type { IUserMaster } from '@/features/users/types';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock hook
+const mockUseUserSelectionStepData = vi.fn();
+vi.mock('../wizard/hooks/useUserSelectionStepData', () => ({
+  useUserSelectionStepData: () => mockUseUserSelectionStepData(),
+}));
+
+import { UserSelectionStep } from '../wizard/UserSelectionStep';
+
+describe('UserSelectionStep', () => {
+  const dummyUsers: IUserMaster[] = [
+    {
+      UserID: 'U001',
+      FullName: '利用者 一郎',
+      DisabilitySupportLevel: '区分3',
+      IsHighIntensitySupportTarget: false,
+      BehaviorScore: 5,
+      ServiceStartDate: '2026-01-01',
+      Status: 'active',
+    },
+    {
+      UserID: 'U002',
+      FullName: '利用者 二郎',
+      DisabilitySupportLevel: '区分6',
+      IsHighIntensitySupportTarget: true,
+      BehaviorScore: 12,
+      ServiceStartDate: '2026-01-01',
+      Status: 'active',
+    },
+  ];
+
+  const defaultFilter: DailySupportUserFilter = {
+    supportLevel: '',
+    usageStatus: '',
+    highIntensityOnly: false,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseUserSelectionStepData.mockReturnValue({
+      abcSummary: {
+        todayCounts: new Map(),
+        latestDates: new Map(),
+      },
+      planningSheets: new Map(),
+    });
+  });
+
+  it('利用者リストが正しく表示されること（強度行動障害対象者、行動関連点数が上位にソートされる）', () => {
+    render(
+      <UserSelectionStep
+        filteredUsers={dummyUsers}
+        allUsersCount={2}
+        filter={defaultFilter}
+        hasActiveFilter={false}
+        onUpdateFilter={vi.fn()}
+        onResetFilter={vi.fn()}
+        onSelectUser={vi.fn()}
+      />,
+    );
+
+    // ソート順の確認: 強度行動障害対象の U002 が先頭に来るはず
+    const userCards = screen.getAllByTestId(/wizard-user-card-/);
+    expect(userCards[0]).toHaveAttribute('data-testid', 'wizard-user-card-U002');
+    expect(userCards[1]).toHaveAttribute('data-testid', 'wizard-user-card-U001');
+
+    expect(screen.getByText('利用者 二郎')).toBeInTheDocument();
+    expect(screen.getByText('行動関連12点')).toBeInTheDocument();
+
+    // 複数マッチするため getAllByText を使用
+    const highIntensityLabels = screen.getAllByText('強度行動障害');
+    expect(highIntensityLabels.length).toBeGreaterThan(0);
+
+    expect(screen.getByText('利用者 一郎')).toBeInTheDocument();
+    expect(screen.getByText('行動関連5点')).toBeInTheDocument();
+  });
+
+  it('計画未作成の場合に警告チップが表示されること', () => {
+    // planningSheets に user-A が含まれていない場合、計画未作成チップが表示される
+    render(
+      <UserSelectionStep
+        filteredUsers={dummyUsers}
+        allUsersCount={2}
+        filter={defaultFilter}
+        hasActiveFilter={false}
+        onUpdateFilter={vi.fn()}
+        onResetFilter={vi.fn()}
+        onSelectUser={vi.fn()}
+      />,
+    );
+
+    expect(screen.getAllByText('計画未作成')).toHaveLength(2);
+  });
+
+  it('今日の ABC 記録がある場合に ABC 件数チップが表示されること', () => {
+    const todayCounts = new Map<string, number>();
+    todayCounts.set('U001', 3);
+
+    mockUseUserSelectionStepData.mockReturnValue({
+      abcSummary: {
+        todayCounts,
+        latestDates: new Map(),
+      },
+      planningSheets: new Map([
+        ['U001', {} as unknown as SupportPlanningSheet],
+        ['U002', {} as unknown as SupportPlanningSheet],
+      ]),
+    });
+
+    render(
+      <UserSelectionStep
+        filteredUsers={dummyUsers}
+        allUsersCount={2}
+        filter={defaultFilter}
+        hasActiveFilter={false}
+        onUpdateFilter={vi.fn()}
+        onResetFilter={vi.fn()}
+        onSelectUser={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('ABC 3件')).toBeInTheDocument();
+  });
+
+  it('カードをクリックした時に onSelectUser が正しくトリガーされること', () => {
+    const handleSelectUser = vi.fn();
+
+    render(
+      <UserSelectionStep
+        filteredUsers={dummyUsers}
+        allUsersCount={2}
+        filter={defaultFilter}
+        hasActiveFilter={false}
+        onUpdateFilter={vi.fn()}
+        onResetFilter={vi.fn()}
+        onSelectUser={handleSelectUser}
+      />,
+    );
+
+    const card = screen.getByTestId('wizard-user-card-U001');
+    fireEvent.click(card);
+
+    expect(handleSelectUser).toHaveBeenCalledWith('U001');
+  });
+
+  it('フィルター操作で onUpdateFilter がトリガーされること', () => {
+    const handleUpdateFilter = vi.fn();
+
+    render(
+      <UserSelectionStep
+        filteredUsers={dummyUsers}
+        allUsersCount={2}
+        filter={defaultFilter}
+        hasActiveFilter={false}
+        onUpdateFilter={handleUpdateFilter}
+        onResetFilter={vi.fn()}
+        onSelectUser={vi.fn()}
+      />,
+    );
+
+    // 強度行動障害のトグルボタンをロールを指定して取得
+    const toggleButton = screen.getByRole('button', { name: '強度行動障害支援対象者のみ表示' });
+    fireEvent.click(toggleButton);
+
+    expect(handleUpdateFilter).toHaveBeenCalledWith({ highIntensityOnly: true });
+  });
+});

--- a/src/features/daily/components/__tests__/useUserSelectionStepData.spec.ts
+++ b/src/features/daily/components/__tests__/useUserSelectionStepData.spec.ts
@@ -1,0 +1,78 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock ABC Record Repository with stable object references to prevent infinite render loops
+const mockGetAll = vi.fn();
+const mockRepo = {
+  getAll: mockGetAll,
+};
+
+vi.mock('@/infra/abc/useAbcRecordRepository', () => ({
+  useAbcRecordRepository: () => mockRepo,
+}));
+
+import { useUserSelectionStepData } from '../wizard/hooks/useUserSelectionStepData';
+
+describe('useUserSelectionStepData', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('初期状態が正しく返されること', async () => {
+    mockGetAll.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useUserSelectionStepData());
+
+    // Wait for useEffect
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(result.current.abcSummary.todayCounts.size).toBe(0);
+    expect(result.current.abcSummary.latestDates.size).toBe(0);
+    expect(result.current.planningSheets.size).toBe(0);
+  });
+
+  it('今日の ABC 記録と最新記録日が正しく集計されること', async () => {
+    const todayStr = new Date().toISOString().slice(0, 10);
+    const mockRecords = [
+      { id: '1', userId: 'user-A', occurredAt: `${todayStr}T10:00:00Z` },
+      { id: '2', userId: 'user-A', occurredAt: `${todayStr}T11:00:00Z` },
+      { id: '3', userId: 'user-B', occurredAt: '2026-05-15T09:00:00Z' },
+    ];
+    mockGetAll.mockResolvedValue(mockRecords);
+
+    const { result } = renderHook(() => useUserSelectionStepData());
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(result.current.abcSummary.todayCounts.get('user-A')).toBe(2);
+    expect(result.current.abcSummary.todayCounts.get('user-B')).toBeUndefined();
+    expect(result.current.abcSummary.latestDates.get('user-A')).toBe(`${todayStr}T11:00:00Z`);
+    expect(result.current.abcSummary.latestDates.get('user-B')).toBe('2026-05-15T09:00:00Z');
+  });
+
+  it('支援計画シートのアクティブなバージョンが正しく解決されること', async () => {
+    mockGetAll.mockResolvedValue([]);
+
+    const mockSheets = [
+      { userId: 'user-A', status: 'active', isCurrent: true, version: 1 },
+      { userId: 'user-A', status: 'active', isCurrent: true, version: 2 }, // latest
+      { userId: 'user-B', status: 'pending', isCurrent: true, version: 1 }, // inactive
+    ];
+    localStorage.setItem('planningSheet.versions.v1', JSON.stringify(mockSheets));
+
+    const { result } = renderHook(() => useUserSelectionStepData());
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(result.current.planningSheets.size).toBe(1);
+    expect(result.current.planningSheets.get('user-A')?.version).toBe(2);
+    expect(result.current.planningSheets.get('user-B')).toBeUndefined();
+  });
+});

--- a/src/features/daily/components/wizard/UserCard.tsx
+++ b/src/features/daily/components/wizard/UserCard.tsx
@@ -1,0 +1,161 @@
+import type { MonitoringDeadlineState } from '@/features/daily/components/MonitoringCountdown';
+import type { IUserMaster } from '@/features/users/types';
+import BlockRoundedIcon from '@mui/icons-material/BlockRounded';
+import EditNoteRoundedIcon from '@mui/icons-material/EditNoteRounded';
+import EventRoundedIcon from '@mui/icons-material/EventRounded';
+import PersonIcon from '@mui/icons-material/Person';
+import WarningAmberRoundedIcon from '@mui/icons-material/WarningAmberRounded';
+import Card from '@mui/material/Card';
+import CardActionArea from '@mui/material/CardActionArea';
+import Chip from '@mui/material/Chip';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import React, { memo, useMemo } from 'react';
+
+export type UserCardProps = {
+  user: IUserMaster;
+  unfilled?: number;
+  abcTodayCount: number;
+  isSelected: boolean;
+  /** 計画未作成フラグ */
+  hasPlan: boolean;
+  /** モニタリングサイクル情報（null = 未設定） */
+  monitoringDeadline: MonitoringDeadlineState | null;
+  onSelect: (userId: string) => void;
+};
+
+export const UserCard: React.FC<UserCardProps> = memo(
+  ({ user, unfilled, abcTodayCount, isSelected, hasPlan, monitoringDeadline, onSelect }) => {
+    const isHighIntensity = user.IsHighIntensitySupportTarget === true;
+    const behaviorScore = user.BehaviorScore;
+    const supportLevel = user.DisabilitySupportLevel;
+
+    // モニタリング期限チップの表示判定
+    const monitoringChip = useMemo(() => {
+      if (!monitoringDeadline || monitoringDeadline.remainingDays === null) return null;
+      const remaining = monitoringDeadline.remainingDays;
+      if (remaining <= 14) return { label: `期限まで${remaining}日`, color: 'error' as const };
+      if (remaining <= 30) return { label: `期限まで${remaining}日`, color: 'warning' as const };
+      return null; // 30日超は非表示
+    }, [monitoringDeadline]);
+
+    return (
+      <Card
+        variant="outlined"
+        sx={{
+          transition: 'box-shadow 0.15s, border-color 0.15s',
+          '&:hover': { borderColor: 'primary.main', boxShadow: 2 },
+          ...(isSelected && {
+            borderColor: 'primary.main',
+            borderWidth: 2,
+            boxShadow: 3,
+          }),
+          ...(!isSelected && isHighIntensity && {
+            borderColor: 'warning.main',
+            borderWidth: 1.5,
+          }),
+        }}
+      >
+        <CardActionArea
+          onClick={() => onSelect(user.UserID)}
+          sx={{ p: 1.5, display: 'flex', flexDirection: 'column', alignItems: 'stretch', gap: 1 }}
+          data-testid={`wizard-user-card-${user.UserID}`}
+        >
+          {/* Row 1: Name */}
+          <Stack direction="row" alignItems="center" spacing={1}>
+            <PersonIcon
+              fontSize="small"
+              sx={{ color: isSelected ? 'primary.main' : isHighIntensity ? 'warning.main' : 'action.active' }}
+            />
+            <Typography variant="subtitle2" fontWeight={700} noWrap sx={{ flex: 1 }}>
+              {user.FullName}
+            </Typography>
+            {unfilled !== undefined && unfilled > 0 && (
+              <Chip
+                label={`残${unfilled}`}
+                size="small"
+                color="warning"
+                variant="outlined"
+                sx={{ fontSize: '0.7rem' }}
+              />
+            )}
+          </Stack>
+
+          {/* Row 2: Support Level + Behavior Score */}
+          <Stack direction="row" spacing={0.5} alignItems="center" flexWrap="wrap" useFlexGap>
+            <Typography variant="caption" color="text.secondary">
+              {supportLevel || '区分未設定'}
+            </Typography>
+            {behaviorScore != null && (
+              <>
+                <Typography variant="caption" color="text.secondary">/</Typography>
+                <Typography
+                  variant="caption"
+                  fontWeight={600}
+                  color={behaviorScore >= 10 ? 'error.main' : 'text.secondary'}
+                >
+                  行動関連{behaviorScore}点
+                </Typography>
+              </>
+            )}
+          </Stack>
+
+          {/* Row 3: Status Chips */}
+          <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
+            {isHighIntensity && (
+              <Chip
+                icon={<WarningAmberRoundedIcon />}
+                label="強度行動障害"
+                size="small"
+                color="warning"
+                variant="filled"
+                sx={{ fontSize: '0.7rem', height: 22 }}
+              />
+            )}
+            {!hasPlan && (
+              <Chip
+                icon={<BlockRoundedIcon />}
+                label="計画未作成"
+                size="small"
+                color="error"
+                variant="outlined"
+                sx={{ fontSize: '0.7rem', height: 22 }}
+              />
+            )}
+            {monitoringChip && (
+              <Chip
+                icon={<EventRoundedIcon />}
+                label={monitoringChip.label}
+                size="small"
+                color={monitoringChip.color}
+                variant="outlined"
+                sx={{ fontSize: '0.7rem', height: 22 }}
+              />
+            )}
+            {abcTodayCount > 0 ? (
+              <Chip
+                icon={<EditNoteRoundedIcon />}
+                label={`ABC ${abcTodayCount}件`}
+                size="small"
+                color="info"
+                variant="outlined"
+                sx={{ fontSize: '0.7rem', height: 22 }}
+              />
+            ) : (
+              isHighIntensity && (
+                <Chip
+                  label="今日未記録"
+                  size="small"
+                  variant="outlined"
+                  sx={{ fontSize: '0.7rem', height: 22, color: 'text.secondary', borderColor: 'divider' }}
+                />
+              )
+            )}
+          </Stack>
+        </CardActionArea>
+      </Card>
+    );
+  },
+);
+
+UserCard.displayName = 'UserCard';

--- a/src/features/daily/components/wizard/UserSelectionStep.tsx
+++ b/src/features/daily/components/wizard/UserSelectionStep.tsx
@@ -14,25 +14,15 @@
  *   ・最新ABC記録日
  *   → 「支援手順へ進む」ボタン
  */
-import type { AbcRecord } from '@/domain/abc/abcRecord';
-import type { SupportPlanningSheet } from '@/domain/isp/schema';
-import { computeMonitoringDeadlineFromSupportStart, type MonitoringDeadlineState } from '@/features/daily/components/MonitoringCountdown';
+import { computeMonitoringDeadlineFromSupportStart } from '@/features/daily/components/MonitoringCountdown';
 import type { DailySupportUserFilter } from '@/features/daily/hooks/useDailySupportUserFilter';
 import type { IUserMaster } from '@/features/users/types';
 import { DISABILITY_SUPPORT_LEVEL_OPTIONS } from '@/features/users/typesExtended';
-import { useAbcRecordRepository } from '@/infra/abc/useAbcRecordRepository';
-
-
-import BlockRoundedIcon from '@mui/icons-material/BlockRounded';
 import EditNoteRoundedIcon from '@mui/icons-material/EditNoteRounded';
-import EventRoundedIcon from '@mui/icons-material/EventRounded';
 import FilterListOffIcon from '@mui/icons-material/FilterListOff';
 import PersonIcon from '@mui/icons-material/Person';
 import WarningAmberRoundedIcon from '@mui/icons-material/WarningAmberRounded';
 import Box from '@mui/material/Box';
-
-import Card from '@mui/material/Card';
-import CardActionArea from '@mui/material/CardActionArea';
 import Chip from '@mui/material/Chip';
 import FormControl from '@mui/material/FormControl';
 import IconButton from '@mui/material/IconButton';
@@ -43,7 +33,9 @@ import Stack from '@mui/material/Stack';
 import ToggleButton from '@mui/material/ToggleButton';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
-import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import React, { memo, useCallback, useMemo } from 'react';
+import { UserCard } from './UserCard';
+import { useUserSelectionStepData } from './hooks/useUserSelectionStepData';
 
 // ─────────────────────────────────────────────
 // Types
@@ -62,229 +54,6 @@ export type UserSelectionStepProps = {
 };
 
 // ─────────────────────────────────────────────
-// ABC 記録データの取得
-// ─────────────────────────────────────────────
-
-interface AbcSummary {
-  /** 利用者ごとの今日の件数 */
-  todayCounts: Map<string, number>;
-  /** 利用者ごとの最新記録日 */
-  latestDates: Map<string, string>;
-}
-
-function useAbcSummary(): AbcSummary {
-  const abcRecordRepo = useAbcRecordRepository();
-  const [summary, setSummary] = useState<AbcSummary>({
-    todayCounts: new Map(),
-    latestDates: new Map(),
-  });
-
-  useEffect(() => {
-    let mounted = true;
-    (async () => {
-      try {
-        const all: AbcRecord[] = await abcRecordRepo.getAll();
-        const today = new Date().toISOString().slice(0, 10);
-        const todayCounts = new Map<string, number>();
-        const latestDates = new Map<string, string>();
-
-        for (const r of all) {
-          // 今日の件数
-          if (r.occurredAt.slice(0, 10) === today) {
-            todayCounts.set(r.userId, (todayCounts.get(r.userId) ?? 0) + 1);
-          }
-          // 最新記録日
-          const existing = latestDates.get(r.userId);
-          if (!existing || r.occurredAt > existing) {
-            latestDates.set(r.userId, r.occurredAt);
-          }
-        }
-        if (mounted) setSummary({ todayCounts, latestDates });
-      } catch {
-        // localStorage 読み込み失敗は無視
-      }
-    })();
-    return () => { mounted = false; };
-  }, [abcRecordRepo]);
-
-  return summary;
-}
-
-// ─────────────────────────────────────────────
-// 支援計画シート状態の取得
-// ─────────────────────────────────────────────
-
-function usePlanningSheetStatus(): Map<string, SupportPlanningSheet> {
-  const [sheets, setSheets] = useState<Map<string, SupportPlanningSheet>>(new Map());
-
-  useEffect(() => {
-    let mounted = true;
-    try {
-      const raw = localStorage.getItem('planningSheet.versions.v1');
-      if (!raw) return;
-      const all: SupportPlanningSheet[] = JSON.parse(raw);
-      const map = new Map<string, SupportPlanningSheet>();
-      // 各ユーザーの最新の active 版を取得
-      for (const s of all) {
-        if (s.status === 'active' && s.isCurrent) {
-          const existing = map.get(s.userId);
-          if (!existing || s.version > (existing.version ?? 0)) {
-            map.set(s.userId, s);
-          }
-        }
-      }
-      if (mounted) setSheets(map);
-    } catch {
-      // ignore
-    }
-    return () => { mounted = false; };
-  }, []);
-
-  return sheets;
-}
-
-// ─────────────────────────────────────────────
-// User Card
-// ─────────────────────────────────────────────
-
-const UserCard: React.FC<{
-  user: IUserMaster;
-  unfilled?: number;
-  abcTodayCount: number;
-  isSelected: boolean;
-  /** 計画未作成フラグ */
-  hasPlan: boolean;
-  /** モニタリングサイクル情報（null = 未設定） */
-  monitoringDeadline: MonitoringDeadlineState | null;
-  onSelect: (userId: string) => void;
-}> = memo(({ user, unfilled, abcTodayCount, isSelected, hasPlan, monitoringDeadline, onSelect }) => {
-  const isHighIntensity = user.IsHighIntensitySupportTarget === true;
-  const behaviorScore = user.BehaviorScore;
-  const supportLevel = user.DisabilitySupportLevel;
-
-  // モニタリング期限チップの表示判定
-  const monitoringChip = useMemo(() => {
-    if (!monitoringDeadline || monitoringDeadline.remainingDays === null) return null;
-    const remaining = monitoringDeadline.remainingDays;
-    if (remaining <= 14) return { label: `期限まで${remaining}日`, color: 'error' as const };
-    if (remaining <= 30) return { label: `期限まで${remaining}日`, color: 'warning' as const };
-    return null; // 30日超は非表示
-  }, [monitoringDeadline]);
-
-  return (
-    <Card
-      variant="outlined"
-      sx={{
-        transition: 'box-shadow 0.15s, border-color 0.15s',
-        '&:hover': { borderColor: 'primary.main', boxShadow: 2 },
-        ...(isSelected && {
-          borderColor: 'primary.main',
-          borderWidth: 2,
-          boxShadow: 3,
-        }),
-        ...(!isSelected && isHighIntensity && {
-          borderColor: 'warning.main',
-          borderWidth: 1.5,
-        }),
-      }}
-    >
-      <CardActionArea
-        onClick={() => onSelect(user.UserID)}
-        sx={{ p: 1.5, display: 'flex', flexDirection: 'column', alignItems: 'stretch', gap: 1 }}
-        data-testid={`wizard-user-card-${user.UserID}`}
-      >
-        {/* Row 1: Name */}
-        <Stack direction="row" alignItems="center" spacing={1}>
-          <PersonIcon
-            fontSize="small"
-            sx={{ color: isSelected ? 'primary.main' : isHighIntensity ? 'warning.main' : 'action.active' }}
-          />
-          <Typography variant="subtitle2" fontWeight={700} noWrap sx={{ flex: 1 }}>
-            {user.FullName}
-          </Typography>
-          {unfilled !== undefined && unfilled > 0 && (
-            <Chip label={`残${unfilled}`} size="small" color="warning" variant="outlined" sx={{ fontSize: '0.7rem' }} />
-          )}
-        </Stack>
-
-        {/* Row 2: Support Level + Behavior Score */}
-        <Stack direction="row" spacing={0.5} alignItems="center" flexWrap="wrap" useFlexGap>
-          <Typography variant="caption" color="text.secondary">
-            {supportLevel || '区分未設定'}
-          </Typography>
-          {behaviorScore != null && (
-            <>
-              <Typography variant="caption" color="text.secondary">/</Typography>
-              <Typography
-                variant="caption"
-                fontWeight={600}
-                color={behaviorScore >= 10 ? 'error.main' : 'text.secondary'}
-              >
-                行動関連{behaviorScore}点
-              </Typography>
-            </>
-          )}
-        </Stack>
-
-        {/* Row 3: Status Chips */}
-        <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
-          {isHighIntensity && (
-            <Chip
-              icon={<WarningAmberRoundedIcon />}
-              label="強度行動障害"
-              size="small"
-              color="warning"
-              variant="filled"
-              sx={{ fontSize: '0.7rem', height: 22 }}
-            />
-          )}
-          {!hasPlan && (
-            <Chip
-              icon={<BlockRoundedIcon />}
-              label="計画未作成"
-              size="small"
-              color="error"
-              variant="outlined"
-              sx={{ fontSize: '0.7rem', height: 22 }}
-            />
-          )}
-          {monitoringChip && (
-            <Chip
-              icon={<EventRoundedIcon />}
-              label={monitoringChip.label}
-              size="small"
-              color={monitoringChip.color}
-              variant="outlined"
-              sx={{ fontSize: '0.7rem', height: 22 }}
-            />
-          )}
-          {abcTodayCount > 0 ? (
-            <Chip
-              icon={<EditNoteRoundedIcon />}
-              label={`ABC ${abcTodayCount}件`}
-              size="small"
-              color="info"
-              variant="outlined"
-              sx={{ fontSize: '0.7rem', height: 22 }}
-            />
-          ) : isHighIntensity && (
-            <Chip
-              label="今日未記録"
-              size="small"
-              variant="outlined"
-              sx={{ fontSize: '0.7rem', height: 22, color: 'text.secondary', borderColor: 'divider' }}
-            />
-          )}
-        </Stack>
-      </CardActionArea>
-    </Card>
-  );
-});
-UserCard.displayName = 'UserCard';
-
-
-
-// ─────────────────────────────────────────────
 // Main Component
 // ─────────────────────────────────────────────
 
@@ -298,15 +67,12 @@ export const UserSelectionStep: React.FC<UserSelectionStepProps> = memo(({
   onSelectUser,
   unfilledCountMap,
 }) => {
-  const abcSummary = useAbcSummary();
-  const planningSheets = usePlanningSheetStatus();
+  const { abcSummary, planningSheets } = useUserSelectionStepData();
 
   // ── カードタップで即 Step 2 へ遷移 ──
   const handleCardClick = useCallback((userId: string) => {
     onSelectUser(userId);
   }, [onSelectUser]);
-
-
 
   // Sort: 強度行動障害対象者を先頭 → 行動関連項目点数の降順
   const sortedUsers = useMemo(() => {
@@ -324,8 +90,6 @@ export const UserSelectionStep: React.FC<UserSelectionStepProps> = memo(({
     () => filteredUsers.filter(u => u.IsHighIntensitySupportTarget === true).length,
     [filteredUsers],
   );
-
-
 
   return (
     <Box sx={{ p: 2, height: '100%', display: 'flex', flexDirection: 'column', gap: 2 }}>

--- a/src/features/daily/components/wizard/hooks/useUserSelectionStepData.ts
+++ b/src/features/daily/components/wizard/hooks/useUserSelectionStepData.ts
@@ -1,0 +1,92 @@
+import type { AbcRecord } from '@/domain/abc/abcRecord';
+import type { SupportPlanningSheet } from '@/domain/isp/schema';
+import { useAbcRecordRepository } from '@/infra/abc/useAbcRecordRepository';
+import { useEffect, useState } from 'react';
+
+export interface AbcSummary {
+  /** 利用者ごとの今日の件数 */
+  todayCounts: Map<string, number>;
+  /** 利用者ごとの最新記録日 */
+  latestDates: Map<string, string>;
+}
+
+export function useAbcSummary(): AbcSummary {
+  const abcRecordRepo = useAbcRecordRepository();
+  const [summary, setSummary] = useState<AbcSummary>({
+    todayCounts: new Map(),
+    latestDates: new Map(),
+  });
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const all: AbcRecord[] = await abcRecordRepo.getAll();
+        const today = new Date().toISOString().slice(0, 10);
+        const todayCounts = new Map<string, number>();
+        const latestDates = new Map<string, string>();
+
+        for (const r of all) {
+          // 今日の件数
+          if (r.occurredAt.slice(0, 10) === today) {
+            todayCounts.set(r.userId, (todayCounts.get(r.userId) ?? 0) + 1);
+          }
+          // 最新記録日
+          const existing = latestDates.get(r.userId);
+          if (!existing || r.occurredAt > existing) {
+            latestDates.set(r.userId, r.occurredAt);
+          }
+        }
+        if (mounted) setSummary({ todayCounts, latestDates });
+      } catch {
+        // localStorage 読み込み失敗は無視
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [abcRecordRepo]);
+
+  return summary;
+}
+
+export function usePlanningSheetStatus(): Map<string, SupportPlanningSheet> {
+  const [sheets, setSheets] = useState<Map<string, SupportPlanningSheet>>(new Map());
+
+  useEffect(() => {
+    let mounted = true;
+    try {
+      const raw = localStorage.getItem('planningSheet.versions.v1');
+      if (!raw) return;
+      const all: SupportPlanningSheet[] = JSON.parse(raw);
+      const map = new Map<string, SupportPlanningSheet>();
+      // 各ユーザーの最新の active 版を取得
+      for (const s of all) {
+        if (s.status === 'active' && s.isCurrent) {
+          const existing = map.get(s.userId);
+          if (!existing || s.version > (existing.version ?? 0)) {
+            map.set(s.userId, s);
+          }
+        }
+      }
+      if (mounted) setSheets(map);
+    } catch {
+      // ignore
+    }
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  return sheets;
+}
+
+export function useUserSelectionStepData() {
+  const abcSummary = useAbcSummary();
+  const planningSheets = usePlanningSheetStatus();
+
+  return {
+    abcSummary,
+    planningSheets,
+  };
+}


### PR DESCRIPTION
## Summary

Decomposes and hardens the large `UserSelectionStep.tsx` component by splitting it into a clean presenter, a dedicated sub-component, and a custom hook, fulfilling the under-400 lines Nightly Patrol standard.

Closes #1012

### Key Changes
1. **Presenter Separation**: Simplified `UserSelectionStep.tsx` to a pure presenter (shrunk from 435 lines to 231 lines) that handles rendering filters, summaries, and the grid.
2. **Sub-component Extraction**: Created `UserCard.tsx` to encapsulate individual user card rendering, including:
   - High intensity support chips
   - Disability level & behavior scores
   - Monitoring countdown deadlines
   - Today's ABC record count indicator
3. **State Hooks Extraction**: Created `hooks/useUserSelectionStepData.ts` containing `useAbcSummary`, `usePlanningSheetStatus`, and the unified orchestrator hook.
4. **Hardened Testing**: Added 8 comprehensive unit tests:
   - `useUserSelectionStepData.spec.ts` (3 tests testing async data aggregations, today's counts, and version resolution)
   - `UserSelectionStep.spec.tsx` (5 tests testing list sorting, status chips, filters, and user card clicks)

### Verification Results
- **TypeScript Compiler (`tsc`):** PASS ✅
- **Unit Tests (`vitest`):** PASS (8/8 new tests passed successfully) ✅
- **No Behavioral Changes:** Presenter / Hook separation only.