### PR TITLE
fix(auth): self-healing guard for Firebase auth in demo/skip-login mode

### DIFF
--- a/src/infra/firestore/__tests__/auth.spec.ts
+++ b/src/infra/firestore/__tests__/auth.spec.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Stubs ──────────────────────────────────────────────────────────
+const signInAnonymouslyMock = vi.fn().mockResolvedValue({
+  user: { uid: 'anon-uid', isAnonymous: true },
+});
+const signInWithCustomTokenMock = vi.fn().mockResolvedValue({
+  user: { uid: 'custom-uid', isAnonymous: false },
+});
+const getAuthMock = vi.fn();
+const getFirebaseAppMock = vi.fn().mockReturnValue({});
+
+// ── Module mocks ───────────────────────────────────────────────────
+vi.mock('firebase/auth', () => ({
+  getAuth: (...args: unknown[]) => getAuthMock(...args),
+  signInAnonymously: (...args: unknown[]) => signInAnonymouslyMock(...args),
+  signInWithCustomToken: (...args: unknown[]) => signInWithCustomTokenMock(...args),
+  connectAuthEmulator: vi.fn(),
+}));
+
+vi.mock('../client', () => ({
+  getFirebaseApp: () => getFirebaseAppMock(),
+}));
+
+const mockGet = vi.fn<(name: string, fallback?: string) => string>();
+const mockGetFlag = vi.fn<(name: string, fallback?: boolean) => boolean>();
+
+vi.mock('@/env', () => ({
+  get: (...args: unknown[]) => mockGet(args[0] as string, args[1] as string),
+  getFlag: (...args: unknown[]) => mockGetFlag(args[0] as string, args[1] as boolean),
+  getRuntimeEnv: vi.fn(() => ({})),
+  isDev: false,
+}));
+
+const mockShouldSkipLogin = vi.fn<() => boolean>();
+vi.mock('@/lib/env', () => ({
+  shouldSkipLogin: () => mockShouldSkipLogin(),
+}));
+
+// ── Helpers ────────────────────────────────────────────────────────
+const setupEnv = (overrides: {
+  apiKey?: string;
+  authMode?: string;
+  e2e?: boolean;
+  anonFallback?: boolean;
+  useEmulator?: boolean;
+  skipLogin?: boolean;
+}) => {
+  mockGet.mockImplementation((name: string, fallback = '') => {
+    if (name === 'VITE_FIREBASE_API_KEY') return overrides.apiKey ?? 'test-api-key';
+    if (name === 'VITE_FIREBASE_AUTH_MODE') return overrides.authMode ?? 'anonymous';
+    return fallback;
+  });
+  mockGetFlag.mockImplementation((name: string, fallback = false) => {
+    if (name === 'VITE_E2E') return overrides.e2e ?? false;
+    if (name === 'VITE_FIREBASE_AUTH_ALLOW_ANON_FALLBACK') return overrides.anonFallback ?? false;
+    if (name === 'VITE_FIREBASE_AUTH_USE_EMULATOR') return overrides.useEmulator ?? false;
+    if (name === 'DEV') return false;
+    return fallback;
+  });
+  mockShouldSkipLogin.mockReturnValue(overrides.skipLogin ?? false);
+};
+
+describe('initFirebaseAuth', () => {
+  let initFirebaseAuth: () => Promise<void>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    getAuthMock.mockReturnValue({
+      currentUser: null,
+      emulatorConfig: null,
+    });
+
+    // Default: valid API key, anonymous mode, no skip-login
+    setupEnv({});
+
+    // Dynamic import to pick up mocks
+    const mod = await import('../auth');
+    initFirebaseAuth = mod.initFirebaseAuth;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ── E2E skip ────────────────────────────────────────────────────
+  it('should skip auth in E2E mode', async () => {
+    setupEnv({ e2e: true });
+
+    await initFirebaseAuth();
+
+    expect(signInAnonymouslyMock).not.toHaveBeenCalled();
+    expect(signInWithCustomTokenMock).not.toHaveBeenCalled();
+  });
+
+  // ── Placeholder API key skip ────────────────────────────────────
+  it.each([
+    '',
+    'dummy-api-key',
+    'your-firebase-api-key',
+    'changeme',
+    'undefined',
+  ])('should skip auth when API key is placeholder: "%s"', async (apiKey) => {
+    setupEnv({ apiKey });
+
+    await initFirebaseAuth();
+
+    expect(signInAnonymouslyMock).not.toHaveBeenCalled();
+    expect(signInWithCustomTokenMock).not.toHaveBeenCalled();
+  });
+
+  // ── Normal anonymous sign-in ────────────────────────────────────
+  it('should sign in anonymously when mode is anonymous', async () => {
+    setupEnv({ authMode: 'anonymous' });
+
+    await initFirebaseAuth();
+
+    expect(signInAnonymouslyMock).toHaveBeenCalledTimes(1);
+    expect(signInWithCustomTokenMock).not.toHaveBeenCalled();
+  });
+
+  // ── Already authenticated ──────────────────────────────────────
+  it('should skip sign-in if already authenticated', async () => {
+    getAuthMock.mockReturnValue({
+      currentUser: { uid: 'existing-uid', isAnonymous: true },
+      emulatorConfig: null,
+    });
+    setupEnv({});
+
+    await initFirebaseAuth();
+
+    expect(signInAnonymouslyMock).not.toHaveBeenCalled();
+    expect(signInWithCustomTokenMock).not.toHaveBeenCalled();
+  });
+
+  // ── Self-healing guard: skip-login + customToken → anonymous ───
+  it('should fallback to anonymous when customToken mode is requested in skip-login mode', async () => {
+    setupEnv({ authMode: 'customToken', skipLogin: true });
+
+    await initFirebaseAuth();
+
+    // Should NOT attempt customToken exchange (MSAL is not available)
+    expect(signInWithCustomTokenMock).not.toHaveBeenCalled();
+    // Should fall back to anonymous
+    expect(signInAnonymouslyMock).toHaveBeenCalledTimes(1);
+  });
+
+  // ── No guard: skip-login + anonymous (already correct mode) ────
+  it('should sign in anonymously normally in skip-login mode when mode is already anonymous', async () => {
+    setupEnv({ authMode: 'anonymous', skipLogin: true });
+
+    await initFirebaseAuth();
+
+    expect(signInAnonymouslyMock).toHaveBeenCalledTimes(1);
+    expect(signInWithCustomTokenMock).not.toHaveBeenCalled();
+  });
+
+  // ── No guard: normal mode + customToken (MSAL should be available) ─
+  // Note: We can't easily test a full customToken flow here because
+  // it requires MSAL mocking. This test verifies the guard does NOT
+  // activate when skipLogin is false.
+  it('should NOT activate the self-healing guard when skipLogin is false', async () => {
+    // If skipLogin=false and mode=customToken, it should attempt
+    // the customToken path (which will fail without MSAL mock, 
+    // but verifies the guard does not interfere)
+    setupEnv({ authMode: 'customToken', skipLogin: false });
+
+    // The call will fail because MSAL is not mocked for full flow,
+    // but the error should NOT be "falling back to anonymous" from the guard
+    await initFirebaseAuth();
+
+    // The self-healing guard should NOT have triggered anonymous sign-in
+    // Error is caught by the outer try-catch (non-fatal logging)
+    expect(signInAnonymouslyMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/infra/firestore/auth.ts
+++ b/src/infra/firestore/auth.ts
@@ -1,4 +1,5 @@
 import { get, getFlag } from '@/env';
+import { shouldSkipLogin } from '@/lib/env';
 import { getAuth, signInAnonymously, signInWithCustomToken } from 'firebase/auth';
 import { getFirebaseApp } from './client';
 
@@ -187,7 +188,14 @@ export async function initFirebaseAuth(): Promise<void> {
   try {
     const app = getFirebaseApp();
     const auth = getAuth(app);
-    const mode = resolveAuthMode();
+    let mode = resolveAuthMode();
+
+    // Self-healing guard: skip-login/demo mode では MSAL が初期化されないため
+    // customToken 認証は必ず失敗する。anonymous に強制フォールバックする。
+    if (shouldSkipLogin() && mode === 'customToken') {
+      console.warn('[firebase-auth] ⚠️ customToken mode requested but skip-login/demo mode is active. Falling back to anonymous.');
+      mode = 'anonymous';
+    }
 
     // ✅ Connect to Emulator if enabled
     if (getFlag('VITE_FIREBASE_AUTH_USE_EMULATOR')) {

--- a/src/lib/data/createDataProvider.ts
+++ b/src/lib/data/createDataProvider.ts
@@ -7,7 +7,7 @@ import {
   DataProviderNotInitializedError 
 } from '@/lib/errors';
 
-import { isDevMode, isDemoModeEnabled, readBool, readOptionalEnv, shouldSkipSharePoint, isTestMode } from '@/lib/env';
+import { isDevMode, isDemoModeEnabled, readBool, readOptionalEnv, shouldSkipSharePoint, isTestMode, shouldSkipLogin } from '@/lib/env';
 
 export type ProviderType = 'sharepoint' | 'memory' | 'local';
 
@@ -102,7 +102,13 @@ export function getActiveProviderType(): ProviderType {
   const urlParams = typeof window !== 'undefined' ? new URLSearchParams(window.location.search) : null;
   const providerParam = urlParams?.get('provider');
   const envProvider = readOptionalEnv('VITE_DATA_PROVIDER');
-  const selected = providerParam || envProvider;
+  let selected = providerParam || envProvider;
+
+  const skipLogin = shouldSkipLogin();
+  if (skipLogin && selected === 'sharepoint') {
+    console.warn('[DataProvider] SharePoint provider requested in skip-login/demo mode. Falling back to memory provider to avoid crash.');
+    selected = 'memory';
+  }
 
   if (selected === 'memory') return 'memory';
   if (selected === 'local') return 'local';


### PR DESCRIPTION
## 概要

デモ / skip-login / force-demo 環境で Firebase Auth の初期化が失敗する問題を修正します。

## 原因

`VITE_SKIP_LOGIN=1` または `VITE_DEMO_MODE=1` の場合、MSAL は初期化をスキップしますが、
Firebase Auth が `customToken` モードで構成されていると、MSAL アカウントを取得しようとしてクラッシュします。

```
Error: MSAL account is not available for token exchange
```

同様に、`VITE_DATA_PROVIDER=sharepoint` が設定されていると、認証なしで SharePoint にアクセスしようとして
schema resolution エラーが発生します。

## 修正内容

### `src/infra/firestore/auth.ts`
- `initFirebaseAuth` に自己修復ガードを追加
- `shouldSkipLogin()` が true かつ `customToken` モードの場合、`anonymous` に自動フォールバック
- 実 SharePoint 本番環境の認証フローには影響なし

### `src/lib/data/createDataProvider.ts` (前回コミットで追加済み)
- `getActiveProviderType` で `shouldSkipLogin()` 時に `sharepoint` → `memory` へフォールバック

### `src/infra/firestore/__tests__/auth.spec.ts` [NEW]
- `initFirebaseAuth` の包括的テスト (11テスト)
  - E2E スキップ
  - プレースホルダー API キーでのスキップ
  - anonymous 正常認証
  - 認証済みユーザーのスキップ
  - **自己修復ガード: skip-login + customToken → anonymous フォールバック**
  - ガード非発動確認 (skipLogin=false)

## 検証結果

```
✅ vitest: 11/11 passed
✅ typecheck: no errors
✅ build: success (1m 4s)
✅ lint-staged: passed
```

## スコープ

- 実 SharePoint / 本番認証フローには一切影響しません
- tenant/client 設定、Firestore rules の変更はありません