### PR TITLE
fix(test): remove lint violations from governance policy specs

### DIFF
--- a/src/features/diagnostics/remediation/domain/__tests__/governancePolicy.spec.ts
+++ b/src/features/diagnostics/remediation/domain/__tests__/governancePolicy.spec.ts
@@ -10,8 +10,8 @@ describe('Governance Policy Audit (4 Core Scenarios)', () => {
       displayName: '利用者マスタ',
       resolve: () => 'Users',
       provisioningFields: [{ internalName: 'UID', type: 'Text' }],
-      operations: ['R'] as any,
-      category: 'user' as any,
+      operations: ['R'],
+      category: 'master',
       essentialFields: ['UID'],
       lifecycle: 'required',
     },
@@ -20,8 +20,8 @@ describe('Governance Policy Audit (4 Core Scenarios)', () => {
       displayName: '監査ログ',
       resolve: () => 'AuditLogs',
       provisioningFields: [{ internalName: 'Log', type: 'Text' }],
-      operations: ['R'] as any,
-      category: 'ops' as any,
+      operations: ['R'],
+      category: 'other',
       essentialFields: ['Log'],
       lifecycle: 'required',
     }
@@ -68,16 +68,19 @@ describe('Governance Policy Audit (4 Core Scenarios)', () => {
   });
 
   it('Scenario 4: 未定義リスト/低優先ノイズ — 優先度を P4 に抑え込むべき', () => {
-    const registryWithUnknown = [...mockRegistry, {
-      key: 'temp_debug_list',
-      displayName: '一時デバッグ',
-      resolve: () => 'Temp',
-      provisioningFields: [{ internalName: 'Dump', type: 'Text' }],
-      operations: ['R'] as any,
-      category: 'ops' as any,
-      essentialFields: ['Dump'],
-      lifecycle: 'required',
-    } as any];
+    const registryWithUnknown: SpListEntry[] = [
+      ...mockRegistry,
+      {
+        key: 'temp_debug_list',
+        displayName: '一時デバッグ',
+        resolve: () => 'Temp',
+        provisioningFields: [{ internalName: 'Dump', type: 'Text' }],
+        operations: ['R'],
+        category: 'other',
+        essentialFields: ['Dump'],
+        lifecycle: 'required',
+      }
+    ];
 
     const signals = [createSignal('temp_debug_list:Dump', 1)];
     const [rec] = deriveGovernanceRecommendations(registryWithUnknown, signals);

--- a/src/features/diagnostics/remediation/domain/__tests__/governancePolicyReview.spec.ts
+++ b/src/features/diagnostics/remediation/domain/__tests__/governancePolicyReview.spec.ts
@@ -6,7 +6,7 @@ describe('Governance Policy Review Simulation (Human-in-the-loop)', () => {
 
   beforeEach(() => {
     store = GovernanceAuditStore.getInstance();
-    (store as any).entries = []; 
+    store.clear();
   });
 
   const generateMockAuditData = () => {
@@ -41,11 +41,6 @@ describe('Governance Policy Review Simulation (Human-in-the-loop)', () => {
     }
 
     const report = store.getAnalysisReport();
-
-    console.log('--- Policy Review Analysis Report ---');
-    console.log(`Accepted Rate: ${report.acceptedRate}%`);
-    console.log(`High Confidence Accepted Rate: ${report.highConfidenceAcceptedRate}%`);
-    console.log(`Auto Executable Accepted Rate: ${report.autoExecutableAcceptedRate}%`);
 
     // 受入基準の検証
     expect(report.acceptedRate).toBe(80); // 8/10


### PR DESCRIPTION
## 概要
ガバナンスポリシー関連のテストスペックファイルにおいて、ESLintの規約違反（`any` のキャスト及び `console.log` の使用）を解消しました。

Closes # (なし)

## 変更内容
### 変更
- `governancePolicyReview.spec.ts`
  - `(store as any).entries = [];` の `any` キャストを排除し、用意されている公開メソッド `store.clear()` を呼ぶように修正しました。
  - テスト結果出力用の `console.log` 記述を削除しました。
- `governancePolicy.spec.ts`
  - モックレジストリ定義における `operations` 及び `category` の `as any` キャストを削除し、それぞれ `SpListOperation` / `SpListCategory` の仕様に合わせた正しい静的値（`['R']`, `'master'`, `'other'`）で型安全に定義しました。
  - `Scenario 4` のモックレジストリ結合部で `registryWithUnknown` オブジェクトに対して行われていた `as any` キャストを削除し、型指定 `SpListEntry[]` で安全に定義し直しました。

## 変更ファイル一覧
| ファイル | 変更種別 | 変更内容 |
|---------|---------|---------| 
| `src/features/diagnostics/remediation/domain/__tests__/governancePolicyReview.spec.ts` | 変更 | `any` の削除、`console.log` の削除、`store.clear()` の採用 |
| `src/features/diagnostics/remediation/domain/__tests__/governancePolicy.spec.ts` | 変更 | `any` キャストの削除、`SpListCategory` と `SpListOperation` の型安全な値割り当て |

## テスト
- [x] 既存テスト通過
- [x] 型チェック通過
- [ ] 新規テスト追加 (リファクタリングのため不要)

## Validation
- [x] `npx eslint src/features/diagnostics/remediation/domain/__tests__/governancePolicyReview.spec.ts src/features/diagnostics/remediation/domain/__tests__/governancePolicy.spec.ts`
- [x] `npm run typecheck`
- [x] `npx vitest run src/features/diagnostics/remediation/domain/__tests__/governancePolicyReview.spec.ts src/features/diagnostics/remediation/domain/__tests__/governancePolicy.spec.ts`

## セルフレビュー
- [x] `console.log` 残していない
- [x] `any` 使っていない
- [x] 責務分離を守っている
- [x] 600行ルール違反なし

## 影響範囲
- `governancePolicyReview.spec.ts` および `governancePolicy.spec.ts` 内のユニットテスト検証に限定され、本番コードへの影響はありません。
