### PR TITLE
fix(daily): stabilize execution record hook dependencies

### DIFF
--- a/src/features/daily/hooks/__tests__/useExecutionRecord.spec.ts
+++ b/src/features/daily/hooks/__tests__/useExecutionRecord.spec.ts
@@ -7,11 +7,15 @@ const mockGetRecord = vi.fn<(...args: unknown[]) => Promise<ExecutionRecord | un
 const mockUpsertRecord = vi.fn<(...args: unknown[]) => Promise<void>>();
 const mockDeleteRecord = vi.fn<(...args: unknown[]) => Promise<void>>();
 
+let getRecordRefChanger = mockGetRecord;
+let upsertRecordRefChanger = mockUpsertRecord;
+let deleteRecordRefChanger = mockDeleteRecord;
+
 vi.mock('../useExecutionData', () => ({
   useExecutionData: () => ({
-    getRecord: mockGetRecord,
-    upsertRecord: mockUpsertRecord,
-    deleteRecord: mockDeleteRecord,
+    getRecord: (...args: unknown[]) => getRecordRefChanger(...args),
+    upsertRecord: (...args: unknown[]) => upsertRecordRefChanger(...args),
+    deleteRecord: (...args: unknown[]) => deleteRecordRefChanger(...args),
   }),
 }));
 
