### PR TITLE
fix(kiosk): resolve context-switch state leak and skipped record display issue in procedure list

### DIFF
--- a/src/features/kiosk/components/KioskProcedureListScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureListScreen.tsx
@@ -193,7 +193,7 @@ export const KioskProcedureListScreen: React.FC = () => {
 
   const hasRecordInput = React.useCallback((record: ExecutionRecord | undefined): boolean => {
     if (!record) return false;
-    if (record.status === 'completed' || record.status === 'triggered') return true;
+    if (record.status === 'completed' || record.status === 'triggered' || record.status === 'skipped') return true;
     const unknownRecord = record as unknown as Record<string, unknown>;
     const inputKeys = ['memo', 'note', 'specialNote', 'additionalInfo', 'situation'];
     return inputKeys.some((key) => {

--- a/src/features/kiosk/components/KioskProcedureListScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureListScreen.tsx
@@ -13,6 +13,7 @@ import { resolveKioskRecordDate } from '../utils/kioskDate';
 import { ExecutionRecord } from '@/features/daily/domain/executionRecordTypes';
 import { normalizeScheduleItemId } from '@/features/daily/utils/normalizeScheduleItemId';
 import { useExecutionStore } from '@/features/daily/stores/executionStore';
+import { isDemoModeEnabled, shouldSkipSharePoint, shouldSkipLogin } from '@/lib/env';
 import { getCurrentExecutionRepositoryKind } from '@/features/daily/repositories/sharepoint/executionRepositoryFactory';
 import { usePlanningSheetRepositories } from '@/features/planning-sheet/hooks/usePlanningSheetRepositories';
 import { usePlanningSheetData } from '@/features/planning-sheet/hooks/usePlanningSheetData';
@@ -177,19 +178,39 @@ export const KioskProcedureListScreen: React.FC = () => {
 
   // 実施記録の取得
   useEffect(() => {
+    if (isUserLoading) return;
+
+    let active = true;
     const fetchRecords = async () => {
       const queryId = queryUserIdFromSearch || user?.UserID || userId;
       if (!queryId) return;
       try {
         const data = await executionRepo.getRecords(selectedDateIso, queryId);
-        setRecords(data);
+        if (active) {
+          setRecords(data);
+        }
       } catch (error) {
-        console.error('Failed to fetch execution records:', error);
-        setShowFetchError(true);
+        if (active) {
+          console.error('Failed to fetch execution records:', error);
+          setShowFetchError(true);
+        }
       }
     };
     void fetchRecords();
-  }, [queryUserIdFromSearch, userId, user?.UserID, executionRepo, selectedDateIso, location.key, location.search]);
+
+    return () => {
+      active = false;
+    };
+  }, [
+    queryUserIdFromSearch,
+    userId,
+    user?.UserID,
+    isUserLoading,
+    executionRepo,
+    selectedDateIso,
+    location.key,
+    location.search,
+  ]);
 
   const hasRecordInput = React.useCallback((record: ExecutionRecord | undefined): boolean => {
     if (!record) return false;
@@ -209,8 +230,11 @@ export const KioskProcedureListScreen: React.FC = () => {
 
     // In sharepoint mode, treat repository result as source of truth to avoid
     // local-only "記録済み" labels that don't survive across devices.
+    // However, if we are in demo mode or SharePoint is bypassed/mocked,
+    // we must allow local store records as fallback.
+    const isMock = isDemoModeEnabled() || shouldSkipSharePoint() || shouldSkipLogin();
     const allCandidateRecords =
-      executionRepositoryKind === 'local' ? [...storeRecords, ...records] : [...records];
+      (executionRepositoryKind === 'local' || isMock) ? [...storeRecords, ...records] : [...records];
     
     for (const record of allCandidateRecords) {
       const key = normalizeScheduleItemId(record.scheduleItemId);

--- a/src/features/kiosk/components/KioskProcedureListScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureListScreen.tsx
@@ -149,6 +149,18 @@ export const KioskProcedureListScreen: React.FC = () => {
   const [records, setRecords] = useState<ExecutionRecord[]>([]);
   const [showFetchError, setShowFetchError] = useState(false);
 
+  // Synchronously reset records state when the active user or date changes
+  // to prevent rendering stale records from the previous context.
+  const currentQueryId = queryUserIdFromSearch || user?.UserID || userId || '';
+  const [prevQueryId, setPrevQueryId] = useState<string>('');
+  const [prevDate, setPrevDate] = useState<string>('');
+
+  if (currentQueryId !== prevQueryId || selectedDateIso !== prevDate) {
+    setPrevQueryId(currentQueryId);
+    setPrevDate(selectedDateIso);
+    setRecords([]);
+  }
+
   const buildKioskAbcRecordLink = React.useCallback((slotId: string) => {
     if (!deepLinkUserId) return '/abc-record';
     const returnParams = new URLSearchParams({ date: selectedDateIso });

--- a/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
@@ -768,4 +768,27 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
     expect(within(firstCard).queryByText('記録済み')).toBeNull();
     expect(within(firstCard).getByText('未実施')).toBeInTheDocument();
   });
+
+  it('marks a procedure as recorded when the record status is "skipped"', async () => {
+    mockGetRecords.mockResolvedValue([
+      { scheduleItemId: '1', status: 'skipped', memo: '' }
+    ]);
+
+    mockUseUser.mockReturnValue({
+      data: { FullName: '田中 太郎', UserID: 'U001' },
+      status: 'success',
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/kiosk/users/U001/procedures']}>
+        <KioskProcedureListScreen />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      const firstCard = screen.getByTestId('kiosk-procedure-card-0');
+      expect(within(firstCard).getByText('記録済み')).toBeInTheDocument();
+      expect(within(firstCard).queryByText('未実施')).toBeNull();
+    });
+  });
 });

--- a/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
@@ -7,12 +7,22 @@ import type { SupportPlanningSheet, PlanningSheetListItem } from '@/domain/isp/s
 
 // Mock dependencies
 let mockRouteUserId = 'U001';
+let mockLocationSearch: string | null = null;
+let mockLocationKey: string | null = null;
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom');
   return {
     ...actual,
     useNavigate: () => vi.fn(),
     useParams: () => ({ userId: mockRouteUserId }),
+    useLocation: () => {
+      const loc = actual.useLocation();
+      return {
+        ...loc,
+        search: mockLocationSearch !== null ? mockLocationSearch : loc.search,
+        key: mockLocationKey !== null ? mockLocationKey : loc.key,
+      };
+    },
   };
 });
 
@@ -75,6 +85,8 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
     vi.setSystemTime(new Date(2026, 4, 8));
     vi.clearAllMocks();
     mockRouteUserId = 'U001';
+    mockLocationSearch = null;
+    mockLocationKey = null;
     mockUseUser.mockReturnValue({ data: { FullName: '田中 太郎' }, status: 'success' });
     mockUseUsers.mockReturnValue({ data: [], status: 'success' });
     mockGetCurrentExecutionRepositoryKind.mockReturnValue('local');
@@ -672,5 +684,88 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
       expect(screen.getByText(/支援開始日: 不正な日付（90日参考）/)).toBeInTheDocument();
       expect(screen.queryByTestId('kiosk-support-start-setup-cta')).toBeNull();
     });
+  });
+
+  it('synchronously clears records when user changes to prevent temporal display of stale records', async () => {
+    mockGetRecords.mockImplementation(async (date, userId) => {
+      if (userId === 'U001') {
+        return [{ scheduleItemId: '1', status: 'completed' }];
+      }
+      return new Promise((resolve) => setTimeout(() => resolve([]), 50));
+    });
+
+    mockUseUser.mockImplementation(() => ({
+      data: { FullName: '田中 太郎', UserID: 'U001' },
+      status: 'success',
+    }));
+
+    const { rerender } = render(
+      <MemoryRouter initialEntries={['/kiosk/users/U001/procedures']}>
+        <KioskProcedureListScreen />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      const firstCard = screen.getByTestId('kiosk-procedure-card-0');
+      expect(within(firstCard).getByText('記録済み')).toBeInTheDocument();
+    });
+
+    mockRouteUserId = 'U002';
+    mockLocationKey = 'new-user-key';
+    mockUseUser.mockImplementation(() => ({
+      data: { FullName: '鈴木 次郎', UserID: 'U002' },
+      status: 'success',
+    }));
+
+    rerender(
+      <MemoryRouter initialEntries={['/kiosk/users/U002/procedures']}>
+        <KioskProcedureListScreen />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/鈴木 次郎/)).toBeInTheDocument();
+    });
+
+    const firstCard = screen.getByTestId('kiosk-procedure-card-0');
+    expect(within(firstCard).queryByText('記録済み')).toBeNull();
+    expect(within(firstCard).getByText('未実施')).toBeInTheDocument();
+  });
+
+  it('synchronously clears records when date query changes to prevent temporal display of stale records', async () => {
+    mockGetRecords.mockImplementation(async (date) => {
+      if (date === '2026-05-08') {
+        return [{ scheduleItemId: '1', status: 'completed' }];
+      }
+      return new Promise((resolve) => setTimeout(() => resolve([]), 50));
+    });
+
+    const { rerender } = render(
+      <MemoryRouter initialEntries={['/kiosk/users/U001/procedures?date=2026-05-08']}>
+        <KioskProcedureListScreen />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      const firstCard = screen.getByTestId('kiosk-procedure-card-0');
+      expect(within(firstCard).getByText('記録済み')).toBeInTheDocument();
+    });
+
+    mockLocationSearch = '?date=2026-05-09';
+    mockLocationKey = 'new-date-key';
+
+    rerender(
+      <MemoryRouter initialEntries={['/kiosk/users/U001/procedures?date=2026-05-09']}>
+        <KioskProcedureListScreen />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/2026年5月9日/)).toBeInTheDocument();
+    });
+
+    const firstCard = screen.getByTestId('kiosk-procedure-card-0');
+    expect(within(firstCard).queryByText('記録済み')).toBeNull();
+    expect(within(firstCard).getByText('未実施')).toBeInTheDocument();
   });
 });

