### PR TITLE
chore(ci): move vitest coverage to nightly patrol to eliminate main lane timeout and maintain strict governance

### DIFF
--- a/.github/workflows/nightly-patrol.yml
+++ b/.github/workflows/nightly-patrol.yml
@@ -49,6 +49,16 @@ jobs:
         env:
           CI: true
 
+      - name: Nightly coverage scan
+        run: |
+          set -o pipefail
+          npm run test:coverage -- --reporter=default
+          if [ -d coverage ]; then
+            mkdir -p docs/nightly-patrol
+            cp coverage/coverage-summary.json docs/nightly-patrol/coverage-summary.json
+            cp coverage/lcov.info docs/nightly-patrol/lcov.info
+          fi
+
       - name: Nightly act warning scan
         id: act_scan
         continue-on-error: true
@@ -192,37 +202,7 @@ jobs:
             echo "- decision: unavailable" >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
-          node - "$FILE" <<'NODE' >> "$GITHUB_STEP_SUMMARY"
-          const fs = require('node:fs');
-          const file = process.argv[2];
-          const data = JSON.parse(fs.readFileSync(file, 'utf8'));
-          console.log(`- verdict: **${data.final?.line ?? 'n/a'}**`);
-          if (Array.isArray(data.reasons?.fail) && data.reasons.fail.length > 0) {
-            console.log(`- failTriggers: ${data.reasons.fail.length}`);
-          } else {
-            console.log('- failTriggers: 0');
-          }
-          if (Array.isArray(data.reasons?.warn) && data.reasons.warn.length > 0) {
-            console.log(`- watchTriggers: ${data.reasons.warn.length}`);
-          } else {
-            console.log('- watchTriggers: 0');
-          }
-          if (Array.isArray(data.reasonCodes?.fail) && data.reasonCodes.fail.length > 0) {
-            console.log(`- failCodes: \`${data.reasonCodes.fail.join(', ')}\``);
-          }
-          if (Array.isArray(data.reasonCodes?.warn) && data.reasonCodes.warn.length > 0) {
-            console.log(`- watchCodes: \`${data.reasonCodes.warn.join(', ')}\``);
-          }
-          if (Array.isArray(data.escalations) && data.escalations.length > 0) {
-            const rows = data.escalations.map((x) => {
-              const type = x?.type || 'unknown';
-              const days = Number.isFinite(x?.days) ? x.days : 'n/a';
-              const code = x?.code || 'n/a';
-              return `${type}:${code} (${days}d)`;
-            });
-            console.log(`- escalations: \`${rows.join(', ')}\``);
-          }
-          NODE
+          node scripts/ops/nightly-decision-summary.mjs "$FILE" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Index Pressure summary
         if: ${{ always() }}
@@ -232,27 +212,7 @@ jobs:
           if [ ! -f "$FILE" ]; then
             echo "- summary: unavailable" >> "$GITHUB_STEP_SUMMARY"
           else
-            node - "$FILE" <<'NODE' >> "$GITHUB_STEP_SUMMARY"
-            const fs = require('node:fs');
-            const file = process.argv[2];
-            const data = JSON.parse(fs.readFileSync(file, 'utf8'));
-            const results = data.results || [];
-            const critical = results.filter(r => ['action_required', 'critical'].includes(r.severity));
-            console.log(`- totalFindings: **${results.length}**`);
-            console.log(`- actionRequired: **${critical.length}**`);
-            if (critical.length > 0) {
-              console.log('\n| List | Field | Severity |');
-              console.log('|------|-------|:---:|');
-              critical.forEach(r => {
-                const sev = r.severity === 'critical' ? '🔴' : '🟠';
-                console.log(`| ${r.listKey} | ${r.fieldName} | ${sev} ${r.severity} |`);
-              });
-            } else if (results.length > 0) {
-              console.log('\n✅ No action required (all findings are low severity)');
-            } else {
-              console.log('\n✅ No index pressure detected');
-            }
-            NODE
+            node scripts/ops/index-pressure-summary.mjs "$FILE" >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Auto-create nightly issues
@@ -326,6 +286,16 @@ jobs:
             /tmp/vitest-nightly-act.log
           if-no-files-found: warn
 
