### PR TITLE
fix(sp): route production SharePoint calls through worker proxy

### DIFF
--- a/src/__tests__/worker.spec.ts
+++ b/src/__tests__/worker.spec.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import worker from '../worker';
+
+describe('Cloudflare Worker - SharePoint Proxy', () => {
+  const defaultEnv = {
+    ASSETS: { fetch: vi.fn() },
+    VITE_SP_RESOURCE: 'https://example.sharepoint.com',
+    VITE_SP_SITE_RELATIVE: '/sites/welfare',
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('returns 204 for OPTIONS request without auth', async () => {
+    const request = new Request('https://app.example/api/sp-proxy', {
+      method: 'OPTIONS',
+    });
+    const response = await worker.fetch(request, defaultEnv);
+    expect(response.status).toBe(204);
+  });
+
+  it('returns 401 if Authorization header is missing', async () => {
+    const request = new Request('https://app.example/api/sp-proxy?url=https%3A%2F%2Fexample.sharepoint.com%2Fsites%2Fwelfare%2F_api%2Fweb%2Flists', {
+      method: 'GET',
+    });
+    const response = await worker.fetch(request, defaultEnv);
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(body).toEqual({ error: 'missing_bearer_token' });
+  });
+
+  it('returns 500 if VITE_SP_RESOURCE is not configured', async () => {
+    const env = { ...defaultEnv, VITE_SP_RESOURCE: '' };
+    const request = new Request('https://app.example/api/sp-proxy?url=https%3A%2F%2Fexample.sharepoint.com%2Fsites%2Fwelfare%2F_api%2Fweb%2Flists', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer valid-token' },
+    });
+    const response = await worker.fetch(request, env);
+    expect(response.status).toBe(500);
+    const body = await response.json();
+    expect(body).toEqual({ error: 'sp_proxy_not_configured' });
+  });
+
+  it('returns 400 for invalid target url', async () => {
+    const request = new Request('https://app.example/api/sp-proxy?url=not-a-url', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer valid-token' },
+    });
+    const response = await worker.fetch(request, defaultEnv);
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body).toEqual({ error: 'invalid_target_url' });
+  });
+
+  it('returns 403 if target origin does not match configured resource', async () => {
+    const request = new Request('https://app.example/api/sp-proxy?url=https%3A%2F%2Fmalicious.com%2Fsites%2Fwelfare%2F_api%2Fweb%2Flists', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer valid-token' },
+    });
+    const response = await worker.fetch(request, defaultEnv);
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body).toEqual({ error: 'target_not_allowed' });
+  });
+
+  it('returns 403 if target path does not start with allowed API path', async () => {
+    const request = new Request('https://app.example/api/sp-proxy?url=https%3A%2F%2Fexample.sharepoint.com%2Fsites%2Fother%2F_api%2Fweb%2Flists', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer valid-token' },
+    });
+    const response = await worker.fetch(request, defaultEnv);
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body).toEqual({ error: 'target_not_allowed' });
+  });
+
+  it('forwards request to target and returns target response if allowed', async () => {
+    const targetResponse = new Response('{"d":[]}', {
+      status: 200,
+      headers: { 'Content-Type': 'application/json', 'ETag': 'W/"1"' },
+    });
+    const fetchMock = vi.fn().mockResolvedValue(targetResponse);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const request = new Request('https://app.example/api/sp-proxy?url=https%3A%2F%2Fexample.sharepoint.com%2Fsites%2Fwelfare%2F_api%2Fweb%2Flists', {
+      method: 'GET',
+      headers: {
+        Authorization: 'Bearer valid-token',
+        Accept: 'application/json',
+      },
+    });
+
+    const response = await worker.fetch(request, defaultEnv);
+    expect(response.status).toBe(200);
+    const text = await response.text();
+    expect(text).toBe('{"d":[]}');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const calledReq = fetchMock.mock.calls[0][0] as Request;
+    expect(calledReq.url).toBe('https://example.sharepoint.com/sites/welfare/_api/web/lists');
+    expect(calledReq.headers.get('Authorization')).toBe('Bearer valid-token');
+    expect(calledReq.headers.get('Accept')).toBe('application/json');
+
+    // Headers picked from response
+    expect(response.headers.get('Content-Type')).toBe('application/json');
+    expect(response.headers.get('ETag')).toBe('W/"1"');
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+  });
+});

