### PR TITLE
feat(procedure-record): persist layer3 records from daily support flow

### DIFF
--- a/.github/workflows/fast-lane.yml
+++ b/.github/workflows/fast-lane.yml
@@ -39,8 +39,24 @@ jobs:
       - name: Install deps
         run: npm ci
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
       - name: Install Playwright (Chromium only)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 5
         run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        timeout-minutes: 5
+        run: npx playwright install-deps chromium
 
       - name: TESTIDS guard
         run: npm run guard:testids

--- a/.github/workflows/kiosk-e2e.yml
+++ b/.github/workflows/kiosk-e2e.yml
@@ -40,8 +40,24 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
       - name: Install Playwright browsers (chromium)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 5
         run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        timeout-minutes: 5
+        run: npx playwright install-deps chromium
 
       - name: Run Kiosk E2E tests
         run: |

--- a/src/pages/TimeBasedSupportRecordPage.tsx
+++ b/src/pages/TimeBasedSupportRecordPage.tsx
@@ -143,6 +143,7 @@ const TimeBasedSupportRecordPage: React.FC = () => {
     targetDate,
     totalSteps,
     unfilledStepsCount,
+    schedule,
   });
 
   // ── Derived data ──

--- a/src/pages/hooks/__tests__/useSupportRecordSubmit.spec.ts
+++ b/src/pages/hooks/__tests__/useSupportRecordSubmit.spec.ts
@@ -11,6 +11,7 @@ const mockExecutionUpsert = vi.fn();
 const mockProcedureCreate = vi.fn();
 const mockPersistDailySubmission = vi.fn();
 const mockAuditLogWarn = vi.fn();
