### PR TITLE
chore(ci): increase workflow job timeouts for stabilization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
     name: TypeCheck & Test
     runs-on: ubuntu-latest
     needs: [contracts, registry-static-audit, registry-ssot, registry-integration, registry-drift-probe]
-    timeout-minutes: 15
+    timeout-minutes: 25
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       ci_full: ${{ steps.changes.outputs.ci_full }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     permissions:
       contents: read
       issues: write
@@ -262,7 +262,7 @@ jobs:
     name: quality_extended
     if: ${{ github.event_name == 'pull_request' && needs.quality.outputs.ci_full == 'true' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     permissions:
       contents: read
       issues: write


### PR DESCRIPTION
## 概要
mainへのプッシュ後や PR ビルド（Quality Gates）における大規模テストスイートの実行およびカバレッジ収集ジョブのタイムアウト（timeoutによるcancelled）を解消するため、関連する主要ワークフローのジョブタイムアウト時間を延長し、CIの安定化を図りました。

Closes # (なし)

## 変更内容
### `.github/workflows/ci.yml`
- **TypeCheck & Test ジョブ (`typecheck-and-test`)**
  - タイムアウト時間を **15分** から **25分** へ引き上げ。

### `.github/workflows/test.yml`
- **Quality Gates ジョブ (`quality`)**
  - タイムアウト時間を **30分** から **45分** へ引き上げ。
- **Quality Gates Extended ジョブ (`quality_extended`)**
  - タイムアウト時間を **30分** から **45分** へ引き上げ。

## 変更ファイル一覧
| ファイル | 変更種別 | 変更内容 |
|---------|---------|---------| 
| `.github/workflows/ci.yml` | 変更 | `typecheck-and-test` ジョブの `timeout-minutes` を 15 から 25 に延長 |
| `.github/workflows/test.yml` | 変更 | `quality` および `quality_extended` ジョブの `timeout-minutes` を 30 から 45 に延長 |

## テスト
- [x] ワークフローの構文バリデーション (スキーマ等の変更はなく時間値の変更のみ)

## セルフレビュー
- [x] `console.log` 残していない (設定ファイルのため該当なし)
- [x] `any` 使っていない (設定ファイルのため該当なし)
- [x] タイムアウト引き上げが短期安定化に寄与し、マトリックス分割などの抜本的対策 (PR-C) の安全な検討基盤となる

## 影響範囲
- CI/CDパイプライン実行の安定性向上に限定され、アプリケーション本番コードの動作や実行時パフォーマンス等への影響はありません。
