### PR TITLE
fix: avoid duplicate ABC support memo merge

### DIFF
--- a/src/features/daily/hooks/useAbcDailySupportIntegration.ts
+++ b/src/features/daily/hooks/useAbcDailySupportIntegration.ts
@@ -45,9 +45,6 @@ export function useAbcDailySupportIntegration() {
     const existing = await executionRepo.getRecord(date, userId, scheduleItemId);
 
     const abcMemo = `【メモ】[ABC記録] 行動: ${behavior.trim()}\n結果: ${consequence.trim()}`;
-    const newMemo = existing?.memo
-      ? `${existing.memo}\n${abcMemo}`
-      : abcMemo;
 
     const nextRecord = {
       id: makeRecordId(date, userId, scheduleItemId),
@@ -56,7 +53,7 @@ export function useAbcDailySupportIntegration() {
       scheduleItemId,
       status: 'completed' as const,
       triggeredBipIds: existing?.triggeredBipIds || [],
-      memo: newMemo,
+      memo: abcMemo,
       recordedBy: recorderName || existing?.recordedBy || '',
       recordedAt: new Date().toISOString(),
     };

--- a/src/pages/abc-record/__tests__/QuickRecordTab.spec.tsx
+++ b/src/pages/abc-record/__tests__/QuickRecordTab.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, renderHook } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import QuickRecordTab, { getInitialOccurredAt } from '../QuickRecordTab';
 import { MemoryRouter } from 'react-router-dom';
@@ -144,5 +144,42 @@ describe('QuickRecordTab Component - ExecutionRecord linkage', () => {
       // 3. コールバックが呼ばれたこと
       expect(mockOnSaved).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it('既存 memo がある場合、ABC連携 hook 側では既存 memo を手動連結せず repository merge に任せる', async () => {
+    mockGetRecord.mockResolvedValueOnce({
+      id: '2026-05-22-user-1-1',
+      date: '2026-05-22',
+      userId: 'user-1',
+      scheduleItemId: '1',
+      status: 'completed',
+      triggeredBipIds: [],
+      memo: '既存メモ',
+      recordedBy: '前回記録者',
+      recordedAt: '2026-05-22T09:00:00.000Z',
+    });
+
+    const { result } = renderHook(() => useAbcDailySupportIntegration());
+
+    await result.current.linkExecutionRecord(
+      'user-1',
+      '大声を出した',
+      '静かな部屋へ誘導した',
+      {
+        source: 'daily-support',
+        date: '2026-05-22',
+        slotId: '10:00|朝のバイタルチェック',
+      },
+      'テスト記録者',
+    );
+
+    expect(mockUpsertRecord).toHaveBeenCalledTimes(1);
+    expect(mockUpsertRecord).toHaveBeenCalledWith(expect.objectContaining({
+      date: '2026-05-22',
+      userId: 'user-1',
+      scheduleItemId: '1',
+      memo: '【メモ】[ABC記録] 行動: 大声を出した\n結果: 静かな部屋へ誘導した',
+      recordedBy: 'テスト記録者',
+    }));
   });
 });


### PR DESCRIPTION
## Summary
- ABC daily-support 連携で hook 側の手動 memo 連結をやめ、repository 既定 merge に一本化
- 既存 memo がある状態でも `existing memo + existing memo + ABC memo` にならないように修正
- 既存 memo ありの ABC 連携回帰テストを追加

## Why
#2034 で `upsertRecord()` の memo merge/overwrite 契約を整理したが、ABC daily-support 連携だけ hook 側で既存 memo を連結したうえで repository 既定 merge を呼ぶ構造が残っていた。

ABC連携は「ABC由来の memo 断片を追加する」操作なので、既存 memo との結合は repository の `merge` 既定に任せる。

## Verification
- `npx vitest run src/pages/abc-record/__tests__/QuickRecordTab.spec.tsx src/features/daily/stores/__tests__/executionStore.spec.ts src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts --reporter=verbose`
- `npm run typecheck`
- pre-push: changed-files eslint passed
