### PR TITLE
feat(daily): guide draft planning sheets to L2 activation

### DIFF
--- a/src/features/kiosk/components/KioskProcedureListScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureListScreen.tsx
@@ -144,6 +144,8 @@ export const KioskProcedureListScreen: React.FC = () => {
   const showSetupCta = !!queryUserId
     && (supportStartDateLabel.includes('未設定（90日参考）') || supportStartDateLabel.includes('不正な日付（90日参考）'));
   const showProvisionalReviewCta = resolvedStartDate.source === 'fallback' && !!currentPlanningSheetId;
+  const currentPlanningSheetStatus = planningSheet?.status ?? currentSheet?.status;
+  const showDraftStatusReviewCta = currentPlanningSheetStatus === 'draft' && !!currentPlanningSheetId;
 
   const { getRecords: getStoreRecords } = useExecutionStore();
   const storeRecords = getStoreRecords(selectedDateIso || '', user?.UserID || userId || '');
@@ -304,7 +306,24 @@ export const KioskProcedureListScreen: React.FC = () => {
                   元シートを確認
                 </Button>
               )}
+              {showDraftStatusReviewCta && (
+                <Button
+                  size="small"
+                  variant="outlined"
+                  color="warning"
+                  component={RouterLink}
+                  to={`/support-planning-sheet/${encodeURIComponent(currentPlanningSheetId)}`}
+                  data-testid="kiosk-planning-draft-review-cta"
+                >
+                  支援計画シートを確認
+                </Button>
+              )}
             </Box>
+            {showDraftStatusReviewCta && (
+              <Typography variant="caption" color="warning.main">
+                この支援計画シートは下書きです。正式運用は支援計画シート画面で開始してください。
+              </Typography>
+            )}
           </Box>
         </Box>
 

--- a/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
@@ -548,6 +548,52 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
     });
   });
 
+  it('shows planning draft review CTA when planning sheet status is draft', async () => {
+    mockUseUser.mockReturnValue({
+      data: { FullName: '田中 太郎', ServiceStartDate: '2026-04-01' },
+      status: 'success',
+    });
+    mockUsePlanningSheetData.mockReturnValue({
+      data: { id: 'sp-123', status: 'draft', supportStartDate: '2026-05-01' } as unknown as SupportPlanningSheet,
+      isLoading: false,
+    });
+
+    render(
+      <MemoryRouter>
+        <KioskProcedureListScreen />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      const cta = screen.getByTestId('kiosk-planning-draft-review-cta');
+      expect(cta).toBeInTheDocument();
+      expect(cta).toHaveAttribute('href', '/support-planning-sheet/sp-123');
+      expect(screen.getByText(/この支援計画シートは下書きです/)).toBeInTheDocument();
+    });
+  });
+
+  it('does not show planning draft review CTA when planning sheet status is active', async () => {
+    mockUseUser.mockReturnValue({
+      data: { FullName: '田中 太郎', ServiceStartDate: '2026-04-01' },
+      status: 'success',
+    });
+    mockUsePlanningSheetData.mockReturnValue({
+      data: { id: 'sp-123', status: 'active', supportStartDate: '2026-05-01' } as unknown as SupportPlanningSheet,
+      isLoading: false,
+    });
+
+    render(
+      <MemoryRouter>
+        <KioskProcedureListScreen />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('kiosk-planning-draft-review-cta')).toBeNull();
+      expect(screen.queryByText(/この支援計画シートは下書きです/)).toBeNull();
+    });
+  });
+
   it('prefers query userId over route userId when loading user-scoped data', async () => {
     mockRouteUserId = '6';
     mockUseUser.mockReturnValue({

--- a/src/pages/TimeBasedSupportRecordPage.tsx
+++ b/src/pages/TimeBasedSupportRecordPage.tsx
@@ -352,6 +352,12 @@ const TimeBasedSupportRecordPage: React.FC = () => {
     return null;
   };
 
+  const showDraftPlanningSheetGuide = Boolean(
+    initialParams.planningSheetId
+      && sheetData
+      && sheetData.status === 'draft',
+  );
+
   return (
     <FullScreenDailyDialogPage
       title="支援手順の実施（行動観察）"
@@ -428,6 +434,24 @@ const TimeBasedSupportRecordPage: React.FC = () => {
                 </Step>
               ))}
             </Stepper>
+          </Box>
+        )}
+        {showDraftPlanningSheetGuide && (
+          <Box sx={{ px: 2, pt: 1 }}>
+            <Alert
+              severity="warning"
+              action={(
+                <Button
+                  color="inherit"
+                  size="small"
+                  onClick={() => navigate(`/support-planning-sheet/${initialParams.planningSheetId}`)}
+                >
+                  支援計画シートを確認して運用開始する
+                </Button>
+              )}
+            >
+              この支援計画シートはまだ下書きです。日々の記録は可能ですが、正式運用を開始するには支援計画シート画面で「運用開始」を実行してください。
+            </Alert>
           </Box>
         )}
 


### PR DESCRIPTION
## Summary

L3（日々の記録）と kiosk で、下書き状態の支援計画シートを検知した際に L2（支援計画シート画面）へ誘導する案内を追加しました。

#1953 で `draft -> active` の運用開始操作を L2 へ移動したため、本PRでは L3/kiosk 側を「参照・誘導のみ」に揃えます。

## Changes

- `/daily/support` で `planningSheetId` 付き遷移時、対象シートが `draft` の場合に warning Alert を表示
- Alert から `/support-planning-sheet/:planningSheetId` へ遷移できる CTA を追加
- kiosk 手順一覧で、対象の支援計画シートが `draft` の場合に案内表示
- kiosk から `/support-planning-sheet/:id` へ遷移できる CTA を追加
- `active` の場合は案内を表示しない
- kiosk の draft / active 表示分岐テストを追加

## Design note

このPRでは L3/kiosk から支援計画シートの status 更新は行いません。

- L2: 支援計画シートの運用開始、起点日、周期、評価設計を管理
- L3/kiosk: 支援計画シートの状態を参照し、必要時に L2 へ誘導
- `activatePlanningSheetVersionInRepository(...)` は L3/kiosk から呼ばない

## Checks

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npx vitest run src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx`

## Note

`TimeBasedSupportRecordPage` は既存テスト基盤が薄いため、今回は UI 実装のみとし、kiosk 側の draft / active 表示分岐を自動テストで担保しています。
