### PR TITLE
fix(kiosk): harden footer navigation active state and exit FAB placement

### DIFF
--- a/src/app/components/KioskExitFab.tsx
+++ b/src/app/components/KioskExitFab.tsx
@@ -98,7 +98,7 @@ export const KioskExitFab: React.FC<KioskExitFabProps> = ({ onExit, disablePorta
       <Box
         sx={{
           position: 'fixed',
-          bottom: 16,
+          bottom: 'calc(var(--kiosk-bottom-nav-height, 96px) + env(safe-area-inset-bottom) + 16px)',
           right: 16,
           zIndex: (t) => t.zIndex.modal + 1,
         }}

--- a/src/app/components/KioskNavigation.tsx
+++ b/src/app/components/KioskNavigation.tsx
@@ -12,6 +12,23 @@ import PhoneInTalkIcon from '@mui/icons-material/PhoneInTalk';
 import EditNoteIcon from '@mui/icons-material/EditNote';
 import { appendKioskSearchParams } from '@/features/kiosk/utils/navigation';
 
+type KioskNavItem =
+  | {
+      label: string;
+      icon: React.ReactElement;
+      path: string;
+      testId: string;
+      kind: 'link';
+      activeMatch: (pathname: string) => boolean;
+    }
+  | {
+      label: string;
+      icon: React.ReactElement;
+      testId: string;
+      kind: 'dialog';
+      onClick: () => void;
+    };
+
 /**
  * KioskNavigation - キオスクモード専用のナビゲーションメニュー
  * 
@@ -22,13 +39,14 @@ export const KioskNavigation: React.FC = () => {
   const location = useLocation();
   const navigate = useNavigate();
 
-  const navItems = [
+  const navItems: KioskNavItem[] = [
     {
       label: 'ホーム',
       icon: <HomeIcon />,
       path: '/kiosk',
       testId: 'kiosk-nav-home',
       kind: 'link',
+      activeMatch: (pathname) => pathname === '/kiosk',
     },
     {
       label: '予定',
@@ -36,6 +54,7 @@ export const KioskNavigation: React.FC = () => {
       path: '/schedules/day',
       testId: 'kiosk-nav-schedule',
       kind: 'link',
+      activeMatch: (pathname) => pathname.startsWith('/schedules'),
     },
     {
       label: '通所',
@@ -43,6 +62,7 @@ export const KioskNavigation: React.FC = () => {
       path: '/daily/attendance',
       testId: 'kiosk-nav-attendance',
       kind: 'link',
+      activeMatch: (pathname) => pathname.startsWith('/daily/attendance'),
     },
     {
       label: '記録',
@@ -50,6 +70,7 @@ export const KioskNavigation: React.FC = () => {
       path: '/daily/table',
       testId: 'kiosk-nav-activity',
       kind: 'link',
+      activeMatch: (pathname) => pathname.startsWith('/daily/table'),
     },
     {
       label: '支援手順',
@@ -57,6 +78,7 @@ export const KioskNavigation: React.FC = () => {
       path: '/kiosk/users',
       testId: 'kiosk-nav-procedures',
       kind: 'link',
+      activeMatch: (pathname) => pathname.startsWith('/kiosk/users'),
     },
     {
       label: '受電ログ',
@@ -76,6 +98,7 @@ export const KioskNavigation: React.FC = () => {
 
   return (
     <Paper
+      data-testid="kiosk-navigation"
       elevation={0}
       sx={{
         position: 'fixed',
@@ -114,11 +137,12 @@ export const KioskNavigation: React.FC = () => {
         }}
       >
         {navItems.map((item) => {
-          const isActive = item.kind === 'link' && location.pathname === item.path;
+          const isActive = item.kind === 'link' && item.activeMatch(location.pathname);
           return (
             <Button
               key={item.label}
               data-testid={item.testId}
+              aria-current={isActive ? 'page' : undefined}
               variant={isActive ? 'contained' : 'text'}
               color={isActive ? 'primary' : 'inherit'}
               startIcon={React.cloneElement(item.icon as React.ReactElement, { sx: { fontSize: '1.5rem !important' } })}

--- a/src/styles/kiosk.css
+++ b/src/styles/kiosk.css
@@ -20,6 +20,7 @@
   --kiosk-font-label: 14px;
   --kiosk-font-hero: 24px;
   --kiosk-gap: 12px;
+  --kiosk-bottom-nav-height: 96px;
 
   /* Prevent accidental double-tap zoom & swipe gestures */
   touch-action: manipulation;
@@ -118,7 +119,9 @@
 
 /* キーボード表示時に固定要素を退避 */
 [data-kiosk='true'] [data-testid='kiosk-exit-fab'] {
-  bottom: calc(16px + var(--keyboard-inset, 0px));
+  bottom: calc(
+    var(--kiosk-bottom-nav-height, 96px) + env(safe-area-inset-bottom) + 16px + var(--keyboard-inset, 0px)
+  );
   transition:
     opacity 0.3s ease,
     bottom 0.3s ease;

--- a/tests/e2e/kiosk-home-smoke.spec.ts
+++ b/tests/e2e/kiosk-home-smoke.spec.ts
@@ -132,6 +132,25 @@ test.describe('Kiosk Home Smoke (memory provider for local kiosk flow checks)', 
       await expect(page).toHaveURL(/\/daily\/table(\?.*provider=memory.*)?/);
     });
 
+    test('should keep schedule navigation active after schedule route redirects', async ({ page }) => {
+      await bootKiosk(page, { route: '/kiosk?kiosk=1' });
+
+      const scheduleNav = page.getByTestId('kiosk-nav-schedule');
+      await scheduleNav.click();
+
+      await expect(page).toHaveURL(/\/schedules/);
+      await expect(scheduleNav).toHaveAttribute('aria-current', 'page');
+    });
+
+    test('should keep exit FAB above the bottom navigation', async ({ page }) => {
+      const fabBox = await page.getByTestId('kiosk-exit-fab').boundingBox();
+      const navBox = await page.getByTestId('kiosk-navigation').boundingBox();
+
+      expect(fabBox).not.toBeNull();
+      expect(navBox).not.toBeNull();
+      expect(fabBox!.y + fabBox!.height).toBeLessThanOrEqual(navBox!.y + 1);
+    });
+
     test('should not display regular footer actions twice', async ({ page }) => {
       // 既存の FooterQuickActions のテスト ID が kiosk-nav-* 以外で存在しないことを確認
       const regularFooterAction = page.getByTestId('footer-action-call-log-quick');


### PR DESCRIPTION
## Summary
- Add `activeMatch` support to kiosk footer navigation.
- Keep 「予定」 active for `/schedules` routes, including redirected schedule pages.
- Add `aria-current="page"` to the active kiosk navigation item.
- Move `KioskExitFab` above the bottom navigation area.
- Introduce `--kiosk-bottom-nav-height` and align kiosk keyboard-avoidance spacing with the bottom nav height.
- Add E2E coverage for schedule active state and Exit FAB non-overlap.

## Verification
- `npm run typecheck`
- `npx playwright test tests/e2e/kiosk-home-smoke.spec.ts`
  - 26 passed
- `git diff --check`
- `npx eslint src/app/components/KioskNavigation.tsx src/app/components/KioskExitFab.tsx tests/e2e/kiosk-home-smoke.spec.ts`

## Notes
- `npx tsc --noEmit` still fails due to existing broad test type errors outside this change, mainly ISP / PlanningSheet test typing issues.
- This PR does not change kiosk menu destinations or normal footer behavior.
