### PR TITLE
feat(kiosk): add support start date setup navigation

### DIFF
--- a/src/features/kiosk/components/KioskProcedureListScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureListScreen.tsx
@@ -95,6 +95,36 @@ export const KioskProcedureListScreen: React.FC = () => {
       undefined
     );
   }, [planningSheet, currentSheet, user?.ServiceStartDate]);
+  const supportStartDateLabel = React.useMemo(() => {
+    const { date, source } = resolvedStartDate;
+    const isLoading = (targetPlanningSheetId && isLoadingPlanningSheet) || isLoadingCurrentSheet;
+
+    if (!date || source === 'none') {
+      return isLoading
+        ? '支援開始日: 確認中（90日参考）'
+        : '支援開始日: 未設定（90日参考）';
+    }
+
+    const dateStr = formatDateJapanese(date);
+    if (!dateStr) {
+      return '支援開始日: 不正な日付（90日参考）';
+    }
+
+    switch (source) {
+      case 'planning':
+        return `支援開始日: ${dateStr}（90日参考・支援計画）`;
+      case 'master':
+        return `支援開始日: ${dateStr}（90日参考・利用者マスタ）`;
+      case 'fallback':
+        return `[暫定] 支援開始日: ${dateStr}（90日参考・計画適用日）`;
+      default:
+        return `支援開始日: ${dateStr}（90日参考）`;
+    }
+  }, [resolvedStartDate, targetPlanningSheetId, isLoadingPlanningSheet, isLoadingCurrentSheet]);
+  const currentPlanningSheetId = (planningSheet?.id ?? currentSheet?.id ?? targetPlanningSheetId ?? '').trim();
+  const showSetupCta = !!queryUserId
+    && (supportStartDateLabel.includes('未設定（90日参考）') || supportStartDateLabel.includes('不正な日付（90日参考）'));
+  const showProvisionalReviewCta = resolvedStartDate.source === 'fallback' && !!currentPlanningSheetId;
 
   const { getRecords: getStoreRecords } = useExecutionStore();
   const storeRecords = getStoreRecords(selectedDateIso || '', user?.UserID || userId || '');
@@ -231,29 +261,30 @@ export const KioskProcedureListScreen: React.FC = () => {
                 {selectedDateStr} の支援手順
               </Typography>
               <Typography variant="subtitle1" color="text.secondary" sx={{ fontWeight: 'medium' }}>
-                • {(() => {
-                  const { date, source } = resolvedStartDate;
-
-                  if (!date || source === 'none') {
-                    return (targetPlanningSheetId && isLoadingPlanningSheet) || isLoadingCurrentSheet
-                      ? '支援開始日: 確認中（90日参考）'
-                      : '支援開始日: 未設定（90日参考）';
-                  }
-
-                  const dateStr = formatDateJapanese(date);
-
-                  switch (source) {
-                    case 'planning':
-                      return `支援開始日: ${dateStr}（90日参考・支援計画）`;
-                    case 'master':
-                      return `支援開始日: ${dateStr}（90日参考・利用者マスタ）`;
-                    case 'fallback':
-                      return `[暫定] 支援開始日: ${dateStr}（90日参考・計画適用日）`;
-                    default:
-                      return `支援開始日: ${dateStr}（90日参考）`;
-                  }
-                })()}
+                • {supportStartDateLabel}
               </Typography>
+              {showSetupCta && (
+                <Button
+                  size="small"
+                  variant="outlined"
+                  component={RouterLink}
+                  to={`/support-planning-sheet/new?userId=${encodeURIComponent(queryUserId ?? '')}`}
+                  data-testid="kiosk-support-start-setup-cta"
+                >
+                  支援計画シートを作成して支援開始日を設定
+                </Button>
+              )}
+              {showProvisionalReviewCta && (
+                <Button
+                  size="small"
+                  variant="text"
+                  component={RouterLink}
+                  to={`/support-planning-sheet/${encodeURIComponent(currentPlanningSheetId)}`}
+                  data-testid="kiosk-support-start-provisional-cta"
+                >
+                  元シートを確認
+                </Button>
+              )}
             </Box>
           </Box>
         </Box>

--- a/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
@@ -519,4 +519,94 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
       expect(screen.getByText(/支援開始日: 2026年5月15日（90日参考・支援計画）/)).toBeInTheDocument();
     });
   });
