### PR TITLE
ci: harden Playwright installs for smoke and integration workflows

### DIFF
--- a/.github/workflows/e2e-smoke-nurse.yml
+++ b/.github/workflows/e2e-smoke-nurse.yml
@@ -13,15 +13,27 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-      - name: Cache Playwright Browsers
+      - run: npm ci
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(npx playwright --version | cut -d' ' -f2)" >> "$GITHUB_OUTPUT"
+      - name: Cache Playwright browsers
         uses: actions/cache@v4
+        id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}-${{ hashFiles('package-lock.json') }}
           restore-keys: |
-            playwright-${{ runner.os }}-
-      - run: npm ci
-      - run: npx playwright install --with-deps chromium
+            ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}-
+            ${{ runner.os }}-playwright-
+      - name: Install Playwright (Chromium only)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 10
+        run: npx playwright install --with-deps chromium
+      - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        timeout-minutes: 10
+        run: npx playwright install-deps chromium
       - name: Run nurse smokes
         env:
           VITE_FEATURE_NURSE_UI: "1"

--- a/.github/workflows/integration-dailyops.yml
+++ b/.github/workflows/integration-dailyops.yml
@@ -39,14 +39,29 @@ jobs:
       - name: Install deps
         run: npm ci
 
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(npx playwright --version | cut -d' ' -f2)" >> "$GITHUB_OUTPUT"
+
       - name: Cache Playwright browsers
         uses: actions/cache@v4
+        id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}-
+            ${{ runner.os }}-playwright-
 
-      - name: Install Playwright browsers
+      - name: Install Playwright (Chromium only)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 10
         run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        timeout-minutes: 10
+        run: npx playwright install-deps chromium
 
       - name: Restore Playwright storageState
         shell: bash

--- a/.github/workflows/integration-staff.yml
+++ b/.github/workflows/integration-staff.yml
@@ -39,8 +39,29 @@ jobs:
       - name: Install deps
         run: npm ci
 
-      - name: Install Playwright browsers (and OS deps)
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(npx playwright --version | cut -d' ' -f2)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}-
+            ${{ runner.os }}-playwright-
+
+      - name: Install Playwright (Chromium only)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 10
         run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        timeout-minutes: 10
+        run: npx playwright install-deps chromium
 
       - name: Restore Playwright storageState
         shell: bash


### PR DESCRIPTION
## Summary
- Apply the proven Playwright browser cache hardening pattern from #2042 to selected smoke/integration workflows.
- Key browser cache by runner OS, Playwright version, and package-lock hash.
- Run full Chromium install only on cache miss.
- Run Playwright system dependency install on cache hit to keep GitHub hosted runners safe.
- Add 10-minute timeout guards around Playwright install steps.

## Scope
- Workflow-only change.
- Limited to:
  - .github/workflows/e2e-smoke-nurse.yml
  - .github/workflows/integration-dailyops.yml
  - .github/workflows/integration-staff.yml
- No app/runtime/test target changes.

## Verification
- git diff --check
- actionlint .github/workflows/e2e-smoke-nurse.yml .github/workflows/integration-dailyops.yml .github/workflows/integration-staff.yml
- npm run typecheck