### PR TITLE
fix(toilet-records): resolve SharePoint field names dynamically

### DIFF
--- a/src/features/kiosk/toilet/SharePointToiletRecordRepository.ts
+++ b/src/features/kiosk/toilet/SharePointToiletRecordRepository.ts
@@ -84,10 +84,25 @@ export class SharePointToiletRecordRepository implements IToiletRecordRepository
     await this.initFields(listTitle);
 
     const recordDateField = this.rfFallback('recordDate');
-    const filter = `(${recordDateField} eq '${dateIso}') and (IsDeleted ne true)`;
+    const isDeletedField = this.rfFallback('isDeleted');
+    const filter = `(${recordDateField} eq '${dateIso}') and (${isDeletedField} ne true)`;
     
     // OData query
-    const select = ['Id', 'Title', 'Created', 'Modified', 'UserId', 'RecordDate', 'OccurredAt', 'ToiletType', 'Amount', 'Memo', 'RecorderName', 'Source', 'IsDeleted'];
+    const select = [
+      'Id',
+      'Title',
+      'Created',
+      'Modified',
+      this.rfFallback('userId'),
+      recordDateField,
+      this.rfFallback('occurredAt'),
+      this.rfFallback('toiletType'),
+      this.rfFallback('amount'),
+      this.rfFallback('memo'),
+      this.rfFallback('recorderName'),
+      this.rfFallback('source'),
+      isDeletedField,
+    ];
     const selectQuery = select.join(',');
 
     const url = `/lists/getbytitle('${encodeURIComponent(listTitle)}')/items?$filter=${encodeURIComponent(filter)}&$select=${selectQuery}`;
@@ -116,13 +131,13 @@ export class SharePointToiletRecordRepository implements IToiletRecordRepository
       Title: recordId,
       [this.rfFallback('userId')]: input.userId,
       [this.rfFallback('recordDate')]: recordDate,
-      OccurredAt: input.occurredAt,
-      ToiletType: input.toiletType,
-      Amount: input.amount,
-      Memo: input.memo?.trim() ?? '',
-      RecorderName: input.recorderName?.trim() ?? 'kiosk',
-      Source: 'kiosk',
-      IsDeleted: false,
+      [this.rfFallback('occurredAt')]: input.occurredAt,
+      [this.rfFallback('toiletType')]: input.toiletType,
+      [this.rfFallback('amount')]: input.amount,
+      [this.rfFallback('memo')]: input.memo?.trim() ?? '',
+      [this.rfFallback('recorderName')]: input.recorderName?.trim() ?? 'kiosk',
+      [this.rfFallback('source')]: 'kiosk',
+      [this.rfFallback('isDeleted')]: false,
     };
 
     const body = this.filterPayload(rawPayload);
@@ -147,21 +162,30 @@ export class SharePointToiletRecordRepository implements IToiletRecordRepository
 
   private mapToDomain(item: JsonRecord): ToiletRecord {
     const title = (item.Title || '') as string;
-    const isDeletedRaw = item.IsDeleted;
+    const isDeletedField = this.rfFallback('isDeleted');
+    const isDeletedRaw = item[isDeletedField] ?? item.IsDeleted;
     const isDeleted = typeof isDeletedRaw === 'boolean' ? isDeletedRaw : isDeletedRaw === 'true' || isDeletedRaw === 1;
 
-    const recordDateRaw = (item.RecordDate || item.recordDate || '') as string;
+    const recordDateField = this.rfFallback('recordDate');
+    const recordDateRaw = (item[recordDateField] ?? item.RecordDate ?? item.recordDate ?? '') as string;
     const recordDate = recordDateRaw ? recordDateRaw.slice(0, 10) : '';
+
+    const userIdField = this.rfFallback('userId');
+    const occurredAtField = this.rfFallback('occurredAt');
+    const toiletTypeField = this.rfFallback('toiletType');
+    const amountField = this.rfFallback('amount');
+    const memoField = this.rfFallback('memo');
+    const recorderNameField = this.rfFallback('recorderName');
 
     return {
       id: title || String(item.Id),
-      userId: (item.UserId || item.userId || '') as string,
+      userId: (item[userIdField] ?? item.UserId ?? item.userId ?? '') as string,
       recordDate,
-      occurredAt: (item.OccurredAt || item.occurredAt || item.Created || '') as string,
-      toiletType: (item.ToiletType || item.toiletType || 'urination') as ToiletRecord['toiletType'],
-      amount: (item.Amount || item.amount || 'normal') as ToiletRecord['amount'],
-      memo: (item.Memo || item.memo || '') as string,
-      recorderName: (item.RecorderName || item.recorderName || '') as string,
+      occurredAt: (item[occurredAtField] ?? item.OccurredAt ?? item.occurredAt ?? item.Created ?? '') as string,
+      toiletType: (item[toiletTypeField] ?? item.ToiletType ?? item.toiletType ?? 'urination') as ToiletRecord['toiletType'],
+      amount: (item[amountField] ?? item.Amount ?? item.amount ?? 'normal') as ToiletRecord['amount'],
+      memo: (item[memoField] ?? item.Memo ?? item.memo ?? '') as string,
+      recorderName: (item[recorderNameField] ?? item.RecorderName ?? item.recorderName ?? '') as string,
       source: 'kiosk',
       isDeleted,
       createdAt: (item.Created || item.createdAt || '') as string,

--- a/src/sharepoint/fields/toiletRecordFields.ts
+++ b/src/sharepoint/fields/toiletRecordFields.ts
@@ -26,12 +26,19 @@ export const FIELD_MAP_TOILET_RECORD = defineFieldMap({
  * ToiletRecords リストの Schema Drift 候補（揺れ吸収）
  */
 export const TOILET_RECORD_CANDIDATES = {
-  userId: ['UserId', 'UserID'],
-  recordDate: ['RecordDate'],
+  userId: ['UserId', 'UserID', 'User_x0020_Id', 'User_x0020_ID', 'User Id', 'User ID'],
+  recordDate: ['RecordDate', 'Record_x0020_Date', 'Record Date'],
+  occurredAt: ['OccurredAt', 'Occurred_x0020_At', 'Occurred At'],
+  toiletType: ['ToiletType', 'Toilet_x0020_Type', 'Toilet Type'],
+  amount: ['Amount'],
+  memo: ['Memo'],
+  recorderName: ['RecorderName', 'Recorder_x0020_Name', 'Recorder Name'],
+  source: ['Source'],
+  isDeleted: ['IsDeleted', 'Is_x0020_Deleted', 'Is Deleted'],
 } as const;
 
 export const TOILET_RECORD_ESSENTIALS: (keyof typeof TOILET_RECORD_CANDIDATES)[] = [
-  'userId', 'recordDate'
+  'userId', 'recordDate', 'occurredAt', 'toiletType', 'isDeleted'
 ];
 
 /**


### PR DESCRIPTION
### Summary
This PR addresses an issue where the Kiosk Toilet Board was throwing OData 400 errors during loading and creation when connecting to a real SharePoint instance, specifically when space-encoded custom field names (such as `User_x0020_ID` or `Record_x0020_Date`) are used in SharePoint.

### Changes
1. **Candidates Extension**: Expanded `TOILET_RECORD_CANDIDATES` in `toiletRecordFields.ts` to support dynamic space-encoded physical field names (`User_x0020_ID`, `Record_x0020_Date`, etc.).
2. **Repository Dynamic Field Resolution**: Updated `SharePointToiletRecordRepository.ts` to resolve field names dynamically using `this.rfFallback('xxx')` for OData query ``, POST payloads, and mapped objects.