### PR TITLE
fix(kiosk): sync daily flow preview user resolution

### DIFF
--- a/src/features/kiosk/hooks/__tests__/useDailyProcedureFlowPreview.spec.ts
+++ b/src/features/kiosk/hooks/__tests__/useDailyProcedureFlowPreview.spec.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useDailyProcedureFlowPreview } from '../useDailyProcedureFlowPreview';
 import { useExecutionData } from '@/features/daily/hooks/useExecutionData';
 import { useProcedureStore } from '@/features/daily/stores/procedureStore';
+import { useUser } from '@/features/users/useUsers';
 
 // Mock the hooks
 vi.mock('@/features/daily/hooks/useExecutionData', () => ({
@@ -11,6 +12,10 @@ vi.mock('@/features/daily/hooks/useExecutionData', () => ({
 
 vi.mock('@/features/daily/stores/procedureStore', () => ({
   useProcedureStore: vi.fn(),
+}));
+
+vi.mock('@/features/users/useUsers', () => ({
+  useUser: vi.fn(),
 }));
 
 describe('useDailyProcedureFlowPreview', () => {
@@ -28,6 +33,11 @@ describe('useDailyProcedureFlowPreview', () => {
     vi.mocked(useProcedureStore).mockReturnValue({
       getByUser: mockGetByUser,
     } as unknown as ReturnType<typeof useProcedureStore>);
+
+    vi.mocked(useUser).mockReturnValue({
+      data: undefined,
+      status: 'idle',
+    } as any);
   });
 
   it('fetches records, matches them with slots, and returns merged daily steps', async () => {
@@ -86,5 +96,26 @@ describe('useDailyProcedureFlowPreview', () => {
 
     expect(result.current.error).toEqual(fetchError);
     expect(result.current.steps).toHaveLength(0);
+  });
+
+  it('uses resolveProcedureUserQueryCandidates to resolve user ID consistently', async () => {
+    mockGetByUser.mockReturnValue([]);
+    mockGetRecords.mockResolvedValue([]);
+
+    // We pass U001 but mock useUser to return U-001 (canonical UserID)
+    vi.mocked(useUser).mockReturnValue({
+      data: { UserID: 'U-001' },
+      status: 'success',
+    } as any);
+
+    const { result } = renderHook(() => useDailyProcedureFlowPreview('U001', '2026-05-11'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // U-001 should be queried instead of raw U001
+    expect(mockGetRecords).toHaveBeenCalledWith('2026-05-11', 'U-001');
+    expect(mockGetByUser).toHaveBeenCalledWith('U-001');
   });
 });

--- a/src/features/kiosk/hooks/useDailyProcedureFlowPreview.ts
+++ b/src/features/kiosk/hooks/useDailyProcedureFlowPreview.ts
@@ -3,6 +3,7 @@ import { useExecutionData } from '@/features/daily/hooks/useExecutionData';
 import { useProcedureStore } from '@/features/daily/stores/procedureStore';
 import type { ExecutionRecord } from '@/features/daily/domain/legacy/executionRecordTypes';
 import { useUser } from '@/features/users/useUsers';
+import { resolveProcedureUserQueryCandidates } from '../utils/resolveProcedureUserQuery';
 import { 
   buildDailyProcedureFlowPreview, 
   type DailyProcedureFlowStep 
@@ -27,7 +28,7 @@ export function useDailyProcedureFlowPreview(
   }, [getRecords]);
 
   const { data: user } = useUser(userId);
-  const canonicalUserId = user?.UserID || userId;
+  const canonicalUserId = resolveProcedureUserQueryCandidates(user, userId);
 
   const procedureStore = useProcedureStore();
   


### PR DESCRIPTION
## Description
PR #2019で「手順一覧」「手順詳細」におけるユーザー解決ロジックを `resolveProcedureUserQueryCandidates` へ統一しましたが、過去日の「1日の流れプレビュー」（`useDailyProcedureFlowPreview`）が古い `user?.UserID || userId` のままになっていたため、別々のユーザーID解決が走り不整合（未記録の空表示など）が発生していました。

本PRでは、`useDailyProcedureFlowPreview` の ID 解決ロジックに `resolveProcedureUserQueryCandidates` を適用し、画面間での ID 解決ルールを完全に一本化・整合させます。

## Scope
- `src/features/kiosk/hooks/useDailyProcedureFlowPreview.ts`: `resolveProcedureUserQueryCandidates(user, userId)` による ID 解決に修正。
- `src/features/kiosk/hooks/__tests__/useDailyProcedureFlowPreview.spec.ts`: 整合性検証のためのテストを追加・整理。

## Verification
- `npx vitest run src/features/kiosk/hooks/__tests__/useDailyProcedureFlowPreview.spec.ts` (Passed)
- `npx vitest run src/features/kiosk/components/__tests__/KioskDailyProcedureFlowPreview.spec.tsx` (Passed)
- `npx vitest run src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx` (Passed)
- `npm run typecheck` (Passed)
- `npm run lint` (Passed)
- `git diff --check` (Passed)