### PR TITLE
[codex] feat(kiosk): add toilet guidance board

### DIFF
--- a/src/app/components/KioskNavigation.tsx
+++ b/src/app/components/KioskNavigation.tsx
@@ -10,6 +10,7 @@ import PlayCircleOutlineIcon from '@mui/icons-material/PlayCircleOutline';
 import HistoryIcon from '@mui/icons-material/History';
 import PhoneInTalkIcon from '@mui/icons-material/PhoneInTalk';
 import EditNoteIcon from '@mui/icons-material/EditNote';
+import WcIcon from '@mui/icons-material/Wc';
 import { appendKioskSearchParams } from '@/features/kiosk/utils/navigation';
 
 type KioskNavItem =
@@ -79,6 +80,14 @@ export const KioskNavigation: React.FC = () => {
       testId: 'kiosk-nav-procedures',
       kind: 'link',
       activeMatch: (pathname) => pathname.startsWith('/kiosk/users'),
+    },
+    {
+      label: 'トイレ確認',
+      icon: <WcIcon />,
+      path: '/kiosk/toilet',
+      testId: 'kiosk-nav-toilet',
+      kind: 'link',
+      activeMatch: (pathname) => pathname.startsWith('/kiosk/toilet'),
     },
     {
       label: '受電ログ',

--- a/src/app/navigation/diagnostics/pathUtils.ts
+++ b/src/app/navigation/diagnostics/pathUtils.ts
@@ -138,6 +138,7 @@ export const ORPHAN_ALLOWLIST_DETAILS: AllowlistRoute[] = [
   { path: '/schedule-ops', category: 'Drilldown', reason: 'スケジュール運用ページ（スケジュール画面からリンク経由）' },
   { path: '/users/hub/:userId', category: 'Detail', reason: '利用者の「活動・実績ハブ」画面（利用者詳細からリンク経由）' },
   { path: '/kiosk', category: 'Kiosk', reason: 'キオスクモード専用 — キオスク入口画面（通常Navに露出しない）' },
+  { path: '/kiosk/toilet', category: 'Kiosk', reason: 'キオスクモード専用 — トイレ確認画面（キオスク下部メニューからリンク）' },
   { path: '/kiosk-users', category: 'Kiosk', reason: 'キオスクモード専用 — 利用者選択画面（通常Navに露出しない）' },
   { path: '/kiosk-procedures', category: 'Kiosk', reason: 'キオスクモード専用 — 支援手順一覧画面（通常Navに露出しない）' },
 ].map(item => ({ ...item, path: normalizeRouterPath(item.path) }));

--- a/src/app/routes/appRoutePaths.ts
+++ b/src/app/routes/appRoutePaths.ts
@@ -103,6 +103,7 @@ export const APP_ROUTE_PATHS = [
   'monitoring-meeting/:userId',
   'call-logs',
   'kiosk',
+  'kiosk/toilet',
   'kiosk-users',
   'kiosk-procedures',
 ] as const;

--- a/src/app/routes/kioskRoutes.tsx
+++ b/src/app/routes/kioskRoutes.tsx
@@ -7,6 +7,7 @@ import {
   SuspendedKioskUserSelectPage,
   SuspendedKioskProcedureListPage,
   SuspendedKioskProcedureDetailPage,
+  SuspendedKioskToiletPage,
 } from './lazyPages';
 import ProtectedRoute from '@/app/ProtectedRoute';
 
@@ -23,6 +24,10 @@ export const kioskRoutes: RouteObject[] = [
       {
         index: true,
         element: <SuspendedKioskHomePage />,
+      },
+      {
+        path: 'toilet',
+        element: <SuspendedKioskToiletPage />,
       },
       {
         path: 'users',

--- a/src/app/routes/lazyPages.tsx
+++ b/src/app/routes/lazyPages.tsx
@@ -206,3 +206,5 @@ const KioskProcedureListPage = React.lazy(() => import('@/pages/kiosk/KioskProce
 export const SuspendedKioskProcedureListPage = createSuspended(KioskProcedureListPage, '支援手順一覧を読み込んでいます…');
 const KioskProcedureDetailPage = React.lazy(() => import('@/pages/kiosk/KioskProcedureDetailPage'));
 export const SuspendedKioskProcedureDetailPage = createSuspended(KioskProcedureDetailPage, '手順詳細を読み込んでいます…');
+const KioskToiletPage = React.lazy(() => import('@/pages/kiosk/KioskToiletPage'));
+export const SuspendedKioskToiletPage = createSuspended(KioskToiletPage, 'トイレ確認を読み込んでいます…');

--- a/src/features/kiosk/toilet/ToiletDailyBoard.tsx
+++ b/src/features/kiosk/toilet/ToiletDailyBoard.tsx
@@ -1,0 +1,349 @@
+import React from 'react';
+import {
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  Grid,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
+import { Link as RouterLink, useLocation } from 'react-router-dom';
+import { toLocalDateISO } from '@/utils/getNow';
+import { useUsers } from '@/features/users/useUsers';
+import type { IUserMaster } from '@/features/users/types';
+import { appendKioskSearchParams } from '../utils/navigation';
+import {
+  TOILET_AMOUNT_LABELS,
+  TOILET_GUIDANCE_TARGET_USER_IDS,
+  TOILET_TYPE_LABELS,
+  type ToiletAmount,
+  type ToiletRecord,
+  type ToiletType,
+} from './types';
+import { useToiletRecords } from './useToiletRecords';
+
+type FormState = {
+  occurredAt: string;
+  toiletType: ToiletType;
+  amount: ToiletAmount;
+  memo: string;
+};
+
+const toMinuteInputValue = (date: Date): string => {
+  const yyyy = date.getFullYear();
+  const mm = String(date.getMonth() + 1).padStart(2, '0');
+  const dd = String(date.getDate()).padStart(2, '0');
+  const hh = String(date.getHours()).padStart(2, '0');
+  const mi = String(date.getMinutes()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}T${hh}:${mi}`;
+};
+
+const formatRecordTime = (occurredAt: string): string => {
+  const date = new Date(occurredAt);
+  if (Number.isNaN(date.getTime())) return occurredAt.slice(11, 16);
+  return date.toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' });
+};
+
+const resolveUserKey = (user: IUserMaster): string => user.UserID || String(user.Id);
+
+const findLatestRecord = (records: ToiletRecord[], userId: string): ToiletRecord | undefined =>
+  records.find((record) => record.userId === userId);
+
+const toiletTargetUserIds = new Set<string>(TOILET_GUIDANCE_TARGET_USER_IDS);
+
+export const ToiletDailyBoard: React.FC = () => {
+  const location = useLocation();
+  const todayIso = toLocalDateISO(new Date());
+  const { data: users, isLoading } = useUsers({ selectMode: 'core' });
+  const { records, create } = useToiletRecords(todayIso);
+  const [selectedUser, setSelectedUser] = React.useState<IUserMaster | null>(null);
+  const [form, setForm] = React.useState<FormState>({
+    occurredAt: toMinuteInputValue(new Date()),
+    toiletType: 'urination',
+    amount: 'normal',
+    memo: '',
+  });
+
+  const targetUsers = React.useMemo(
+    () =>
+      users
+        .filter((user) => user.IsActive !== false)
+        .filter((user) => toiletTargetUserIds.has(resolveUserKey(user))),
+    [users],
+  );
+
+  const rows = React.useMemo(
+    () =>
+      targetUsers.map((user) => {
+        const latestRecord = findLatestRecord(records, resolveUserKey(user));
+        return { user, latestRecord, recorded: Boolean(latestRecord) };
+      }),
+    [records, targetUsers],
+  );
+
+  const recordedCount = rows.filter((row) => row.recorded).length;
+  const unrecordedCount = rows.length - recordedCount;
+  const recordsByUserKey = React.useMemo(() => {
+    const grouped = new Map<string, ToiletRecord[]>();
+    records.forEach((record) => {
+      const existing = grouped.get(record.userId) ?? [];
+      grouped.set(record.userId, [...existing, record]);
+    });
+    return grouped;
+  }, [records]);
+
+  const openForm = (user: IUserMaster) => {
+    setSelectedUser(user);
+    setForm({
+      occurredAt: toMinuteInputValue(new Date()),
+      toiletType: 'urination',
+      amount: 'normal',
+      memo: '',
+    });
+  };
+
+  const handleSave = () => {
+    if (!selectedUser) return;
+    create({
+      userId: resolveUserKey(selectedUser),
+      occurredAt: new Date(form.occurredAt).toISOString(),
+      toiletType: form.toiletType,
+      amount: form.amount,
+      memo: form.memo,
+      recorderName: 'kiosk',
+    });
+    setSelectedUser(null);
+  };
+
+  return (
+    <Box data-testid="toilet-daily-board" sx={{ p: { xs: 2, md: 4 }, pb: 16, maxWidth: 1040, mx: 'auto' }}>
+      <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 3 }}>
+        <IconButton
+          component={RouterLink}
+          to={appendKioskSearchParams('/kiosk', location.search)}
+          sx={{ bgcolor: 'action.hover' }}
+          data-testid="toilet-board-back"
+          aria-label="キオスクへ戻る"
+        >
+          <ArrowBackIcon />
+        </IconButton>
+        <Box sx={{ minWidth: 0, flex: 1 }}>
+          <Typography variant="h5" component="h1" sx={{ fontWeight: 900 }}>
+            本日のトイレ確認
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {todayIso}
+          </Typography>
+        </Box>
+        <Chip
+          data-testid="toilet-board-summary"
+          color={unrecordedCount > 0 ? 'warning' : 'success'}
+          label={`未記録 ${unrecordedCount}名 / 記録済み ${recordedCount}名`}
+          sx={{ height: 40, borderRadius: 2, fontWeight: 800, fontSize: '0.95rem' }}
+        />
+      </Stack>
+
+      {isLoading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress size={48} />
+        </Box>
+      ) : (
+        <Stack spacing={3}>
+          <Grid container spacing={1.5}>
+            {rows.map(({ user, latestRecord, recorded }) => (
+              <Grid key={user.Id} size={12}>
+                <Paper
+                  data-testid={`toilet-user-row-${resolveUserKey(user)}`}
+                  variant="outlined"
+                  sx={{
+                    p: { xs: 1.5, md: 2 },
+                    borderRadius: 2,
+                    borderColor: recorded ? 'success.light' : 'warning.light',
+                    bgcolor: recorded ? 'rgba(46, 125, 50, 0.06)' : 'rgba(237, 108, 2, 0.08)',
+                  }}
+                >
+                  <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5} alignItems={{ xs: 'stretch', sm: 'center' }}>
+                    <Chip
+                      icon={recorded ? <CheckCircleIcon /> : <ErrorOutlineIcon />}
+                      color={recorded ? 'success' : 'warning'}
+                      label={recorded ? '済' : '未'}
+                      sx={{ width: 72, borderRadius: 2, fontWeight: 900 }}
+                    />
+                    <Box sx={{ flex: 1, minWidth: 0 }}>
+                      <Typography variant="h6" sx={{ fontWeight: 900, lineHeight: 1.2 }}>
+                        {user.FullName}
+                      </Typography>
+                      <Typography data-testid={`toilet-user-latest-${resolveUserKey(user)}`} color="text.secondary" sx={{ mt: 0.5 }}>
+                        {latestRecord
+                          ? `${formatRecordTime(latestRecord.occurredAt)} ${TOILET_TYPE_LABELS[latestRecord.toiletType]} ${TOILET_AMOUNT_LABELS[latestRecord.amount]}`
+                          : '最終記録なし'}
+                      </Typography>
+                    </Box>
+                    <Button
+                      data-testid={`toilet-record-button-${resolveUserKey(user)}`}
+                      variant={recorded ? 'outlined' : 'contained'}
+                      color={recorded ? 'primary' : 'warning'}
+                      startIcon={<AddCircleOutlineIcon />}
+                      onClick={() => openForm(user)}
+                      sx={{ minHeight: 48, px: 3, borderRadius: 2, fontWeight: 900 }}
+                    >
+                      {recorded ? '追加記録' : '記録する'}
+                    </Button>
+                  </Stack>
+                </Paper>
+              </Grid>
+            ))}
+
+            {rows.length === 0 && (
+              <Grid size={12}>
+                <Paper variant="outlined" sx={{ p: 5, textAlign: 'center', borderRadius: 2 }}>
+                  <Typography color="text.secondary">トイレ誘導対象の利用者がいません</Typography>
+                </Paper>
+              </Grid>
+            )}
+          </Grid>
+
+          <Paper data-testid="toilet-record-history" variant="outlined" sx={{ p: { xs: 1.5, md: 2 }, borderRadius: 2 }}>
+            <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1.5 }}>
+              <Typography variant="h6" component="h2" sx={{ fontWeight: 900 }}>
+                本日の全記録（個人別）
+              </Typography>
+              <Chip label={`${records.length}件`} size="small" sx={{ borderRadius: 1, fontWeight: 800 }} />
+            </Stack>
+            <Stack spacing={1.25}>
+              {targetUsers.map((user) => {
+                const userKey = resolveUserKey(user);
+                const userRecords = recordsByUserKey.get(userKey) ?? [];
+
+                return (
+                  <Box
+                    key={userKey}
+                    data-testid={`toilet-history-user-${userKey}`}
+                    sx={{
+                      p: 1.25,
+                      border: '1px solid',
+                      borderColor: 'divider',
+                      borderRadius: 1.5,
+                    }}
+                  >
+                    <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: userRecords.length > 0 ? 1 : 0 }}>
+                      <Typography sx={{ fontWeight: 900 }}>{user.FullName}</Typography>
+                      <Chip label={`${userRecords.length}件`} size="small" variant="outlined" sx={{ borderRadius: 1, fontWeight: 800 }} />
+                    </Stack>
+
+                    {userRecords.length === 0 ? (
+                      <Typography color="text.secondary">記録なし</Typography>
+                    ) : (
+                      <Stack spacing={0.75}>
+                        {userRecords.map((record) => (
+                          <Box
+                            key={record.id}
+                            data-testid={`toilet-history-record-${record.id}`}
+                            sx={{
+                              display: 'grid',
+                              gridTemplateColumns: { xs: '1fr', sm: '96px 120px 120px 1fr' },
+                              gap: { xs: 0.5, sm: 1.5 },
+                              alignItems: 'center',
+                              p: 1,
+                              borderRadius: 1.25,
+                              bgcolor: 'action.hover',
+                            }}
+                          >
+                            <Typography sx={{ fontWeight: 900 }}>{formatRecordTime(record.occurredAt)}</Typography>
+                            <Typography color="text.secondary">{TOILET_TYPE_LABELS[record.toiletType]}</Typography>
+                            <Typography color="text.secondary">{TOILET_AMOUNT_LABELS[record.amount]}</Typography>
+                            <Typography color="text.secondary">{record.memo || 'メモなし'}</Typography>
+                          </Box>
+                        ))}
+                      </Stack>
+                    )}
+                  </Box>
+                );
+              })}
+            </Stack>
+          </Paper>
+        </Stack>
+      )}
+
+      <Dialog open={Boolean(selectedUser)} onClose={() => setSelectedUser(null)} fullWidth maxWidth="sm">
+        <DialogTitle sx={{ fontWeight: 900 }}>
+          {selectedUser ? `${selectedUser.FullName}さんのトイレ記録` : 'トイレ記録'}
+        </DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} sx={{ pt: 1 }}>
+            <TextField
+              label="利用者"
+              value={selectedUser?.FullName ?? ''}
+              InputProps={{ readOnly: true }}
+              fullWidth
+            />
+            <TextField
+              label="時間"
+              type="datetime-local"
+              value={form.occurredAt}
+              onChange={(event) => setForm((prev) => ({ ...prev, occurredAt: event.target.value }))}
+              fullWidth
+              InputLabelProps={{ shrink: true }}
+            />
+            <FormControl fullWidth>
+              <InputLabel id="toilet-type-label">種類</InputLabel>
+              <Select
+                labelId="toilet-type-label"
+                label="種類"
+                value={form.toiletType}
+                onChange={(event) => setForm((prev) => ({ ...prev, toiletType: event.target.value as ToiletType }))}
+              >
+                {Object.entries(TOILET_TYPE_LABELS).map(([value, label]) => (
+                  <MenuItem key={value} value={value}>{label}</MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <FormControl fullWidth>
+              <InputLabel id="toilet-amount-label">量</InputLabel>
+              <Select
+                labelId="toilet-amount-label"
+                label="量"
+                value={form.amount}
+                onChange={(event) => setForm((prev) => ({ ...prev, amount: event.target.value as ToiletAmount }))}
+              >
+                {Object.entries(TOILET_AMOUNT_LABELS).map(([value, label]) => (
+                  <MenuItem key={value} value={value}>{label}</MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <TextField
+              label="メモ"
+              value={form.memo}
+              onChange={(event) => setForm((prev) => ({ ...prev, memo: event.target.value }))}
+              multiline
+              minRows={3}
+              fullWidth
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 3 }}>
+          <Button onClick={() => setSelectedUser(null)}>キャンセル</Button>
+          <Button data-testid="toilet-record-save" variant="contained" onClick={handleSave}>
+            保存
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+};

--- a/src/features/kiosk/toilet/toiletRecordRepository.ts
+++ b/src/features/kiosk/toilet/toiletRecordRepository.ts
@@ -1,0 +1,57 @@
+import type { ToiletRecord, ToiletRecordInput } from './types';
+import { toLocalDateISO } from '@/utils/getNow';
+
+const STORAGE_KEY = 'kiosk.toiletRecords.v1';
+
+type StorageShape = {
+  version: 1;
+  records: ToiletRecord[];
+};
+
+const emptyStorage = (): StorageShape => ({ version: 1, records: [] });
+
+const readStorage = (): StorageShape => {
+  if (typeof window === 'undefined') return emptyStorage();
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return emptyStorage();
+    const parsed = JSON.parse(raw) as Partial<StorageShape>;
+    if (parsed.version !== 1 || !Array.isArray(parsed.records)) return emptyStorage();
+    return { version: 1, records: parsed.records };
+  } catch {
+    return emptyStorage();
+  }
+};
+
+const writeStorage = (shape: StorageShape): void => {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(shape));
+};
+
+export const listToiletRecordsByDate = (dateIso: string): ToiletRecord[] => {
+  return readStorage().records
+    .filter((record) => !record.isDeleted && toLocalDateISO(new Date(record.occurredAt)) === dateIso)
+    .sort((a, b) => b.occurredAt.localeCompare(a.occurredAt));
+};
+
+export const createToiletRecord = (input: ToiletRecordInput): ToiletRecord => {
+  const now = new Date().toISOString();
+  const record: ToiletRecord = {
+    id: `toilet-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    userId: input.userId,
+    occurredAt: input.occurredAt,
+    toiletType: input.toiletType,
+    amount: input.amount,
+    memo: input.memo?.trim() ?? '',
+    recorderName: input.recorderName?.trim() ?? '',
+    source: 'kiosk',
+    isDeleted: false,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  const storage = readStorage();
+  writeStorage({ version: 1, records: [record, ...storage.records] });
+  return record;
+};

--- a/src/features/kiosk/toilet/types.ts
+++ b/src/features/kiosk/toilet/types.ts
@@ -1,0 +1,43 @@
+export const TOILET_GUIDANCE_TARGET_USER_IDS = [
+  'I005',
+] as const;
+
+export type ToiletType = 'urination' | 'bowel' | 'both' | 'other';
+export type ToiletAmount = 'small' | 'normal' | 'large' | 'unknown';
+
+export type ToiletRecord = {
+  id: string;
+  userId: string;
+  occurredAt: string;
+  toiletType: ToiletType;
+  amount: ToiletAmount;
+  memo: string;
+  recorderName: string;
+  source: 'kiosk';
+  isDeleted: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ToiletRecordInput = {
+  userId: string;
+  occurredAt: string;
+  toiletType: ToiletType;
+  amount: ToiletAmount;
+  memo?: string;
+  recorderName?: string;
+};
+
+export const TOILET_TYPE_LABELS: Record<ToiletType, string> = {
+  urination: '排尿',
+  bowel: '排便',
+  both: '両方',
+  other: 'その他',
+};
+
+export const TOILET_AMOUNT_LABELS: Record<ToiletAmount, string> = {
+  small: '少量',
+  normal: '普通',
+  large: '多量',
+  unknown: '不明',
+};

--- a/src/features/kiosk/toilet/types.ts
+++ b/src/features/kiosk/toilet/types.ts
@@ -1,5 +1,6 @@
 export const TOILET_GUIDANCE_TARGET_USER_IDS = [
   'I005',
+  'I022',
 ] as const;
 
 export type ToiletType = 'urination' | 'bowel' | 'both' | 'other';

--- a/src/features/kiosk/toilet/useToiletRecords.ts
+++ b/src/features/kiosk/toilet/useToiletRecords.ts
@@ -1,0 +1,23 @@
+import { useCallback, useEffect, useState } from 'react';
+import { createToiletRecord, listToiletRecordsByDate } from './toiletRecordRepository';
+import type { ToiletRecord, ToiletRecordInput } from './types';
+
+export function useToiletRecords(dateIso: string) {
+  const [records, setRecords] = useState<ToiletRecord[]>([]);
+
+  const refresh = useCallback(() => {
+    setRecords(listToiletRecordsByDate(dateIso));
+  }, [dateIso]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const create = useCallback((input: ToiletRecordInput) => {
+    const record = createToiletRecord(input);
+    refresh();
+    return record;
+  }, [refresh]);
+
+  return { records, create, refresh };
+}

--- a/src/pages/kiosk/KioskToiletPage.tsx
+++ b/src/pages/kiosk/KioskToiletPage.tsx
@@ -1,0 +1,5 @@
+import { ToiletDailyBoard } from '@/features/kiosk/toilet/ToiletDailyBoard';
+
+export default function KioskToiletPage() {
+  return <ToiletDailyBoard />;
+}

--- a/tests/e2e/kiosk-home-smoke.spec.ts
+++ b/tests/e2e/kiosk-home-smoke.spec.ts
@@ -110,6 +110,7 @@ test.describe('Kiosk Home Smoke (memory provider for local kiosk flow checks)', 
       await expect(page.getByTestId('kiosk-nav-attendance')).toBeVisible({ timeout: 15000 });
       await expect(page.getByTestId('kiosk-nav-activity')).toBeVisible({ timeout: 15000 });
       await expect(page.getByTestId('kiosk-nav-procedures')).toBeVisible({ timeout: 15000 });
+      await expect(page.getByTestId('kiosk-nav-toilet')).toBeVisible({ timeout: 15000 });
       await expect(page.getByTestId('kiosk-nav-calllog')).toBeVisible({ timeout: 15000 });
       await expect(page.getByTestId('kiosk-nav-handoff')).toBeVisible({ timeout: 15000 });
     });
@@ -130,6 +131,24 @@ test.describe('Kiosk Home Smoke (memory provider for local kiosk flow checks)', 
     test('should navigate to records from navigation and maintain params', async ({ page }) => {
       await page.getByTestId('kiosk-nav-activity').click();
       await expect(page).toHaveURL(/\/daily\/table(\?.*provider=memory.*)?/);
+    });
+
+    test('should navigate to toilet board and mark a target user recorded', async ({ page }) => {
+      await page.getByTestId('kiosk-nav-toilet').click();
+
+      await expect(page).toHaveURL(/\/kiosk\/toilet(\?.*provider=memory.*)?/);
+      await expect(page.getByTestId('toilet-daily-board')).toBeVisible();
+      await expect(page.getByTestId('toilet-board-summary')).toContainText('未記録 1名 / 記録済み 0名');
+
+      await page.getByTestId('toilet-record-button-I005').click();
+      await expect(page.getByRole('heading', { name: /石渡 由喜子さんのトイレ記録/ })).toBeVisible();
+      await page.getByTestId('toilet-record-save').click();
+
+      await expect(page.getByTestId('toilet-board-summary')).toContainText('未記録 0名 / 記録済み 1名');
+      await expect(page.getByTestId('toilet-user-latest-I005')).toContainText('排尿 普通');
+      await expect(page.getByTestId('toilet-record-history')).toContainText('本日の全記録（個人別）');
+      await expect(page.getByTestId('toilet-history-user-I005')).toContainText('石渡 由喜子');
+      await expect(page.getByTestId('toilet-history-user-I005')).toContainText('1件');
     });
 
     test('should keep schedule navigation active after schedule route redirects', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Add a kiosk footer navigation item for `トイレ確認` and route it to `/kiosk/toilet`.
- Add a daily toilet guidance board for checking whether the target user has a toilet record today.
- Add a quick record form backed by local in-browser storage for PR-A UX validation.
- Show latest record status per user and a per-user view of all records for the day.

## Notes
- Toilet guidance target users are currently controlled by `TOILET_GUIDANCE_TARGET_USER_IDS`.
- This PR intentionally does not add User Master columns or SharePoint schema changes.
- The current fixed target list contains `I005` (石渡 由喜子) and `I022` (中村 裕樹).
- Records are stored in browser localStorage only in this PR; SharePoint persistence is intentionally deferred to PR-B.
- A follow-up PR will replace the fixed target list with `user.RequiresToiletGuidance === true` while keeping UserID-based save/match keys.

## Validation
- Commit hook: `guard:tz`, `eslint --ext .ts,.tsx src --max-warnings=200`, `tsc -p tsconfig.build.json --noEmit`, `lint-staged eslint --fix`
- `npm run typecheck`
- `npx playwright test tests/e2e/kiosk-home-smoke.spec.ts -g "toilet board" --project=chromium --reporter=line`
- `npx vitest run tests/unit/app/navigation/nav-router-consistency.spec.ts tests/unit/pages/NavigationDiagnosticsPage.spec.tsx --reporter=verbose`
