### PR TITLE
fix(kiosk): partial lookup resilience and strict RowKey prefix

### DIFF
--- a/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
+++ b/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
@@ -236,7 +236,7 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
     const normalizedUserId = normalizeExecutionUserId(userId);
     const rf = await this.getResolvedFields();
     const dailyKey = `${normalizedDate}-${normalizedUserId}`;
-    const rowKeyPrefix = dailyKey;
+    const rowKeyPrefix = `${dailyKey}-`;
     
     // Safety check: if rf.rowKey is RowKey but was resolved without actual presence, OData will fail.
     // However, resolveInternalNames is supposed to be accurate. 

--- a/src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts
+++ b/src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts
@@ -216,6 +216,31 @@ describe('SharePointExecutionRecordRepository', () => {
     await expect(repo.upsertRecord(record)).rejects.toThrow('row create failed');
   });
 
+  it('uses a delimited RowKey prefix when fetching records for one user/date', async () => {
+    mockSpFetch.mockReset();
+    mockSpFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ value: [] }),
+    });
+
+    const repoWithFreshFields = new SharePointExecutionRecordRepository({
+      spFetch: mockSpFetch,
+      getListFieldInternalNames: mockGetFields,
+    });
+
+    await repoWithFreshFields.getRecords('2026-05-25', '17');
+
+    const recordsCall = mockSpFetch.mock.calls.find((call) => {
+      const url = decodeURIComponent(String(call[0]));
+      return url.includes('DailyRecordRows') && url.includes('$filter=startswith');
+    });
+
+    expect(recordsCall).toBeDefined();
+    const decodedUrl = decodeURIComponent(String(recordsCall![0]));
+    expect(decodedUrl).toMatch(/startswith\((Title|RowKey), '2026-05-25-17-'\)/);
+    expect(decodedUrl).not.toMatch(/startswith\((Title|RowKey), '2026-05-25-17'\)/);
+  });
+
   describe('mapToDomain fallback', () => {
     it('correctly falls back to parsing scheduleItemId from Title if RowNo is missing', () => {
       const mockItem = {

--- a/src/features/kiosk/components/KioskProcedureListScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureListScreen.tsx
@@ -247,28 +247,39 @@ export const KioskProcedureListScreen: React.FC = () => {
     let active = true;
     const fetchRecords = async () => {
       if (executionUserIdCandidates.length === 0) return;
-      try {
-        const batches = await Promise.all(
-          executionUserIdCandidates.map((candidateUserId) =>
-            executionRepo.getRecords(selectedDateIso, candidateUserId),
-          ),
-        );
-        const deduped = new Map<string, ExecutionRecord>();
-        for (const record of batches.flat()) {
-          const key = `${record.date}|${record.userId}|${record.scheduleItemId}|${record.id ?? ''}`;
-          deduped.set(key, record);
-        }
-        const data = Array.from(deduped.values());
-        if (active) {
-          setRecords(data);
-          setHasFetchedRecords(true);
-        }
-      } catch (error) {
+      const results = await Promise.allSettled(
+        executionUserIdCandidates.map((candidateUserId) =>
+          executionRepo.getRecords(selectedDateIso, candidateUserId),
+        ),
+      );
+      const successfulBatches = results
+        .filter((result): result is PromiseFulfilledResult<ExecutionRecord[]> => result.status === 'fulfilled')
+        .map((result) => result.value);
+      const failedResults = results.filter((result) => result.status === 'rejected');
+
+      if (successfulBatches.length === 0) {
+        const error = failedResults[0]?.reason ?? new Error('No execution record fetches completed');
         if (active) {
           console.error('Failed to fetch execution records:', error);
           setShowFetchError(true);
           setHasFetchedRecords(true);
         }
+        return;
+      }
+
+      if (failedResults.length > 0) {
+        console.warn('Some execution record lookups failed:', failedResults.map((result) => result.reason));
+      }
+
+      const deduped = new Map<string, ExecutionRecord>();
+      for (const record of successfulBatches.flat()) {
+        const key = `${record.date}|${record.userId}|${record.scheduleItemId}|${record.id ?? ''}`;
+        deduped.set(key, record);
+      }
+      const data = Array.from(deduped.values());
+      if (active) {
+        setRecords(data);
+        setHasFetchedRecords(true);
       }
     };
     void fetchRecords();

--- a/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
@@ -268,6 +268,53 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
     });
   });
 
+  it('keeps successful candidate records when one execution user ID lookup fails', async () => {
+    mockRouteUserId = '17';
+    const procedures17 = Array.from({ length: 17 }, (_, index) => {
+      const rowNo = index + 1;
+      return {
+        id: `base-${rowNo}`,
+        rowNo,
+        time: `${String(9 + Math.floor(index / 2)).padStart(2, '0')}:00`,
+        activity: `手順 ${rowNo}`,
+        instruction: `支援内容 ${rowNo}`,
+      };
+    });
+    mockGetByUser.mockReturnValue(procedures17);
+    mockUseUser.mockReturnValue({
+      data: { FullName: '対象 利用者', UserID: 'U017' },
+      status: 'success',
+    });
+    mockGetRecords.mockImplementation(async (_date, userId) => {
+      if (userId === '17') {
+        throw new Error('numeric lookup failed');
+      }
+      if (userId === 'U017') {
+        return [
+          { scheduleItemId: 'base-1', status: 'completed' },
+          { scheduleItemId: 'row-2', status: 'completed' },
+          { scheduleItemId: 'procedure-3', status: 'completed' },
+          { scheduleItemId: 'slot_4', status: 'completed' },
+          { scheduleItemId: 'base-5', status: 'completed' },
+        ];
+      }
+      return [];
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/kiosk/users/17/procedures?date=2026-05-25']}>
+        <KioskProcedureListScreen />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('実施状況: 5 / 17')).toBeInTheDocument();
+      expect(screen.getByText('5 完了')).toBeInTheDocument();
+      expect(screen.getAllByText('記録済み')).toHaveLength(5);
+      expect(screen.queryByText('記録の取得に失敗しました。再読み込みしてください。')).toBeNull();
+    });
+  });
+
   it('prefers fetched SharePoint records over stale local cache after remote read completes', async () => {
     mockGetCurrentExecutionRepositoryKind.mockReturnValue('sharepoint');
     mockGetStoreRecords.mockReturnValue([


### PR DESCRIPTION
Tolerate partial candidate ID fetch failures to prevent clearing completed counts, and enforce strict RowKey prefix matching (e.g. 17- instead of 17) to avoid bleeding into other IDs like 170.