### PR TITLE
fix(kiosk): respect demo memory backend in execution repository factory

### DIFF
--- a/src/features/daily/repositories/sharepoint/__tests__/executionRepositoryFactory.spec.ts
+++ b/src/features/daily/repositories/sharepoint/__tests__/executionRepositoryFactory.spec.ts
@@ -40,11 +40,11 @@ describe('executionRepositoryFactory', () => {
     window.history.pushState({}, '', '/');
   });
 
-  it('forces sharepoint in kiosk runtime even when skipLogin is true', () => {
+  it('uses local in kiosk runtime when skipLogin is true', () => {
     envState.shouldSkipLogin = true;
     window.history.pushState({}, '', '/kiosk/users/6/procedures');
 
-    expect(getCurrentExecutionRepositoryKind()).toBe('sharepoint');
+    expect(getCurrentExecutionRepositoryKind()).toBe('local');
   });
 
   it('respects local provider hint outside kiosk runtime', () => {
@@ -86,6 +86,13 @@ describe('executionRepositoryFactory', () => {
   it('respects sharepoint provider hint in kiosk runtime during local development', () => {
     envState.isDev = true;
     envState.dataProvider = 'sharepoint';
+    window.history.pushState({}, '', '/kiosk/users/6/procedures');
+
+    expect(getCurrentExecutionRepositoryKind()).toBe('sharepoint');
+  });
+
+  it('forces sharepoint in kiosk runtime when local/memory provider hint is detected in production', () => {
+    envState.dataProvider = 'memory';
     window.history.pushState({}, '', '/kiosk/users/6/procedures');
 
     expect(getCurrentExecutionRepositoryKind()).toBe('sharepoint');

--- a/src/features/daily/repositories/sharepoint/executionRepositoryFactory.ts
+++ b/src/features/daily/repositories/sharepoint/executionRepositoryFactory.ts
@@ -50,6 +50,13 @@ const shouldUseLocalRepository = (): boolean => {
     return false;
   }
 
+  // 1. demo / skip-login / force-demo は最優先で local
+  const isDemo = isDemoModeEnabled() || isForceDemoEnabled();
+  const isSkipLogin = shouldSkipLogin();
+  if (isDemo || isSkipLogin) {
+    return true;
+  }
+
   const { isDev } = getAppConfig();
   const isTest = isTestMode();
   const isE2E = readBool('VITE_E2E', false) || readBool('VITE_E2E_MSAL_MOCK', false);
@@ -59,11 +66,11 @@ const shouldUseLocalRepository = (): boolean => {
   // Kiosk must rely on SharePoint so history and cross-device consistency work.
   // Keep tests isolated by allowing local mode only while running test runtime.
   if (isKioskRuntime && !isTest) {
-    const isMock = isDemoModeEnabled() || isForceDemoEnabled() || shouldSkipLogin() || isDev;
+    const isMock = isDemo || isSkipLogin || isDev;
 
     // In local development or demo/mock modes, we default to the local repository
     // unless the provider hint explicitly requests SharePoint.
-    const isLocalDevOrDemo = isDemoModeEnabled() || isForceDemoEnabled() || isDev;
+    const isLocalDevOrDemo = isDemo || isDev;
     if (isLocalDevOrDemo && providerHint !== 'sharepoint') {
       return true;
     }
@@ -72,7 +79,7 @@ const shouldUseLocalRepository = (): boolean => {
     if ((providerHint === 'local' || providerHint === 'memory') && (isE2E || isMock)) {
       return true;
     }
-    if (providerHint === 'local' || providerHint === 'memory' || shouldSkipLogin()) {
+    if (providerHint === 'local' || providerHint === 'memory') {
       console.warn(
         '[ExecutionRepositoryFactory] local/memory hint detected in kiosk runtime; forcing SharePoint adapter.',
       );

--- a/src/features/daily/repositories/sharepoint/modules/SchemaResolver.ts
+++ b/src/features/daily/repositories/sharepoint/modules/SchemaResolver.ts
@@ -1,4 +1,5 @@
 import type { SpFetchFn } from '@/lib/sp/spLists';
+import { isDemoModeEnabled, isForceDemoEnabled, shouldSkipLogin } from '@/lib/env';
 import { 
     DAILY_RECORD_FIELDS, 
     DAILY_RECORD_ROWS_FIELDS,
@@ -77,12 +78,15 @@ export class DailyRecordSchemaResolver {
             }
 
             this.listPathResolutionFailed = true;
-            console.warn('[DailyRecordSchemaResolver] Daily record list not found in site list catalog', {
-                requested: this.listTitle,
-                tried: candidates,
-                suggestions: suggestListTitles(availableTitles, this.listTitle, candidates),
-                schemaMismatches: schemaMismatches.slice(0, 8),
-            });
+            const isDemo = isDemoModeEnabled() || isForceDemoEnabled() || shouldSkipLogin();
+            if (!isDemo) {
+                console.warn('[DailyRecordSchemaResolver] Daily record list not found in site list catalog', {
+                    requested: this.listTitle,
+                    tried: candidates,
+                    suggestions: suggestListTitles(availableTitles, this.listTitle, candidates),
+                    schemaMismatches: schemaMismatches.slice(0, 8),
+                });
+            }
             return null;
         }
 


### PR DESCRIPTION
## Summary
- Respect demo / force-demo / skip-login environments before kiosk SharePoint enforcement.
- Return the local execution repository in demo-like environments to avoid SharePoint adapter creation.
- Suppress DailyRecordSchemaResolver list-missing warning noise in demo-like runtime.
- Update execution repository factory tests to cover the new precedence.

## Why
In demo / skip-login mode, auth and DataProvider already fall back safely to anonymous + memory, but the kiosk execution repository factory still forced the SharePoint adapter. This caused repeated DailyRecordSchemaResolver list-missing warnings and noisy runtime behavior.

## Checks
- `npx vitest run src/features/daily/repositories/sharepoint/__tests__/executionRepositoryFactory.spec.ts`
- `npx vitest run src/features/daily/repositories/sharepoint/__tests__/`
- `npm run typecheck`
- `npx eslint src/features/daily/repositories/sharepoint/executionRepositoryFactory.ts src/features/daily/repositories/sharepoint/modules/SchemaResolver.ts`
- `git diff --check`