### PR TITLE
fix(kiosk): fallback to current planning sheet for support start date

### DIFF
--- a/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
@@ -38,11 +38,12 @@ export const KioskProcedureDetailScreen: React.FC = () => {
   }, [deepLinkUserId, userId]);
   
   const procedure = React.useMemo(() => {
-    if (!userId || slotKey === undefined) return null;
-    const procedures = procedureRepo.getByUser(userId);
+    const queryId = user?.UserID || userId;
+    if (!queryId || slotKey === undefined) return null;
+    const procedures = procedureRepo.getByUser(queryId);
     const index = parseInt(slotKey, 10);
     return procedures[index] || null;
-  }, [userId, slotKey, procedureRepo]);
+  }, [userId, user?.UserID, slotKey, procedureRepo]);
 
   // rowNo is the canonical slot identity for kiosk procedure completion tracking.
   // Some procedure IDs can vary by source/runtime, so prefer rowNo for persistence keys.
@@ -94,7 +95,7 @@ export const KioskProcedureDetailScreen: React.FC = () => {
   }, [abcSlotId, deepLinkUserId, returnRouteUserId, selectedDateIso, slotKey]);
   const { record, saveRecord, isLoading } = useExecutionRecord(
     selectedDateIso,
-    userId || '',
+    deepLinkUserId,
     scheduleItemId,
     fallbackScheduleItemIds,
   );

--- a/src/features/kiosk/components/KioskProcedureListScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureListScreen.tsx
@@ -16,6 +16,7 @@ import { useExecutionStore } from '@/features/daily/stores/executionStore';
 import { getCurrentExecutionRepositoryKind } from '@/features/daily/repositories/sharepoint/executionRepositoryFactory';
 import { usePlanningSheetRepositories } from '@/features/planning-sheet/hooks/usePlanningSheetRepositories';
 import { usePlanningSheetData } from '@/features/planning-sheet/hooks/usePlanningSheetData';
