### PR TITLE
refactor(users): harden split-list integration and drift resilience

### DIFF
--- a/src/features/users/infra/services/UserFieldResolver.ts
+++ b/src/features/users/infra/services/UserFieldResolver.ts
@@ -120,7 +120,23 @@ export class UserFieldResolver {
   ): Promise<{ resolvedFields: Record<string, string | undefined>, resolvedKeys: Set<string> }> {
     try {
       const available = await this.provider.getFieldInternalNames(listTitle);
-      const { resolved } = resolveInternalNamesDetailed(available, candidates);
+
+      const essentialsSet = new Set(essentials);
+      const { resolved } = resolveInternalNamesDetailed(
+        available,
+        candidates,
+        {
+          onDrift: (fieldName, resolutionType, driftType) => {
+            const isEssential = essentialsSet.has(fieldName as string);
+            if (isEssential) {
+              emitDriftRecord(listTitle, fieldName, resolutionType as DriftResolutionType, driftType as DriftType, undefined, 'warn');
+            } else {
+              // Silent drift: log to internal auditLog only, no persistent event
+              auditLog.info('users:drift', `Silent drift detected in non-essential field "${fieldName}" of list "${listTitle}".`, { resolutionType, driftType });
+            }
+          }
+        }
+      );
       
       const bestEffort: Record<string, string | undefined> = {};
       const resolvedKeys = new Set<string>();

--- a/src/features/users/infra/services/__tests__/UserFieldResolver.spec.ts
+++ b/src/features/users/infra/services/__tests__/UserFieldResolver.spec.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { UserFieldResolver } from '../UserFieldResolver';
+import { emitDriftRecord } from '@/features/diagnostics/drift/domain/driftLogic';
+import { AuthRequiredError } from '@/lib/errors';
+import type { IDataProvider } from '@/lib/data/dataProvider.interface';
+
+vi.mock('@/features/diagnostics/drift/domain/driftLogic', () => ({
+  emitDriftRecord: vi.fn(),
+}));
+
+describe('UserFieldResolver', () => {
+  let mockProvider: any;
+  let resolver: UserFieldResolver;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockProvider = {
+      getFieldInternalNames: vi.fn(),
+    };
+    resolver = new UserFieldResolver(mockProvider as unknown as IDataProvider, 'Users_Master');
+  });
+
+  describe('resolveAccessoryFields', () => {
+    it('should call emitDriftRecord when an essential field drifts', async () => {
+      mockProvider.getFieldInternalNames.mockResolvedValue(new Set(['essentialField0', 'nonEssentialField0']));
+
+      const candidates = {
+        essentialField: ['essentialField'],
+        nonEssentialField: ['nonEssentialField'],
+      };
+
+      const essentials = ['essentialField'];
+
+      const result = await resolver.resolveAccessoryFields('accessory_list', candidates, essentials);
+
+      // Verify the essential field is resolved correctly
+      expect(result.resolvedFields.essentialField).toBe('essentialField0');
+      expect(result.resolvedKeys.has('essentialField')).toBe(true);
+
+      // Verify emitDriftRecord is called for the essential field
+      expect(emitDriftRecord).toHaveBeenCalledWith(
+        'accessory_list',
+        'essentialField',
+        'fuzzy_match',
+        'suffix_mismatch',
+        undefined,
+        'warn'
+      );
+    });
+
+    it('should NOT call emitDriftRecord when a non-essential field drifts', async () => {
+      mockProvider.getFieldInternalNames.mockResolvedValue(new Set(['essentialField', 'nonEssentialField0']));
+
+      const candidates = {
+        essentialField: ['essentialField'],
+        nonEssentialField: ['nonEssentialField', 'nonEssentialField0'],
+      };
+
+      const essentials = ['essentialField'];
+
+      const result = await resolver.resolveAccessoryFields('accessory_list', candidates, essentials);
+
+      // Verify non-essential field is resolved
+      expect(result.resolvedFields.nonEssentialField).toBe('nonEssentialField0');
+      
+      // Verify emitDriftRecord is NOT called for the non-essential field
+      expect(emitDriftRecord).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to primary candidate when getFieldInternalNames fails', async () => {
+      mockProvider.getFieldInternalNames.mockRejectedValue(new Error('Network error'));
+
+      const candidates = {
+        essentialField: ['essentialField', 'essentialField0'],
+        nonEssentialField: ['nonEssentialField', 'nonEssentialField0'],
+      };
+
+      const essentials = ['essentialField'];
+
+      const result = await resolver.resolveAccessoryFields('accessory_list', candidates, essentials);
+
+      // Verify essential falls back to primary candidate
+      expect(result.resolvedFields.essentialField).toBe('essentialField');
+      // Verify non-essential falls back to undefined
+      expect(result.resolvedFields.nonEssentialField).toBeUndefined();
+      // Verify resolvedKeys is empty
+      expect(result.resolvedKeys.size).toBe(0);
+    });
+
+    it('should propagate AuthRequiredError when getFieldInternalNames throws it', async () => {
+      const authError = new AuthRequiredError('Auth failed');
+      mockProvider.getFieldInternalNames.mockRejectedValue(authError);
+
+      const candidates = {
+        essentialField: ['essentialField'],
+      };
+
+      await expect(
+        resolver.resolveAccessoryFields('accessory_list', candidates, ['essentialField'])
+      ).rejects.toThrow(authError);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds drift handling to UserFieldResolver.resolveAccessoryFields()
- Reports essential accessory-list drift through emitDriftRecord as warn
- Keeps non-essential accessory-list drift silent via auditLog.info
- Preserves fallback behavior and AuthRequiredError propagation

## Scope
- Users split-list resilience
- Accessory list drift absorbing
- Repository hardening

## Out of scope
- Health UI changes
- Telemetry UI changes
- SharePoint environment/index repair
- support_record_daily drift repair
- patrol output updates

## Checks
- npx vitest run src/features/users
- npm run lint -- --max-warnings=0
- npm run typecheck
- npm run patrol:admin-status
- git diff --check