+
+  it('shows setup CTA when support start date is unset', async () => {
+    mockUseUser.mockReturnValue({
+      data: { FullName: '田中 太郎', ServiceStartDate: undefined },
+      status: 'success',
+    });
+    mockUsePlanningSheetData.mockReturnValue({
+      data: null,
+      isLoading: false,
+    });
+
+    render(
+      <MemoryRouter>
+        <KioskProcedureListScreen />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      const cta = screen.getByTestId('kiosk-support-start-setup-cta');
+      expect(cta).toBeInTheDocument();
+      expect(cta).toHaveAttribute('href', '/support-planning-sheet/new?userId=U001');
+    });
+  });
+
+  it('does not show setup CTA when support start date is from planning sheet', async () => {
+    mockUseUser.mockReturnValue({
+      data: { FullName: '田中 太郎', ServiceStartDate: '2026-04-01' },
+      status: 'success',
+    });
+    mockUsePlanningSheetData.mockReturnValue({
+      data: { supportStartDate: '2026-05-01' } as unknown as SupportPlanningSheet,
+      isLoading: false,
+    });
+
+    render(
+      <MemoryRouter>
+        <KioskProcedureListScreen />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('kiosk-support-start-setup-cta')).toBeNull();
+    });
+  });
+
+  it('shows provisional review CTA for fallback source', async () => {
+    mockUseUser.mockReturnValue({
+      data: { FullName: '田中 太郎', ServiceStartDate: undefined },
+      status: 'success',
+    });
+    mockUsePlanningSheetData.mockReturnValue({
+      data: { id: 'sp-123', supportStartDate: undefined, appliedFrom: '2026-03-01' } as unknown as SupportPlanningSheet,
+      isLoading: false,
+    });
+
+    render(
+      <MemoryRouter>
+        <KioskProcedureListScreen />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      const cta = screen.getByTestId('kiosk-support-start-provisional-cta');
+      expect(cta).toBeInTheDocument();
+      expect(cta).toHaveAttribute('href', '/support-planning-sheet/sp-123');
+      expect(screen.queryByTestId('kiosk-support-start-setup-cta')).toBeNull();
+    });
+  });
+
+  it('shows setup CTA when support start date is invalid', async () => {
+    mockUseUser.mockReturnValue({
+      data: { FullName: '田中 太郎', ServiceStartDate: undefined },
+      status: 'success',
+    });
+    mockUsePlanningSheetData.mockReturnValue({
+      data: { id: 'sp-123', supportStartDate: '2026-13-99' } as unknown as SupportPlanningSheet,
+      isLoading: false,
+    });
+
+    render(
+      <MemoryRouter>
+        <KioskProcedureListScreen />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/支援開始日: 不正な日付（90日参考）/)).toBeInTheDocument();
+      expect(screen.getByTestId('kiosk-support-start-setup-cta')).toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Kiosk の利用者手順一覧画面で、支援開始日（モニタリング起点）が未設定または不正な場合に、L2 の支援計画シート作成画面へ誘導する CTA を追加しました。

Kiosk 側では日付を直接編集せず、あくまで「検知・誘導」に留め、正式な支援開始日は `/support-planning-sheet/new` の `supportStartDate` として保存する設計を維持しています。

## Changes

- `unset / invalid` の場合のみ setup CTA を表示
  - 文言: `支援計画シートを作成して支援開始日を設定`
  - 遷移先: `/support-planning-sheet/new?userId={userId}`
- `provisional` fallback の場合は新規作成 CTA を出さず、`元シートを確認` CTA を表示
- `official / planning / master` の場合は CTA 非表示
- 無効日付は `支援開始日: 不正な日付（90日参考）` に表示統一
- KioskProcedureListScreen の分岐テストを追加

## Design Note

SupportStartDate / ServiceStartDate は L2 側の責務であり、Kiosk は L3/現場端末として解決状態を表示し、必要時に L2 画面へ誘導します。  
Kiosk 画面内で支援開始日を直接編集しないことで、Support Date Governance の責務分離を維持しています。

## Checks

- [x] `npx vitest run src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx`
- [x] `npm run typecheck`
