### PR TITLE
fix: harden kiosk fallback and throttle request amplification

### DIFF
--- a/src/app/AppShell.kiosk-route.spec.tsx
+++ b/src/app/AppShell.kiosk-route.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import AppShell from './AppShell';
@@ -14,6 +14,14 @@ const createTestQueryClient = () =>
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
 
+vi.mock('./components/KioskExitFab', () => ({
+  KioskExitFab: ({ onExit }: { onExit: () => void }) => (
+    <button type="button" onClick={onExit}>
+      exit kiosk
+    </button>
+  ),
+}));
+
 vi.mock('@/features/auth/store', async () => {
   return {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -24,6 +32,11 @@ vi.mock('@/features/auth/store', async () => {
       }),
   };
 });
+
+const CurrentPath = () => {
+  const location = useLocation();
+  return <div data-testid="current-path">{location.pathname}</div>;
+};
 
 function renderAppShell(initialPath: string) {
   return render(
@@ -37,6 +50,7 @@ function renderAppShell(initialPath: string) {
                 element={
                   <AppShell>
                     <div data-testid="kiosk-route-child">child</div>
+                    <CurrentPath />
                   </AppShell>
                 }
               />
@@ -93,5 +107,25 @@ describe('AppShell kiosk query routing', () => {
       expect(appShell).toHaveAttribute('data-kiosk', 'true');
     });
   });
-});
 
+  it('navigates out of forced /kiosk routes when exiting kiosk mode', async () => {
+    localStorage.setItem(
+      SETTINGS_STORAGE_KEY,
+      JSON.stringify({
+        ...DEFAULT_SETTINGS,
+        layoutMode: 'kiosk',
+      }),
+    );
+
+    renderAppShell('/kiosk/users/23/procedures');
+
+    fireEvent.click(screen.getByRole('button', { name: 'exit kiosk' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('current-path')).toHaveTextContent('/dashboard');
+    });
+
+    const stored = JSON.parse(localStorage.getItem(SETTINGS_STORAGE_KEY) ?? '{}');
+    expect(stored.layoutMode).toBe('normal');
+  });
+});

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -72,6 +72,13 @@ const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) => {
     }
   }, [navigate, location.pathname]);
 
+  const handleExitKioskMode = React.useCallback(() => {
+    updateSettings({ layoutMode: 'normal' });
+    if (location.pathname.startsWith('/kiosk')) {
+      navigate('/dashboard', { replace: true });
+    }
+  }, [location.pathname, navigate, updateSettings]);
+
   const headerContent = isFullscreenMode ? null : (
     <AppShellHeader
       isDesktop={isDesktop}
@@ -175,7 +182,7 @@ const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) => {
           {isKioskMode && (
             <>
               <KioskNavigation />
-              <KioskExitFab onExit={() => updateSettings({ layoutMode: 'normal' })} />
+              <KioskExitFab onExit={handleExitKioskMode} />
             </>
           )}
         </div>

--- a/src/features/daily/domain/ExecutionRecordRepository.ts
+++ b/src/features/daily/domain/ExecutionRecordRepository.ts
@@ -20,6 +20,14 @@
  */
 import type { ExecutionRecord } from './executionRecordTypes';
 
+export type ExecutionRecordUpsertOptions = {
+  /**
+   * - merge: keep existing memo text and append a different incoming memo.
+   * - overwrite: replace the memo with the incoming value.
+   */
+  memoMode?: 'merge' | 'overwrite';
+};
+
 export interface ExecutionRecordRepository {
   /**
    * Get all execution records for a given date × user.
@@ -38,7 +46,7 @@ export interface ExecutionRecordRepository {
    * If a record with the same (date, userId, scheduleItemId) exists, it is replaced.
    * Otherwise a new record is appended.
    */
-  upsertRecord(record: ExecutionRecord): Promise<void>;
+  upsertRecord(record: ExecutionRecord, options?: ExecutionRecordUpsertOptions): Promise<void>;
 
   /**
    * Calculate completion rate for a date × user.
@@ -69,4 +77,3 @@ export interface ExecutionRecordRepository {
    */
   deleteRecord(date: string, userId: string, scheduleItemId: string): Promise<void>;
 }
-

--- a/src/features/daily/hooks/__tests__/useExecutionRecord.spec.ts
+++ b/src/features/daily/hooks/__tests__/useExecutionRecord.spec.ts
@@ -73,6 +73,7 @@ describe('useExecutionRecord', () => {
         scheduleItemId: legacyRecord.scheduleItemId,
         memo: 'new memo',
       }),
+      { memoMode: 'overwrite' },
     );
   });
 

