### PR TITLE
feat(planning-sheet): improve support procedure import UX

### DIFF
--- a/.agents/task_improve_support_procedure_import_ux.md
+++ b/.agents/task_improve_support_procedure_import_ux.md
@@ -1,0 +1,101 @@
+# Task Specification: 支援手順インポーターUX改善 🛠️
+
+## 1. 目的・背景
+`ImportTemplateDialog` の「テンプレートから取り込み」画面は、現状CSV選択に寄っており、CSVの仕様やサンプルダウンロード、および内蔵マスタの適用導線が不足しているため、現場の職員（初見のユーザー）が迷いやすい（バラバラ感がある）というUX上の課題を抱えています。
+本タスクでは、**「PR連携型インポート＝恒久マスタ登録」** と **「UIインポート＝一時検証」** の役割分担を画面上で明確に示し、迷わず安全に手順を取り込めるプレミアムなUIへとアップグレードします。
+
+---
+
+## 2. 実装スコープ・要件
+
+### 1) ImportTemplateDialog.tsx の2タブ化
+ダイアログの上部に `MUI Tabs` を導入し、以下の2つの取り込みルートにUIを分離します。
+* **タブ1**: 「標準テンプレートから選択（推奨）」
+* **タブ2**: 「CSVファイルからインポート」
+
+### 2) タブ1: 「標準テンプレートから選択」の実装
+* `userProcedureDetails.ts` に定義されている、内蔵の17行マスタデータを利用者ID（`userId`）に応じて適用できるワンクリック適用ボタンを配置します。
+* 対象利用者のマスタデータが未登録の場合は、エラーで落とさず「標準テンプレート未登録」と分かりやすく表示します。
+* 既存の手順データが上書きされる可能性がある場合は、適用前に上書き確認のアラート（Warning）を表示します。
+
+### 3) タブ2: 「CSVファイルからインポート」の実装
+* 画面内にCSVの構成列（ヘッダーカラム名）の仕様をヘルプテーブルで明示します。
+  - `RowNo` (任意: 手順の並び順)
+  - `活動内容` (**必須**: 手順内容のベース)
+  - `本人の動き` (任意: 活動内容と自動結合)
+  - `支援者の動き` (任意: 担当スタッフ)
+  - `時間帯` (任意: タイミング)
+* そのままExcel等で編集してインポート可能な **サンプルCSVのダウンロードボタン** を追加します。
+  - 日本語文字化け（Excel等で開く際）を避けるため、**UTF-8 BOM付き** (`0xEF, 0xBB, 0xBF`) の Blob で CSV バイナリを動的生成・ダウンロード可能にします。
+* 既存の `PapaParse` によるCSVパース挙動および変換ロジックは壊さず維持します。
+
+### 4) 2つのインポートルートの役割分担の明示
+ダイアログの上部または説明欄に、以下の役割分担（インセプションガイド）を明記します。
+> 💡 **恒久的な標準手順の登録**は、管理者による「Excel原紙 → MarkItDown → マスタ追加 → テスト → PR」のワークフローで行います。
+>
+> 💻 **この画面のCSV取り込み**は、編集中の支援計画シートへ一時的に手順を差し込んで確認するための機能（一時検証・下書き用）です。
+
+### 5) 支援手順の取り込みガイド（docsヘルプリンク）の設置
+* ダイアログ内の見やすい位置に、管理者向けの「PR連携マスタ登録手順」を解説している公式ドキュメント **`docs/guides/support-procedure-addition-guide.md`**（支援手順追加ガイド）への参照、または **「❓ 取り込みガイドを確認」** のようなガイドリンク（ヘルプボタン）を設置します。
+* これにより、一般の現場職員が「Excelから恒久的にシステムに手順を反映したい」と考えた際に、迷わず公式のPRデプロイルートを参照して管理者と連携できるように促します。
+
+---
+
+## 3. ガードレール・制約事項（厳守）
+* `dailyProcedureMapper.ts` は原則として一切変更しない（L2→L3変換ロジック本体は変更しない）。
+* SharePointへの書き込み・保存仕様は変更しない。
+* UX改善に限定し、1つのクリーンなPRで完結する小さな差分（デグレーションをゼロにする）に抑えること。
+
+---
+
+## 4. 受け入れ条件（Acceptance Criteria）
+* 「テンプレートから取り込み」ダイアログを開いた時点で、恒久登録と一時取り込みの違いが直感的に理解できること。
+* CSVの列仕様がコードやADRを読まなくても画面上で理解できること。
+* サンプルCSVをBOM付きで正常にダウンロードできること。
+* 既存のCSVパースとインポートが壊れず動作すること。
+* 内蔵マスタがある利用者（デモユーザー等）では標準手順を一発適用できること。
+* 内蔵マスタがない利用者でも画面が壊れないこと。
+* `dailyProcedureMapper.ts` の仕様テストおよび既存テストがすべて `PASS` すること。
+
+---
+
+## 5. 検証コマンド
+実装完了後、以下の検証を実施し、すべてクリアすることを確認してください：
+```bash
+npm run typecheck
+npx vitest run src/features/planning-sheet
+npx vitest run src/features/planning-sheet/logic/__tests__/dailyProcedureMapper.spec.ts
+git diff --check
+```
+
+---
+
+## 6. PR情報テンプレート
+
+* **ブランチ名**: `feat/planning-sheet-support-procedure-import-ux`
+* **PRタイトル**: `feat(planning-sheet): improve support procedure import UX`
+* **対象ファイル**:
+  - `src/features/planning-sheet/components/ImportTemplateDialog.tsx`
+  - `src/features/planning-sheet/components/EditablePlanningDesignSection.tsx`
+  - `src/features/planning-sheet/bridge/supportTemplateBridge.ts`
+  - `src/features/planning-sheet/constants/userProcedureDetails.ts`
+  - 関連するテストファイル
+
+### PR説明欄 (Description)
+```markdown
+## Summary
+- 支援手順インポートダイアログを2タブ構成に改善
+- 内蔵標準テンプレート（userProcedureDetails）のワンクリック適用導線を追加
+- CSVの仕様説明テーブルと、BOM付きサンプルCSVのダウンロード機能を追加
+- 画面上に「Excel→PR（恒久マスタ）」と「UI（一時検証）」の役割分担を明示
+
+## Scope
+- UX改善のみ
+- L2→L3変換ロジック、およびSharePoint保存仕様は変更なし
+
+## Checks
+- npm run typecheck (PASS)
+- npx vitest run src/features/planning-sheet (PASS)
+- npx vitest run src/features/planning-sheet/logic/__tests__/dailyProcedureMapper.spec.ts (PASS)
+- git diff --check (PASS)
+```

