### PR TITLE
fix(kiosk): stabilize historical records hook references

### DIFF
--- a/src/features/daily/hooks/__tests__/useHistoricalRecords.spec.ts
+++ b/src/features/daily/hooks/__tests__/useHistoricalRecords.spec.ts
@@ -6,10 +6,11 @@ import type { ExecutionRecord } from '../../domain/legacy/executionRecordTypes';
 const mockGetHistoricalRecords = vi.fn<(...args: unknown[]) => Promise<ExecutionRecord[]>>();
 const mockGetRecordsInRange = vi.fn<(...args: unknown[]) => Promise<ExecutionRecord[]>>();
 
+// useExecutionData の返す関数を毎レンダーで再作成し、参照揺れをシミュレートする
 vi.mock('../useExecutionData', () => ({
   useExecutionData: () => ({
-    getHistoricalRecords: mockGetHistoricalRecords,
-    getRecordsInRange: mockGetRecordsInRange,
+    getHistoricalRecords: (...args: unknown[]) => mockGetHistoricalRecords(...args),
+    getRecordsInRange: (...args: unknown[]) => mockGetRecordsInRange(...args),
   }),
 }));
 
@@ -78,5 +79,159 @@ describe('useHistoricalRecords', () => {
       'r-2026-05-06',
       'r-2026-05-05',
     ]);