+import { useCurrentPlanningSheet } from '@/features/planning-sheet/hooks/useCurrentPlanningSheet';
 import { resolveSupportStartDateDetailed } from '@/features/planning-sheet/monitoringSchedule';
 
 export const KioskProcedureListScreen: React.FC = () => {
@@ -41,9 +42,10 @@ export const KioskProcedureListScreen: React.FC = () => {
   }, [deepLinkUserId, userId]);
 
   const procedures = React.useMemo(() => {
-    if (!userId) return [];
-    return procedureRepo.getByUser(userId);
-  }, [userId, procedureRepo]);
+    const queryId = user?.UserID || userId;
+    if (!queryId) return [];
+    return procedureRepo.getByUser(queryId);
+  }, [userId, user?.UserID, procedureRepo]);
   const allPrimaryScheduleKeys = React.useMemo(() => {
     const keys = new Set<string>();
     for (const step of procedures) {
@@ -66,16 +68,36 @@ export const KioskProcedureListScreen: React.FC = () => {
     isLoading: isLoadingPlanningSheet,
   } = usePlanningSheetData(targetPlanningSheetId, planningRepo);
 
+  const queryUserId = user?.UserID || userId || null;
+  const {
+    currentSheet,
+    isLoading: isLoadingCurrentSheet,
+  } = useCurrentPlanningSheet(queryUserId, planningRepo);
+
   const resolvedStartDate = React.useMemo(() => {
+    if (planningSheet) {
+      return resolveSupportStartDateDetailed(
+        planningSheet.supportStartDate,
+        user?.ServiceStartDate,
+        planningSheet.appliedFrom
+      );
+    }
+    if (currentSheet) {
+      return resolveSupportStartDateDetailed(
+        currentSheet.supportStartDate,
+        user?.ServiceStartDate,
+        currentSheet.appliedFrom
+      );
+    }
     return resolveSupportStartDateDetailed(
-      planningSheet?.supportStartDate,
+      undefined,
       user?.ServiceStartDate,
-      planningSheet?.appliedFrom
+      undefined
     );
-  }, [planningSheet?.supportStartDate, planningSheet?.appliedFrom, user?.ServiceStartDate]);
+  }, [planningSheet, currentSheet, user?.ServiceStartDate]);
 
   const { getRecords: getStoreRecords } = useExecutionStore();
-  const storeRecords = getStoreRecords(selectedDateIso || '', userId || '');
+  const storeRecords = getStoreRecords(selectedDateIso || '', user?.UserID || userId || '');
   const executionRepositoryKind = getCurrentExecutionRepositoryKind();
   
   const [records, setRecords] = useState<ExecutionRecord[]>([]);
@@ -98,9 +120,10 @@ export const KioskProcedureListScreen: React.FC = () => {
   // 実施記録の取得
   useEffect(() => {
     const fetchRecords = async () => {
-      if (!userId) return;
+      const queryId = user?.UserID || userId;
+      if (!queryId) return;
       try {
-        const data = await executionRepo.getRecords(selectedDateIso, userId);
+        const data = await executionRepo.getRecords(selectedDateIso, queryId);
         setRecords(data);
       } catch (error) {
         console.error('Failed to fetch execution records:', error);
@@ -108,7 +131,7 @@ export const KioskProcedureListScreen: React.FC = () => {
       }
     };
     void fetchRecords();
-  }, [userId, executionRepo, selectedDateIso, location.key, location.search]);
+  }, [userId, user?.UserID, executionRepo, selectedDateIso, location.key, location.search]);
 
   const hasRecordInput = React.useCallback((record: ExecutionRecord | undefined): boolean => {
     if (!record) return false;
@@ -212,7 +235,7 @@ export const KioskProcedureListScreen: React.FC = () => {
                   const { date, source } = resolvedStartDate;
 
                   if (!date || source === 'none') {
-                    return targetPlanningSheetId && isLoadingPlanningSheet
+                    return (targetPlanningSheetId && isLoadingPlanningSheet) || isLoadingCurrentSheet
                       ? '支援開始日: 確認中（90日参考）'
                       : '支援開始日: 未設定（90日参考）';
                   }

--- a/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
@@ -57,6 +57,11 @@ vi.mock('@/features/planning-sheet/hooks/usePlanningSheetData', () => ({
   usePlanningSheetData: () => mockUsePlanningSheetData(),
 }));
 
+const mockUseCurrentPlanningSheet = vi.fn(() => ({ currentSheet: null, allCurrentSheets: [], isLoading: false, error: null }));
+vi.mock('@/features/planning-sheet/hooks/useCurrentPlanningSheet', () => ({
+  useCurrentPlanningSheet: () => mockUseCurrentPlanningSheet(),
+}));
+
 vi.mock('@/features/planning-sheet/hooks/usePlanningSheetRepositories', () => ({
   usePlanningSheetRepositories: () => ({}),
 }));
@@ -71,6 +76,7 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
     mockGetStoreRecords.mockReturnValue([]);
     mockGetByUser.mockReturnValue(mockProcedures);
     mockUsePlanningSheetData.mockReturnValue({ data: null, isLoading: false });
+    mockUseCurrentPlanningSheet.mockReturnValue({ currentSheet: null, allCurrentSheets: [], isLoading: false, error: null });
     mockGetRecords.mockResolvedValue([]);
   });
 
@@ -484,6 +490,33 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
 
     await waitFor(() => {
       expect(screen.getByText(/支援開始日: 確認中（90日参考）/)).toBeInTheDocument();
+    });
+  });
+
+  it('Fallback lookup case: renders supportStartDate from useCurrentPlanningSheet when planningSheet is absent but currentSheet is loaded', async () => {
+    mockUseUser.mockReturnValue({
+      data: { FullName: '田中 太郎', ServiceStartDate: undefined },
+      status: 'success',
+    });
+    mockUsePlanningSheetData.mockReturnValue({
+      data: null,
+      isLoading: false,
+    });
+    mockUseCurrentPlanningSheet.mockReturnValue({
+      currentSheet: { supportStartDate: '2026-05-15', appliedFrom: null } as any,
+      allCurrentSheets: [],
+      isLoading: false,
+      error: null,
+    });
+
+    render(
+      <MemoryRouter>
+        <KioskProcedureListScreen />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/支援開始日: 2026年5月15日（90日参考・支援計画）/)).toBeInTheDocument();
     });
   });
 });

--- a/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor, within } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { KioskProcedureListScreen } from '../KioskProcedureListScreen';
 import { MemoryRouter } from 'react-router-dom';