--- a/docs/ai-operations-log.md
+++ b/docs/ai-operations-log.md
@@ -77,6 +77,38 @@
 
 <!-- ↓ ここから下に追記していく -->
 
+### 2026-05-18 — kiosk / ISP / E2E Hardening Verification 🏁
+
+**ワークフロー**: `/scan` → `/test` → 環境確認
+**対象**: 支援開始日フォールバック、UI/Telemetry警告解消、ISP ID正規化、Kiosk E2Eシードデータ整備
+
+| 判断 | 内容 |
+|------|------|
+| ✅ 採用 | `#1942` Kiosk 支援開始日の `useCurrentPlanningSheet` によるフォールバック解決 |
+| ✅ 採用 | `#1942` `deepLinkUserId` を一貫して用いるIDの正規化により、記録済み不整合バグを解消 |
+| ✅ 採用 | `#1943` Firestore 送信前の `undefined` フィルタリングによるテレメトリ警告の完全クリーンアップ |
+| ✅ 採用 | `#1943` `IcebergIllustration` の `height="auto"` を `style={{ height: 'auto' }}` に移管しSVG属性警告を解消 |
+| ✅ 採用 | `#1944` `row.id` / `Id` / `ID` のフォールバックチェーンとトリミングによるIDパースの頑健化 |
+| ✅ 採用 | `#1945` インメモリプロバイダーへのリアルなシードデータ整備と `page.clock.install` による決定論的E2Eテスト |
+
+**成果**:
+- Git 同期：コミット `6424050f` (origin/main) への完全アライメント
+- ユニットテスト (`mapper.spec.ts` 他 33件) / Playwright E2E (`kiosk-ux-regression.smoke.spec.ts` 4件) → **ALL PASS** 🟢
+- ブラウザ実機検証にて「📅 モニタリング期限」の描画および開始日フォールバックが正常に動作することを確認
+
+**効果測定**:
+- コンソール警告検出数: Before=複数件 (Firestore undefined / SVG invalid attribute) → After=**0件** 🟢
+- テスト実行時のタイミング起因による Flakiness: Before=動的な現在時刻差分により不安定化リスク → After=**時間凍結により極めて強固で決定論的にパス** 🟢
+
+**学び**:
+- **E2Eテストでの時間凍結の強力さ**: モニタリング期限などの経過日数カウントダウンは日付が動的に変わるためテストが壊れやすい。`page.clock.install` を E2E でしっかりと噛ませることで、再現性を完璧に維持できる。
+- **SharePoint ID 揺れの許容**: SharePoint上のプロパティ名は大文字小文字が物理環境によってブレる（`id`, `Id`, `ID`）ため、Candidates フォールバックをモデルマッパーに設けておくアプローチはシステムを壊さない安全弁として極めて有効。
+- **14日警告と実機での超過表示のズレの整理**: PR #1945 の想定設計上の「次回モニタリング期限まで 14日」と、モック環境での判定式による「期限超過 33日」のズレについて、算出スロットや基準日の違いを把握し、レポート上で正しく説明責任（Accountability）を果たすことが重要である。
+
+**所要時間**: 約 20min
+
+#foundation #kiosk #compliance #e2e #stabilization #skill-matrix-20260518
+
 ### 2026-04-21 — Auth Readiness Contract / Types Stabilization Green Recovery 🏁
 
 **内容**: 認証準備状態（Auth Readiness）を前提とした契約の安定化を進め、認証モック・プロバイダー・ドメインテストフィクスチャに起因していた型不整合を解消。

--- a/src/features/planning-sheet/__tests__/supportTemplateBridge.spec.ts
+++ b/src/features/planning-sheet/__tests__/supportTemplateBridge.spec.ts
@@ -9,6 +9,7 @@ import {
   scheduleItemsToProcedureSteps,
   procedureStepToScheduleItem,
   procedureStepsToScheduleItems,
+  masterRowsToProcedureSteps,
 } from '../bridge/supportTemplateBridge';
 import type { SupportTemplateCsvRow } from '@/features/import/domain/csvImportTypes';
 import type { ProcedureStep } from '@/domain/isp/schema';