+  });
+
+  it('does not re-trigger fetch when parent passes new arrays with the same values', async () => {
+    mockGetHistoricalRecords.mockResolvedValue([]);
+    mockGetRecordsInRange.mockResolvedValue([]);
+
+    const { result, rerender } = renderHook(
+      ({ fallbackScheduleItemIds, fallbackUserIds }) =>
+        useHistoricalRecords('U001', '0', fallbackScheduleItemIds, fallbackUserIds),
+      {
+        initialProps: {
+          fallbackScheduleItemIds: ['1'] as readonly string[],
+          fallbackUserIds: ['U002'] as readonly string[],
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const initialCallCount = mockGetHistoricalRecords.mock.calls.length;
+
+    // 再レンダリングで同一要素だが別インスタンスの配列を渡す
+    rerender({
+      fallbackScheduleItemIds: ['1'] as readonly string[],
+      fallbackUserIds: ['U002'] as readonly string[],
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(mockGetHistoricalRecords.mock.calls.length).toBe(initialCallCount);
+  });
+
+  it('does not re-trigger fetch when function references from useExecutionData change', async () => {
+    mockGetHistoricalRecords.mockResolvedValue([]);
+    mockGetRecordsInRange.mockResolvedValue([]);
+
+    const { result, rerender } = renderHook(() =>
+      useHistoricalRecords('U001', '0', [], []),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const initialCallCount = mockGetHistoricalRecords.mock.calls.length;
+
+    // 再描画を呼び出す（useExecutionData は新しい無名関数を返すが、内部的には hook の副作用がトリガーされないはず）
+    rerender();
+
+    expect(result.current.isLoading).toBe(false);
+    expect(mockGetHistoricalRecords.mock.calls.length).toBe(initialCallCount);
+  });
+
+  it('discards stale fetch results if params change during flight (Sequence Guard)', async () => {
+    mockGetHistoricalRecords.mockResolvedValue([]);
+    mockGetRecordsInRange.mockResolvedValue([]);
+
+    let resolveFirstFetch: (value: ExecutionRecord[]) => void = () => {};
+    const firstFetchPromise = new Promise<ExecutionRecord[]>((resolve) => {
+      resolveFirstFetch = resolve;
+    });
+
+    // 引数に応じて精密にモックの挙動を切り替える
+    mockGetHistoricalRecords.mockImplementation(async (userId, scheduleItemId) => {
+      if (userId === 'U001' && String(scheduleItemId) === '1') {
+        return firstFetchPromise;
+      }
+      if (userId === 'U001' && String(scheduleItemId) === '2') {
+        return [record('r-2026-05-15', '2026-05-15', '2')];
+      }
+      return [];
+    });
+
+    const { result, rerender } = renderHook(
+      ({ userId, scheduleItemId }) => useHistoricalRecords(userId, scheduleItemId, [], []),
+      {
+        initialProps: { userId: 'U001', scheduleItemId: '1' },
+      },
+    );
+
+    // まだローディング中
+    expect(result.current.isLoading).toBe(true);
+
+    // 1回目が保留されている間に、パラメータを変更して2回目を走らせる
+    rerender({ userId: 'U001', scheduleItemId: '2' });
+
+    // 2回目のフェッチは即座に解決される
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.records.map((r) => r.id)).toEqual(['r-2026-05-15']);
+
+    // ここで1回目のフェッチが遅れて解決する
+    resolveFirstFetch([record('r-2026-05-10', '2026-05-10', '1')]);
+
+    // しばらく待っても records が古い 1 回目のデータで上書きされないことを確認
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(result.current.records.map((r) => r.id)).toEqual(['r-2026-05-15']);
+  });
+
+  it('discards stale fetch results if params become empty during flight', async () => {
+    mockGetHistoricalRecords.mockResolvedValue([]);
+    mockGetRecordsInRange.mockResolvedValue([]);
+
+    let resolveFirstFetch: (value: ExecutionRecord[]) => void = () => {};
+    const firstFetchPromise = new Promise<ExecutionRecord[]>((resolve) => {
+      resolveFirstFetch = resolve;
+    });
+
+    mockGetHistoricalRecords.mockImplementation(async (userId, scheduleItemId) => {
+      if (userId === 'U001' && String(scheduleItemId) === '1') {
+        return firstFetchPromise;
+      }
+      return [];
+    });
+
+    const { result, rerender } = renderHook(
+      ({ userId, scheduleItemId }) => useHistoricalRecords(userId, scheduleItemId, [], []),
+      {
+        initialProps: { userId: 'U001', scheduleItemId: '1' },
+      },
+    );
+
+    // 1回目が保留されている間に、params を空にする
+    rerender({ userId: 'U001', scheduleItemId: '' });
+
+    // paramsが空になったので即座にローディングや状態がクリアされるはず
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.records).toEqual([]);
+
+    // 1回目のフェッチが遅れて解決する
+    resolveFirstFetch([record('r-2026-05-10', '2026-05-10', '1')]);
+
+    // しばらく待っても records が古い 1 回目のデータで復活しないことを確認
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(result.current.records).toEqual([]);
+  });
+
+  it('does not loop infinitely when fetch fails and sets error state', async () => {
+    const apiError = new Error('SharePoint Throttle or CORS Blocked');
+    mockGetHistoricalRecords.mockRejectedValue(apiError);
+
+    const { result } = renderHook(() => useHistoricalRecords('U001', '0', [], []));
+
+    await waitFor(() => {
+      expect(result.current.error).not.toBeNull();
+    });
+
+    expect(result.current.error?.message).toBe('SharePoint Throttle or CORS Blocked');
+    expect(result.current.isLoading).toBe(false);
+
+    // 再フェッチの無限ループに入らず、コール数が1回で止まっていること
+    expect(mockGetHistoricalRecords.mock.calls.length).toBe(1);
   });
 });

--- a/src/features/daily/hooks/useHistoricalRecords.ts
+++ b/src/features/daily/hooks/useHistoricalRecords.ts
@@ -1,31 +1,62 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useExecutionData } from './useExecutionData';
 import type { ExecutionRecord } from '../domain/legacy/executionRecordTypes';
 import { normalizeScheduleItemId } from '../utils/normalizeScheduleItemId';
 import { buildExecutionUserIdCandidates } from '../utils/normalizeExecutionLookup';
 
+const EMPTY_IDS: readonly string[] = [];
+
 export function useHistoricalRecords(
   userId: string,
   scheduleItemId: string,
-  fallbackScheduleItemIds: string[] = [],
-  fallbackUserIds: string[] = [],
+  fallbackScheduleItemIds: readonly string[] = EMPTY_IDS,
+  fallbackUserIds: readonly string[] = EMPTY_IDS,
 ) {
   const { getHistoricalRecords, getRecordsInRange } = useExecutionData();
+
+  // 最新の関数の参照を useRef に格納
+  const getHistoricalRecordsRef = useRef(getHistoricalRecords);
+  const getRecordsInRangeRef = useRef(getRecordsInRange);
+  const requestSeqRef = useRef(0);
+
+  useEffect(() => {
+    getHistoricalRecordsRef.current = getHistoricalRecords;
+    getRecordsInRangeRef.current = getRecordsInRange;
+  }, [getHistoricalRecords, getRecordsInRange]);
 
   const [records, setRecords] = useState<ExecutionRecord[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 
+  // 配列の参照揺れを防ぐため文字列キー化
+  const fallbackScheduleKey = fallbackScheduleItemIds.join('\u0000');
+  const fallbackUserKey = fallbackUserIds.join('\u0000');
+
   const fetchHistory = useCallback(async () => {
-    if (!userId || !scheduleItemId) return;
-    
+    const requestSeq = ++requestSeqRef.current;
+
+    if (!userId || !scheduleItemId) {
+      setRecords([]);
+      setError(null);
+      setIsLoading(false);
+      return;
+    }
+
     setIsLoading(true);
     setError(null);
     try {
-      const userCandidates = buildExecutionUserIdCandidates(userId, ...fallbackUserIds);
+      const fallbackScheduleIds = fallbackScheduleKey
+        ? fallbackScheduleKey.split('\u0000')
+        : [];
+
+      const fallbackUsers = fallbackUserKey
+        ? fallbackUserKey.split('\u0000')
+        : [];
+
+      const userCandidates = buildExecutionUserIdCandidates(userId, ...fallbackUsers);
 
       const primaryId = normalizeScheduleItemId(scheduleItemId);
-      const fallbackIds = fallbackScheduleItemIds
+      const fallbackIds = fallbackScheduleIds
         .map((id) => normalizeScheduleItemId(id))
         .filter((id) => Boolean(id) && id !== primaryId);
       const scheduleCandidates = [primaryId, ...fallbackIds];
@@ -60,7 +91,7 @@ export function useHistoricalRecords(
       let history: ExecutionRecord[] = [];
       for (const candidateUserId of userCandidates) {
         for (const candidateScheduleId of scheduleCandidates) {
-          const result = await getHistoricalRecords(candidateUserId, candidateScheduleId, 150);
+          const result = await getHistoricalRecordsRef.current(candidateUserId, candidateScheduleId, 150);
           merge(result);
         }
       }
@@ -86,7 +117,7 @@ export function useHistoricalRecords(
       };
 
       for (const candidateUserId of userCandidates) {
-        const rangeRecords = await getRecordsInRange(candidateUserId, fromStr, toStr);
+        const rangeRecords = await getRecordsInRangeRef.current(candidateUserId, fromStr, toStr);
         const matched = rangeRecords
           .filter((record) => isScheduleMatch(record.scheduleItemId))
           .sort((a, b) => (b.recordedAt || b.id).localeCompare(a.recordedAt || a.id));
@@ -97,14 +128,19 @@ export function useHistoricalRecords(
       history = Array.from(byId.values())
         .sort((a, b) => (b.recordedAt || b.id).localeCompare(a.recordedAt || a.id))
         .slice(0, 150);
+
+      if (requestSeq !== requestSeqRef.current) return;
       setRecords(history);
     } catch (err) {
+      if (requestSeq !== requestSeqRef.current) return;
       console.error('[useHistoricalRecords] Failed to fetch history:', err);
       setError(err instanceof Error ? err : new Error('Failed to fetch history'));
     } finally {
-      setIsLoading(false);
+      if (requestSeq === requestSeqRef.current) {
+        setIsLoading(false);
+      }
     }
-  }, [userId, scheduleItemId, fallbackScheduleItemIds, fallbackUserIds, getHistoricalRecords, getRecordsInRange]);
+  }, [userId, scheduleItemId, fallbackScheduleKey, fallbackUserKey]);
 
   useEffect(() => {
     void fetchHistory();


### PR DESCRIPTION
## Summary
Stabilize the historical records hook (`useHistoricalRecords`) references and prevent infinite render loops when loading history panels in the Kiosk screen.

### Key Changes
- **Ref Pattern**: Wrapped hook functions `getHistoricalRecords` and `getRecordsInRange` with a stable `useRef` updated via `useEffect` to break reference changes originating from state/Zustand store updates.
- **String Serialization**: Serialized fallback array arguments (`fallbackScheduleItemIds`, `fallbackUserIds`) using `join('\u0000')` to pass as unified string values in `useCallback` dependency array, avoiding rendering cycles driven by empty/new arrays from parents.
- **Sequence Guard**: Added `requestSeqRef` to track active requests and discard out-of-order stale fetch responses.
- **Parameter Clear Reset**: Ensured the request sequence is advanced even when empty arguments (`userId`/`scheduleItemId`) are passed, immediately clearing previous records to prevent background response leaks.
- **Linter Alignment**: Replaced generic `any[]` arguments inside test mocks with typed `unknown[]` arguments to prevent `no-explicit-any` rules from triggering.