### PR TITLE
refactor(support-plan-guide): split presentation helpers from guide page

### DIFF
--- a/src/features/support-plan-guide/components/DraftProgressChips.tsx
+++ b/src/features/support-plan-guide/components/DraftProgressChips.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import Tooltip from '@mui/material/Tooltip';
+import Chip from '@mui/material/Chip';
+import VerifiedUserRoundedIcon from '@mui/icons-material/VerifiedUserRounded';
+import { SupportPlanDraft } from '../types';
+import { computeRequiredCompletion } from '../domain/progress';
+
+interface DraftProgressChipsProps {
+  drafts: SupportPlanDraft[];
+  activeDraftId: string | null;
+  onSelectDraft: (id: string) => void;
+}
+
+export const DraftProgressChips: React.FC<DraftProgressChipsProps> = ({
+  drafts,
+  activeDraftId,
+  onSelectDraft,
+}) => {
+  return (
+    <>
+      {drafts.map((draft) => {
+        const progress = computeRequiredCompletion(draft.data);
+        const lastUpdated = draft.updatedAt ? new Date(draft.updatedAt).toLocaleString('ja-JP') : '未記録';
+        const displayName = draft.name.trim() || '未設定の利用者';
+        const code = draft.userCode?.trim();
+        const chipLabel = `${displayName}${code ? ` / ${code}` : ''} (${progress}%)`;
+        const tooltipParts = [`必須達成: ${progress}%`, `最終更新: ${lastUpdated}`];
+        if (code) {
+          tooltipParts.push(`利用者コード: ${code}`);
+        }
+        if (draft.userId != null) {
+          tooltipParts.push(`レコードID: ${draft.userId}`);
+        }
+        const linkedToMaster = draft.userId != null;
+
+        return (
+          <Tooltip key={draft.id} title={tooltipParts.join(' ・ ')} arrow>
+            <Chip
+              icon={linkedToMaster ? <VerifiedUserRoundedIcon fontSize="small" /> : undefined}
+              clickable
+              color={draft.id === activeDraftId ? 'primary' : 'default'}
+              label={chipLabel}
+              onClick={() => onSelectDraft(draft.id)}
+            />
+          </Tooltip>
+        );
+      })}
+    </>
+  );
+};

--- a/src/features/support-plan-guide/components/TabPanel.tsx
+++ b/src/features/support-plan-guide/components/TabPanel.tsx
@@ -1,0 +1,24 @@
+import React, { Suspense } from 'react';
+import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
+import { SectionKey } from '../types';
+
+const TabFallback = <CircularProgress size={20} sx={{ m: 2 }} />;
+
+interface TabPanelProps {
+  current: SectionKey;
+  value: SectionKey;
+  children: React.ReactNode;
+}
+
+export const TabPanel: React.FC<TabPanelProps> = ({ current, value, children }) => (
+  <Box
+    role="tabpanel"
+    hidden={current !== value}
+    id={`support-plan-tabpanel-${value}`}
+    aria-labelledby={`support-plan-tab-${value}`}
+    sx={{ mt: 2 }}
+  >
+    {current === value ? <Suspense fallback={TabFallback}>{children}</Suspense> : null}
+  </Box>
+);

--- a/src/pages/SupportPlanGuidePage.tsx
+++ b/src/pages/SupportPlanGuidePage.tsx
@@ -21,16 +21,16 @@ import { useIcebergPdcaList } from '@/features/ibd/analysis/pdca/queries/useIceb
 
 import { useIcebergEvidence } from '@/features/ibd/analysis/pdca/queries/useIcebergEvidence';
 import type {
-    SectionKey,
-    SupportPlanDraft
+    SectionKey
 } from '@/features/support-plan-guide/types';
 import {
     FIELD_KEYS,
 } from '@/features/support-plan-guide/types';
-import { computeRequiredCompletion } from '@/features/support-plan-guide/domain/progress';
 import { getAllSubsFlat } from '@/features/support-plan-guide/domain/tabRoute';
 import { findSectionKeyByFieldKey } from '@/features/support-plan-guide/domain/sectionMeta';
 import SupportPlanTabHeader from '@/features/support-plan-guide/components/SupportPlanTabHeader';
+import { TabPanel } from '@/features/support-plan-guide/components/TabPanel';
+import { DraftProgressChips } from '@/features/support-plan-guide/components/DraftProgressChips';
 import { useUsersStore } from '@/features/users/store';
 import { HYDRATION_FEATURES, startFeatureSpan } from '@/hydration/features';
 import { TESTIDS, tid } from '@/testids';
@@ -38,14 +38,12 @@ import { cancelIdle, runOnIdle } from '@/utils/runOnIdle';
 import CloudDoneRoundedIcon from '@mui/icons-material/CloudDoneRounded';
 import CloudOffRoundedIcon from '@mui/icons-material/CloudOffRounded';
 import CloudSyncRoundedIcon from '@mui/icons-material/CloudSyncRounded';
-import VerifiedUserRoundedIcon from '@mui/icons-material/VerifiedUserRounded';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
 import CircularProgress from '@mui/material/CircularProgress';
 import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
