### PR TITLE
fix(e2e): seed kiosk monitoring users for memory provider

### DIFF
--- a/src/data/isp/__tests__/mapper.spec.ts
+++ b/src/data/isp/__tests__/mapper.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { mapPlanningSheetRowToDomain } from '../mapper';
+import { mapPlanningSheetRowToDomain, mapPlanningSheetRowToListItem, extractSpId } from '../mapper';
 import type { SpPlanningSheetRow } from '@/lib/sp/types';
 
 describe('isp mapper parseDateOnly', () => {
@@ -35,3 +35,29 @@ describe('isp mapper parseDateOnly', () => {
     expect(domain3.appliedFrom).toBeNull();
   });
 });
+
+describe('isp mapper ID normalization', () => {
+  it('mapPlanningSheetRowToListItem handles id, Id, ID keys correctly', () => {
+    const baseRow: Partial<SpPlanningSheetRow> = {
+      title: 'Test',
+      userCode: 'U-001',
+      ispId: 'isp-123',
+    };
+
+    const rowId = { ...baseRow, id: 101 } as unknown as SpPlanningSheetRow;
+    const rowIdUpper = { ...baseRow, Id: 102 } as unknown as SpPlanningSheetRow;
+    const rowIdAllCaps = { ...baseRow, ID: 103 } as unknown as SpPlanningSheetRow;
+
+    expect(mapPlanningSheetRowToListItem(rowId).id).toBe('sp-101');
+    expect(mapPlanningSheetRowToListItem(rowIdUpper).id).toBe('sp-102');
+    expect(mapPlanningSheetRowToListItem(rowIdAllCaps).id).toBe('sp-103');
+  });
+
+  it('extractSpId correctly trims and parses various formats', () => {
+    expect(extractSpId(' sp-123 ')).toBe(123);
+    expect(extractSpId('sp-456')).toBe(456);
+    expect(extractSpId(' 789 ')).toBe(789);
+    expect(extractSpId('invalid')).toBeNull();
+  });
+});
+

