### PR TITLE
fix(health): suppress mock schema drift noise for self-identical fields

### DIFF
--- a/src/features/diagnostics/health/checks/configChecks.ts
+++ b/src/features/diagnostics/health/checks/configChecks.ts
@@ -159,7 +159,7 @@ export async function runConfigChecks(
           label: "診断モード（Mock/Bypass シミュレーション）",
           category: "config",
           summary:
-            "SharePoint モックシミュレーション診断を実行中（VITE_SKIP_SHAREPOINT=1）。",
+            "SharePoint モックシミュレーション診断を実行中（demo / skip-login / mock mode）。",
           detail:
             "この診断は、定義されたリストスペックに基づき、テスト環境向けに自動整合性シミュレーションを実行しています。",
           evidence: flags,

--- a/src/features/diagnostics/health/checks/listChecks.ts
+++ b/src/features/diagnostics/health/checks/listChecks.ts
@@ -170,7 +170,14 @@ async function runListChecks(
     );
 
     const drifted = spec.requiredFields.filter(
-      (f) => !f.isSilent && fieldStatus[f.internalName]?.isDrifted
+      (f) => {
+        if (f.isSilent) return false;
+        const status = fieldStatus[f.internalName];
+        if (!status || !status.isDrifted) return false;
+        // expected (f.internalName) と actual (resolvedName) が完全に一致している（自己一致）場合は drift とみなさない
+        if (status.resolvedName === f.internalName) return false;
+        return true;
+      }
     );
 
     // 4. Report Results


### PR DESCRIPTION
This PR silences false schema drift WARNs (such as Id -> Id) where the resolved physical name exactly matches the expected internal name, preventing diagnostic noise during demo/skip-login mode. It also updates the mock diagnostic summary message to reflect the active flags correctly.