### PR TITLE
fix(sp): dedupe SharePoint field metadata fetches

### DIFF
--- a/src/lib/sp/__tests__/spListSchema.fields-cache.spec.ts
+++ b/src/lib/sp/__tests__/spListSchema.fields-cache.spec.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  __clearFieldInternalNamesRuntimeCacheForTests,
+  getListFieldInternalNames,
+} from '../spListSchema';
+
+const baseUrl = 'https://example.sharepoint.com/sites/welfare/_api/web';
+
+const fieldsResponse = () =>
+  new Response(JSON.stringify({
+    value: [
+      { InternalName: 'Title' },
+      { InternalName: 'UserCode' },
+      { InternalName: 'RecordDate' },
+    ],
+  }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+describe('getListFieldInternalNames cache', () => {
+  beforeEach(() => {
+    __clearFieldInternalNamesRuntimeCacheForTests();
+    sessionStorage.clear();
+  });
+
+  it('shares one in-flight fields request for concurrent callers', async () => {
+    let resolveFetch: (response: Response) => void = () => {};
+    const pendingResponse = new Promise<Response>((resolve) => {
+      resolveFetch = resolve;
+    });
+    const spFetch = vi.fn(() => pendingResponse);
+
+    const first = getListFieldInternalNames(spFetch, baseUrl, 'SupportPlans');
+    const second = getListFieldInternalNames(spFetch, baseUrl, 'SupportPlans');
+    const third = getListFieldInternalNames(spFetch, baseUrl, 'SupportPlans');
+
+    expect(spFetch).toHaveBeenCalledTimes(1);
+    expect(spFetch).toHaveBeenCalledWith(
+      "/lists/getbytitle('SupportPlans')/fields?$select=InternalName&$top=5000",
+    );
+
+    resolveFetch(fieldsResponse());
+
+    await expect(first).resolves.toEqual(new Set(['Title', 'UserCode', 'RecordDate']));
+    await expect(second).resolves.toEqual(new Set(['Title', 'UserCode', 'RecordDate']));
+    await expect(third).resolves.toEqual(new Set(['Title', 'UserCode', 'RecordDate']));
+    expect(spFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses runtime cache after the first successful fields request', async () => {
+    const spFetch = vi.fn(async () => fieldsResponse());
+
+    const first = await getListFieldInternalNames(spFetch, baseUrl, 'SupportPlans');
+    first.add('InjectedByCaller');
+
+    const second = await getListFieldInternalNames(spFetch, baseUrl, 'SupportPlans');
+
+    expect(spFetch).toHaveBeenCalledTimes(1);
+    expect(second).toEqual(new Set(['Title', 'UserCode', 'RecordDate']));
+    expect(second.has('InjectedByCaller')).toBe(false);
+  });
+});

--- a/src/lib/sp/spListSchema.ts
+++ b/src/lib/sp/spListSchema.ts
@@ -35,6 +35,32 @@ import type {
 // ── Constants ───────────────────────────────────────────────────────────────
 
 const DEFAULT_LIST_TEMPLATE = 100;
+const runtimeFieldsCache = new Map<string, FieldsCacheEntry>();
+const inFlightFieldsRequests = new Map<string, Promise<Set<string>>>();
+
+const cloneFieldSet = (fields: Set<string>): Set<string> => new Set(fields);
+
+const isValidFieldsCacheEntry = (
+  cached: FieldsCacheEntry,
+  siteUrl: string,
+  listTitle: string,
+): boolean => {
+  const age = nowMs() - cached.savedAt;
+  return (
+    cached.v === 1 &&
+    cached.siteUrl === siteUrl &&
+    cached.listTitle === listTitle &&
+    age >= 0 &&
+    age < FIELDS_CACHE_TTL_MS &&
+    Array.isArray(cached.internalNames) &&
+    cached.internalNames.length > 0
+  );
+};
+
+export const __clearFieldInternalNamesRuntimeCacheForTests = (): void => {
+  runtimeFieldsCache.clear();
+  inFlightFieldsRequests.clear();
+};
 
 // ── List metadata ───────────────────────────────────────────────────────────
 
@@ -146,18 +172,29 @@ export async function getListFieldInternalNames(
   const siteUrl = baseUrl;
   const cacheKey = makeFieldsCacheKey(siteUrl, listTitle);
 
+  const runtimeCached = runtimeFieldsCache.get(cacheKey);
+  if (runtimeCached) {
+    if (isValidFieldsCacheEntry(runtimeCached, siteUrl, listTitle)) {
+      if (debug) {
+        auditLog.debug('sp:fields', 'runtime_cache_hit', {
+          listTitle,
+          count: runtimeCached.internalNames.length,
+          ageMs: nowMs() - runtimeCached.savedAt,
+        });
+      }
+      return new Set(runtimeCached.internalNames);
+    }
+    runtimeFieldsCache.delete(cacheKey);
+  }
+
   // 1) Cache hit check
   if (typeof sessionStorage !== 'undefined') {
     const cached = safeJsonParse<FieldsCacheEntry>(sessionStorage.getItem(cacheKey));
     if (cached && cached.v === 1) {
       const age = nowMs() - cached.savedAt;
-      const valid =
-        cached.siteUrl === siteUrl &&
-        cached.listTitle === listTitle &&
-        age >= 0 &&
-        age < FIELDS_CACHE_TTL_MS;
+      const valid = isValidFieldsCacheEntry(cached, siteUrl, listTitle);
 
-      if (valid && Array.isArray(cached.internalNames) && cached.internalNames.length > 0) {
+      if (valid) {
         if (debug) {
           auditLog.debug('sp:fields', 'cache_hit', {
             listTitle,
@@ -165,6 +202,7 @@ export async function getListFieldInternalNames(
             ageMs: age,
           });
         }
+        runtimeFieldsCache.set(cacheKey, cached);
         return new Set(cached.internalNames);
       }
 
@@ -181,11 +219,19 @@ export async function getListFieldInternalNames(
     }
   }
 
+  const existingRequest = inFlightFieldsRequests.get(cacheKey);
+  if (existingRequest) {
+    if (debug) {
+      auditLog.debug('sp:fields', 'inflight_join', { listTitle });
+    }
+    return cloneFieldSet(await existingRequest);
+  }
+
   // 2) Network fetch
   const base = resolveListPath(listTitle);
   const path = `${base}/fields?$select=InternalName&$top=5000`;
 
-  try {
+  const fetchFields = async (): Promise<Set<string>> => {
     const res = await spFetch(path);
     const json = (await res.json().catch(() => ({ value: [] }))) as {
       value?: { InternalName?: string }[];
@@ -198,7 +244,7 @@ export async function getListFieldInternalNames(
     }
 
     // 3) Save cache (skip if empty)
-    if (typeof sessionStorage !== 'undefined' && names.size > 0) {
+    if (names.size > 0) {
       const entry: FieldsCacheEntry = {
         v: 1,
         savedAt: nowMs(),
@@ -206,20 +252,33 @@ export async function getListFieldInternalNames(
         siteUrl,
         internalNames: Array.from(names),
       };
-      const s = safeJsonStringify(entry);
-      if (s) {
-        sessionStorage.setItem(cacheKey, s);
-        if (debug) {
-          auditLog.debug('sp:fields', 'cache_save', { listTitle, count: names.size });
+      runtimeFieldsCache.set(cacheKey, entry);
+
+      if (typeof sessionStorage !== 'undefined') {
+        const s = safeJsonStringify(entry);
+        if (s) {
+          sessionStorage.setItem(cacheKey, s);
         }
       }
-    } else if (debug && names.size === 0) {
+
+      if (debug) {
+        auditLog.debug('sp:fields', 'cache_save', { listTitle, count: names.size });
+      }
+    } else if (debug) {
       auditLog.debug('sp:fields', 'cache_empty', { listTitle });
     }
 
     return names;
+  };
+
+  const request = fetchFields();
+  inFlightFieldsRequests.set(cacheKey, request);
+
+  try {
+    return cloneFieldSet(await request);
   } catch (e) {
     // 4) On failure, do not leave stale cache
+    runtimeFieldsCache.delete(cacheKey);
     if (typeof sessionStorage !== 'undefined') {
       sessionStorage.removeItem(cacheKey);
     }
@@ -227,6 +286,10 @@ export async function getListFieldInternalNames(
       auditLog.warn('sp:fields', 'fetch_failed', { listTitle, error: e });
     }
     throw e;
+  } finally {
+    if (inFlightFieldsRequests.get(cacheKey) === request) {
+      inFlightFieldsRequests.delete(cacheKey);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Add a runtime cache for SharePoint list field metadata lookups.
- Deduplicate concurrent `fields?$select=InternalName` fetches for the same site/list while the first request is in flight.
- Promote valid `sessionStorage` cache entries into the runtime cache and return cloned `Set` instances to avoid caller mutation leaks.

## Root Cause
Initial page loads can start multiple parallel field-resolution paths before `sessionStorage` has been populated. Those calls each fetched the same SharePoint list metadata independently, increasing request volume and contributing to 429 throttling during real SharePoint sessions.

## Verification
- `npm test -- src/lib/sp/__tests__/spListSchema.fields-cache.spec.ts src/lib/sp/__tests__/spFetch.retry-guard.spec.ts`
- commit hook: `npm run lint`
- commit hook: `npm run typecheck`
- pre-push hook: changed-file eslint
- `git show --check HEAD`

## Notes
This keeps the existing cache TTL behavior and only changes request coordination/caching inside `getListFieldInternalNames`.