### PR TITLE
fix(planning-sheet): resolve ID mapping conflicts between Shiota-san and Katsuragawa-san

### DIFF
--- a/src/features/daily/utils/__tests__/normalizeExecutionLookup.spec.ts
+++ b/src/features/daily/utils/__tests__/normalizeExecutionLookup.spec.ts
@@ -10,6 +10,14 @@ describe('buildExecutionUserIdCandidates', () => {
     expect(candidates).toContain('U-010');
   });
 
+  it('builds stable variants for non-default prefix', () => {
+    const candidates = buildExecutionUserIdCandidates('I005');
+    expect(candidates).toContain('5');
+    expect(candidates).toContain('I5');
+    expect(candidates).toContain('I005');
+    expect(candidates).toContain('I-005');
+  });
+
   it('keeps unique candidates when mixed formats are provided', () => {
     const candidates = buildExecutionUserIdCandidates('10', 'U-010', 'U010');
     expect(new Set(candidates).size).toBe(candidates.length);

--- a/src/features/daily/utils/normalizeExecutionLookup.ts
+++ b/src/features/daily/utils/normalizeExecutionLookup.ts
@@ -27,16 +27,18 @@ export const buildExecutionUserIdCandidates = (...values: unknown[]): string[] =
     push(raw.replace(/-/g, ''));
 
     const compact = raw.replace(/-/g, '').toUpperCase();
-    const digitMatch = compact.match(/^U?(\d+)$/);
-    if (!digitMatch) continue;
+    const match = compact.match(/^([A-Z]*)(\d+)$/);
+    if (!match) continue;
 
-    const digits = digitMatch[1];
+    const prefix = match[1] || 'U';
+    const digits = match[2];
     const noPad = String(Number.parseInt(digits, 10));
     const pad3 = digits.padStart(3, '0');
     push(noPad);
-    push(`U${digits}`);
-    push(`U${pad3}`);
-    push(`U-${pad3}`);
+    push(`${prefix}${digits}`);
+    push(`${prefix}${noPad}`);
+    push(`${prefix}${pad3}`);
+    push(`${prefix}-${pad3}`);
   }
 
   return out;

--- a/src/features/planning-sheet/__tests__/supportTemplateBridge.spec.ts
+++ b/src/features/planning-sheet/__tests__/supportTemplateBridge.spec.ts
@@ -186,6 +186,17 @@ describe('supportTemplateBridge', () => {
       });
     });
 
