### PR TITLE
fix(health): align auth diagnostics with mock bypass mode

### DIFF
--- a/src/features/diagnostics/health/checks/authChecks.ts
+++ b/src/features/diagnostics/health/checks/authChecks.ts
@@ -1,6 +1,6 @@
 import { HealthCheckResult, HealthContext } from "../types";
 import { SpAdapter } from "../spAdapter";
-import { pass, fail, safe } from "./utils";
+import { pass, fail, safe, isMockOrBypassMode } from "./utils";
 
 export type AuthConnectivityCheckSummary = {
   currentUserStatus: "pass" | "fail";
@@ -14,14 +14,14 @@ export async function runAuthAndConnectivityChecks(
   sp: SpAdapter,
   results: HealthCheckResult[]
 ): Promise<AuthConnectivityCheckSummary> {
-  const isSkipSharePoint = ctx.env["VITE_SKIP_SHAREPOINT"] === "1";
+  const isMockOrBypass = isMockOrBypassMode(ctx.env);
   let currentUserStatus: "pass" | "fail" = "fail";
   let currentUserDetail: string | undefined;
   let webStatus: "pass" | "fail" = "fail";
   let webDetail: string | undefined;
 
   // --- B) Auth / Connectivity ---
-  const currentUser = isSkipSharePoint
+  const currentUser = isMockOrBypass
     ? { ok: true as const, v: { title: "Mock Test User", email: "mock@example.com" } }
     : await safe(() => sp.getCurrentUser());
   if (!currentUser.ok) {
@@ -58,7 +58,7 @@ export async function runAuthAndConnectivityChecks(
     currentUserStatus = "pass";
   }
 
-  const webTitle = isSkipSharePoint
+  const webTitle = isMockOrBypass
     ? { ok: true as const, v: "Mock SharePoint Site" }
     : await safe(() => sp.getWebTitle());
   if (!webTitle.ok) {

--- a/src/features/diagnostics/health/checks/configChecks.ts
+++ b/src/features/diagnostics/health/checks/configChecks.ts
@@ -1,6 +1,6 @@
 import { HealthCheckResult, HealthContext } from "../types";
 import { getRuntimeEnv } from "@/env";
-import { pass, fail, warn, pickEnvKeys, hasPlaceholder, isEnabled } from "./utils";
+import { pass, fail, warn, pickEnvKeys, hasPlaceholder, isEnabled, isMockOrBypassMode } from "./utils";
 
 export async function runConfigChecks(
   ctx: HealthContext,
@@ -135,24 +135,18 @@ export async function runConfigChecks(
 
   // Mock / skip mode guard:
   {
-    const skipSharePoint = isEnabled(ctx.env["VITE_SKIP_SHAREPOINT"]);
-    const skipLogin = isEnabled(ctx.env["VITE_SKIP_LOGIN"]);
-    const demoMode = isEnabled(ctx.env["VITE_DEMO_MODE"]) || isEnabled(ctx.env["VITE_DEMO"]);
-    const e2eMode = isEnabled(ctx.env["VITE_E2E"]) || isEnabled(ctx.env["VITE_E2E_MSAL_MOCK"]);
-    const dummyClientId = String(ctx.env["VITE_MSAL_CLIENT_ID"] ?? "").trim() === "00000000-0000-0000-0000-000000000000";
-    const dummyTenantId = String(ctx.env["VITE_MSAL_TENANT_ID"] ?? "").trim().toLowerCase() === "dummy";
+    const mockOrBypass = isMockOrBypassMode(ctx.env);
+    if (mockOrBypass) {
+      const flags = {
+        VITE_SKIP_SHAREPOINT: isEnabled(ctx.env["VITE_SKIP_SHAREPOINT"]),
+        VITE_SKIP_LOGIN: isEnabled(ctx.env["VITE_SKIP_LOGIN"]),
+        VITE_DEMO_MODE: isEnabled(ctx.env["VITE_DEMO_MODE"]) || isEnabled(ctx.env["VITE_DEMO"]),
+        VITE_E2E: isEnabled(ctx.env["VITE_E2E"]) || isEnabled(ctx.env["VITE_E2E_MSAL_MOCK"]),
+        VITE_E2E_MSAL_MOCK: isEnabled(ctx.env["VITE_E2E_MSAL_MOCK"]),
+        dummyClientId: String(ctx.env["VITE_MSAL_CLIENT_ID"] ?? "").trim() === "00000000-0000-0000-0000-000000000000",
+        dummyTenantId: String(ctx.env["VITE_MSAL_TENANT_ID"] ?? "").trim().toLowerCase() === "dummy",
+      };
 
-    const flags = {
-      VITE_SKIP_SHAREPOINT: skipSharePoint,
-      VITE_SKIP_LOGIN: skipLogin,
-      VITE_DEMO_MODE: demoMode,
-      VITE_E2E: e2eMode,
-      VITE_E2E_MSAL_MOCK: isEnabled(ctx.env["VITE_E2E_MSAL_MOCK"]),
-      dummyClientId,
-      dummyTenantId,
-    };
-
-    if (skipSharePoint || skipLogin || demoMode || e2eMode || dummyClientId || dummyTenantId) {
       results.push(
         warn({
           key: "config.mockOrBypassMode",

--- a/src/features/diagnostics/health/checks/utils.ts
+++ b/src/features/diagnostics/health/checks/utils.ts
@@ -125,3 +125,15 @@ export async function safeWithRetry<T>(
   }
   return { ok: false, err: "retry loop exited unexpectedly", attempts: maxAttempts };
 }
+
+export function isMockOrBypassMode(env: Record<string, unknown>): boolean {
+  const skipSharePoint = isEnabled(env["VITE_SKIP_SHAREPOINT"]);
+  const skipLogin = isEnabled(env["VITE_SKIP_LOGIN"]);
+  const demoMode = isEnabled(env["VITE_DEMO_MODE"]) || isEnabled(env["VITE_DEMO"]);
+  const e2eMode = isEnabled(env["VITE_E2E"]) || isEnabled(env["VITE_E2E_MSAL_MOCK"]);
+  const dummyClientId = String(env["VITE_MSAL_CLIENT_ID"] ?? "").trim() === "00000000-0000-0000-0000-000000000000";
+  const dummyTenantId = String(env["VITE_MSAL_TENANT_ID"] ?? "").trim().toLowerCase() === "dummy";
+
+  return skipSharePoint || skipLogin || demoMode || e2eMode || dummyClientId || dummyTenantId;
+}
+


### PR DESCRIPTION
Ensure authChecks uses the same comprehensive mock/bypass check as configChecks to avoid false SharePoint connectivity errors in demo/mock/skip-login environments.