### PR TITLE
fix(planning-sheet): warn when support start date is empty

### DIFF
--- a/src/features/planning-sheet/components/new-form/sections/SectionBasicAndTarget.tsx
+++ b/src/features/planning-sheet/components/new-form/sections/SectionBasicAndTarget.tsx
@@ -33,6 +33,12 @@ export const SectionBasicAndTarget: React.FC<SectionBasicAndTargetProps> = ({
     </Alert>
   ) : null;
 
+  const supportStartDateWarning = !form.supportStartDate ? (
+    <Alert severity="warning" variant="outlined">
+      支援開始日（モニタリング起点）が未入力です。未入力のまま保存すると保存日で補完されます。L2（支援計画シート）で正式な支援開始日を設定してください。
+    </Alert>
+  ) : null;
+
   if (step === 0) {
     // §1 基本情報
     return (
@@ -57,6 +63,7 @@ export const SectionBasicAndTarget: React.FC<SectionBasicAndTargetProps> = ({
           InputLabelProps={{ shrink: true }}
           helperText="90日モニタリングの起点となる日付です。通常は利用開始日を設定します。"
         />
+        {supportStartDateWarning}
         {schedulePreview}
         <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
           <TextField select label="関与研修" value={form.trainingLevel} onChange={e => updateField('trainingLevel', e.target.value)} fullWidth>

--- a/tests/unit/SectionBasicAndTarget.spec.tsx
+++ b/tests/unit/SectionBasicAndTarget.spec.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SectionBasicAndTarget } from '@/features/planning-sheet/components/new-form/sections/SectionBasicAndTarget';
+import { INITIAL_FORM } from '@/features/planning-sheet/components/new-form/constants';
+
+describe('SectionBasicAndTarget', () => {
+  it('支援開始日が未入力の場合に警告を表示する', () => {
+    render(
+      <SectionBasicAndTarget
+        step={0}
+        form={{ ...INITIAL_FORM, supportStartDate: '' }}
+        updateField={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText(/未入力のまま保存すると保存日で補完されます/),
+    ).toBeInTheDocument();
+  });
+
+  it('支援開始日が入力済みの場合は警告を表示しない', () => {
+    render(
+      <SectionBasicAndTarget
+        step={0}
+        form={{ ...INITIAL_FORM, supportStartDate: '2026-05-01' }}
+        updateField={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.queryByText(/未入力のまま保存すると保存日で補完されます/),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

新規支援計画シートの「支援開始日（モニタリング起点）」が未入力のとき、保存時に当日で補完されることを事前に知らせる警告を追加しました。

保存ロジックは変更せず、誤って「今日」を90日モニタリング起点にしてしまう運用リスクを下げるためのUI警告のみです。

## Changes

- `supportStartDate` が空のとき warning Alert を表示
- 未入力時は保存日で補完されることを明示
- 正式な支援開始日は L2（支援計画シート）で設定すべきことを明示
- 空入力時 / 入力済み時の表示テストを追加

## Checks

- [x] `npx vitest run tests/unit/SectionBasicAndTarget.spec.tsx` — 2 tests passed
- [x] `npm run typecheck`
- [x] `git diff --check`