--- a/src/features/daily/hooks/legacy-stores/executionStore.ts
+++ b/src/features/daily/hooks/legacy-stores/executionStore.ts
@@ -14,6 +14,7 @@ import {
     type DailyUserRecords,
     type ExecutionRecord,
 } from '@/features/daily/domain/legacy/executionRecordTypes';
+import type { ExecutionRecordUpsertOptions } from '@/features/daily/domain/legacy/ExecutionRecordRepository';
 
 // ---------------------------------------------------------------------------
 // localStorage persistence
@@ -120,7 +121,7 @@ export function useExecutionStore() {
 
   /** 記録を追加/更新 (upsert) */
   const upsertRecord = useCallback(
-    (record: ExecutionRecord) => {
+    (record: ExecutionRecord, _options?: ExecutionRecordUpsertOptions) => {
       const existing = getRecords(record.date, record.userId);
       const index = existing.findIndex((r) => r.scheduleItemId === record.scheduleItemId);
 

--- a/src/features/daily/hooks/useExecutionRecord.ts
+++ b/src/features/daily/hooks/useExecutionRecord.ts
@@ -107,7 +107,7 @@ export function useExecutionRecord(
         recordedAt: new Date().toISOString(),
       };
       setRecord(next);
-      await upsertRecordRef.current(next);
+      await upsertRecordRef.current(next, { memoMode: 'overwrite' });
     },
     [record],
   );
@@ -127,7 +127,7 @@ export function useExecutionRecord(
         recordedAt: new Date().toISOString(),
       };
       setRecord(next);
-      await upsertRecordRef.current(next);
+      await upsertRecordRef.current(next, { memoMode: 'overwrite' });
     },
     [record, resolveMutationTarget],
   );

--- a/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
+++ b/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
@@ -1,6 +1,6 @@
 import type { SpFetchFn } from '@/lib/sp/spLists';
 import type { ExecutionRecord, RecordStatus } from '../../domain/legacy/executionRecordTypes';
-import type { ExecutionRecordRepository } from '../../domain/legacy/ExecutionRecordRepository';
+import type { ExecutionRecordRepository, ExecutionRecordUpsertOptions } from '../../domain/legacy/ExecutionRecordRepository';
 import { 
   getListTitle, 
   getRowsListTitle, 
@@ -23,7 +23,7 @@ type SharePointExecutionRecordRepositoryOptions = {
   getListFieldInternalNames?: (listTitle: string) => Promise<Set<string>>;
   store?: {
     getRecords: (date: string, userId: string) => ExecutionRecord[];
-    upsertRecord: (record: ExecutionRecord) => void;
+    upsertRecord: (record: ExecutionRecord, options?: ExecutionRecordUpsertOptions) => void;
     deleteRecord?: (date: string, userId: string, scheduleItemId: string) => void;
   };
 };
@@ -358,7 +358,7 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
     ))?.record;
   }
 
