### PR TITLE
feat(kiosk): harden execution record concurrency and reset flow

### DIFF
--- a/src/features/daily/domain/ExecutionRecordRepository.ts
+++ b/src/features/daily/domain/ExecutionRecordRepository.ts
@@ -63,4 +63,10 @@ export interface ExecutionRecordRepository {
    * Useful for 90-day monitoring aggregation.
    */
   getRecordsInRange(userId: string, from: string, to: string): Promise<ExecutionRecord[]>;
+
+  /**
+   * Delete an execution record by date × user × scheduleItemId.
+   */
+  deleteRecord(date: string, userId: string, scheduleItemId: string): Promise<void>;
 }
+

--- a/src/features/daily/hooks/legacy-stores/executionStore.ts
+++ b/src/features/daily/hooks/legacy-stores/executionStore.ts
@@ -134,6 +134,17 @@ export function useExecutionStore() {
     [getRecords],
   );
 
+  /** 記録を削除 */
+  const deleteRecord = useCallback(
+    (date: string, userId: string, scheduleItemId: string) => {
+      const existing = getRecords(date, userId);
+      const updated = existing.filter((r) => r.scheduleItemId !== scheduleItemId);
+
+      saveDailyRecords(date, userId, updated);
+    },
+    [getRecords],
+  );
+
   /** 完了率を計算（completed / total） */
   const getCompletionRate = useCallback(
     (date: string, userId: string, totalSlots: number): { completed: number; triggered: number; rate: number } => {
@@ -175,9 +186,10 @@ export function useExecutionStore() {
       getRecords,
       getRecord,
       upsertRecord,
+      deleteRecord,
       getCompletionRate,
       getRecordsInRange,
     } as const),
-    [getRecords, getRecord, upsertRecord, getCompletionRate, getRecordsInRange]
+    [getRecords, getRecord, upsertRecord, deleteRecord, getCompletionRate, getRecordsInRange]
   );
 }

--- a/src/features/daily/hooks/useAbcDailySupportIntegration.ts
+++ b/src/features/daily/hooks/useAbcDailySupportIntegration.ts
@@ -1,0 +1,68 @@
+import { useCallback } from 'react';
+import { useProcedureData } from './useProcedureData';
+import { useExecutionData } from './useExecutionData';
+import { makeRecordId } from '../domain/executionRecordTypes';
+import { formatInTimeZone } from '@/lib/tz';
+import type { AbcRecordSourceContext } from '@/domain/abc/abcRecord';
+
+export function useAbcDailySupportIntegration() {
+  const procedureRepo = useProcedureData();
+  const executionRepo = useExecutionData();
+
+  const linkExecutionRecord = useCallback(async (
+    userId: string,
+    behavior: string,
+    consequence: string,
+    sourceContext: AbcRecordSourceContext,
+    recorderName: string
+  ) => {
+    if (sourceContext.source !== 'daily-support') return;
+
+    const date = sourceContext.date || formatInTimeZone(new Date(), 'Asia/Tokyo', 'yyyy-MM-dd');
+    const slotId = sourceContext.slotId; // 例: "09:30|通所・朝の準備"
+
+    if (!slotId) return;
+
+    const parts = slotId.split('|');
+    const targetTime = parts[0];
+    const targetActivity = parts[1];
+
+    // ユーザーの支援手順を取得
+    const steps = procedureRepo.getByUser(userId);
+    const matchingStep = steps.find(
+      (step) => step.time === targetTime && step.activity === targetActivity
+    );
+
+    if (!matchingStep) return;
+
+    const scheduleItemId = matchingStep.rowNo !== undefined
+      ? String(matchingStep.rowNo)
+      : matchingStep.id;
+
+    if (!scheduleItemId) return;
+
+    // 既存の実施記録を取得
+    const existing = await executionRepo.getRecord(date, userId, scheduleItemId);
+
+    const abcMemo = `【メモ】[ABC記録] 行動: ${behavior.trim()}\n結果: ${consequence.trim()}`;
+    const newMemo = existing?.memo
+      ? `${existing.memo}\n${abcMemo}`
+      : abcMemo;
+
+    const nextRecord = {
+      id: makeRecordId(date, userId, scheduleItemId),
+      date,
+      userId,
+      scheduleItemId,
+      status: 'completed' as const,
+      triggeredBipIds: existing?.triggeredBipIds || [],
+      memo: newMemo,
+      recordedBy: recorderName || existing?.recordedBy || '',
+      recordedAt: new Date().toISOString(),
+    };
+
+    await executionRepo.upsertRecord(nextRecord);
+  }, [procedureRepo, executionRepo]);
+
+  return { linkExecutionRecord };
+}

