### PR TITLE
fix(kiosk): prevent duplicate execution record matching

### DIFF
--- a/src/features/kiosk/components/KioskProcedureListScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureListScreen.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/features/daily/utils/normalizeExecutionLookup';
 import { useExecutionStore } from '@/features/daily/stores/executionStore';
 import { isStrictSameProcedureSlot, isShiftedProcedureSlot } from '../domain/buildDailyProcedureFlowPreview';
+import type { ProcedureItem } from '@/features/daily/stores/procedureStore';
 
 import { getCurrentExecutionRepositoryKind } from '@/features/daily/repositories/sharepoint/executionRepositoryFactory';
 import { usePlanningSheetRepositories } from '@/features/planning-sheet/hooks/usePlanningSheetRepositories';
@@ -477,7 +478,7 @@ export const KioskProcedureListScreen: React.FC = () => {
         ...step,
         rowNo: step.rowNo !== undefined ? Number(step.rowNo) : undefined,
         id: step.id ? String(step.id) : undefined,
-      } as any;
+      } as ProcedureItem;
 
       const strictMatch = dedupedRecords.find(r => isStrictSameProcedureSlot(slot, r));
       if (strictMatch) {
@@ -492,7 +493,7 @@ export const KioskProcedureListScreen: React.FC = () => {
         ...step,
         rowNo: step.rowNo !== undefined ? Number(step.rowNo) : undefined,
         id: step.id ? String(step.id) : undefined,
-      } as any;
+      } as ProcedureItem;
 
       const key = slot.rowNo ?? (index + 1);
       let matchedRecord = strictMatchMap.get(key);

--- a/src/features/kiosk/components/KioskProcedureListScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureListScreen.tsx
@@ -18,6 +18,7 @@ import {
   normalizeScheduleItemId,
 } from '@/features/daily/utils/normalizeExecutionLookup';
 import { useExecutionStore } from '@/features/daily/stores/executionStore';
+import { isStrictSameProcedureSlot, isShiftedProcedureSlot } from '../domain/buildDailyProcedureFlowPreview';
 
 import { getCurrentExecutionRepositoryKind } from '@/features/daily/repositories/sharepoint/executionRepositoryFactory';
 import { usePlanningSheetRepositories } from '@/features/planning-sheet/hooks/usePlanningSheetRepositories';