--- a/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
@@ -79,6 +79,20 @@ vi.mock('@/features/planning-sheet/hooks/usePlanningSheetRepositories', () => ({
   usePlanningSheetRepositories: () => ({}),
 }));
 
+const mockIsDemoModeEnabled = vi.fn(() => false);
+const mockShouldSkipSharePoint = vi.fn(() => false);
+const mockShouldSkipLogin = vi.fn(() => false);
+
+vi.mock('@/lib/env', async () => {
+  const actual = await vi.importActual('@/lib/env');
+  return {
+    ...actual,
+    isDemoModeEnabled: () => mockIsDemoModeEnabled(),
+    shouldSkipSharePoint: () => mockShouldSkipSharePoint(),
+    shouldSkipLogin: () => mockShouldSkipLogin(),
+  };
+});
+
 describe('KioskProcedureListScreen (includes local/memory-style recorded-state checks)', () => {
   beforeEach(() => {
     vi.useFakeTimers({ toFake: ['Date'] });
@@ -791,4 +805,56 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
       expect(within(firstCard).queryByText('未実施')).toBeNull();
     });
   });
+
+  it('waits for user to load and does not perform stale fetches with fallback route ID', async () => {
+    mockRouteUserId = '17';
+    // Start as loading
+    let userState = { data: undefined as any, status: 'loading' };
+    mockUseUser.mockImplementation(() => userState);
+
+    // Track calls to mockGetRecords
+    mockGetRecords.mockClear();
+    mockGetRecords.mockImplementation(async (date, userId) => {
+      if (userId === 'U001') {
+        return [{ scheduleItemId: '1', status: 'completed' }];
+      }
+      return [];
+    });
+
+    const { rerender } = render(
+      <MemoryRouter initialEntries={['/kiosk/users/17/procedures']}>
+        <KioskProcedureListScreen />
+      </MemoryRouter>
+    );
+
+    // Initial render should be loading state
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+    // At this point, mockGetRecords should NOT have been called because user loading is true
+    expect(mockGetRecords).not.toHaveBeenCalled();
+
+    // Now, transition user to success
+    userState = {
+      data: { FullName: '田中 太郎', UserID: 'U001' } as any,
+      status: 'success',
+    };
+    
+    // Trigger rerender to simulate useUser state update
+    rerender(
+      <MemoryRouter initialEntries={['/kiosk/users/17/procedures']}>
+        <KioskProcedureListScreen />
+      </MemoryRouter>
+    );
+
+    // Verify it loads and shows "記録済み"
+    await waitFor(() => {
+      expect(screen.queryByText('読み込み中...')).toBeNull();
+      const firstCard = screen.getByTestId('kiosk-procedure-card-0');
+      expect(within(firstCard).getByText('記録済み')).toBeInTheDocument();
+    });
+
+    // Verify that mockGetRecords was called only with U001 and never with '17'
+    expect(mockGetRecords).toHaveBeenCalledWith(expect.any(String), 'U001');
+    expect(mockGetRecords).not.toHaveBeenCalledWith(expect.any(String), '17');
+  });
 });