--- a/src/features/daily/hooks/useExecutionRecord.ts
+++ b/src/features/daily/hooks/useExecutionRecord.ts
@@ -14,7 +14,7 @@ export function useExecutionRecord(
   scheduleItemId: string,
   fallbackScheduleItemIds?: string[],
 ) {
-  const { getRecord, upsertRecord } = useExecutionData();
+  const { getRecord, upsertRecord, deleteRecord } = useExecutionData();
   const [record, setRecord] = useState<ExecutionRecord | undefined>();
   const [isLoading, setIsLoading] = useState(true);
 
@@ -102,6 +102,11 @@ export function useExecutionRecord(
     [date, userId, scheduleItemId, record],
   );
 
-  return { record, setStatus, setMemo, saveRecord, isLoading, refresh: fetchRecord } as const;
+  const deleteRecordFn = useCallback(async () => {
+    await deleteRecord(date, userId, scheduleItemId);
+    setRecord(undefined);
+  }, [date, userId, scheduleItemId, deleteRecord]);
+
+  return { record, setStatus, setMemo, saveRecord, deleteRecord: deleteRecordFn, isLoading, refresh: fetchRecord } as const;
 }
 

--- a/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
+++ b/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
@@ -23,6 +23,7 @@ type SharePointExecutionRecordRepositoryOptions = {
   store?: {
     getRecords: (date: string, userId: string) => ExecutionRecord[];
     upsertRecord: (record: ExecutionRecord) => void;
+    deleteRecord?: (date: string, userId: string, scheduleItemId: string) => void;
   };
 };
 
@@ -298,24 +299,43 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
     const parentId = await this.ensureParentRecord(dailyKey, normalizedDate, normalizedUserId);
     const existing = await this.getRecord(normalizedDate, normalizedUserId, normalizedScheduleItemId);
 
+    // Concurrency Protection: Merge memos if existing record has a different memo.
+    let finalMemo = normalizedRecord.memo;
+    if (existing && existing.memo && normalizedRecord.memo && existing.memo !== normalizedRecord.memo) {
+      if (!existing.memo.includes(normalizedRecord.memo)) {
+        const timeStr = new Date().toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' });
+        const staffName = normalizedRecord.recordedBy || '職員';
+        finalMemo = `${existing.memo}\n[${timeStr} ${staffName}] ${normalizedRecord.memo}`;
+      } else {
+        finalMemo = existing.memo;
+      }
+    } else if (existing && existing.memo && !normalizedRecord.memo) {
+      finalMemo = existing.memo;
+    }
+
+    const mergedRecord = {
+      ...normalizedRecord,
+      memo: finalMemo,
+    };
+
     await this.initFields(this.childListTitle);
     const rawBody: Record<string, unknown> = {
       [rf.rowKey]: rowKey,
       [rf.parentId]: parentId,
-      [rf.userId]: normalizedRecord.userId,
-      [rf.status]: normalizedRecord.status,
-      [rf.payload]: normalizedRecord.memo, // Standard payload fallback
-      [rf.recordedAt]: normalizedRecord.recordedAt,
+      [rf.userId]: mergedRecord.userId,
+      [rf.status]: mergedRecord.status,
+      [rf.payload]: mergedRecord.memo, // Standard payload fallback
+      [rf.recordedAt]: mergedRecord.recordedAt,
     };
     
