### PR TITLE
fix(auth): clear stale MSAL sign-in guard on retry

### DIFF
--- a/src/app/AuthNotices.tsx
+++ b/src/app/AuthNotices.tsx
@@ -25,7 +25,7 @@ export type AuthNoticeProps = {
   flag?: keyof FeatureFlagSnapshot;
   pendingPath: string;
   fallbackPath: NavigateProps['to'];
-  onSignIn?: () => Promise<{ success: boolean }>;
+  onSignIn?: (options?: { force?: boolean }) => Promise<{ success: boolean }>;
   // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
   success?: boolean;
   diagSummary?: AuthDiagSummary;
@@ -89,7 +89,7 @@ const copyToClipboard = async (text: string): Promise<boolean> => {
 export const clearMsalCache = (): number => {
   if (typeof window === 'undefined') return 0;
   const storages = [window.sessionStorage, window.localStorage];
-  const matcher = (key: string) => /^msal/i.test(key);
+  const matcher = (key: string) => /^(?:__)?msal/i.test(key);
   let removed = 0;
   storages.forEach((storage) => {
     const keys = Object.keys(storage);
@@ -131,7 +131,7 @@ function useAuthActions(props: AuthNoticeProps) {
           correlationId: corrId,
         });
       }
-      await onSignIn();
+      await onSignIn({ force: true });
     } catch (error) {
       console.error('[ProtectedRoute] sign-in failed', error);
     } finally {

--- a/src/auth/__tests__/useAuth.spec.ts
+++ b/src/auth/__tests__/useAuth.spec.ts
@@ -54,6 +54,7 @@ import { useMsalContext } from '@/auth/MsalProvider';
 import { isE2eMsalMockEnabled, shouldSkipLogin } from '@/lib/env';
 import { createE2EMsalAccount, persistMsalToken } from '@/lib/msal';
 import { useAuth, __resetTokenCache } from '../useAuth';
+import { clearMsalCache } from '@/app/AuthNotices';
 
 // ── typesafe mock refs ─────────────────────────────────────────────
 const mockIsE2e = vi.mocked(isE2eMsalMockEnabled);
@@ -563,6 +564,46 @@ describe('useAuth', () => {
 
       expect(signInResult).toEqual({ success: false });
     });
+
+    it('bypasses session guard and calls loginRedirect when force=true', async () => {
+      const instance = createMockMsalInstance({
+        loginRedirect: vi.fn().mockResolvedValue(undefined),
+      });
+      setupMsalContext({ instance });
+
+      const { result } = renderHook(() => useAuth());
+
+      // Set session guard to true to simulate an in-progress or stuck attempt
+      const key = `__msal_signin_attempted__http://localhost`;
+      sessionStorage.setItem(key, 'true');
+
+      // Regular sign-in should be skipped
+      const firstResult = await act(async () => result.current.signIn());
+      expect(firstResult).toEqual({ success: false });
+      expect(instance.loginRedirect).not.toHaveBeenCalled();
+
+      // Forced sign-in should bypass the guard
+      const secondResult = await act(async () => result.current.signIn({ force: true }));
+      expect(secondResult).toEqual({ success: true });
+      expect(instance.loginRedirect).toHaveBeenCalledTimes(1);
+    });
+
+    it('removes signInSessionKey from sessionStorage if loginRedirect throws', async () => {
+      const instance = createMockMsalInstance({
+        loginRedirect: vi.fn().mockRejectedValue(new Error('MSAL error')),
+      });
+      setupMsalContext({ instance });
+
+      const { result } = renderHook(() => useAuth());
+      const key = `__msal_signin_attempted__http://localhost`;
+
+      await act(async () => {
+        await result.current.signIn();
+      });
+
+      // After failing, the key should be removed to avoid stuck state
+      expect(sessionStorage.getItem(key)).toBeNull();
+    });
   });
 
   // ════════════════════════════════════════════════════════════════
@@ -630,6 +671,48 @@ describe('useAuth', () => {
       const { result } = renderHook(() => useAuth());
 
       expect(result.current.getListReadyState()).toBe(true);
+    });
+  });
+
+  // ════════════════════════════════════════════════════════════════
+  //  8. clearMsalCache Helper
+  // ════════════════════════════════════════════════════════════════
+  describe('clearMsalCache helper', () => {
+    it('removes keys starting with msal or __msal', () => {
+      const store = new Map<string, string>();
+      store.set('msal.token', 'val1');
+      store.set('__msal_signin_attempted__http://localhost', 'val2');
+      store.set('other_key', 'val3');
+
+      const mockStorage = {
+        getItem: vi.fn((key: string) => store.get(key) ?? null),
+        setItem: vi.fn((key: string, val: string) => {
+          store.set(key, val);
+          (mockStorage as any)[key] = val;
+        }),
+        removeItem: vi.fn((key: string) => {
+          store.delete(key);
+          delete (mockStorage as any)[key];
+        }),
+        clear: vi.fn(() => {
+          store.clear();
+        }),
+        get length() { return store.size; },
+        key: vi.fn(),
+      };
+
+      store.forEach((val, key) => {
+        (mockStorage as any)[key] = val;
+      });
+
+      vi.stubGlobal('sessionStorage', mockStorage);
+      vi.stubGlobal('localStorage', mockStorage);
+
+      const removedCount = clearMsalCache();
+      expect(removedCount).toBe(2);
+      expect(store.has('msal.token')).toBe(false);
+      expect(store.has('__msal_signin_attempted__http://localhost')).toBe(false);
+      expect(store.has('other_key')).toBe(true);
     });
   });
 });

