### PR TITLE
fix(toilet): align repository resolution with demo mode

### DIFF
--- a/src/features/kiosk/toilet/__tests__/toiletRecordRepository.spec.ts
+++ b/src/features/kiosk/toilet/__tests__/toiletRecordRepository.spec.ts
@@ -4,6 +4,7 @@ import { SharePointToiletRecordRepository } from '../SharePointToiletRecordRepos
 import { getToiletRepository } from '../toiletRepositoryFactory';
 import type { ToiletRecordInput } from '../types';
 import * as env from '@/lib/env';
+import * as factory from '@/lib/createRepositoryFactory';
 
 // Mock list registry
 vi.mock('@/sharepoint/spListRegistry', () => ({
@@ -16,6 +17,7 @@ vi.mock('@/sharepoint/spListRegistry', () => ({
 describe('ToiletRecord Repository & Factory Tests', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.restoreAllMocks();
     if (typeof window !== 'undefined') {
       window.localStorage.clear();
     }
@@ -199,16 +201,22 @@ describe('ToiletRecord Repository & Factory Tests', () => {
 
   // ── 3. toiletRepositoryFactory ──
   describe('toiletRepositoryFactory', () => {
-    it('should resolve LocalStorageRepository when env or demo mode mandates it', () => {
-      vi.spyOn(env, 'isDemoModeEnabled').mockReturnValue(true);
+    it('should resolve LocalStorageRepository when defaultShouldUseDemo() resolves to true', () => {
+      vi.spyOn(factory, 'defaultShouldUseDemo').mockReturnValue(true);
       const repo = getToiletRepository(vi.fn());
       expect(repo).toBeInstanceOf(LocalStorageToiletRecordRepository);
     });
 
-    it('should resolve SharePointRepository when fetch exists and demo/test modes are off', () => {
-      vi.spyOn(env, 'isDemoModeEnabled').mockReturnValue(false);
-      vi.spyOn(env, 'isForceDemoEnabled').mockReturnValue(false);
-      vi.spyOn(env, 'shouldSkipLogin').mockReturnValue(false);
+    it('should resolve LocalStorageRepository when defaultShouldUseDemo() is false but provider is memory', () => {
+      vi.spyOn(factory, 'defaultShouldUseDemo').mockReturnValue(false);
+      vi.spyOn(env, 'readOptionalEnv').mockReturnValue('memory');
+
+      const repo = getToiletRepository(vi.fn());
+      expect(repo).toBeInstanceOf(LocalStorageToiletRecordRepository);
+    });
+
+    it('should resolve SharePointRepository when defaultShouldUseDemo() resolves to false', () => {
+      vi.spyOn(factory, 'defaultShouldUseDemo').mockReturnValue(false);
       vi.spyOn(env, 'readOptionalEnv').mockReturnValue('sharepoint');
 
       const repo = getToiletRepository(vi.fn());

--- a/src/features/kiosk/toilet/toiletRepositoryFactory.ts
+++ b/src/features/kiosk/toilet/toiletRepositoryFactory.ts
@@ -2,7 +2,8 @@ import { IToiletRecordRepository } from './types';
 import { LocalStorageToiletRecordRepository } from './toiletRecordRepository';
 import { SharePointToiletRecordRepository } from './SharePointToiletRecordRepository';
 import type { SpFetchFn } from '@/lib/sp/spLists';
-import { readOptionalEnv, isDemoModeEnabled, isForceDemoEnabled, shouldSkipLogin } from '@/lib/env';
+import { readOptionalEnv } from '@/lib/env';
+import { defaultShouldUseDemo } from '@/lib/createRepositoryFactory';
 
 export type ToiletRepositoryKind = 'local' | 'sharepoint';
 
@@ -12,8 +13,8 @@ const shouldUseLocalRepository = (): boolean => {
   const providerEnv = readOptionalEnv('VITE_DATA_PROVIDER');
   const providerHint = (providerParam ?? providerEnv ?? '').trim().toLowerCase();
 
-  // 1. demo / skip-login / force-demo は最優先で local
-  if (isDemoModeEnabled() || isForceDemoEnabled() || shouldSkipLogin()) {
+  // 1. 全体標準のデモ判定（hasSpfxContext などの安全なフォールバックを含む）に従う
+  if (defaultShouldUseDemo()) {
     return true;
   }
 


### PR DESCRIPTION
- Align ToiletRecordRepository resolution with the standard defaultShouldUseDemo() behavior.
- Fixes Workers/demo/SPFx-absent environments where kiosk toilet users load from demo/local mode but saving attempted a SharePoint write.
- Keeps the change scoped to repository resolution only.
- No SharePoint schema, payload, or field mapping changes.

Verification:
- npx vitest run src/features/kiosk/toilet/__tests__/toiletRecordRepository.spec.ts src/features/kiosk/toilet/__tests__/useToiletRecords.spec.ts
- npm run typecheck
- git diff --check