-    if (rf.rowNo) rawBody[rf.rowNo] = normalizedRecord.scheduleItemId;
-    if (rf.memo) rawBody[rf.memo] = normalizedRecord.memo;
-    if (rf.staffName) rawBody[rf.staffName] = normalizedRecord.recordedBy;
-    if (rf.bipsJSON) rawBody[rf.bipsJSON] = JSON.stringify(normalizedRecord.triggeredBipIds);
+    if (rf.rowNo) rawBody[rf.rowNo] = mergedRecord.scheduleItemId;
+    if (rf.memo) rawBody[rf.memo] = mergedRecord.memo;
+    if (rf.staffName) rawBody[rf.staffName] = mergedRecord.recordedBy;
+    if (rf.bipsJSON) rawBody[rf.bipsJSON] = JSON.stringify(mergedRecord.triggeredBipIds);
     
     // Title is needed for POST (creation) but often ignored in MERGE if it doesn't change
     if (!existing) {
-        rawBody[this.resolvedParentFields?.title ?? DAILY_RECORD_FIELDS.title] = normalizedRecord.id;
+        rawBody[this.resolvedParentFields?.title ?? DAILY_RECORD_FIELDS.title] = mergedRecord.id;
     }
 
     const body = this.filterPayload(this.childListTitle, rawBody);
@@ -364,6 +384,42 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
     // Sync to local store
     if (this.store) {
       this.store.upsertRecord(normalizedRecord);
+    }
+  }
+
+  async deleteRecord(date: string, userId: string, scheduleItemId: string): Promise<void> {
+    const normalizedDate = normalizeExecutionDate(date);
+    const normalizedUserId = normalizeExecutionUserId(userId);
+    const normalizedScheduleItemId = normalizeScheduleItemId(scheduleItemId);
+    const rf = await this.getResolvedFields();
+    const rowKey = `${normalizedDate}-${normalizedUserId}-${normalizedScheduleItemId}`;
+
+    const filter = `${rf.rowKey} eq '${rowKey}'`;
+    const searchUrl = `${this.resolvedChildPath}/items?$filter=${encodeURIComponent(filter)}&$select=Id`;
+    const searchResp = await this.spFetch(searchUrl);
+    if (!searchResp.ok) {
+      throw new Error(`[ExecutionRepo] delete lookup failed: ${searchResp.status} ${searchResp.statusText}`);
+    }
+    const searchData: SharePointResponse<JsonRecord> = await searchResp.json();
+
+    if (searchData.value && searchData.value.length > 0) {
+      const internalId = searchData.value[0].Id;
+      const deleteUrl = `${this.resolvedChildPath}/items(${internalId})`;
+      const deleteResp = await this.spFetch(deleteUrl, {
+        method: 'POST',
+        headers: {
+          'X-HTTP-Method': 'DELETE',
+          'If-Match': '*',
+        },
+      });
+      if (!deleteResp.ok) {
+        throw new Error(`[ExecutionRepo] row delete failed: ${deleteResp.status} ${deleteResp.statusText}`);
+      }
+    }
+
+    // Sync to local store
+    if (this.store && this.store.deleteRecord) {
+      this.store.deleteRecord(normalizedDate, normalizedUserId, normalizedScheduleItemId);
     }
   }
 

