### PR TITLE
fix(kiosk): always merge local execution records for immediate list feedback

### DIFF
--- a/src/features/kiosk/components/KioskProcedureListScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureListScreen.tsx
@@ -13,7 +13,7 @@ import { resolveKioskRecordDate } from '../utils/kioskDate';
 import { ExecutionRecord } from '@/features/daily/domain/executionRecordTypes';
 import { normalizeScheduleItemId } from '@/features/daily/utils/normalizeScheduleItemId';
 import { useExecutionStore } from '@/features/daily/stores/executionStore';
-import { isDemoModeEnabled, shouldSkipSharePoint, shouldSkipLogin, isDevMode, isTestMode } from '@/lib/env';
+
 import { getCurrentExecutionRepositoryKind } from '@/features/daily/repositories/sharepoint/executionRepositoryFactory';
 import { usePlanningSheetRepositories } from '@/features/planning-sheet/hooks/usePlanningSheetRepositories';
 import { usePlanningSheetData } from '@/features/planning-sheet/hooks/usePlanningSheetData';
@@ -228,13 +228,10 @@ export const KioskProcedureListScreen: React.FC = () => {
   const recordsByScheduleItemId = React.useMemo(() => {
     const map = new Map<string, ExecutionRecord>();
 
-    // In sharepoint mode, treat repository result as source of truth to avoid
-    // local-only "記録済み" labels that don't survive across devices.
-    // However, if we are in demo mode or SharePoint is bypassed/mocked,
-    // we must allow local store records as fallback.
-    const isMock = isDemoModeEnabled() || shouldSkipSharePoint() || shouldSkipLogin() || (isDevMode() && !isTestMode());
-    const allCandidateRecords =
-      (executionRepositoryKind === 'local' || isMock) ? [...storeRecords, ...records] : [...records];
+    // To ensure immediate visual feedback (reactivity) after saving a record and
+    // returning to the list screen, we always merge storeRecords (local state) with records
+    // (remote repository fetch result), regardless of the repository kind or mock status.
+    const allCandidateRecords = [...storeRecords, ...records];
     
     for (const record of allCandidateRecords) {
       const key = normalizeScheduleItemId(record.scheduleItemId);

--- a/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
@@ -301,7 +301,7 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
     });
   });
 
-  it('does not show "記録済み" from store-only data when repository kind is sharepoint', async () => {
+  it('shows "記録済み" from store-only data even when repository kind is sharepoint for immediate reactivity', async () => {
     mockGetCurrentExecutionRepositoryKind.mockReturnValue('sharepoint');
     mockGetRecords.mockResolvedValue([]);
     mockGetStoreRecords.mockReturnValue([
@@ -316,9 +316,9 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
 
     await waitFor(() => {
       const firstCard = screen.getByTestId('kiosk-procedure-card-0');
-      expect(within(firstCard).queryByText('記録済み')).toBeNull();
-      expect(within(firstCard).getByText('未実施')).toBeInTheDocument();
-      expect(screen.getByText('実施状況: 0 / 2')).toBeInTheDocument();
+      expect(within(firstCard).getByText('記録済み')).toBeInTheDocument();
+      expect(within(firstCard).queryByText('未実施')).toBeNull();
+      expect(screen.getByText('実施状況: 1 / 2')).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## 概要

PR #1988 / #1989 後も、Kiosk一覧画面の最終表示計算では SharePoint mode かつ mock 判定外の場合に `storeRecords` が候補から外れ、保存直後の一覧反映が非同期 fetch に依存していました。

保存直後の視覚的フィードバックを保証するため、repository kind / mock status に関わらず `storeRecords` と `records` を常にマージするように修正します。

これにより、詳細画面で保存して一覧へ戻った直後に「未実施」へ戻る・変化なしに見える問題を解消します。

## 変更内容

- `KioskProcedureListScreen.tsx` の進捗計算で、`executionRepositoryKind` / mock 判定に関わらず `storeRecords` と repository fetch 結果 `records` を常に候補としてマージ
- 旧仕様に依存していた `KioskProcedureListScreen.spec.tsx` の期待値を更新
- 保存直後の optimistic UI として、local state の記録済み状態を即時表示できるようにした

## 検証

- `npx vitest run src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx` → 34 passed
- `npm run typecheck` → passed

## 影響範囲

- Kiosk支援手順一覧画面 `/kiosk/users/:userId/procedures`
- 保存直後の一覧表示・進捗表示のみ

## 補足

本番SharePoint環境でも保存直後は local state を optimistic UI として表示します。repository fetch 完了後は同じ `scheduleItemId` の map 統合により整合します。