### PR TITLE
test(kiosk): cover domain user id query fallback

### DIFF
--- a/src/features/kiosk/components/KioskProcedureListScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureListScreen.tsx
@@ -5,7 +5,7 @@ import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import AccessTimeIcon from '@mui/icons-material/AccessTime';
 import { useNavigate, useParams, useLocation, Link as RouterLink } from 'react-router-dom';
 import { appendKioskSearchParams } from '../utils/navigation';
-import { useUser } from '@/features/users/useUsers';
+import { useUser, useUsers } from '@/features/users/useUsers';
 import { useProcedureData } from '@/features/daily/hooks/useProcedureData';
 import { useExecutionData } from '@/features/daily/hooks/useExecutionData';
 import { formatDateJapanese } from '@/lib/dateFormat';
@@ -28,8 +28,22 @@ export const KioskProcedureListScreen: React.FC = () => {
     return (params.get('userId') || params.get('user') || '').trim() || null;
   }, [location.search]);
   const userLookupId = queryUserIdFromSearch || userId || '';
-  const { data: user, status } = useUser(userLookupId);
-  const isUserLoading = status === 'loading' || status === 'idle';
+  const numericUserLookupId = Number.isFinite(Number(userLookupId)) ? Number(userLookupId) : undefined;
+  const { data: userByNumericId, status: numericUserStatus } = useUser(numericUserLookupId);
+  const { data: users, status: usersStatus } = useUsers({ selectMode: 'core' });
+  const userByCode = React.useMemo(() => {
+    const lookup = String(userLookupId).trim();
+    if (!lookup) return null;
+    return users.find((candidate) => {
+      const candidateUserId = String(candidate.UserID ?? '').trim();
+      if (candidateUserId && candidateUserId === lookup) return true;
+      return String(candidate.Id ?? '').trim() === lookup;
+    }) ?? null;
+  }, [userLookupId, users]);
+  const user = userByNumericId ?? userByCode;
+  const isUserLoading = numericUserLookupId != null
+    ? (numericUserStatus === 'loading' || numericUserStatus === 'idle')
+    : (usersStatus === 'loading' || usersStatus === 'idle');
   const procedureRepo = useProcedureData();
   const executionRepo = useExecutionData();
   

--- a/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
@@ -17,8 +17,10 @@ vi.mock('react-router-dom', async () => {
 });
 
 const mockUseUser = vi.fn(() => ({ data: { FullName: '田中 太郎', ServiceStartDate: undefined as string | undefined } as unknown as Record<string, unknown>, status: 'success' }));
+const mockUseUsers = vi.fn(() => ({ data: [], status: 'success' as const }));
 vi.mock('@/features/users/useUsers', () => ({
   useUser: () => mockUseUser(),
+  useUsers: () => mockUseUsers(),
 }));
 
 const mockProcedures = [
@@ -74,6 +76,7 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
     vi.clearAllMocks();
     mockRouteUserId = 'U001';
     mockUseUser.mockReturnValue({ data: { FullName: '田中 太郎' }, status: 'success' });
+    mockUseUsers.mockReturnValue({ data: [], status: 'success' });
     mockGetCurrentExecutionRepositoryKind.mockReturnValue('local');
     mockGetStoreRecords.mockReturnValue([]);
     mockGetByUser.mockReturnValue(mockProcedures);

--- a/tests/e2e/kiosk-procedure-list.spec.ts
+++ b/tests/e2e/kiosk-procedure-list.spec.ts
@@ -35,4 +35,19 @@ test.describe('Kiosk Procedure List', () => {
     }, selector);
     await expect(page).toHaveURL(/.*\/kiosk\/users.*/, { timeout: 30000 });
   });
+
+  test('should prioritize query userId over route param and avoid setup CTA when support start date is resolved', async ({ page }) => {
+    await bootKiosk(page, {
+      route: '/kiosk/users/6/procedures?wizard=plan&user=I005&userId=I005',
+      userId: 'I005',
+    });
+
+    await expect(page).toHaveURL(/\/kiosk\/users\/6\/procedures\?wizard=plan&user=I005&userId=I005&provider=memory/);
+    await expect(page.getByText('石渡')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText(/支援開始日: .*（90日参考・(支援計画|利用者マスタ)）/)).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText(/支援開始日: 未設定（90日参考）/)).toHaveCount(0);
+    await expect(page.getByText(/\[暫定\] 支援開始日:/)).toHaveCount(0);
+    await expect(page.getByTestId('kiosk-support-start-setup-cta')).toHaveCount(0);
+    await expect(page.getByText('支援計画シートを作成して支援開始日を設定')).toHaveCount(0);
+  });
 });


### PR DESCRIPTION
## Summary

Kiosk 利用者手順一覧で、route param の `:userId` と query の `userId/user` が異なる実運用URLを E2E で固定しました。

対象URL:

`/kiosk/users/6/procedures?wizard=plan&user=I005&userId=I005`

このケースでは query 側の domain user id (`I005`) を正として扱う必要があります。

## Changes

- `tests/e2e/kiosk-procedure-list.spec.ts` に userId 不一致ケースの E2E を追加
- `query userId/user` が文字列ID（例: `I005`）の場合に、数値ID前提の `useUser` 解決で詰まる問題を修正
- Kiosk 側が I005 の利用者・支援開始日を正しく解決することを検証
- `useUsers` 追加に合わせて Kiosk unit mock を更新

## Verified behavior

- I005 系利用者（石渡）が表示される
- 支援開始日が解決される
- 未設定 / 暫定表示にならない
- `kiosk-support-start-setup-cta` が表示されない
- 「支援計画シートを作成して支援開始日を設定」が表示されない

## Checks

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npx vitest run src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx` — 28 passed
- [x] `npx playwright test tests/e2e/kiosk-procedure-list.spec.ts --project=chromium --workers=1` — 4 passed
