### PR TITLE
fix(kiosk): avoid auth-required bootstrap fatal panel

### DIFF
--- a/src/__tests__/bootstrapFatal.spec.ts
+++ b/src/__tests__/bootstrapFatal.spec.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AuthRequiredError } from '@/lib/errors';
+import { installFatalHandlers } from '../bootstrapFatal';
+
+const dispatchUnhandledRejection = (reason: unknown) => {
+  const event = new Event('unhandledrejection', { cancelable: true }) as Event & {
+    reason: unknown;
+  };
+  event.reason = reason;
+  window.dispatchEvent(event);
+  return event;
+};
+
+describe('bootstrapFatal', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="root"></div>';
+    window.__APP_RENDERED__ = undefined;
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    window.__APP_RENDERED__ = undefined;
+    vi.restoreAllMocks();
+  });
+
+  it('renders bootstrap fatal panel before React has rendered', () => {
+    installFatalHandlers();
+
+    dispatchUnhandledRejection(new Error('chunk failed'));
+
+    expect(document.getElementById('root')?.textContent).toContain('起動エラー (Async Promise)');
+    expect(document.getElementById('root')?.textContent).toContain('chunk failed');
+  });
+
+  it('does not replace the app with a fatal panel after React has rendered', () => {
+    installFatalHandlers();
+    const root = document.getElementById('root');
+    if (root) root.textContent = 'app content';
+    window.__APP_RENDERED__ = true;
+
+    dispatchUnhandledRejection(new Error('runtime data load failed'));
+
+    expect(document.getElementById('root')?.textContent).toBe('app content');
+  });
+
+  it('does not show a bootstrap fatal panel for auth-required rejections', () => {
+    installFatalHandlers();
+
+    const event = dispatchUnhandledRejection(new AuthRequiredError());
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(document.getElementById('root')?.textContent).toBe('');
+  });
+});

--- a/src/bootstrapFatal.ts
+++ b/src/bootstrapFatal.ts
@@ -8,6 +8,18 @@
  * - Displays error detail on screen since console may not be accessible on tablet
  */
 
+import { isAuthRequiredError } from '@/lib/errors';
+
+declare global {
+  interface Window {
+    __APP_RENDERED__?: boolean;
+  }
+}
+
+function isBootstrapFatalActive(): boolean {
+  return typeof window !== 'undefined' && window.__APP_RENDERED__ !== true;
+}
+
 function renderFatalPanel(title: string, detail?: unknown): void {
   const root = document.getElementById('root');
   if (!root) return;
@@ -99,6 +111,7 @@ export function installFatalHandlers(): void {
   window.addEventListener('error', (event: ErrorEvent) => {
     // eslint-disable-next-line no-console
     console.error('[bootstrap] Error event:', event.error ?? event.message);
+    if (!isBootstrapFatalActive()) return;
     renderFatalPanel('起動エラー (Synchronous)', event.error ?? event.message);
   });
 
@@ -106,6 +119,11 @@ export function installFatalHandlers(): void {
   window.addEventListener('unhandledrejection', (event: PromiseRejectionEvent) => {
     // eslint-disable-next-line no-console
     console.error('[bootstrap] Unhandled rejection:', event.reason);
+    if (isAuthRequiredError(event.reason)) {
+      event.preventDefault();
+      return;
+    }
+    if (!isBootstrapFatalActive()) return;
     renderFatalPanel('起動エラー (Async Promise)', event.reason);
   });
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -395,6 +395,9 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     </React.Suspense>
   </ErrorBoundary>
     );
+    if (typeof window !== 'undefined') {
+      window.__APP_RENDERED__ = true;
+    }
 
     const settle = (error?: unknown) => {
       finalizeHydrationSpan(completeRender, error);


### PR DESCRIPTION
## Summary
- Prevent `AUTH_REQUIRED` async rejections from replacing the app with the bootstrap fatal panel.
- Limit bootstrap fatal rendering to failures that occur before the React app has rendered.
- Mark the app as rendered after the React root render call.
- Add focused coverage for bootstrap-time rejection, post-render rejection, and auth-required rejection behavior.

## Root Cause
The production kiosk route `/kiosk/users/23/procedures/1` could load the static HTML successfully, then an unauthenticated SharePoint/MSAL data load rejection (`AuthRequiredError: AUTH_REQUIRED`) was handled by the global bootstrap fatal handler. That replaced the app root with `起動エラー (Async Promise)`, making route loading appear unstable even though the app had already rendered.

## Scope
- Does not change login/session acquisition behavior.
- Does not change SharePoint repository behavior.
- Does not change kiosk route data lookup or user/procedure existence handling.
- Does not address local preview CSP warnings from development-only Firestore/dummy-project setup.

## Verification
- `npx vitest run src/__tests__/bootstrapFatal.spec.ts src/features/kiosk/domain/__tests__/kioskProcedureMemo.spec.ts src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx src/features/kiosk/components/__tests__/KioskProcedureHistoryPanel.spec.tsx src/features/daily/hooks/__tests__/useExecutionRecord.spec.ts src/features/daily/hooks/__tests__/useHistoricalRecords.spec.ts src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts` — 42 tests passed
- `npx eslint src/bootstrapFatal.ts src/main.tsx src/__tests__/bootstrapFatal.spec.ts src/features/daily/hooks/useExecutionRecord.ts src/features/daily/hooks/__tests__/useExecutionRecord.spec.ts src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts src/features/kiosk/components/KioskProcedureDetailScreen.tsx src/features/kiosk/components/KioskProcedureHistoryPanel.tsx src/features/kiosk/domain/kioskProcedureMemo.ts src/features/kiosk/domain/__tests__/kioskProcedureMemo.spec.ts` — passed
- `git diff --check` — passed
- `npm run build` — passed with existing Vite chunk-size/dynamic-import warnings
- Local production preview for `/kiosk/users/23/procedures/1?b=1` no longer renders the bootstrap fatal panel after `AUTH_REQUIRED`; it renders the route-level app UI instead.