@@ -37,6 +41,9 @@ describe('useExecutionRecord', () => {
     mockDeleteRecord.mockReset();
     mockUpsertRecord.mockResolvedValue(undefined);
     mockDeleteRecord.mockResolvedValue(undefined);
+    getRecordRefChanger = mockGetRecord;
+    upsertRecordRefChanger = mockUpsertRecord;
+    deleteRecordRefChanger = mockDeleteRecord;
   });
 
   it('updates the concrete record key found through fallback lookup', async () => {
@@ -104,5 +111,178 @@ describe('useExecutionRecord', () => {
     });
 
     expect(mockDeleteRecord).toHaveBeenCalledWith('2026-05-07', 'legacy-user', 'legacy-slot');
+  });
+
+  it('does not re-fetch when new arrays with identical values are passed for fallbacks', async () => {
+    mockGetRecord.mockResolvedValue(undefined);
+
+    const { result, rerender } = renderHook(
+      ({ fallbackSchedules, fallbackUsers }) =>
+        useExecutionRecord('2026-05-07', 'user-1', 'slot-1', fallbackSchedules, fallbackUsers),
+      {
+        initialProps: {
+          fallbackSchedules: ['slot-2'],
+          fallbackUsers: ['user-2'],
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(mockGetRecord).toHaveBeenCalledTimes(4); // 2 users * 2 slots
+    mockGetRecord.mockClear();
+
+    // Rerender with new array instances containing identical values
+    rerender({
+      fallbackSchedules: ['slot-2'],
+      fallbackUsers: ['user-2'],
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(mockGetRecord).not.toHaveBeenCalled();
+  });
+
+  it('does not trigger infinite fetch loop when function references from useExecutionData change', async () => {
+    mockGetRecord.mockResolvedValue(undefined);
+
+    const { result, rerender } = renderHook(() =>
+      useExecutionRecord('2026-05-07', 'user-1', 'slot-1', ['slot-2'], ['user-2']),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(mockGetRecord).toHaveBeenCalledTimes(4);
+    mockGetRecord.mockClear();
+
+    // Force hook to get new function wrapper instances by triggering rerender
+    getRecordRefChanger = (...args: unknown[]) => mockGetRecord(...args);
+    upsertRecordRefChanger = (...args: unknown[]) => mockUpsertRecord(...args);
+    deleteRecordRefChanger = (...args: unknown[]) => mockDeleteRecord(...args);
+    rerender();
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(mockGetRecord).not.toHaveBeenCalled();
+  });
+
+  it('discards stale fetch results if parameters change mid-flight', async () => {
+    let resolveFirstFetch: (value: ExecutionRecord | undefined) => void = () => {};
+    const firstFetchPromise = new Promise<ExecutionRecord | undefined>((resolve) => {
+      resolveFirstFetch = resolve;
+    });
+
+    mockGetRecord.mockImplementation(async (date, userId, scheduleItemId) => {
+      if (userId === 'user-1' && scheduleItemId === 'slot-1') {
+        return firstFetchPromise;
+      }
+      if (userId === 'user-2' && scheduleItemId === 'slot-2') {
+        return {
+          id: 'record-2',
+          date: '2026-05-07',
+          userId: 'user-2',
+          scheduleItemId: 'slot-2',
+          status: 'completed',
+          triggeredBipIds: [],
+          memo: 'second memo',
+          recordedBy: 'Staff A',
+          recordedAt: '2026-05-07T09:00:00.000Z',
+        };
+      }
+      return undefined;
+    });
+
+    const { result, rerender } = renderHook(
+      ({ userId, scheduleItemId }) =>
+        useExecutionRecord('2026-05-07', userId, scheduleItemId),
+      {
+        initialProps: { userId: 'user-1', scheduleItemId: 'slot-1' },
+      },
+    );
+
+    // Props change mid-flight
+    rerender({ userId: 'user-2', scheduleItemId: 'slot-2' });
+
+    await waitFor(() => {
+      expect(result.current.record?.id).toBe('record-2');
+    });
+
+    // Resolve the first fetch
+    resolveFirstFetch({
+      id: 'record-1',
+      date: '2026-05-07',
+      userId: 'user-1',
+      scheduleItemId: 'slot-1',
+      status: 'completed',
+      triggeredBipIds: [],
+      memo: 'first memo',
+      recordedBy: 'Staff A',
+      recordedAt: '2026-05-07T09:00:00.000Z',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(result.current.record?.id).toBe('record-2');
+  });
+
+  it('clears record and increments sequence when parameters become empty mid-flight', async () => {
+    let resolveFirstFetch: (value: ExecutionRecord | undefined) => void = () => {};
+    const firstFetchPromise = new Promise<ExecutionRecord | undefined>((resolve) => {
+      resolveFirstFetch = resolve;
+    });
+
+    mockGetRecord.mockImplementation(async (date, userId, scheduleItemId) => {
+      if (userId === 'user-1' && scheduleItemId === 'slot-1') {
+        return firstFetchPromise;
+      }
+      return undefined;
+    });
+
+    const { result, rerender } = renderHook(
+      ({ userId, scheduleItemId }) =>
+        useExecutionRecord('2026-05-07', userId, scheduleItemId),
+      {
+        initialProps: { userId: 'user-1', scheduleItemId: 'slot-1' },
+      },
+    );
+
+    // Empty parameters mid-flight
+    rerender({ userId: '', scheduleItemId: '' });
+
+    expect(result.current.record).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+
+    resolveFirstFetch({
+      id: 'record-1',
+      date: '2026-05-07',
+      userId: 'user-1',
+      scheduleItemId: 'slot-1',
+      status: 'completed',
+      triggeredBipIds: [],
+      memo: 'first memo',
+      recordedBy: 'Staff A',
+      recordedAt: '2026-05-07T09:00:00.000Z',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(result.current.record).toBeUndefined();
+  });
+
+  it('sets error and sets isLoading to false when getRecord rejects, without infinite looping', async () => {
+    const errorInstance = new Error('Database connection failed');
+    mockGetRecord.mockRejectedValue(errorInstance);
+
+    const { result } = renderHook(() =>
+      useExecutionRecord('2026-05-07', 'user-1', 'slot-1'),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.error).toBe(errorInstance);
+    expect(mockGetRecord).toHaveBeenCalledTimes(1);
+
+    mockGetRecord.mockClear();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(mockGetRecord).not.toHaveBeenCalled();
   });
 });

--- a/src/features/daily/hooks/useExecutionRecord.ts
+++ b/src/features/daily/hooks/useExecutionRecord.ts
@@ -8,6 +8,8 @@ import { type RecordStatus, makeRecordId, type ExecutionRecord } from '../domain
 import { useExecutionData } from './useExecutionData';
 import { normalizeScheduleItemId } from '../utils/normalizeScheduleItemId';
 
+const EMPTY_IDS: string[] = [];
+
 export function useExecutionRecord(
   date: string,
   userId: string,
@@ -18,23 +20,36 @@ export function useExecutionRecord(
   const { getRecord, upsertRecord, deleteRecord } = useExecutionData();
   const [record, setRecord] = useState<ExecutionRecord | undefined>();
   const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
 
   const getRecordRef = useRef(getRecord);
   const upsertRecordRef = useRef(upsertRecord);
+  const deleteRecordRef = useRef(deleteRecord);
+  const requestSeqRef = useRef(0);
 
   useEffect(() => {
     getRecordRef.current = getRecord;
     upsertRecordRef.current = upsertRecord;
-  }, [getRecord, upsertRecord]);
+    deleteRecordRef.current = deleteRecord;
+  }, [getRecord, upsertRecord, deleteRecord]);
+
+  const fallbackScheduleKey = (fallbackScheduleItemIds ?? EMPTY_IDS).join('\u0000');
+  const fallbackUserKey = (fallbackUserIds ?? EMPTY_IDS).join('\u0000');
 
   const fetchRecord = useCallback(async () => {
+    const seq = ++requestSeqRef.current;
     setIsLoading(true);
+    setError(null);
+
+    const fallbackUserIdsParsed = fallbackUserKey ? fallbackUserKey.split('\u0000') : EMPTY_IDS;
     const userIds = Array.from(
-      new Set([userId, ...(fallbackUserIds ?? [])].map((value) => String(value ?? '').trim()).filter(Boolean)),
+      new Set([userId, ...fallbackUserIdsParsed].map((value) => String(value ?? '').trim()).filter(Boolean)),
     );
+
+    const fallbackScheduleIdsParsed = fallbackScheduleKey ? fallbackScheduleKey.split('\u0000') : EMPTY_IDS;
     const scheduleItemIds = Array.from(
       new Set(
-        [scheduleItemId, ...(fallbackScheduleItemIds ?? [])]
+        [scheduleItemId, ...fallbackScheduleIdsParsed]
           .map((value) => normalizeScheduleItemId(value))
           .filter(Boolean),
       ),
@@ -46,21 +61,31 @@ export function useExecutionRecord(
       return;
     }
 
-    let resolved: ExecutionRecord | undefined;
-    for (const candidateUserId of userIds) {
-      for (const candidateScheduleItemId of scheduleItemIds) {
-        const candidateRecord = await getRecordRef.current(date, candidateUserId, candidateScheduleItemId);
-        if (candidateRecord) {
-          resolved = candidateRecord;
-          break;
+    try {
+      let resolved: ExecutionRecord | undefined;
+      for (const candidateUserId of userIds) {
+        for (const candidateScheduleItemId of scheduleItemIds) {
+          const candidateRecord = await getRecordRef.current(date, candidateUserId, candidateScheduleItemId);
+          if (seq !== requestSeqRef.current) return;
+          if (candidateRecord) {
+            resolved = candidateRecord;
+            break;
+          }
         }
+        if (resolved) break;
       }
-      if (resolved) break;
-    }
 
-    setRecord(resolved);
-    setIsLoading(false);
-  }, [date, userId, scheduleItemId, fallbackScheduleItemIds, fallbackUserIds]);
+      if (seq === requestSeqRef.current) {
+        setRecord(resolved);
+        setIsLoading(false);
+      }
+    } catch (err) {
+      if (seq === requestSeqRef.current) {
+        setError(err instanceof Error ? err : new Error('Failed to fetch execution record'));
+        setIsLoading(false);
+      }
+    }
+  }, [date, userId, scheduleItemId, fallbackScheduleKey, fallbackUserKey]);
 
   useEffect(() => {
     void fetchRecord();
@@ -134,9 +159,9 @@ export function useExecutionRecord(
 
   const deleteRecordFn = useCallback(async () => {
     const target = resolveMutationTarget();
-    await deleteRecord(target.date, target.userId, target.scheduleItemId);
+    await deleteRecordRef.current(target.date, target.userId, target.scheduleItemId);
     setRecord(undefined);
-  }, [deleteRecord, resolveMutationTarget]);
+  }, [resolveMutationTarget]);
 
-  return { record, setStatus, setMemo, saveRecord, deleteRecord: deleteRecordFn, isLoading, refresh: fetchRecord } as const;
+  return { record, setStatus, setMemo, saveRecord, deleteRecord: deleteRecordFn, isLoading, error, refresh: fetchRecord } as const;
 }


### PR DESCRIPTION
## Summary
- Refactored `useExecutionRecord` to resolve infinite re-rendering and request storm risks.
- Applied stable string keys (`fallbackScheduleKey` and `fallbackUserKey` joined by `\u0000`) for array dependencies in the fetch callback.
- Introduced `requestSeqRef` sequence guard to drop stale async fetch results.
- Wrapped all hook functions (`getRecord`, `upsertRecord`, `deleteRecord`) in refs to guarantee absolute stability.
- Ensured immediate sequence advancement and record clearance if arguments become empty mid-flight.
- Handled errors in async fetch cleanly, preventing fetch loops on state updates.

## Verification
- Added 5 new robust unit tests in `useExecutionRecord.spec.ts` validating arrays stability, dynamic mock reference changes, sequence guards, empty inputs, and rejected fetches.
- Run unit tests: `npx vitest run src/features/daily/hooks/__tests__/useExecutionRecord.spec.ts` (7 PASS)
- Run typecheck: `npm run typecheck` (PASS)