+

--- a/tests/e2e/kiosk-procedure-list.spec.ts
+++ b/tests/e2e/kiosk-procedure-list.spec.ts
@@ -50,4 +50,20 @@ test.describe('Kiosk Procedure List', () => {
     await expect(page.getByTestId('kiosk-support-start-setup-cta')).toHaveCount(0);
     await expect(page.getByText('支援計画シートを作成して支援開始日を設定')).toHaveCount(0);
   });
+
+  test('should display procedure as recorded when its status is skipped', async ({ page }) => {
+    await bootKiosk(page, {
+      route: '/kiosk/users/1/procedures',
+      userId: 'U-001',
+      records: [
+        { scheduleItemId: 'seed-U-001-1', status: 'skipped' }
+      ]
+    });
+
+    await expect(page.getByText('の支援手順')).toBeVisible({ timeout: 10000 });
+
+    const firstCard = page.getByTestId('kiosk-procedure-card-0');
+    await expect(firstCard.getByText('記録済み')).toBeVisible();
+    await expect(firstCard.getByText('未実施')).toHaveCount(0);
+  });
 });


### PR DESCRIPTION
## 概要
キオスク支援手順一覧画面における以下の不具合・整合性の問題を修正しました：

1. **一瞬「記録済み」になった後に「未実施」に戻るレースコンディション（競合状態）の解決**
   - 利用者マスタの非同期ロード中（`isUserLoading === true`）に、数値のルートID（例: `"17"`, DBのId）を用いて古いIDでのフェッチがトリガーされ、直後に解決する正規ID（例: `"U-017"`, UserID）のフェッチと競合するレースコンディションを解消。
