### PR TITLE
fix(auth): gate kiosk bootstrap until MSAL account is available

### DIFF
--- a/src/app/routes/kioskRoutes.tsx
+++ b/src/app/routes/kioskRoutes.tsx
@@ -1,18 +1,25 @@
 /**
  * Kiosk mode routes: /kiosk/*
  */
-import { type RouteObject } from 'react-router-dom';
+import { type RouteObject, Outlet } from 'react-router-dom';
 import { 
   SuspendedKioskHomePage, 
   SuspendedKioskUserSelectPage,
   SuspendedKioskProcedureListPage,
   SuspendedKioskProcedureDetailPage,
 } from './lazyPages';
+import ProtectedRoute from '@/app/ProtectedRoute';
 
 export const kioskRoutes: RouteObject[] = [
   {
     path: 'kiosk',
+    element: (
+      <ProtectedRoute>
+        <Outlet />
+      </ProtectedRoute>
+    ),
     children: [
+
       {
         index: true,
         element: <SuspendedKioskHomePage />,

--- a/src/data/isp/infra/__tests__/DataProviderPlanningSheetRepository.spec.ts
+++ b/src/data/isp/infra/__tests__/DataProviderPlanningSheetRepository.spec.ts
@@ -351,10 +351,11 @@ describe('DataProviderPlanningSheetRepository', () => {
     });
 
     it('should call emitDriftRecord when an essential field drifts', async () => {
-      // Simulate that essential field 'appliedFrom' drifts to 'appliedFrom0'
+      // Simulate that essential field 'status' drifts to 'status0'
+      // PLANNING_SHEET_ESSENTIALS = ['userCode', 'status']
       provider.getFieldInternalNames = async () => new Set([
-        'Id', 'Title', 'UserCode', 'ISPId', 'VersionNo', 'IsCurrent', 'Status',
-        'appliedFrom0' // Drifted
+        'Id', 'Title', 'UserCode', 'ISPId', 'VersionNo', 'IsCurrent',
+        'status0' // Drifted essential field
       ]);
 
       provider.getItemById = async () => {
@@ -365,7 +366,7 @@ describe('DataProviderPlanningSheetRepository', () => {
 
       expect(emitDriftRecord).toHaveBeenCalledWith(
         PLANNING_SHEET_LIST_TITLE,
-        'appliedFrom',
+        'status',
         'fuzzy_match',
         'suffix_mismatch',
         undefined,
@@ -375,6 +376,7 @@ describe('DataProviderPlanningSheetRepository', () => {
 
     it('should NOT call emitDriftRecord when a non-essential field drifts', async () => {
       // Simulate that non-essential field 'targetDomain' drifts to 'targetDomain0'
+      // 'appliedFrom' is NOT in PLANNING_SHEET_ESSENTIALS, so it is non-essential
       provider.getFieldInternalNames = async () => new Set([
         'Id', 'Title', 'UserCode', 'ISPId', 'VersionNo', 'IsCurrent', 'Status',
         'AppliedFrom', 'targetDomain0' // Non-essential drifted

--- a/src/infra/firestore/auth.ts
+++ b/src/infra/firestore/auth.ts
@@ -197,6 +197,17 @@ export async function initFirebaseAuth(): Promise<void> {
       mode = 'anonymous';
     }
 
+    if (mode === 'customToken') {
+      const [{ getPcaSingleton }] = await Promise.all([import('@/auth/azureMsal')]);
+      const msal = await getPcaSingleton();
+      const msalAccount = msal.getActiveAccount() ?? msal.getAllAccounts()[0] ?? null;
+      if (!msalAccount) {
+        console.info('[firebase-auth] skipped: waiting for MSAL account');
+        return;
+      }
+    }
+
+
     // ✅ Connect to Emulator if enabled
     if (getFlag('VITE_FIREBASE_AUTH_USE_EMULATOR')) {
       const emulatorUrl = get('VITE_FIREBASE_AUTH_EMULATOR_URL') || 'http://localhost:9099';

--- a/src/lib/data/__tests__/createDataProvider.spec.ts
+++ b/src/lib/data/__tests__/createDataProvider.spec.ts
@@ -7,6 +7,7 @@ vi.mock('@/lib/env', () => ({
   readBool: vi.fn(),
   readOptionalEnv: vi.fn(),
   isTestMode: vi.fn(),
+  shouldSkipLogin: vi.fn(),
 }));
 
 import * as envModule from '@/lib/env';
@@ -23,7 +24,9 @@ describe('getActiveProviderType Priority Contract', () => {
     vi.mocked(envModule.readBool).mockReturnValue(false);
     vi.mocked(envModule.readOptionalEnv).mockReturnValue(undefined);
     vi.mocked(envModule.isTestMode).mockReturnValue(false);
+    vi.mocked(envModule.shouldSkipLogin).mockReturnValue(false);
   });
+
 
   it('CASE: VITE_DATA_PROVIDER=local should return local', async () => {
     vi.mocked(envModule.readOptionalEnv).mockImplementation((key: string) =>

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -8,6 +8,17 @@ export class AuthRequiredError extends Error {
   }
 }
 
+export function isAuthRequiredError(error: unknown): boolean {
+  if (error instanceof AuthRequiredError) return true;
+  if (!error || typeof error !== 'object') return false;
+  const err = error as Record<string, unknown>;
+  return (
+    err.name === 'AuthRequiredError' ||
+    err.code === 'AUTH_REQUIRED' ||
+    err.message === 'AUTH_REQUIRED'
+  );
+}
+
 export class DataProviderItemNotFoundError extends Error {
   constructor(public resourceName: string, public id: string | number) {
     super(`Item not found in ${resourceName}: ${id}`);


### PR DESCRIPTION
## Summary
- Add `isAuthRequiredError` helper for consistent auth-required detection.
- Skip Firebase customToken initialization while no MSAL account is available.
- Wrap kiosk routes with `ProtectedRoute` so kiosk pages do not render or preload SharePoint data before login.
- Preserve demo / skip-login compatibility through the existing `ProtectedRoute` bypass behavior.

## Why
After restoring the production SharePoint backend, unauthenticated visits to kiosk URLs entered the normal MSAL flow, but Firebase customToken exchange and SharePoint/Kiosk preload still ran before an MSAL account existed. This produced `MSAL account is not available for token exchange` and unhandled `AuthRequiredError: AUTH_REQUIRED` logs.

## Checks
- `npx vitest run src/infra/firestore/__tests__/auth.spec.ts` ✅ 11 passed
- `npm run test:e2e:smoke` ⚠️ 46/47 passed; one unrelated timeout in `admin can create and save from week view`