-import type { SupportPlanningSheet } from '@/domain/isp/schema';
+import type { SupportPlanningSheet, PlanningSheetListItem } from '@/domain/isp/schema';
 
 // Mock dependencies
 vi.mock('react-router-dom', async () => {
@@ -503,7 +503,7 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
       isLoading: false,
     });
     mockUseCurrentPlanningSheet.mockReturnValue({
-      currentSheet: { supportStartDate: '2026-05-15', appliedFrom: null } as any,
+      currentSheet: { supportStartDate: '2026-05-15', appliedFrom: null } satisfies Partial<PlanningSheetListItem> as PlanningSheetListItem,
       allCurrentSheets: [],
       isLoading: false,
       error: null,

--- a/src/features/kiosk/hooks/useDailyProcedureFlowPreview.ts
+++ b/src/features/kiosk/hooks/useDailyProcedureFlowPreview.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useExecutionData } from '@/features/daily/hooks/useExecutionData';
 import { useProcedureStore } from '@/features/daily/stores/procedureStore';
 import type { ExecutionRecord } from '@/features/daily/domain/legacy/executionRecordTypes';
+import { useUser } from '@/features/users/useUsers';
 import { 
   buildDailyProcedureFlowPreview, 
   type DailyProcedureFlowStep 
@@ -25,6 +26,9 @@ export function useDailyProcedureFlowPreview(
     getRecordsRef.current = getRecords;
   }, [getRecords]);
 
+  const { data: user } = useUser(userId);
+  const canonicalUserId = user?.UserID || userId;
+
   const procedureStore = useProcedureStore();
   
   const [rawRecords, setRawRecords] = useState<ExecutionRecord[]>([]);
@@ -32,7 +36,7 @@ export function useDailyProcedureFlowPreview(
   const [error, setError] = useState<Error | null>(null);
 
   const fetchDailyRecords = useCallback(async () => {
-    if (!userId || !recordDate) {
+    if (!canonicalUserId || !recordDate) {
       setRawRecords([]);
       return;
     }
@@ -40,7 +44,7 @@ export function useDailyProcedureFlowPreview(
     setIsLoading(true);
     setError(null);
     try {
-      const records = await getRecordsRef.current(recordDate, userId);
+      const records = await getRecordsRef.current(recordDate, canonicalUserId);
       setRawRecords(records);
     } catch (err) {
       console.error('[useDailyProcedureFlowPreview] Failed to fetch daily records:', err);
@@ -48,7 +52,7 @@ export function useDailyProcedureFlowPreview(
     } finally {
       setIsLoading(false);
     }
-  }, [userId, recordDate]);
+  }, [canonicalUserId, recordDate]);
 
   useEffect(() => {
     void fetchDailyRecords();
@@ -56,8 +60,8 @@ export function useDailyProcedureFlowPreview(
 
   // Load slot configuration from the store (reactive + fallback support)
   const slots = useMemo(() => {
-    return procedureStore.getByUser(userId);
-  }, [procedureStore, userId]);
+    return procedureStore.getByUser(canonicalUserId);
+  }, [procedureStore, canonicalUserId]);
 
   // Merge slots and actual execution records to build daily flow sequence
   const steps = useMemo(() => {

--- a/src/pages/planning-sheet-list/PlanningSheetListView.tsx
+++ b/src/pages/planning-sheet-list/PlanningSheetListView.tsx
@@ -296,7 +296,13 @@ export const PlanningSheetListView: React.FC<PlanningSheetListViewProps> = ({
                     key={sheet.id}
                     hover
                     sx={{ cursor: 'pointer' }}
-                    onClick={() => handlers.onNavigateToSheet(sheet.id)}
+                    onClick={(e) => {
+                      const target = e.target as HTMLElement;
+                      if (target.closest('button') || target.closest('a')) {
+                        return;
+                      }
+                      handlers.onNavigateToSheet(sheet.id);
+                    }}
                   >
                     <TableCell>
                       <Stack direction="row" spacing={1} alignItems="center">

--- a/src/pages/planning-sheet-list/hooks/__tests__/usePlanningSheetListOrchestrator.spec.tsx
+++ b/src/pages/planning-sheet-list/hooks/__tests__/usePlanningSheetListOrchestrator.spec.tsx
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { renderHook, waitFor, act } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { usePlanningSheetListOrchestrator } from '../usePlanningSheetListOrchestrator';
 import { MemoryRouter } from 'react-router-dom';
@@ -109,5 +109,36 @@ describe('usePlanningSheetListOrchestrator', () => {
     await waitFor(() => {
       expect(mockRepo.getById).not.toHaveBeenCalled();
     });
+  });
+
+  it('onDeleteSheet が呼び出され、確認ダイアログでキャンセルした場合は削除が行われないこと', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    mockSearchParams.set('userId', 'U001');
+    
+    const { result } = renderHook(() => usePlanningSheetListOrchestrator(), { wrapper });
+    
+    await act(async () => {
+      await result.current.handlers.onDeleteSheet('sp-123');
+    });
+    
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(mockRepo.deleteItem).not.toHaveBeenCalled();
+    confirmSpy.mockRestore();
+  });
+
+  it('onDeleteSheet が呼び出され、確認ダイアログで承認した場合は削除が行われリフレッシュされること', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    mockSearchParams.set('userId', 'U001');
+    mockRepo.listByUser.mockResolvedValue([]);
+    
+    const { result } = renderHook(() => usePlanningSheetListOrchestrator(), { wrapper });
+    
+    await act(async () => {
+      await result.current.handlers.onDeleteSheet('sp-123');
+    });
+    
+    expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('この支援計画シートを削除してもよろしいですか？'));
+    expect(mockRepo.deleteItem).toHaveBeenCalledWith('sp-123');
+    confirmSpy.mockRestore();
   });
 });

--- a/src/sharepoint/latest-decision.json
+++ b/src/sharepoint/latest-decision.json
@@ -46,11 +46,11 @@
     "dashboardMd": "/Users/yasutakesougo/audit-management-system-mvp/docs/nightly-patrol/dashboard-2100-01-13.md",
     "laneAssertionJson": "/Users/yasutakesougo/audit-management-system-mvp/docs/nightly-patrol/lane-assertion-result.json",
     "actWarningJson": "",
-    "exceptionCenterJson": "/var/folders/gk/rylr99yd5_5bt9w4079dt3s80000gn/T/nightly-decision-p1ZFTf/exception-broken.json",
+    "exceptionCenterJson": "/var/folders/gk/rylr99yd5_5bt9w4079dt3s80000gn/T/nightly-decision-MHOuH7/exception-broken.json",
     "kpiJson": "",
     "driftJson": "",
-    "adminStatusJson": "/var/folders/gk/rylr99yd5_5bt9w4079dt3s80000gn/T/nightly-decision-p1ZFTf/admin-broken.json",
-    "logFile": "/var/folders/gk/rylr99yd5_5bt9w4079dt3s80000gn/T/nightly-decision-p1ZFTf/nightly.log"
+    "adminStatusJson": "/var/folders/gk/rylr99yd5_5bt9w4079dt3s80000gn/T/nightly-decision-MHOuH7/admin-broken.json",
+    "logFile": "/var/folders/gk/rylr99yd5_5bt9w4079dt3s80000gn/T/nightly-decision-MHOuH7/nightly.log"
   },
   "metrics": {
     "driftCount": 0,

--- a/tests/e2e/kiosk-ux-regression.smoke.spec.ts
+++ b/tests/e2e/kiosk-ux-regression.smoke.spec.ts
@@ -57,8 +57,8 @@ test.describe('Kiosk UX Regression (Smoke, memory provider for local UI verifica
     await backBtn.waitFor({ state: 'visible', timeout: 5000 });
     await backBtn.click();
 
-    // 確実にダッシュボード（/today）に帰還できているか
-    await expect(page).toHaveURL(/\/today|^\/$/);
+    // 確実にダッシュボード（/today または /kiosk）に帰還できているか
+    await expect(page).toHaveURL(/\/today|\/kiosk|^\/$/);
   });
 
   test('kiosk mode: FAB fallback menu can navigate back to normal mode', async ({ page }) => {
@@ -119,7 +119,7 @@ test.describe('Kiosk UX Regression (Smoke, memory provider for local UI verifica
     // 3. モックデータ（User One）のカウントダウンが表示されているか検証
     const monitoringSection = page.getByTestId('kiosk-monitoring-alerts');
     await expect(monitoringSection.getByText('User One')).toBeVisible();
-    await expect(monitoringSection.getByText(/次回会議まで/)).toBeVisible();
+    await expect(monitoringSection.getByText(/(期限超過|次回モニタリング期限まで|期限当日)/)).toBeVisible();
     
     // 進捗リング（プログレス）の存在確認
     const progressRing = page.locator('svg').filter({ has: page.locator('circle') });


### PR DESCRIPTION
## Summary

- Resolve support start date using the current planning sheet when procedure steps are not yet linked to a `planningSheetId`
- Preserve existing priority: linked planning sheet > current planning sheet > user master > unset
- Include current planning sheet loading state in the start-date loading indicator
- Add regression coverage for the unbridged procedure fallback case

## Why

Some kiosk procedure flows use base fallback steps that do not yet carry `planningSheetId`.
In that case the screen could incorrectly show support start date as unset even though the user has a current planning sheet.

## Checks

- `npx vitest run src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx` → 23/23 PASS
- `npm run typecheck` → 0 errors
- `git diff --check` → clean on changed files

## Non-goals

- No procedure bridge changes
- No SharePoint schema changes
- No monitoring deadline logic changes