--- a/src/features/today/components/KioskHeroBlock.tsx
+++ b/src/features/today/components/KioskHeroBlock.tsx
@@ -164,6 +164,7 @@ export const KioskHeroBlock: React.FC<KioskHeroBlockProps> = ({
   // ── モニタリング警告（残り30日以内） ──
   const monitoringAlerts = React.useMemo(() => {
     if (!users) return [];
+
     const now = new Date();
     return users
       .filter((u) => u.LastAssessmentDate)

--- a/src/lib/data/inMemoryDataProvider.ts
+++ b/src/lib/data/inMemoryDataProvider.ts
@@ -21,19 +21,65 @@ export class InMemoryDataProvider implements IDataProvider {
       { Id: 2, StaffID: 'STF002', FullName: 'Staff Two', Role: 'admin', IsActive: true },
     ]);
     this.storage.set('Users_Master', [
-      { 
-        Id: 1, 
-        UserID: 'USR001', 
-        FullName: 'User One', 
-        Status: 'active', 
-        IsActive: true, 
-        RecipientCertNumber: '1234567890',
-        LastAssessmentDate: '2026-02-15' // 約3ヶ月前
+      {
+        Id: 1,
+        UserID: 'U-001',
+        FullName: '桂川 進太朗',
+        Furigana: 'かつらがわ しんたろう',
+        ServiceStartDate: '2034-04-01',
+        ContractDate: '2034-03-15',
+        IsActive: true,
+        IsHighIntensitySupportTarget: true,
+        IsSupportProcedureTarget: true,
+        ServiceEndDate: null,
+        AttendanceDays: ['月', '火', '水', '木', '金'],
+        LastAssessmentDate: '2026-01-15',
+      },
+      {
+        Id: 2,
+        UserID: 'U-005',
+        FullName: '田中 太郎',
+        Furigana: 'たなか たろう',
+        ServiceStartDate: '2034-06-01',
+        ContractDate: '2034-05-20',
+        IsActive: true,
+        IsHighIntensitySupportTarget: true,
+        IsSupportProcedureTarget: false,
+        ServiceEndDate: null,
+        AttendanceDays: ['月', '水', '金'],
+        LastAssessmentDate: '2026-02-10',
+      },
+      {
+        Id: 3,
+        UserID: 'U-012',
+        FullName: '塩田 裕貴',
+        Furigana: 'しおだ ひろき',
+        ServiceStartDate: '2034-08-01',
+        ContractDate: '2034-07-15',
+        IsActive: true,
+        IsHighIntensitySupportTarget: true,
+        IsSupportProcedureTarget: true,
+        ServiceEndDate: null,
+        AttendanceDays: ['火', '木', '金'],
+        LastAssessmentDate: '2025-12-20',
+      },
+      {
+        Id: 4,
+        UserID: 'I005',
+        FullName: '石渡 由喜子',
+        Furigana: 'いしわた ゆきこ',
+        ServiceStartDate: '2034-04-15',
+        ContractDate: '2034-03-30',
+        IsActive: true,
+        IsHighIntensitySupportTarget: true,
+        IsSupportProcedureTarget: true,
+        ServiceEndDate: null,
+        AttendanceDays: ['月', '水', '金'],
       },
     ]);
     // 支援手順の実施状況
     this.storage.set('SupportRecord_Daily', [
-      { Id: 1, UserID: 'USR001', SupportProcedureExecution_Target: '{}', RecordDate: new Date().toISOString().split('T')[0] }
+      { Id: 1, UserID: 'U-001', SupportProcedureExecution_Target: '{}', RecordDate: new Date().toISOString().split('T')[0] }
     ]);
     // スケジュール解決用のダミー (resolveFields が失敗しないため)
     this.storage.set('Schedules', [

--- a/tests/e2e/kiosk-ux-regression.smoke.spec.ts
+++ b/tests/e2e/kiosk-ux-regression.smoke.spec.ts
@@ -108,18 +108,20 @@ test.describe('Kiosk UX Regression (Smoke, memory provider for local UI verifica
   });
 
   test('kiosk mode: display monitoring countdown for impending deadlines', async ({ page }) => {
+    // Freeze time to make countdown deterministic relative to "2026-01-15" last assessment date
+    await page.clock.install({ time: new Date('2026-04-01T00:00:00Z') });
     // 1. KioskモードをURLパラメータで強制し、メモリプロバイダーを使用
     await page.goto('/today?kiosk=1&provider=memory');
     await page.waitForLoadState('networkidle');
 
     // 2. モニタリングアラートセクションが表示されているか検証
-    const monitoringHeader = page.getByText('モニタリング期限', { exact: false });
+    const monitoringHeader = page.getByText('📅 モニタリング期限');
     await expect(monitoringHeader).toBeVisible();
 
-    // 3. モックデータ（User One）のカウントダウンが表示されているか検証
+    // 3. モックデータ（桂川 進太朗）のカウントダウンが表示されているか検証
     const monitoringSection = page.getByTestId('kiosk-monitoring-alerts');
-    await expect(monitoringSection.getByText('User One')).toBeVisible();
-    await expect(monitoringSection.getByText(/(期限超過|次回モニタリング期限まで|期限当日)/)).toBeVisible();
+    await expect(monitoringSection.getByText('桂川 進太朗')).toBeVisible();
+    await expect(monitoringSection).toContainText(/(期限超過|次回モニタリング期限まで|期限当日)/);
     
     // 進捗リング（プログレス）の存在確認
     const progressRing = page.locator('svg').filter({ has: page.locator('circle') });


### PR DESCRIPTION
## Summary

- Seed the memory data provider with the demo users required by kiosk monitoring countdown scenarios
- Align SupportRecord_Daily memory seed with canonical UserID values
- Make the kiosk monitoring heading locator strict-mode safe in Playwright

## Why

The kiosk UX regression smoke test runs with `provider=memory`.
The in-memory provider previously only seeded a minimal `USR001` user, so the dashboard could not render the expected monitoring countdown alert for `桂川 進太朗`.

With realistic demo users seeded, `LastAssessmentDate: 2026-01-15` is available and the clock-frozen E2E scenario can deterministically show the 14-day monitoring warning.

## Checks

- `npx playwright test tests/e2e/kiosk-ux-regression.smoke.spec.ts --project=chromium`
- `npm run typecheck`
- `npx vitest run src/features/today`

## Non-goals

- No production SharePoint data changes
- No monitoring deadline algorithm changes
- No UI redesign