@@ -168,6 +169,32 @@ describe('supportTemplateBridge', () => {
       expect(restored[0].instruction).toBe('声掛け');
       expect(restored[1].time).toBe('10:00');
       expect(restored[1].activity).toBe('作業');
+    });
+  });
+
+  // ── Master Rows → ProcedureStep ──
+
+  describe('masterRowsToProcedureSteps', () => {
+    it('converts static master data for user U-002 / I005 (Ishiwata-san)', () => {
+      const steps = masterRowsToProcedureSteps('I005');
+      expect(steps).toHaveLength(17);
+      expect(steps[0]).toMatchObject({
+        order: 1,
+        instruction: '通所・朝の準備（送迎車で来所\n手洗い\n荷物の片づけ）',
+        staff: '送迎担当と引継ぎ\nご本人と朝の準備（手洗い・荷物をロッカーへ）\nトイレ誘導・介助',
+        timing: '9:30頃',
+      });
+    });
+
+    it('returns default/empty steps when no specific master registered', () => {
+      const steps = masterRowsToProcedureSteps('NON_EXISTENT_USER');
+      expect(steps).toHaveLength(17);
+      expect(steps[0]).toMatchObject({
+        order: 1,
+        instruction: '通所・朝の準備（手洗い、消毒、荷物をロッカーへ入れる）',
+        staff: '通所時の様子を確認し、必要に応じて声かけ・見守りを行う',
+        timing: '9:30頃',
+      });
     });
   });
 });

--- a/src/features/planning-sheet/bridge/supportTemplateBridge.ts
+++ b/src/features/planning-sheet/bridge/supportTemplateBridge.ts
@@ -121,3 +121,32 @@ export function procedureStepsToScheduleItems(steps: ProcedureStep[]): ScheduleI
     .sort((a, b) => a.order - b.order)
     .map(procedureStepToScheduleItem);
 }
+
+/**
+ * 静的マスタデータ（buildUserProcedureRows）を ProcedureStep[] に変換する。
+ */
+import { buildUserProcedureRows } from '@/features/planning-sheet/constants/userProcedureDetails';
+
+export function masterRowsToProcedureSteps(userId: string | number): ProcedureStep[] {
+  const rows = buildUserProcedureRows(userId);
+  return rows.map((row) => {
+    const activity = row.activity?.trim() || '';
+    const personAction = row.activityDetail?.trim() || '';
+    const supporterAction = row.instructionDetail?.trim() || '';
+    const timeLabel = row.timeLabel?.trim() || '';
+
+    const instruction = personAction
+      ? `${activity}（${personAction}）`
+      : activity;
+
+    return {
+      order: row.rowNo,
+      instruction,
+      staff: supporterAction,
+      timing: timeLabel,
+      activityDetail: personAction,
+      instructionDetail: supporterAction,
+      condition: '',
+    };
+  });
+}

--- a/src/features/planning-sheet/components/EditablePlanningDesignSection.tsx
+++ b/src/features/planning-sheet/components/EditablePlanningDesignSection.tsx
@@ -52,6 +52,8 @@ interface Props {
   strategyUsageLoading?: boolean;
   /** Phase C-3b: トレンド結果 */
   trendResult?: StrategyUsageTrendResult | null;
+  /** 対象利用者ID（マスタ取り込み判定用） */
+  userId?: string;
 }
 
 // ── ChipInput（再利用） ──
