### PR TITLE
fix(planning-sheet): move activation flow to L2 screen

### DIFF
--- a/src/features/ibd/procedures/daily-records/components/MonitoringRevisionDialog.tsx
+++ b/src/features/ibd/procedures/daily-records/components/MonitoringRevisionDialog.tsx
@@ -127,7 +127,7 @@ export const MonitoringRevisionDialog: React.FC<MonitoringRevisionDialogProps> =
           {/* 改訂フォーム */}
           {success ? (
             <Alert severity="success" variant="filled">
-              ✅ {currentSPS.version} → 新バージョンへの改訂が完了しました。次回見直し期限は 90 日後にリセットされました。
+              ✅ 改訂ドラフトを保存しました。運用開始は支援計画シート画面（L2）で実行してください。
             </Alert>
           ) : (
             <>

--- a/src/pages/individual-support/hooks/useIndividualSupportOrchestrator.ts
+++ b/src/pages/individual-support/hooks/useIndividualSupportOrchestrator.ts
@@ -11,7 +11,6 @@ import { usePdcaCycleState } from '@/features/ibd/analysis/pdca/queries/usePdcaC
 import { useSupportStepTemplates } from '@/features/ibd/procedures/templates/hooks/useSupportStepTemplates';
 import { toLocalDateISO } from '@/utils/getNow';
 import {
-  activatePlanningSheetVersionInRepository,
   createPlanningSheetRevision,
   getCurrentOrLatestPlanningSheet,
   listPlanningSheetSeries,
@@ -221,17 +220,14 @@ export function useIndividualSupportOrchestrator(): {
           },
         );
 
-        const series = await activatePlanningSheetVersionInRepository(
+        const series = await listPlanningSheetSeries(
           planningSheetRepository,
-          draft.id,
-          {
-            activatedBy: operatorId,
-            appliedFrom: toLocalDateISO(),
-          },
+          draft.userId,
+          draft.ispId,
         );
 
         const latest =
-          series.find((sheet) => sheet.id === draft.id) ??
+          series.find((sheet) => sheet.isCurrent && sheet.status === 'active') ??
           series[0] ??
           draft;
 
@@ -239,6 +235,7 @@ export function useIndividualSupportOrchestrator(): {
         uiActions.setActiveSPSHistory(
           buildShadowSpsHistory(series, latest.id, selectedUser.Id),
         );
+        uiActions.showSnackbar('改訂ドラフトを保存しました。運用開始は支援計画シート画面（L2）で実行してください。', 'success');
         return true;
       } catch (error) {
         console.error('[useIndividualSupportOrchestrator] revise failed', error);

--- a/src/pages/support-planning-sheet/SheetHeader.tsx
+++ b/src/pages/support-planning-sheet/SheetHeader.tsx
@@ -18,6 +18,7 @@ import DescriptionRoundedIcon from '@mui/icons-material/DescriptionRounded';
 import EditRoundedIcon from '@mui/icons-material/EditRounded';
 import LoopRoundedIcon from '@mui/icons-material/LoopRounded';
 import PlayArrowRoundedIcon from '@mui/icons-material/PlayArrowRounded';
+import RocketLaunchRoundedIcon from '@mui/icons-material/RocketLaunchRounded';
 import SaveRoundedIcon from '@mui/icons-material/SaveRounded';
 import UndoRoundedIcon from '@mui/icons-material/UndoRounded';
 
@@ -47,6 +48,9 @@ interface SheetHeaderProps {
   onSave: () => void;
   onImportAssessment: () => void;
   onImportMonitoring: () => void;
+  onActivateOperationStart?: () => void;
+  activateOperationDisabledReason?: string | null;
+  isActivatingOperationStart?: boolean;
   /** 支援手順の実施ボタンのクリック（IBD対象者のみ表示） */
   onNavigateToExecution?: () => void;
   /** 見直し・PDCAボタンのクリック（IBD対象者のみ表示） */
@@ -72,6 +76,9 @@ const SheetHeader: React.FC<SheetHeaderProps> = ({
   onSave,
   onImportAssessment,
   onImportMonitoring,
+  onActivateOperationStart,
+  activateOperationDisabledReason,
+  isActivatingOperationStart = false,
   onNavigateToExecution,
   onNavigateToPdca,
 }) => (
@@ -176,18 +183,38 @@ const SheetHeader: React.FC<SheetHeaderProps> = ({
               </Button>
             </>
           ) : (
-            <Button
-              size="small"
-              variant="outlined"
-              startIcon={<EditRoundedIcon />}
-              onClick={onEdit}
-              {...tid(TESTIDS['planning-sheet-btn-edit'])}
-            >
-              編集
-            </Button>
+            <>
+              {sheet.status === 'draft' && onActivateOperationStart && (
+                <Button
+                  size="small"
+                  variant="contained"
+                  color="success"
+                  startIcon={isActivatingOperationStart ? <CircularProgress size={16} /> : <RocketLaunchRoundedIcon />}
+                  onClick={onActivateOperationStart}
+                  disabled={Boolean(activateOperationDisabledReason) || isActivatingOperationStart}
+                >
+                  {isActivatingOperationStart ? '運用開始中…' : 'この支援計画シートを運用開始する'}
+                </Button>
+              )}
+              <Button
+                size="small"
+                variant="outlined"
+                startIcon={<EditRoundedIcon />}
+                onClick={onEdit}
+                {...tid(TESTIDS['planning-sheet-btn-edit'])}
+              >
+                編集
+              </Button>
+            </>
           )}
         </Stack>
       </Stack>
+
+      {sheet.status === 'draft' && activateOperationDisabledReason && (
+        <Typography variant="caption" color="warning.main">
+          運用開始できません: {activateOperationDisabledReason}
+        </Typography>
+      )}
 
       <Stack direction="row" spacing={2} alignItems="center" flexWrap="wrap" useFlexGap>
         <DescriptionRoundedIcon color="primary" />

--- a/src/pages/support-planning-sheet/SupportPlanningSheetView.tsx
+++ b/src/pages/support-planning-sheet/SupportPlanningSheetView.tsx
@@ -11,6 +11,7 @@ import Typography from '@mui/material/Typography';
 import { useIspRepository } from '@/features/planning-sheet/hooks/useIspRepository';
 import { usePlanningSheetRepositories } from '@/features/planning-sheet/hooks/usePlanningSheetRepositories';
 import { usePlanPatchRepository } from '@/features/planning-sheet/hooks/usePlanPatchRepository';
+import { activatePlanningSheetVersionInRepository } from '@/features/planning-sheet/domain/planningSheetVersionWorkflow';
 import { NewPlanningSheetForm } from '@/features/planning-sheet/components/NewPlanningSheetForm';
 import { TESTIDS, tid } from '@/testids';
 import {
@@ -26,6 +27,7 @@ import { ImportDialogsSection } from './sections/ImportDialogsSection';
 import { PlanningMainStackSection } from './sections/PlanningMainStackSection';
 import { DifferenceInsightBar } from './components/DifferenceInsightBar';
 import { ReflectPreviewDialog } from './components/ReflectPreviewDialog';
+import { toLocalDateISO } from '@/utils/getNow';
 
 export const SupportPlanningSheetView: React.FC<SupportPlanningSheetViewProps> = ({
   viewModel,
@@ -37,6 +39,7 @@ export const SupportPlanningSheetView: React.FC<SupportPlanningSheetViewProps> =
   const [pendingPatchCount, setPendingPatchCount] = React.useState(0);
   const [pendingPatches, setPendingPatches] = React.useState<PlanPatch[]>([]);
   const [patchActionMessage, setPatchActionMessage] = React.useState<string | null>(null);
+  const [isActivatingOperationStart, setIsActivatingOperationStart] = React.useState(false);
   const hasPendingPlanUpdate = React.useMemo(
     () => detectPlanNeedsUpdate(pendingPatches),
     [pendingPatches],
@@ -180,6 +183,47 @@ export const SupportPlanningSheetView: React.FC<SupportPlanningSheetViewProps> =
     await orchestratorApplyPatch(patch, sheet);
   };
 
+  const isValidDate = (value: string | null | undefined): boolean => {
+    if (!value) return false;
+    const date = new Date(value);
+    return !Number.isNaN(date.getTime());
+  };
+
+  const activationDisabledReason = React.useMemo(() => {
+    if (sheet.status !== 'draft') return null;
+    if (!sheet.supportStartDate) return '支援開始日（モニタリング起点）を設定してください。';
+    if (!isValidDate(sheet.supportStartDate)) return '支援開始日の形式が不正です。';
+    const hasProcedureSteps = (sheet.planning?.procedureSteps?.length ?? 0) > 0;
+    const hasSupportPolicy = sheet.supportPolicy.trim().length > 0;
+    if (!hasProcedureSteps && !hasSupportPolicy) {
+      return '支援設計（手順または支援方針）を入力してください。';
+    }
+    return null;
+  }, [sheet]);
+
+  const handleActivateOperationStart = async () => {
+    if (sheet.status !== 'draft') return;
+    if (activationDisabledReason) return;
+    setIsActivatingOperationStart(true);
+    try {
+      await activatePlanningSheetVersionInRepository(
+        planningSheetRepo,
+        sheet.id,
+        {
+          activatedBy: sheet.updatedBy || sheet.authoredByStaffId || 'current-user',
+          appliedFrom: sheet.supportStartDate || toLocalDateISO(),
+        },
+      );
+      setPatchActionMessage('支援計画シートを運用開始しました。');
+      handlers.onRefresh();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setPatchActionMessage(`運用開始に失敗しました: ${message}`);
+    } finally {
+      setIsActivatingOperationStart(false);
+    }
+  };
+
   return (
     <Box sx={{ display: 'flex', position: 'relative' }}>
       <Box sx={{ flex: 1, p: { xs: 2, md: 3 }, pb: 4 }} {...tid(TESTIDS['planning-sheet-page'])}>
@@ -273,6 +317,11 @@ export const SupportPlanningSheetView: React.FC<SupportPlanningSheetViewProps> =
             onSave: handlers.onSave,
             onImportAssessment: handlers.onImportAssessment,
             onImportMonitoring: handlers.onImportMonitoring,
+            onActivateOperationStart: () => {
+              void handleActivateOperationStart();
+            },
+            activateOperationDisabledReason: activationDisabledReason,
+            isActivatingOperationStart,
             onNavigateToExecution: handlers.onNavigateToExecution,
             onNavigateToPdca: handlers.onNavigateToPdca,
           }}

--- a/src/pages/support-planning-sheet/__tests__/SupportPlanningSheetReflection.spec.tsx
+++ b/src/pages/support-planning-sheet/__tests__/SupportPlanningSheetReflection.spec.tsx
@@ -54,6 +54,7 @@ const mockHandlers: SupportPlanningSheetActionHandlers = {
   onOpenReflectPreview: vi.fn(),
   onCloseReflectPreview: vi.fn(),
   onConfirmReflect: vi.fn(),
+  onRefresh: vi.fn(),
 };
 
 const mockViewModel: SupportPlanningSheetViewModel = {

--- a/src/pages/support-planning-sheet/__tests__/SupportPlanningSheetView.regression.spec.tsx
+++ b/src/pages/support-planning-sheet/__tests__/SupportPlanningSheetView.regression.spec.tsx
@@ -47,6 +47,7 @@ const mockHandlers: SupportPlanningSheetActionHandlers = {
   onReflectCandidate: vi.fn(),
   onNavigateToExecution: vi.fn(),
   onNavigateToPdca: vi.fn(),
+  onRefresh: vi.fn(),
 };
 
 const baseViewModel = {

--- a/src/pages/support-planning-sheet/hooks/useSupportPlanningSheetOrchestrator.ts
+++ b/src/pages/support-planning-sheet/hooks/useSupportPlanningSheetOrchestrator.ts
@@ -319,7 +319,10 @@ export function useSupportPlanningSheetOrchestrator(): {
         message: '氷山分析の結果を反映しました。保存ボタンを押すまで確定されません。',
         severity: 'info'
       });
-    }
+    },
+    onRefresh: () => {
+      void refetch();
+    },
   };
 
   return { viewModel, handlers };

--- a/src/pages/support-planning-sheet/types.tsx
+++ b/src/pages/support-planning-sheet/types.tsx
@@ -173,6 +173,8 @@ export interface SupportPlanningSheetActionHandlers {
   onCloseReflectPreview: () => void;
   /** 反映を実行する（UI上でのマージ） */
   onConfirmReflect: () => void;
+  /** 画面データを再取得する */
+  onRefresh: () => void;
 }
 
 export interface SupportPlanningSheetViewProps {


### PR DESCRIPTION
## Summary

支援計画シートの `draft -> active` 昇格操作を L2（支援計画シート画面）へ移動しました。

これまで L3 寄りの個別支援フローで改訂時に即 active 化していたため、データ管理上は L2/L3 が分離されている一方で、UI導線だけが L3 側に寄っていました。

今回の変更により、以下の責務境界に揃えています。

- L2: 支援計画シートの起点日・周期・評価設計・運用開始
- L3: 日々の実績、会議記録、改訂ドラフト作成
- L3 から L2 ステータスを直接 active 化しない

## Changes

- L2 支援計画シート画面に「この支援計画シートを運用開始する」アクションを追加
- `draft` のみ表示し、以下を満たす場合のみ実行可能にしました
  - `supportStartDate` が存在する
  - `supportStartDate` が有効な日付である
  - `procedureSteps` または `supportPolicy` が存在する
- 条件未達時は理由を表示してボタンを disabled にしました
- 実行時は `activatePlanningSheetVersionInRepository(...)` で active 化し、画面を再取得します
- L3 個別支援フローからの直接 active 化を停止しました
- L3 側の保存成功メッセージを「運用開始は L2 で実行」に変更しました
- 支援計画シート画面の `onRefresh` ハンドラを追加しました
- 関連テストモックを更新しました

## Checks

- [x] `git diff --check`
- [x] `rg "activatePlanningSheetVersionInRepository|status.*active|draft.*active" src/pages src/features`
- [x] `npm run typecheck`
- [x] `npx vitest run src/pages/support-planning-sheet/__tests__/SupportPlanningSheetView.regression.spec.tsx src/pages/support-planning-sheet/__tests__/SupportPlanningSheetReflection.spec.tsx` — 5 passed

## Follow-up

別PRで `/daily/support` と kiosk に、下書き状態の支援計画シートを検知した際の L2 誘導リンクを追加予定です。
