### PR TITLE
fix(kiosk): resolve daily schedule preview unrecorded issue for older user dates

### DIFF
--- a/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
+++ b/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
@@ -15,6 +15,7 @@ import { normalizeScheduleItemId } from '@/features/daily/utils/normalizeSchedul
 import {
   normalizeExecutionDate,
   normalizeExecutionUserId,
+  buildExecutionUserIdCandidates,
 } from '@/features/daily/utils/normalizeExecutionLookup';
 
 type SharePointExecutionRecordRepositoryOptions = {
@@ -539,13 +540,24 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
         if (key.length > 11 && /^\d{4}-\d{2}-\d{2}-/.test(key)) {
           const parsedDate = key.slice(0, 10);
           const suffix = key.slice(11); // userId-scheduleItemId
-          const userPrefix = `${userId}-`;
-          if (suffix.startsWith(userPrefix)) {
+
+          // Build user ID candidates including both current userId and any logical representations
+          const userCandidates = buildExecutionUserIdCandidates(userId);
+          let matchedCandidate: string | null = null;
+
+          for (const candidate of userCandidates) {
+            if (suffix.startsWith(`${candidate}-`)) {
+              matchedCandidate = candidate;
+              break;
+            }
+          }
+
+          if (matchedCandidate) {
             if (!/^\d{4}-\d{2}-\d{2}/.test(date)) {
               date = parsedDate;
             }
             if (!scheduleItemId) {
-              scheduleItemId = normalizeScheduleItemId(suffix.slice(userPrefix.length));
+              scheduleItemId = normalizeScheduleItemId(suffix.slice(matchedCandidate.length + 1));
             }
             break;
           }

--- a/src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts
+++ b/src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts
@@ -306,6 +306,37 @@ describe('SharePointExecutionRecordRepository', () => {
       expect(mapped.date).toBe('2026-05-08');
     });
 
+    it('correctly parses date and scheduleItemId when userId is mismatched (e.g. U006 in userId but 6 in key/title)', () => {
+      const mockItem = {
+        Title: '2026-05-20-6-0', // Old/migrated format has '6'
+        User_x0020_ID: 'U006',    // Current userId is 'U006'
+        Status: 'completed',
+        Memo: 'Test memo',
+        Recorded_x0020_At: '2026-05-20T12:00:00Z',
+      };
+
+      const rf = {
+        parentId: 'Parent_x0020_ID',
+        userId: 'User_x0020_ID',
+        version: 'Version',
+        status: 'Status',
+        payload: 'Payload',
+        recordedAt: 'Recorded_x0020_At',
+        rowKey: 'Title',
+        rowNo: 'RowNo',
+        memo: 'Memo',
+        staffName: 'StaffName',
+        bipsJSON: 'BipsJSON',
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mapped = (repo as any).mapToDomain(mockItem, rf);
+
+      expect(mapped.scheduleItemId).toBe('0');
+      expect(mapped.userId).toBe('U006');
+      expect(mapped.date).toBe('2026-05-20');
+    });
+
     it('uses Memo when Memo has content', () => {
       const mockItem = {
         Title: '2026-05-08-4-1',


### PR DESCRIPTION
## Problem
When accessing the daily procedure preview for a past date (specifically before 2026-05-22), the timeline steps were marked as "Unrecorded" (未記録) even though execution records actually existed in SharePoint.

## Rationale
During the recent standardisation of `userId` representation (from numeric `6` to padded strings like `U006`), past/migrated SharePoint records that still had `6` in their `Title` or `RowKey` composite string suffixes (e.g. `2026-05-20-6-0`) failed the exact `suffix.startsWith(userId + '-')` check (which evaluated with `U006-`). Consequently, the `mapToDomain` mapping logic failed to extract the date or schedule ID, treating them as unrecorded.

## Proposed Changes
- **`SharePointExecutionRecordRepository.ts`**:
  - Update `mapToDomain` to leverage `buildExecutionUserIdCandidates` which generates both the raw and candidate format variations of the user ID (e.g. `U006`, `6`).
  - Iteratively check if the suffix starts with any of the candidate user IDs to tolerate differences in older formats.
- **`SharePointExecutionRecordRepository.spec.ts`**:
  - Add a dedicated unit test `correctly parses date and scheduleItemId when userId is mismatched (e.g. U006 in userId but 6 in key/title)` to verify the fix.

## Verification
- `npx vitest run SharePointExecutionRecordRepository.spec.ts` (Passed)
- `npm run typecheck` (Passed)
- `npm run lint -- --max-warnings=999` (Passed)