### PR TITLE
fix(ui): remove invalid telemetry and svg attribute warnings

### DIFF
--- a/src/app/navigation/planningNavTelemetry.ts
+++ b/src/app/navigation/planningNavTelemetry.ts
@@ -89,13 +89,16 @@ export function recordPlanningNavTelemetry(event: PlanningNavTelemetryEvent): vo
     return;
   }
 
-  const payload = {
+  const payloadBase = {
     ...event,
     event: event.eventName,
     type: 'planning_nav_telemetry' as const,
     ts: serverTimestamp(),
     clientTs: new Date().toISOString(),
   };
+  const payload = Object.fromEntries(
+    Object.entries(payloadBase).filter(([, value]) => value !== undefined),
+  );
 
   try {
     addDoc(collection(getDb(), 'telemetry'), payload).catch((err) => {
@@ -165,4 +168,3 @@ export function maybeRecordPlanningNavRetention(
     retentionWindowDays,
   });
 }
-

--- a/src/features/planning-sheet/components/new-form/components/illustrations/IcebergIllustration.tsx
+++ b/src/features/planning-sheet/components/new-form/components/illustrations/IcebergIllustration.tsx
@@ -25,10 +25,9 @@ export const IcebergIllustration: React.FC<IcebergIllustrationProps> = ({ surfac
       <svg
         viewBox="0 0 520 400"
         width="100%"
-        height="auto"
         role="img"
         aria-label="氷山分析の構造図"
-        style={{ display: 'block', maxWidth: '520px' }}
+        style={{ display: 'block', maxWidth: '520px', height: 'auto' }}
       >
         {/* タイトル */}
         <text x="260" y="30" textAnchor="middle" fontSize="22" fontWeight="800" fill="#0c4a6e">氷山分析</text>


### PR DESCRIPTION
## Summary

- Avoid sending undefined fromPath values to Firestore planning navigation telemetry
- Remove invalid svg height="auto" attribute from IcebergIllustration and move sizing to style

## Why

Browser logs showed two actionable warning sources:
- planning-nav:telemetry Unsupported field value: undefined (fromPath)
- <svg> attribute height: Expected length, "auto"

## Checks

- npm run typecheck
- npx vitest run src/app/navigation/__tests__/planningNavTelemetry.spec.ts

## Non-goals

- No telemetry schema redesign
- No illustration visual redesign
- No SharePoint or planning-sheet data changes