### PR TITLE
fix(kiosk): align procedure user aliases with user master

### DIFF
--- a/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
@@ -19,6 +19,7 @@ import {
   parseKioskProcedureMemo,
   serializeKioskProcedureMemo,
 } from '../domain/kioskProcedureMemo';
+import { resolveProcedureUserQueryCandidates } from '../utils/resolveProcedureUserQuery';
 
 const MOOD_CHIPS = ['落ち着いていた', '不安そう', '拒否あり', '興奮あり', '切り替え困難'];
 const ACTION_CHIPS = ['見守り', '声かけ', '環境調整', '活動変更', '距離を取る', 'クールダウン'];
@@ -75,12 +76,12 @@ export const KioskProcedureDetailScreen: React.FC = () => {
   }, [deepLinkUserId, userId]);
   
   const procedure = React.useMemo(() => {
-    const queryId = user?.UserID || userId;
+    const queryId = resolveProcedureUserQueryCandidates(user, userId);
     if (!queryId || slotKey === undefined) return null;
     const procedures = procedureRepo.getByUser(queryId);
     const index = parseInt(slotKey, 10);
     return procedures[index] || null;
-  }, [userId, user?.UserID, slotKey, procedureRepo]);
+  }, [userId, user, slotKey, procedureRepo]);
 
   // rowNo is the canonical slot identity for kiosk procedure completion tracking.
   // Some procedure IDs can vary by source/runtime, so prefer rowNo for persistence keys.

--- a/src/features/kiosk/components/KioskProcedureListScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureListScreen.tsx
@@ -22,6 +22,7 @@ import { usePlanningSheetRepositories } from '@/features/planning-sheet/hooks/us
 import { usePlanningSheetData } from '@/features/planning-sheet/hooks/usePlanningSheetData';
 import { useCurrentPlanningSheet } from '@/features/planning-sheet/hooks/useCurrentPlanningSheet';
 import { resolveSupportStartDateDetailed } from '@/features/planning-sheet/monitoringSchedule';
+import { resolveProcedureUserQueryCandidates } from '../utils/resolveProcedureUserQuery';
 
 const extractProcedureRowKey = (value: unknown): string => {
   const normalized = normalizeScheduleItemId(value);
@@ -107,10 +108,10 @@ export const KioskProcedureListScreen: React.FC = () => {
   }, [deepLinkUserId, userId]);
 
   const procedures = React.useMemo(() => {
-    const queryId = queryUserIdFromSearch || user?.UserID || userId;
+    const queryId = resolveProcedureUserQueryCandidates(user, userId, queryUserIdFromSearch);
     if (!queryId) return [];
     return procedureRepo.getByUser(queryId);
-  }, [queryUserIdFromSearch, userId, user?.UserID, procedureRepo]);
+  }, [queryUserIdFromSearch, userId, user, procedureRepo]);
   const allPrimaryScheduleKeys = React.useMemo(() => {
     const keys = new Set<string>();
     for (const step of procedures) {
@@ -137,7 +138,7 @@ export const KioskProcedureListScreen: React.FC = () => {
     isLoading: isLoadingPlanningSheet,
   } = usePlanningSheetData(targetPlanningSheetId, planningRepo);
 
-  const queryUserId = queryUserIdFromSearch || user?.UserID || userId || null;
+  const queryUserId = resolveProcedureUserQueryCandidates(user, userId, queryUserIdFromSearch) || null;
   const {
     currentSheet,
     isLoading: isLoadingCurrentSheet,

--- a/src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { KioskProcedureDetailScreen } from '../KioskProcedureDetailScreen';
 import { MemoryRouter } from 'react-router-dom';
+import { resolveProcedureUserQueryCandidates } from '../../utils/resolveProcedureUserQuery';
 
 // Mock dependencies
 const mockNavigate = vi.fn();
@@ -219,5 +220,18 @@ describe('KioskProcedureDetailScreen (memory provider URL for local UI behavior 
       expect(screen.getByText('手順記録の内容を1つ以上入力してください。')).toBeInTheDocument();
     });
     expect(mockSaveRecord).not.toHaveBeenCalled();
+  });
+
+  describe('resolveProcedureUserQueryCandidates alias resolution logic', () => {
+    it('resolves correct candidates and prevents route and user code collision', () => {
+      // Case 1: user has canonical UserID (e.g. U-006)
+      expect(resolveProcedureUserQueryCandidates({ UserID: 'U-006' } as any, '7')).toBe('U-006');
+
+      // Case 2: no user loaded, falls back to route id
+      expect(resolveProcedureUserQueryCandidates(null, '7')).toBe('7');
+
+      // Case 3: query parameter override is present
+      expect(resolveProcedureUserQueryCandidates({ UserID: 'U-006' } as any, '7', 'override-id')).toBe('override-id');
+    });
   });
 });

