### PR TITLE
fix(toilet): query SharePoint date records by local-day UTC range

### DIFF
--- a/src/features/kiosk/toilet/SharePointToiletRecordRepository.ts
+++ b/src/features/kiosk/toilet/SharePointToiletRecordRepository.ts
@@ -85,7 +85,18 @@ export class SharePointToiletRecordRepository implements IToiletRecordRepository
 
     const recordDateField = this.rfFallback('recordDate');
     const isDeletedField = this.rfFallback('isDeleted');
-    const filter = `(${recordDateField} eq '${dateIso}') and (${isDeletedField} ne true)`;
+
+    // Convert dateIso (YYYY-MM-DD) to JST UTC range (since welfare records operate in JST/UTC+9)
+    const parts = dateIso.split('-');
+    const year = parseInt(parts[0], 10);
+    const month = parseInt(parts[1], 10) - 1;
+    const day = parseInt(parts[2], 10);
+    const startMs = Date.UTC(year, month, day, 0, 0, 0) - 9 * 60 * 60 * 1000;
+    const endMs = startMs + 24 * 60 * 60 * 1000;
+    const startUtc = new Date(startMs).toISOString().replace('.000Z', 'Z');
+    const endUtc = new Date(endMs).toISOString().replace('.000Z', 'Z');
+
+    const filter = `(${recordDateField} ge datetime'${startUtc}') and (${recordDateField} lt datetime'${endUtc}') and (${isDeletedField} ne true)`;
     
     // OData query
     const select = [

--- a/src/features/kiosk/toilet/__tests__/toiletRecordRepository.spec.ts
+++ b/src/features/kiosk/toilet/__tests__/toiletRecordRepository.spec.ts
@@ -99,7 +99,7 @@ describe('ToiletRecord Repository & Factory Tests', () => {
 
   // ── 2. SharePointToiletRecordRepository ──
   describe('SharePointToiletRecordRepository', () => {
-    it('should list records using spFetch and filter by date', async () => {
+    it('should list records using spFetch and filter by JST local-day UTC range', async () => {
       const mockSpFetch = vi.fn().mockResolvedValue({
         ok: true,
         json: async () => ({
@@ -108,7 +108,7 @@ describe('ToiletRecord Repository & Factory Tests', () => {
               Id: 101,
               Title: 'toilet-1',
               UserId: 'I005',
-              RecordDate: '2026-05-26T00:00:00Z',
+              RecordDate: '2026-05-25T15:00:00Z', // 2026-05-26 00:00:00 JST
               OccurredAt: '2026-05-26T10:00:00Z',
               ToiletType: 'urination',
               Amount: 'normal',
@@ -133,9 +133,18 @@ describe('ToiletRecord Repository & Factory Tests', () => {
       const [url] = mockSpFetch.mock.calls[0];
       expect(url).toContain("/lists/getbytitle('ToiletRecords')/items");
       const decodedUrl = decodeURIComponent(url);
-      expect(decodedUrl).toContain("RecordDate eq '2026-05-26'");
+
+      // 1. Should not use exact date equality filter
+      expect(decodedUrl).not.toContain("RecordDate eq '2026-05-26'");
+
+      // 2. Should use local-day UTC range query
+      expect(decodedUrl).toContain("RecordDate ge datetime'2026-05-25T15:00:00Z'");
+      expect(decodedUrl).toContain("RecordDate lt datetime'2026-05-26T15:00:00Z'");
+
+      // 4. IsDeleted condition should be preserved
       expect(decodedUrl).toContain("IsDeleted ne true");
 
+      // 3. SharePoint '2026-05-25T15:00:00Z' maps back to JST local date '2026-05-26'
       expect(records).toHaveLength(1);
       expect(records[0]).toMatchObject({
         id: 'toilet-1',


### PR DESCRIPTION
## Summary
- Replace exact Date-column equality filter with JST local-day UTC range query (`Record_x0020_Date ge datetime'<startUtc>' and Record_x0020_Date lt datetime'<endUtc>'`).
- Fix saved ToiletRecords not reappearing after successful POST because SharePoint stores date-only values as UTC timestamps with local offset (e.g. `2026-05-28T15:00:00Z` for JST `2026-05-29`).
- Keep existing local-date mapper from #2058.
- No schema or payload changes.

## Verification
- Verified by unit tests in `toiletRecordRepository.spec.ts` asserting against the new UTC range queries.
- Checked that typecheck compiles successfully (`npm run typecheck`).
- Checked that vitest tests pass successfully (`npx vitest run src/features/kiosk/toilet`).