+    it('converts static master data for user U-012 (Shiota-san)', () => {
+      const steps = masterRowsToProcedureSteps('U-012');
+      expect(steps).toHaveLength(17);
+      expect(steps[0]).toMatchObject({
+        order: 1,
+        instruction: '通所・朝の準備（手洗い、消毒。荷物を入れる。）',
+        staff: '通所時の様子を確認し、必要に応じて声かけを行う。',
+        timing: '9:30頃',
+      });
+    });
+
     it('returns default/empty steps when no specific master registered', () => {
       const steps = masterRowsToProcedureSteps('NON_EXISTENT_USER');
       expect(steps).toHaveLength(17);

--- a/src/features/planning-sheet/constants/userProcedureDetails.ts
+++ b/src/features/planning-sheet/constants/userProcedureDetails.ts
@@ -330,38 +330,61 @@ export const USER_PROCEDURE_DETAILS: UserProcedureDetail[] = [
   { userId: 'I016', rowNo: 17, personAction: '外活動に参加する', supporterAction: '外活動中の安全確認、同行支援、見守りを行う' },
 ];
 
-function isIshiwataUserId(userId: string | number): boolean {
+function isDetailIshiwata(detailUserId: string | number): boolean {
+  return String(detailUserId) === '4';
+}
+
+function isDetailKatsuragawa(detailUserId: string | number): boolean {
+  return String(detailUserId) === '3';
+}
+
+function isDetailNakamura(detailUserId: string | number): boolean {
+  return String(detailUserId) === '7';
+}
+
+function isDetailShiota(detailUserId: string | number): boolean {
+  return String(detailUserId) === 'I016';
+}
+
+function isQueryIshiwata(userId: string | number): boolean {
   const s = String(userId);
   return s === '4' || s === '6' || s === 'U-002' || s === 'U-003' || s === 'I005';
 }
 
-function isKatsuragawaUserId(userId: string | number): boolean {
+function isQueryKatsuragawa(userId: string | number): boolean {
   const s = String(userId);
-  return s === '3' || s === '10' || s === 'U-001' || s === 'I009';
+  return s === '1' || s === '10' || s === 'U-001' || s === 'I009';
 }
 
-function isNakamuraUserId(userId: string | number): boolean {
+function isQueryNakamura(userId: string | number): boolean {
   const s = String(userId);
   return s === '7' || s === '23' || s === 'U-006' || s === 'I017' || s === 'I022';
 }
 
-function isShiotaUserId(userId: string | number): boolean {
+function isQueryShiota(userId: string | number): boolean {
   const s = String(userId);
-  return s === 'I016';
+  return s === '3' || s === 'U-012' || s === 'I016';
+}
+
+function isUserMatch(detailUserId: string | number, queryUserId: string | number): boolean {
+  if (isDetailIshiwata(detailUserId)) {
+    return isQueryIshiwata(queryUserId);
+  }
+  if (isDetailKatsuragawa(detailUserId)) {
+    return isQueryKatsuragawa(queryUserId);
+  }
+  if (isDetailNakamura(detailUserId)) {
+    return isQueryNakamura(queryUserId);
+  }
+  if (isDetailShiota(detailUserId)) {
+    return isQueryShiota(queryUserId);
+  }
+  return String(detailUserId) === String(queryUserId);
 }
 
 export function findUserProcedureDetail(userId: string | number, rowNo: number): UserProcedureDetail | undefined {
   return USER_PROCEDURE_DETAILS.find((detail) => {
-    const isUserMatch = isIshiwataUserId(detail.userId)
-      ? isIshiwataUserId(userId)
-      : isKatsuragawaUserId(detail.userId)
-        ? isKatsuragawaUserId(userId)
-        : isNakamuraUserId(detail.userId)
-          ? isNakamuraUserId(userId)
-          : isShiotaUserId(detail.userId)
-            ? isShiotaUserId(userId)
-            : String(detail.userId) === String(userId);
-    return isUserMatch && detail.rowNo === rowNo;
+    return isUserMatch(detail.userId, userId) && detail.rowNo === rowNo;
   });
 }
 
@@ -408,28 +431,12 @@ export const USER_PROCEDURE_SHEET_NOTES: UserProcedureSheetNotes[] = [
 
 export function findUserProcedureSheetNotes(userId: string | number): UserProcedureSheetNotes | undefined {
   return USER_PROCEDURE_SHEET_NOTES.find((notes) => {
-    return isIshiwataUserId(notes.userId)
-      ? isIshiwataUserId(userId)
-      : isKatsuragawaUserId(notes.userId)
-        ? isKatsuragawaUserId(userId)
-        : isNakamuraUserId(notes.userId)
-          ? isNakamuraUserId(userId)
-          : isShiotaUserId(notes.userId)
-            ? isShiotaUserId(userId)
-            : String(notes.userId) === String(userId);
+    return isUserMatch(notes.userId, userId);
   });
 }
 
 export function hasUserProcedureMaster(userId: string | number): boolean {
   return USER_PROCEDURE_DETAILS.some((detail) => {
-    return isIshiwataUserId(detail.userId)
-      ? isIshiwataUserId(userId)
-      : isKatsuragawaUserId(detail.userId)
-        ? isKatsuragawaUserId(userId)
-        : isNakamuraUserId(detail.userId)
-          ? isNakamuraUserId(userId)
-          : isShiotaUserId(detail.userId)
-            ? isShiotaUserId(userId)
-            : String(detail.userId) === String(userId);
+    return isUserMatch(detail.userId, userId);
   });
 }


### PR DESCRIPTION
Kioskの支援手順機能において、非同期のユーザーロード前後でマスタIDが不整合を起こし、保存した記録（塩田様の5/22分など）が「未実施」のまま一覧に反映されなくなる不具合を解消しました。

### 変更内容
- **ID競合の解消**:
  -  内において、手技定義マスタ上の固定ID（例：桂川様 = 3）と、現在のシステムでクエリされる実際のID（例：塩田様 = 3）の競合を解消しました。
  - 手技マスタ定義側で使われているID（）を識別する判定（例：）と、クエリされる実際のID（ / ）を識別する判定（例：）を分離し、双方が混同しない  判定ロジックへリファクタリングしました。
- **テストの追加と期待値の修正**:
  -  で、塩田様の  手順の期待値が  と  が結合された形式 () になっているべきところを単一の personAction 文字列になっていた問題を修正しました。
  - テストが 11 passed で全件パスすることを確認しました。