### PR TITLE
fix(kiosk): prevent stale raw records from reviving deleted procedure preview state

### DIFF
--- a/src/features/daily/stores/__tests__/executionStore.spec.ts
+++ b/src/features/daily/stores/__tests__/executionStore.spec.ts
@@ -32,6 +32,7 @@ describe('executionStore', () => {
   it('returns empty array for unknown date/user', () => {
     const { result } = renderHook(() => useExecutionStore());
     expect(result.current.getRecords('2025-04-01', 'I001')).toEqual([]);
+    expect(result.current.hasInitializedRecords('2025-04-01', 'I001')).toBe(false);
   });
 
   // -----------------------------------------------------------------------
@@ -53,6 +54,26 @@ describe('executionStore', () => {
     const records = result.current.getRecords('2025-04-01', 'I001');
     expect(records).toHaveLength(1);
     expect(records[0].status).toBe('completed');
+    expect(result.current.hasInitializedRecords('2025-04-01', 'I001')).toBe(true);
+  });
+
+  it('keeps a user/date initialized after deleting the last record', () => {
+    const { result } = renderHook(() => useExecutionStore());
+    const record = {
+      ...createEmptyRecord('2025-04-01', 'I001', 'base-0900'),
+      status: 'completed' as const,
+      recordedAt: '2025-04-01T10:00:00Z',
+    };
+
+    act(() => {
+      result.current.upsertRecord(record);
+    });
+    act(() => {
+      result.current.deleteRecord('2025-04-01', 'I001', 'base-0900');
+    });
+
+    expect(result.current.getRecords('2025-04-01', 'I001')).toEqual([]);
+    expect(result.current.hasInitializedRecords('2025-04-01', 'I001')).toBe(true);
   });
 
   // -----------------------------------------------------------------------

--- a/src/features/daily/stores/executionStore.ts
+++ b/src/features/daily/stores/executionStore.ts
@@ -106,6 +106,23 @@ export function __resetStore() {
 export function useExecutionStore() {
   const snapshot = useExecutionStoreBase((s) => s.store);
 
+  /** 日付×ユーザーの記録集合が store 側で確定済みかを判定 */
+  const hasInitializedRecords = useCallback(
+    (date: string, userId: string): boolean => {
+      const normalizedDate = normalizeExecutionDate(date);
+      const normalizedUserId = normalizeExecutionUserId(userId);
+      const key = makeDailyUserKey(normalizedDate, normalizedUserId);
+      if (snapshot[key]) return true;
+
+      // Legacy fallback: scan keys and compare normalized date/userId
+      return Object.values(snapshot).some((daily) => (
+        normalizeExecutionDate(daily.date) === normalizedDate &&
+        normalizeExecutionUserId(daily.userId) === normalizedUserId
+      ));
+    },
+    [snapshot],
+  );
+
   /** 日付×ユーザーの全記録を取得 */
   const getRecords = useCallback(
     (date: string, userId: string): ExecutionRecord[] => {
@@ -245,9 +262,10 @@ export function useExecutionStore() {
   return useMemo(() => ({
     getRecords,
     getRecord,
+    hasInitializedRecords,
     upsertRecord,
     deleteRecord,
     getCompletionRate,
     getRecordsInRange,
-  }), [getRecords, getRecord, upsertRecord, deleteRecord, getCompletionRate, getRecordsInRange]);
+  }), [getRecords, getRecord, hasInitializedRecords, upsertRecord, deleteRecord, getCompletionRate, getRecordsInRange]);
 }

--- a/src/features/kiosk/hooks/__tests__/useDailyProcedureFlowPreview.spec.ts
+++ b/src/features/kiosk/hooks/__tests__/useDailyProcedureFlowPreview.spec.ts
@@ -27,6 +27,7 @@ describe('useDailyProcedureFlowPreview', () => {
   const mockGetRecords = vi.fn();
   const mockGetByUser = vi.fn();
   const mockGetStoreRecords = vi.fn();
+  const mockHasInitializedRecords = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -47,6 +48,7 @@ describe('useDailyProcedureFlowPreview', () => {
 
     vi.mocked(useExecutionStore).mockReturnValue({
       getRecords: mockGetStoreRecords.mockReturnValue([]),
+      hasInitializedRecords: mockHasInitializedRecords.mockReturnValue(false),
     } as any);
   });
 
@@ -155,5 +157,28 @@ describe('useDailyProcedureFlowPreview', () => {
       status: 'completed',
       memo: 'Optimistic completed',
     }));
+  });
+
+  it('does not revive stale repository records after the store initialized an empty user/date', async () => {
+    const mockSlots = [
+      { id: '1', rowNo: 1, time: '09:30', activity: 'Morning Assembly', block: 'morning' },
+    ];
+    const mockRepositoryRecords = [
+      { scheduleItemId: '1', status: 'completed', memo: 'Deleted on client', date: '2026-05-11', userId: 'U001' },
+    ];
+
+    mockGetByUser.mockReturnValue(mockSlots);
+    mockGetRecords.mockResolvedValue(mockRepositoryRecords);
+    mockGetStoreRecords.mockReturnValue([]);
+    mockHasInitializedRecords.mockReturnValue(true);
+
+    const { result } = renderHook(() => useDailyProcedureFlowPreview('U001', '2026-05-11'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.steps).toHaveLength(1);
+    expect(result.current.steps[0].record).toBeUndefined();
   });
 });

--- a/src/features/kiosk/hooks/useDailyProcedureFlowPreview.ts
+++ b/src/features/kiosk/hooks/useDailyProcedureFlowPreview.ts
@@ -72,7 +72,7 @@ export function useDailyProcedureFlowPreview(
     [userId]
   );
   
-  const { getRecords: getStoreRecords } = useExecutionStore();
+  const { getRecords: getStoreRecords, hasInitializedRecords } = useExecutionStore();
   const storeRecords = useMemo(() => {
     const deduped = new Map<string, ExecutionRecord>();
     for (const candidateUserId of executionUserIdCandidates) {
@@ -84,8 +84,21 @@ export function useDailyProcedureFlowPreview(
     return Array.from(deduped.values());
   }, [executionUserIdCandidates, getStoreRecords, recordDate]);
 
-  // Merge server records and Zustand store records to allow instant reactive updates
+  const hasInitializedStoreRecords = useMemo(
+    () => executionUserIdCandidates.some((candidateUserId) => (
+      hasInitializedRecords(recordDate || '', candidateUserId)
+    )),
+    [executionUserIdCandidates, hasInitializedRecords, recordDate],
+  );
+
+  // Once the local store has initialized a user/date, it is authoritative for
+  // reactive changes including deletes. Otherwise stale raw records can revive
+  // a preview item immediately after deletion.
   const mergedRecords = useMemo(() => {
+    if (hasInitializedStoreRecords) {
+      return storeRecords;
+    }
+
     const deduped = new Map<string, ExecutionRecord>();
     const addRecord = (r: ExecutionRecord) => {
       const key = `${r.date}|${r.userId}|${r.scheduleItemId}`;
@@ -94,7 +107,7 @@ export function useDailyProcedureFlowPreview(
     rawRecords.forEach(addRecord);
     storeRecords.forEach(addRecord);
     return Array.from(deduped.values());
-  }, [rawRecords, storeRecords]);
+  }, [hasInitializedStoreRecords, rawRecords, storeRecords]);
 
   // Merge slots and actual execution records to build daily flow sequence
   const steps = useMemo(() => {
@@ -108,4 +121,3 @@ export function useDailyProcedureFlowPreview(
     refresh: fetchDailyRecords,
   };
 }
-


### PR DESCRIPTION
## Summary
- Add `hasInitializedRecords(date, userId)` to `executionStore`.
- Treat Zustand store records as authoritative in `useDailyProcedureFlowPreview` once a user/date pair has been initialized.
- Prevent stale repository `rawRecords` from reviving deleted procedure records in the daily flow preview.
- Add regression tests for deletion-aware preview synchronization.

## Why
After PR #2037, the Kiosk procedure flow preview correctly synced saved records in most cases. However, deletion/rollback still had a stale-cache risk: if a record was removed from the Zustand store but remained in the initially fetched repository `rawRecords`, the preview could re-display the deleted record.

This follow-up makes the initialized Zustand store state authoritative for the user/date pair, including the empty-array case after deleting the last record.

## Verification
- `npx vitest run src/features/kiosk/hooks/__tests__/useDailyProcedureFlowPreview.spec.ts src/features/daily/stores/__tests__/executionStore.spec.ts`
- `npm run typecheck`
- `npm run lint -- --max-warnings=999`
- Previous target regression tests: 8 files / 121 tests passed

## Manual verification target
- Open `/kiosk/users/:userId/procedures`
- Save a procedure record and confirm the daily flow preview updates immediately
- Delete or revert the saved record
- Confirm the daily flow preview returns to 未記録 and does not revive the deleted record from stale repository data
