### PR TITLE
fix(kiosk): preserve recent saves and harden proxy allowlist

### DIFF
--- a/src/__tests__/worker.spec.ts
+++ b/src/__tests__/worker.spec.ts
@@ -62,7 +62,7 @@ describe('Cloudflare Worker - SharePoint Proxy', () => {
     const response = await worker.fetch(request, defaultEnv);
     expect(response.status).toBe(403);
     const body = await response.json();
-    expect(body).toEqual({ error: 'target_not_allowed' });
+    expect(body.error).toBe('target_not_allowed');
   });
 
   it('returns 403 if target path does not start with allowed API path', async () => {
@@ -73,7 +73,7 @@ describe('Cloudflare Worker - SharePoint Proxy', () => {
     const response = await worker.fetch(request, defaultEnv);
     expect(response.status).toBe(403);
     const body = await response.json();
-    expect(body).toEqual({ error: 'target_not_allowed' });
+    expect(body.error).toBe('target_not_allowed');
   });
 
   it('forwards request to target and returns target response if allowed', async () => {

--- a/src/features/kiosk/components/KioskProcedureListScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureListScreen.tsx
@@ -313,11 +313,22 @@ export const KioskProcedureListScreen: React.FC = () => {
     const map = new Map<string, ExecutionRecord[]>();
 
     // In SharePoint mode, once the server read has completed it is authoritative.
-    // Local store is only a pre-fetch/optimistic cache; otherwise stale cache from this
-    // terminal can keep a row marked as recorded after another terminal changes it.
+    // However, to protect against SharePoint indexing/replication lag, we keep recently
+    // saved optimistic local records (within 2 minutes) even after the fetch completes.
     const allCandidateRecords =
       executionRepositoryKind === 'sharepoint' && hasFetchedRecords
-        ? records
+        ? [
+            ...records,
+            ...storeRecords.filter((r) => {
+              if (!r.recordedAt) return false;
+              try {
+                const ageMs = Date.now() - new Date(r.recordedAt).getTime();
+                return ageMs >= 0 && ageMs < 120 * 1000;
+              } catch {
+                return false;
+              }
+            }),
+          ]
         : [...storeRecords, ...records];
     
     for (const record of allCandidateRecords) {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -403,8 +403,22 @@ const handleSharePointProxy = async (request: Request, env: Env): Promise<Respon
 
   const allowedOrigin = new URL(configuredResource).origin;
   const allowedApiPath = `${configuredSiteRelative}/_api/web`;
-  if (target.origin !== allowedOrigin || !target.pathname.startsWith(allowedApiPath)) {
-    return jsonResponse(403, { error: 'target_not_allowed' });
+  
+  const allowedOriginLower = allowedOrigin.toLowerCase();
+  const allowedApiPathLower = allowedApiPath.toLowerCase();
+  const targetOriginLower = target.origin.toLowerCase();
+  const targetPathLower = target.pathname.toLowerCase();
+
+  if (targetOriginLower !== allowedOriginLower || !targetPathLower.startsWith(allowedApiPathLower)) {
+    return jsonResponse(403, { 
+      error: 'target_not_allowed',
+      details: {
+        targetOrigin: targetOriginLower,
+        allowedOrigin: allowedOriginLower,
+        targetPath: targetPathLower,
+        allowedApiPath: allowedApiPathLower
+      }
+    });
   }
 
   try {


### PR DESCRIPTION
## Summary
- Preserve very recent optimistic kiosk execution records to avoid UI rollback while SharePoint consistency catches up after save.
- Harden SharePoint Worker proxy allowlist comparisons for origin/path casing differences.
- Surface additional proxy rejection details to make 403 diagnostics easier.

## Context
This formalizes the follow-up fixes that were temporarily deployed during the production investigation. The PR is intentionally opened as Draft so the final diff can be reviewed through the normal CI/review path before merge.

## Scope check before ready
Current branch diff should be reviewed carefully. In particular, confirm whether `src/sharepoint/latest-decision.json` is intended operational evidence or should be removed from this code PR before marking ready.

## Verification to confirm
- Kiosk save flow keeps the just-saved record visible during SharePoint propagation delay.
- Worker proxy still rejects unauthorized/out-of-scope targets and provides useful diagnostics on 403.
- Run targeted kiosk tests and worker proxy tests before ready.
