### PR TITLE
fix(planning-sheet): avoid conditional hook order in activation guard

### DIFF
--- a/src/pages/support-planning-sheet/SupportPlanningSheetView.tsx
+++ b/src/pages/support-planning-sheet/SupportPlanningSheetView.tsx
@@ -189,7 +189,7 @@ export const SupportPlanningSheetView: React.FC<SupportPlanningSheetViewProps> =
     return !Number.isNaN(date.getTime());
   };
 
-  const activationDisabledReason = React.useMemo(() => {
+  const activationDisabledReason = (() => {
     if (sheet.status !== 'draft') return null;
     if (!sheet.supportStartDate) return '支援開始日（モニタリング起点）を設定してください。';
     if (!isValidDate(sheet.supportStartDate)) return '支援開始日の形式が不正です。';
@@ -199,7 +199,7 @@ export const SupportPlanningSheetView: React.FC<SupportPlanningSheetViewProps> =
       return '支援設計（手順または支援方針）を入力してください。';
     }
     return null;
-  }, [sheet]);
+  })();
 
   const handleActivateOperationStart = async () => {
     if (sheet.status !== 'draft') return;


### PR DESCRIPTION
## Summary

支援計画シート詳細画面で、`activationDisabledReason` の計算に使っていた `React.useMemo(...)` を通常計算へ戻し、早期 return による hook order 不一致を避けます。

#1953 で L2 の「運用開始」アクションを追加した際、`activationDisabledReason` の `useMemo` が `isLoading` / `new` / `error` などの早期 return より後に置かれていたため、レンダー状態によって hook 数が変わる可能性がありました。

## Changes

- `SupportPlanningSheetView.tsx` の `activationDisabledReason` を `React.useMemo(...)` から通常計算に変更
- hook を追加・削除せず、運用開始ガード条件そのものは維持
- L2 activation flow / L3誘導ロジックには変更なし

## Checks

- [x] `npm run typecheck`
- [x] `npx vitest run src/pages/support-planning-sheet/__tests__/SupportPlanningSheetView.regression.spec.tsx src/pages/support-planning-sheet/__tests__/SupportPlanningSheetReflection.spec.tsx`

## Scope

このPRは hook order 修正のみです。

- `draft -> active` の仕様変更なし
- L3/kiosk の draft誘導変更なし
- `activatePlanningSheetVersionInRepository(...)` の呼び出し位置変更なし
