### PR TITLE
fix(kiosk): prevent stale userId from being saved before user master loads on detail screen

### DIFF
--- a/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
@@ -93,9 +93,12 @@ export const KioskProcedureDetailScreen: React.FC = () => {
     });
     return `/abc-record?${params.toString()}`;
   }, [abcSlotId, deepLinkUserId, returnRouteUserId, selectedDateIso, slotKey]);
+  // isUserLoading 中は空文字を渡し、確定前の userId が saveRecord のクロージャに
+  // 束縛されて Zustand に誤ったキーで保存されるのを防ぐ
+  const resolvedUserId = isUserLoading ? '' : deepLinkUserId;
   const { record, saveRecord, isLoading } = useExecutionRecord(
     selectedDateIso,
-    deepLinkUserId,
+    resolvedUserId,
     scheduleItemId,
     fallbackScheduleItemIds,
   );
@@ -152,7 +155,7 @@ export const KioskProcedureDetailScreen: React.FC = () => {
   };
 
   const handleSave = async () => {
-    if (!userId) return;
+    if (!userId || isUserLoading || !resolvedUserId) return;
     const finalMemo = serializeMemo();
     if (!finalMemo.trim()) {
       setShowValidationError(true);


### PR DESCRIPTION
## 概要

`/kiosk/users/17/procedures/0` で記録を保存しても `/kiosk/users/17/procedures` では「未実施」になる不具合を修正しました。

## 根本原因

`KioskProcedureDetailScreen` が `useUser("17")` で利用者マスタを非同期ロードする間、`deepLinkUserId` は数値ルートID `"17"` のままです。

```
deepLinkUserId = user?.UserID || userId
                 ↑ userロード中は "17" が使われる
useExecutionRecord(date, deepLinkUserId, ...)
  → saveRecord() → Zustand に { userId: "17" } で保存
```

一方、List 画面はユーザーロード完了後に `user.UserID = "U-017"` で Zustand を参照するため、キー不一致で「未実施」が表示されます。`normalizeExecutionUserId` は `String(value).trim()` のみで `"17" ≠ "U-017"` を同一視しません。

## 変更内容

`src/features/kiosk/components/KioskProcedureDetailScreen.tsx`

- `isUserLoading` 中は `deepLinkUserId` の代わりに `''` を `useExecutionRecord` に渡す（`resolvedUserId`）。これにより `saveRecord` のクロージャに誤った ID が束縛されることを防止。
- `handleSave` の先頭ガードに `isUserLoading || !resolvedUserId` を追加し、ID 確定前の保存を二重ブロック。

## 影響範囲

キオスク手順詳細画面（`/kiosk/users/:userId/procedures/:slotKey`）のみ。SharePoint 保存フロー・ABC記録・DailyActivityRecords には一切触れていません。

## テスト

- `npm run typecheck` → エラーなし
- `npx vitest run src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx` → 8 passed