+      - name: Upload nightly coverage artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-coverage-${{ github.run_number }}
+          path: |
+            docs/nightly-patrol/coverage-summary.json
+            docs/nightly-patrol/lcov.info
+          if-no-files-found: ignore
+
       - name: Upload lane assertion result
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
@@ -348,37 +318,45 @@ jobs:
       - name: Nightly act warning summary
         if: ${{ always() }}
         run: |
-          echo "## Nightly act(...) warning monitor" >> "$GITHUB_STEP_SUMMARY"
-          if [ -f /tmp/act-warnings-nightly.json ]; then
-            node - <<'NODE' >> "$GITHUB_STEP_SUMMARY"
-          const fs = require('node:fs');
-          const p = '/tmp/act-warnings-nightly.json';
-          const s = JSON.parse(fs.readFileSync(p, 'utf8'));
-          const total = Number(s.totalWarnings || 0);
-          const affected = Number(s.affectedFiles || 0);
-          const maxFile = s.maxWarningsFile || 'none';
-          const maxCount = Number(s.maxWarningsPerFile || 0);
-          console.log(`- totalWarnings: **${total}**`);
-          console.log(`- affectedFiles: **${affected}**`);
-          console.log(`- maxWarningsFile: **${maxFile}**`);
-          console.log(`- maxWarningsPerFile: **${maxCount}**`);
-          NODE
-          else
-            echo "- summary: unavailable" >> "$GITHUB_STEP_SUMMARY"
-          fi
-          echo "- openIssueCount: **${{ steps.act_issue.outputs.open_count || '0' }}**" >> "$GITHUB_STEP_SUMMARY"
-          if [ -n "${{ steps.act_issue.outputs.open_url }}" ]; then
-            echo "- openIssue: ${{ steps.act_issue.outputs.open_url }}" >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "- openIssue: none" >> "$GITHUB_STEP_SUMMARY"
-          fi
-          if [ -f /tmp/act-warnings-nightly.json ]; then
-            total=$(node -e "const s=require('/tmp/act-warnings-nightly.json');console.log(Number(s.totalWarnings||0));")
-            if [ "$total" -eq 0 ]; then
-              echo "" >> "$GITHUB_STEP_SUMMARY"
-              echo "✅ 0件維持を確認しました。" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Nightly act(...) warning monitor"
+            node scripts/ops/nightly-act-warning-summary.mjs /tmp/act-warnings-nightly.json
+            echo "- openIssueCount: **${{ steps.act_issue.outputs.open_count || '0' }}**"
+            if [ -n "${{ steps.act_issue.outputs.open_url }}" ]; then
+              echo "- openIssue: ${{ steps.act_issue.outputs.open_url }}"
+            else
+              echo "- openIssue: none"
             fi
