### PR TITLE
fix(health): treat demo and skip-login environments as mock diagnostics

### DIFF
--- a/src/features/diagnostics/health/checks/listChecks.ts
+++ b/src/features/diagnostics/health/checks/listChecks.ts
@@ -29,7 +29,22 @@ async function runListChecks(
   ctx: HealthContext
 ) {
   let fieldStatus: ResolutionResult<string>['fieldStatus'] = {};
-  const isSkipSharePoint = ctx.env["VITE_SKIP_SHAREPOINT"] === "1";
+
+  const isTrue = (val: unknown): boolean => {
+    if (typeof val === 'boolean') return val;
+    if (typeof val === 'number') return val !== 0;
+    if (typeof val === 'string') {
+      const s = val.trim().toLowerCase();
+      return s === '1' || s === 'true' || s === 'yes' || s === 'y' || s === 'on' || s === 'enabled';
+    }
+    return false;
+  };
+
+  const isSkipSharePoint =
+    isTrue(ctx.env["VITE_SKIP_SHAREPOINT"]) ||
+    isTrue(ctx.env["VITE_SKIP_LOGIN"]) ||
+    isTrue(ctx.env["VITE_DEMO_MODE"]) ||
+    isTrue(ctx.env["VITE_FORCE_DEMO"]);
 
   // List existence
   const listInfo = isSkipSharePoint


### PR DESCRIPTION
Summary:
- Extend mock/bypass diagnostic detection in health list checks.
- Treat VITE_SKIP_LOGIN, VITE_DEMO_MODE, and VITE_FORCE_DEMO as simulation environments.
- Prevent demo production builds from surfacing large false-positive FAIL counts.

Scope:
- This change only affects health-check classification under demo / skip-login / force-demo modes.
- It does not relax real SharePoint schema validation when running in actual SharePoint verification mode.

Validation:
- npx vitest run src/features/diagnostics/health/__tests__/
- npm run typecheck
- npm run build