### PR TITLE
fix(kiosk): stabilize toilet records repository references

### DIFF
--- a/src/features/kiosk/toilet/__tests__/useToiletRecords.spec.ts
+++ b/src/features/kiosk/toilet/__tests__/useToiletRecords.spec.ts
@@ -1,0 +1,155 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useToiletRecords } from '../useToiletRecords';
+
+const mockListByDate = vi.fn();
+const mockCreate = vi.fn();
+
+let currentSpFetch = vi.fn();
+let currentGetListFieldInternalNames = vi.fn();
+
+vi.mock('@/lib/spClient', () => ({
+  useSP: () => ({
+    spFetch: (...args: unknown[]) => currentSpFetch(...args),
+    getListFieldInternalNames: (...args: unknown[]) => currentGetListFieldInternalNames(...args),
+  }),
+}));
+
+vi.mock('../toiletRepositoryFactory', () => ({
+  getToiletRepository: (spFetch: any, getListFieldInternalNames: any) => ({
+    listByDate: (dateIso: string) => mockListByDate(dateIso, spFetch, getListFieldInternalNames),
+    create: (input: any) => mockCreate(input),
+  }),
+}));
+
+describe('useToiletRecords', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    currentSpFetch = vi.fn().mockResolvedValue({ ok: true });
+    currentGetListFieldInternalNames = vi.fn().mockResolvedValue(new Set());
+    mockListByDate.mockReset();
+    mockCreate.mockReset();
+  });
+
+  it('does not trigger re-fetch loop even if useSP returns new function instances on every render', async () => {
+    mockListByDate.mockResolvedValue([]);
+
+    const { result, rerender } = renderHook(() => useToiletRecords('2026-05-28'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockListByDate).toHaveBeenCalledTimes(1);
+
+    // Rerender multiple times to simulate function reference changes on every render
+    rerender();
+    rerender();
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(mockListByDate).toHaveBeenCalledTimes(1);
+  });
+
+  it('correctly routes spFetch calls to the latest spFetchRef.current reference after change', async () => {
+    const firstSpFetchMock = vi.fn().mockResolvedValue({ ok: true });
+    const secondSpFetchMock = vi.fn().mockResolvedValue({ ok: true });
+
+    currentSpFetch = firstSpFetchMock;
+    mockListByDate.mockImplementation(async (dateIso, spFetch) => {
+      await spFetch('test-path');
+      return [];
+    });
+
+    const { result, rerender } = renderHook(() => useToiletRecords('2026-05-28'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(firstSpFetchMock).toHaveBeenCalledWith('test-path', undefined);
+    firstSpFetchMock.mockClear();
+
+    // Update the spFetch implementation
+    currentSpFetch = secondSpFetchMock;
+    rerender();
+
+    // Trigger refresh manually
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(secondSpFetchMock).toHaveBeenCalledWith('test-path', undefined);
+    expect(firstSpFetchMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps refresh and create references completely stable across renders', async () => {
+    mockListByDate.mockResolvedValue([]);
+
+    const { result, rerender } = renderHook(() => useToiletRecords('2026-05-28'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const initialRefresh = result.current.refresh;
+    const initialCreate = result.current.create;
+
+    // Change spFetch instance and trigger rerender
+    currentSpFetch = vi.fn().mockResolvedValue({ ok: true });
+    rerender();
+
+    expect(result.current.refresh).toBe(initialRefresh);
+    expect(result.current.create).toBe(initialCreate);
+  });
+
+  it('sets error and sets isLoading to false when listByDate rejects, without infinite looping', async () => {
+    const dbError = new Error('SharePoint timeout');
+    mockListByDate.mockRejectedValue(dbError);
+
+    const { result } = renderHook(() => useToiletRecords('2026-05-28'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBe(dbError);
+    expect(mockListByDate).toHaveBeenCalledTimes(1);
+
+    mockListByDate.mockClear();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(mockListByDate).not.toHaveBeenCalled();
+  });
+
+  it('discards stale fetch results if date parameter changes mid-flight', async () => {
+    let resolveFirstFetch: (value: any[]) => void = () => {};
+    const firstFetchPromise = new Promise<any[]>((resolve) => {
+      resolveFirstFetch = resolve;
+    });
+
+    mockListByDate.mockImplementation(async (dateIso) => {
+      if (dateIso === '2026-05-28') {
+        return firstFetchPromise;
+      }
+      return [{ id: 'record-2' }];
+    });
+
+    const { result, rerender } = renderHook(
+      ({ date }) => useToiletRecords(date),
+      {
+        initialProps: { date: '2026-05-28' },
+      },
+    );
+
+    // Props change mid-flight
+    rerender({ date: '2026-05-29' });
+
+    await waitFor(() => {
+      expect(result.current.records).toEqual([{ id: 'record-2' }]);
+    });
+
+    // Resolve the first fetch
+    resolveFirstFetch([{ id: 'record-1' }]);
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(result.current.records).toEqual([{ id: 'record-2' }]);
+  });
+});

--- a/src/features/kiosk/toilet/useToiletRecords.ts
+++ b/src/features/kiosk/toilet/useToiletRecords.ts
@@ -1,31 +1,62 @@
-import { useCallback, useEffect, useState, useMemo } from 'react';
+import { useCallback, useEffect, useState, useMemo, useRef } from 'react';
 import { getToiletRepository } from './toiletRepositoryFactory';
 import type { ToiletRecord, ToiletRecordInput } from './types';
 import { useSP } from '@/lib/spClient';
+import type { SpFetchFn } from '@/lib/sp/spLists';
 
 export function useToiletRecords(dateIso: string) {
   const [records, setRecords] = useState<ToiletRecord[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<Error | null>(null);
   const { spFetch, getListFieldInternalNames } = useSP();
 
-  const repository = useMemo(() => {
-    return getToiletRepository(spFetch, getListFieldInternalNames);
+  const spFetchRef = useRef(spFetch);
+  const getListFieldInternalNamesRef = useRef(getListFieldInternalNames);
+  const requestSeqRef = useRef(0);
+
+  useEffect(() => {
+    spFetchRef.current = spFetch;
+    getListFieldInternalNamesRef.current = getListFieldInternalNames;
   }, [spFetch, getListFieldInternalNames]);
 
+  const repository = useMemo(() => {
+    const stableSpFetch: SpFetchFn = (path, init) => spFetchRef.current(path, init);
+    const stableGetListFieldInternalNames = (listTitle: string) => {
+      if (getListFieldInternalNamesRef.current) {
+        return getListFieldInternalNamesRef.current(listTitle);
+      }
+      return Promise.resolve(new Set<string>());
+    };
+    return getToiletRepository(stableSpFetch, stableGetListFieldInternalNames);
+  }, []);
+
   const refresh = useCallback(async () => {
+    const seq = ++requestSeqRef.current;
     setIsLoading(true);
+    setError(null);
     try {
+      if (!dateIso) {
+        if (seq === requestSeqRef.current) {
+          setRecords([]);
+          setIsLoading(false);
+        }
+        return;
+      }
       const data = await repository.listByDate(dateIso);
-      setRecords(data);
-    } catch (error) {
-      console.error('[useToiletRecords] Failed to load toilet records:', error);
-    } finally {
-      setIsLoading(false);
+      if (seq === requestSeqRef.current) {
+        setRecords(data);
+        setIsLoading(false);
+      }
+    } catch (err) {
+      if (seq === requestSeqRef.current) {
+        setError(err instanceof Error ? err : new Error('Failed to load toilet records'));
+        setIsLoading(false);
+      }
     }
   }, [dateIso, repository]);
 
   useEffect(() => {
-    refresh();
+    void refresh();
   }, [refresh]);
 
   const create = useCallback(async (input: ToiletRecordInput) => {
@@ -33,11 +64,11 @@ export function useToiletRecords(dateIso: string) {
       const record = await repository.create(input);
       await refresh();
       return record;
-    } catch (error) {
-      console.error('[useToiletRecords] Failed to create toilet record:', error);
-      throw error;
+    } catch (err) {
+      console.error('[useToiletRecords] Failed to create toilet record:', err);
+      throw err;
     }
   }, [refresh, repository]);
 
-  return { records, create, refresh, isLoading };
+  return { records, create, refresh, isLoading, error };
 }


### PR DESCRIPTION
## Summary
- Refactored `useToiletRecords` hook to solve reference changes and request loops.
- Applied Ref Pattern (`spFetchRef` and `getListFieldInternalNamesRef`) to track external functions.
- Stabilized `repository` using `useMemo([], ...)` with custom wrappers delegating to the refs, guaranteeing the repository instance is created exactly once.
- Introduced `requestSeqRef` sequence guard to prevent stale result overwrites.
- Handled rejects/errors cleanly and added an `error` return property to the hook.

## Verification
- Created new unit tests in `useToiletRecords.spec.ts` validating:
  1. No re-fetch loop even if useSP wrapper changes on every render.
  2. spFetch calls map to the latest spFetchRef.current reference.
  3. Stable refresh and create callback references across renders.
  4. Proper error handling and loop prevention on fetch reject.
  5. Stale result prevention via sequence guard on parameter changes.
- Tested: `npx vitest run src/features/kiosk/toilet` (12 PASS)
- Typecheck: `npm run typecheck` (PASS)
- Blank lines / whitespace diff check: `git diff --check` (PASS)