--- a/src/features/daily/repositories/sharepoint/executionRepositoryFactory.ts
+++ b/src/features/daily/repositories/sharepoint/executionRepositoryFactory.ts
@@ -108,6 +108,7 @@ export type ExecutionStoreHooks = {
   getRecords: (date: string, userId: string) => ExecutionRecord[];
   getRecord: (date: string, userId: string, scheduleItemId: string) => ExecutionRecord | undefined;
   upsertRecord: (record: ExecutionRecord) => void;
+  deleteRecord: (date: string, userId: string, scheduleItemId: string) => void;
   getCompletionRate: (
     date: string,
     userId: string,
@@ -143,6 +144,12 @@ function createLocalStorageExecutionAdapter(
         userId: normalizeExecutionUserId(record.userId),
         scheduleItemId: normalizeScheduleItemId(record.scheduleItemId),
       }),
+    deleteRecord: async (date: string, userId: string, scheduleItemId: string) =>
+      store.deleteRecord(
+        normalizeExecutionDate(date),
+        normalizeExecutionUserId(userId),
+        normalizeScheduleItemId(scheduleItemId),
+      ),
     getCompletionRate: async (date: string, userId: string, totalSlots: number) =>
       store.getCompletionRate(date, userId, totalSlots),
     getHistoricalRecords: async () => [], // Historical records not supported in local store
@@ -161,6 +168,8 @@ function createSharePointExecutionAdapter(
       repository.getRecord(date, userId, scheduleItemId),
     upsertRecord: async (record: ExecutionRecord) =>
       repository.upsertRecord(record),
+    deleteRecord: async (date: string, userId: string, scheduleItemId: string) =>
+      repository.deleteRecord(date, userId, scheduleItemId),
     getCompletionRate: async (date: string, userId: string, totalSlots: number) =>
       repository.getCompletionRate(date, userId, totalSlots),
     getHistoricalRecords: async (userId: string, scheduleItemId: string, limit?: number) =>

--- a/src/features/daily/stores/executionStore.ts
+++ b/src/features/daily/stores/executionStore.ts
@@ -150,18 +150,53 @@ export function useExecutionStore() {
         userId: normalizedUserId,
         scheduleItemId: normalizedScheduleItemId,
       };
-      const existing = getRecords(normalizedDate, normalizedUserId);
-      const index = existing.findIndex((r) => normalizeScheduleItemId(r.scheduleItemId) === normalizedScheduleItemId);
+      const existingRecords = getRecords(normalizedDate, normalizedUserId);
+      const index = existingRecords.findIndex((r) => normalizeScheduleItemId(r.scheduleItemId) === normalizedScheduleItemId);
+      const existing = index >= 0 ? existingRecords[index] : undefined;
+
+      // Concurrency Protection: Merge memos if existing record has a different memo.
+      let finalMemo = normalizedRecord.memo;
+      if (existing && existing.memo && normalizedRecord.memo && existing.memo !== normalizedRecord.memo) {
+        if (!existing.memo.includes(normalizedRecord.memo)) {
+          const timeStr = new Date().toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' });
+          const staffName = normalizedRecord.recordedBy || '職員';
+          finalMemo = `${existing.memo}\n[${timeStr} ${staffName}] ${normalizedRecord.memo}`;
+        } else {
+          finalMemo = existing.memo;
+        }
+      } else if (existing && existing.memo && !normalizedRecord.memo) {
+        finalMemo = existing.memo;
+      }
+
+      const mergedRecord: ExecutionRecord = {
+        ...normalizedRecord,
+        memo: finalMemo,
+      };
 
       const updated =
         index >= 0
-          ? existing.map((r, i) => (i === index ? normalizedRecord : r))
-          : [...existing, normalizedRecord];
+          ? existingRecords.map((r, i) => (i === index ? mergedRecord : r))
+          : [...existingRecords, mergedRecord];
 
       saveDailyRecords(normalizedDate, normalizedUserId, updated);
     },
     [getRecords],
   );
+
+  /** 記録を削除 */
+  const deleteRecord = useCallback(
+    (date: string, userId: string, scheduleItemId: string) => {
+      const normalizedDate = normalizeExecutionDate(date);
+      const normalizedUserId = normalizeExecutionUserId(userId);
+      const normalizedScheduleItemId = normalizeScheduleItemId(scheduleItemId);
+      const existing = getRecords(normalizedDate, normalizedUserId);
+      const updated = existing.filter((r) => normalizeScheduleItemId(r.scheduleItemId) !== normalizedScheduleItemId);
+
+      saveDailyRecords(normalizedDate, normalizedUserId, updated);
+    },
+    [getRecords],
+  );
+
 
   /** 完了率を計算（completed / total） */
   const getCompletionRate = useCallback(
@@ -204,7 +239,9 @@ export function useExecutionStore() {
     getRecords,
     getRecord,
     upsertRecord,
+    deleteRecord,
     getCompletionRate,
     getRecordsInRange,
-  }), [getRecords, getRecord, upsertRecord, getCompletionRate, getRecordsInRange]);
+  }), [getRecords, getRecord, upsertRecord, deleteRecord, getCompletionRate, getRecordsInRange]);
 }