--- a/src/auth/useAuth.ts
+++ b/src/auth/useAuth.ts
@@ -18,6 +18,7 @@ const tokenMetrics = {
   lastRefreshEpoch: 0,
 };
 
+type SignInOptions = { force?: boolean };
 type SignInResult = { success: boolean };
 
 // ③ Cooldown + Singleflight guards to prevent rapid-fire popup loops
@@ -360,15 +361,21 @@ export const useAuth = () => {
 
   // --- signIn (real) ---
 
-  const signIn = useCallback(async (): Promise<SignInResult> => {
+  const signIn = useCallback(async (options?: SignInOptions): Promise<SignInResult> => {
     // 🛡️ LATEST context access via stable ref bridge to ensure function identity stability
     const current = msalStateRef.current;
     
+    const isForce = options?.force === true;
+
     if (signInSessionKey) {
-      const alreadyAttempted = window.sessionStorage.getItem(signInSessionKey) === 'true';
-      if (alreadyAttempted) {
-        debugLog('login skipped (session guard)');
-        return { success: false };
+      if (isForce) {
+        window.sessionStorage.removeItem(signInSessionKey);
+      } else {
+        const alreadyAttempted = window.sessionStorage.getItem(signInSessionKey) === 'true';
+        if (alreadyAttempted) {
+          debugLog('login skipped (session guard)');
+          return { success: false };
+        }
       }
       window.sessionStorage.setItem(signInSessionKey, 'true');
     }
@@ -385,7 +392,7 @@ export const useAuth = () => {
     }
 
     // StrictMode guard (React 18 dev): prevent double-execution on initial render
-    if (signInAttemptedRef.current) {
+    if (!isForce && signInAttemptedRef.current) {
       debugLog('[StrictMode Guard] signIn already attempted; skipping to prevent duplicate MSAL popup');
       return { success: false };
     }
@@ -393,11 +400,11 @@ export const useAuth = () => {
     // ③ Cooldown guard: prevent rapid-fire attempts
     const now = Date.now();
     const timeSinceLastAttempt = now - lastSignInAttemptTime;
-    if (timeSinceLastAttempt < SIGN_IN_COOLDOWN_MS) {
+    if (!isForce && timeSinceLastAttempt < SIGN_IN_COOLDOWN_MS) {
       debugLog(`login skipped (cooldown active, ${timeSinceLastAttempt}ms / ${SIGN_IN_COOLDOWN_MS}ms)`);
       return { success: false };
     }
-    lastSignInAttemptTime = now;
+    lastSignInAttemptTime = isForce ? 0 : now;
     signInAttemptedRef.current = true;
 
     signInInFlight = (async () => {
@@ -410,6 +417,9 @@ export const useAuth = () => {
           name: msalError?.name,
           code: msalError?.errorCode,
         });
+        if (signInSessionKey) {
+          window.sessionStorage.removeItem(signInSessionKey);
+        }
         return { success: false };
       } finally {
         signInInFlight = null;


### PR DESCRIPTION
Summary:
- Add force sign-in option to bypass stale MSAL retry guards.
- Clear the sign-in session guard when loginRedirect fails.
- Extend MSAL cache clearing to include __msal* session keys.
- Route explicit re-login actions through signIn({ force: true }).

Scope:
- Fixes sign-in retry deadlock after failed/cancelled MSAL login.
- Does not change tenant/client configuration.
- Does not change SharePoint permissions or data access behavior.

Validation:
- npx vitest run src/auth/__tests__/useAuth.spec.ts
- npx vitest run src/auth/__tests__/
- npm run typecheck
- npm run build