### PR TITLE
fix(auth): pass force true to signIn from right-hand sign-in button

### DIFF
--- a/src/ui/components/SignInButton.tsx
+++ b/src/ui/components/SignInButton.tsx
@@ -27,7 +27,7 @@ const [signingIn, setSigningIn] = useState(false);
 		if (signingIn) return;
 		try {
 			setSigningIn(true);
-			const result = await signIn();
+			const result = await signIn({ force: true });
 			if (result?.success && !useRedirectLogin) {
 				navigate('/dashboard', { replace: true });
 			}

--- a/tests/unit/ui.components.spec.tsx
+++ b/tests/unit/ui.components.spec.tsx
@@ -100,7 +100,7 @@ describe('UI components', () => {
     const button = screen.getByRole('button', { name: 'サインイン' });
     fireEvent.click(button);
     await waitFor(() => {
-      expect(signIn).toHaveBeenCalled();
+      expect(signIn).toHaveBeenCalledWith({ force: true });
     });
   });
 


### PR DESCRIPTION
This PR adds the missing force: true parameter to the right-hand sign-in button, ensuring that any stale session guards are bypassed and the sign-in prompt is successfully triggered when clicked.