### PR TITLE
fix(planning-sheet): allow editing support start date

### DIFF
--- a/src/features/planning-sheet/components/EditableOverviewSection.tsx
+++ b/src/features/planning-sheet/components/EditableOverviewSection.tsx
@@ -57,6 +57,18 @@ export const EditableOverviewSection: React.FC<Props> = ({ values, setFieldValue
       />
     </Stack>
 
+    <TextField
+      label="支援開始日（モニタリング起点）"
+      type="date"
+      value={values.supportStartDate ?? ''}
+      onChange={(e) => setFieldValue('supportStartDate', e.target.value || undefined)}
+      error={!!errors.supportStartDate}
+      helperText={errors.supportStartDate ?? '90日モニタリング周期と運用開始判定の起点日です。'}
+      fullWidth
+      size="small"
+      InputLabelProps={{ shrink: true }}
+    />
+
     <Divider />
 
     <Box>


### PR DESCRIPTION
## Summary

既存支援計画シートの編集画面で、支援開始日（モニタリング起点）を入力・更新できるようにしました。

`draft -> active` の運用開始ガードでは `supportStartDate` を必須にしていますが、既存シート編集UIには入力欄がなく、既存シートを運用開始できないケースがありました。

## Changes

- `EditableOverviewSection` の基本情報セクションに `支援開始日（モニタリング起点）` 入力欄を追加
- `type="date"` で `values.supportStartDate` を表示
- 変更時に `setFieldValue('supportStartDate', e.target.value || undefined)` でフォーム値へ反映
- `errors.supportStartDate` を表示
- 補助文言として「90日モニタリング周期と運用開始判定の起点日です。」を表示

## Checks

- [x] `npm run typecheck`
- [x] `npx vitest run src/pages/support-planning-sheet src/features/planning-sheet`

## Scope

- 既存シート編集UIへの入力欄追加のみ
- `draft -> active` の運用開始ロジックは変更なし
- 新規作成フローは変更なし
- SharePoint schema / repository は変更なし