-  async upsertRecord(record: ExecutionRecord): Promise<void> {
+  async upsertRecord(record: ExecutionRecord, options?: ExecutionRecordUpsertOptions): Promise<void> {
     const normalizedDate = normalizeExecutionDate(record.date);
     const normalizedUserId = normalizeExecutionUserId(record.userId);
     const normalizedScheduleItemId = normalizeScheduleItemId(record.scheduleItemId);
@@ -387,7 +387,13 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
 
     // Concurrency Protection: Merge memos if existing record has a different memo.
     let finalMemo = normalizedRecord.memo;
-    if (existing && existing.memo && normalizedRecord.memo && existing.memo !== normalizedRecord.memo) {
+    if (
+      options?.memoMode !== 'overwrite' &&
+      existing &&
+      existing.memo &&
+      normalizedRecord.memo &&
+      existing.memo !== normalizedRecord.memo
+    ) {
       if (!existing.memo.includes(normalizedRecord.memo)) {
         const timeStr = new Date().toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' });
         const staffName = normalizedRecord.recordedBy || '職員';
@@ -463,7 +469,7 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
 
     // Sync to local store
     if (this.store) {
-      this.store.upsertRecord(mergedRecord);
+      this.store.upsertRecord(mergedRecord, options);
     }
   }
 

--- a/src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts
+++ b/src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts
@@ -277,11 +277,93 @@ describe('SharePointExecutionRecordRepository', () => {
       expect.objectContaining({
         memo: expect.stringContaining('existing memo'),
       }),
+      undefined,
     );
     expect(store.upsertRecord).toHaveBeenCalledWith(
       expect.objectContaining({
         memo: expect.stringContaining('new memo'),
       }),
+      undefined,
+    );
+  });
+
+  it('overwrites an existing memo when upsert requests overwrite mode', async () => {
+    const mockGetFieldsWithMemo = vi.fn().mockResolvedValue(new Set([
+      'Title',
+      'RecordDate',
+      EXECUTION_RECORD_FIELDS.rowKey,
+      EXECUTION_RECORD_FIELDS.status,
+      EXECUTION_RECORD_FIELDS.parentId,
+      EXECUTION_RECORD_FIELDS.userId,
+      EXECUTION_RECORD_FIELDS.rowNo,
+      EXECUTION_RECORD_FIELDS.memo,
+      EXECUTION_RECORD_FIELDS.recordedAt,
+      EXECUTION_RECORD_FIELDS.bipsJSON,
+      'Payload',
+    ]));
+    const store = {
+      getRecords: vi.fn(() => []),
+      upsertRecord: vi.fn(),
+      deleteRecord: vi.fn(),
+    };
+    const repoWithStore = new SharePointExecutionRecordRepository({
+      spFetch: mockSpFetch,
+      getListFieldInternalNames: mockGetFieldsWithMemo,
+      store,
+    });
+    const record: ExecutionRecord = {
+      id: '2024-01-01-U001-S001',
+      date: '2024-01-01',
+      userId: 'U001',
+      scheduleItemId: 'S001',
+      status: 'completed',
+      memo: 'new memo',
+      recordedAt: '2024-01-01T10:00:00Z',
+      recordedBy: 'Staff A',
+      triggeredBipIds: [],
+    };
+
+    mockSpFetch.mockReset();
+    mockSpFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url.includes('SupportRecord_Daily') && url.includes('/items?$filter=')) {
+        return { ok: true, json: async () => ({ value: [{ Id: 123 }] }) };
+      }
+      if (url.includes('DailyRecordRows') && url.includes('/items?$filter=')) {
+        return {
+          ok: true,
+          json: async () => ({
+            value: [
+              {
+                Id: 456,
+                Title: '2024-01-01-U001-S001',
+                User_x0020_ID: 'U001',
+                RowNo: 'S001',
+                Status: 'completed',
+                Memo: 'existing memo',
+                Recorded_x0020_At: '2024-01-01T09:00:00Z',
+              },
+            ],
+          }),
+        };
+      }
+      if (url.includes('DailyRecordRows') && url.includes('/items(456)') && init?.method === 'POST') {
+        return { ok: true, json: async () => ({}) };
+      }
+      return { ok: true, json: async () => ({ value: [] }) };
+    });
+
+    await repoWithStore.upsertRecord(record, { memoMode: 'overwrite' });
+
+    const updateCall = mockSpFetch.mock.calls.find((call) =>
+      String(call[0]).includes('DailyRecordRows') && String(call[0]).includes('/items(456)'),
+    );
+    expect(updateCall).toBeDefined();
+    const body = JSON.parse(updateCall![1]!.body as string);
+    expect(body[EXECUTION_RECORD_FIELDS.memo]).toBe('new memo');
+    expect(body.Payload).toBe('new memo');
+    expect(store.upsertRecord).toHaveBeenCalledWith(
+      expect.objectContaining({ memo: 'new memo' }),
+      { memoMode: 'overwrite' },
     );
   });
 

--- a/src/features/daily/repositories/sharepoint/executionRepositoryFactory.ts
+++ b/src/features/daily/repositories/sharepoint/executionRepositoryFactory.ts
@@ -20,7 +20,7 @@ import {
     readBool,
     readOptionalEnv,
 } from '@/lib/env';
-import type { ExecutionRecordRepository } from '../../domain/legacy/ExecutionRecordRepository';
+import type { ExecutionRecordRepository, ExecutionRecordUpsertOptions } from '../../domain/legacy/ExecutionRecordRepository';
 import type { ExecutionRecord } from '../../domain/legacy/executionRecordTypes';
 import { SharePointExecutionRecordRepository } from './SharePointExecutionRecordRepository';
 import type { SpFetchFn } from '@/lib/sp/spLists';
