### PR TITLE
fix(auth): bind SignInButton login check and signout to useAuth

### DIFF
--- a/src/ui/components/SignInButton.tsx
+++ b/src/ui/components/SignInButton.tsx
@@ -13,10 +13,10 @@ const { isDev: isDevEnv } = getAppConfig();
 
 const SignInButton: React.FC = () => {
 const { instance, accounts } = useMsalContext();
-const { signIn } = useAuth();
+const { signIn, signOut, isAuthenticated } = useAuth();
 const [signingIn, setSigningIn] = useState(false);
 	const navigate = useNavigate();
-	const signedIn = accounts.length > 0;
+	const signedIn = isAuthenticated;
 	const tooltip = useMemo(() => {
 		if (!signedIn) return '未サインイン';
 		const account = (instance.getActiveAccount() as { name?: string; username?: string } | null) ?? (accounts[0] as { name?: string; username?: string } | undefined) ?? null;
@@ -56,17 +56,10 @@ const [signingIn, setSigningIn] = useState(false);
 	}, [accounts, instance]);
 
 	const handleSignOut = async () => {
-		const instanceWithPopup = instance as unknown as { logoutPopup?: () => Promise<void>; logoutRedirect: () => Promise<void> };
 		try {
-			if (typeof instanceWithPopup.logoutPopup === 'function') {
-				await instanceWithPopup.logoutPopup();
-			} else {
-				await instanceWithPopup.logoutRedirect();
-			}
+			await signOut();
 		} catch (error) {
 			console.error('[auth] logout failed', error);
-		} finally {
-			instance.setActiveAccount(null);
 		}
 	};
 

--- a/tests/unit/ui.components.spec.tsx
+++ b/tests/unit/ui.components.spec.tsx
@@ -75,6 +75,7 @@ describe('UI components', () => {
 
   it('renders sign-in button when no MSAL accounts exist', async () => {
     const signIn = vi.fn().mockResolvedValue({ success: true });
+    const signOut = vi.fn().mockResolvedValue(undefined);
     mockUseMsalContext.mockReturnValue({
       accounts: [],
       instance: {
@@ -88,7 +89,7 @@ describe('UI components', () => {
         setActiveAccount: vi.fn(),
       },
     });
-    mockUseAuth.mockReturnValue({ signIn });
+    mockUseAuth.mockReturnValue({ signIn, signOut, isAuthenticated: false });
 
     // Fix CI: SignInButton uses useNavigate, requires Router context
     render(
@@ -104,7 +105,35 @@ describe('UI components', () => {
     });
   });
 
-  // Sign-out tooltip tests for legacy UI are intentionally omitted until the component reintroduces
-  // authenticated states or alternative affordances. This keeps the suite focused on currently
-  // rendered behaviors.
+  it('renders sign-out button when authenticated', async () => {
+    const signIn = vi.fn().mockResolvedValue({ success: true });
+    const signOut = vi.fn().mockResolvedValue(undefined);
+    mockUseMsalContext.mockReturnValue({
+      accounts: [{ username: 'testuser', homeAccountId: 'id' }],
+      instance: {
+        loginRedirect: vi.fn(),
+        logoutRedirect: vi.fn(),
+        logoutPopup: vi.fn(),
+        acquireTokenSilent: vi.fn(),
+        acquireTokenRedirect: vi.fn(),
+        getActiveAccount: vi.fn(() => ({ name: 'Test User' })),
+        getAllAccounts: vi.fn(() => []),
+        setActiveAccount: vi.fn(),
+      },
+    });
+    mockUseAuth.mockReturnValue({ signIn, signOut, isAuthenticated: true });
+
+    render(
+      <MemoryRouter>
+        <SignInButton />
+      </MemoryRouter>
+    );
+
+    const button = screen.getByRole('button', { name: 'サインアウト' });
+    expect(button).toBeInTheDocument();
+    fireEvent.click(button);
+    await waitFor(() => {
+      expect(signOut).toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
This PR fixes the SignInButton component which was previously still using the old accounts.length > 0 check and manually calling MSAL instance signout. Now it is fully bound to useAuth().isAuthenticated and useAuth().signOut.