### PR TITLE
fix(kiosk): normalize procedure execution lookup keys

### DIFF
--- a/src/features/daily/hooks/useExecutionRecord.ts
+++ b/src/features/daily/hooks/useExecutionRecord.ts
@@ -13,6 +13,7 @@ export function useExecutionRecord(
   userId: string,
   scheduleItemId: string,
   fallbackScheduleItemIds?: string[],
+  fallbackUserIds?: string[],
 ) {
   const { getRecord, upsertRecord, deleteRecord } = useExecutionData();
   const [record, setRecord] = useState<ExecutionRecord | undefined>();
@@ -28,23 +29,38 @@ export function useExecutionRecord(
 
   const fetchRecord = useCallback(async () => {
     setIsLoading(true);
-    let resolved = await getRecordRef.current(date, userId, scheduleItemId);
+    const userIds = Array.from(
+      new Set([userId, ...(fallbackUserIds ?? [])].map((value) => String(value ?? '').trim()).filter(Boolean)),
+    );
+    const scheduleItemIds = Array.from(
+      new Set(
+        [scheduleItemId, ...(fallbackScheduleItemIds ?? [])]
+          .map((value) => normalizeScheduleItemId(value))
+          .filter(Boolean),
+      ),
+    );
 
-    if (!resolved && fallbackScheduleItemIds && fallbackScheduleItemIds.length > 0) {
-      for (const fallbackId of fallbackScheduleItemIds) {
-        const normalizedFallbackId = normalizeScheduleItemId(fallbackId);
-        if (!normalizedFallbackId || normalizedFallbackId === scheduleItemId) continue;
-        const fallbackRecord = await getRecordRef.current(date, userId, normalizedFallbackId);
-        if (fallbackRecord) {
-          resolved = fallbackRecord;
+    if (!date || userIds.length === 0 || scheduleItemIds.length === 0) {
+      setRecord(undefined);
+      setIsLoading(false);
+      return;
+    }
+
+    let resolved: ExecutionRecord | undefined;
+    for (const candidateUserId of userIds) {
+      for (const candidateScheduleItemId of scheduleItemIds) {
+        const candidateRecord = await getRecordRef.current(date, candidateUserId, candidateScheduleItemId);
+        if (candidateRecord) {
+          resolved = candidateRecord;
           break;
         }
       }
+      if (resolved) break;
     }
 
     setRecord(resolved);
     setIsLoading(false);
-  }, [date, userId, scheduleItemId, fallbackScheduleItemIds]);
+  }, [date, userId, scheduleItemId, fallbackScheduleItemIds, fallbackUserIds]);
 
   useEffect(() => {
     void fetchRecord();
@@ -109,4 +125,3 @@ export function useExecutionRecord(
 
   return { record, setStatus, setMemo, saveRecord, deleteRecord: deleteRecordFn, isLoading, refresh: fetchRecord } as const;
 }
-

--- a/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
@@ -11,11 +11,44 @@ import { useUser } from '@/features/users/useUsers';
 import { useProcedureData } from '@/features/daily/hooks/useProcedureData';
 import { useExecutionRecord } from '@/features/daily/hooks/useExecutionRecord';
 import { resolveKioskRecordDate } from '../utils/kioskDate';
-import { normalizeScheduleItemId } from '@/features/daily/utils/normalizeScheduleItemId';
+import {
+  buildExecutionUserIdCandidates,
+  normalizeScheduleItemId,
+} from '@/features/daily/utils/normalizeExecutionLookup';
 
 const MOOD_CHIPS = ['落ち着いていた', '不安そう', '拒否あり', '興奮あり', '切り替え困難'];
 const ACTION_CHIPS = ['見守り', '声かけ', '環境調整', '活動変更', '距離を取る', 'クールダウン'];
 const RESULT_CHIPS = ['改善した', '変化なし', '悪化した', '途中で落ち着いた'];
+
+const buildScheduleItemIdCandidates = (
+  procedure: { id?: unknown; rowNo?: unknown } | null,
+  slotKey: string | undefined,
+): string[] => {
+  const keys = new Set<string>();
+  const push = (value: unknown) => {
+    const normalized = normalizeScheduleItemId(value);
+    if (normalized) keys.add(normalized);
+  };
+
+  const rowNo = normalizeScheduleItemId(procedure?.rowNo);
+  const slotIndex = Number.parseInt(String(slotKey ?? ''), 10);
+  const indexPlusOne = Number.isNaN(slotIndex) ? '' : String(slotIndex + 1);
+  const rowCandidates = [rowNo, indexPlusOne].filter(Boolean);
+
+  push(procedure?.id);
+  push(slotKey);
+  for (const rowCandidate of rowCandidates) {
+    push(rowCandidate);
+    push(`base-${rowCandidate}`);
+    push(`row-${rowCandidate}`);
+    push(`procedure-${rowCandidate}`);
+    push(`slot-${rowCandidate}`);
+    push(`slot_${rowCandidate}`);
+    push(`step-${rowCandidate}`);
+  }
+
+  return Array.from(keys);
+};
 
 export const KioskProcedureDetailScreen: React.FC = () => {
   const navigate = useNavigate();
@@ -69,8 +102,12 @@ export const KioskProcedureDetailScreen: React.FC = () => {
     );
   }, [user?.UserID, userId]);
   const fallbackScheduleItemIds = React.useMemo(
-    () => [normalizeScheduleItemId(slotKey)].filter((value): value is string => Boolean(value)),
-    [slotKey],
+    () => buildScheduleItemIdCandidates(procedure, slotKey),
+    [procedure, slotKey],
+  );
+  const fallbackUserIds = React.useMemo(
+    () => (isUserLoading ? [] : buildExecutionUserIdCandidates(deepLinkUserId, userId)),
+    [deepLinkUserId, isUserLoading, userId],
   );
 
   const abcSlotId = React.useMemo(() => {
@@ -101,6 +138,7 @@ export const KioskProcedureDetailScreen: React.FC = () => {
     resolvedUserId,
     scheduleItemId,
     fallbackScheduleItemIds,
+    fallbackUserIds,
   );
   
   const [isSaving, setIsSaving] = useState(false);

--- a/src/features/kiosk/components/KioskProcedureListScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureListScreen.tsx
@@ -11,7 +11,10 @@ import { useExecutionData } from '@/features/daily/hooks/useExecutionData';
 import { formatDateJapanese } from '@/lib/dateFormat';
 import { resolveKioskRecordDate } from '../utils/kioskDate';
 import { ExecutionRecord } from '@/features/daily/domain/executionRecordTypes';
-import { normalizeScheduleItemId } from '@/features/daily/utils/normalizeScheduleItemId';
+import {
+  buildExecutionUserIdCandidates,
+  normalizeScheduleItemId,
+} from '@/features/daily/utils/normalizeExecutionLookup';
 import { useExecutionStore } from '@/features/daily/stores/executionStore';
 
 import { getCurrentExecutionRepositoryKind } from '@/features/daily/repositories/sharepoint/executionRepositoryFactory';
@@ -19,6 +22,48 @@ import { usePlanningSheetRepositories } from '@/features/planning-sheet/hooks/us
 import { usePlanningSheetData } from '@/features/planning-sheet/hooks/usePlanningSheetData';
 import { useCurrentPlanningSheet } from '@/features/planning-sheet/hooks/useCurrentPlanningSheet';
 import { resolveSupportStartDateDetailed } from '@/features/planning-sheet/monitoringSchedule';
+
+const extractProcedureRowKey = (value: unknown): string => {
+  const normalized = normalizeScheduleItemId(value);
+  if (!normalized) return '';
+  if (/^\d+$/.test(normalized)) return String(Number.parseInt(normalized, 10));
+
+  const match = normalized.match(/(?:^|[-_])(row|base|procedure|slot|step)[-_]?(\d+)$/i);
+  return match ? String(Number.parseInt(match[2], 10)) : '';
+};
+
+const buildProcedureMatchKeys = (
+  procedure: { id?: unknown; rowNo?: unknown },
+  index: number,
+  allPrimaryScheduleKeys: Set<string>,
+): string[] => {
+  const keys = new Set<string>();
+  const push = (value: string) => {
+    if (value) keys.add(value);
+  };
+
+  const idKey = normalizeScheduleItemId(procedure.id);
+  const rowNoKey = normalizeScheduleItemId(procedure.rowNo);
+  push(idKey);
+  push(rowNoKey);
+  push(extractProcedureRowKey(procedure.id));
+  push(extractProcedureRowKey(procedure.rowNo));
+
+  const indexKey = index.toString();
+  const canUseIndexFallback = !allPrimaryScheduleKeys.has(indexKey) || keys.has(indexKey);
+  if (canUseIndexFallback) push(indexKey);
+
+  return Array.from(keys);
+};
+
+const buildRecordMatchKeys = (record: ExecutionRecord): string[] => {
+  const keys = new Set<string>();
+  const scheduleItemId = normalizeScheduleItemId(record.scheduleItemId);
+  if (scheduleItemId) keys.add(scheduleItemId);
+  const rowKey = extractProcedureRowKey(scheduleItemId);
+  if (rowKey) keys.add(rowKey);
+  return Array.from(keys);
+};
 
 export const KioskProcedureListScreen: React.FC = () => {
   const navigate = useNavigate();
@@ -73,6 +118,10 @@ export const KioskProcedureListScreen: React.FC = () => {
       const rowNoKey = normalizeScheduleItemId(step.rowNo);
       if (idKey) keys.add(idKey);
       if (rowNoKey) keys.add(rowNoKey);
+      const idRowKey = extractProcedureRowKey(step.id);
+      const rowNoRowKey = extractProcedureRowKey(step.rowNo);
+      if (idRowKey) keys.add(idRowKey);
+      if (rowNoRowKey) keys.add(rowNoRowKey);
     }
     return keys;
   }, [procedures]);
@@ -144,8 +193,20 @@ export const KioskProcedureListScreen: React.FC = () => {
 
 
   const { getRecords: getStoreRecords } = useExecutionStore();
-  const storeUserIdForLookup = queryUserIdFromSearch || user?.UserID || userId || '';
-  const storeRecords = getStoreRecords(selectedDateIso || '', storeUserIdForLookup);
+  const executionUserIdCandidates = React.useMemo(
+    () => buildExecutionUserIdCandidates(queryUserIdFromSearch, user?.UserID, userId),
+    [queryUserIdFromSearch, user?.UserID, userId],
+  );
+  const storeRecords = React.useMemo(() => {
+    const deduped = new Map<string, ExecutionRecord>();
+    for (const candidateUserId of executionUserIdCandidates) {
+      for (const record of getStoreRecords(selectedDateIso || '', candidateUserId)) {
+        const key = `${record.date}|${record.userId}|${record.scheduleItemId}|${record.id ?? ''}`;
+        deduped.set(key, record);
+      }
+    }
+    return Array.from(deduped.values());
+  }, [executionUserIdCandidates, getStoreRecords, selectedDateIso]);
   const executionRepositoryKind = getCurrentExecutionRepositoryKind();
   
   const [records, setRecords] = useState<ExecutionRecord[]>([]);
@@ -154,7 +215,7 @@ export const KioskProcedureListScreen: React.FC = () => {
 
   // Synchronously reset records state when the active user or date changes
   // to prevent rendering stale records from the previous context.
-  const currentQueryId = queryUserIdFromSearch || user?.UserID || userId || '';
+  const currentQueryId = executionUserIdCandidates.join('|');
   const [prevQueryId, setPrevQueryId] = useState<string>('');
   const [prevDate, setPrevDate] = useState<string>('');
 
@@ -185,10 +246,19 @@ export const KioskProcedureListScreen: React.FC = () => {
 
     let active = true;
     const fetchRecords = async () => {
-      const queryId = queryUserIdFromSearch || user?.UserID || userId;
-      if (!queryId) return;
+      if (executionUserIdCandidates.length === 0) return;
       try {
-        const data = await executionRepo.getRecords(selectedDateIso, queryId);
+        const batches = await Promise.all(
+          executionUserIdCandidates.map((candidateUserId) =>
+            executionRepo.getRecords(selectedDateIso, candidateUserId),
+          ),
+        );
+        const deduped = new Map<string, ExecutionRecord>();
+        for (const record of batches.flat()) {
+          const key = `${record.date}|${record.userId}|${record.scheduleItemId}|${record.id ?? ''}`;
+          deduped.set(key, record);
+        }
+        const data = Array.from(deduped.values());
         if (active) {
           setRecords(data);
           setHasFetchedRecords(true);
@@ -207,9 +277,7 @@ export const KioskProcedureListScreen: React.FC = () => {
       active = false;
     };
   }, [
-    queryUserIdFromSearch,
-    userId,
-    user?.UserID,
+    executionUserIdCandidates,
     isUserLoading,
     executionRepo,
     selectedDateIso,
@@ -231,7 +299,7 @@ export const KioskProcedureListScreen: React.FC = () => {
   // 進捗サマリーの計算
   const totalCount = procedures.length;
   const recordsByScheduleItemId = React.useMemo(() => {
-    const map = new Map<string, ExecutionRecord>();
+    const map = new Map<string, ExecutionRecord[]>();
 
     // In SharePoint mode, once the server read has completed it is authoritative.
     // Local store is only a pre-fetch/optimistic cache; otherwise stale cache from this
@@ -242,35 +310,21 @@ export const KioskProcedureListScreen: React.FC = () => {
         : [...storeRecords, ...records];
     
     for (const record of allCandidateRecords) {
-      const key = normalizeScheduleItemId(record.scheduleItemId);
-      if (!key) continue;
-      
-      const existing = map.get(key);
-      // まだ未登録、または新しいレコードが入力済みデータを持っている場合は上書き
-      if (!existing || hasRecordInput(record)) {
-        map.set(key, record);
+      for (const key of buildRecordMatchKeys(record)) {
+        const existing = map.get(key) ?? [];
+        if (existing.length === 0 || hasRecordInput(record)) {
+          map.set(key, [record, ...existing.filter((item) => item !== record)]);
+        }
       }
     }
     return map;
   }, [executionRepositoryKind, hasFetchedRecords, storeRecords, records, hasRecordInput]);
   const getRecordedRecordForProcedure = React.useCallback((procedure: { id?: unknown; rowNo?: unknown }, index: number) => {
-    const primaryCandidates = [
-      normalizeScheduleItemId(procedure.id),
-      normalizeScheduleItemId(procedure.rowNo),
-    ].filter(Boolean);
-    const matchedRecord = primaryCandidates
-      .map((key) => recordsByScheduleItemId.get(key))
+    const procedureKeys = buildProcedureMatchKeys(procedure, index, allPrimaryScheduleKeys);
+    const matchedRecord = procedureKeys
+      .flatMap((key) => recordsByScheduleItemId.get(key) ?? [])
       .find((record) => hasRecordInput(record));
     if (matchedRecord) return matchedRecord;
-
-    const indexKey = index.toString();
-    const canUseIndexFallback = !allPrimaryScheduleKeys.has(indexKey) || primaryCandidates.includes(indexKey);
-    if (!canUseIndexFallback) return undefined;
-
-    const fallbackRecord = recordsByScheduleItemId.get(indexKey);
-    if (hasRecordInput(fallbackRecord)) {
-      return fallbackRecord;
-    }
     return undefined;
   }, [allPrimaryScheduleKeys, hasRecordInput, recordsByScheduleItemId]);
   const recordedRecordsByProcedure = React.useMemo(

--- a/src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx
@@ -39,13 +39,25 @@ vi.mock('@/features/daily/hooks/useProcedureData', () => ({
 }));
 
 const mockSaveRecord = vi.fn().mockResolvedValue(undefined);
-const mockUseExecutionRecord = vi.fn((_date?: string, _userId?: string, _scheduleItemId?: string, _fallbackScheduleItemIds?: string[]) => ({
+const mockUseExecutionRecord = vi.fn((
+  _date?: string,
+  _userId?: string,
+  _scheduleItemId?: string,
+  _fallbackScheduleItemIds?: string[],
+  _fallbackUserIds?: string[],
+) => ({
   record: null,
   saveRecord: mockSaveRecord,
   isLoading: false,
 }));
 vi.mock('@/features/daily/hooks/useExecutionRecord', () => ({
-  useExecutionRecord: (date: string, userId: string, scheduleItemId: string, fallbackScheduleItemIds?: string[]) => mockUseExecutionRecord(date, userId, scheduleItemId, fallbackScheduleItemIds),
+  useExecutionRecord: (
+    date: string,
+    userId: string,
+    scheduleItemId: string,
+    fallbackScheduleItemIds?: string[],
+    fallbackUserIds?: string[],
+  ) => mockUseExecutionRecord(date, userId, scheduleItemId, fallbackScheduleItemIds, fallbackUserIds),
 }));
 
 describe('KioskProcedureDetailScreen (memory provider URL for local UI behavior tests)', () => {
@@ -130,7 +142,13 @@ describe('KioskProcedureDetailScreen (memory provider URL for local UI behavior 
       </MemoryRouter>
     );
 
-    expect(mockUseExecutionRecord).toHaveBeenCalledWith('2026-05-07', 'U001', 'P001', ['0']);
+    expect(mockUseExecutionRecord).toHaveBeenCalledWith(
+      '2026-05-07',
+      'U001',
+      'P001',
+      expect.arrayContaining(['P001', '0', '1', 'base-1', 'row-1', 'procedure-1', 'slot-1', 'slot_1', 'step-1']),
+      expect.arrayContaining(['U001', '1', 'U1', 'U-001']),
+    );
 
     fireEvent.click(screen.getByTestId('mood-chip-不安そう'));
     fireEvent.click(screen.getByTestId('kiosk-observation-submit'));

--- a/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
@@ -223,6 +223,51 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
     });
   });
 
+  it('counts records saved under route and master user IDs with row-prefixed schedule keys', async () => {
+    mockRouteUserId = '17';
+    const procedures17 = Array.from({ length: 17 }, (_, index) => {
+      const rowNo = index + 1;
+      return {
+        id: `base-${rowNo}`,
+        rowNo,
+        time: `${String(9 + Math.floor(index / 2)).padStart(2, '0')}:00`,
+        activity: `手順 ${rowNo}`,
+        instruction: `支援内容 ${rowNo}`,
+      };
+    });
+    mockGetByUser.mockReturnValue(procedures17);
+    mockUseUser.mockReturnValue({
+      data: { FullName: '対象 利用者', UserID: 'U017' },
+      status: 'success',
+    });
+    mockGetRecords.mockImplementation(async (_date, userId) => {
+      if (userId === 'U017') {
+        return [{ scheduleItemId: 'base-1', status: 'completed' }];
+      }
+      if (userId === '17') {
+        return [
+          { scheduleItemId: 'row-2', status: 'completed' },
+          { scheduleItemId: 'procedure-3', status: 'completed' },
+          { scheduleItemId: 'slot_4', status: 'completed' },
+          { scheduleItemId: 'base-5', status: 'completed' },
+        ];
+      }
+      return [];
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/kiosk/users/17/procedures']}>
+        <KioskProcedureListScreen />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('実施状況: 5 / 17')).toBeInTheDocument();
+      expect(screen.getByText('5 完了')).toBeInTheDocument();
+      expect(screen.getAllByText('記録済み')).toHaveLength(5);
+    });
+  });
+
   it('prefers fetched SharePoint records over stale local cache after remote read completes', async () => {
     mockGetCurrentExecutionRepositoryKind.mockReturnValue('sharepoint');
     mockGetStoreRecords.mockReturnValue([
@@ -827,7 +872,7 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
     });
   });
 
-  it('waits for user to load and does not perform stale fetches with fallback route ID', async () => {
+  it('waits for user to load before fetching route and master user ID candidates', async () => {
     mockRouteUserId = '17';
     // Start as loading
     let userState = { data: undefined as any, status: 'loading' };
@@ -873,8 +918,8 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
       expect(within(firstCard).getByText('記録済み')).toBeInTheDocument();
     });
 
-    // Verify that mockGetRecords was called only with U001 and never with '17'
+    // Verify that fetches start only after the master user is resolved.
     expect(mockGetRecords).toHaveBeenCalledWith(expect.any(String), 'U001');
-    expect(mockGetRecords).not.toHaveBeenCalledWith(expect.any(String), '17');
+    expect(mockGetRecords).toHaveBeenCalledWith(expect.any(String), '17');
   });
 });


### PR DESCRIPTION
## Summary
- Normalize kiosk execution lookup across numeric and canonical user IDs such as `17`, `U017`, and `U-017`.
- Match procedure execution records across row-key variants such as `base-4`, `row-4`, `procedure-4`, and `slot_4`.
- Apply the same candidate ID/key lookup logic to both kiosk procedure list and detail screens.
- Add regression coverage for the expected `5 / 17` completed state.

## Context
This follows the previous stale-local-cache fix, but addresses a separate root cause:
- Previous fix: stale local cache could still affect display after SharePoint records were fetched.
- This fix: fetched execution records could be missed when `userId` or row-key formats differed between route, user master, and saved SharePoint rows.

## Verification
- `npm test -- KioskProcedureListScreen.spec.tsx KioskProcedureDetailScreen.spec.tsx` -> 44 passed
- `npm run typecheck` -> passed
- `npm run lint -- --max-warnings=999` -> passed
- `npx playwright test tests/e2e/kiosk-procedure-list.spec.ts --project=chromium` -> 5 passed
- Local browser: confirmed `実施状況: 5 / 17`, `5 完了`, and 5 `記録済み` items
