### PR TITLE
test(e2e): stabilize planning sheet support date stubs

### DIFF
--- a/tests/e2e/_helpers/setupSharePointStubs.ts
+++ b/tests/e2e/_helpers/setupSharePointStubs.ts
@@ -232,11 +232,22 @@ export async function setupSharePointStubs(page: Page, options: SetupSharePointS
         if (remainder === '' || remainder === '/' || remainder.startsWith('?')) {
           await fulfill(route, { status: 200, body: { Title: state.config.name, Id: state.config.name, BaseType: 0, EntityTypeName: state.config.name } });
         } else {
-          const keys = new Set<string>(['Id', 'Title', 'Created', 'AuthorId', 'EditorId', 'Modified']);
+          const keys = new Set<string>();
+          const lowerKeys = new Set<string>();
+          const addKey = (k: string) => {
+            if (!k) return;
+            const lower = k.toLowerCase();
+            if (!lowerKeys.has(lower)) {
+              lowerKeys.add(lower);
+              keys.add(k);
+            }
+          };
+
+          ['Id', 'Title', 'Created', 'AuthorId', 'EditorId', 'Modified'].forEach(addKey);
           const items = getItems();
           if (items.length > 0) {
             for (const item of items) {
-              Object.keys(item).forEach((k) => keys.add(k));
+              Object.keys(item).forEach(addKey);
             }
           }
 
@@ -246,46 +257,46 @@ export async function setupSharePointStubs(page: Page, options: SetupSharePointS
           const isStaff = listKey.includes('staff');
 
           if (isSchedule) {
-            ['Title', 'EventDate', 'EndDate', 'Status', 'ServiceType', 'TargetUserId', 'cr014_personName', 'AssignedStaffId', 'LocationName', 'Note', 'RowKey', 'cr014_dayKey', 'MonthKey', 'cr014_fiscalYear', 'VehicleId', 'Visibility', 'StatusReason', 'AcceptedOn', 'AcceptedBy', 'AcceptedNote'].forEach(k => keys.add(k));
+            ['Title', 'EventDate', 'EndDate', 'Status', 'ServiceType', 'TargetUserId', 'cr014_personName', 'AssignedStaffId', 'LocationName', 'Note', 'RowKey', 'cr014_dayKey', 'MonthKey', 'cr014_fiscalYear', 'VehicleId', 'Visibility', 'StatusReason', 'AcceptedOn', 'AcceptedBy', 'AcceptedNote'].forEach(addKey);
           }
           if (isUser) {
-            ['UserID', 'FullName', 'Furigana', 'FullNameKana', 'ContractDate', 'ServiceStartDate', 'ServiceEndDate', 'IsHighIntensitySupportTarget', 'IsSupportProcedureTarget', 'IsActive', 'UsageStatus', 'AttendanceDays', 'TransportToDays', 'TransportFromDays', 'TransportCourse', 'TransportSchedule', 'TransportAdditionType', 'RecipientCertNumber', 'RecipientCertExpiry', 'GrantMunicipality', 'GrantPeriodStart', 'GrantPeriodEnd', 'DisabilitySupportLevel', 'GrantedDaysPerMonth', 'UserCopayLimit', 'MealAddition', 'CopayPaymentMethod'].forEach(k => keys.add(k));
+            ['UserID', 'FullName', 'Furigana', 'FullNameKana', 'ContractDate', 'ServiceStartDate', 'ServiceEndDate', 'IsHighIntensitySupportTarget', 'IsSupportProcedureTarget', 'IsActive', 'UsageStatus', 'AttendanceDays', 'TransportToDays', 'TransportFromDays', 'TransportCourse', 'TransportSchedule', 'TransportAdditionType', 'RecipientCertNumber', 'RecipientCertExpiry', 'GrantMunicipality', 'GrantPeriodStart', 'GrantPeriodEnd', 'DisabilitySupportLevel', 'GrantedDaysPerMonth', 'UserCopayLimit', 'MealAddition', 'CopayPaymentMethod'].forEach(addKey);
           }
           if (isStaff) {
-            ['StaffID', 'FullName', 'Furigana', 'FullNameKana', 'JobTitle', 'Role', 'RBACRole', 'IsActive', 'Department', 'HireDate', 'ResignDate', 'Email', 'Phone', 'WorkDays', 'BaseWorkingDays', 'BaseShiftStartTime', 'BaseShiftEndTime', 'Certifications'].forEach(k => keys.add(k));
+            ['StaffID', 'FullName', 'Furigana', 'FullNameKana', 'JobTitle', 'Role', 'RBACRole', 'IsActive', 'Department', 'HireDate', 'ResignDate', 'Email', 'Phone', 'WorkDays', 'BaseWorkingDays', 'BaseShiftStartTime', 'BaseShiftEndTime', 'Certifications'].forEach(addKey);
           }
           if (listKey.includes('isp')) {
-            ['Title', 'UserCode', 'PlanStartDate', 'PlanEndDate', 'Status', 'VersionNo', 'IsCurrent', 'FormDataJson', 'UserSnapshotJson'].forEach(k => keys.add(k));
+            ['Title', 'UserCode', 'PlanStartDate', 'PlanEndDate', 'Status', 'VersionNo', 'IsCurrent', 'FormDataJson', 'UserSnapshotJson'].forEach(addKey);
           }
           if (listKey.includes('planning')) {
-            ['Title', 'UserCode', 'ISPId', 'TargetScene', 'Status', 'VersionNo', 'IsCurrent', 'FormDataJson', 'IntakeJson', 'AssessmentJson', 'PlanningJson'].forEach(k => keys.add(k));
+            ['Title', 'UserCode', 'ISPId', 'TargetScene', 'Status', 'VersionNo', 'IsCurrent', 'FormDataJson', 'IntakeJson', 'AssessmentJson', 'PlanningJson', 'TargetDomain', 'CollectedInformation', 'EnvironmentalAdjustments', 'AppliedFrom', 'NextReviewAt', 'AuthoredByStaffId', 'ApplicableServiceType', 'SupportStartDate', 'MonitoringCycleDays', 'ObservationFacts', 'InterpretationHypothesis', 'SupportIssues', 'SupportPolicy', 'ConcreteApproaches', 'UserId'].forEach(addKey);
           }
           if (listKey.includes('monitoring')) {
-            ['Title', 'cr014_recordId', 'cr014_userId', 'cr014_meetingDate', 'cr014_status'].forEach(k => keys.add(k));
+            ['Title', 'cr014_recordId', 'cr014_userId', 'cr014_meetingDate', 'cr014_status'].forEach(addKey);
           }
           if (listKey.includes('patch')) {
-            ['Title', 'PatchId', 'PlanningSheetId', 'PatchTarget', 'BaseVersion', 'BeforeJson', 'AfterJson', 'PatchReason', 'EvidenceIdsJson', 'PatchStatus', 'PatchDueAt', 'PatchCreatedAt', 'PatchUpdatedAt'].forEach(k => keys.add(k));
+            ['Title', 'PatchId', 'PlanningSheetId', 'PatchTarget', 'BaseVersion', 'BeforeJson', 'AfterJson', 'PatchReason', 'EvidenceIdsJson', 'PatchStatus', 'PatchDueAt', 'PatchCreatedAt', 'PatchUpdatedAt'].forEach(addKey);
           }
           if (listKey.includes('result') || listKey.includes('record')) {
-            ['Title', 'RecordId', 'UserCode', 'TargetDate', 'Status', 'ResultJson', 'ExecutorId'].forEach(k => keys.add(k));
+            ['Title', 'RecordId', 'UserCode', 'TargetDate', 'Status', 'ResultJson', 'ExecutorId'].forEach(addKey);
           }
           if (listKey.includes('log') || listKey.includes('approval')) {
-            ['Title', 'RecordId', 'TargetId', 'Action', 'Comment', 'ActorId', 'ActorName', 'Status', 'ApprovedAt', 'ApprovalAction', 'ApprovedBy', 'ApproverId', 'ApproverName'].forEach(k => keys.add(k));
+            ['Title', 'RecordId', 'TargetId', 'Action', 'Comment', 'ActorId', 'ActorName', 'Status', 'ApprovedAt', 'ApprovalAction', 'ApprovedBy', 'ApproverId', 'ApproverName'].forEach(addKey);
           }
           if (listKey.includes('flag') || listKey.includes('feature')) {
-            ['Title', 'UserCode', 'FeatureKey', 'IsEnabled', 'ConfigJson'].forEach(k => keys.add(k));
+            ['Title', 'UserCode', 'FeatureKey', 'IsEnabled', 'ConfigJson'].forEach(addKey);
           }
           // Use explicitly defined fields if available
           if (state.config.fields) {
-            state.config.fields.forEach(f => keys.add(f.InternalName));
+            state.config.fields.forEach(f => addKey(f.InternalName));
           } else {
             // Default fields to avoid provisioning storm
-            ['Status', 'UserCode', 'RecordId', 'TargetDate', 'FormDataJson', 'PlanningJson', 'CreatedAt', 'UpdatedAt', 'IsCurrent', 'PlanId', 'SheetId', 'UserId', 'TargetYearMonth', 'ExecutorId', 'VerifierId', 'ApprovalStatus', 'Comment', 'ActionType', 'ItemJson', 'RecordDate', 'ActivityJson', 'ExecutionJson', 'StepsJson', 'YearMonth', 'ID', 'EditorId', 'AuthorId', 'Modified', 'Created', 'GUID', 'PlanningSheetId', 'PeriodEnd'].forEach(k => keys.add(k));
+            ['Status', 'UserCode', 'RecordId', 'TargetDate', 'FormDataJson', 'PlanningJson', 'CreatedAt', 'UpdatedAt', 'IsCurrent', 'PlanId', 'SheetId', 'UserId', 'TargetYearMonth', 'ExecutorId', 'VerifierId', 'ApprovalStatus', 'Comment', 'ActionType', 'ItemJson', 'RecordDate', 'ActivityJson', 'ExecutionJson', 'StepsJson', 'YearMonth', 'ID', 'EditorId', 'AuthorId', 'Modified', 'Created', 'GUID', 'PlanningSheetId', 'PeriodEnd'].forEach(addKey);
           }
 
           // Dynamic fields
           if (dynamicFields.has(match.key)) {
-            dynamicFields.get(match.key)!.forEach(k => keys.add(k));
+            dynamicFields.get(match.key)!.forEach(addKey);
           }
 
           const results = Array.from(keys).map((k) => ({

--- a/tests/e2e/planning-sheet-creation-iceberg.spec.ts
+++ b/tests/e2e/planning-sheet-creation-iceberg.spec.ts
@@ -133,7 +133,7 @@ test.describe('Support Planning Sheet — Iceberg Creation Flow', () => {
     // Wait for the automatic import preview dialog to appear (since it is a modal that blocks the background)
     const previewDialog = page.getByRole('dialog', { name: /取込プレビュー/ });
     await expect(previewDialog).toBeVisible({ timeout: 10000 });
-    await previewDialog.getByRole('button', { name: 'この内容で取り込む' }).click();
+    await previewDialog.getByRole('button', { name: '確認してフォームに反映する' }).click();
     await expect(previewDialog).toBeHidden();
 
     // Now that the modal is closed, the background content should be visible and interactive


### PR DESCRIPTION
## Summary

Planning Sheet 関連E2Eの SharePoint stub と selector を現行実装に合わせて安定化しました。

Support Date Governance E2E で `sp-undefined` へ遷移する原因は、SharePoint fields mock が `Id` / `ID` を重複登録し、case-insensitive 解決時に `id` が `ID` へ解決されていたことでした。

実環境の SharePoint internal name 解決に近づけるため、stub 側の field metadata を case-insensitive に dedupe し、Planning Sheet 作成・保存に必要な候補列を追加しています。

## Changes

- `setupSharePointStubs.ts`
  - fields metadata の case-insensitive dedupe を追加
  - Planning Sheet に必要な candidate fields を stub に追加
  - `sp-undefined` redirect を引き起こす ID 解決ズレを修正
- `planning-sheet-creation-iceberg.spec.ts`
  - 取込ボタン selector を現行UI文言 `確認してフォームに反映する` に更新

## Checks

- [x] `git diff --check`
- [x] `npx playwright test tests/e2e/support-date-governance.spec.ts`
- [x] `npx playwright test tests/e2e/planning-sheet-creation-iceberg.spec.ts`

## Scope

- E2E stub / test selector の安定化のみ
- 本番ロジック変更なし
- SharePoint schema / repository 実装変更なし
