### PR TITLE
ci: harden Playwright browser install for deep tests

### DIFF
--- a/.github/workflows/e2e-deep.yml
+++ b/.github/workflows/e2e-deep.yml
@@ -66,24 +66,29 @@ jobs:
       
       - name: Install dependencies
         run: npm ci
+
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(npx playwright --version | cut -d' ' -f2)" >> "$GITHUB_OUTPUT"
       
       - name: Cache Playwright browsers
         uses: actions/cache@v4
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}-${{ hashFiles('package-lock.json') }}
           restore-keys: |
+            ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}-
             ${{ runner.os }}-playwright-
 
-      - name: Install Playwright browsers
+      - name: Install Playwright (Chromium only)
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        timeout-minutes: 5
+        timeout-minutes: 10
         run: npx playwright install --with-deps chromium
 
       - name: Install Playwright system dependencies
         if: steps.playwright-cache.outputs.cache-hit == 'true'
-        timeout-minutes: 5
+        timeout-minutes: 10
         run: npx playwright install-deps chromium
       
       - name: Build application (preview mode)
@@ -259,24 +264,29 @@ jobs:
       
       - name: Install dependencies
         run: npm ci
+
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(npx playwright --version | cut -d' ' -f2)" >> "$GITHUB_OUTPUT"
       
       - name: Cache Playwright browsers
         uses: actions/cache@v4
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}-${{ hashFiles('package-lock.json') }}
           restore-keys: |
+            ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}-
             ${{ runner.os }}-playwright-
 
-      - name: Install Playwright browsers
+      - name: Install Playwright (Chromium only)
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        timeout-minutes: 5
+        timeout-minutes: 10
         run: npx playwright install --with-deps chromium
 
       - name: Install Playwright system dependencies
         if: steps.playwright-cache.outputs.cache-hit == 'true'
-        timeout-minutes: 5
+        timeout-minutes: 10
         run: npx playwright install-deps chromium
       
       - name: Run integration tests


### PR DESCRIPTION
## Summary
- Add Playwright browser cache hardening to Deep Tests only.
- Key the cache by runner OS, package-lock hash, and installed Playwright version.
- Skip Chromium browser install on cache hit and run install only on cache miss.
- Add a 10-minute timeout guard to the Playwright install step.

## Scope
- Limited to .github/workflows/e2e-deep.yml.
- Does not change Deep Tests job names, required check names, projects, coverage, or test targets.

## Verification
- git diff --check
- actionlint .github/workflows/e2e-deep.yml