+const mockGetCurrentByUser = vi.fn();
 
 vi.mock('@/features/regulatory/hooks/useProcedureRecordRepository', () => ({
   useProcedureRecordRepository: () => ({
@@ -39,13 +40,27 @@ vi.mock('@/lib/runtimeEnv', () => ({
   },
 }));
 
+vi.mock('@/features/planning-sheet/hooks/useIspRepository', () => ({
+  useIspRepository: () => ({
+    getCurrentByUser: mockGetCurrentByUser,
+  }),
+}));
+
 vi.mock('@/features/ibd/core/ibdStore', () => ({
   getLatestSPS: (userId: number) => ({
     id: 'sps-001',
     userId,
-    ispId: 'isp-001',
+    version: 'v1',
     createdAt: '2026-03-01T00:00:00Z',
-    status: 'confirmed',
+    status: 'confirmed' as const,
+    confirmedBy: null,
+    confirmedAt: null,
+    icebergModel: {
+      observableBehaviors: [],
+      underlyingFactors: [],
+      environmentalAdjustments: [],
+    },
+    positiveConditions: [],
   }),
 }));
 
@@ -80,6 +95,7 @@ describe('useSupportRecordSubmit - Layer 3 Persistence', () => {
     mockProcedureCreate.mockReset();
     mockPersistDailySubmission.mockReset();
     mockAuditLogWarn.mockReset();
+    mockGetCurrentByUser.mockReset();
 
     // Default successes
     mockBehaviorRepoAdd.mockImplementation(async (payload) => ({
@@ -90,6 +106,7 @@ describe('useSupportRecordSubmit - Layer 3 Persistence', () => {
     mockExecutionUpsert.mockResolvedValue(undefined);
     mockProcedureCreate.mockResolvedValue({} as SupportProcedureRecord);
     mockPersistDailySubmission.mockResolvedValue(undefined);
+    mockGetCurrentByUser.mockResolvedValue({ id: 'isp-001' });
   });
 
   it('successfully persists SupportProcedureRecord (Layer 3) when step is convertible', async () => {
@@ -241,5 +258,114 @@ describe('useSupportRecordSubmit - Layer 3 Persistence', () => {
     // Layer 3 create must NOT be called since step is not convertible
     expect(mockProcedureCreate).not.toHaveBeenCalled();
     expect(mockAuditLogWarn).not.toHaveBeenCalled();
+  });
+
+  it('keeps submission flow completely successful when current ISP is not found (L3 created without ispId)', async () => {
+    // Current ISP is not found (null)
+    mockGetCurrentByUser.mockResolvedValue(null);
+
+    const { result } = renderHook(() =>
+      useSupportRecordSubmit({
+        behaviorRepo: { add: mockBehaviorRepoAdd } as any,
+        executionStore: { upsertRecord: mockExecutionUpsert } as any,
+        targetUserId: 'U001',
+        targetDate: '2026-05-28',
+        totalSteps: 1,
+        unfilledStepsCount: 1,
+        schedule: defaultSchedule,
+      })
+    );
+
+    await act(async () => {
+      await result.current.handleRecordSubmit({
+        recordedAt: '2026-05-28T10:00:00.000Z',
+        behavior: '日常記録',
+        actualObservation: '元気に登校した',
+        staffResponse: '挨拶を交わした',
+        followUpNote: '',
+        planSlotKey: '09:00|朝の会',
+        antecedent: '',
+        antecedentTags: [],
+        consequence: '',
+        intensity: 1,
+      });
+    });
+
+    expect(mockBehaviorRepoAdd).toHaveBeenCalled();
+    expect(mockExecutionUpsert).toHaveBeenCalled();
+
+    // Layer 3 create must be called but ispId should be undefined
+    expect(mockProcedureCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'U001',
+        planningSheetId: 'ps-001',
+        ispId: undefined, // no ispId
+        recordDate: '2026-05-28',
+        timeSlot: '09:00',
+        activity: '朝の会',
+        procedureText: '挨拶と検温',
+        executionStatus: 'done',
+      })
+    );
+    expect(mockAuditLogWarn).not.toHaveBeenCalled();
+  });
+
+  it('keeps submission flow completely successful when ISP resolution throws an error (L3 created without ispId)', async () => {
+    // Current ISP throws an error
+    const testError = new Error('ISP fetch failed');
+    mockGetCurrentByUser.mockRejectedValue(testError);
+
+    const { result } = renderHook(() =>
+      useSupportRecordSubmit({
+        behaviorRepo: { add: mockBehaviorRepoAdd } as any,
+        executionStore: { upsertRecord: mockExecutionUpsert } as any,
+        targetUserId: 'U001',
+        targetDate: '2026-05-28',
+        totalSteps: 1,
+        unfilledStepsCount: 1,
+        schedule: defaultSchedule,
+      })
+    );
+
+    await act(async () => {
+      await result.current.handleRecordSubmit({
+        recordedAt: '2026-05-28T10:00:00.000Z',
+        behavior: '日常記録',
+        actualObservation: '元気に登校した',
+        staffResponse: '挨拶を交わした',
+        followUpNote: '',
+        planSlotKey: '09:00|朝の会',
+        antecedent: '',
+        antecedentTags: [],
+        consequence: '',
+        intensity: 1,
+      });
+    });
+
+    expect(mockBehaviorRepoAdd).toHaveBeenCalled();
+    expect(mockExecutionUpsert).toHaveBeenCalled();
+
+    // Layer 3 create must be called but ispId should be undefined
+    expect(mockProcedureCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'U001',
+        planningSheetId: 'ps-001',
+        ispId: undefined,
+        recordDate: '2026-05-28',
+        timeSlot: '09:00',
+        activity: '朝の会',
+        procedureText: '挨拶と検温',
+        executionStatus: 'done',
+      })
+    );
+
+    // Warning log must be recorded specifically for ISP resolution failure
+    expect(mockAuditLogWarn).toHaveBeenCalledWith(
+      'daily/support',
+      'Failed to resolve current ISP ID for Layer 3 persistence',
+      testError,
+      'U001',
+      '09:00|朝の会'
+    );
   });
 });

--- a/src/pages/hooks/__tests__/useSupportRecordSubmit.spec.ts
+++ b/src/pages/hooks/__tests__/useSupportRecordSubmit.spec.ts
@@ -1,0 +1,245 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useSupportRecordSubmit } from '../useSupportRecordSubmit';
+import type { ProcedureStep } from '@/features/daily/domain/ProcedureRepository';
+import type { SupportProcedureRecord } from '@/domain/isp/schema';
+
+// ── Mock Repositories & Stores ──────────────────────────────────────────────
+
+const mockBehaviorRepoAdd = vi.fn();
+const mockExecutionUpsert = vi.fn();
+const mockProcedureCreate = vi.fn();
+const mockPersistDailySubmission = vi.fn();
+const mockAuditLogWarn = vi.fn();
+
+vi.mock('@/features/regulatory/hooks/useProcedureRecordRepository', () => ({
+  useProcedureRecordRepository: () => ({
+    create: mockProcedureCreate,
+  }),
+}));
+
+vi.mock('@/features/ibd/analysis/pdca/persistDailyPdca', () => ({
+  makeIdempotencyKey: () => 'mock-idempotency-key',
+  persistDailySubmission: (...args: unknown[]) => mockPersistDailySubmission(...args),
+}));
+
+vi.mock('@/lib/debugLogger', () => ({
+  auditLog: {
+    warn: (...args: unknown[]) => mockAuditLogWarn(...args),
+    debug: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/runtimeEnv', () => ({
+  getEnv: (key: string) => {
+    if (key === 'VITE_FIREBASE_ACTOR_ID') return 'staff-001';
+    return 'mock-env';
+  },
+}));
+
+vi.mock('@/features/ibd/core/ibdStore', () => ({
+  getLatestSPS: (userId: number) => ({
+    id: 'sps-001',
+    userId,
+    ispId: 'isp-001',
+    createdAt: '2026-03-01T00:00:00Z',
+    status: 'confirmed',
+  }),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('@/auth/useUserAuthz', () => ({
+  useUserAuthz: () => ({ role: 'admin' }),
+}));
+
+// ── Test Cases ──────────────────────────────────────────────────────────────
+
+describe('useSupportRecordSubmit - Layer 3 Persistence', () => {
+  const defaultSchedule: ProcedureStep[] = [
+    {
+      id: 'step-1',
+      time: '09:00',
+      activity: '朝の会',
+      instruction: '挨拶と検温',
+      isKey: true,
+      source: 'planning_sheet',
+      planningSheetId: 'ps-001',
+      sourceStepOrder: 1,
+    },
+  ];
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockBehaviorRepoAdd.mockReset();
+    mockExecutionUpsert.mockReset();
+    mockProcedureCreate.mockReset();
+    mockPersistDailySubmission.mockReset();
+    mockAuditLogWarn.mockReset();
+
+    // Default successes
+    mockBehaviorRepoAdd.mockImplementation(async (payload) => ({
+      id: 'abc-001',
+      userId: 'U001',
+      ...payload,
+    }));
+    mockExecutionUpsert.mockResolvedValue(undefined);
+    mockProcedureCreate.mockResolvedValue({} as SupportProcedureRecord);
+    mockPersistDailySubmission.mockResolvedValue(undefined);
+  });
+
+  it('successfully persists SupportProcedureRecord (Layer 3) when step is convertible', async () => {
+    const { result } = renderHook(() =>
+      useSupportRecordSubmit({
+        behaviorRepo: { add: mockBehaviorRepoAdd } as any,
+        executionStore: { upsertRecord: mockExecutionUpsert } as any,
+        targetUserId: 'U001',
+        targetDate: '2026-05-28',
+        totalSteps: 1,
+        unfilledStepsCount: 1,
+        schedule: defaultSchedule,
+      })
+    );
+
+    await act(async () => {
+      await result.current.handleRecordSubmit({
+        recordedAt: '2026-05-28T10:00:00.000Z',
+        behavior: '日常記録',
+        actualObservation: '元気に登校した',
+        staffResponse: '挨拶を交わした',
+        followUpNote: '',
+        planSlotKey: '09:00|朝の会',
+        antecedent: '',
+        antecedentTags: [],
+        consequence: '',
+        intensity: 1,
+      });
+    });
+
+    // Behavior and Execution must be saved
+    expect(mockBehaviorRepoAdd).toHaveBeenCalled();
+    expect(mockExecutionUpsert).toHaveBeenCalled();
+
+    // Layer 3 create must be called with converted payload
+    expect(mockProcedureCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'U001',
+        planningSheetId: 'ps-001',
+        ispId: 'isp-001',
+        recordDate: '2026-05-28',
+        timeSlot: '09:00',
+        activity: '朝の会',
+        procedureText: '挨拶と検温',
+        executionStatus: 'done',
+        userResponse: '元気に登校した',
+        specialNotes: '挨拶を交わした',
+        handoffNotes: '',
+        performedBy: 'staff-001',
+        performedAt: '2026-05-28T10:00:00.000Z',
+        sourceStepOrder: 1,
+      })
+    );
+
+    // No warning log should be recorded
+    expect(mockAuditLogWarn).not.toHaveBeenCalled();
+  });
+
+  it('keeps submission flow completely successful even if Layer 3 persistence throws an error', async () => {
+    // Simulate Layer 3 persistence error
+    const testError = new Error('SharePoint save failed');
+    mockProcedureCreate.mockRejectedValue(testError);
+
+    const { result } = renderHook(() =>
+      useSupportRecordSubmit({
+        behaviorRepo: { add: mockBehaviorRepoAdd } as any,
+        executionStore: { upsertRecord: mockExecutionUpsert } as any,
+        targetUserId: 'U001',
+        targetDate: '2026-05-28',
+        totalSteps: 1,
+        unfilledStepsCount: 1,
+        schedule: defaultSchedule,
+      })
+    );
+
+    await act(async () => {
+      await result.current.handleRecordSubmit({
+        recordedAt: '2026-05-28T10:00:00.000Z',
+        behavior: '日常記録',
+        actualObservation: '元気に登校した',
+        staffResponse: '挨拶を交わした',
+        followUpNote: '',
+        planSlotKey: '09:00|朝の会',
+        antecedent: '',
+        antecedentTags: [],
+        consequence: '',
+        intensity: 1,
+      });
+    });
+
+    // Main flows must still succeed
+    expect(mockBehaviorRepoAdd).toHaveBeenCalled();
+    expect(mockExecutionUpsert).toHaveBeenCalled();
+    expect(mockProcedureCreate).toHaveBeenCalled();
+
+    // Error must be logged as a warning, and NOT crash/throw
+    expect(mockAuditLogWarn).toHaveBeenCalledWith(
+      'daily/support',
+      'Failed to persist Layer 3 SupportProcedureRecord',
+      testError,
+      'U001',
+      '09:00|朝の会'
+    );
+  });
+
+  it('bypasses Layer 3 persistence when step is not convertible', async () => {
+    // Set up schedule with a base_step (not from planning_sheet)
+    const baseSchedule: ProcedureStep[] = [
+      {
+        id: 'step-1',
+        time: '09:00',
+        activity: '朝の会',
+        instruction: '挨拶',
+        isKey: true,
+        source: 'base_steps',
+      },
+    ];
+
+    const { result } = renderHook(() =>
+      useSupportRecordSubmit({
+        behaviorRepo: { add: mockBehaviorRepoAdd } as any,
+        executionStore: { upsertRecord: mockExecutionUpsert } as any,
+        targetUserId: 'U001',
+        targetDate: '2026-05-28',
+        totalSteps: 1,
+        unfilledStepsCount: 1,
+        schedule: baseSchedule,
+      })
+    );
+
+    await act(async () => {
+      await result.current.handleRecordSubmit({
+        recordedAt: '2026-05-28T10:00:00.000Z',
+        behavior: '日常記録',
+        actualObservation: '元気に登校した',
+        staffResponse: '挨拶を交わした',
+        followUpNote: '',
+        planSlotKey: '09:00|朝の会',
+        antecedent: '',
+        antecedentTags: [],
+        consequence: '',
+        intensity: 1,
+      });
+    });
+
+    expect(mockBehaviorRepoAdd).toHaveBeenCalled();
+    expect(mockExecutionUpsert).toHaveBeenCalled();
+
+    // Layer 3 create must NOT be called since step is not convertible
+    expect(mockProcedureCreate).not.toHaveBeenCalled();
+    expect(mockAuditLogWarn).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/hooks/useSupportRecordSubmit.ts
+++ b/src/pages/hooks/useSupportRecordSubmit.ts
@@ -3,7 +3,7 @@
  *
  * TimeBasedSupportRecordPage の handleRecordSubmit, handleRetryPersist を抽出 (#766)
  */
-import { useCallback, useRef, useState, useMemo } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { ABCRecord } from '@/domain/behavior';
 import { getScheduleKey } from '@/features/daily';
@@ -13,7 +13,7 @@ import {
     persistDailySubmission,
     type PersistDailyPdcaInput,
 } from '@/features/ibd/analysis/pdca/persistDailyPdca';
-import { getLatestSPS } from '@/features/ibd/core/ibdStore';
+import { useIspRepository } from '@/features/planning-sheet/hooks/useIspRepository';
 import {
   canConvertToRecord,
   toProcedureRecord,
@@ -62,8 +62,7 @@ export function useSupportRecordSubmit({
   const isSimpleMode = role === 'viewer' || (!canAccess(role, 'reception') && !canAccess(role, 'admin'));
 
   const procedureRecordRepo = useProcedureRecordRepository();
-  const numericUserId = targetUserId ? Number(targetUserId.replace(/\D/g, '')) || 0 : 0;
-  const latestSPS = useMemo(() => (numericUserId ? getLatestSPS(numericUserId) : undefined), [numericUserId]);
+  const ispRepo = useIspRepository();
 
   const [snackbarOpen, setSnackbarOpen] = useState(false);
   const [snackbarMessage, setSnackbarMessage] = useState('記録が完了しました');
@@ -115,7 +114,21 @@ export function useSupportRecordSubmit({
         });
 
         if (currentStep && canConvertToRecord(currentStep)) {
-          const resolvedIspId = (latestSPS as Record<string, unknown> | undefined)?.ispId as string | undefined;
+          let resolvedIspId: string | undefined = undefined;
+          try {
+            const currentIsp = await ispRepo.getCurrentByUser(targetUserId);
+            resolvedIspId = currentIsp?.id;
+          } catch (ispError) {
+            // ISP解決失敗は警告ログを残すが、全体の処理は止めない
+            auditLog.warn(
+              'daily/support',
+              'Failed to resolve current ISP ID for Layer 3 persistence',
+              ispError,
+              targetUserId,
+              payload.planSlotKey
+            );
+          }
+
           const options = resolvedIspId ? { ispId: resolvedIspId } : undefined;
 
           const recordInput = toProcedureRecord(
@@ -244,7 +257,7 @@ export function useSupportRecordSubmit({
     isSimpleMode,
     schedule,
     procedureRecordRepo,
-    latestSPS,
+    ispRepo,
   ]);
 
   const handleRetryPersist = useCallback(async () => {

--- a/src/pages/hooks/useSupportRecordSubmit.ts
+++ b/src/pages/hooks/useSupportRecordSubmit.ts
@@ -3,21 +3,40 @@
  *
  * TimeBasedSupportRecordPage の handleRecordSubmit, handleRetryPersist を抽出 (#766)
  */
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useRef, useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { ABCRecord } from '@/domain/behavior';
+import { getScheduleKey } from '@/features/daily';
 import type { BehaviorRepository, ExecutionRecordRepository } from '@/features/daily';
 import {
     makeIdempotencyKey,
     persistDailySubmission,
     type PersistDailyPdcaInput,
 } from '@/features/ibd/analysis/pdca/persistDailyPdca';
+import { getLatestSPS } from '@/features/ibd/core/ibdStore';
+import {
+  canConvertToRecord,
+  toProcedureRecord,
+} from '@/domain/isp/bridge/toProcedureRecord';
+import { useProcedureRecordRepository } from '@/features/regulatory/hooks/useProcedureRecordRepository';
+import type { ProcedureStep } from '@/features/daily/domain/ProcedureRepository';
 import { auditLog } from '@/lib/debugLogger';
 import { getEnv } from '@/lib/runtimeEnv';
 import { useUserAuthz } from '@/auth/useUserAuthz';
 import { canAccess } from '@/auth/roles';
 
 const ERROR_STORAGE_KEY = 'daily-support-submit-error';
+
+// Helper to find the matching step in the schedule for the given planSlotKey
+const findCurrentProcedureStep = (params: {
+  schedule: readonly ProcedureStep[];
+  planSlotKey?: string;
+}): ProcedureStep | undefined => {
+  if (!params.planSlotKey) return undefined;
+  return params.schedule.find(
+    (item) => getScheduleKey(item.time, item.activity) === params.planSlotKey
+  );
+};
 
 export type UseSupportRecordSubmitArgs = {
   behaviorRepo: BehaviorRepository;
@@ -26,6 +45,7 @@ export type UseSupportRecordSubmitArgs = {
   targetDate: string;
   totalSteps: number;
   unfilledStepsCount: number;
+  schedule: readonly ProcedureStep[];
 };
 
 export function useSupportRecordSubmit({
@@ -35,10 +55,15 @@ export function useSupportRecordSubmit({
   targetDate,
   totalSteps,
   unfilledStepsCount,
+  schedule, // Added
 }: UseSupportRecordSubmitArgs) {
   const navigate = useNavigate();
   const { role } = useUserAuthz();
   const isSimpleMode = role === 'viewer' || (!canAccess(role, 'reception') && !canAccess(role, 'admin'));
+
+  const procedureRecordRepo = useProcedureRecordRepository();
+  const numericUserId = targetUserId ? Number(targetUserId.replace(/\D/g, '')) || 0 : 0;
+  const latestSPS = useMemo(() => (numericUserId ? getLatestSPS(numericUserId) : undefined), [numericUserId]);
 
   const [snackbarOpen, setSnackbarOpen] = useState(false);
   const [snackbarMessage, setSnackbarMessage] = useState('記録が完了しました');
@@ -59,7 +84,7 @@ export function useSupportRecordSubmit({
   const handleRecordSubmit = useCallback(async (payload: Omit<ABCRecord, 'id' | 'userId'>) => {
     if (!targetUserId) return;
     try {
-      await behaviorRepo.add({
+      const savedRecord = await behaviorRepo.add({
         ...payload,
         userId: targetUserId,
       });
@@ -80,6 +105,38 @@ export function useSupportRecordSubmit({
           recordedAt: new Date().toISOString(),
         });
 
+      }
+
+      // 第3層永続化 (SupportProcedureRecord_Daily への自動接続)
+      try {
+        const currentStep = findCurrentProcedureStep({
+          schedule,
+          planSlotKey: payload.planSlotKey,
+        });
+
+        if (currentStep && canConvertToRecord(currentStep)) {
+          const resolvedIspId = (latestSPS as Record<string, unknown> | undefined)?.ispId as string | undefined;
+          const options = resolvedIspId ? { ispId: resolvedIspId } : undefined;
+
+          const recordInput = toProcedureRecord(
+            savedRecord,
+            currentStep,
+            actorUserId,
+            options
+          );
+
+          if (recordInput) {
+            await procedureRecordRepo.create(recordInput);
+          }
+        }
+      } catch (layer3Error) {
+        auditLog.warn(
+          'daily/support',
+          'Failed to persist Layer 3 SupportProcedureRecord',
+          layer3Error,
+          targetUserId,
+          payload.planSlotKey
+        );
       }
 
       if (typeof window !== 'undefined') {
@@ -185,6 +242,9 @@ export function useSupportRecordSubmit({
     totalSteps,
     unfilledStepsCount,
     isSimpleMode,
+    schedule,
+    procedureRecordRepo,
+    latestSPS,
   ]);
 
   const handleRetryPersist = useCallback(async () => {


### PR DESCRIPTION
## Summary
- Connect Layer 3 `SupportProcedureRecord_Daily` persistence to the active `/daily/support` submit path.
- Move the implementation from the unused legacy hook path to `useSupportRecordSubmit.ts`, which is used by `TimeBasedSupportRecordPage.tsx`.
- Use `canConvertToRecord` / `toProcedureRecord` as the SSOT for procedure-record conversion.
- Keep Layer 3 persistence fault-tolerant: failures are logged with `auditLog.warn` and do not block daily support submission.

## Scope
- Modified `src/pages/hooks/useSupportRecordSubmit.ts`
- Modified `src/pages/TimeBasedSupportRecordPage.tsx` to pass `schedule`
- Added `src/pages/hooks/__tests__/useSupportRecordSubmit.spec.ts`
- Reverted legacy `useTimeBasedSupportPage.ts` changes; no redundant logic remains there

## Tests
- `npx vitest run --reporter=verbose src/pages/hooks/__tests__/useSupportRecordSubmit.spec.ts`
  - 3 tests passed:
    - Layer 3 persistence success
    - Layer 3 persistence failure remains non-blocking
    - Non-convertible step bypass

## Typecheck note
- `npx tsc --noEmit` currently reports existing unrelated test-file errors outside this PR scope.
- Filtered check confirmed no reported errors for:
  - `useSupportRecordSubmit`
  - `TimeBasedSupportRecordPage`

## Risk / Availability
- Layer 3 persistence is intentionally non-blocking.
- Existing daily support save flow remains the source of user-visible success.
- `SupportProcedureRecord_Daily` write failure does not prevent ABC / execution record / daily submission flow.

## Follow-up fix
- Resolve parent L1 ISP ID from the ISP repository instead of reading non-existent `ispId` from `latestSPS`.
- Keep Layer 3 persistence non-blocking when ISP resolution fails, and log distinct warning messages.
- Update tests to avoid adding mock-only `ispId` fields to `SupportPlanSheet`, and add edge-case regression tests for ISP resolution errors.

## Updated verification
- `npx vitest run src/pages/hooks/__tests__/useSupportRecordSubmit.spec.ts`
  - 5 tests passed
- Filtered typecheck:
  - No type errors found in modified files

## CI follow-up
- Stabilize Playwright browser installation in GitHub Actions to avoid CI hangs during E2E setup.
- Keep existing E2E coverage and required check names unchanged.
