### PR TITLE
fix(kiosk): harden ExecutionRecord persistence consistency

### DIFF
--- a/src/features/daily/hooks/__tests__/useExecutionRecord.spec.ts
+++ b/src/features/daily/hooks/__tests__/useExecutionRecord.spec.ts
@@ -1,0 +1,107 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ExecutionRecord } from '../../domain/executionRecordTypes';
+import { useExecutionRecord } from '../useExecutionRecord';
+
+const mockGetRecord = vi.fn<(...args: unknown[]) => Promise<ExecutionRecord | undefined>>();
+const mockUpsertRecord = vi.fn<(...args: unknown[]) => Promise<void>>();
+const mockDeleteRecord = vi.fn<(...args: unknown[]) => Promise<void>>();
+
+vi.mock('../useExecutionData', () => ({
+  useExecutionData: () => ({
+    getRecord: mockGetRecord,
+    upsertRecord: mockUpsertRecord,
+    deleteRecord: mockDeleteRecord,
+  }),
+}));
+
+const legacyRecord: ExecutionRecord = {
+  id: '2026-05-07-legacy-user-legacy-slot',
+  date: '2026-05-07',
+  userId: 'legacy-user',
+  scheduleItemId: 'legacy-slot',
+  status: 'completed',
+  triggeredBipIds: [],
+  memo: 'old memo',
+  recordedBy: 'Staff A',
+  recordedAt: '2026-05-07T09:00:00.000Z',
+};
+
+describe('useExecutionRecord', () => {
+  const fallbackScheduleItemIds = ['legacy-slot'];
+  const fallbackUserIds = ['legacy-user'];
+
+  beforeEach(() => {
+    mockGetRecord.mockReset();
+    mockUpsertRecord.mockReset();
+    mockDeleteRecord.mockReset();
+    mockUpsertRecord.mockResolvedValue(undefined);
+    mockDeleteRecord.mockResolvedValue(undefined);
+  });
+
+  it('updates the concrete record key found through fallback lookup', async () => {
+    mockGetRecord.mockImplementation(async (_date, userId, scheduleItemId) => {
+      if (userId === 'legacy-user' && scheduleItemId === 'legacy-slot') {
+        return legacyRecord;
+      }
+      return undefined;
+    });
+
+    const { result } = renderHook(() =>
+      useExecutionRecord(
+        '2026-05-07',
+        'canonical-user',
+        'canonical-slot',
+        fallbackScheduleItemIds,
+        fallbackUserIds,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(result.current.record).toEqual(legacyRecord);
+    });
+
+    await act(async () => {
+      await result.current.saveRecord('completed', 'new memo');
+    });
+
+    expect(mockUpsertRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: legacyRecord.id,
+        date: legacyRecord.date,
+        userId: legacyRecord.userId,
+        scheduleItemId: legacyRecord.scheduleItemId,
+        memo: 'new memo',
+      }),
+    );
+  });
+
+  it('deletes the concrete record key found through fallback lookup', async () => {
+    mockGetRecord.mockImplementation(async (_date, userId, scheduleItemId) => {
+      if (userId === 'legacy-user' && scheduleItemId === 'legacy-slot') {
+        return legacyRecord;
+      }
+      return undefined;
+    });
+
+    const { result } = renderHook(() =>
+      useExecutionRecord(
+        '2026-05-07',
+        'canonical-user',
+        'canonical-slot',
+        fallbackScheduleItemIds,
+        fallbackUserIds,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(result.current.record).toEqual(legacyRecord);
+    });
+
+    await act(async () => {
+      await result.current.deleteRecord();
+    });
+
+    expect(mockDeleteRecord).toHaveBeenCalledWith('2026-05-07', 'legacy-user', 'legacy-slot');
+  });
+});

--- a/src/features/daily/hooks/useExecutionRecord.ts
+++ b/src/features/daily/hooks/useExecutionRecord.ts
@@ -66,13 +66,26 @@ export function useExecutionRecord(
     void fetchRecord();
   }, [fetchRecord]);
 