--- a/src/lib/env.schema.ts
+++ b/src/lib/env.schema.ts
@@ -96,6 +96,7 @@ export const envSchema = z.object({
   VITE_SP_SITE_URL: z.string().optional(), // Legacy support
   VITE_FORCE_SHAREPOINT: zBoolFromString.optional().default(false),
   VITE_ALLOW_SHAREPOINT_OUTSIDE_SPFX: zBoolFromString.optional().default(false),
+  VITE_SP_USE_PROXY: zBoolFromString.optional().default(false),
   VITE_SKIP_SHAREPOINT: zBoolFromString.optional().default(false),
   VITE_SKIP_LOGIN: zBoolFromString.optional().default(false),
   VITE_SP_ENABLED: z.string().optional().default('false'),

--- a/src/lib/sp/__tests__/spFetch.retry-guard.spec.ts
+++ b/src/lib/sp/__tests__/spFetch.retry-guard.spec.ts
@@ -6,6 +6,8 @@ function createTestEnv(): EnvRecord {
   return {
     VITE_SKIP_LOGIN: '0',
     VITE_SKIP_SHAREPOINT: '0',
+    VITE_FORCE_SHAREPOINT: '1',
+    VITE_DEMO_MODE: '0',
     VITE_E2E_MSAL_MOCK: '0',
     VITE_AUDIT_DEBUG: '0',
   } as unknown as EnvRecord;
@@ -16,6 +18,21 @@ function createFetcher() {
     acquireToken: async () => 'test-token',
     baseUrl: 'https://example.sharepoint.com/sites/welfare',
     config: createTestEnv(),
+    retrySettings: { maxAttempts: 4, baseDelay: 2000, capDelay: 30000 },
+    debugEnabled: false,
+    spSiteLegacy: '/sites/welfare',
+    throwOnError: false,
+  });
+}
+
+function createProxyFetcher() {
+  return createSpFetch({
+    acquireToken: async () => 'test-token',
+    baseUrl: 'https://example.sharepoint.com/sites/welfare/_api/web',
+    config: {
+      ...createTestEnv(),
+      VITE_SP_USE_PROXY: '1',
+    },
     retrySettings: { maxAttempts: 4, baseDelay: 2000, capDelay: 30000 },
     debugEnabled: false,
     spSiteLegacy: '/sites/welfare',
@@ -89,5 +106,26 @@ describe('spFetch retry guard for SharePoint throttle/cors', () => {
 
     await expect(spFetch('/_api/web/lists')).rejects.toThrow('Failed to fetch');
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes SharePoint requests through same-origin proxy when enabled', async () => {
+    const ok = new Response(JSON.stringify({ value: [] }), { status: 200 });
+    const fetchMock = vi.fn().mockResolvedValue(ok);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const spFetch = createProxyFetcher();
+
+    const response = await spFetch("/lists/getbytitle('SupportPlans')/fields?$select=InternalName");
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] ?? [];
+    const proxyUrl = new URL(String(url), 'https://app.example');
+    expect(proxyUrl.pathname).toBe('/api/sp-proxy');
+    expect(proxyUrl.searchParams.get('url')).toBe(
+      "https://example.sharepoint.com/sites/welfare/_api/web/lists/getbytitle('SupportPlans')/fields?$select=InternalName",
+    );
+    const headers = init?.headers instanceof Headers ? init.headers : new Headers(init?.headers);
+    expect(headers.get('Authorization')).toBe('Bearer test-token');
   });
 });

--- a/src/lib/sp/spFetch.ts
+++ b/src/lib/sp/spFetch.ts
@@ -8,7 +8,7 @@
 import { isDebugFlag } from '@/lib/debugFlag';
 import { auditLog } from '@/lib/debugLogger';
 import type { EnvRecord } from '@/lib/env';
-import { isE2eMsalMockEnabled, shouldSkipLogin, skipSharePoint } from '@/lib/env';
+import { isE2eMsalMockEnabled, readBool, shouldSkipLogin, skipSharePoint } from '@/lib/env';
 import { AuthRequiredError } from '@/lib/errors';
 import { startFetchSpan } from '@/telemetry/fetchSpan';
 import { raiseHttpError } from './helpers';
@@ -268,11 +268,19 @@ export function createSpFetch(deps: SpFetchDeps) {
   const writeLane = new Semaphore(2);
   const provisionLane = new Semaphore(1);
 
-  const resolveUrl = (targetPath: string) => {
+  const resolveDirectUrl = (targetPath: string) => {
     if (/^https?:\/\//i.test(targetPath)) return targetPath;
     const base = baseUrl.replace(/\/+$/, '');
     const path = targetPath.startsWith('/') ? targetPath : `/${targetPath}`;
     return `${base}${path}`;
+  };
+
+  const resolveUrl = (targetPath: string) => {
+    const directUrl = resolveDirectUrl(targetPath);
+    if (!readBool('VITE_SP_USE_PROXY', false, config)) {
+      return directUrl;
+    }
+    return `/api/sp-proxy?url=${encodeURIComponent(directUrl)}`;
   };
 
   return async function spFetch(path: string, init: import('./types').SpRequestInit = {}): Promise<Response> {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -7,6 +7,8 @@ interface Env {
   ASSETS: {
     fetch: (request: Request) => Promise<Response>;
   };
+  VITE_SP_RESOURCE?: string;
+  VITE_SP_SITE_RELATIVE?: string;
   ALLOWED_TENANT_ID?: string;
   ORG_ID_OVERRIDE?: string;
   GOOGLE_SERVICE_ACCOUNT_JSON?: string;
@@ -67,6 +69,9 @@ const RUNTIME_ENV_ALLOWLIST = new Set([
   'VITE_ADMIN_GROUP_ID',
   'VITE_FEATURE_TODAY_OPS',
   'VITE_FEATURE_TODAY_LITE_UI',
+  'VITE_SP_RESOURCE',
+  'VITE_SP_SITE_RELATIVE',
+  'VITE_SP_USE_PROXY',
 ]);
 
 const pickRuntimeEnvFromBindings = (env: Env): Record<string, string> => {
@@ -324,6 +329,103 @@ const handleFirebaseExchange = async (request: Request, env: Env): Promise<Respo
   }
 };
 
+const normalizeSiteRelative = (value: string): string => {
+  const trimmed = value.trim();
+  if (!trimmed) return '';
+  const prefixed = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+  return prefixed.replace(/\/+$/, '');
+};
+
+const pickSharePointRequestHeaders = (request: Request): Headers => {
+  const headers = new Headers();
+  const allowed = [
+    'accept',
+    'authorization',
+    'content-type',
+    'if-match',
+    'odata-version',
+    'prefer',
+    'x-http-method',
+  ];
+
+  for (const key of allowed) {
+    const value = request.headers.get(key);
+    if (value) headers.set(key, value);
+  }
+
+  return headers;
+};
+
+const pickSharePointResponseHeaders = (response: Response): Headers => {
+  const headers = new Headers();
+  const allowed = [
+    'content-type',
+    'etag',
+    'last-modified',
+    'odata-version',
+    'preference-applied',
+    'request-id',
+    'sprequestguid',
+  ];
+
+  for (const key of allowed) {
+    const value = response.headers.get(key);
+    if (value) headers.set(key, value);
+  }
+
+  headers.set('Cache-Control', 'no-store');
+  return headers;
+};
+
+const handleSharePointProxy = async (request: Request, env: Env): Promise<Response> => {
+  if (request.method === 'OPTIONS') {
+    return new Response(null, { status: 204 });
+  }
+
+  const authHeader = request.headers.get('Authorization') ?? '';
+  if (!authHeader.startsWith('Bearer ')) {
+    return jsonResponse(401, { error: 'missing_bearer_token' });
+  }
+
+  const configuredResource = env.VITE_SP_RESOURCE?.trim().replace(/\/+$/, '');
+  const configuredSiteRelative = normalizeSiteRelative(env.VITE_SP_SITE_RELATIVE ?? '');
+  if (!configuredResource || !configuredSiteRelative) {
+    return jsonResponse(500, { error: 'sp_proxy_not_configured' });
+  }
+
+  let target: URL;
+  try {
+    const sourceUrl = new URL(request.url);
+    target = new URL(sourceUrl.searchParams.get('url') ?? '');
+  } catch {
+    return jsonResponse(400, { error: 'invalid_target_url' });
+  }
+
+  const allowedOrigin = new URL(configuredResource).origin;
+  const allowedApiPath = `${configuredSiteRelative}/_api/web`;
+  if (target.origin !== allowedOrigin || !target.pathname.startsWith(allowedApiPath)) {
+    return jsonResponse(403, { error: 'target_not_allowed' });
+  }
+
+  try {
+    const response = await fetch(new Request(target.toString(), {
+      method: request.method,
+      headers: pickSharePointRequestHeaders(request),
+      body: request.method === 'GET' || request.method === 'HEAD' ? null : request.body,
+      redirect: 'manual',
+    }));
+
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: pickSharePointResponseHeaders(response),
+    });
+  } catch (error) {
+    console.error('[sp-proxy] fetch failed', error);
+    return jsonResponse(502, { error: 'sharepoint_fetch_failed' });
+  }
+};
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
@@ -357,6 +459,10 @@ export default {
 
     if (url.pathname === '/api/firebase/exchange') {
       return handleFirebaseExchange(request, env);
+    }
+
+    if (url.pathname === '/api/sp-proxy') {
+      return handleSharePointProxy(request, env);
     }
 
     // API routes - pass through

--- a/tests/unit/spClient.more-branches.spec.ts
+++ b/tests/unit/spClient.more-branches.spec.ts
@@ -10,6 +10,7 @@ const defaultConfig = {
 vi.mock('@/lib/env', () => ({
   getAppConfig: () => ({ ...defaultConfig }),
   readEnv: (key: string, fallback: string) => (defaultConfig as any)[key] ?? fallback,
+  readBool: (key: string, fallback: boolean) => fallback,
   skipSharePoint: () => false,
   shouldSkipLogin: () => false,
   isE2eMsalMockEnabled: () => false,

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -7,6 +7,11 @@ name = "audit-management-system-mvp"
 compatibility_date = "2026-01-17"
 main = "src/worker.ts"
 
+[vars]
+VITE_SP_RESOURCE = "https://isogokatudouhome.sharepoint.com"
+VITE_SP_SITE_RELATIVE = "/sites/welfare"
+VITE_SP_USE_PROXY = "1"
+
 [assets]
 directory = "./dist"
 # not_found_handling is handled manually in worker.ts for SPA routing


### PR DESCRIPTION
## Summary
- Route production SharePoint REST calls through a same-origin Cloudflare Worker proxy when `VITE_SP_USE_PROXY=1`.
- Add `/api/sp-proxy` to the Worker and restrict targets to the configured SharePoint resource/site `_api/web` path.
- Preserve the existing direct SharePoint fetch path when the proxy flag is disabled.
- Configure production env/wrangler vars to enable the proxy for the current SharePoint site.

## Root Cause
The app was hosted on `workers.dev` but the browser was fetching SharePoint REST endpoints directly. Even with a valid MSAL token, browser-side cross-origin SharePoint REST calls can fail with CORS/redirect-style `net::ERR_FAILED`, especially for metadata calls such as `fields?$select=InternalName`.

## Verification
- `npm test -- src/lib/sp/__tests__/spFetch.retry-guard.spec.ts`
- `npm run typecheck`
- `npm run lint -- --max-warnings=999`
- `npm run build`
- `npx wrangler deploy --dry-run`
- `git diff --check`