+

--- a/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Box, Typography, IconButton, Paper, Grid, Button, Chip, Stack, Alert, Snackbar, TextField, CircularProgress } from '@mui/material';
+import { Box, Typography, IconButton, Paper, Grid, Button, Chip, Stack, Alert, Snackbar, TextField, CircularProgress, Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import { useNavigate, useParams, useLocation } from 'react-router-dom';
@@ -96,7 +96,7 @@ export const KioskProcedureDetailScreen: React.FC = () => {
   // isUserLoading 中は空文字を渡し、確定前の userId が saveRecord のクロージャに
   // 束縛されて Zustand に誤ったキーで保存されるのを防ぐ
   const resolvedUserId = isUserLoading ? '' : deepLinkUserId;
-  const { record, saveRecord, isLoading } = useExecutionRecord(
+  const { record, saveRecord, deleteRecord, isLoading } = useExecutionRecord(
     selectedDateIso,
     resolvedUserId,
     scheduleItemId,
@@ -104,9 +104,13 @@ export const KioskProcedureDetailScreen: React.FC = () => {
   );
   
   const [isSaving, setIsSaving] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [showSuccess, setShowSuccess] = useState(false);
   const [showSaveError, setShowSaveError] = useState(false);
   const [showValidationError, setShowValidationError] = useState(false);
+  const [showDeleteSuccess, setShowDeleteSuccess] = useState(false);
+  const [showDeleteError, setShowDeleteError] = useState(false);
   const [showHistory, setShowHistory] = useState(false);
 
   // 観察チップ用ステート
@@ -173,6 +177,22 @@ export const KioskProcedureDetailScreen: React.FC = () => {
       console.error('Failed to save execution record:', error);
       setShowSaveError(true);
       setIsSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    try {
+      await deleteRecord();
+      setDeleteDialogOpen(false);
+      setShowDeleteSuccess(true);
+      setTimeout(() => {
+        navigate(appendKioskSearchParams(`/kiosk/users/${userId}/procedures`, location.search));
+      }, 1500);
+    } catch (error) {
+      console.error('Failed to delete execution record:', error);
+      setShowDeleteError(true);
+      setIsDeleting(false);
     }
   };
 
@@ -439,12 +459,24 @@ export const KioskProcedureDetailScreen: React.FC = () => {
 
             {/* 操作ボタン */}
             <Stack direction="row" spacing={2} justifyContent="flex-end" sx={{ pt: 2 }}>
+              {isCompleted && (
+                <Button
+                  variant="outlined"
+                  color="error"
+                  onClick={() => setDeleteDialogOpen(true)}
+                  sx={{ py: 1.5, px: 3, borderRadius: 3, fontSize: '1.1rem', mr: 'auto' }}
+                  disabled={isSaving || isDeleting}
+                  data-testid="kiosk-observation-revert"
+                >
+                  記録を取り消す
+                </Button>
+              )}
               <Button
                 variant="outlined"
                 color="inherit"
                 onClick={() => navigate(appendKioskSearchParams(`/kiosk/users/${userId}/procedures`, location.search))}
                 sx={{ py: 1.5, px: 3, borderRadius: 3, fontSize: '1.1rem' }}
-                disabled={isSaving}
+                disabled={isSaving || isDeleting}
               >
                 一覧に戻る
               </Button>
@@ -453,7 +485,7 @@ export const KioskProcedureDetailScreen: React.FC = () => {
                 color="primary"
                 onClick={handleSave}
                 sx={{ py: 1.5, px: 4, borderRadius: 3, fontSize: '1.1rem', fontWeight: 'bold' }}
-                disabled={isSaving}
+                disabled={isSaving || isDeleting}
                 data-testid="kiosk-observation-submit"
               >
                 記録を保存する
@@ -494,6 +526,71 @@ export const KioskProcedureDetailScreen: React.FC = () => {
       >
         <Alert severity="warning" sx={{ width: '100%' }}>
           手順記録の内容を1つ以上入力してください。
+        </Alert>
+      </Snackbar>
+
+      {/* 削除確認ダイアログ */}
+      <Dialog
+        open={deleteDialogOpen}
+        onClose={() => !isDeleting && setDeleteDialogOpen(false)}
+        aria-labelledby="delete-dialog-title"
+        aria-describedby="delete-dialog-description"
+        PaperProps={{
+          sx: { borderRadius: 4, p: 2 }
+        }}
+      >
+        <DialogTitle id="delete-dialog-title" sx={{ fontWeight: 'bold', fontSize: '1.3rem' }}>
+          記録を取り消しますか？
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText id="delete-dialog-description" sx={{ fontSize: '1.1rem', color: 'text.primary' }}>
+            この手順の実施記録とメモを完全に削除し、未実施の状態に戻します。この操作は取り消せません。
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2, gap: 1 }}>
+          <Button
+            variant="outlined"
+            color="secondary"
+            onClick={() => setDeleteDialogOpen(false)}
+            disabled={isDeleting}
+            sx={{ borderRadius: 3, px: 3 }}
+          >
+            キャンセル
+          </Button>
+          <Button
+            variant="contained"
+            color="error"
+            onClick={handleDelete}
+            disabled={isDeleting}
+            sx={{ borderRadius: 3, px: 3, fontWeight: 'bold' }}
+            autoFocus
+            data-testid="kiosk-observation-revert-confirm"
+          >
+            {isDeleting ? '取り消し中...' : '取り消す'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* 削除成功メッセージ */}
+      <Snackbar 
+        open={showDeleteSuccess} 
+        autoHideDuration={3000} 
+        onClose={() => setShowDeleteSuccess(false)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert severity="success" sx={{ width: '100%', fontSize: '1.2rem', fontWeight: 'bold' }}>
+          記録を取り消しました
+        </Alert>
+      </Snackbar>
+
+      <Snackbar
+        open={showDeleteError}
+        autoHideDuration={4000}
+        onClose={() => setShowDeleteError(false)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert severity="error" sx={{ width: '100%' }}>
+          記録の取り消しに失敗しました。再度お試しください。
         </Alert>
       </Snackbar>
 

--- a/src/pages/abc-record/AbcRecordPage.tsx
+++ b/src/pages/abc-record/AbcRecordPage.tsx
@@ -33,6 +33,7 @@ import type { AbcRecord, AbcRecordSourceContext } from '@/domain/abc/abcRecord';
 import { useAbcRecordRepository } from '@/infra/abc/useAbcRecordRepository';
 import { useUsers } from '@/features/users/useUsers';
 import { useAuth } from '@/auth/useAuth';
+import { useAbcDailySupportIntegration } from '@/features/daily/hooks/useAbcDailySupportIntegration';
 
 // ── Local ──
 import type { UserOption } from './types';
@@ -137,6 +138,17 @@ const AbcRecordPage: React.FC = () => {
   }, [source, urlSlotId, urlDate]);
 
   const recorderName = (account as { name?: string })?.name ?? '不明';
+
+  const { linkExecutionRecord } = useAbcDailySupportIntegration();
+
+  const handleLinkExecutionRecord = useCallback(async (
+    userId: string,
+    behavior: string,
+    consequence: string,
+    sourceContext: AbcRecordSourceContext
+  ) => {
+    await linkExecutionRecord(userId, behavior, consequence, sourceContext, recorderName);
+  }, [linkExecutionRecord, recorderName]);
 
   const userOptions = useMemo<UserOption[]>(
     () => users.map(u => ({ id: u.UserID, label: `${u.FullName} (${u.UserID})` })),
@@ -311,6 +323,7 @@ const AbcRecordPage: React.FC = () => {
               sourceContext={sourceContextForSave}
               initialBehavior={initialBehavior}
               targetDate={targetDate}
+              onLinkExecutionRecord={handleLinkExecutionRecord}
             />
           ) : (
             <LogTab

--- a/src/pages/abc-record/QuickRecordTab.tsx
+++ b/src/pages/abc-record/QuickRecordTab.tsx
@@ -36,12 +36,6 @@ import { ABC_INTENSITY_VALUES, ABC_INTENSITY_DISPLAY } from '@/domain/abc/abcRec
 import type { AbcIntensity } from '@/domain/abc/abcRecord';
 import { useAbcRecordRepository } from '@/infra/abc/useAbcRecordRepository';
 
-// ── Daily Support Features ──
-import { useProcedureData } from '@/features/daily/hooks/useProcedureData';
-import { useExecutionData } from '@/features/daily/hooks/useExecutionData';
-import { makeRecordId } from '@/features/daily/domain/executionRecordTypes';
-
-
 // ── Local ──
 import type { UserOption } from './types';
 import { EMPTY_FORM, SETTING_PRESETS, TAG_PRESETS } from './constants';
@@ -57,6 +51,13 @@ interface QuickRecordTabProps {
   /** MVP-5: Step 3 からの下書き behavior テキスト */
   initialBehavior?: string;
   targetDate: string;
+  /** 連動する実施記録の保存処理（親コンポーネントから注入） */
+  onLinkExecutionRecord?: (
+    userId: string,
+    behavior: string,
+    consequence: string,
+    sourceContext: AbcRecordSourceContext
+  ) => Promise<void>;
 }
 
 export function getInitialOccurredAt(date?: string, slotId?: string): string {
@@ -88,11 +89,9 @@ export function getInitialOccurredAt(date?: string, slotId?: string): string {
   return `${targetDate}T${targetTime}`;
 }
 
-const QuickRecordTab: React.FC<QuickRecordTabProps> = ({ users, recorderName, onSaved, initialUserId, todayRecords, sourceContext, initialBehavior, targetDate }) => {
+const QuickRecordTab: React.FC<QuickRecordTabProps> = ({ users, recorderName, onSaved, initialUserId, todayRecords, sourceContext, initialBehavior, targetDate, onLinkExecutionRecord }) => {
   const navigate = useNavigate();
   const abcRecordRepo = useAbcRecordRepository();
-  const procedureRepo = useProcedureData();
-  const executionRepo = useExecutionData();
   const [selectedUser, setSelectedUser] = useState<UserOption | null>(null);
   const [form, setForm] = useState(() => ({
     ...EMPTY_FORM,
@@ -160,53 +159,14 @@ const QuickRecordTab: React.FC<QuickRecordTabProps> = ({ users, recorderName, on
       await abcRecordRepo.save(input);
 
       // ── 支援手順実施記録（ExecutionRecord）の連動保存 ──
-      if (sourceContext && sourceContext.source === 'daily-support') {
+      if (sourceContext && sourceContext.source === 'daily-support' && onLinkExecutionRecord) {
         try {
-          const date = sourceContext.date || formatInTimeZone(new Date(), 'Asia/Tokyo', 'yyyy-MM-dd');
-          const userId = selectedUser.id;
-          const slotId = sourceContext.slotId; // 例: "09:30|通所・朝の準備"
-
-          if (slotId) {
-            const parts = slotId.split('|');
-            const targetTime = parts[0];
-            const targetActivity = parts[1];
-
-            // ユーザーの支援手順を取得
-            const steps = procedureRepo.getByUser(userId);
-            const matchingStep = steps.find(
-              (step) => step.time === targetTime && step.activity === targetActivity
-            );
-
-            if (matchingStep) {
-              const scheduleItemId = matchingStep.rowNo !== undefined
-                ? String(matchingStep.rowNo)
-                : matchingStep.id;
-
-              if (scheduleItemId) {
-                // 既存の実施記録を取得
-                const existing = await executionRepo.getRecord(date, userId, scheduleItemId);
-
-                const abcMemo = `【メモ】[ABC記録] 行動: ${form.behavior.trim()}\n結果: ${form.consequence.trim()}`;
-                const newMemo = existing?.memo
-                  ? `${existing.memo}\n${abcMemo}`
-                  : abcMemo;
-
-                const nextRecord = {
-                  id: makeRecordId(date, userId, scheduleItemId),
-                  date,
-                  userId,
-                  scheduleItemId,
-                  status: 'completed' as const,
-                  triggeredBipIds: existing?.triggeredBipIds || [],
-                  memo: newMemo,
-                  recordedBy: recorderName || existing?.recordedBy || '',
-                  recordedAt: new Date().toISOString(),
-                };
-
-                await executionRepo.upsertRecord(nextRecord);
-              }
-            }
-          }
+          await onLinkExecutionRecord(
+            selectedUser.id,
+            form.behavior.trim(),
+            form.consequence.trim(),
+            sourceContext
+          );
         } catch (linkErr) {
           // 安全設計：連動保存の失敗はABC記録本体の保存を邪魔しないようログ出力のみ
           console.error('Failed to link ExecutionRecord with ABCRecord:', linkErr);
@@ -228,7 +188,7 @@ const QuickRecordTab: React.FC<QuickRecordTabProps> = ({ users, recorderName, on
     } finally {
       setIsSaving(false);
     }
-  }, [selectedUser, form, canSave, recorderName, onSaved, abcRecordRepo]);
+  }, [selectedUser, form, canSave, recorderName, onSaved, abcRecordRepo, sourceContext, onLinkExecutionRecord]);
 
   return (
     <Stack spacing={2.5}>

--- a/src/pages/abc-record/__tests__/QuickRecordTab.spec.tsx
+++ b/src/pages/abc-record/__tests__/QuickRecordTab.spec.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import QuickRecordTab, { getInitialOccurredAt } from '../QuickRecordTab';
 import { MemoryRouter } from 'react-router-dom';
+import { useAbcDailySupportIntegration } from '@/features/daily/hooks/useAbcDailySupportIntegration';
 
 // モック定義
 const mockSaveAbcRecord = vi.fn().mockResolvedValue({ id: 'abc-123' });
@@ -79,8 +80,9 @@ describe('QuickRecordTab Component - ExecutionRecord linkage', () => {
   });
 
   it('daily-support コンテキストから遷移した際、保存時に ExecutionRecord が連動して upsert されること', async () => {
-    render(
-      <MemoryRouter>
+    const TestWrapper = () => {
+      const { linkExecutionRecord } = useAbcDailySupportIntegration();
+      return (
         <QuickRecordTab
           users={mockUsers}
           recorderName="テスト記録者"
@@ -94,7 +96,16 @@ describe('QuickRecordTab Component - ExecutionRecord linkage', () => {
             slotId: '10:00|朝のバイタルチェック',
             slotLabel: '朝のバイタルチェック',
           }}
+          onLinkExecutionRecord={(userId, behavior, consequence, sourceContext) =>
+            linkExecutionRecord(userId, behavior, consequence, sourceContext, 'テスト記録者')
+          }
         />
+      );
+    };
+
+    render(
+      <MemoryRouter>
+        <TestWrapper />
       </MemoryRouter>
     );
 


### PR DESCRIPTION
## 概要
Fortress AIレビューで次スプリント改善として残していた、Kiosk支援手順記録の同時編集保護・誤操作リセット・ABC連携ロジック疎結合化を実装します。

## 変更内容
- ExecutionRecord の upsert 時に既存メモと新規メモをマージ追記し、Last Write Wins によるメモ消失を抑制
- ExecutionRecordRepository / local store / SharePoint repository に deleteRecord を追加
- KioskProcedureDetailScreen に「記録を取り消す」ボタンと確認ダイアログを追加
- QuickRecordTab から daily-support 直接依存を外し、onLinkExecutionRecord callback による依存性逆転へ変更
- useAbcDailySupportIntegration に ABC → ExecutionRecord 連動処理を集約

## 検証
- npm run typecheck
- npx vitest run src/features/daily src/pages/abc-record