+  const resolveMutationTarget = useCallback(() => {
+    const targetDate = record?.date || date;
+    const targetUserId = record?.userId || userId;
+    const targetScheduleItemId = record?.scheduleItemId || scheduleItemId;
+    return {
+      date: targetDate,
+      userId: targetUserId,
+      scheduleItemId: targetScheduleItemId,
+      id: record?.id || makeRecordId(targetDate, targetUserId, targetScheduleItemId),
+    };
+  }, [date, record, scheduleItemId, userId]);
+
   const setStatus = useCallback(
     async (status: RecordStatus) => {
+      const target = resolveMutationTarget();
       const next: ExecutionRecord = {
-        id: makeRecordId(date, userId, scheduleItemId),
-        date,
-        userId,
-        scheduleItemId,
+        id: target.id,
+        date: target.date,
+        userId: target.userId,
+        scheduleItemId: target.scheduleItemId,
         status,
         memo: record?.memo ?? '',
         triggeredBipIds: record?.triggeredBipIds ?? [],
@@ -82,7 +95,7 @@ export function useExecutionRecord(
       setRecord(next);
       await upsertRecordRef.current(next);
     },
-    [date, userId, scheduleItemId, record],
+    [record, resolveMutationTarget],
   );
 
   const setMemo = useCallback(
@@ -101,11 +114,12 @@ export function useExecutionRecord(
 
   const saveRecord = useCallback(
     async (status: RecordStatus, memo?: string, triggeredBipIds?: string[]) => {
+      const target = resolveMutationTarget();
       const next: ExecutionRecord = {
-        id: makeRecordId(date, userId, scheduleItemId),
-        date,
-        userId,
-        scheduleItemId,
+        id: target.id,
+        date: target.date,
+        userId: target.userId,
+        scheduleItemId: target.scheduleItemId,
         status,
         memo: memo !== undefined ? memo : (record?.memo ?? ''),
         triggeredBipIds: triggeredBipIds !== undefined ? triggeredBipIds : (record?.triggeredBipIds ?? []),
@@ -115,13 +129,14 @@ export function useExecutionRecord(
       setRecord(next);
       await upsertRecordRef.current(next);
     },
-    [date, userId, scheduleItemId, record],
+    [record, resolveMutationTarget],
   );
 
   const deleteRecordFn = useCallback(async () => {
-    await deleteRecord(date, userId, scheduleItemId);
+    const target = resolveMutationTarget();
+    await deleteRecord(target.date, target.userId, target.scheduleItemId);
     setRecord(undefined);
-  }, [date, userId, scheduleItemId, deleteRecord]);
+  }, [deleteRecord, resolveMutationTarget]);
 
   return { record, setStatus, setMemo, saveRecord, deleteRecord: deleteRecordFn, isLoading, refresh: fetchRecord } as const;
 }

--- a/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
+++ b/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
@@ -282,7 +282,13 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
     const data: SharePointResponse<JsonRecord> = await response.json();
     if (!data.value || data.value.length === 0) return undefined;
 
-    return this.mapToDomain(data.value[0], rf);
+    const mapped = this.mapToDomain(data.value[0], rf);
+    return {
+      ...mapped,
+      date: normalizedDate,
+      userId: normalizedUserId,
+      scheduleItemId: normalizedScheduleItemId,
+    };
   }
 
   async upsertRecord(record: ExecutionRecord): Promise<void> {
@@ -386,7 +392,7 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
 
     // Sync to local store
     if (this.store) {
-      this.store.upsertRecord(normalizedRecord);
+      this.store.upsertRecord(mergedRecord);
     }
   }
 

--- a/src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts
+++ b/src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts
@@ -216,6 +216,85 @@ describe('SharePointExecutionRecordRepository', () => {
     await expect(repo.upsertRecord(record)).rejects.toThrow('row create failed');
   });
 
+  it('syncs merged memo to the local store after SharePoint upsert', async () => {
+    const mockGetFieldsWithMemo = vi.fn().mockResolvedValue(new Set([
+      'Title',
+      'RecordDate',
+      EXECUTION_RECORD_FIELDS.rowKey,
+      EXECUTION_RECORD_FIELDS.status,
+      EXECUTION_RECORD_FIELDS.parentId,
+      EXECUTION_RECORD_FIELDS.userId,
+      EXECUTION_RECORD_FIELDS.rowNo,
+      EXECUTION_RECORD_FIELDS.memo,
+      EXECUTION_RECORD_FIELDS.recordedAt,
+      EXECUTION_RECORD_FIELDS.bipsJSON,
+      'Payload',
+    ]));
+    const store = {
+      getRecords: vi.fn(() => []),
+      upsertRecord: vi.fn(),
+      deleteRecord: vi.fn(),
+    };
+    const repoWithStore = new SharePointExecutionRecordRepository({
+      spFetch: mockSpFetch,
+      getListFieldInternalNames: mockGetFieldsWithMemo,
+      store,
+    });
+    const record: ExecutionRecord = {
+      id: '2024-01-01-U001-S001',
+      date: '2024-01-01',
+      userId: 'U001',
+      scheduleItemId: 'S001',
+      status: 'completed',
+      memo: 'new memo',
+      recordedAt: '2024-01-01T10:00:00Z',
+      recordedBy: 'Staff A',
+      triggeredBipIds: [],
+    };
+
+    mockSpFetch.mockReset();
+    mockSpFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url.includes('SupportRecord_Daily') && url.includes('/items?$filter=')) {
+        return { ok: true, json: async () => ({ value: [{ Id: 123 }] }) };
+      }
+      if (url.includes('DailyRecordRows') && url.includes('/items?$filter=')) {
+        return {
+          ok: true,
+          json: async () => ({
+            value: [
+              {
+                Id: 456,
+                Title: '2024-01-01-U001-S001',
+                User_x0020_ID: 'U001',
+                RowNo: 'S001',
+                Status: 'completed',
+                Memo: 'existing memo',
+                Recorded_x0020_At: '2024-01-01T09:00:00Z',
+              },
+            ],
+          }),
+        };
+      }
+      if (url.includes('DailyRecordRows') && init?.method === 'POST') {
+        return { ok: true, json: async () => ({ Id: 456 }) };
+      }
+      return { ok: true, json: async () => ({ value: [] }) };
+    });
+
+    await repoWithStore.upsertRecord(record);
+
+    expect(store.upsertRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        memo: expect.stringContaining('existing memo'),
+      }),
+    );
+    expect(store.upsertRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        memo: expect.stringContaining('new memo'),
+      }),
+    );
+  });
+
   it('uses a delimited RowKey prefix with multiple user candidates when fetching records for one user/date', async () => {
     mockSpFetch.mockReset();
     mockSpFetch.mockResolvedValue({
@@ -239,6 +318,42 @@ describe('SharePointExecutionRecordRepository', () => {
     const decodedUrl = decodeURIComponent(String(recordsCall![0]));
     expect(decodedUrl).toContain("startswith(Title, '2026-05-25-17-')");
     expect(decodedUrl).toContain("startswith(Title, '2026-05-25-U017-')");
+  });
+
+  it('returns the queried concrete key from getRecord for legacy fallback mutation', async () => {
+    mockSpFetch.mockReset();
+    mockSpFetch.mockImplementation(async (url: string) => {
+      const decoded = decodeURIComponent(url);
+      if (decoded.includes('DailyRecordRows') && decoded.includes("Title eq '2026-05-20-6-0'")) {
+        return {
+          ok: true,
+          json: async () => ({
+            value: [
+              {
+                Id: 1,
+                Title: '2026-05-20-6-0',
+                User_x0020_ID: 'U006',
+                RowNo: '0',
+                Status: 'completed',
+                Memo: 'legacy memo',
+                Payload: 'legacy memo',
+                Recorded_x0020_At: '2026-05-20T12:00:00Z',
+              },
+            ],
+          }),
+        };
+      }
+      return { ok: true, json: async () => ({ value: [] }) };
+    });
+
+    const record = await repo.getRecord('2026-05-20', '6', '0');
+
+    expect(record).toEqual(expect.objectContaining({
+      date: '2026-05-20',
+      userId: '6',
+      scheduleItemId: '0',
+      memo: 'legacy memo',
+    }));
   });
 
   describe('mapToDomain fallback', () => {

--- a/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
@@ -15,6 +15,10 @@ import {
   buildExecutionUserIdCandidates,
   normalizeScheduleItemId,
 } from '@/features/daily/utils/normalizeExecutionLookup';
+import {
+  parseKioskProcedureMemo,
+  serializeKioskProcedureMemo,
+} from '../domain/kioskProcedureMemo';
 
 const MOOD_CHIPS = ['落ち着いていた', '不安そう', '拒否あり', '興奮あり', '切り替え困難'];
 const ACTION_CHIPS = ['見守り', '声かけ', '環境調整', '活動変更', '距離を取る', 'クールダウン'];
@@ -164,36 +168,23 @@ export const KioskProcedureDetailScreen: React.FC = () => {
     if (isLoading || isInitialized) return;
     
     if (record) {
-      const memoText = record.memo || '';
-      const moodMatch = memoText.match(/【様子】([^\n]+)/);
-      const actionMatch = memoText.match(/【対応】([^\n]+)/);
-      const resultMatch = memoText.match(/【変化】([^\n]+)/);
-      const textMatch = memoText.match(/【メモ】([\s\S]+)/);
-      
-      if (moodMatch) setSelectedMood(moodMatch[1].trim());
-      if (actionMatch) setSelectedAction(actionMatch[1].trim());
-      if (resultMatch) setSelectedResult(resultMatch[1].trim());
-      
-      if (textMatch) {
-        setTextMemo(textMatch[1].trim());
-      } else if (memoText.trim()) {
-        const hasLabels = memoText.includes('【様子】') || memoText.includes('【対応】') || memoText.includes('【変化】');
-        if (!hasLabels) {
-          setTextMemo(memoText.trim());
-        }
-      }
+      const parsedMemo = parseKioskProcedureMemo(record.memo);
+      setSelectedMood(parsedMemo.mood);
+      setSelectedAction(parsedMemo.action);
+      setSelectedResult(parsedMemo.result);
+      setTextMemo(parsedMemo.memo);
     }
     
     setIsInitialized(true);
   }, [record, isLoading, isInitialized]);
 
   const serializeMemo = () => {
-    const parts: string[] = [];
-    if (selectedMood) parts.push(`【様子】${selectedMood}`);
-    if (selectedAction) parts.push(`【対応】${selectedAction}`);
-    if (selectedResult) parts.push(`【変化】${selectedResult}`);
-    if (textMemo.trim()) parts.push(`【メモ】${textMemo.trim()}`);
-    return parts.join('\n');
+    return serializeKioskProcedureMemo({
+      mood: selectedMood,
+      action: selectedAction,
+      result: selectedResult,
+      memo: textMemo,
+    });
   };
 
   const handleSave = async () => {

--- a/src/features/kiosk/components/KioskProcedureHistoryPanel.tsx
+++ b/src/features/kiosk/components/KioskProcedureHistoryPanel.tsx
@@ -22,6 +22,7 @@ import { useHistoricalRecords } from '@/features/daily/hooks/useHistoricalRecord
 import { formatDateShort } from '@/lib/dateFormat';
 import type { ExecutionRecord } from '@/features/daily/domain/legacy/executionRecordTypes';
 import { KioskDailyProcedureFlowPreview } from './KioskDailyProcedureFlowPreview';
+import { parseKioskProcedureMemo } from '../domain/kioskProcedureMemo';
 
 interface KioskProcedureHistoryPanelProps {
   userId: string;
@@ -86,9 +87,8 @@ export const KioskProcedureHistoryPanel: React.FC<KioskProcedureHistoryPanelProp
       // Mood distribution
       const moods: Record<string, number> = {};
       filteredRecords.forEach(r => {
-        const match = r.memo.match(/【様子】([^\n]+)/);
-        if (match) {
-          const mood = match[1].trim();
+        const { mood } = parseKioskProcedureMemo(r.memo);
+        if (mood) {
           moods[mood] = (moods[mood] || 0) + 1;
         }
       });

--- a/src/features/kiosk/domain/__tests__/kioskProcedureMemo.spec.ts
+++ b/src/features/kiosk/domain/__tests__/kioskProcedureMemo.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseKioskProcedureMemo,
+  serializeKioskProcedureMemo,
+} from '../kioskProcedureMemo';
+
+describe('kioskProcedureMemo', () => {
+  it('serializes kiosk procedure memo in the existing label format', () => {
+    expect(
+      serializeKioskProcedureMemo({
+        mood: '不安そう',
+        action: '声かけ',
+        result: '途中で落ち着いた',
+        memo: '追加メモ',
+      }),
+    ).toBe('【様子】不安そう\n【対応】声かけ\n【変化】途中で落ち着いた\n【メモ】追加メモ');
+  });
+
+  it('parses the existing label format', () => {
+    expect(
+      parseKioskProcedureMemo('【様子】落ち着いていた\n【対応】見守り\n【変化】改善した\n【メモ】補足'),
+    ).toEqual({
+      mood: '落ち着いていた',
+      action: '見守り',
+      result: '改善した',
+      memo: '補足',
+    });
+  });
+
+  it('treats unlabeled legacy text as free memo', () => {
+    expect(parseKioskProcedureMemo('ラベルなしの記録')).toEqual({
+      mood: '',
+      action: '',
+      result: '',
+      memo: 'ラベルなしの記録',
+    });
+  });
+
+  it('keeps multiline free memo content', () => {
+    expect(parseKioskProcedureMemo('【様子】不安そう\n【メモ】1行目\n2行目')).toEqual({
+      mood: '不安そう',
+      action: '',
+      result: '',
+      memo: '1行目\n2行目',
+    });
+  });
+});

--- a/src/features/kiosk/domain/kioskProcedureMemo.ts
+++ b/src/features/kiosk/domain/kioskProcedureMemo.ts
@@ -1,0 +1,57 @@
+export type KioskProcedureMemoParts = {
+  mood: string;
+  action: string;
+  result: string;
+  memo: string;
+};
+
+const LABELS = {
+  mood: '様子',
+  action: '対応',
+  result: '変化',
+  memo: 'メモ',
+} as const;
+
+const LABEL_PATTERN = /【(様子|対応|変化|メモ)】([\s\S]*?)(?=\n?【(?:様子|対応|変化|メモ)】|$)/g;
+
+export function parseKioskProcedureMemo(value: unknown): KioskProcedureMemoParts {
+  const raw = String(value ?? '');
+  const parts: KioskProcedureMemoParts = {
+    mood: '',
+    action: '',
+    result: '',
+    memo: '',
+  };
+
+  let hasKnownLabel = false;
+  for (const match of raw.matchAll(LABEL_PATTERN)) {
+    hasKnownLabel = true;
+    const label = match[1];
+    const text = match[2].trim();
+    if (label === LABELS.mood) parts.mood = text;
+    if (label === LABELS.action) parts.action = text;
+    if (label === LABELS.result) parts.result = text;
+    if (label === LABELS.memo) parts.memo = text;
+  }
+
+  if (!hasKnownLabel && raw.trim()) {
+    parts.memo = raw.trim();
+  }
+
+  return parts;
+}
+
+export function serializeKioskProcedureMemo(parts: Partial<KioskProcedureMemoParts>): string {
+  const lines: string[] = [];
+  const mood = parts.mood?.trim();
+  const action = parts.action?.trim();
+  const result = parts.result?.trim();
+  const memo = parts.memo?.trim();
+
+  if (mood) lines.push(`【${LABELS.mood}】${mood}`);
+  if (action) lines.push(`【${LABELS.action}】${action}`);
+  if (result) lines.push(`【${LABELS.result}】${result}`);
+  if (memo) lines.push(`【${LABELS.memo}】${memo}`);
+
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary
- Sync local execution record store with the merged SharePoint upsert result.
- Add pure Kiosk memo parse/serialize helpers.
- Route detail restore/save and history aggregation through the shared memo helpers.
- Use the concrete fallback record key for update/delete mutations.
- Return concrete keys from SharePoint getRecord() for legacy fallback mutation support.

## Scope
- No ExecutionRecord model change.
- No structured Payload persistence.
- No SharePoint column changes.
- No automatic canonical-key migration or legacy-row purge.

## Out of scope
- ExecutionRecord model changes
- SharePoint column changes
- structured Payload persistence
- automatic canonical-key migration
- legacy-row purge

## Verification
- `npx vitest run src/features/kiosk/domain/__tests__/kioskProcedureMemo.spec.ts src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx src/features/kiosk/components/__tests__/KioskProcedureHistoryPanel.spec.tsx src/features/daily/hooks/__tests__/useExecutionRecord.spec.ts src/features/daily/hooks/__tests__/useHistoricalRecords.spec.ts src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts` — 36 tests passed
- `npx eslint src/features/daily/hooks/useExecutionRecord.ts src/features/daily/hooks/__tests__/useExecutionRecord.spec.ts src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts src/features/kiosk/components/KioskProcedureDetailScreen.tsx src/features/kiosk/components/KioskProcedureHistoryPanel.tsx src/features/kiosk/domain/kioskProcedureMemo.ts src/features/kiosk/domain/__tests__/kioskProcedureMemo.spec.ts` — passed
- `git diff --check` — passed
- pre-commit hook: `guard:tz`, `npm run lint`, `npm run typecheck`, lint-staged `eslint --fix` — passed
- `npx tsc --noEmit --pretty false` was executed but currently fails due to broad existing test fixture / type-definition issues outside this diff.

## Notes
The legacy fallback mutation policy intentionally updates/deletes the concrete record found by lookup, rather than migrating it to a canonical key. This keeps the change low-risk and preserves audit semantics.

Follow-up to #2015.