@@ -135,6 +137,7 @@ export const EditablePlanningDesignSection: React.FC<Props> = ({
   strategyUsage,
   strategyUsageLoading,
   trendResult,
+  userId,
 }) => {
   const hasEvidence = abcRecords.length > 0 || pdcaItems.length > 0;
 
@@ -336,6 +339,7 @@ export const EditablePlanningDesignSection: React.FC<Props> = ({
         onClose={() => setImportOpen(false)}
         onImport={handleImport}
         existingStepCount={planning.procedureSteps.length}
+        userId={userId}
       />
     </Stack>
   );

--- a/src/features/planning-sheet/components/ImportTemplateDialog.tsx
+++ b/src/features/planning-sheet/components/ImportTemplateDialog.tsx
@@ -14,9 +14,12 @@ import {
 import { hasUserProcedureMaster } from '@/features/planning-sheet/constants/userProcedureDetails';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import CloudUploadRoundedIcon from '@mui/icons-material/CloudUploadRounded';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
+import Collapse from '@mui/material/Collapse';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
@@ -38,6 +41,43 @@ import Tab from '@mui/material/Tab';
 import Tooltip from '@mui/material/Tooltip';
 import Papa from 'papaparse';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
+
+// ─────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────
+
+const AGENT_PROMPT_TEMPLATE = `支援手順追加ガイドに従って、〇〇さんの USER_PROCEDURE_DETAILS / USER_PROCEDURE_SHEET_NOTES を追加してください。
+
+前提:
+- 公式ガイド: docs/guides/support-procedure-addition-guide.md
+- 1利用者 = 1PR
+- 原紙文言は要約しない
+- セル内改行は \\n で保持する
+- 本人の動きと支援者の動きを混ぜない
+- 一日全体の注意事項を row データに混ぜない
+- dailyProcedureMapper.ts などの L2→L3 変換ロジック本体は原則変更しない
+
+作業手順:
+1. 対象者のExcel原紙を確認する
+2. 本番UserID・fixture userId・DEMO IDを確認する
+3. 17行の「本人の動き」「支援者の動き」を抽出する
+4. 下部欄「一日を通して気を付ける事」「その他」を抽出する
+5. src/features/planning-sheet/constants/userProcedureDetails.ts の USER_PROCEDURE_DETAILS に17行を追加する
+6. USER_PROCEDURE_SHEET_NOTES に下部欄を追加する
+7. isUserMatch / 個別ID判定に必要な alias を追加する
+8. src/features/planning-sheet/logic/__tests__/dailyProcedureMapper.spec.ts に代表行・下部欄・ID解決テストを追加する
+9. 以下を実行して検証する
+   - npx vitest run src/features/planning-sheet/logic/__tests__/dailyProcedureMapper.spec.ts
+   - npx vitest run src/features/planning-sheet
+   - npm run typecheck
+10. データ追加だけの小PRを作成する
+
+PR本文には以下を必ず記載してください:
+- データソース
+- 対象者ID / ID alias
+- 追加した17行手順の概要
+- 下部欄メモの有無
+- 検証コマンドと結果`;
 
 // ─────────────────────────────────────────────
 // Props
@@ -72,6 +112,21 @@ export const ImportTemplateDialog: React.FC<Props> = ({
   const [selectedUser, setSelectedUser] = useState<string>('');
   const [error, setError] = useState<string | null>(null);
   const [fileName, setFileName] = useState<string>('');
+
+  // 🤖 エージェントプロンプトコピーステート
+  const [showPromptPreview, setShowPromptPreview] = useState<boolean>(false);
+  const [copied, setCopied] = useState<boolean>(false);
+
+  const handleCopyPrompt = useCallback(() => {
+    navigator.clipboard.writeText(AGENT_PROMPT_TEMPLATE)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 3000); // 3秒後に「コピー完了」を戻す
+      })
+      .catch((err) => {
+        console.error('Failed to copy prompt template:', err);
+      });
+  }, []);
 
   // ── 1. 静的マスタ手順のロード ──
   const masterSteps = useMemo(() => {
@@ -221,8 +276,52 @@ export const ImportTemplateDialog: React.FC<Props> = ({
             <Typography variant="body2" color="text.primary" component="div">
               • <b>恒久的な標準手順の登録（管理者向け）:</b><br />
               Excel原紙からの恒久マスタへの追加は「原紙 ➔ 定数追加 ➔ テスト ➔ PRマージ」のPR連携ワークフローで行います。
+              <Box sx={{ mt: 1, pl: 1.5, borderLeft: '2px solid', borderColor: 'info.light' }}>
+                <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 0.5 }}>
+                  初めて作業する場合は、以下のプロンプトをコピーして開発エージェントに渡してください。
+                </Typography>
+                <Stack direction="row" spacing={1} alignItems="center">
+                  <Button
+                    size="small"
+                    variant="contained"
+                    color="info"
+                    onClick={handleCopyPrompt}
+                    startIcon={copied ? <CheckCircleOutlineIcon /> : <ContentCopyIcon />}
+                    sx={{ textTransform: 'none', fontWeight: 600, fontSize: '0.75rem', py: 0.25 }}
+                  >
+                    {copied ? 'プロンプトをコピーしました！' : '🤖 エージェント指示プロンプトをコピー'}
+                  </Button>
+                  <Button
+                    size="small"
+                    variant="text"
+                    color="info"
+                    onClick={() => setShowPromptPreview(!showPromptPreview)}
+                    sx={{ textTransform: 'none', fontSize: '0.75rem', py: 0.25 }}
+                  >
+                    {showPromptPreview ? 'プレビューを非表示' : 'プロンプトを表示'}
+                  </Button>
+                </Stack>
+                
+                <Collapse in={showPromptPreview} sx={{ mt: 1 }}>
+                  <Paper
+                    variant="outlined"
+                    sx={{
+                      p: 1.5,
+                      bgcolor: 'background.paper',
+                      maxHeight: 200,
+                      overflowY: 'auto',
+                      fontSize: '0.75rem',
+                      fontFamily: 'monospace',
+                      whiteSpace: 'pre-wrap',
+                      color: 'text.secondary',
+                    }}
+                  >
+                    {AGENT_PROMPT_TEMPLATE}
+                  </Paper>
+                </Collapse>
+              </Box>
             </Typography>
-            <Typography variant="body2" color="text.primary" component="div" sx={{ mt: 1 }}>
+            <Typography variant="body2" color="text.primary" component="div" sx={{ mt: 1.5 }}>
               • <b>画面上のCSV取り込み・適用（一時検証）:</b><br />
               編集中の支援計画シートへ一時的に手順を差し込んで確認するための機能（一時検証・下書き用）です。
             </Typography>

--- a/src/features/planning-sheet/components/ImportTemplateDialog.tsx
+++ b/src/features/planning-sheet/components/ImportTemplateDialog.tsx
@@ -1,18 +1,17 @@
 /**
- * ImportTemplateDialog — SupportTemplate CSV → ProcedureStep 取り込みダイアログ
+ * ImportTemplateDialog — SupportTemplate CSV / 静的マスタ → ProcedureStep 取り込みダイアログ
  *
  * EditablePlanningDesignSection から開かれ、
- * 既存の支援手順テンプレート CSV をプレビュー → PlanningSheet に取り込む。
- *
- * フロー:
- *  1. CSV ファイル選択
- *  2. ユーザー選択（CSV 内に複数ユーザーがいる場合）
- *  3. プレビュー表示
- *  4. 取り込み確定 → 親の onChange コールバックへ ProcedureStep[] を渡す
+ * 内蔵の標準テンプレート（USER_PROCEDURE_DETAILS）またはCSVファイルからプレビューし、
+ * PlanningSheet に取り込む。
  */
 import type { ProcedureStep } from '@/domain/isp/schema';
 import type { SupportTemplateCsvRow } from '@/features/import/domain/csvImportTypes';
-import { csvRowsToProcedureSteps } from '@/features/planning-sheet/bridge/supportTemplateBridge';
+import {
+  csvRowsToProcedureSteps,
+  masterRowsToProcedureSteps,
+} from '@/features/planning-sheet/bridge/supportTemplateBridge';
+import { hasUserProcedureMaster } from '@/features/planning-sheet/constants/userProcedureDetails';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import CloudUploadRoundedIcon from '@mui/icons-material/CloudUploadRounded';
 import Alert from '@mui/material/Alert';
@@ -34,6 +33,9 @@ import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
+import Tabs from '@mui/material/Tabs';
+import Tab from '@mui/material/Tab';
+import Tooltip from '@mui/material/Tooltip';
 import Papa from 'papaparse';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 
@@ -48,6 +50,8 @@ interface Props {
   onImport: (steps: ProcedureStep[]) => void;
   /** 既存の ProcedureSteps の件数（上書き確認用） */
   existingStepCount: number;
+  /** 対象利用者のID（標準テンプレートの自動紐づけ用） */
+  userId?: string;
 }
 
 // ─────────────────────────────────────────────
@@ -59,15 +63,23 @@ export const ImportTemplateDialog: React.FC<Props> = ({
   onClose,
   onImport,
   existingStepCount,
+  userId,
 }) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const [tabValue, setTabValue] = useState<number>(0);
   const [parsedRows, setParsedRows] = useState<SupportTemplateCsvRow[]>([]);
   const [userCodes, setUserCodes] = useState<string[]>([]);
   const [selectedUser, setSelectedUser] = useState<string>('');
   const [error, setError] = useState<string | null>(null);
   const [fileName, setFileName] = useState<string>('');
 
-  // ── File handling ──
+  // ── 1. 静的マスタ手順のロード ──
+  const masterSteps = useMemo(() => {
+    if (!userId || !hasUserProcedureMaster(userId)) return [];
+    return masterRowsToProcedureSteps(userId);
+  }, [userId]);
+
+  // ── 2. CSV パース ──
   const handleFileSelect = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
@@ -99,26 +111,29 @@ export const ImportTemplateDialog: React.FC<Props> = ({
     }
   }, []);
 
-  // ── Filtered rows for selected user ──
   const filteredRows = useMemo(
     () => parsedRows.filter((r) => r.UserCode?.trim() === selectedUser),
     [parsedRows, selectedUser],
   );
 
-  // ── Preview: converted ProcedureSteps ──
-  const previewSteps = useMemo(
+  const csvPreviewSteps = useMemo(
     () => csvRowsToProcedureSteps(filteredRows),
     [filteredRows],
   );
 
-  // ── Import handler ──
+  // ── 3. アクティブな手順の選択（タブ準拠） ──
+  const activeSteps = useMemo(() => {
+    return tabValue === 0 ? masterSteps : csvPreviewSteps;
+  }, [tabValue, masterSteps, csvPreviewSteps]);
+
+  // ── 4. インポート確定 ──
   const handleImport = useCallback(() => {
-    onImport(previewSteps);
+    onImport(activeSteps);
     handleReset();
     onClose();
-  }, [previewSteps, onImport, onClose]);
+  }, [activeSteps, onImport, onClose]);
 
-  // ── Reset ──
+  // ── 5. リセット & クローズ ──
   const handleReset = useCallback(() => {
     setParsedRows([]);
     setUserCodes([]);
@@ -130,8 +145,33 @@ export const ImportTemplateDialog: React.FC<Props> = ({
 
   const handleClose = useCallback(() => {
     handleReset();
+    setTabValue(0);
     onClose();
   }, [handleReset, onClose]);
+
+  // ── 6. サンプル CSV の BOM付きダウンロード ──
+  const handleDownloadSample = useCallback(() => {
+    const csvContent = [
+      'RowNo,活動内容,本人の動き,支援者の動き,時間帯',
+      '1,通所・朝の準備,手洗い、消毒、荷物をロッカーへ入れる,通所時の様子を確認し、必要に応じて声かけ・見守りを行う,9:30頃',
+      '2,体操,体操に参加する,本人の様子を見ながら参加を促す,10:00頃',
+      '3,スケジュール確認,一日の予定を確認する,本人と一緒に予定を確認し、見通しが持てるよう支援する,10:10頃',
+      '4,お茶休憩,手洗い後、お茶を飲む,お茶の準備、片付け、必要に応じた声かけを行う,10:15頃',
+    ].join('\r\n');
+
+    // UTF-8 BOM (\uFEFF -> 0xEF, 0xBB, 0xBF)
+    const bom = new Uint8Array([0xEF, 0xBB, 0xBF]);
+    const blob = new Blob([bom, csvContent], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+
+    const link = document.createElement('a');
+    link.setAttribute('href', url);
+    link.setAttribute('download', 'support_procedure_sample.csv');
+    link.style.visibility = 'hidden';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  }, []);
 
   return (
     <Dialog
@@ -139,87 +179,236 @@ export const ImportTemplateDialog: React.FC<Props> = ({
       onClose={handleClose}
       maxWidth="md"
       fullWidth
-      PaperProps={{ sx: { minHeight: 400 } }}
+      PaperProps={{ sx: { minHeight: 400, borderRadius: 2 } }}
     >
       <DialogTitle>
-        <Stack direction="row" spacing={1} alignItems="center">
-          <CloudUploadRoundedIcon color="primary" />
-          <Typography variant="h6" fontWeight={700}>テンプレートから取り込み</Typography>
+        <Stack direction="row" spacing={1} alignItems="center" justifyContent="space-between">
+          <Stack direction="row" spacing={1.2} alignItems="center">
+            <CloudUploadRoundedIcon color="primary" />
+            <Typography variant="h6" fontWeight={700}>テンプレートから取り込み</Typography>
+          </Stack>
+          <Tooltip title="docs/guides/support-procedure-addition-guide.md を参照 (ローカル環境用)">
+            <Button
+              size="small"
+              variant="text"
+              color="primary"
+              href="file:///Users/yasutakesougo/audit-management-system-mvp/docs/guides/support-procedure-addition-guide.md"
+              target="_blank"
+              rel="noopener noreferrer"
+              sx={{ textTransform: 'none', fontWeight: 600 }}
+            >
+              ❓ 取り込みガイドを確認
+            </Button>
+          </Tooltip>
         </Stack>
       </DialogTitle>
 
       <DialogContent dividers>
         <Stack spacing={2.5}>
-          {/* ── Step 1: File Select ── */}
-          <Paper variant="outlined" sx={{ p: 2 }}>
-            <Typography variant="subtitle2" fontWeight={600} gutterBottom>
-              1. SupportTemplate CSV を選択
+          {/* 💡 インセプションガイド（役割分担） */}
+          <Alert
+            severity="info"
+            variant="outlined"
+            sx={{
+              borderColor: 'info.light',
+              bgcolor: 'rgba(2, 136, 209, 0.04)',
+              '& .MuiAlert-icon': { color: 'info.main' },
+            }}
+          >
+            <Typography variant="subtitle2" fontWeight={700} color="info.dark" sx={{ mb: 0.5 }}>
+              取り込み機能の使い分けについて
             </Typography>
-            <Stack direction="row" spacing={2} alignItems="center">
-              <Button
-                variant="outlined"
-                component="label"
-                startIcon={<CloudUploadRoundedIcon />}
-              >
-                CSV を選択
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  accept=".csv"
-                  hidden
-                  onChange={handleFileSelect}
-                />
-              </Button>
-              {fileName && (
-                <Chip size="small" label={fileName} variant="outlined" onDelete={handleReset} />
+            <Typography variant="body2" color="text.primary" component="div">
+              • <b>恒久的な標準手順の登録（管理者向け）:</b><br />
+              Excel原紙からの恒久マスタへの追加は「原紙 ➔ 定数追加 ➔ テスト ➔ PRマージ」のPR連携ワークフローで行います。
+            </Typography>
+            <Typography variant="body2" color="text.primary" component="div" sx={{ mt: 1 }}>
+              • <b>画面上のCSV取り込み・適用（一時検証）:</b><br />
+              編集中の支援計画シートへ一時的に手順を差し込んで確認するための機能（一時検証・下書き用）です。
+            </Typography>
+          </Alert>
+
+          {/* ── タブ切り替え ── */}
+          <Tabs
+            value={tabValue}
+            onChange={(_e, v) => setTabValue(v)}
+            sx={{ borderBottom: 1, borderColor: 'divider' }}
+          >
+            <Tab label="標準テンプレートから選択 (推奨)" sx={{ fontWeight: 600 }} />
+            <Tab label="CSVファイルからインポート" sx={{ fontWeight: 600 }} />
+          </Tabs>
+
+          {/* ── タブ1: 標準テンプレートから選択 ── */}
+          {tabValue === 0 && (
+            <Stack spacing={2}>
+              {userId && hasUserProcedureMaster(userId) ? (
+                <Paper
+                  variant="outlined"
+                  sx={{
+                    p: 2,
+                    bgcolor: 'rgba(46, 125, 50, 0.04)',
+                    borderColor: 'success.light',
+                  }}
+                >
+                  <Typography variant="subtitle2" fontWeight={700} color="success.dark" gutterBottom>
+                    利用者の標準テンプレートが見つかりました
+                  </Typography>
+                  <Typography variant="body2" color="text.primary">
+                    対象利用者 (ID: <b>{userId}</b>) の静的マスタに登録されている標準支援手順 (17行構成) が利用可能です。<br />
+                    下部のプレビューを確認し、問題なければ [取り込む] ボタンを押してください。
+                  </Typography>
+                </Paper>
+              ) : (
+                <Paper
+                  variant="outlined"
+                  sx={{
+                    p: 2,
+                    bgcolor: 'rgba(211, 47, 47, 0.04)',
+                    borderColor: 'error.light',
+                  }}
+                >
+                  <Typography variant="subtitle2" fontWeight={700} color="error.dark" gutterBottom>
+                    標準テンプレート未登録
+                  </Typography>
+                  <Typography variant="body2" color="text.primary" sx={{ mb: 1.5 }}>
+                    対象利用者 (ID: <b>{userId || '未設定'}</b>) の標準支援手順はマスタに登録されていません。
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary" display="block">
+                    新規に利用者の標準マスタを登録したい場合は、公式ガイド <code>docs/guides/support-procedure-addition-guide.md</code> を確認の上、静的マスタ定数ファイルを更新し、PRをマージして反映させてください。
+                  </Typography>
+                </Paper>
               )}
             </Stack>
-          </Paper>
-
-          {error && <Alert severity="error">{error}</Alert>}
-
-          {/* ── Step 2: User Select ── */}
-          {userCodes.length > 0 && (
-            <Paper variant="outlined" sx={{ p: 2 }}>
-              <Typography variant="subtitle2" fontWeight={600} gutterBottom>
-                2. 利用者を選択
-              </Typography>
-              <Stack direction="row" spacing={2} alignItems="center">
-                <TextField
-                  select
-                  label="利用者コード"
-                  value={selectedUser}
-                  onChange={(e) => setSelectedUser(e.target.value)}
-                  size="small"
-                  sx={{ minWidth: 200 }}
-                >
-                  {userCodes.map((code) => (
-                    <MenuItem key={code} value={code}>
-                      {code}（{parsedRows.filter((r) => r.UserCode?.trim() === code).length} 手順）
-                    </MenuItem>
-                  ))}
-                </TextField>
-                <Chip
-                  size="small"
-                  variant="outlined"
-                  label={`${userCodes.length} 名分のデータ`}
-                />
-              </Stack>
-            </Paper>
           )}
 
-          {/* ── Step 3: Preview ── */}
-          {previewSteps.length > 0 && (
+          {/* ── タブ2: CSVファイルからインポート ── */}
+          {tabValue === 1 && (
+            <Stack spacing={2.5}>
+              <Paper variant="outlined" sx={{ p: 2 }}>
+                <Typography variant="subtitle2" fontWeight={600} gutterBottom>
+                  1. SupportTemplate CSV を選択
+                </Typography>
+                <Stack direction="row" spacing={2} alignItems="center">
+                  <Button
+                    variant="outlined"
+                    component="label"
+                    startIcon={<CloudUploadRoundedIcon />}
+                  >
+                    CSV を選択
+                    <input
+                      ref={fileInputRef}
+                      type="file"
+                      accept=".csv"
+                      hidden
+                      onChange={handleFileSelect}
+                    />
+                  </Button>
+                  <Button
+                    variant="outlined"
+                    color="secondary"
+                    onClick={handleDownloadSample}
+                  >
+                    サンプル CSV をダウンロード
+                  </Button>
+                  {fileName && (
+                    <Chip size="small" label={fileName} variant="outlined" onDelete={handleReset} />
+                  )}
+                </Stack>
+              </Paper>
+
+              {error && <Alert severity="error">{error}</Alert>}
+
+              {userCodes.length > 0 && (
+                <Paper variant="outlined" sx={{ p: 2 }}>
+                  <Typography variant="subtitle2" fontWeight={600} gutterBottom>
+                    2. 利用者を選択
+                  </Typography>
+                  <Stack direction="row" spacing={2} alignItems="center">
+                    <TextField
+                      select
+                      label="利用者コード"
+                      value={selectedUser}
+                      onChange={(e) => setSelectedUser(e.target.value)}
+                      size="small"
+                      sx={{ minWidth: 200 }}
+                    >
+                      {userCodes.map((code) => (
+                        <MenuItem key={code} value={code}>
+                          {code}（{parsedRows.filter((r) => r.UserCode?.trim() === code).length} 手順）
+                        </MenuItem>
+                      ))}
+                    </TextField>
+                    <Chip
+                      size="small"
+                      variant="outlined"
+                      label={`${userCodes.length} 名分のデータ`}
+                    />
+                  </Stack>
+                </Paper>
+              )}
+
+              {/* 💡 仕様ヘルプテーブル */}
+              <Paper variant="outlined" sx={{ p: 2, bgcolor: 'background.default' }}>
+                <Typography variant="subtitle2" fontWeight={700} gutterBottom>
+                  💡 CSV 列の構成仕様 (ヘッダー名)
+                </Typography>
+                <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 1.5 }}>
+                  CSVファイルを自作または編集する際は、必ず以下の構成名に揃えてください。
+                </Typography>
+                <TableContainer>
+                  <Table size="small">
+                    <TableHead>
+                      <TableRow>
+                        <TableCell sx={{ fontWeight: 600 }}>列名 (ヘッダー)</TableCell>
+                        <TableCell sx={{ fontWeight: 600 }}>必須 / 任意</TableCell>
+                        <TableCell sx={{ fontWeight: 600 }}>説明</TableCell>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      <TableRow>
+                        <TableCell><code>RowNo</code></TableCell>
+                        <TableCell><Chip label="任意" size="small" /></TableCell>
+                        <TableCell>手順の並び順 (1, 2, 3...)。指定がない場合は上から順に採番</TableCell>
+                      </TableRow>
+                      <TableRow>
+                        <TableCell><code>活動内容</code></TableCell>
+                        <TableCell><Chip label="必須" color="primary" size="small" /></TableCell>
+                        <TableCell>手順内容の基本となる活動項目</TableCell>
+                      </TableRow>
+                      <TableRow>
+                        <TableCell><code>本人の動き</code></TableCell>
+                        <TableCell><Chip label="任意" size="small" /></TableCell>
+                        <TableCell>本人の詳細な行動。活動内容と自動的に結合されます</TableCell>
+                      </TableRow>
+                      <TableRow>
+                        <TableCell><code>支援者の動き</code></TableCell>
+                        <TableCell><Chip label="任意" size="small" /></TableCell>
+                        <TableCell>スタッフ側の具体的な介入・支援内容 (担当・介入方法)</TableCell>
+                      </TableRow>
+                      <TableRow>
+                        <TableCell><code>時間帯</code></TableCell>
+                        <TableCell><Chip label="任意" size="small" /></TableCell>
+                        <TableCell>実施の目安タイミング (例: 9:30頃)</TableCell>
+                      </TableRow>
+                    </TableBody>
+                  </Table>
+                </TableContainer>
+              </Paper>
+            </Stack>
+          )}
+
+          {/* ── 共通プレビュー ── */}
+          {activeSteps.length > 0 && (
             <>
               <Divider />
               <Paper variant="outlined" sx={{ p: 2 }}>
                 <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1.5 }}>
                   <Typography variant="subtitle2" fontWeight={600}>
-                    3. プレビュー
+                    {tabValue === 0 ? '標準テンプレートプレビュー' : 'CSV取り込みプレビュー'}
                   </Typography>
                   <Chip
                     size="small"
-                    label={`${previewSteps.length} ステップ`}
+                    label={`${activeSteps.length} ステップ`}
                     color="primary"
                     variant="outlined"
                   />
@@ -242,7 +431,7 @@ export const ImportTemplateDialog: React.FC<Props> = ({
                       </TableRow>
                     </TableHead>
                     <TableBody>
-                      {previewSteps.map((step) => (
+                      {activeSteps.map((step) => (
                         <TableRow key={step.order}>
                           <TableCell>
                             <Typography variant="caption" fontWeight={600}>{step.order}</Typography>
@@ -273,11 +462,11 @@ export const ImportTemplateDialog: React.FC<Props> = ({
         <Button onClick={handleClose}>キャンセル</Button>
         <Button
           variant="contained"
-          disabled={previewSteps.length === 0}
+          disabled={activeSteps.length === 0}
           onClick={handleImport}
           startIcon={<CheckCircleOutlineIcon />}
         >
-          {previewSteps.length} ステップを取り込む
+          {activeSteps.length} ステップを取り込む
         </Button>
       </DialogActions>
     </Dialog>

--- a/src/features/planning-sheet/constants/userProcedureDetails.ts
+++ b/src/features/planning-sheet/constants/userProcedureDetails.ts
@@ -419,3 +419,17 @@ export function findUserProcedureSheetNotes(userId: string | number): UserProced
             : String(notes.userId) === String(userId);
   });
 }
+
+export function hasUserProcedureMaster(userId: string | number): boolean {
+  return USER_PROCEDURE_DETAILS.some((detail) => {
+    return isIshiwataUserId(detail.userId)
+      ? isIshiwataUserId(userId)
+      : isKatsuragawaUserId(detail.userId)
+        ? isKatsuragawaUserId(userId)
+        : isNakamuraUserId(detail.userId)
+          ? isNakamuraUserId(userId)
+          : isShiotaUserId(detail.userId)
+            ? isShiotaUserId(userId)
+            : String(detail.userId) === String(userId);
+  });
+}

--- a/src/pages/support-planning-sheet/sections/PlanningTabsSection.tsx
+++ b/src/pages/support-planning-sheet/sections/PlanningTabsSection.tsx
@@ -178,6 +178,7 @@ export function PlanningTabsSection({
               strategyUsage={strategyUsage}
               strategyUsageLoading={strategyUsageLoading}
               trendResult={trendResult}
+              userId={sheet.userId}
             />
           ) : (
             <PlanningDesignSection


### PR DESCRIPTION
## Summary

- 支援手順インポートダイアログを2タブ化し、標準テンプレートとCSVファイル取り込みの選択を分かりやすく整理しました。
- 内蔵標準テンプレート適用導線を追加し、対象利用者（石渡さん I005 等）の登録済みマスタテンプレート（17行構成）を自動判定・プレビューし、ワンクリックで差し替えられるようにしました。
- 恒久マスタ追加時の作業属人化を防ぐ**「🤖 エージェント指示プロンプトをコピー」**機能を追加しました。
  - Excel原紙から定数追加・テスト・小PR作成までを自動で正しく指示できる最適な開発プロンプトを、画面からワンクリックでクリップボードへコピー可能です。
  - プロンプトの構成内容は折りたたみアコーディオン（Collapse）で画面上でも簡単にプレビュー可能です。
- CSV仕様説明とサンプルCSVダウンロードを追加しました。
  - 対応列: `RowNo`, `活動内容`, `本人の動き`, `支援者の動き`, `時間帯`
  - Windows Excelでの文字化けを防ぐため、UTF-8 BOM付きサンプルCSVを動的生成します。
- Excel→PR取り込みとUI一時取り込みの役割分担を明示しました。
  - 恒久登録: 管理者によるマスタ定数追加・テスト・PR連携ワークフロー
  - 一時検証: 画面上でのCSV・標準マスタ読み込み
- 公式支援手順追加ガイドへのヘルプ導線を追加しました。
  - `docs/guides/support-procedure-addition-guide.md`
  - 「❓ 取り込みガイドを確認」から確認可能

## Scope

- UX改善・運用ツール追加のみ
- L2→L3変換ロジックは変更なし
- SharePoint保存仕様は変更なし
- `dailyProcedureMapper.ts` は変更なし

## Checks

- [x] `npm run typecheck`
- [x] `npx vitest run src/features/planning-sheet`  
  - 全281件 PASS
- [x] `npx vitest run src/features/planning-sheet/logic/__tests__/dailyProcedureMapper.spec.ts`
- [x] `git diff --check`

## Manual Smoke Check

- [x] Opened `/support-planning-sheet/sp-1807?tab=planning`
- [x] Confirmed 「テンプレートから取り込み」 opens the import dialog
- [x] Confirmed 2-tab layout:
  - 標準テンプレートから選択
  - CSVファイルからインポート
- [x] Confirmed I005 standard 17-row template preview and apply flow
- [x] Confirmed overwrite warning appears when existing steps may be replaced
- [x] Confirmed CSV spec table:
  - `RowNo`
  - `活動内容`
  - `本人の動き`
  - `支援者の動き`
  - `時間帯`
- [x] Confirmed UTF-8 BOM sample CSV download
- [x] Confirmed CSV select → preview → import flow
- [x] Confirmed 「取り込みガイドを確認」 guide link
- [x] Confirmed agent prompt copy feedback: 「プロンプトをコピーしました！」
- [x] Confirmed prompt preview Collapse toggle
- [x] Confirmed no fatal console errors or 400/500 network errors
