### PR TITLE
fix(health): classify SharePoint throttling as external warning

### DIFF
--- a/src/features/diagnostics/health/__tests__/throttlingClassification.spec.ts
+++ b/src/features/diagnostics/health/__tests__/throttlingClassification.spec.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it, vi } from 'vitest';
+import { runHealthChecks } from '../checks';
+import type { HealthContext, ListSpec } from '../types';
+import type { SpAdapter } from '../spAdapter';
+
+// --- Helpers ---
+
+/**
+ * Creates an error that mimics SpThrottleRedirectError from spFetch.ts.
+ * The error has no numeric `status` property — this is the root cause
+ * of the original misclassification as FAIL.
+ */
+function makeThrottleError(): Error {
+  const e = new Error(
+    '[SharePoint] Throttled: redirected to Throttle.htm. Retry stopped to avoid request storm.'
+  );
+  e.name = 'SpThrottleRedirectError';
+  return e;
+}
+
+function makeHttpError(status: number, message: string): Error & { status: number } {
+  const e = new Error(message) as Error & { status: number };
+  e.status = status;
+  return e;
+}
+
+// --- Shared fixtures ---
+
+const baseCtx: HealthContext = {
+  env: {
+    VITE_SP_RESOURCE: 'https://tenant.sharepoint.com',
+    VITE_MSAL_CLIENT_ID: 'client-id',
+    VITE_MSAL_TENANT_ID: 'tenant-id',
+  },
+  siteUrl: 'https://tenant.sharepoint.com/sites/test',
+  listSpecs: () => [],
+  isProductionLike: true,
+  autonomyLevel: 'F',
+};
+
+/** Mimics the real-world `user_benefit_profile_ext` list that triggered the original issue */
+const userBenefitProfileExtSpec: ListSpec = {
+  key: 'user_benefit_profile_ext',
+  displayName: '利用者給付プロフィール（拡張）',
+  resolvedTitle: 'UserBenefit_Profile_Ext',
+  requiredFields: [],
+  createItem: {},
+  updateItem: {},
+};
+
+function makePassingSpAdapter(): SpAdapter {
+  return {
+    getCurrentUser: vi.fn().mockResolvedValue({ id: 1, title: 'Test User' }),
+    getWebTitle: vi.fn().mockResolvedValue('Test Site'),
+    getListByTitle: vi.fn().mockResolvedValue({ id: '1', title: 'UserBenefit_Profile_Ext' }),
+    getFields: vi.fn().mockResolvedValue([]),
+    getItemsTop1: vi.fn().mockResolvedValue([]),
+    createItem: vi.fn().mockResolvedValue({ id: 101 }),
+    updateItem: vi.fn().mockResolvedValue(undefined),
+    deleteItem: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+// ==========================================================================
+// Tests
+// ==========================================================================
+
+describe('Health Checks — SharePoint throttling classification', () => {
+  // ------------------------------------------------------------------
+  // 1. schema.fields.user_benefit_profile_ext — the original regression
+  // ------------------------------------------------------------------
+  describe('schema.fields.user_benefit_profile_ext (original regression)', () => {
+    it('classifies SpThrottleRedirectError on getFields as WARN, not FAIL', async () => {
+      const sp = makePassingSpAdapter();
+      sp.getFields = vi.fn().mockRejectedValue(makeThrottleError());
+
+      const results = await runHealthChecks(
+        { ...baseCtx, listSpecs: () => [userBenefitProfileExtSpec] },
+        sp
+      );
+
+      const schemaCheck = results.find(
+        (r) => r.key === 'schema.fields.user_benefit_profile_ext'
+      );
+      expect(schemaCheck).toBeDefined();
+      expect(schemaCheck?.status).toBe('warn');
+      expect(schemaCheck?.summary).toContain('スロットリング');
+      expect(schemaCheck?.detail).toContain('throttling');
+    });
+
+    it('keeps genuine schema fetch failure as FAIL', async () => {
+      const sp = makePassingSpAdapter();
+      sp.getFields = vi.fn().mockRejectedValue(
+        makeHttpError(500, 'Internal Server Error')
+      );
+
+      const results = await runHealthChecks(
+        { ...baseCtx, listSpecs: () => [userBenefitProfileExtSpec] },
+        sp
+      );
+
+      const schemaCheck = results.find(
+        (r) => r.key === 'schema.fields.user_benefit_profile_ext'
+      );
+      expect(schemaCheck).toBeDefined();
+      expect(schemaCheck?.status).toBe('fail');
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // 2. permissions.read.user_benefit_profile_ext — the other regression
+  // ------------------------------------------------------------------
+  describe('permissions.read.user_benefit_profile_ext (original regression)', () => {
+    it('classifies SpThrottleRedirectError on getItemsTop1 as WARN, not FAIL', async () => {
+      const sp = makePassingSpAdapter();
+      sp.getItemsTop1 = vi.fn().mockRejectedValue(makeThrottleError());
+
+      const results = await runHealthChecks(
+        { ...baseCtx, listSpecs: () => [userBenefitProfileExtSpec] },
+        sp
+      );
+
+      const readCheck = results.find(
+        (r) => r.key === 'permissions.read.user_benefit_profile_ext'
+      );
+      expect(readCheck).toBeDefined();
+      expect(readCheck?.status).toBe('warn');
+      expect(readCheck?.summary).toContain('スロットリング');
+    });
+
+    it('keeps 403 Forbidden on read as FAIL', async () => {
+      const sp = makePassingSpAdapter();
+      sp.getItemsTop1 = vi.fn().mockRejectedValue(
+        makeHttpError(403, 'Forbidden')
+      );
+
+      const results = await runHealthChecks(
+        { ...baseCtx, listSpecs: () => [userBenefitProfileExtSpec] },
+        sp
+      );
+
+      const readCheck = results.find(
+        (r) => r.key === 'permissions.read.user_benefit_profile_ext'
+      );
+      expect(readCheck).toBeDefined();
+      expect(readCheck?.status).toBe('fail');
+      expect(readCheck?.summary).toContain('権限がありません');
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // 3. lists.exists — throttling on getListByTitle
+  // ------------------------------------------------------------------
+  describe('lists.exists — throttling on list existence check', () => {
+    it('classifies SpThrottleRedirectError on getListByTitle as WARN', async () => {
+      const sp = makePassingSpAdapter();
+      sp.getListByTitle = vi.fn().mockRejectedValue(makeThrottleError());
+
+      const results = await runHealthChecks(
+        { ...baseCtx, listSpecs: () => [userBenefitProfileExtSpec] },
+        sp
+      );
+
+      const listCheck = results.find(
+        (r) => r.key === 'lists.exists.user_benefit_profile_ext'
+      );
+      expect(listCheck).toBeDefined();
+      expect(listCheck?.status).toBe('warn');
+      expect(listCheck?.summary).toContain('スロットリング');
+    });
+
+    it('keeps genuine list-not-found as FAIL', async () => {
+      const sp = makePassingSpAdapter();
+      sp.getListByTitle = vi.fn().mockRejectedValue(
+        makeHttpError(404, 'List not found')
+      );
+
+      const results = await runHealthChecks(
+        { ...baseCtx, listSpecs: () => [userBenefitProfileExtSpec] },
+        sp
+      );
+
+      const listCheck = results.find(
+        (r) => r.key === 'lists.exists.user_benefit_profile_ext'
+      );
+      expect(listCheck).toBeDefined();
+      expect(listCheck?.status).toBe('fail');
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // 4. auth.currentUser — throttling on getCurrentUser
+  // ------------------------------------------------------------------
+  describe('auth.currentUser — throttling on authentication check', () => {
+    it('classifies SpThrottleRedirectError on getCurrentUser as WARN', async () => {
+      const sp = makePassingSpAdapter();
+      sp.getCurrentUser = vi.fn().mockRejectedValue(makeThrottleError());
+
+      const results = await runHealthChecks(baseCtx, sp);
+
+      const authCheck = results.find((r) => r.key === 'auth.currentUser');
+      expect(authCheck).toBeDefined();
+      expect(authCheck?.status).toBe('warn');
+      expect(authCheck?.summary).toContain('スロットリング');
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // 5. connectivity.web — throttling on getWebTitle
+  // ------------------------------------------------------------------
+  describe('connectivity.web — throttling on site connectivity check', () => {
+    it('classifies SpThrottleRedirectError on getWebTitle as WARN', async () => {
+      const sp = makePassingSpAdapter();
+      sp.getWebTitle = vi.fn().mockRejectedValue(makeThrottleError());
+
+      const results = await runHealthChecks(baseCtx, sp);
+
+      const webCheck = results.find((r) => r.key === 'connectivity.web');
+      expect(webCheck).toBeDefined();
+      expect(webCheck?.status).toBe('warn');
+      expect(webCheck?.summary).toContain('スロットリング');
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // 6. permissions.create — throttling on createItem
+  // ------------------------------------------------------------------
+  describe('permissions.create — throttling on create check', () => {
+    it('classifies SpThrottleRedirectError on createItem as WARN (no retry amplification)', async () => {
+      const sp = makePassingSpAdapter();
+      const createFn = vi.fn().mockRejectedValue(makeThrottleError());
+      sp.createItem = createFn;
+
+      const results = await runHealthChecks(
+        { ...baseCtx, listSpecs: () => [userBenefitProfileExtSpec] },
+        sp
+      );
+
+      const createCheck = results.find(
+        (r) => r.key === 'permissions.create.user_benefit_profile_ext'
+      );
+      expect(createCheck).toBeDefined();
+      expect(createCheck?.status).toBe('warn');
+      expect(createCheck?.summary).toContain('スロットリング');
+      // safeWithRetry should NOT retry when isThrottled is true
+      expect(createFn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // 7. Ensure existing transient HTTP status handling is preserved
+  // ------------------------------------------------------------------
+  describe('existing transient HTTP status handling preserved', () => {
+    it('still classifies HTTP 429 on update as WARN with retries', async () => {
+      const sp = makePassingSpAdapter();
+      const updateFn = vi.fn().mockRejectedValue(
+        makeHttpError(429, 'Too Many Requests')
+      );
+      sp.updateItem = updateFn;
+
+      const results = await runHealthChecks(
+        { ...baseCtx, listSpecs: () => [userBenefitProfileExtSpec] },
+        sp
+      );
+
+      const updateCheck = results.find(
+        (r) => r.key === 'permissions.update.user_benefit_profile_ext'
+      );
+      expect(updateCheck?.status).toBe('warn');
+      // 429 is retryable, so safeWithRetry should attempt maxRetries+1 = 3 times
+      expect(updateFn).toHaveBeenCalledTimes(3);
+    });
+  });
+});

--- a/src/features/diagnostics/health/checks/authChecks.ts
+++ b/src/features/diagnostics/health/checks/authChecks.ts
@@ -1,11 +1,11 @@
 import { HealthCheckResult, HealthContext } from "../types";
 import { SpAdapter } from "../spAdapter";
-import { pass, fail, safe, isMockOrBypassMode } from "./utils";
+import { pass, fail, warn, safe, isMockOrBypassMode } from "./utils";
 
 export type AuthConnectivityCheckSummary = {
-  currentUserStatus: "pass" | "fail";
+  currentUserStatus: "pass" | "warn" | "fail";
   currentUserDetail?: string;
-  webStatus: "pass" | "fail";
+  webStatus: "pass" | "warn" | "fail";
   webDetail?: string;
 };
 
@@ -15,9 +15,9 @@ export async function runAuthAndConnectivityChecks(
   results: HealthCheckResult[]
 ): Promise<AuthConnectivityCheckSummary> {
   const isMockOrBypass = isMockOrBypassMode(ctx.env);
-  let currentUserStatus: "pass" | "fail" = "fail";
+  let currentUserStatus: "pass" | "warn" | "fail" = "fail";
   let currentUserDetail: string | undefined;
-  let webStatus: "pass" | "fail" = "fail";
+  let webStatus: "pass" | "warn" | "fail" = "fail";
   let webDetail: string | undefined;
 
   // --- B) Auth / Connectivity ---
@@ -25,26 +25,48 @@ export async function runAuthAndConnectivityChecks(
     ? { ok: true as const, v: { title: "Mock Test User", email: "mock@example.com" } }
     : await safe(() => sp.getCurrentUser());
   if (!currentUser.ok) {
-    results.push(
-      fail({
-        key: "auth.currentUser",
-        label: "認証（currentUser）",
-        category: "auth",
-        summary:
-          "サインイン状態の確認に失敗しました（SharePoint API）。",
-        detail: currentUser.err,
-        nextActions: [
-          {
-            kind: "doc",
-            label: "権限/同意の確認手順",
-            value:
-              "docs/security/msal.md, README.md > Azure AD / MSAL configuration",
-          },
-        ],
-      })
-    );
-    currentUserStatus = "fail";
-    currentUserDetail = currentUser.err;
+    if (currentUser.isThrottled) {
+      results.push(
+        warn({
+          key: "auth.currentUser",
+          label: "認証（currentUser）",
+          category: "auth",
+          summary:
+            "SharePoint 側の一時的なスロットリングを検知しました。",
+          detail: `SharePoint throttling detected. This is treated as an external transient condition. Retry after the tenant recovers. (Error: ${currentUser.err})`,
+          nextActions: [
+            {
+              kind: "doc",
+              label: "時間をおいて再実行する（スロットリングは一時エラー）",
+              value: "Health 診断を 5〜10 分後に再実行してください。",
+            },
+          ],
+        })
+      );
+      currentUserStatus = "warn";
+      currentUserDetail = currentUser.err;
+    } else {
+      results.push(
+        fail({
+          key: "auth.currentUser",
+          label: "認証（currentUser）",
+          category: "auth",
+          summary:
+            "サインイン状態の確認に失敗しました（SharePoint API）。",
+          detail: currentUser.err,
+          nextActions: [
+            {
+              kind: "doc",
+              label: "権限/同意の確認手順",
+              value:
+                "docs/security/msal.md, README.md > Azure AD / MSAL configuration",
+            },
+          ],
+        })
+      );
+      currentUserStatus = "fail";
+      currentUserDetail = currentUser.err;
+    }
   } else {
     results.push(
       pass({
@@ -62,18 +84,33 @@ export async function runAuthAndConnectivityChecks(
     ? { ok: true as const, v: "Mock SharePoint Site" }
     : await safe(() => sp.getWebTitle());
   if (!webTitle.ok) {
-    results.push(
-      fail({
-        key: "connectivity.web",
-        label: "サイト到達（web title）",
-        category: "connectivity",
-        summary: "SharePoint サイトに到達できません。",
-        detail: webTitle.err,
-        evidence: { siteUrl: ctx.siteUrl },
-      })
-    );
-    webStatus = "fail";
-    webDetail = webTitle.err;
+    if (webTitle.isThrottled) {
+      results.push(
+        warn({
+          key: "connectivity.web",
+          label: "サイト到達（web title）",
+          category: "connectivity",
+          summary: "SharePoint 側の一時的なスロットリングを検知しました。",
+          detail: `SharePoint throttling detected. This is treated as an external transient condition. Retry after the tenant recovers. (Error: ${webTitle.err})`,
+          evidence: { siteUrl: ctx.siteUrl },
+        })
+      );
+      webStatus = "warn";
+      webDetail = webTitle.err;
+    } else {
+      results.push(
+        fail({
+          key: "connectivity.web",
+          label: "サイト到達（web title）",
+          category: "connectivity",
+          summary: "SharePoint サイトに到達できません。",
+          detail: webTitle.err,
+          evidence: { siteUrl: ctx.siteUrl },
+        })
+      );
+      webStatus = "fail";
+      webDetail = webTitle.err;
+    }
   } else {
     results.push(
       pass({

--- a/src/features/diagnostics/health/checks/listChecks.ts
+++ b/src/features/diagnostics/health/checks/listChecks.ts
@@ -51,7 +51,25 @@ async function runListChecks(
     ? { ok: true as const, v: { id: `mock-${spec.key}`, title: spec.resolvedTitle } }
     : await safe(() => sp.getListByTitle(spec.resolvedTitle));
   if (!listInfo.ok) {
-    if (spec.isOptional) {
+    if (listInfo.isThrottled) {
+      results.push(
+        warn({
+          key: `lists.exists.${spec.key}`,
+          label: `リスト存在：${spec.displayName}`,
+          category: "lists",
+          summary: `SharePoint 側の一時的なスロットリングを検知しました。`,
+          detail: `SharePoint throttling detected. This is treated as an external transient condition, not an application schema failure. Retry after the tenant recovers. (Error: ${listInfo.err})`,
+          evidence: { listKey: spec.key, listTitle: spec.resolvedTitle, label: spec.displayName },
+          nextActions: [
+            {
+              kind: "doc",
+              label: "時間をおいて再実行する（429/5xx またはスロットリングは一時エラー）",
+              value: "Health 診断を 5〜10 分後に再実行してください。",
+            },
+          ],
+        })
+      );
+    } else if (spec.isOptional) {
       results.push(
         warn({
           key: `lists.exists.${spec.key}`,
@@ -128,16 +146,36 @@ async function runListChecks(
       }
     : await safe(() => sp.getFields(spec.resolvedTitle));
   if (!fields.ok) {
-    results.push(
-      fail({
-        key: `schema.fields.${spec.key}`,
-        label: `スキーマ：${spec.displayName}`,
-        category: "schema",
-        summary: "列（フィールド）情報の取得に失敗しました。",
-        detail: fields.err,
-        evidence: { listTitle: spec.resolvedTitle },
-      })
-    );
+    if (fields.isThrottled) {
+      results.push(
+        warn({
+          key: `schema.fields.${spec.key}`,
+          label: `スキーマ：${spec.displayName}`,
+          category: "schema",
+          summary: `SharePoint 側の一時的なスロットリングを検知しました。`,
+          detail: `SharePoint throttling detected. This is treated as an external transient condition, not an application schema failure. Retry after the tenant recovers. (Error: ${fields.err})`,
+          evidence: { listTitle: spec.resolvedTitle },
+          nextActions: [
+            {
+              kind: "doc",
+              label: "時間をおいて再実行する（429/5xx またはスロットリングは一時エラー）",
+              value: "Health 診断を 5〜10 分後に再実行してください。",
+            },
+          ],
+        })
+      );
+    } else {
+      results.push(
+        fail({
+          key: `schema.fields.${spec.key}`,
+          label: `スキーマ：${spec.displayName}`,
+          category: "schema",
+          summary: "列（フィールド）情報の取得に失敗しました。",
+          detail: fields.err,
+          evidence: { listTitle: spec.resolvedTitle },
+        })
+      );
+    }
   } else {
     // 1. Resolve fields with drift detection
     const candidates = Object.fromEntries(
@@ -311,19 +349,23 @@ async function runListChecks(
     ? { ok: true as const, v: [] as unknown[] }
     : await safe(() => sp.getItemsTop1(spec.resolvedTitle));
   if (!read.ok) {
-    if (isTransientPermissionStatus(read.status)) {
+    if (isTransientPermissionStatus(read.status) || read.isThrottled) {
       results.push(
         warn({
           key: `permissions.read.${spec.key}`,
           label: `権限：Read（${spec.displayName}）`,
           category: "permissions",
-          summary: `閲覧（Read）確認中に一時的エラー（${summarizeHttpStatus(read.status)}）を検出しました。`,
-          detail: read.err,
+          summary: read.isThrottled
+            ? `一時的エラー：SharePoint 側の一時的なスロットリングを検知しました。`
+            : `閲覧（Read）確認中に一時的エラー（${summarizeHttpStatus(read.status)}）を検出しました。`,
+          detail: read.isThrottled
+            ? `SharePoint throttling detected. This is treated as an external transient condition, not an application schema failure. Retry after the tenant recovers. (Error: ${read.err})`
+            : read.err,
           evidence: { listTitle: spec.resolvedTitle },
           nextActions: [
             {
               kind: "doc",
-              label: "時間をおいて再実行する（429/5xx は一時エラー）",
+              label: "時間をおいて再実行する（429/5xx またはスロットリングは一時エラー）",
               value: "Health 診断を 5〜10 分後に再実行してください。",
             },
           ],
@@ -406,23 +448,26 @@ async function runListChecks(
         isTransientPermissionStatus,
       );
   if (!created.ok) {
-    if (isTransientPermissionStatus(created.status)) {
+    if (isTransientPermissionStatus(created.status) || created.isThrottled) {
       const retryCount = Math.max(0, created.attempts - 1);
       results.push(
         warn({
           key: `permissions.create.${spec.key}`,
           label: `権限：Create（${spec.displayName}）`,
           category: "permissions",
-          summary: `作成（Create）確認中に一時的エラー（${summarizeHttpStatus(created.status)}）を検出しました。`,
-          detail:
-            retryCount > 0
+          summary: created.isThrottled
+            ? `一時的エラー：SharePoint 側の一時的なスロットリングを検知しました。`
+            : `作成（Create）確認中に一時的エラー（${summarizeHttpStatus(created.status)}）を検出しました。`,
+          detail: created.isThrottled
+            ? `SharePoint throttling detected. Retry after the tenant recovers. (Error: ${created.err})`
+            : retryCount > 0
               ? `${created.err} (自動リトライ ${retryCount} 回後も解消せず)`
               : created.err,
           evidence: { listTitle: spec.resolvedTitle, payload: createBody },
           nextActions: [
             {
               kind: "doc",
-              label: "時間をおいて再実行する（429/5xx は一時エラー）",
+              label: "時間をおいて再実行する（429/5xx またはスロットリングは一時エラー）",
               value: "Health 診断を 5〜10 分後に再実行してください。",
             },
           ],
@@ -473,23 +518,26 @@ async function runListChecks(
         }
       );
   if (!updated.ok) {
-    if (isTransientPermissionStatus(updated.status)) {
+    if (isTransientPermissionStatus(updated.status) || updated.isThrottled) {
       const retryCount = Math.max(0, updated.attempts - 1);
       results.push(
         warn({
           key: `permissions.update.${spec.key}`,
           label: `権限：Update（${spec.displayName}）`,
           category: "permissions",
-          summary: `更新（Update）確認中に一時的エラー（${summarizeHttpStatus(updated.status)}）を検出しました。`,
-          detail:
-            retryCount > 0
+          summary: updated.isThrottled
+            ? `一時的エラー：SharePoint 側の一時的なスロットリングを検知しました。`
+            : `更新（Update）確認中に一時的エラー（${summarizeHttpStatus(updated.status)}）を検出しました。`,
+          detail: updated.isThrottled
+            ? `SharePoint throttling detected. Retry after the tenant recovers. (Error: ${updated.err})`
+            : retryCount > 0
               ? `${updated.err} (自動リトライ ${retryCount} 回後も解消せず)`
               : updated.err,
           evidence: { id: created.v.id, listTitle: spec.resolvedTitle },
           nextActions: [
             {
               kind: "doc",
-              label: "時間をおいて再実行する（429/5xx は一時エラー）",
+              label: "時間をおいて再実行する（429/5xx またはスロットリングは一時エラー）",
               value: "Health 診断を 5〜10 分後に再実行してください。",
             },
           ],

--- a/src/features/diagnostics/health/checks/utils.ts
+++ b/src/features/diagnostics/health/checks/utils.ts
@@ -1,4 +1,5 @@
 import { HealthCheckResult, HealthStatus } from "../types";
+import { isSharePointThrottleError } from "@/lib/sp";
 
 // statusRank is retained for potential future worst-of aggregation.
 export const statusRank: Record<HealthStatus, number> = { pass: 0, warn: 1, fail: 2 };
@@ -89,7 +90,7 @@ export function isEnabled(v: unknown): boolean {
   return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
 }
 
-export type SafeResult<T> = { ok: true; v: T } | { ok: false; err: string; status?: number };
+export type SafeResult<T> = { ok: true; v: T } | { ok: false; err: string; status?: number; isThrottled?: boolean };
 
 export async function safe<T>(
   fn: () => Promise<T>
@@ -97,7 +98,12 @@ export async function safe<T>(
   try {
     return { ok: true, v: await fn() };
   } catch (e) {
-    return { ok: false, err: stringifyErr(e), status: extractHttpStatus(e) };
+    return {
+      ok: false,
+      err: stringifyErr(e),
+      status: extractHttpStatus(e),
+      isThrottled: isSharePointThrottleError(e),
+    };
   }
 }
 
@@ -116,7 +122,7 @@ export async function safeWithRetry<T>(
     if (result.ok) {
       return { ...result, attempts };
     }
-    if (!shouldRetry(result.status) || attempts >= maxAttempts) {
+    if (result.isThrottled || !shouldRetry(result.status) || attempts >= maxAttempts) {
       return { ...result, attempts };
     }
     const jitter = options.jitterMs > 0 ? Math.floor(Math.random() * options.jitterMs) : 0;


### PR DESCRIPTION
## Summary

SharePoint throttling errors (`SpThrottleRedirectError` / `Throttle.htm` redirect / CORS network errors during throttling) were previously classified as `FAIL` in health diagnostics. This happened because `SpThrottleRedirectError` carries no numeric HTTP status, so it bypassed the existing `isTransientPermissionStatus` check (which only recognizes 429/500/502/503/504).

This fix classifies these errors as `WARN` (external transient condition) instead of `FAIL` (application/schema error), keeping the 3-state diagnostic model (`pass`/`warn`/`fail`) intact.

## Changes

### `checks/utils.ts`
- Import `isSharePointThrottleError` from `@/lib/sp`
- Add `isThrottled?: boolean` to `SafeResult<T>` error branch
- `safe()` now populates `isThrottled` via `isSharePointThrottleError(e)`
- `safeWithRetry()` exits immediately when `isThrottled` is true — prevents request storm amplification

### `checks/listChecks.ts`
- List existence: throttled → `warn` (previously `fail`)
- Schema fields: throttled → `warn` (previously `fail`)
- Read permission: throttled → `warn` (previously `fail`)
- Create permission: throttled → `warn` (previously fell through to `fail`)
- Update permission: throttled → `warn` (previously fell through to `fail`)

### `checks/authChecks.ts`
- `getCurrentUser`: throttled → `warn` (previously `fail`)
- `getWebTitle`: throttled → `warn` (previously `fail`)
- `AuthConnectivityCheckSummary` type expanded: `"pass" | "warn" | "fail"`

### `throttlingClassification.spec.ts` (NEW)
10 regression tests covering:
- `schema.fields.user_benefit_profile_ext` — the original regression case
- `permissions.read.user_benefit_profile_ext` — the other original regression case
- List existence, auth, connectivity, create permissions
- Preserved 429 retry behavior (3 attempts, still `warn`)
- 403 Forbidden / 404 Not Found / genuine schema errors remain `FAIL`

## What is NOT changed
- SharePoint list schema / API contracts / persistence format
- Request storm prevention logic (`SpThrottleRedirectError` still stops retries)
- Genuine errors (403, 404, missing required fields, schema drift) remain `FAIL`

## Verification
- `npx vitest run src/features/diagnostics`: **90 tests, 19 files, all PASS**
- `npm run typecheck`: **PASS**
- `git diff --check`: **CLEAN**
- Pre-commit hooks (lint + typecheck + lint-staged): **ALL PASS**

## Context
Follow-up to PR #2054. During that PR's health diagnosis run, `schema.fields.user_benefit_profile_ext` and `permissions.read.user_benefit_profile_ext` appeared as `FAIL` due to SharePoint throttling. This was correctly identified as an external environment condition, not a code defect — but the diagnostic output was misleading.