--- a/src/features/kiosk/utils/resolveProcedureUserQuery.ts
+++ b/src/features/kiosk/utils/resolveProcedureUserQuery.ts
@@ -1,0 +1,32 @@
+import type { IUserMaster } from '@/sharepoint/fields';
+
+/**
+ * Consolidate the user query ID candidates to resolve procedures.
+ * Ensures consistent inputs for `procedureRepo.getByUser()` on both the
+ * List view and Detail view.
+ * 
+ * Under standard business logic:
+ * 1. Prefer the canonical `UserID` (e.g. "U-006") from the loaded User Master record.
+ * 2. Fall back to the raw `routeUserId` (e.g. "7" or "23").
+ * 3. Never let transient numeric IDs mismatch when the master database maps them
+ *    to completely distinct records (e.g. U-023 Fujita vs U-006 Nakamura).
+ */
+export function resolveProcedureUserQueryCandidates(
+  user: IUserMaster | null,
+  routeUserId: string | undefined,
+  queryUserIdFromSearch?: string | null
+): string {
+  // If search query override is provided, respect it.
+  if (queryUserIdFromSearch?.trim()) {
+    return queryUserIdFromSearch.trim();
+  }
+
+  // Prefer canonical UserID (e.g., U-006)
+  const canonical = String(user?.UserID ?? '').trim();
+  if (canonical) {
+    return canonical;
+  }
+
+  // Fall back to raw route identifier (e.g., "7")
+  return String(routeUserId ?? '').trim();
+}

--- a/src/features/planning-sheet/constants/userProcedureDetails.ts
+++ b/src/features/planning-sheet/constants/userProcedureDetails.ts
@@ -358,7 +358,7 @@ function isQueryKatsuragawa(userId: string | number): boolean {
 
 function isQueryNakamura(userId: string | number): boolean {
   const s = String(userId);
-  return s === '7' || s === '23' || s === 'U-006' || s === 'I017' || s === 'I022';
+  return s === '7' || s === 'U-006' || s === 'I017' || s === 'I022';
 }
 
 function isQueryShiota(userId: string | number): boolean {


### PR DESCRIPTION
## Problem
Visiting a Kiosk user detail URL such as `/kiosk/users/23/procedures/0` resulted in "Information not found" even though the list page could identify records.

This was caused by a user ID mapping collision between `DEMO_USERS` and `userProcedureDetails.ts`:

- In `DEMO_USERS`, `Id: 23` is `藤田 康平` / `UserID: U-023` / `IsSupportProcedureTarget: false`.
- In `userProcedureDetails.ts`, numeric ID `23` was registered inside `isQueryNakamura`, the alias map for `中村 裕樹`.
- In `DEMO_USERS`, `中村 裕樹` is actually `Id: 7` / `UserID: U-006`.

As a result, resolving `/kiosk/users/23` loaded `藤田 康平`, then the detail screen queried procedures with `U-023`, producing an empty procedure result.

## Rationale & Proposed Changes
To prevent user identity collisions and keep Kiosk list/detail resolution consistent:

1. Removed stale numeric ID `23` from `isQueryNakamura` in `userProcedureDetails.ts`.
2. Added `resolveProcedureUserQueryCandidates(user, routeUserId, queryUserIdFromSearch)` as a pure helper.
3. Integrated the helper into both `KioskProcedureListScreen.tsx` and `KioskProcedureDetailScreen.tsx`.
4. Added regression tests for the user-resolution behavior.

## Verification
- `npx vitest run src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx` — 9 tests passed
- `npm run typecheck` — passed
- `npm run lint -- --max-warnings=999` — passed
- `git diff --check` — passed

## Critical data-source check
- In `DEMO_USERS`, `Id: 23` is `藤田 康平` / `U-023` / `IsSupportProcedureTarget: false`.
- In `userProcedureDetails.ts`, `23` was previously mapped to `中村 裕樹`.
- Production SharePoint verification confirmed that `中村 裕樹` uses canonical `U-006` and numeric `7`.
- Therefore, `23` was a stale mock/legacy alias and removing it from `isQueryNakamura` is safe.

## Scope
- Aligns Kiosk procedure alias resolution with the user master.
- Keeps list and detail procedure lookup rules consistent.

## Out of scope
- No SharePoint data migration.
- No user master schema change.
- No ExecutionRecord model change.
- No procedure payload/storage format change.