@@ -439,14 +440,7 @@ export const KioskProcedureListScreen: React.FC = () => {
 
   // 進捗サマリーの計算
   const totalCount = procedures.length;
-  const recordsByScheduleItemId = React.useMemo(() => {
-    const map = new Map<string, ExecutionRecord[]>();
-
-    // In SharePoint mode, once the server read has completed it is authoritative.
-    // However, to protect against SharePoint indexing/replication lag, we keep recently
-    // saved optimistic local records (within 2 minutes) even after the fetch completes.
-    // When the server fetch failed (e.g. throttled), use ALL store records as the
-    // best available data without the 2-minute recency filter.
+  const recordedRecordsByProcedure = React.useMemo(() => {
     const allCandidateRecords =
       executionRepositoryKind === 'sharepoint' && hasFetchedRecords
         ? fetchFailed
@@ -464,29 +458,57 @@ export const KioskProcedureListScreen: React.FC = () => {
               }),
             ]
         : [...storeRecords, ...records];
-    
+
+    const uniqueRecordsMap = new Map<string, ExecutionRecord>();
     for (const record of allCandidateRecords) {
-      for (const key of buildRecordMatchKeys(record)) {
-        const existing = map.get(key) ?? [];
-        if (existing.length === 0 || hasRecordInput(record)) {
-          map.set(key, [record, ...existing.filter((item) => item !== record)]);
-        }
+      const key = `${record.date}|${record.userId}|${record.scheduleItemId}|${record.id ?? ''}`;
+      const existing = uniqueRecordsMap.get(key);
+      if (!existing || (!hasRecordInput(existing) && hasRecordInput(record))) {
+        uniqueRecordsMap.set(key, record);
       }
     }
-    return map;
-  }, [executionRepositoryKind, hasFetchedRecords, fetchFailed, storeRecords, records, hasRecordInput]);
-  const getRecordedRecordForProcedure = React.useCallback((procedure: { id?: unknown; rowNo?: unknown }, index: number) => {
-    const procedureKeys = buildProcedureMatchKeys(procedure, index, allPrimaryScheduleKeys);
-    const matchedRecord = procedureKeys
-      .flatMap((key) => recordsByScheduleItemId.get(key) ?? [])
-      .find((record) => hasRecordInput(record));
-    if (matchedRecord) return matchedRecord;
-    return undefined;
-  }, [allPrimaryScheduleKeys, hasRecordInput, recordsByScheduleItemId]);
-  const recordedRecordsByProcedure = React.useMemo(
-    () => procedures.map((procedure, index) => getRecordedRecordForProcedure(procedure, index)),
-    [procedures, getRecordedRecordForProcedure]
-  );
+    const dedupedRecords = Array.from(uniqueRecordsMap.values());
+
+    const strictlyMatchedRecords = new Set<ExecutionRecord>();
+    const strictMatchMap = new Map<number, ExecutionRecord>();
+
+    procedures.forEach((step, index) => {
+      const slot = {
+        ...step,
+        rowNo: step.rowNo !== undefined ? Number(step.rowNo) : undefined,
+        id: step.id ? String(step.id) : undefined,
+      } as any;
+
+      const strictMatch = dedupedRecords.find(r => isStrictSameProcedureSlot(slot, r));
+      if (strictMatch) {
+        const key = slot.rowNo ?? (index + 1);
+        strictMatchMap.set(key, strictMatch);
+        strictlyMatchedRecords.add(strictMatch);
+      }
+    });
+
+    return procedures.map((step, index) => {
+      const slot = {
+        ...step,
+        rowNo: step.rowNo !== undefined ? Number(step.rowNo) : undefined,
+        id: step.id ? String(step.id) : undefined,
+      } as any;
+
+      const key = slot.rowNo ?? (index + 1);
+      let matchedRecord = strictMatchMap.get(key);
+
+      if (!matchedRecord) {
+        matchedRecord = dedupedRecords.find(r =>
+          !strictlyMatchedRecords.has(r) && isShiftedProcedureSlot(slot, r)
+        );
+      }
+
+      if (matchedRecord && hasRecordInput(matchedRecord)) {
+        return matchedRecord;
+      }
+      return undefined;
+    });
+  }, [executionRepositoryKind, hasFetchedRecords, fetchFailed, storeRecords, records, procedures, hasRecordInput]);
   const doneCount = recordedRecordsByProcedure.filter((r) => r?.status === 'completed').length;
   const recordedCount = recordedRecordsByProcedure.filter(Boolean).length;
   const progress = totalCount > 0 ? (recordedCount / totalCount) * 100 : 0;

--- a/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
@@ -1109,4 +1109,39 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
     expect(mockGetRecords).toHaveBeenCalledWith(expect.any(String), 'U001');
     expect(mockGetRecords).toHaveBeenCalledWith(expect.any(String), '17');
   });
+
+  it('correctly matches 6 completed execution records (1 to 6) to the first 6 procedure rows (1-based rowNo match)', async () => {
+    const procedures17 = Array.from({ length: 17 }, (_, index) => {
+      const rowNo = index + 1;
+      return {
+        id: `base-${rowNo}`,
+        rowNo,
+        time: `${String(9 + Math.floor(index / 2)).padStart(2, '0')}:00`,
+        activity: `手順 ${rowNo}`,
+        instruction: `支援内容 ${rowNo}`,
+      };
+    });
+    mockGetByUser.mockReturnValue(procedures17);
+
+    mockGetRecords.mockResolvedValue([
+      { scheduleItemId: '1', status: 'completed', memo: '実施済み1' },
+      { scheduleItemId: '2', status: 'completed', memo: '実施済み2' },
+      { scheduleItemId: '3', status: 'completed', memo: '実施済み3' },
+      { scheduleItemId: '4', status: 'completed', memo: '実施済み4' },
+      { scheduleItemId: '5', status: 'completed', memo: '実施済み5' },
+      { scheduleItemId: '6', status: 'completed', memo: '実施済み6' },
+    ]);
+
+    render(
+      <MemoryRouter>
+        <KioskProcedureListScreen />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('実施状況: 6 / 17')).toBeInTheDocument();
+      expect(screen.getByText('6 完了')).toBeInTheDocument();
+      expect(screen.getAllByText('記録済み')).toHaveLength(6);
+    });
+  });
 });

