### PR TITLE
fix(abc): resolve timezone mismatch and target date sync bug on ABC record page

### DIFF
--- a/src/pages/abc-record/AbcRecordPage.tsx
+++ b/src/pages/abc-record/AbcRecordPage.tsx
@@ -9,6 +9,8 @@
  */
 import React, { useState, useCallback, useMemo, useEffect } from 'react';
 import { useSearchParams, useNavigate, useLocation } from 'react-router-dom';
+import { formatInTimeZone } from '@/lib/tz';
+import { formatDateJapanese } from '@/lib/dateFormat';
 
 // ── MUI ──
 import AccessTimeRoundedIcon from '@mui/icons-material/AccessTimeRounded';
@@ -178,13 +180,22 @@ const AbcRecordPage: React.FC = () => {
   // 追加state: LogTab に渡す focused record ID
   const [focusedRecordId, setFocusedRecordId] = useState<string | undefined>(undefined);
 
-  // 今日の記録（対象ユーザーに絞る）
+  const targetDate = useMemo(() => {
+    if (urlDate) return urlDate;
+    return formatInTimeZone(new Date(), 'Asia/Tokyo', 'yyyy-MM-dd');
+  }, [urlDate]);
+
+  const isToday = useMemo(() => {
+    const todayStr = formatInTimeZone(new Date(), 'Asia/Tokyo', 'yyyy-MM-dd');
+    return targetDate === todayStr;
+  }, [targetDate]);
+
+  // 対象日の記録（対象ユーザーに絞る）
   const todayRecords = useMemo(() => {
-    const today = new Date().toISOString().slice(0, 10);
     return records
-      .filter(r => r.occurredAt.slice(0, 10) === today && (!urlUserId || r.userId === urlUserId))
+      .filter(r => r.occurredAt.slice(0, 10) === targetDate && (!urlUserId || r.userId === urlUserId))
       .sort((a, b) => b.occurredAt.localeCompare(a.occurredAt));
-  }, [records, urlUserId]);
+  }, [records, urlUserId, targetDate]);
 
   const handleBack = useCallback(() => {
     if (source === 'support-planning') {
@@ -226,7 +237,7 @@ const AbcRecordPage: React.FC = () => {
                   </Typography>
                   <Typography variant="body2" color="text.secondary">
                     {contextUserName
-                      ? `${new Date().toLocaleDateString('ja-JP')} — 行動の前後関係を素早く記録`
+                      ? `${formatDateJapanese(targetDate)} — 行動の前後関係を素早く記録`
                       : '行動の前後関係を記録して支援計画に活かす'}
                   </Typography>
                 </Box>
@@ -240,7 +251,7 @@ const AbcRecordPage: React.FC = () => {
               />
               {todayRecords.length > 0 && (
                 <Chip
-                  label={`今日 ${todayRecords.length} 件`}
+                  label={isToday ? `今日 ${todayRecords.length} 件` : `${targetDate} ${todayRecords.length} 件`}
                   size="small"
                   color="info"
                   variant="filled"
@@ -299,6 +310,7 @@ const AbcRecordPage: React.FC = () => {
               todayRecords={todayRecords}
               sourceContext={sourceContextForSave}
               initialBehavior={initialBehavior}
+              targetDate={targetDate}
             />
           ) : (
             <LogTab

--- a/src/pages/abc-record/QuickRecordTab.tsx
+++ b/src/pages/abc-record/QuickRecordTab.tsx
@@ -5,6 +5,7 @@
  */
 import React, { useState, useCallback, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { formatInTimeZone } from '@/lib/tz';
 import { buildIcebergPdcaUrl } from '@/app/links/navigationLinks';
 
 // ── MUI ──
@@ -49,13 +50,46 @@ interface QuickRecordTabProps {
   sourceContext?: AbcRecordSourceContext;
   /** MVP-5: Step 3 からの下書き behavior テキスト */
   initialBehavior?: string;
+  targetDate: string;
 }
 
-const QuickRecordTab: React.FC<QuickRecordTabProps> = ({ users, recorderName, onSaved, initialUserId, todayRecords, sourceContext, initialBehavior }) => {
+export function getInitialOccurredAt(date?: string, slotId?: string): string {
+  const tz = 'Asia/Tokyo';
+  const now = new Date();
+  const todayStr = formatInTimeZone(now, tz, 'yyyy-MM-dd');
+  const targetDate = date ? date.trim() : todayStr;
+
+  let targetTime = '';
+  if (slotId) {
+    const parts = slotId.split('|');
+    const timePart = parts[0] ?? '';
+    const match = timePart.match(/(\d{1,2}):(\d{2})/);
+    if (match) {
+      const hour = match[1].padStart(2, '0');
+      const minute = match[2];
+      targetTime = `${hour}:${minute}`;
+    }
+  }
+
+  if (!targetTime) {
+    if (targetDate === todayStr) {
+      targetTime = formatInTimeZone(now, tz, 'HH:mm');
+    } else {
+      targetTime = '12:00';
+    }
+  }
+
+  return `${targetDate}T${targetTime}`;
+}
+
+const QuickRecordTab: React.FC<QuickRecordTabProps> = ({ users, recorderName, onSaved, initialUserId, todayRecords, sourceContext, initialBehavior, targetDate }) => {
   const navigate = useNavigate();
   const abcRecordRepo = useAbcRecordRepository();
   const [selectedUser, setSelectedUser] = useState<UserOption | null>(null);
-  const [form, setForm] = useState(EMPTY_FORM);
+  const [form, setForm] = useState(() => ({
+    ...EMPTY_FORM,
+    occurredAt: getInitialOccurredAt(sourceContext?.date, sourceContext?.slotId),
+  }));
   const [isSaving, setIsSaving] = useState(false);
   const [saveSuccess, setSaveSuccess] = useState(false);
   const [lastSavedUserId, setLastSavedUserId] = useState<string | null>(null);
@@ -67,6 +101,14 @@ const QuickRecordTab: React.FC<QuickRecordTabProps> = ({ users, recorderName, on
       if (found) setSelectedUser(found);
     }
   }, [initialUserId, users, selectedUser]);
+
+  // URL context（date/slotId）が変更されたら発生日時を同期
+  useEffect(() => {
+    setForm(prev => ({
+      ...prev,
+      occurredAt: getInitialOccurredAt(sourceContext?.date, sourceContext?.slotId),
+    }));
+  }, [sourceContext?.date, sourceContext?.slotId]);
 
   // MVP-5: 下書き behavior を初期値としてセット
   const [draftApplied, setDraftApplied] = useState(false);
@@ -110,10 +152,10 @@ const QuickRecordTab: React.FC<QuickRecordTabProps> = ({ users, recorderName, on
       await abcRecordRepo.save(input);
       setSaveSuccess(true);
       setLastSavedUserId(selectedUser.id);
-      // リセット（利用者は維持）
+      // リセット（利用者は維持、発生日時もコンテキストに合わせてリセット）
       setForm({
         ...EMPTY_FORM,
-        occurredAt: new Date().toISOString().slice(0, 16),
+        occurredAt: getInitialOccurredAt(sourceContext?.date, sourceContext?.slotId),
       });
       onSaved();
       // 3秒後に成功メッセージを消す
@@ -323,7 +365,7 @@ const QuickRecordTab: React.FC<QuickRecordTabProps> = ({ users, recorderName, on
           <Divider sx={{ mt: 2 }} />
           <Box sx={{ mt: 1 }}>
             <Typography variant="subtitle2" fontWeight={700} color="text.secondary" sx={{ mb: 1 }}>
-              📋 今日の記録 ({todayRecords.length}件)
+              📋 {targetDate === formatInTimeZone(new Date(), 'Asia/Tokyo', 'yyyy-MM-dd') ? '今日の記録' : `${targetDate} の記録`} ({todayRecords.length}件)
             </Typography>
             <Stack spacing={0.75}>
               {todayRecords.map(r => (
@@ -338,7 +380,7 @@ const QuickRecordTab: React.FC<QuickRecordTabProps> = ({ users, recorderName, on
                   }}
                 >
                   <Typography variant="caption" color="primary" fontWeight={700} sx={{ minWidth: 40 }}>
-                    {new Date(r.occurredAt).toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' })}
+                    {formatInTimeZone(r.occurredAt, 'Asia/Tokyo', 'HH:mm')}
                   </Typography>
                   {r.setting && (
                     <Chip label={r.setting} size="small" variant="outlined" sx={{ height: 20, fontSize: '0.65rem' }} />

--- a/src/pages/abc-record/__tests__/QuickRecordTab.spec.ts
+++ b/src/pages/abc-record/__tests__/QuickRecordTab.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getInitialOccurredAt } from '../QuickRecordTab';
+
+describe('getInitialOccurredAt', () => {
+  beforeEach(() => {
+    // 2026-05-22 11:22:33 JST (Asia/Tokyo) = 2026-05-22 02:22:33 UTC
+    const mockDate = new Date('2026-05-22T11:22:33+09:00');
+    vi.useFakeTimers();
+    vi.setSystemTime(mockDate);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('URL引数なしの場合、現在の日本時間 (Asia/Tokyo) を返す', () => {
+    const result = getInitialOccurredAt();
+    expect(result).toBe('2026-05-22T11:22');
+  });
+
+  it('date のみ指定された場合、本日であれば現在のローカル時刻、過去日であれば 12:00 を返す', () => {
+    // 本日
+    const resultToday = getInitialOccurredAt('2026-05-22');
+    expect(resultToday).toBe('2026-05-22T11:22');
+
+    // 過去日
+    const resultPast = getInitialOccurredAt('2026-05-20');
+    expect(resultPast).toBe('2026-05-20T12:00');
+
+    // 未来日
+    const resultFuture = getInitialOccurredAt('2026-05-25');
+    expect(resultFuture).toBe('2026-05-25T12:00');
+  });
+
+  it('date と slotId (時刻情報あり) が指定された場合、slotId から時刻をパースして結合する', () => {
+    const result = getInitialOccurredAt('2026-05-20', '9:30頃|通所・朝の準備');
+    expect(result).toBe('2026-05-20T09:30');
+
+    const result2 = getInitialOccurredAt('2026-05-20', '13:00|作業時間');
+    expect(result2).toBe('2026-05-20T13:00');
+  });
+
+  it('slotId の時刻パースに失敗した場合、デフォルトのフォールバックルールを適用する', () => {
+    // 時刻を含まない slotId
+    const result = getInitialOccurredAt('2026-05-20', 'お昼休み|食事');
+    expect(result).toBe('2026-05-20T12:00'); // 過去日なので 12:00
+  });
+});


### PR DESCRIPTION
### 概要
保存失敗ではなく、URL由来の対象日コンテキストと発生日時初期値、およびミニ一覧のフィルタ基準が一致していなかったことによる表示反映ズレを修正します。

### 変更点
1. **QuickRecordTab**:
   - URLパラメータ (`date` / `slotId`) から発生日時の初期値を日本時間（Asia/Tokyo）前提で安全にパースする `getInitialOccurredAt` ヘルパーを実装。
   - 保存成功時のリセット時やパラメータ変更時にも、このコンテキストを維持・追従するように修正。
2. **AbcRecordPage**:
   - 一覧のフィルタリング基準を「今日（本日日付）」固定から `targetDate` に修正し、過去日付で保存した時にも即座に検証用ミニ一覧へ反映されるよう改善。
3. **テスト**:
   - `getInitialOccurredAt` のパース・フォールバックロジックを検証する単体テストを追加。
