### PR TITLE
fix(sp): avoid repeated SharePoint list discovery during kiosk execution lookup

### DIFF
--- a/.github/workflows/e2e-deep.yml
+++ b/.github/workflows/e2e-deep.yml
@@ -67,8 +67,24 @@ jobs:
       - name: Install dependencies
         run: npm ci
       
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 5
         run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        timeout-minutes: 5
+        run: npx playwright install-deps chromium
       
       - name: Build application (preview mode)
         run: npm run build
@@ -244,8 +260,24 @@ jobs:
       - name: Install dependencies
         run: npm ci
       
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 5
         run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        timeout-minutes: 5
+        run: npx playwright install-deps chromium
       
       - name: Run integration tests
         id: integration_tests

--- a/src/features/daily/repositories/sharepoint/modules/SchemaResolver.ts
+++ b/src/features/daily/repositories/sharepoint/modules/SchemaResolver.ts
@@ -23,6 +23,12 @@ import {
 } from '../utils/Helpers';
 import { resolveInternalNames } from '@/lib/sp/helpers';
 
+let availableListTitlesCache = new WeakMap<SpFetchFn, Promise<string[] | null>>();
+
+export const __clearDailyRecordSchemaResolverCachesForTests = (): void => {
+    availableListTitlesCache = new WeakMap<SpFetchFn, Promise<string[] | null>>();
+};
+
 export class DailyRecordSchemaResolver {
     private resolvedListPath: string | null = null;
     private listPathResolutionFailed = false;
@@ -336,13 +342,24 @@ export class DailyRecordSchemaResolver {
     }
 
     private async getAvailableListTitles(): Promise<string[] | null> {
-        try {
+        const cached = availableListTitlesCache.get(this.spFetch);
+        if (cached) return cached;
+
+        const request = (async () => {
             const response = await this.spFetch("lists?$select=Title&$top=5000");
             const payload = (await response.json()) as SharePointResponse<{ Title?: string }>;
             return (payload.value ?? [])
                 .map((item) => item.Title?.trim())
                 .filter((title): title is string => Boolean(title));
+        })();
+        availableListTitlesCache.set(this.spFetch, request);
+
+        try {
+            return await request;
         } catch (error) {
+            if (availableListTitlesCache.get(this.spFetch) === request) {
+                availableListTitlesCache.delete(this.spFetch);
+            }
             if (getHttpStatus(error) === 404) return null;
             throw error;
         }

--- a/src/features/daily/repositories/sharepoint/modules/__tests__/SchemaResolver.cache.spec.ts
+++ b/src/features/daily/repositories/sharepoint/modules/__tests__/SchemaResolver.cache.spec.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SpFetchFn } from '@/lib/sp/spLists';
+import { DailyRecordSchemaResolver, __clearDailyRecordSchemaResolverCachesForTests } from '../SchemaResolver';
+import { DAILY_RECORD_FIELDS } from '../../constants';
+
+const responseJson = (value: unknown): Response =>
+  ({
+    ok: true,
+    json: async () => value,
+  }) as Response;
+
+const requiredParentFields = new Set<string>([
+  DAILY_RECORD_FIELDS.title,
+  DAILY_RECORD_FIELDS.recordDate,
+  DAILY_RECORD_FIELDS.reporterName,
+  DAILY_RECORD_FIELDS.userRowsJSON,
+]);
+
+describe('DailyRecordSchemaResolver list discovery cache', () => {
+  beforeEach(() => {
+    __clearDailyRecordSchemaResolverCachesForTests();
+    vi.clearAllMocks();
+  });
+
+  it('shares list discovery across resolver instances for the same SharePoint fetcher', async () => {
+    const spFetch = vi.fn<SpFetchFn>().mockResolvedValue(
+      responseJson({
+        value: [
+          { Title: 'SupportRecord_Daily' },
+          { Title: 'DailyRecordRows' },
+        ],
+      }),
+    );
+    const getListFieldInternalNames = vi.fn().mockResolvedValue(requiredParentFields);
+
+    const first = new DailyRecordSchemaResolver(spFetch, 'SupportRecord_Daily', getListFieldInternalNames);
+    const second = new DailyRecordSchemaResolver(spFetch, 'SupportRecord_Daily', getListFieldInternalNames);
+
+    await first.resolveListPath();
+    await second.resolveRowsPath('DailyRecordRows');
+
+    expect(spFetch).toHaveBeenCalledTimes(1);
+    expect(spFetch).toHaveBeenCalledWith('lists?$select=Title&$top=5000');
+  });
+
+  it('coalesces parallel list discovery calls into one request', async () => {
+    let resolveResponse: (response: Response) => void = () => {};
+    const responsePromise = new Promise<Response>((resolve) => {
+      resolveResponse = resolve;
+    });
+    const spFetch = vi.fn<SpFetchFn>().mockReturnValue(responsePromise);
+
+    const first = new DailyRecordSchemaResolver(spFetch, 'SupportRecord_Daily');
+    const second = new DailyRecordSchemaResolver(spFetch, 'SupportRecord_Daily');
+
+    const firstResolution = first.resolveRowsPath('DailyRecordRows');
+    const secondResolution = second.resolveRowsPath('DailyRecordRows');
+    resolveResponse(responseJson({ value: [{ Title: 'DailyRecordRows' }] }));
+
+    await expect(Promise.all([firstResolution, secondResolution])).resolves.toEqual([
+      "lists/getbytitle('DailyRecordRows')",
+      "lists/getbytitle('DailyRecordRows')",
+    ]);
+    expect(spFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not keep a failed discovery request cached', async () => {
+    const throttleError = new Error('SpThrottleRedirectError');
+    throttleError.name = 'SpThrottleRedirectError';
+    const spFetch = vi
+      .fn<SpFetchFn>()
+      .mockRejectedValueOnce(throttleError)
+      .mockResolvedValueOnce(responseJson({ value: [{ Title: 'DailyRecordRows' }] }));
+
+    const first = new DailyRecordSchemaResolver(spFetch, 'SupportRecord_Daily');
+    await expect(first.resolveRowsPath('DailyRecordRows')).rejects.toBe(throttleError);
+
+    const second = new DailyRecordSchemaResolver(spFetch, 'SupportRecord_Daily');
+    await expect(second.resolveRowsPath('DailyRecordRows')).resolves.toBe("lists/getbytitle('DailyRecordRows')");
+    expect(spFetch).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- Cache or avoid repeated SharePoint list discovery during Kiosk execution lookup.
- Reduce calls to `/_api/web/lists?$select=Title&$top=5000`.
- Keep existing completed-status / detail restore / daily flow preview behavior unchanged.

## Why
Kiosk SharePoint acceptance checks were blocked by SharePoint throttle redirects (`Throttle.htm#17`). The app already stops retry storms safely, but repeated list discovery during execution lookup can still contribute to throttling.

## Verification
- git diff --check
- npm run typecheck
- npm run lint -- --max-warnings=999
- npx vitest run src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx src/features/kiosk/hooks/__tests__/useDailyProcedureFlowPreview.spec.ts src/features/kiosk/components/__tests__/KioskDailyProcedureFlowPreview.spec.tsx src/features/daily/utils/__tests__/normalizeExecutionLookup.spec.ts src/features/daily/repositories/sharepoint/utils/__tests__/readSharePointText.spec.ts src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts src/features/daily/repositories/sharepoint/modules/__tests__/SchemaResolver.cache.spec.ts

## Manual verification target
- Open `/kiosk/users/10/procedures`
- Confirm no repeated `/_api/web/lists?$select=Title&$top=5000`
- Confirm execution records load without `Throttle.htm#17`
- Confirm completed status appears

## CI follow-up
- Apply the same Playwright browser cache / install timeout hardening to Deep Tests (Chromium).
- Keep the existing Deep Tests coverage and required check name unchanged.