2. **デモ・ローカル環境での Zustand 保存記録の表示整合**
   - ローカル開発やデモ環境（`VITE_FORCE_SHAREPOINT=1` 含むモック環境）において、`executionRepositoryKind` が `'sharepoint'` の際にもローカルの Zustand ストア（`storeRecords`）をマージし、詳細から戻ったときに確実に記録状態が維持されるようフォールバック処理を拡張。
3. **スキップ記録（`skipped`）が「未実施」と表示される不具合の修正**
   - すでに「スキップ」で記録されている手順が「未実施」と判定される誤表示を修正。

---

## 変更内容

### 1. レースコンディション対策 & クリーンアップ追加
- **対象**: `src/features/kiosk/components/KioskProcedureListScreen.tsx`
  - `isUserLoading` が `true` の場合は `useEffect` でのフェッチ処理をスキップ（早期リターン）し、数値ID（`17`）による無駄なフェッチとそれに伴う競合を防止。
  - `useEffect` 内に `active` フラグ（クリーンアップ関数 `() => { active = false; }`）を導入。コンポーネントのアンマウントや切り替え時に古い非同期フェッチの結果で `records` が上書きされるのを確実に防止。

### 2. モック/デモ動作時の Zustand マージ判定拡張
- **対象**: `src/features/kiosk/components/KioskProcedureListScreen.tsx`
  - `@/lib/env` から `isDemoModeEnabled`, `shouldSkipSharePoint`, `shouldSkipLogin` を取得し、モック・デモ稼働中（`isMock`）の場合は、SharePoint リポジトリ種別であっても Zustand ストア（`storeRecords`）をマージ対象に含めるように修正。

### 3. スキップ記録の表示不具合修正
- **対象**: `src/features/kiosk/components/KioskProcedureListScreen.tsx`
  - `hasRecordInput` 判定関数に `record.status === 'skipped'` を追加し、スキップとして記録された場合も「記録済み」としてマークされるように修正。

---

## 追加されたテスト

- `src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx`
  - `waits for user to load and does not perform stale fetches with fallback route ID`（マスタロード中の古いIDフェッチ抑制とレースコンディションの検証）
  - `marks a procedure as recorded when the record status is "skipped"`（スキップ記録が記録済みになるかの検証）
  - 利用者・日付切り替え時の同期クリア検証（2ケース）

---

## 影響範囲
キオスク手順一覧画面（`/kiosk/users/:userId/procedures`）