-import Tooltip from '@mui/material/Tooltip';
 
 import React, { Suspense } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -67,26 +65,6 @@ const RegulatorySection = React.lazy(() => import('@/features/support-plan-guide
 const NextActionPanelContainer = React.lazy(() => import('@/features/support-plan-guide/components/planner-assist/NextActionPanelContainer'));
 
 const TabFallback = <CircularProgress size={20} sx={{ m: 2 }} />;
-
-// ────────────────────────────────────────────
-// TabPanel (internal)
-// ────────────────────────────────────────────
-
-const TabPanel: React.FC<{ current: SectionKey; value: SectionKey; children: React.ReactNode }> = ({
-  current,
-  value,
-  children,
-}) => (
-  <Box
-    role="tabpanel"
-    hidden={current !== value}
-    id={`support-plan-tabpanel-${value}`}
-    aria-labelledby={`support-plan-tab-${value}`}
-    sx={{ mt: 2 }}
-  >
-    {current === value ? <Suspense fallback={TabFallback}>{children}</Suspense> : null}
-  </Box>
-);
 
 // ────────────────────────────────────────────
 // Page Component
@@ -327,38 +305,6 @@ export default function SupportPlanGuidePage() {
     can,
   };
 
-  // ── Draft progress chip (render helper) ──
-  const getDraftProgressChip = (draft: SupportPlanDraft) => {
-    const progress = computeRequiredCompletion(draft.data);
-    const lastUpdated = draft.updatedAt ? new Date(draft.updatedAt).toLocaleString('ja-JP') : '未記録';
-    const displayName = draft.name.trim() || '未設定の利用者';
-    const code = draft.userCode?.trim();
-    const chipLabel = `${displayName}${code ? ` / ${code}` : ''} (${progress}%)`;
-    const tooltipParts = [`必須達成: ${progress}%`, `最終更新: ${lastUpdated}`];
-    if (code) {
-      tooltipParts.push(`利用者コード: ${code}`);
-    }
-    if (draft.userId != null) {
-      tooltipParts.push(`レコードID: ${draft.userId}`);
-    }
-    const linkedToMaster = draft.userId != null;
-
-    return (
-      <Tooltip key={draft.id} title={tooltipParts.join(' ・ ')} arrow>
-        <Chip
-          icon={linkedToMaster ? <VerifiedUserRoundedIcon fontSize="small" /> : undefined}
-          clickable
-          color={draft.id === activeDraftId ? 'primary' : 'default'}
-          label={chipLabel}
-          onClick={() => {
-            setActiveDraftId(draft.id);
-            setActiveTab('overview');
-          }}
-        />
-      </Tooltip>
-    );
-  };
-
   // ── Tab content renderer ──
   const renderTabContent = (tabKey: SectionKey): React.ReactNode => {
     switch (tabKey) {
@@ -530,7 +476,14 @@ export default function SupportPlanGuidePage() {
               useFlexGap
             >
               {draftList.length > 0 ? (
-                draftList.map(getDraftProgressChip)
+                <DraftProgressChips
+                  drafts={draftList}
+                  activeDraftId={activeDraftId}
+                  onSelectDraft={(id) => {
+                    setActiveDraftId(id);
+                    setActiveTab('overview');
+                  }}
+                />
               ) : (
                 <Chip size="small" variant="outlined" label="ドラフト未作成" />
               )}


### PR DESCRIPTION
## 概要
健康度スコア回復ロードマップのフェーズ1（低リスクUI分割）の第一ステップとして、603行の巨大ファイルであった `SupportPlanGuidePage.tsx` から、表示用ヘルパーおよびサブコンポーネントを切り出し、ファイルサイズを制限（600行）未満に削減しました。

Closes #1972

## 変更内容
### 追加
- `src/features/support-plan-guide/components/TabPanel.tsx`: `TabPanel` コンポーネントを新規切り出し
- `src/features/support-plan-guide/components/DraftProgressChips.tsx`: `DraftProgressChips` コンポーネントを新規切り出し

### 変更
- `src/pages/SupportPlanGuidePage.tsx`:
  - 内部 `TabPanel` コンポーネントの削除と新規切り出しモジュールからのインポート適用
  - 内部 `getDraftProgressChip` レンダラー関数の削除と新規切り出しモジュール `DraftProgressChips` の適用
  - 不要となったインポートのクリーンアップ

## 変更ファイル一覧
| ファイル | 変更種別 | 変更内容 |
|---------|---------|---------|
| `src/pages/SupportPlanGuidePage.tsx` | 変更 | 内部プレゼンテーション要素の切り出しによる行数削減 (603行 -> 558行) |
| `src/features/support-plan-guide/components/TabPanel.tsx` | 追加 | `TabPanel` 表示コンポーネントの新規追加 |
| `src/features/support-plan-guide/components/DraftProgressChips.tsx` | 追加 | `DraftProgressChips` 表示コンポーネントの新規追加 |

## テスト
- [x] 既存テスト通過
- [x] 型チェック通過

## セルフレビュー
- [x] `console.log` 残していない
- [x] `any` 使っていない
- [x] 責務分離を守っている
- [x] 600行ルール違反なし (558行)

## 影響範囲
- `SupportPlanGuidePage` 内の表示ロジックのみを対象としたリファクタリングであり、ルーティングや認証、ドラフトの状態管理、タブ制御等のコアドメインロジックへの影響はありません。
