### PR TITLE
feat(isp): implement schema drift warning and fallback resilience in ISP and planning sheet repos

### DIFF
--- a/src/data/isp/infra/DataProviderIspRepository.ts
+++ b/src/data/isp/infra/DataProviderIspRepository.ts
@@ -8,6 +8,7 @@ import {
 import { reportResourceResolution, useDataProviderObservabilityStore } from '@/lib/data/dataProviderObservabilityStore';
 import { summarizeSpError } from '@/lib/errors';
 import { auditLog } from '@/lib/debugLogger';
+import { emitDriftRecord, type DriftResolutionType, type DriftType } from '@/features/diagnostics/drift/domain/driftLogic';
 import type { 
   IspRepository, 
   IspCreateInput, 
@@ -64,7 +65,23 @@ export class DataProviderIspRepository implements IspRepository {
     try {
       const available = await this.provider.getFieldInternalNames(this.listTitle);
       const candidates = ISP_MASTER_CANDIDATES as unknown as Record<string, string[]>;
-      const { resolved, fieldStatus } = resolveInternalNamesDetailed(available, candidates);
+      
+      const essentialsSet = new Set(ISP_MASTER_ESSENTIALS as string[]);
+      const { resolved, fieldStatus } = resolveInternalNamesDetailed(
+        available,
+        candidates,
+        {
+          onDrift: (fieldName, resolutionType, driftType) => {
+            const isEssential = essentialsSet.has(fieldName as string);
+            if (isEssential) {
+              emitDriftRecord(this.listTitle, fieldName, resolutionType as DriftResolutionType, driftType as DriftType, undefined, 'warn');
+            } else {
+              // Silent drift: log to internal auditLog only, no persistent event
+              auditLog.info('isp:drift', `Silent drift detected in non-essential field "${fieldName}" of list "${this.listTitle}".`, { resolutionType, driftType });
+            }
+          }
+        }
+      );
 
       const isHealthy = areEssentialFieldsResolved(resolved, ISP_MASTER_ESSENTIALS as unknown as string[]);
       
@@ -115,8 +132,8 @@ export class DataProviderIspRepository implements IspRepository {
     const numericId = extractSpId(id);
     if (numericId === null) return null;
 
-    const { title, fields, candidates } = await this.resolveSource();
     try {
+      const { title, fields, candidates } = await this.resolveSource();
       const row = await this.provider.getItemById<SpIspMasterRow>(title, numericId);
       if (!row) return null;
       

--- a/src/data/isp/infra/DataProviderPlanningSheetRepository.ts
+++ b/src/data/isp/infra/DataProviderPlanningSheetRepository.ts
@@ -6,6 +6,8 @@ import {
   washRows
 } from '@/lib/sp/helpers';
 import { reportResourceResolution } from '@/lib/data/dataProviderObservabilityStore';
+import { emitDriftRecord, type DriftResolutionType, type DriftType } from '@/features/diagnostics/drift/domain/driftLogic';
+import { auditLog } from '@/lib/debugLogger';
 import type { 
   PlanningSheetRepository, 
   PlanningSheetCreateInput, 
@@ -135,7 +137,23 @@ export class DataProviderPlanningSheetRepository implements PlanningSheetReposit
     try {
       const available = await this.provider.getFieldInternalNames(this.listTitle);
       const candidates = PLANNING_SHEET_CANDIDATES as unknown as Record<string, string[]>;
-      const { resolved, fieldStatus } = resolveInternalNamesDetailed(available, candidates);
+      
+      const essentialsSet = new Set(PLANNING_SHEET_ESSENTIALS as string[]);
+      const { resolved, fieldStatus } = resolveInternalNamesDetailed(
+        available,
+        candidates,
+        {
+          onDrift: (fieldName, resolutionType, driftType) => {
+            const isEssential = essentialsSet.has(fieldName as string);
+            if (isEssential) {
+              emitDriftRecord(this.listTitle, fieldName, resolutionType as DriftResolutionType, driftType as DriftType, undefined, 'warn');
+            } else {
+              // Silent drift: log to internal auditLog only, no persistent event
+              auditLog.info('isp:drift', `Silent drift detected in non-essential field "${fieldName}" of list "${this.listTitle}".`, { resolutionType, driftType });
+            }
+          }
+        }
+      );
 
       const isHealthy = areEssentialFieldsResolved(resolved, PLANNING_SHEET_ESSENTIALS as unknown as string[]);
       
@@ -186,8 +204,8 @@ export class DataProviderPlanningSheetRepository implements PlanningSheetReposit
     const numericId = extractSpId(id);
     if (numericId === null) return null;
 
-    const { title, fields, candidates } = await this.resolveSource();
     try {
+      const { title, fields, candidates } = await this.resolveSource();
       const row = await this.provider.getItemById<SpPlanningSheetRow>(title, numericId);
       if (!row) return null;
       

--- a/src/data/isp/infra/__tests__/DataProviderIspRepository.spec.ts
+++ b/src/data/isp/infra/__tests__/DataProviderIspRepository.spec.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DataProviderIspRepository } from '../DataProviderIspRepository';
+import { emitDriftRecord } from '@/features/diagnostics/drift/domain/driftLogic';
+import { AuthRequiredError } from '@/lib/errors';
+import type { IDataProvider } from '@/lib/data/dataProvider.interface';
+import { 
+  ISP_MASTER_CANDIDATES,
+  ISP_MASTER_ESSENTIALS 
+} from '@/sharepoint/fields/ispThreeLayerFields';
+
+vi.mock('@/features/diagnostics/drift/domain/driftLogic', () => ({
+  emitDriftRecord: vi.fn(),
+}));
+
+describe('DataProviderIspRepository', () => {
+  let mockProvider: any;
+  let repository: DataProviderIspRepository;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockProvider = {
+      getFieldInternalNames: vi.fn(),
+      getItemById: vi.fn(),
+      listItems: vi.fn(),
+    };
+    repository = new DataProviderIspRepository(mockProvider as unknown as IDataProvider, 'ISP_Master');
+  });
+
+  describe('drift resilience and error fallback', () => {
+    it('should call emitDriftRecord when an essential field drifts', async () => {
+      // Simulate that essential field 'planStartDate' drifts to 'planStartDate0'
+      const essentialKey = 'planStartDate';
+      const driftName = 'planStartDate0';
+      
+      const candidates = { ...(ISP_MASTER_CANDIDATES as unknown as Record<string, string[]>) };
+
+      const availableSet = new Set<string>();
+      Object.entries(candidates).forEach(([key, val]) => {
+        if (key === essentialKey) {
+          availableSet.add(driftName);
+        } else {
+          availableSet.add(val[0]);
+        }
+      });
+
+      mockProvider.getFieldInternalNames.mockResolvedValue(availableSet);
+      mockProvider.getItemById.mockResolvedValue({
+        ID: 123,
+        Title: 'ISP 123',
+        UserCode: 'user-001',
+        [driftName]: '2026-05-22T00:00:00Z',
+        Status: 'active',
+        VersionNo: 1,
+        IsCurrent: true,
+      });
+
+      const result = await repository.getById('sp-123');
+
+      expect(result).toBeDefined();
+      
+      // Verify emitDriftRecord is called for the essential field drift
+      expect(emitDriftRecord).toHaveBeenCalledWith(
+        'ISP_Master',
+        essentialKey,
+        'fuzzy_match',
+        'suffix_mismatch',
+        undefined,
+        'warn'
+      );
+    });
+
+    it('should NOT call emitDriftRecord when a non-essential field drifts', async () => {
+      // Find a non-essential field candidate
+      const essentials = new Set(ISP_MASTER_ESSENTIALS as unknown as string[]);
+      const candidates = ISP_MASTER_CANDIDATES as unknown as Record<string, string[]>;
+      const nonEssentialKey = Object.keys(candidates).find(key => !essentials.has(key));
+      
+      if (!nonEssentialKey) {
+        throw new Error('Test setup error: No non-essential field found in ISP_MASTER_CANDIDATES');
+      }
+
+      const driftName = `${nonEssentialKey}0`;
+
+      const availableSet = new Set<string>();
+      Object.entries(candidates).forEach(([key, val]) => {
+        if (key === nonEssentialKey) {
+          availableSet.add(driftName);
+        } else {
+          availableSet.add(val[0]);
+        }
+      });
+
+      mockProvider.getFieldInternalNames.mockResolvedValue(availableSet);
+      mockProvider.getItemById.mockResolvedValue({
+        ID: 123,
+        Title: 'ISP 123',
+        UserCode: 'user-001',
+        PlanStartDate: '2026-05-22T00:00:00Z',
+        Status: 'active',
+        VersionNo: 1,
+        IsCurrent: true,
+        [driftName]: 'some-val',
+      });
+
+      const result = await repository.getById('sp-123');
+
+      expect(result).toBeDefined();
+
+      // Verify emitDriftRecord is NOT called for non-essential field drift
+      expect(emitDriftRecord).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to default behavior when getFieldInternalNames fails with generic error', async () => {
+      mockProvider.getFieldInternalNames.mockRejectedValue(new Error('SharePoint request failed'));
+      
+      const result = await repository.getById('sp-123');
+      
+      expect(result).toBeNull();
+    });
+
+    it('should propagate AuthRequiredError when resolveSource throws it', async () => {
+      const authError = new AuthRequiredError('Auth failed');
+      mockProvider.getFieldInternalNames.mockRejectedValue(authError);
+      
+      await expect(
+        repository.listByUser('user-001')
+      ).rejects.toThrow(authError);
+    });
+  });
+});

--- a/src/data/isp/infra/__tests__/DataProviderPlanningSheetRepository.spec.ts
+++ b/src/data/isp/infra/__tests__/DataProviderPlanningSheetRepository.spec.ts
@@ -1,6 +1,11 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { DataProviderPlanningSheetRepository } from '../DataProviderPlanningSheetRepository';
+import { emitDriftRecord } from '@/features/diagnostics/drift/domain/driftLogic';
+
+vi.mock('@/features/diagnostics/drift/domain/driftLogic', () => ({
+  emitDriftRecord: vi.fn(),
+}));
 import type {
   DataProviderOptions,
   IDataProvider,
@@ -337,6 +342,51 @@ describe('DataProviderPlanningSheetRepository', () => {
       expect(capturedPayload.cr013_monitoringCycleDays).toBe(90);
       expect(capturedPayload.SupportStartDate).toBeUndefined();
       expect(capturedPayload.MonitoringCycleDays).toBeUndefined();
+    });
+  });
+
+  describe('drift resilience and warning events', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('should call emitDriftRecord when an essential field drifts', async () => {
+      // Simulate that essential field 'appliedFrom' drifts to 'appliedFrom0'
+      provider.getFieldInternalNames = async () => new Set([
+        'Id', 'Title', 'UserCode', 'ISPId', 'VersionNo', 'IsCurrent', 'Status',
+        'appliedFrom0' // Drifted
+      ]);
+
+      provider.getItemById = async () => {
+        return row({ Id: 123, UserCode: 'U-001' }) as any;
+      };
+
+      await repo.getById('sp-123');
+
+      expect(emitDriftRecord).toHaveBeenCalledWith(
+        PLANNING_SHEET_LIST_TITLE,
+        'appliedFrom',
+        'fuzzy_match',
+        'suffix_mismatch',
+        undefined,
+        'warn'
+      );
+    });
+
+    it('should NOT call emitDriftRecord when a non-essential field drifts', async () => {
+      // Simulate that non-essential field 'targetDomain' drifts to 'targetDomain0'
+      provider.getFieldInternalNames = async () => new Set([
+        'Id', 'Title', 'UserCode', 'ISPId', 'VersionNo', 'IsCurrent', 'Status',
+        'AppliedFrom', 'targetDomain0' // Non-essential drifted
+      ]);
+
+      provider.getItemById = async () => {
+        return row({ Id: 123, UserCode: 'U-001' }) as any;
+      };
+
+      await repo.getById('sp-123');
+
+      expect(emitDriftRecord).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
This PR implements schema drift resilience and warning capabilities in DataProviderIspRepository and DataProviderPlanningSheetRepository, mirroring DataProviderProcedureRecordRepository.