### PR TITLE
fix(ci): split preflight typecheck lint unit steps

### DIFF
--- a/.github/workflows/ci-preflight.yml
+++ b/.github/workflows/ci-preflight.yml
@@ -50,10 +50,19 @@ jobs:
 
       - run: npm ci
 
-      - name: Preflight (typecheck, lint, unit)
+      - name: Test IDs guard
+        run: npm run guard:testids --silent
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Unit required suite
         env:
           NODE_OPTIONS: '--max-old-space-size=4096'
-        run: npm run preflight
+        run: npm run test:ci:required
 
   schedule-unit:
     name: Schedule unit (TZ matrix)

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -14,11 +14,11 @@ npm run lint
 
 if [ "$MODE" = "unit" ]; then
   echo "▶ Unit (fast mode)"
-  npm run test:ci
+  npm run test:ci:required
   echo "✅ Preflight (unit) OK"
 elif [ "$MODE" = "e2e" ]; then
   echo "▶ Unit"
-  npm run test:ci
+  npm run test:ci:required
   
   echo "▶ Schedule unit suite"
   npx vitest run tests/unit/schedule --reporter=verbose


### PR DESCRIPTION
Split CI Preflight into explicit steps and use the required unit suite.