@@ -114,7 +114,7 @@ const resolveKind = (forced?: ExecutionRepositoryKind): ExecutionRepositoryKind 
 export type ExecutionStoreHooks = {
   getRecords: (date: string, userId: string) => ExecutionRecord[];
   getRecord: (date: string, userId: string, scheduleItemId: string) => ExecutionRecord | undefined;
-  upsertRecord: (record: ExecutionRecord) => void;
+  upsertRecord: (record: ExecutionRecord, options?: ExecutionRecordUpsertOptions) => void;
   deleteRecord: (date: string, userId: string, scheduleItemId: string) => void;
   getCompletionRate: (
     date: string,
@@ -144,13 +144,13 @@ function createLocalStorageExecutionAdapter(
         normalizeExecutionUserId(userId),
         normalizeScheduleItemId(scheduleItemId),
       ),
-    upsertRecord: async (record: ExecutionRecord) =>
+    upsertRecord: async (record: ExecutionRecord, options?: ExecutionRecordUpsertOptions) =>
       store.upsertRecord({
         ...record,
         date: normalizeExecutionDate(record.date),
         userId: normalizeExecutionUserId(record.userId),
         scheduleItemId: normalizeScheduleItemId(record.scheduleItemId),
-      }),
+      }, options),
     deleteRecord: async (date: string, userId: string, scheduleItemId: string) =>
       store.deleteRecord(
         normalizeExecutionDate(date),
@@ -173,8 +173,8 @@ function createSharePointExecutionAdapter(
       repository.getRecords(date, userId),
     getRecord: async (date: string, userId: string, scheduleItemId: string) =>
       repository.getRecord(date, userId, scheduleItemId),
-    upsertRecord: async (record: ExecutionRecord) =>
-      repository.upsertRecord(record),
+    upsertRecord: async (record: ExecutionRecord, options?: ExecutionRecordUpsertOptions) =>
+      repository.upsertRecord(record, options),
     deleteRecord: async (date: string, userId: string, scheduleItemId: string) =>
       repository.deleteRecord(date, userId, scheduleItemId),
     getCompletionRate: async (date: string, userId: string, totalSlots: number) =>

--- a/src/features/daily/stores/__tests__/executionStore.spec.ts
+++ b/src/features/daily/stores/__tests__/executionStore.spec.ts
@@ -88,6 +88,57 @@ describe('executionStore', () => {
     expect(records[0].memo).toBe('パニック発生');
   });
 
+  it('merges different memo text by default for existing records', () => {
+    const { result } = renderHook(() => useExecutionStore());
+    const record = {
+      ...createEmptyRecord('2025-04-01', 'I001', 'base-0900'),
+      status: 'completed' as const,
+      memo: '既存メモ',
+      recordedBy: 'Staff A',
+      recordedAt: '2025-04-01T10:00:00Z',
+    };
+
+    act(() => {
+      result.current.upsertRecord(record);
+    });
+    act(() => {
+      result.current.upsertRecord({
+        ...record,
+        memo: '修正メモ',
+        recordedAt: '2025-04-01T10:05:00Z',
+      });
+    });
+
+    const records = result.current.getRecords('2025-04-01', 'I001');
+    expect(records[0].memo).toContain('既存メモ');
+    expect(records[0].memo).toContain('修正メモ');
+  });
+
+  it('overwrites memo text when requested for existing records', () => {
+    const { result } = renderHook(() => useExecutionStore());
+    const record = {
+      ...createEmptyRecord('2025-04-01', 'I001', 'base-0900'),
+      status: 'completed' as const,
+      memo: '既存メモ',
+      recordedBy: 'Staff A',
+      recordedAt: '2025-04-01T10:00:00Z',
+    };
+
+    act(() => {
+      result.current.upsertRecord(record);
+    });
+    act(() => {
+      result.current.upsertRecord({
+        ...record,
+        memo: '修正メモ',
+        recordedAt: '2025-04-01T10:05:00Z',
+      }, { memoMode: 'overwrite' });
+    });
+
+    const records = result.current.getRecords('2025-04-01', 'I001');
+    expect(records[0].memo).toBe('修正メモ');
+  });
+
   // -----------------------------------------------------------------------
   // getRecord (single)
   // -----------------------------------------------------------------------

--- a/src/features/daily/stores/executionStore.ts
+++ b/src/features/daily/stores/executionStore.ts
@@ -14,6 +14,7 @@ import {
     type DailyUserRecords,
     type ExecutionRecord,
 } from '@/features/daily/domain/executionRecordTypes';
+import type { ExecutionRecordUpsertOptions } from '@/features/daily/domain/ExecutionRecordRepository';
 import {
   normalizeExecutionDate,
   normalizeExecutionUserId,
@@ -140,7 +141,7 @@ export function useExecutionStore() {
 
   /** 記録を追加/更新 (upsert) */
   const upsertRecord = useCallback(
-    (record: ExecutionRecord) => {
+    (record: ExecutionRecord, options?: ExecutionRecordUpsertOptions) => {
       const normalizedDate = normalizeExecutionDate(record.date);
       const normalizedUserId = normalizeExecutionUserId(record.userId);
       const normalizedScheduleItemId = normalizeScheduleItemId(record.scheduleItemId);
@@ -156,7 +157,13 @@ export function useExecutionStore() {
 
       // Concurrency Protection: Merge memos if existing record has a different memo.
       let finalMemo = normalizedRecord.memo;
-      if (existing && existing.memo && normalizedRecord.memo && existing.memo !== normalizedRecord.memo) {
+      if (
+        options?.memoMode !== 'overwrite' &&
+        existing &&
+        existing.memo &&
+        normalizedRecord.memo &&
+        existing.memo !== normalizedRecord.memo
+      ) {
         if (!existing.memo.includes(normalizedRecord.memo)) {
           const timeStr = new Date().toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' });
           const staffName = normalizedRecord.recordedBy || '職員';
@@ -244,4 +251,3 @@ export function useExecutionStore() {
     getRecordsInRange,
   }), [getRecords, getRecord, upsertRecord, deleteRecord, getCompletionRate, getRecordsInRange]);
 }
-

--- a/src/features/kiosk/components/KioskProcedureListScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureListScreen.tsx
@@ -30,7 +30,14 @@ const extractProcedureRowKey = (value: unknown): string => {
   if (/^\d+$/.test(normalized)) return String(Number.parseInt(normalized, 10));
 
   const match = normalized.match(/(?:^|[-_])(row|base|procedure|slot|step)[-_]?(\d+)$/i);
-  return match ? String(Number.parseInt(match[2], 10)) : '';
+  if (match) return String(Number.parseInt(match[2], 10));
+
+  // Planning-sheet derived procedure IDs can be source-scoped, e.g.
+  // "official-<sheetId>-1". The final small numeric segment is the rowNo.
+  const tailNumber = normalized.match(/[-_](\d{1,2})$/);
+  if (!tailNumber) return '';
+  const rowNo = Number.parseInt(tailNumber[1], 10);
+  return rowNo > 0 && rowNo <= 99 ? String(rowNo) : '';
 };
 
 const buildProcedureMatchKeys = (
@@ -57,6 +64,22 @@ const buildProcedureMatchKeys = (
   return Array.from(keys);
 };
 
+const buildProcedureLookupKeys = (procedure: { id?: unknown; rowNo?: unknown }, index: number): string[] => {
+  const keys = new Set<string>();
+  const push = (value: string) => {
+    if (value) keys.add(value);
+  };
+
+  // For SharePoint point lookups, prefer the physical row number first.
+  // Source-scoped planning IDs such as "official-<sheetId>-1" are not row keys.
+  push(extractProcedureRowKey(procedure.rowNo));
+  push(extractProcedureRowKey(procedure.id));
+  push(normalizeScheduleItemId(procedure.rowNo));
+  push(normalizeScheduleItemId(procedure.id));
+  push(index.toString());
+  return Array.from(keys);
+};
+
 const buildRecordMatchKeys = (record: ExecutionRecord): string[] => {
   const keys = new Set<string>();
   const scheduleItemId = normalizeScheduleItemId(record.scheduleItemId);
@@ -64,6 +87,19 @@ const buildRecordMatchKeys = (record: ExecutionRecord): string[] => {
   const rowKey = extractProcedureRowKey(scheduleItemId);
   if (rowKey) keys.add(rowKey);
   return Array.from(keys);
+};
+
+const isSharePointThrottleError = (error: unknown): boolean => {
+  if (!(error instanceof Error)) return false;
+  const message = `${error.name} ${error.message}`.toLowerCase();
+  return (
+    message.includes('spthrottleredirecterror') ||
+    message.includes('throttle.htm') ||
+    message.includes('throttled') ||
+    message.includes('failed to fetch') ||
+    message.includes('networkerror') ||
+    message.includes('cors')
+  );
 };
 
 export const KioskProcedureListScreen: React.FC = () => {
@@ -214,6 +250,7 @@ export const KioskProcedureListScreen: React.FC = () => {
   const [hasFetchedRecords, setHasFetchedRecords] = useState(false);
   const [fetchFailed, setFetchFailed] = useState(false);
   const [showFetchError, setShowFetchError] = useState(false);
+  const procedureLookupThrottleKeyRef = React.useRef('');
 
   // Synchronously reset records state when the active user or date changes
   // to prevent rendering stale records from the previous context.
@@ -227,6 +264,7 @@ export const KioskProcedureListScreen: React.FC = () => {
     setRecords([]);
     setHasFetchedRecords(false);
     setFetchFailed(false);
+    procedureLookupThrottleKeyRef.current = '';
   }
 
   const buildKioskAbcRecordLink = React.useCallback((slotId: string) => {
@@ -297,10 +335,83 @@ export const KioskProcedureListScreen: React.FC = () => {
       }
 
       const deduped = new Map<string, ExecutionRecord>();
-      for (const record of successfulBatches.flat()) {
+      const addRecord = (record: ExecutionRecord) => {
         const key = `${record.date}|${record.userId}|${record.scheduleItemId}|${record.id ?? ''}`;
         deduped.set(key, record);
+      };
+      for (const record of successfulBatches.flat()) {
+        addRecord(record);
       }
+
+      const procedureLookupKey = `${dateStr}|${queryUserIds.join('|')}`;
+      if (
+        procedures.length > 0 &&
+        deduped.size < procedures.length &&
+        typeof executionRepo.getRecord === 'function' &&
+        procedureLookupThrottleKeyRef.current !== procedureLookupKey
+      ) {
+        const matchedKeys = new Set<string>();
+        for (const record of deduped.values()) {
+          for (const key of buildRecordMatchKeys(record)) {
+            matchedKeys.add(key);
+          }
+        }
+
+        let lookupAttempts = 0;
+        let abortProcedureLookups = false;
+        const maxLookupAttempts = executionRepositoryKind === 'sharepoint' ? 12 : Number.POSITIVE_INFINITY;
+
+        for (let index = 0; index < procedures.length; index += 1) {
+          const procedureKeys = buildProcedureMatchKeys(procedures[index], index, allPrimaryScheduleKeys);
+          if (procedureKeys.some((key) => matchedKeys.has(key))) continue;
+
+          let foundRecord: ExecutionRecord | undefined;
+          const lookupKeys = buildProcedureLookupKeys(procedures[index], index);
+          for (const candidateUserId of queryUserIds) {
+            for (const scheduleItemId of lookupKeys) {
+              if (lookupAttempts >= maxLookupAttempts) {
+                abortProcedureLookups = true;
+                break;
+              }
+              lookupAttempts += 1;
+              try {
+                const record = await executionRepo.getRecord(dateStr, candidateUserId, scheduleItemId);
+                if (record) {
+                  foundRecord = record;
+                  break;
+                }
+              } catch (error) {
+                if (isSharePointThrottleError(error)) {
+                  console.warn('Procedure-level execution lookup stopped because SharePoint is throttling:', {
+                    userId: candidateUserId,
+                    scheduleItemId,
+                    error,
+                  });
+                  procedureLookupThrottleKeyRef.current = procedureLookupKey;
+                  abortProcedureLookups = true;
+                  break;
+                }
+                console.warn('Procedure-level execution record lookup failed:', {
+                  userId: candidateUserId,
+                  scheduleItemId,
+                  error,
+                });
+              }
+            }
+            if (foundRecord || abortProcedureLookups) break;
+          }
+
+          if (foundRecord) {
+            addRecord(foundRecord);
+            for (const key of buildRecordMatchKeys(foundRecord)) {
+              matchedKeys.add(key);
+            }
+          }
+
+          if (abortProcedureLookups) break;
+        }
+      }
+
       const data = Array.from(deduped.values());
       if (active) {
         setRecords(data);
@@ -318,6 +429,8 @@ export const KioskProcedureListScreen: React.FC = () => {
     executionRepo,
     selectedDateIso,
     executionRepositoryKind,
+    allPrimaryScheduleKeys,
+    procedures,
     user?.UserID,
     userId,
     location.key,

--- a/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
@@ -46,6 +46,7 @@ vi.mock('@/features/daily/hooks/useProcedureData', () => ({
 }));
 
 const mockGetRecords = vi.fn();
+const mockGetRecord = vi.fn();
 const mockGetStoreRecords = vi.fn();
 const mockGetCurrentExecutionRepositoryKind = vi.fn(() => 'local' as 'local' | 'sharepoint');
 
@@ -57,7 +58,8 @@ vi.mock('@/features/daily/stores/executionStore', () => ({
 
 vi.mock('@/features/daily/hooks/useExecutionData', () => ({
   useExecutionData: () => ({
-    getRecords: mockGetRecords
+    getRecords: mockGetRecords,
+    getRecord: mockGetRecord,
   }),
 }));
 
@@ -109,6 +111,7 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
     mockUsePlanningSheetData.mockReturnValue({ data: null, isLoading: false });
     mockUseCurrentPlanningSheet.mockReturnValue({ currentSheet: null, allCurrentSheets: [], isLoading: false, error: null });
     mockGetRecords.mockResolvedValue([]);
+    mockGetRecord.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -944,6 +947,107 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
       expect(within(firstCard).getByText('記録済み')).toBeInTheDocument();
       expect(within(firstCard).queryByText('未実施')).toBeNull();
     });
+  });
+
+  it('matches planning-sheet scoped procedure IDs to row-number execution records', async () => {
+    mockGetByUser.mockReturnValue([
+      {
+        id: 'official-sheet-1809-1',
+        time: '9:30頃',
+        activity: '通所・朝の準備',
+        instruction: '送迎担当と引継ぎ',
+      },
+      {
+        id: 'official-sheet-1809-2',
+        time: '10:00頃',
+        activity: '体操',
+        instruction: '見守り',
+      },
+    ]);
+    mockGetRecords.mockResolvedValue([
+      { scheduleItemId: '1', status: 'completed', memo: 'saved row 1' },
+      { scheduleItemId: '2', status: 'completed', memo: 'saved row 2' },
+    ]);
+
+    render(
+      <MemoryRouter initialEntries={['/kiosk/users/U001/procedures']}>
+        <KioskProcedureListScreen />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('実施状況: 2 / 2')).toBeInTheDocument();
+      expect(screen.getAllByText('記録済み')).toHaveLength(2);
+    });
+  });
+
+  it('fills sparse bulk results with procedure-level record lookups', async () => {
+    mockGetByUser.mockReturnValue([
+      {
+        id: 'official-sheet-1809-1',
+        time: '9:30頃',
+        activity: '通所・朝の準備',
+        instruction: '送迎担当と引継ぎ',
+      },
+      {
+        id: 'official-sheet-1809-2',
+        time: '10:00頃',
+        activity: '体操',
+        instruction: '見守り',
+      },
+    ]);
+    mockGetRecords.mockResolvedValue([]);
+    mockGetRecord.mockImplementation(async (_date, _userId, scheduleItemId) => {
+      if (scheduleItemId === '1') {
+        return { scheduleItemId: '1', status: 'completed', memo: 'saved row 1' };
+      }
+      return undefined;
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/kiosk/users/U001/procedures']}>
+        <KioskProcedureListScreen />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('実施状況: 1 / 2')).toBeInTheDocument();
+      const firstCard = screen.getByTestId('kiosk-procedure-card-0');
+      expect(within(firstCard).getByText('記録済み')).toBeInTheDocument();
+      expect(within(firstCard).queryByText('未実施')).toBeNull();
+    });
+  });
+
+  it('stops procedure-level lookups when SharePoint throttle/CORS is detected', async () => {
+    mockGetByUser.mockReturnValue([
+      {
+        id: 'official-sheet-1809-1',
+        time: '9:30頃',
+        activity: '通所・朝の準備',
+        instruction: '送迎担当と引継ぎ',
+      },
+      {
+        id: 'official-sheet-1809-2',
+        time: '10:00頃',
+        activity: '体操',
+        instruction: '見守り',
+      },
+    ]);
+    mockGetCurrentExecutionRepositoryKind.mockReturnValue('sharepoint');
+    mockGetRecords.mockResolvedValue([]);
+    mockGetRecord.mockRejectedValue(new Error('[SharePoint] Throttled: redirected to Throttle.htm.'));
+
+    render(
+      <MemoryRouter initialEntries={['/kiosk/users/U001/procedures']}>
+        <KioskProcedureListScreen />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('実施状況: 0 / 2')).toBeInTheDocument();
+    });
+    expect(mockGetRecord.mock.calls.length).toBeLessThanOrEqual(2);
+    expect(mockGetRecord).toHaveBeenCalledWith(expect.any(String), 'U001', '1');
   });
 
   it('waits for user to load before fetching route and master user ID candidates', async () => {

--- a/src/features/sp/health/spHealthSignalStore.ts
+++ b/src/features/sp/health/spHealthSignalStore.ts
@@ -105,7 +105,7 @@ const REASON_ACTION_MAP: Record<SpHealthReasonCode, ActionSpec> = {
   sp_schema_drift: {
     actionUrl: '/admin/status?highlight=sp_schema_drift',
     actionType: 'internal',
-    actionGuide: '列名に微細な不整合（末尾 host _0 付与等）が検出されました。放置すると 8KB 制限の原因となるため、クリーンアップが必要です。',
+    actionGuide: '列名の差異が検出されました。アプリ側で自動吸収できている場合は、列削除ではなく診断結果と実保存を確認してください。',
   },
   sp_gate_escape_hatch: {
     actionUrl: '/admin/status?highlight=sp_gate_escape_hatch',

--- a/src/sharepoint/spProvisioningCoordinator.ts
+++ b/src/sharepoint/spProvisioningCoordinator.ts
@@ -360,18 +360,9 @@ export class SharePointProvisioningCoordinator {
             severity: 'warning',
             reasonCode: 'sp_schema_drift',
             listName,
-            message: `「${listName}」で列名のドリフト（末尾への _0 付与等）を検出しました: ${driftDetails.join(', ')}`,
+            message: `「${listName}」で列名のドリフトを検出しましたが、アプリ側で実列名へ自動解決しています: ${driftDetails.join(', ')}`,
             source: 'realtime',
             occurredAt: new Date().toISOString(),
-            remediation: {
-              summary: '不整合を起こしている重複列（ドリフト列）の削除を推奨します。',
-              commands: driftDetails.map(d => {
-                const driftedName = d.split(' -> ')[1];
-                return `m365 spo field remove --webUrl $SITE_URL --listTitle "${listName}" --internalName "${driftedName}" --confirm`;
-              }),
-              caution: '削除前に対象の列にデータが入っていないか、または重複している本物の列があるかを確認してください。',
-              isDestructive: true
-            }
           });
 
           return { 

--- a/tests/unit/sharepoint/spProvisioningCoordinator.spec.ts
+++ b/tests/unit/sharepoint/spProvisioningCoordinator.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { spProvisioningCoordinator } from '@/sharepoint/spProvisioningCoordinator';
 import type { useSP } from '@/lib/spClient';
+import { reportSpHealthEvent } from '@/features/sp/health/spHealthSignalStore';
 
 /**
  * SharePointProvisioningCoordinator - フィールド整合性チェックのテスト
@@ -28,6 +29,10 @@ vi.mock('@/sharepoint/spListRegistry', async (importOriginal) => {
         ]
     };
 });
+
+vi.mock('@/features/sp/health/spHealthSignalStore', () => ({
+  reportSpHealthEvent: vi.fn(),
+}));
 
 describe('SharePointProvisioningCoordinator - Granular Integrity Check', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -95,5 +100,21 @@ describe('SharePointProvisioningCoordinator - Granular Integrity Check', () => {
     // FullName0 は FullName として正常に解決されるはず。
     expect(result.isValid).toBe(true);
     expect(result.missingFields).toHaveLength(0);
+  });
+
+  it('reports drift without destructive field removal remediation', async () => {
+    mockClient.tryGetListMetadata.mockResolvedValue({ title: 'Users_Master' });
+    mockClient.getListFieldInternalNames.mockResolvedValue(new Set(['Title', 'FullName0', 'UserStatus']));
+
+    const result = await spProvisioningCoordinator.checkFieldIntegrity(mockClient, 'users_master');
+
+    expect(result.isValid).toBe(true);
+    expect(reportSpHealthEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reasonCode: 'sp_schema_drift',
+        listName: 'Users_Master',
+      }),
+    );
+    expect(vi.mocked(reportSpHealthEvent).mock.calls.at(-1)?.[0]).not.toHaveProperty('remediation');
   });
 });


### PR DESCRIPTION
## Summary
- kiosk 強制ルート (`/kiosk/*`) からの通常画面復帰時に `/dashboard` へ遷移するよう修正
- `sp_schema_drift` 警告で destructive な列削除コマンドを提案しないように修正
- `KioskProcedureListScreen` で SharePoint throttle redirect (`Throttle.htm#17`) / CORS blocked 検知時に補完リクエストを即停止
- 手順補完の照合は rowNo 優先に変更し、同一 user/date の throttle 中再試行を抑止
- SharePoint 再取得が不安定でも local store の記録表示を維持
- キオスク手順の通常修正保存では `memoMode: 'overwrite'` を使い、既存 memo と新 memo の追記連結を避ける
- 汎用 `upsertRecord()` の既定は従来どおり `merge` に維持し、競合保護用途を壊さない
- SharePoint / localStorage の両 repository で overwrite/merge 契約を統一
- ABC daily-support 連携では hook 側の手動 memo 連結をやめ、repository 既定 merge に一本化して二重追記を防止

## Classification
transport hardening + kiosk fallback/request amplification hardening + kiosk procedure memo correction

## Audit note
2026-05-26 時点で throttle redirect (Throttle.htm#17) に起因する CORS blocked を確認し、一覧側の補完リクエスト増幅を停止するガードを導入。

キオスク手順の通常修正保存は、現場職員の correction/edit-save 操作として扱い、保存済み `ExecutionRecord.memo` を追記ではなく上書きする。汎用 upsert の merge 既定は競合保護用途として維持する。

ABC daily-support 連携は「ABC由来の memo 断片」を渡す責務に限定し、既存 memo との結合は repository の既定 merge に一本化する。

## Verification
- `npx vitest run src/app/AppShell.kiosk-route.spec.tsx src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx tests/unit/sharepoint/spProvisioningCoordinator.spec.ts --reporter=verbose`
- `npx vitest run src/features/daily/hooks/__tests__/useExecutionRecord.spec.ts src/features/daily/stores/__tests__/executionStore.spec.ts src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts --reporter=verbose`
- `npx vitest run src/pages/abc-record/__tests__/QuickRecordTab.spec.tsx src/features/daily/hooks/__tests__/useExecutionRecord.spec.ts src/features/daily/stores/__tests__/executionStore.spec.ts src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts --reporter=verbose`
- `npm run typecheck`
- commit hook: lint / typecheck passed
- pre-push: changed-files eslint passed

## Final verification checklist
1. Network に Throttle.htm#17 / CORS blocked が出ても、追加の `getRecord` 連打が増えない
2. 同じユーザー・日付で throttle 中に再リロードしても、再試行が抑止される
3. local store に残る記録が「記録済み」として維持表示される
4. キオスク手順詳細で保存済み記録を修正保存しても、`memo` が旧 memo + 新 memo にならない
5. ABC daily-support 連携で既存 memo がある場合も、hook 側で既存 memo を二重連結しない
