### PR TITLE
fix(kiosk): prevent invalid DOM nesting in daily flow preview

### DIFF
--- a/src/features/kiosk/components/KioskDailyProcedureFlowPreview.tsx
+++ b/src/features/kiosk/components/KioskDailyProcedureFlowPreview.tsx
@@ -133,8 +133,9 @@ export const KioskDailyProcedureFlowPreview: React.FC<KioskDailyProcedureFlowPre
                 }}
               >
                 <ListItemText
+                  disableTypography
                   primary={
-                    <Stack direction="row" spacing={1.5} alignItems="center" flexWrap="wrap" useFlexGap sx={{ mb: 1 }}>
+                    <Stack component="div" direction="row" spacing={1.5} alignItems="center" flexWrap="wrap" useFlexGap sx={{ mb: 1 }}>
                       {/* Row No & Time Label */}
                       <Chip 
                         size="small" 
@@ -170,7 +171,7 @@ export const KioskDailyProcedureFlowPreview: React.FC<KioskDailyProcedureFlowPre
                     </Stack>
                   }
                   secondary={
-                    <Box sx={{ pl: 1, mt: 0.5 }}>
+                    <Box component="div" sx={{ pl: 1, mt: 0.5 }}>
                       {/* Instruction (Welfare procedure context) */}
                       {step.activityDetail && (
                         <Typography variant="caption" display="block" color="text.secondary" sx={{ mb: 0.5 }}>
@@ -196,7 +197,7 @@ export const KioskDailyProcedureFlowPreview: React.FC<KioskDailyProcedureFlowPre
                             mt: 1
                           }}
                         >
-                          <Typography variant="body2" color="text.primary" sx={{ whiteSpace: 'pre-wrap', lineHeight: 1.5 }}>
+                          <Typography component="div" variant="body2" color="text.primary" sx={{ whiteSpace: 'pre-wrap', lineHeight: 1.5 }}>
                             {step.record?.memo || '（様子・メモ未記入）'}
                           </Typography>
                           
@@ -210,7 +211,7 @@ export const KioskDailyProcedureFlowPreview: React.FC<KioskDailyProcedureFlowPre
                           )}
                         </Paper>
                       ) : (
-                        <Typography variant="body2" color="text.disabled" sx={{ fontStyle: 'italic', mt: 0.5 }}>
+                        <Typography component="div" variant="body2" color="text.disabled" sx={{ fontStyle: 'italic', mt: 0.5 }}>
                           記録はありません
                         </Typography>
                       )}


### PR DESCRIPTION
## Summary
- Prevent MUI `ListItemText` from wrapping block preview markup in generated Typography tags.
- Explicitly render preview containers and memo/no-record text with valid block components.

## Root Cause
`ListItemText` was receiving `Stack`, `Box`, and `Paper` content through `primary` / `secondary`. MUI can wrap those slots in Typography elements, producing invalid DOM such as `<p><div>...</div></p>` and `validateDOMNesting` warnings.

## Verification
- `npm test -- KioskDailyProcedureFlowPreview.spec.tsx KioskProcedureDetailScreen.spec.tsx`
- `npm run typecheck`
- `npm run lint -- --max-warnings=999`
- `git diff --check`