--- a/src/features/kiosk/domain/buildDailyProcedureFlowPreview.ts
+++ b/src/features/kiosk/domain/buildDailyProcedureFlowPreview.ts
@@ -46,9 +46,9 @@ export function isStrictSameProcedureSlot(slot: ProcedureItem, record: Execution
 
   const recordKeys = new Set<string>();
   recordKeys.add(normRecordId);
-  recordKeys.add(record.scheduleItemId);
+  recordKeys.add(String(record.scheduleItemId));
 
-  const recordTrailingMatch = record.scheduleItemId.match(/\d+$/);
+  const recordTrailingMatch = String(record.scheduleItemId).match(/\d+$/);
   if (recordTrailingMatch) {
     recordKeys.add(recordTrailingMatch[0]);
     recordKeys.add(normalizeScheduleItemId(recordTrailingMatch[0]));
@@ -64,9 +64,10 @@ export function isStrictSameProcedureSlot(slot: ProcedureItem, record: Execution
  * Robust matching with 0-based to 1-based index shift fallback
  */
 export function isShiftedProcedureSlot(slot: ProcedureItem, record: ExecutionRecord): boolean {
+  const recordScheduleItemIdStr = String(record.scheduleItemId ?? '');
   // Support 0-based and 1-based index mismatch robustly only when the record scheduleItemId is a pure numeric string
-  if (/^\d+$/.test(record.scheduleItemId)) {
-    const recordNum = parseInt(record.scheduleItemId, 10);
+  if (/^\d+$/.test(recordScheduleItemIdStr)) {
+    const recordNum = parseInt(recordScheduleItemIdStr, 10);
     if (slot.rowNo === recordNum + 1) {
       return true;
     }
@@ -74,9 +75,9 @@ export function isShiftedProcedureSlot(slot: ProcedureItem, record: ExecutionRec
   // Also check if slotId trailing digit has index shift (e.g. slotId ends with 'base-1' and record.scheduleItemId is '0')
   const slotId = slot.id || '';
   const slotTrailingMatch = slotId.match(/\d+$/);
-  if (slotTrailingMatch && /^\d+$/.test(record.scheduleItemId)) {
+  if (slotTrailingMatch && /^\d+$/.test(recordScheduleItemIdStr)) {
     const slotVal = parseInt(slotTrailingMatch[0], 10);
-    const recordVal = parseInt(record.scheduleItemId, 10);
+    const recordVal = parseInt(recordScheduleItemIdStr, 10);
     if (slotVal === recordVal + 1) {
       return true;
     }
@@ -153,7 +154,7 @@ export function buildDailyProcedureFlowPreview(
   const sortedSlots = [...slots].sort((a, b) => (a.rowNo ?? 0) - (b.rowNo ?? 0));
 
   // Build strict matching map first to prevent cross-row mismatch pollution
-  const strictlyMatchedRecordIds = new Set<string>();
+  const strictlyMatchedRecords = new Set<ExecutionRecord>();
   const strictMatchMap = new Map<number, ExecutionRecord>();
 
   sortedSlots.forEach(slot => {
@@ -161,9 +162,7 @@ export function buildDailyProcedureFlowPreview(
     const strictMatch = records.find(r => isStrictSameProcedureSlot(slot, r));
     if (strictMatch) {
       strictMatchMap.set(rowNo, strictMatch);
-      if (strictMatch.id) {
-        strictlyMatchedRecordIds.add(strictMatch.id);
-      }
+      strictlyMatchedRecords.add(strictMatch);
     }
   });
 
@@ -176,7 +175,7 @@ export function buildDailyProcedureFlowPreview(
     // 2. If no strict match, fallback to index shift matching (filtering out strictly matched records)
     if (!matchedRecord) {
       matchedRecord = records.find(r =>
-        (!r.id || !strictlyMatchedRecordIds.has(r.id)) && isShiftedProcedureSlot(slot, r)
+        !strictlyMatchedRecords.has(r) && isShiftedProcedureSlot(slot, r)
       );
     }
 


### PR DESCRIPTION
## Summary

- Prevent the same `ExecutionRecord` from being matched to multiple kiosk procedure rows.
- Track consumed execution records during procedure-row matching.
- Align daily procedure flow preview matching with kiosk procedure list behavior.
- Reduce incorrect recorded-state display caused by row/index matching drift.

## Verification

- `npx vitest run src/features/kiosk`
- `npx vitest run src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx`
  - verifies 6 completed records are matched to the first 6 procedure rows
- `npx playwright test tests/e2e/kiosk-procedure-list.spec.ts`
- `npm run typecheck`
- `git diff --check`

## Notes

This PR is intentionally separated from PR #2052.

PR #2052 covers diagnostic query propagation tests only, while this PR fixes execution-record matching consistency.

This change does not alter persistence format or SharePoint repository behavior.
