### PR TITLE
fix(toilet): remove datetime prefix from SharePoint range query filter

### DIFF
--- a/src/features/kiosk/toilet/SharePointToiletRecordRepository.ts
+++ b/src/features/kiosk/toilet/SharePointToiletRecordRepository.ts
@@ -96,7 +96,7 @@ export class SharePointToiletRecordRepository implements IToiletRecordRepository
     const startUtc = new Date(startMs).toISOString().replace('.000Z', 'Z');
     const endUtc = new Date(endMs).toISOString().replace('.000Z', 'Z');
 
-    const filter = `(${recordDateField} ge datetime'${startUtc}') and (${recordDateField} lt datetime'${endUtc}') and (${isDeletedField} ne true)`;
+    const filter = `(${recordDateField} ge '${startUtc}') and (${recordDateField} lt '${endUtc}') and (${isDeletedField} ne true)`;
     
     // OData query
     const select = [

--- a/src/features/kiosk/toilet/__tests__/toiletRecordRepository.spec.ts
+++ b/src/features/kiosk/toilet/__tests__/toiletRecordRepository.spec.ts
@@ -138,8 +138,8 @@ describe('ToiletRecord Repository & Factory Tests', () => {
       expect(decodedUrl).not.toContain("RecordDate eq '2026-05-26'");
 
       // 2. Should use local-day UTC range query
-      expect(decodedUrl).toContain("RecordDate ge datetime'2026-05-25T15:00:00Z'");
-      expect(decodedUrl).toContain("RecordDate lt datetime'2026-05-26T15:00:00Z'");
+      expect(decodedUrl).toContain("RecordDate ge '2026-05-25T15:00:00Z'");
+      expect(decodedUrl).toContain("RecordDate lt '2026-05-26T15:00:00Z'");
 
       // 4. IsDeleted condition should be preserved
       expect(decodedUrl).toContain("IsDeleted ne true");


### PR DESCRIPTION
This hotfix removes the 'datetime' prefix from the local-day range query filter in SharePointToiletRecordRepository.ts. OData filters on DateOnly/DateTime columns inside this codebase consistently use plain string ISO literals without the 'datetime' prefix (e.g. 'YYYY-MM-DDTHH:mm:ssZ'). Exact range query with 'datetime' prefix failed to return items on the live environment.