-          fi
+            if [ -f /tmp/act-warnings-nightly.json ]; then
+              total=$(node -e "const s=require('/tmp/act-warnings-nightly.json');console.log(Number(s.totalWarnings||0));")
+              if [ "$total" -eq 0 ]; then
+                echo ""
+                echo "✅ 0件維持を確認しました。"
+              fi
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Nightly coverage summary
+        if: ${{ always() }}
+        run: |
+          {
+            echo "## Nightly coverage monitor"
+            if [ -f docs/nightly-patrol/coverage-summary.json ]; then
+              pct=$(node -e "const s=require('./docs/nightly-patrol/coverage-summary.json');console.log(s.total.lines.pct)")
+              echo "- totalLinesCoverage: **${pct}%**"
+              # 閾値 44% と比較
+              if [ -n "$pct" ]; then
+                is_low=$(node -e "console.log(Number('$pct') < 44)")
+                if [ "$is_low" = "true" ]; then
+                  echo "⚠️ **WARNING**: Coverage ($pct%) is below threshold (44%)!"
+                else
+                  echo "✅ Coverage ($pct%) meets threshold (44%)."
+                fi
+              fi
+            else
+              echo "- summary: unavailable"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Commit report if changed
         if: ${{ always() }}
@@ -399,4 +377,5 @@ jobs:
         if: ${{ always() && steps.decision.outputs.exit_code != '0' }}
         run: |
           echo "🔴 Nightly Patrol failed with exit code ${{ steps.decision.outputs.exit_code }}"
-          exit ${{ steps.decision.outputs.exit_code }}
+          EXIT_CODE="${{ steps.decision.outputs.exit_code }}"
+          exit "${EXIT_CODE:-0}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,24 +120,7 @@ jobs:
             --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             --branch "${{ github.ref_name }}" \
             --sha "${{ github.sha }}"
-      - name: Test (coverage)
-        if: ${{ github.event_name != 'pull_request' }}
-        run: |
-          set -o pipefail
-          npm run test:coverage -- --reporter=default 2>&1 | tee /tmp/vitest-coverage.log
-          node scripts/ci/check-act-warnings.mjs /tmp/vitest-coverage.log --json --json-output /tmp/act-warnings-coverage.json
-      - name: Create/Update act warning regression issue (coverage)
-        if: ${{ failure() && github.event_name != 'pull_request' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          node scripts/ci/create-act-warning-issue.mjs \
-            --summary /tmp/act-warnings-coverage.json \
-            --repo "${{ github.repository }}" \
-            --workflow "${{ github.workflow }}" \
-            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            --branch "${{ github.ref_name }}" \
-            --sha "${{ github.sha }}"
+
       - name: Free port 5173 (best-effort, lsof OR fuser)
         if: github.event_name == 'workflow_dispatch' || (github.ref == 'refs/heads/main' && steps.changes.outputs.playwright == 'true')
         run: |
@@ -236,30 +219,11 @@ jobs:
             reports/perf-summary.md
             reports/perf-summary.json
             lhci-results.json
-      - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: lcov.info
-          path: coverage/lcov.info
-          if-no-files-found: warn
-      - name: Coverage summary
-        if: always()
-        run: |
-          if [ -f coverage/coverage-summary.json ]; then
-            pct=$(node -e "const s=require('./coverage/coverage-summary.json');console.log(s.total.lines.pct)")
-            {
-              echo "### Coverage"
-              echo "**Lines:** ${pct}%  "
-            } >> "$GITHUB_STEP_SUMMARY"
-          else
-            {
-              echo "### Coverage"
-              echo "coverage summary not found"
-            } >> "$GITHUB_STEP_SUMMARY"
-          fi
+
 
   quality_extended:
     name: quality_extended
+    needs: quality
     if: ${{ github.event_name == 'pull_request' && needs.quality.outputs.ci_full == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45

--- a/scripts/ops/index-pressure-summary.mjs
+++ b/scripts/ops/index-pressure-summary.mjs
@@ -1,0 +1,25 @@
+import fs from 'node:fs';
+
+const file = process.argv[2];
+if (!file) {
+  console.error('Error: Please provide index pressure json file path.');
+  process.exit(1);
+}
+
+const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+const results = data.results || [];
+const critical = results.filter(r => ['action_required', 'critical'].includes(r.severity));
+console.log(`- totalFindings: **${results.length}**`);
+console.log(`- actionRequired: **${critical.length}**`);
+if (critical.length > 0) {
+  console.log('\n| List | Field | Severity |');
+  console.log('|------|-------|:---:|');
+  critical.forEach(r => {
+    const sev = r.severity === 'critical' ? '🔴' : '🟠';
+    console.log(`| ${r.listKey} | ${r.fieldName} | ${sev} ${r.severity} |`);
+  });
+} else if (results.length > 0) {
+  console.log('\n✅ No action required (all findings are low severity)');
+} else {
+  console.log('\n✅ No index pressure detected');
+}

--- a/scripts/ops/nightly-act-warning-summary.mjs
+++ b/scripts/ops/nightly-act-warning-summary.mjs
@@ -1,0 +1,17 @@
+import fs from 'node:fs';
+
+const file = process.argv[2] || '/tmp/act-warnings-nightly.json';
+if (!fs.existsSync(file)) {
+  console.log('- summary: unavailable');
+  process.exit(0);
+}
+
+const s = JSON.parse(fs.readFileSync(file, 'utf8'));
+const total = Number(s.totalWarnings || 0);
+const affected = Number(s.affectedFiles || 0);
+const maxFile = s.maxWarningsFile || 'none';
+const maxCount = Number(s.maxWarningsPerFile || 0);
+console.log(`- totalWarnings: **${total}**`);
+console.log(`- affectedFiles: **${affected}**`);
+console.log(`- maxWarningsFile: **${maxFile}**`);
+console.log(`- maxWarningsPerFile: **${maxCount}**`);

--- a/scripts/ops/nightly-decision-summary.mjs
+++ b/scripts/ops/nightly-decision-summary.mjs
@@ -1,0 +1,35 @@
+import fs from 'node:fs';
+
+const file = process.argv[2];
+if (!file) {
+  console.error('Error: Please provide decision json file path.');
+  process.exit(1);
+}
+
+const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+console.log(`- verdict: **${data.final?.line ?? 'n/a'}**`);
+if (Array.isArray(data.reasons?.fail) && data.reasons.fail.length > 0) {
+  console.log(`- failTriggers: ${data.reasons.fail.length}`);
+} else {
+  console.log('- failTriggers: 0');
+}
+if (Array.isArray(data.reasons?.warn) && data.reasons.warn.length > 0) {
+  console.log(`- watchTriggers: ${data.reasons.warn.length}`);
+} else {
+  console.log('- watchTriggers: 0');
+}
+if (Array.isArray(data.reasonCodes?.fail) && data.reasonCodes.fail.length > 0) {
+  console.log(`- failCodes: \`${data.reasonCodes.fail.join(', ')}\``);
+}
+if (Array.isArray(data.reasonCodes?.warn) && data.reasonCodes.warn.length > 0) {
+  console.log(`- watchCodes: \`${data.reasonCodes.warn.join(', ')}\``);
+}
+if (Array.isArray(data.escalations) && data.escalations.length > 0) {
+  const rows = data.escalations.map((x) => {
+    const type = x?.type || 'unknown';
+    const days = Number.isFinite(x?.days) ? x.days : 'n/a';
+    const code = x?.code || 'n/a';
+    return `${type}:${code} (${days}d)`;
+  });
+  console.log(`- escalations: \`${rows.join(', ')}\``);
+}


### PR DESCRIPTION
## 概要

Vitest のフルテストスイートで実行していた重いカバレッジ測定 (`test:coverage`) を、PRレーンおよび main ブランチへの push レーン (`test.yml`) から完全に排除し、毎晩実行される Nightly Patrol ワークフロー (`nightly-patrol.yml`) へ安全に移行します。

これにより、最も大きなタイムアウト（25〜30分超過による `cancelled`）の引き金となっていたカバレッジオーバーヘッドを解消し、通常レーン CI の劇的な高速化と安定化を図ります。

## 変更内容

1. **`test.yml` (通常CI)**:
   - `Test (coverage)` ステップ、lcov アップロード、および GITHUB_STEP_SUMMARY へのカバレッジ要約の書き出しを完全に削除。
   - `quality_extended` ジョブで不足していた `needs: quality` を追加し、GitHub Actions の構文・動作ガバナンスを修正。

2. **`nightly-patrol.yml` (Nightly Patrol)**:
   - ワークフロー初期段階に `Nightly coverage scan` ステップを追加し、`npm run test:coverage` を実行。
   - カバレッジの成果物 (`coverage-summary.json`, `lcov.info`) を `docs/nightly-patrol/` に保存し、Nightly の自動レポートコミットフローに統合。
   - 翌朝の Patrol Summary にカバレッジ要約を綺麗に出力する `Nightly coverage summary` を追加。
   - `vitest.config.ts` で定義されたカバレッジ閾値（lines: 44%, functions: 38% など）を下回った場合、`npm run test:coverage` が exit code 1 となりワークフロー全体が自動的に失敗（Failure）するように構成（強固なガバナンス）。

3. **モジュール性の向上 (scripts/ops/)**:
   - YAML 内の `node - <<'EOF'` heredoc が shellcheck のエラー (SC1039) や YAML パーサとの競合を頻発させていたため、以下の簡易スクリプトに完全分離・外部化：
     - `scripts/ops/nightly-decision-summary.mjs`
     - `scripts/ops/index-pressure-summary.mjs`
     - `scripts/ops/nightly-act-warning-summary.mjs`
   - これにより、`actionlint` による GitHub Actions 構文＆動作チェックは**完全にエラー・警告ゼロの Green 状態**となりました。

## 安全性とガバナンスへの影響

- **Required Check 名は変更なし**: PR-C1 で構築した `ci.yml` 側の `TypeCheck & Test` aggregator およびブランチ保護ルールは一切変更せず、完全に尊重・維持しています。
- **カバレッジ劣化の早期検知**: 毎晩のパトロール実行時にカバレッジが計測され、基準を満たさない場合は直ちにワークフローが失敗（Failure）してアラートが飛ぶため、本番品質は厳格に保護されます。
- **Playwright Sharding には影響なし**: 計画通り、Playwright の sharding は後続 PR-C4 の別スコープとし、本 PR には含めていません。