### PR TITLE
fix(kiosk): reduce startup SharePoint throttling on kiosk routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,6 +48,8 @@ function App() {
     return () => clearInterval(saveInterval);
   }, []);
 
+  const isKiosk = typeof window !== 'undefined' && window.location.pathname.startsWith('/kiosk');
+
   return (
     <MsalProvider>
       <QueryClientProvider client={queryClient}>
@@ -57,8 +59,8 @@ function App() {
             <DataLayerStatusBanner />
             <WriteDisabledBanner />
             <ToastProvider>
-              <DriftMonitor />
-              <RemediationAuditMonitor />
+              {!isKiosk && <DriftMonitor />}
+              {!isKiosk && <RemediationAuditMonitor />}
               <SpInitBridge />
               <DemoProcedureSeeder />
               <ToastNotifierBridge />

--- a/src/app/SpInitBridge.tsx
+++ b/src/app/SpInitBridge.tsx
@@ -44,6 +44,15 @@ export const SpInitBridge: React.FC = () => {
     bootstrapStartedRef.current = true;
 
     const bootstrap = async () => {
+      // 🩺 Bypass heavy list provisioning on Kiosk routes to prevent 429 throttling
+      const isKiosk = typeof window !== 'undefined' && window.location.pathname.startsWith('/kiosk');
+      if (isKiosk) {
+        await loadHolidaysFromSharePoint(sp).catch((err) => {
+          console.warn('[SpInitBridge] Holiday load failed (non-fatal):', err);
+        });
+        return;
+      }
+
       // 1. SharePoint リストの一括プロビジョニング・検証（SharePoint モードのみ）
       // Demo/Smoke モード（VITE_SKIP_SHAREPOINT=1）ではプロビジョニングをスキップして 404 を回避する
       const { shouldSkipSharePoint } = await import('@/lib/env');

--- a/src/features/users/infra/services/UserFieldResolver.ts
+++ b/src/features/users/infra/services/UserFieldResolver.ts
@@ -46,6 +46,7 @@ export class UserFieldResolver {
   private resolvedFields: Record<string, string | undefined> | null = null;
   private fieldStatus: Record<string, UserFieldStatus> | null = null;
   private resolvingPromise: Promise<Record<string, string | undefined> | null> | null = null;
+  private accessoryResolvingPromises = new Map<string, Promise<{ resolvedFields: Record<string, string | undefined>, resolvedKeys: Set<string> }>>();
   private cachedBenefitCutoverStage: CutoverStageValue | null = null;
 
   constructor(
@@ -118,56 +119,71 @@ export class UserFieldResolver {
     candidates: Record<string, string[]>,
     essentials: string[] = []
   ): Promise<{ resolvedFields: Record<string, string | undefined>, resolvedKeys: Set<string> }> {
-    try {
-      const available = await this.provider.getFieldInternalNames(listTitle);
+    const existing = this.accessoryResolvingPromises.get(listTitle);
+    if (existing) return existing;
 
-      const essentialsSet = new Set(essentials);
-      const { resolved } = resolveInternalNamesDetailed(
-        available,
-        candidates,
-        {
-          onDrift: (fieldName, resolutionType, driftType) => {
-            const isEssential = essentialsSet.has(fieldName as string);
-            if (isEssential) {
-              emitDriftRecord(listTitle, fieldName, resolutionType as DriftResolutionType, driftType as DriftType, undefined, 'warn');
-            } else {
-              // Silent drift: log to internal auditLog only, no persistent event
-              auditLog.info('users:drift', `Silent drift detected in non-essential field "${fieldName}" of list "${listTitle}".`, { resolutionType, driftType });
+    const promise = (async () => {
+      try {
+        const available = await this.provider.getFieldInternalNames(listTitle);
+
+        const essentialsSet = new Set(essentials);
+        const { resolved } = resolveInternalNamesDetailed(
+          available,
+          candidates,
+          {
+            onDrift: (fieldName, resolutionType, driftType) => {
+              const isEssential = essentialsSet.has(fieldName as string);
+              if (isEssential) {
+                emitDriftRecord(listTitle, fieldName, resolutionType as DriftResolutionType, driftType as DriftType, undefined, 'warn');
+              } else {
+                // Silent drift: log to internal auditLog only, no persistent event
+                auditLog.info('users:drift', `Silent drift detected in non-essential field "${fieldName}" of list "${listTitle}".`, { resolutionType, driftType });
+              }
             }
           }
+        );
+
+        const bestEffort: Record<string, string | undefined> = {};
+        const resolvedKeys = new Set<string>();
+
+        const hasAnyResolved = Object.values(resolved).some(v => typeof v === 'string' && v.length > 0);
+
+        for (const [key, cands] of Object.entries(candidates)) {
+          if (resolved[key]) {
+            bestEffort[key] = resolved[key] as string;
+            resolvedKeys.add(key);
+          } else if (essentials.includes(key)) {
+            bestEffort[key] = cands[0];
+          } else if (!hasAnyResolved) {
+            // スキーマ情報が十分に観測できない初期状態（例: 空リスト）では
+            // optional も primary 候補へ best-effort でフォールバックして write を阻害しない。
+            bestEffort[key] = cands[0];
+          } else {
+            bestEffort[key] = undefined;
+          }
         }
-      );
-      
-      const bestEffort: Record<string, string | undefined> = {};
-      const resolvedKeys = new Set<string>();
 
-      const hasAnyResolved = Object.values(resolved).some(v => typeof v === 'string' && v.length > 0);
-
-      for (const [key, cands] of Object.entries(candidates)) {
-        if (resolved[key]) {
-          bestEffort[key] = resolved[key] as string;
-          resolvedKeys.add(key);
-        } else if (essentials.includes(key)) {
-          bestEffort[key] = cands[0];
-        } else if (!hasAnyResolved) {
-          // スキーマ情報が十分に観測できない初期状態（例: 空リスト）では
-          // optional も primary 候補へ best-effort でフォールバックして write を阻害しない。
-          bestEffort[key] = cands[0];
-        } else {
-          bestEffort[key] = undefined;
+        return { resolvedFields: bestEffort, resolvedKeys };
+      } catch (err) {
+        if (isAuthRequiredLike(err)) {
+          throw err;
         }
+        const fallback: Record<string, string | undefined> = {};
+        for (const [key, cands] of Object.entries(candidates)) {
+          fallback[key] = essentials.includes(key) ? cands[0] : undefined;
+        }
+        return { resolvedFields: fallback, resolvedKeys: new Set<string>() };
       }
+    })();
 
-      return { resolvedFields: bestEffort, resolvedKeys };
-    } catch (err) {
-      if (isAuthRequiredLike(err)) {
-        throw err;
+    this.accessoryResolvingPromises.set(listTitle, promise);
+
+    try {
+      return await promise;
+    } finally {
+      if (this.accessoryResolvingPromises.get(listTitle) === promise) {
+        this.accessoryResolvingPromises.delete(listTitle);
       }
-      const fallback: Record<string, string | undefined> = {};
-      for (const [key, cands] of Object.entries(candidates)) {
-        fallback[key] = essentials.includes(key) ? cands[0] : undefined;
-      }
-      return { resolvedFields: fallback, resolvedKeys: new Set() };
     }
   }
 

--- a/src/features/users/infra/services/__tests__/UserFieldResolver.spec.ts
+++ b/src/features/users/infra/services/__tests__/UserFieldResolver.spec.ts
@@ -99,5 +99,27 @@ describe('UserFieldResolver', () => {
         resolver.resolveAccessoryFields('accessory_list', candidates, ['essentialField'])
       ).rejects.toThrow(authError);
     });
+
+    it('should singleflight concurrent resolveAccessoryFields calls for the same list', async () => {
+      let resolvePromise: (value: any) => void = () => {};
+      const promise = new Promise((resolve) => {
+        resolvePromise = resolve;
+      });
+      mockProvider.getFieldInternalNames.mockReturnValue(promise);
+
+      const candidates = {
+        essentialField: ['essentialField'],
+      };
+
+      const call1 = resolver.resolveAccessoryFields('accessory_list', candidates, ['essentialField']);
+      const call2 = resolver.resolveAccessoryFields('accessory_list', candidates, ['essentialField']);
+
+      resolvePromise(new Set(['essentialField']));
+
+      const [res1, res2] = await Promise.all([call1, call2]);
+
+      expect(res1).toEqual(res2);
+      expect(mockProvider.getFieldInternalNames).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/lib/sp/spDataProvider.ts
+++ b/src/lib/sp/spDataProvider.ts
@@ -53,6 +53,12 @@ export class SharePointDataProvider implements IDataProvider {
         return;
       }
 
+      // 🩺 Bypass self-healing list provisioning on Kiosk routes to prevent 429 throttling
+      const isKiosk = typeof window !== 'undefined' && window.location.pathname.startsWith('/kiosk');
+      if (isKiosk) {
+        return;
+      }
+
       const entry = findListEntry(name) || SP_LIST_REGISTRY.find(e => 
         e.key.toLowerCase() === name.toLowerCase() || 
         e.resolve().toLowerCase() === name.toLowerCase()

--- a/src/lib/sp/spListSchema.ts
+++ b/src/lib/sp/spListSchema.ts
@@ -37,6 +37,7 @@ import type {
 const DEFAULT_LIST_TEMPLATE = 100;
 const runtimeFieldsCache = new Map<string, FieldsCacheEntry>();
 const inFlightFieldsRequests = new Map<string, Promise<Set<string>>>();
+const inFlightExistingFieldsRequests = new Map<string, Promise<Map<string, ExistingFieldShape>>>();
 
 const cloneFieldSet = (fields: Set<string>): Set<string> => new Set(fields);
 
@@ -143,21 +144,40 @@ export async function fetchExistingFields(
   spFetch: SpFetchFn,
   listTitle: string,
 ): Promise<Map<string, ExistingFieldShape>> {
-  const base = resolveListPath(listTitle);
-  // SharePoint fields endpoint is paged; without $top large lists can hide existing fields,
-  // causing false negatives in ensureListExists() and duplicate-suffixed columns
-  // (e.g. ApprovedBy0, ApprovedBy1 regrowth on Approval_Logs).
-  const path = `${base}/fields?$select=InternalName,TypeAsString,Required,Indexed&$top=5000`;
-  const res = await spFetch(path);
-  const json = (await res.json().catch(() => ({ value: [] }))) as {
-    value?: ExistingFieldShape[];
-  };
-  const map = new Map<string, ExistingFieldShape>();
-  for (const row of json.value ?? []) {
-    if (!row || typeof row.InternalName !== 'string') continue;
-    map.set(row.InternalName, row);
+  const cacheKey = listTitle;
+  const existingRequest = inFlightExistingFieldsRequests.get(cacheKey);
+  if (existingRequest) {
+    return existingRequest;
   }
-  return map;
+
+  const doFetch = async (): Promise<Map<string, ExistingFieldShape>> => {
+    const base = resolveListPath(listTitle);
+    // SharePoint fields endpoint is paged; without $top large lists can hide existing fields,
+    // causing false negatives in ensureListExists() and duplicate-suffixed columns
+    // (e.g. ApprovedBy0, ApprovedBy1 regrowth on Approval_Logs).
+    const path = `${base}/fields?$select=InternalName,TypeAsString,Required,Indexed&$top=5000`;
+    const res = await spFetch(path);
+    const json = (await res.json().catch(() => ({ value: [] }))) as {
+      value?: ExistingFieldShape[];
+    };
+    const map = new Map<string, ExistingFieldShape>();
+    for (const row of json.value ?? []) {
+      if (!row || typeof row.InternalName !== 'string') continue;
+      map.set(row.InternalName, row);
+    }
+    return map;
+  };
+
+  const request = doFetch();
+  inFlightExistingFieldsRequests.set(cacheKey, request);
+
+  try {
+    return await request;
+  } finally {
+    if (inFlightExistingFieldsRequests.get(cacheKey) === request) {
+      inFlightExistingFieldsRequests.delete(cacheKey);
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
## Description
本PRは、キオスク画面（Kiosk routes）の初期ロード時に大量の診断・検証リクエストが並行して走り、SharePoint側で429スロットリング（過負荷エラー）が発生する問題を解決するための「起動時スロットリング対策」です。

### 主な変更点

1. **Kiosk画面における管理者用診断・監視の抑制・遅延 ( / )**
   - パスが `/kiosk` で始まる場合、管理者・監査用の `DriftMonitor` および `RemediationAuditMonitor` を**マウントしない**ように修正しました。
   - `SpInitBridge` で起動時に実行される重いリスト整合性検証（`SharePointProvisioningCoordinator.bootstrap` — 20以上のリストの存在確認）を、`/kiosk` ルートでは**完全にスキップ**するようにしました。

2. **データプロバイダの自己修復（ensureResource）のKioskバイパス (`spDataProvider.ts`)**
   - `/kiosk` ルートでのデータ操作時、不要なリスト構造の再チェックと列フェッチ (`ensureResource`) を**完全にバイパス**するように修正しました。これによってキオスク画面でのDBアクセス負荷が激減します。

3. **共通メタデータ解決層の Singleflight Promise キャッシュ化 (`spListSchema.ts`)**
   - 共通のフィールドメタデータ解決 (`fetchExistingFields`) で、同一リストに対する concurrent なリクエストを **in-flight Promise cache** により一本化し、重複する物理列フェッチ（`/fields?$top=5000`）を完全に防止します。

4. **アクセサリ列解決の Singleflight Promise キャッシュ化 (`UserFieldResolver.ts`)**
   - ユーザー関連アクセサリテーブルの物理列名解決 (`resolveAccessoryFields`) でも、同一リストへの並行リクエストに対して **in-flight Promise cache** による Singleflight を追加しました。

---

## Scope
- `src/App.tsx`
- `src/app/SpInitBridge.tsx`
- `src/lib/sp/spDataProvider.ts`
- `src/lib/sp/spListSchema.ts`
- `src/features/users/infra/services/UserFieldResolver.ts`
- `src/features/users/infra/services/__tests__/UserFieldResolver.spec.ts`

---

## Verification
- `npx vitest run src/features/users/infra/services/__tests__/UserFieldResolver.spec.ts` (Passed, including new singleflight concurrency test)
- `npx vitest run src/lib/sp/__tests__/spListSchema.fields-cache.spec.ts` (Passed)
- `npx vitest run src/lib/sp/__tests__/spFetch.retry-guard.spec.ts` (Passed)
- `npm run typecheck` (Passed)
- `npm run lint` (Passed)
- `git diff --check` (Passed)
