### PR TITLE
fix(a11y): resolve users page strict accessibility violations

### DIFF
--- a/src/app/AppShellHeader.tsx
+++ b/src/app/AppShellHeader.tsx
@@ -131,12 +131,13 @@ export const AppShellHeader: React.FC<Props> = ({
           {currentBreadcrumb ? (
             <Typography
               variant="caption"
+              color="primary.contrastText"
               sx={{
                 lineHeight: '44px',
                 height: 44,
                 display: 'flex',
                 alignItems: 'center',
-                opacity: 0.8,
+                fontWeight: 500,
               }}
             >
               / {currentBreadcrumb}

--- a/src/app/AppShellSidebar.tsx
+++ b/src/app/AppShellSidebar.tsx
@@ -16,6 +16,7 @@ import Divider from '@mui/material/Divider';
 import IconButton from '@mui/material/IconButton';
 import InputAdornment from '@mui/material/InputAdornment';
 import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
@@ -171,8 +172,10 @@ const NavItemRow: React.FC<{
     </ListItemButton>
   );
 
+  let renderedElement = button;
+
   if (navCollapsed && !showLabel) {
-    return (
+    renderedElement = (
       <Tooltip key={`${label}-${currentPathname}`} title={label} placement="right" enterDelay={100} disableInteractive>
         <Box sx={{ width: '100%' }}>
           {button}
@@ -181,7 +184,11 @@ const NavItemRow: React.FC<{
     );
   }
 
-  return button;
+  return (
+    <ListItem disablePadding component="li">
+      {renderedElement}
+    </ListItem>
+  );
 });
 NavItemRow.displayName = 'NavItemRow';
 
@@ -217,11 +224,11 @@ const GroupedNavList: React.FC<{
         const isLastGroup = index === groupedNavItems.ORDER.length - 1;
 
         return (
-          <List
-            key={group}
-            subheader={
-              !navCollapsed ? (
+          <List key={group}>
+            {!navCollapsed ? (
+              <ListItem component="li" disablePadding>
                 <ListSubheader
+                  component="div"
                   sx={{
                     lineHeight: '32px',
                     fontSize: '0.7rem',
@@ -230,15 +237,17 @@ const GroupedNavList: React.FC<{
                     letterSpacing: '0.05em',
                     color: 'text.secondary',
                     bgcolor: 'transparent',
+                    px: 2,
                   }}
                 >
                   {groupLabel[group]}
                 </ListSubheader>
-              ) : (
-                <Divider sx={{ my: 1, opacity: 0.6 }} />
-              )
-            }
-          >
+              </ListItem>
+            ) : (
+              <ListItem component="li" disablePadding>
+                <Divider sx={{ my: 1, opacity: 0.6, width: '100%' }} />
+              </ListItem>
+            )}
             {items.map((item) => (
               <NavItemRow
                 key={item.label}
@@ -250,7 +259,11 @@ const GroupedNavList: React.FC<{
                 onNavigate={onNavigate}
               />
             ))}
-            {!navCollapsed && !isLastGroup && <Divider sx={{ mt: 1, mb: 0.5 }} />}
+            {!navCollapsed && !isLastGroup && (
+              <ListItem component="li" disablePadding>
+                <Divider sx={{ mt: 1, mb: 0.5, width: '100%' }} />
+              </ListItem>
+            )}
           </List>
         );
       })}

--- a/src/components/DataLayerGuard.tsx
+++ b/src/components/DataLayerGuard.tsx
@@ -41,7 +41,6 @@ export const DataLayerGuard: React.FC<{ children: React.ReactNode }> = ({ childr
   // [DIAGNOSTIC] Provide a stable container for the children to avoid reconciliation errors
   return (
     <Box 
-      component="main" 
       id="app-main-container" 
       data-provider={currentProvider}
       sx={{ height: '100vh', display: 'flex', flexDirection: 'column' }}

--- a/src/features/kiosk/components/KioskProcedureListScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureListScreen.tsx
@@ -144,7 +144,8 @@ export const KioskProcedureListScreen: React.FC = () => {
 
 
   const { getRecords: getStoreRecords } = useExecutionStore();
-  const storeRecords = getStoreRecords(selectedDateIso || '', user?.UserID || userId || '');
+  const storeUserIdForLookup = user?.UserID || userId || '';
+  const storeRecords = getStoreRecords(selectedDateIso || '', storeUserIdForLookup);
   const executionRepositoryKind = getCurrentExecutionRepositoryKind();
   
   const [records, setRecords] = useState<ExecutionRecord[]>([]);


### PR DESCRIPTION
## 概要
/users ページの strict a11y gate で検出されていた color-contrast / list / listitem 違反を修正しました。

## 変更内容
- AppShellHeader のテキストコントラストを改善
- AppShellSidebar の MUI List 構造を axe が期待する list/listitem 構造に整理
- main landmark / shell 周辺の構造を調整
- 一時デバッグログを削除

## 検証
- VITE_E2E=1 VITE_SKIP_LOGIN=1 VITE_E2E_MSAL_MOCK=1 VITE_SKIP_SHAREPOINT=1 npx playwright test tests/e2e/a11y-complex-page.spec.ts --project=chromium
  - 4 passed
- npm run typecheck
  - passed