### PR TITLE
refactor(health): split HealthDiagnosisPage into focused sub-components

### DIFF
--- a/src/features/diagnostics/health/HealthDiagnosisPage.tsx
+++ b/src/features/diagnostics/health/HealthDiagnosisPage.tsx
@@ -7,8 +7,6 @@ import {
     Button,
     Chip,
     CircularProgress,
-    Collapse,
-    Divider,
     Paper,
     Stack,
     Tab,
@@ -16,27 +14,24 @@ import {
     Tooltip,
     Typography,
 } from "@mui/material";
-import ContentCopyIcon from "@mui/icons-material/ContentCopy";
-import LaunchIcon from "@mui/icons-material/Launch";
-import DescriptionIcon from "@mui/icons-material/Description";
 import React from "react";
 import { Link as RouterLink, useSearchParams } from "react-router-dom";
 import { StatusChip, statusColor } from "./components/StatusChip";
 import { toAdminSummary } from "./toAdminSummary";
 import { HealthContext, HealthReport } from "./types";
-// import { useHealthChecks } from "./useHealthChecks"; // Moved to parent
-import { spTelemetryStore } from "@/lib/telemetry/spTelemetryStore";
 import { DriftObservabilityPanel } from "../drift/observability/DriftObservabilityPanel";
 import { HealthFilterBar, type HealthFilterState } from "./components/HealthFilterBar";
 import { useSpHealthSignal } from "@/features/sp/health/hooks/useSpHealthSignal";
 import type { SpHealthReasonCode } from "@/features/sp/health/spHealthSignalStore";
 import { GovernanceAdvisePanel } from "../remediation/components/GovernanceAdvisePanel";
 import { SpIndexPressurePanel } from "@/features/sp/health/indexAdvisor/SpIndexPressurePanel";
-import { GovernanceBadge } from "./components/GovernanceBadge";
 import { SpRemediationCard } from "@/features/sp/health/remediation/SpRemediationCard";
 import { useNightlySignalIngestion } from "@/features/sp/health/hooks/useNightlySignalIngestion";
 import { SelfHealingResultsPanel } from "@/features/sp/health/remediation/SelfHealingResultsPanel";
 import { SilentDriftSummaryCard } from "./components/SilentDriftSummaryCard";
+import { DiagnosticsSummaryPanel } from "./components/DiagnosticsSummaryPanel";
+import { SpTelemetryPanel } from "./components/SpTelemetryPanel";
+import { CheckResultsPanel } from "./components/CheckResultsPanel";
 
 
 // ─── highlight: reasonCode → category ─────────────────────────────────────────
@@ -95,7 +90,6 @@ export function HealthDiagnosisPage(props: {
   run: () => Promise<void>
 }) {
   const { report, loading, error, run } = props;
-  const [openKeys, setOpenKeys] = React.useState<Record<string, boolean>>({});
   const [activeTab, setActiveTab] = React.useState<string | "all">("all");
   const [filterState, setFilterState] = React.useState<HealthFilterState>({ level: 'all', resource: '' });
   const [searchParams] = useSearchParams();
@@ -142,17 +136,6 @@ export function HealthDiagnosisPage(props: {
     success: false,
     error: null,
   });
-
-  const toggle = (k: string) => setOpenKeys((p) => ({ ...p, [k]: !p[k] }));
-
-  // SharePoint通信テレメトリ Snapshot ポーリング
-  const [spSnapshot, setSpSnapshot] = React.useState(() => spTelemetryStore.getSnapshot());
-  React.useEffect(() => {
-    const timer = setInterval(() => {
-      setSpSnapshot(spTelemetryStore.getSnapshot());
-    }, 2000);
-    return () => clearInterval(timer);
-  }, []);
 
   // ─────────────────────────────────────────────────────────────
   // Title 生成: "health:<tenant>:<site>"
@@ -218,15 +201,6 @@ export function HealthDiagnosisPage(props: {
     return results;
   }, [report, activeTab, filterState]);
 
-  // highlight: このカテゴリ + fail/warn のアイテムを強調
-  const isHighlighted = React.useCallback(
-    (r: { category: string; status: string }) =>
-      Boolean(highlightCategory) &&
-      r.category === highlightCategory &&
-      r.status !== 'pass',
-    [highlightCategory],
-  );
-
   return (
     <Box sx={{ p: 2 }}>
       <Stack spacing={2}>
@@ -271,20 +245,16 @@ export function HealthDiagnosisPage(props: {
             {currentSignal.listName ? ` [${currentSignal.listName}]` : ''}
             {' '}
             <Typography component="span" variant="caption" color="inherit">
-              ({currentSignal.source === 'realtime' ? 'Realtime' : 'Nightly'} /{' '}
+              ({currentSignal.source === 'realtime' ? 'Realtime' : 'Nightly'} {' '}
               {currentSignal.occurredAt.slice(0, 16).replace('T', ' ')})
             </Typography>
           </Alert>
         )}
 
-        {/* ─────────────────────────────────────────────────────────────
-            Self-Healing 結果パネル (Nightly Patrol の成果を表示)
-            ───────────────────────────────────────────────────────────── */}
+        {/* Self-Healing 結果パネル */}
         <SelfHealingResultsPanel />
 
-        {/* ─────────────────────────────────────────────────────────────
-            Self-Healing 候補パネル / 修復推奨カード
-            ───────────────────────────────────────────────────────────── */}
+        {/* Self-Healing 候補パネル / 修復推奨カード */}
         {currentSignal?.remediation && (
           <SpRemediationCard />
         )}
@@ -296,9 +266,7 @@ export function HealthDiagnosisPage(props: {
           />
         )}
 
-        {/* ─────────────────────────────────────────────────────────────
-            highlight バナー（?highlight= クエリがある場合）
-            ───────────────────────────────────────────────────────────── */}
+        {/* highlight バナー（?highlight= クエリがある場合） */}
         {highlightCode && (
           <Alert severity="info" onClose={() => {}}>
             <strong>{HIGHLIGHT_STATUS_LABEL[highlightCode] ?? highlightCode}</strong>
@@ -309,11 +277,7 @@ export function HealthDiagnosisPage(props: {
         {/* ─────────────────────────────────────────────────────────────
             ヘッダー: タイトル + アクションボタン
             ───────────────────────────────────────────────────────────── */}
-        <Stack
-          direction="row"
-          alignItems="center"
-          justifyContent="space-between"
-        >
+        <Stack direction="row" alignItems="center" justifyContent="space-between">
           <Stack direction="row" spacing={1} alignItems="center">
             <Typography variant="h5">環境診断</Typography>
             <Typography
@@ -386,9 +350,7 @@ export function HealthDiagnosisPage(props: {
           </Stack>
         </Stack>
 
-        {/* ─────────────────────────────────────────────────────────────
-            トースト通知: 保存成功 / 失敗
-            ───────────────────────────────────────────────────────────── */}
+        {/* トースト通知: 保存成功 / 失敗 */}
         {savingState.success && (
           <Alert severity="success" onClose={() => setSavingState((p) => ({ ...p, success: false }))} data-testid="diagnostics-save-alert">
             ✅ 診断結果を SharePoint に保存しました
@@ -401,9 +363,7 @@ export function HealthDiagnosisPage(props: {
           </Alert>
         )}
 
-        {/* ─────────────────────────────────────────────────────────────
-            ローカル stub モード注記
-            ───────────────────────────────────────────────────────────── */}
+        {/* ローカル stub モード注記 */}
         {!props.ctx.isProductionLike && (
           <Alert severity="info" data-testid="diagnostics-stub-notice">
             ローカル／stub モードで実行中です。auth・connectivity・lists の FAIL は SharePoint に接続していないため期待どおりです。
@@ -411,9 +371,7 @@ export function HealthDiagnosisPage(props: {
           </Alert>
         )}
 
-        {/* ─────────────────────────────────────────────────────────────
-            総合判定パネル（実行中/エラー情報）
-            ───────────────────────────────────────────────────────────── */}
+        {/* 総合判定パネル */}
         <Paper variant="outlined" sx={{ p: 2 }}>
           <Stack direction="row" spacing={2} alignItems="center">
             <Typography variant="subtitle1">総合判定</Typography>
@@ -433,148 +391,23 @@ export function HealthDiagnosisPage(props: {
           )}
         </Paper>
 
-        {/* ─────────────────────────────────────────────────────────────
-            SP通信状態パネル
-            ───────────────────────────────────────────────────────────── */}
-        <Paper variant="outlined" sx={{ p: 2 }}>
-          <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 1 }}>
-            <Typography variant="subtitle1">🌐 SP通信状態</Typography>
-            <StatusChip
-              status={
-                spSnapshot.summary.failedCount > 5
-                  ? "fail"
-                  : spSnapshot.summary.throttledCount > 20
-                  ? "warn"
-                  : "pass"
-              }
-            />
-          </Stack>
-          <Divider sx={{ my: 1 }} />
-          <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
-            {`Throttled: ${spSnapshot.summary.throttledCount} / Retry: ${spSnapshot.summary.retryCount} / Failed: ${spSnapshot.summary.failedCount}`}
-            <br/>{`Avg Duration: ${spSnapshot.summary.avgDurationMs}ms / P95: ${spSnapshot.summary.p95DurationMs}ms`}
-            <br/>{`Avg Queue: ${spSnapshot.summary.avgQueuedMs}ms / Max Queue: ${spSnapshot.summary.maxQueuedMs}ms`}
-          </Typography>
-          {spSnapshot.topEndpoints.length > 0 && (
-            <Box sx={{ mt: 1 }}>
-              <Typography variant="caption" color="text.secondary">
-                Top Failing Endpoints:
-              </Typography>
-              <Box component="ul" sx={{ m: 0, pl: 2, typography: "body2" }}>
-                {spSnapshot.topEndpoints.map((ep: { endpoint: string; failures: number; retries: number }, i: number) => (
-                  <li key={i}>
-                    <code>{ep.endpoint}</code> (Fail: {ep.failures}, Retry: {ep.retries})
-                  </li>
-                ))}
-              </Box>
-            </Box>
-          )}
-        </Paper>
+        {/* SP通信状態パネル */}
+        <SpTelemetryPanel />
 
         <SilentDriftSummaryCard />
         <DriftObservabilityPanel />
 
         <GovernanceAdvisePanel />
 
-        {/* ─────────────────────────────────────────────────────────────
-            診断結果表示パネル
-            - overall, topIssue(1行), summaryText(複数行)
-            - reportLink（あれば表示）
-            ───────────────────────────────────────────────────────────── */}
-        {report && report.overall !== "pass" && (
-          <Paper variant="outlined" sx={{ p: 2, bgcolor: "action.hover", border: "2px solid" }}>
-            <Typography variant="subtitle1" sx={{ mb: 1.5, fontWeight: 600 }}>
-              📋 診断結果サマリー
-            </Typography>
-            <Divider sx={{ mb: 1.5 }} />
-
-            <Stack spacing={1.5}>
-              {/* Overall */}
-              <Stack direction="row" spacing={1} alignItems="center">
-                <Typography variant="body2" sx={{ fontWeight: 600, minWidth: "100px" }}>
-                  総合判定:
-                </Typography>
-                <StatusChip status={report.overall} />
-              </Stack>
-
-              {/* Title (安定キー) */}
-              <Stack direction="row" spacing={1} alignItems="flex-start">
-                <Typography variant="body2" sx={{ fontWeight: 600, minWidth: "100px" }}>
-                  Title:
-                </Typography>
-                <Typography
-                  variant="body2"
-                  sx={{
-                    fontFamily: "monospace",
-                    p: 1,
-                    bgcolor: "background.paper",
-                    borderRadius: 1,
-                    border: "1px solid",
-                    borderColor: "divider",
-                    flex: 1,
-                    wordBreak: "break-all",
-                  }}
-                >
-                  {generateDiagnosticsTitle()}
-                </Typography>
-              </Stack>
-
-              {/* TopIssue (1行) */}
-              {report.results.find((r) => r.status !== "pass") && (
-                <Stack direction="row" spacing={1} alignItems="flex-start">
-                  <Typography variant="body2" sx={{ fontWeight: 600, minWidth: "100px" }}>
-                    最上位課題:
-                  </Typography>
-                  <Typography variant="body2" sx={{ flex: 1 }}>
-                    {report.results.find((r) => r.status === "fail")?.label ||
-                      report.results.find((r) => r.status === "warn")?.label ||
-                      "特定されませんでした"}
-                  </Typography>
-                </Stack>
-              )}
-
-              {/* SummaryText (複数行) */}
-              <Stack direction="row" spacing={1} alignItems="flex-start">
-                <Typography variant="body2" sx={{ fontWeight: 600, minWidth: "100px" }}>
-                  詳細:
-                </Typography>
-                <Box
-                  sx={{
-                    p: 1.5,
-                    bgcolor: "background.paper",
-                    borderRadius: 1,
-                    border: "1px solid",
-                    borderColor: "divider",
-                    flex: 1,
-                    maxHeight: "150px",
-                    overflow: "auto",
-                  }}
-                >
-                  <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
-                    {Object.entries(report.byCategory).map(([name, cat]) => (
-                      <Chip
-                        key={name}
-                        size="small"
-                        label={`${categoryLabels[name] || name}: ${cat.counts.fail}/${cat.counts.warn}/${cat.counts.pass}`}
-                        color={statusColor(cat.overall)}
-                        variant={cat.overall === "pass" ? "outlined" : "filled"}
-                        sx={{ fontSize: '0.75rem', height: 24 }}
-                      />
-                    ))}
-                  </Stack>
-                </Box>
-              </Stack>
-            </Stack>
-
-            <Typography variant="caption" color="text.secondary">
-              💾 ボタン「SharePoint に保存」でこの情報を記録します
-            </Typography>
-          </Paper>
+        {/* 診断結果サマリーパネル */}
+        {report && (
+          <DiagnosticsSummaryPanel
+            report={report}
+            diagnosticsTitle={generateDiagnosticsTitle()}
+          />
         )}
 
-        {/* ─────────────────────────────────────────────────────────────
-            カテゴリ別フィルタ (Tabs)
-            ───────────────────────────────────────────────────────────── */}
+        {/* カテゴリ別フィルタ (Tabs) */}
         {report && (
            <Paper variant="outlined" sx={{ bgcolor: 'background.paper' }}>
              <Tabs
@@ -621,9 +454,7 @@ export function HealthDiagnosisPage(props: {
            </Paper>
         )}
 
-        {/* ─────────────────────────────────────────────────────────────
-            フィルタバー（level / resource）
-            ───────────────────────────────────────────────────────────── */}
+        {/* フィルタバー（level / resource） */}
         {report && activeTab !== "drift" && (
           <HealthFilterBar
             results={report.results}
@@ -632,138 +463,16 @@ export function HealthDiagnosisPage(props: {
           />
         )}
 
-        {/* ─────────────────────────────────────────────────────────────
-            個別チェック
-            ───────────────────────────────────────────────────────────── */}
-        {report && activeTab !== "drift" && (
-          <Paper variant="outlined" sx={{ p: 2 }}>
-            <Typography variant="subtitle1" sx={{ mb: 1 }}>
-              個別チェック ({categoryLabels[activeTab] || activeTab})
-            </Typography>
-            <Divider sx={{ my: 1 }} />
-
-            <Stack spacing={1}>
-              {filteredResults.map((r) => {
-                const open = Boolean(openKeys[r.key]);
-                const highlighted = isHighlighted(r);
-                return (
-                  <Paper
-                    key={r.key}
-                    variant="outlined"
-                    sx={{
-                      p: 1.5,
-                      ...(highlighted
-                        ? { border: '2px solid', borderColor: 'warning.main', bgcolor: 'warning.50' }
-                        : {}),
-                    }}
-                  >
-                    <Stack
-                      direction="row"
-                      spacing={1}
-                      alignItems="center"
-                      justifyContent="space-between"
-                    >
-                      <Stack spacing={0.25} sx={{ minWidth: 0, flex: 1 }}>
-                        <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap>
-                          <StatusChip status={r.status} />
-                          <Typography variant="subtitle2" noWrap title={r.label} sx={{ flex: 1, minWidth: 0 }}>
-                            {r.label}
-                          </Typography>
-                          {r.governance && <GovernanceBadge decision={r.governance} />}
-                          <Chip size="small" variant="outlined" label={r.category} sx={{ height: 20, fontSize: '0.65rem' }} />
-                        </Stack>
-                        <Typography variant="body2" color="text.secondary">
-                          {r.summary}
-                        </Typography>
-                      </Stack>
-
-                      <Button
-                        size="small"
-                        onClick={() => toggle(r.key)}
-                        sx={{ whiteSpace: "nowrap" }}
-                      >
-                        {open ? "閉じる" : "詳細"}
-                      </Button>
-                    </Stack>
-
-                    <Collapse in={open} unmountOnExit>
-                      <Divider sx={{ my: 1 }} />
-                      {r.detail && (
-                        <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
-                          {r.detail}
-                        </Typography>
-                      )}
-
-                      {r.evidence && (
-                        <Box sx={{ mt: 1 }}>
-                          <Typography variant="caption" color="text.secondary">
-                            証跡（evidence）
-                          </Typography>
-                          
-                          {/* 構造整合性（ドリフト）情報の特別表示 */}
-                          {r.category === "schema" && Array.isArray((r.evidence as Record<string, unknown>).drifted) ? (
-                            <Box sx={{ mt: 0.5, p: 1, bgcolor: "background.paper", borderRadius: 1, border: "1px dashed", borderColor: "warning.main" }}>
-                              <Typography variant="body2" sx={{ mb: 1, fontWeight: 600, color: "warning.main" }}>
-                                ⚠️ 内部名マッピングの自動調整（整合性）を検出しました
-                              </Typography>
-                              <Stack spacing={0.5}>
-                                {((r.evidence as Record<string, unknown>).drifted as Record<string, string>[]).map((d: Record<string, string>, i: number) => (
-                                  <Stack key={i} direction="row" spacing={1} alignItems="center">
-                                    <Chip size="small" label={d.expected} variant="outlined" />
-                                    <Typography variant="caption">→</Typography>
-                                    <Chip size="small" label={d.actual} color="warning" variant="filled" />
-                                    {d.driftType && (
-                                      <Chip size="small" label={d.driftType} variant="outlined" sx={{ fontSize: '0.65rem', height: 20 }} />
-                                    )}
-                                  </Stack>
-                                ))}
-                              </Stack>
-                            </Box>
-                          ) : (
-                            <pre style={{ margin: 0, whiteSpace: "pre-wrap", overflow: "auto", maxHeight: "200px", padding: "8px", backgroundColor: "rgba(0,0,0,0.04)", borderRadius: "4px" }}>
-                              {JSON.stringify(r.evidence, null, 2)}
-                            </pre>
-                          )}
-                        </Box>
-                      )}
-
-                      {r.nextActions.length > 0 && (
-                        <Box sx={{ mt: 1 }}>
-                          <Typography variant="caption" color="text.secondary">
-                            次にやること
-                          </Typography>
-                          <Stack spacing={0.75} sx={{ mt: 0.75 }}>
-                            {r.nextActions.map((a, idx) => (
-                              <Paper key={idx} variant="outlined" sx={{ p: 1.25, bgcolor: "action.selected" }}>
-                                <Stack direction="row" spacing={1.25} alignItems="center">
-                                  <Box sx={{ color: "primary.main", flexShrink: 0 }}>
-                                    {a.kind === "copy" ? <ContentCopyIcon sx={{ fontSize: 18 }} /> :
-                                     a.kind === "link" ? <LaunchIcon sx={{ fontSize: 18 }} /> :
-                                     <DescriptionIcon sx={{ fontSize: 18 }} />}
-                                  </Box>
-                                  <Box sx={{ flex: 1, minWidth: 0 }}>
-                                    <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>{a.label}</Typography>
-                                    <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.25, whiteSpace: "pre-wrap", fontFamily: a.kind === "copy" ? "monospace" : "inherit" }}>
-                                      {a.value}
-                                    </Typography>
-                                  </Box>
-                                  {a.kind === "copy" && (
-                                    <Button size="small" onClick={() => { copyToClipboard(a.value); alert("コピーしました"); }} sx={{ fontSize: '0.65rem', py: 0 }}>
-                                      コピー
-                                    </Button>
-                                  )}
-                                </Stack>
-                              </Paper>
-                            ))}
-                          </Stack>
-                        </Box>
-                      )}
-                    </Collapse>
-                  </Paper>
-                );
-              })}
-            </Stack>
-          </Paper>
+        {/* 個別チェック結果パネル */}
+        {report && (
+          <CheckResultsPanel
+            report={report}
+            activeTab={activeTab}
+            filterState={filterState}
+            filteredResults={filteredResults}
+            highlightCategory={highlightCategory}
+            highlightCode={highlightCode}
+          />
         )}
 
         {/* 注記 */}

--- a/src/features/diagnostics/health/components/CheckResultsPanel.tsx
+++ b/src/features/diagnostics/health/components/CheckResultsPanel.tsx
@@ -1,0 +1,278 @@
+import {
+  Box,
+  Button,
+  Chip,
+  Collapse,
+  Divider,
+  Paper,
+  Stack,
+  Typography,
+} from "@mui/material";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import LaunchIcon from "@mui/icons-material/Launch";
+import DescriptionIcon from "@mui/icons-material/Description";
+import React from "react";
+import { StatusChip } from "./StatusChip";
+import { GovernanceBadge } from "./GovernanceBadge";
+import type { HealthReport } from "../types";
+import type { HealthFilterState } from "./HealthFilterBar";
+import type { SpHealthReasonCode } from "@/features/sp/health/spHealthSignalStore";
+
+const categoryLabels: Record<string, string> = {
+  all: "すべて",
+  config: "設定",
+  auth: "認証",
+  connectivity: "通信",
+  lists: "リスト",
+  schema: "構造整合性",
+  permissions: "権限",
+};
+
+async function copyToClipboard(text: string): Promise<void> {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return;
+    }
+  } catch {
+    // fallback
+  }
+  const ta = document.createElement("textarea");
+  ta.value = text;
+  ta.style.position = "fixed";
+  ta.style.left = "-9999px";
+  ta.style.top = "-9999px";
+  document.body.appendChild(ta);
+  ta.focus();
+  ta.select();
+  try {
+    document.execCommand("copy");
+  } finally {
+    document.body.removeChild(ta);
+  }
+}
+
+interface CheckResultsPanelProps {
+  report: HealthReport;
+  activeTab: string | "all";
+  filterState: HealthFilterState;
+  filteredResults: HealthReport["results"];
+  highlightCategory: string;
+  highlightCode: SpHealthReasonCode | "";
+}
+
+/**
+ * 🔍 個別チェック結果パネル
+ *
+ * カテゴリ別フィルタ + level / resource フィルタを適用した診断結果を
+ * アコーディオン形式で表示する。drift タブ選択時は表示しない。
+ */
+export function CheckResultsPanel({
+  activeTab,
+  filteredResults,
+  highlightCategory,
+}: CheckResultsPanelProps) {
+  const [openKeys, setOpenKeys] = React.useState<Record<string, boolean>>({});
+  const toggle = (k: string) => setOpenKeys((p) => ({ ...p, [k]: !p[k] }));
+
+  const isHighlighted = React.useCallback(
+    (r: { category: string; status: string }) =>
+      Boolean(highlightCategory) &&
+      r.category === highlightCategory &&
+      r.status !== "pass",
+    [highlightCategory],
+  );
+
+  if (activeTab === "drift") return null;
+
+  return (
+    <Paper variant="outlined" sx={{ p: 2 }}>
+      <Typography variant="subtitle1" sx={{ mb: 1 }}>
+        個別チェック ({categoryLabels[activeTab] || activeTab})
+      </Typography>
+      <Divider sx={{ my: 1 }} />
+
+      <Stack spacing={1}>
+        {filteredResults.map((r) => {
+          const open = Boolean(openKeys[r.key]);
+          const highlighted = isHighlighted(r);
+          return (
+            <Paper
+              key={r.key}
+              variant="outlined"
+              sx={{
+                p: 1.5,
+                ...(highlighted
+                  ? { border: "2px solid", borderColor: "warning.main", bgcolor: "warning.50" }
+                  : {}),
+              }}
+            >
+              <Stack
+                direction="row"
+                spacing={1}
+                alignItems="center"
+                justifyContent="space-between"
+              >
+                <Stack spacing={0.25} sx={{ minWidth: 0, flex: 1 }}>
+                  <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap>
+                    <StatusChip status={r.status} />
+                    <Typography variant="subtitle2" noWrap title={r.label} sx={{ flex: 1, minWidth: 0 }}>
+                      {r.label}
+                    </Typography>
+                    {r.governance && <GovernanceBadge decision={r.governance} />}
+                    <Chip
+                      size="small"
+                      variant="outlined"
+                      label={r.category}
+                      sx={{ height: 20, fontSize: "0.65rem" }}
+                    />
+                  </Stack>
+                  <Typography variant="body2" color="text.secondary">
+                    {r.summary}
+                  </Typography>
+                </Stack>
+
+                <Button
+                  size="small"
+                  onClick={() => toggle(r.key)}
+                  sx={{ whiteSpace: "nowrap" }}
+                >
+                  {open ? "閉じる" : "詳細"}
+                </Button>
+              </Stack>
+
+              <Collapse in={open} unmountOnExit>
+                <Divider sx={{ my: 1 }} />
+                {r.detail && (
+                  <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
+                    {r.detail}
+                  </Typography>
+                )}
+
+                {r.evidence && (
+                  <Box sx={{ mt: 1 }}>
+                    <Typography variant="caption" color="text.secondary">
+                      証跡（evidence）
+                    </Typography>
+
+                    {/* 構造整合性（ドリフト）情報の特別表示 */}
+                    {r.category === "schema" &&
+                    Array.isArray((r.evidence as Record<string, unknown>).drifted) ? (
+                      <Box
+                        sx={{
+                          mt: 0.5,
+                          p: 1,
+                          bgcolor: "background.paper",
+                          borderRadius: 1,
+                          border: "1px dashed",
+                          borderColor: "warning.main",
+                        }}
+                      >
+                        <Typography
+                          variant="body2"
+                          sx={{ mb: 1, fontWeight: 600, color: "warning.main" }}
+                        >
+                          ⚠️ 内部名マッピングの自動調整（整合性）を検出しました
+                        </Typography>
+                        <Stack spacing={0.5}>
+                          {(
+                            (r.evidence as Record<string, unknown>).drifted as Record<
+                              string,
+                              string
+                            >[]
+                          ).map((d: Record<string, string>, i: number) => (
+                            <Stack key={i} direction="row" spacing={1} alignItems="center">
+                              <Chip size="small" label={d.expected} variant="outlined" />
+                              <Typography variant="caption">→</Typography>
+                              <Chip size="small" label={d.actual} color="warning" variant="filled" />
+                              {d.driftType && (
+                                <Chip
+                                  size="small"
+                                  label={d.driftType}
+                                  variant="outlined"
+                                  sx={{ fontSize: "0.65rem", height: 20 }}
+                                />
+                              )}
+                            </Stack>
+                          ))}
+                        </Stack>
+                      </Box>
+                    ) : (
+                      <pre
+                        style={{
+                          margin: 0,
+                          whiteSpace: "pre-wrap",
+                          overflow: "auto",
+                          maxHeight: "200px",
+                          padding: "8px",
+                          backgroundColor: "rgba(0,0,0,0.04)",
+                          borderRadius: "4px",
+                        }}
+                      >
+                        {JSON.stringify(r.evidence, null, 2)}
+                      </pre>
+                    )}
+                  </Box>
+                )}
+
+                {r.nextActions.length > 0 && (
+                  <Box sx={{ mt: 1 }}>
+                    <Typography variant="caption" color="text.secondary">
+                      次にやること
+                    </Typography>
+                    <Stack spacing={0.75} sx={{ mt: 0.75 }}>
+                      {r.nextActions.map((a, idx) => (
+                        <Paper key={idx} variant="outlined" sx={{ p: 1.25, bgcolor: "action.selected" }}>
+                          <Stack direction="row" spacing={1.25} alignItems="center">
+                            <Box sx={{ color: "primary.main", flexShrink: 0 }}>
+                              {a.kind === "copy" ? (
+                                <ContentCopyIcon sx={{ fontSize: 18 }} />
+                              ) : a.kind === "link" ? (
+                                <LaunchIcon sx={{ fontSize: 18 }} />
+                              ) : (
+                                <DescriptionIcon sx={{ fontSize: 18 }} />
+                              )}
+                            </Box>
+                            <Box sx={{ flex: 1, minWidth: 0 }}>
+                              <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+                                {a.label}
+                              </Typography>
+                              <Typography
+                                variant="caption"
+                                color="text.secondary"
+                                sx={{
+                                  display: "block",
+                                  mt: 0.25,
+                                  whiteSpace: "pre-wrap",
+                                  fontFamily: a.kind === "copy" ? "monospace" : "inherit",
+                                }}
+                              >
+                                {a.value}
+                              </Typography>
+                            </Box>
+                            {a.kind === "copy" && (
+                              <Button
+                                size="small"
+                                onClick={() => {
+                                  copyToClipboard(a.value);
+                                  alert("コピーしました");
+                                }}
+                                sx={{ fontSize: "0.65rem", py: 0 }}
+                              >
+                                コピー
+                              </Button>
+                            )}
+                          </Stack>
+                        </Paper>
+                      ))}
+                    </Stack>
+                  </Box>
+                )}
+              </Collapse>
+            </Paper>
+          );
+        })}
+      </Stack>
+    </Paper>
+  );
+}

--- a/src/features/diagnostics/health/components/DiagnosticsSummaryPanel.tsx
+++ b/src/features/diagnostics/health/components/DiagnosticsSummaryPanel.tsx
@@ -1,0 +1,122 @@
+import { Box, Chip, Divider, Paper, Stack, Typography } from "@mui/material";
+import { statusColor, StatusChip } from "./StatusChip";
+import { HealthReport } from "../types";
+
+const categoryLabels: Record<string, string> = {
+  all: "すべて",
+  config: "設定",
+  auth: "認証",
+  connectivity: "通信",
+  lists: "リスト",
+  schema: "構造整合性",
+  permissions: "権限",
+};
+
+interface DiagnosticsSummaryPanelProps {
+  report: HealthReport;
+  diagnosticsTitle: string;
+}
+
+/**
+ * 📋 診断結果サマリーパネル
+ *
+ * overall が pass でない場合のみ表示する。
+ * overall / title / topIssue / カテゴリ別 chip を表示する。
+ */
+export function DiagnosticsSummaryPanel({
+  report,
+  diagnosticsTitle,
+}: DiagnosticsSummaryPanelProps) {
+  if (report.overall === "pass") return null;
+
+  return (
+    <Paper variant="outlined" sx={{ p: 2, bgcolor: "action.hover", border: "2px solid" }}>
+      <Typography variant="subtitle1" sx={{ mb: 1.5, fontWeight: 600 }}>
+        📋 診断結果サマリー
+      </Typography>
+      <Divider sx={{ mb: 1.5 }} />
+
+      <Stack spacing={1.5}>
+        {/* Overall */}
+        <Stack direction="row" spacing={1} alignItems="center">
+          <Typography variant="body2" sx={{ fontWeight: 600, minWidth: "100px" }}>
+            総合判定:
+          </Typography>
+          <StatusChip status={report.overall} />
+        </Stack>
+
+        {/* Title (安定キー) */}
+        <Stack direction="row" spacing={1} alignItems="flex-start">
+          <Typography variant="body2" sx={{ fontWeight: 600, minWidth: "100px" }}>
+            Title:
+          </Typography>
+          <Typography
+            variant="body2"
+            sx={{
+              fontFamily: "monospace",
+              p: 1,
+              bgcolor: "background.paper",
+              borderRadius: 1,
+              border: "1px solid",
+              borderColor: "divider",
+              flex: 1,
+              wordBreak: "break-all",
+            }}
+          >
+            {diagnosticsTitle}
+          </Typography>
+        </Stack>
+
+        {/* TopIssue (1行) */}
+        {report.results.find((r) => r.status !== "pass") && (
+          <Stack direction="row" spacing={1} alignItems="flex-start">
+            <Typography variant="body2" sx={{ fontWeight: 600, minWidth: "100px" }}>
+              最上位課題:
+            </Typography>
+            <Typography variant="body2" sx={{ flex: 1 }}>
+              {report.results.find((r) => r.status === "fail")?.label ||
+                report.results.find((r) => r.status === "warn")?.label ||
+                "特定されませんでした"}
+            </Typography>
+          </Stack>
+        )}
+
+        {/* SummaryText (複数行) */}
+        <Stack direction="row" spacing={1} alignItems="flex-start">
+          <Typography variant="body2" sx={{ fontWeight: 600, minWidth: "100px" }}>
+            詳細:
+          </Typography>
+          <Box
+            sx={{
+              p: 1.5,
+              bgcolor: "background.paper",
+              borderRadius: 1,
+              border: "1px solid",
+              borderColor: "divider",
+              flex: 1,
+              maxHeight: "150px",
+              overflow: "auto",
+            }}
+          >
+            <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+              {Object.entries(report.byCategory).map(([name, cat]) => (
+                <Chip
+                  key={name}
+                  size="small"
+                  label={`${categoryLabels[name] || name}: ${cat.counts.fail}/${cat.counts.warn}/${cat.counts.pass}`}
+                  color={statusColor(cat.overall)}
+                  variant={cat.overall === "pass" ? "outlined" : "filled"}
+                  sx={{ fontSize: "0.75rem", height: 24 }}
+                />
+              ))}
+            </Stack>
+          </Box>
+        </Stack>
+      </Stack>
+
+      <Typography variant="caption" color="text.secondary">
+        💾 ボタン「SharePoint に保存」でこの情報を記録します
+      </Typography>
+    </Paper>
+  );
+}

--- a/src/features/diagnostics/health/components/SpTelemetryPanel.tsx
+++ b/src/features/diagnostics/health/components/SpTelemetryPanel.tsx
@@ -1,0 +1,60 @@
+import { Box, Divider, Paper, Stack, Typography } from "@mui/material";
+import { StatusChip } from "./StatusChip";
+import { spTelemetryStore } from "@/lib/telemetry/spTelemetryStore";
+import React from "react";
+
+/**
+ * 🌐 SP通信状態パネル
+ *
+ * spTelemetryStore を 2 秒間隔でポーリングし、
+ * Throttled / Retry / Failed / Duration / Top Endpoints を表示する。
+ */
+export function SpTelemetryPanel() {
+  const [spSnapshot, setSpSnapshot] = React.useState(() => spTelemetryStore.getSnapshot());
+
+  React.useEffect(() => {
+    const timer = setInterval(() => {
+      setSpSnapshot(spTelemetryStore.getSnapshot());
+    }, 2000);
+    return () => clearInterval(timer);
+  }, []);
+
+  return (
+    <Paper variant="outlined" sx={{ p: 2 }}>
+      <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 1 }}>
+        <Typography variant="subtitle1">🌐 SP通信状態</Typography>
+        <StatusChip
+          status={
+            spSnapshot.summary.failedCount > 5
+              ? "fail"
+              : spSnapshot.summary.throttledCount > 20
+              ? "warn"
+              : "pass"
+          }
+        />
+      </Stack>
+      <Divider sx={{ my: 1 }} />
+      <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
+        {`Throttled: ${spSnapshot.summary.throttledCount} / Retry: ${spSnapshot.summary.retryCount} / Failed: ${spSnapshot.summary.failedCount}`}
+        <br />{`Avg Duration: ${spSnapshot.summary.avgDurationMs}ms / P95: ${spSnapshot.summary.p95DurationMs}ms`}
+        <br />{`Avg Queue: ${spSnapshot.summary.avgQueuedMs}ms / Max Queue: ${spSnapshot.summary.maxQueuedMs}ms`}
+      </Typography>
+      {spSnapshot.topEndpoints.length > 0 && (
+        <Box sx={{ mt: 1 }}>
+          <Typography variant="caption" color="text.secondary">
+            Top Failing Endpoints:
+          </Typography>
+          <Box component="ul" sx={{ m: 0, pl: 2, typography: "body2" }}>
+            {spSnapshot.topEndpoints.map(
+              (ep: { endpoint: string; failures: number; retries: number }, i: number) => (
+                <li key={i}>
+                  <code>{ep.endpoint}</code> (Fail: {ep.failures}, Retry: {ep.retries})
+                </li>
+              ),
+            )}
+          </Box>
+        </Box>
+      )}
+    </Paper>
+  );
+}


### PR DESCRIPTION
## 概要
Phase 1 最終：`src/features/diagnostics/health/HealthDiagnosisPage.tsx`（786行）を複数のサブコンポーネントに分割し、600行しきい値を下回る496行まで削減しました。

## 変更内容

### 新規ファイル（3件）
1. `components/DiagnosticsSummaryPanel.tsx` (122行): 診断結果サマリーカード（overall / title / topIssue / カテゴリchip群）を抽出
2. `components/SpTelemetryPanel.tsx` (60行): SP通信状態パネル（spTelemetryStore を2秒間隔でポーリング）を抽出
3. `components/CheckResultsPanel.tsx` (278行): 個別チェック結果のアコーディオンリストを抽出

### 修正ファイル（1件）
- `HealthDiagnosisPage.tsx`: **786行 → 496行（37%削減）** — signal バナー・ヘッダー・Tabs・フィルタバーのみを保持する構成にし、上記3コンポーネントをインポート

## 検証
- `npm run typecheck` : ✅ パス
- lint エラー 0件（warnings 84件は既存）