### PR TITLE
test(kiosk): verify diagnostic query propagation

### DIFF
--- a/docs/ai-operations-log.md
+++ b/docs/ai-operations-log.md
@@ -77,7 +77,39 @@
 
 <!-- ↓ ここから下に追記していく -->
 
+### 2026-05-29 — kiosk: diagnostic query propagation 追補PR完成 🏁
+
+**ワークフロー**: `/test` → `/docs`
+**対象**: `src/features/kiosk/utils/__tests__/navigation.spec.ts` / `tests/e2e/kiosk-procedure-list.spec.ts`
+
+| 判断 | 内容 |
+|------|------|
+| ✅ 採用 | **Unit Test 追加**: `appendKioskSearchParams` に空文字列・`?`なしクエリのエッジケース、および `/kiosk` 完全一致・サブパスの両方でstate paramsがクレンジングされることを検証する2件を追加（合計7件）。 |
+| ✅ 採用 | **E2E Test 追加**: 手順一覧画面の「戻る」ボタン押下時に `highlight` / `list` が維持され、`userId` / `slotId` / `step` がクレンジングされることを `new URL(page.url()).searchParams` レベルで検証する1件を追加（合計9件）。 |
+| ❌ 却下 | 業務ロジック・SharePoint永続化ロジック・workflow ymlへの変更。 |
+| 💡 却下理由 | 本PRのスコープはテスト強化と運用ログ更新のみに限定し、回帰リスクを排除するため。 |
+
+**成果**:
+- Unit test: `navigation.spec.ts` — **7/7 PASS** 🟢
+- E2E test: `kiosk-procedure-list.spec.ts` — **9/9 PASS** 🟢
+- Typecheck: **PASS** 🟢
+- `git diff --check`: **PASS** 🟢
+- 差分は対象3ファイルのみに収まっている。
+
+**効果測定**:
+- Kiosk画面間遷移（前進・後退の両方向）で診断パラメータの伝播が自動テストで保証された 🟢
+- エッジケース（空クエリ、`?`なし入力）に対する防御がユニットテストで明示的に保証された 🟢
+
+**学び**:
+- **双方向遷移のテスト**: 「ユーザー選択→手順一覧」の前進遷移だけでなく、「手順一覧→ユーザー選択」の後退遷移でもクエリパラメータの挙動を検証することで、`appendKioskSearchParams` の契約を全方向から封じ込められる。
+- **`git diff --check` の早期実行**: trailing whitespace はCIで落ちるため、コミット前に `git diff --check` を毎回実行するルーチンが手戻りを防ぐ。
+
+**所要時間**: 約 10min
+
+#kiosk #e2e #testing #stability #operations-log
+
 ### 2026-05-28 — kiosk: verify diagnostic query propagation (follow-up PR) 🏁
+
 
 **ワークフロー**: `/implement` → `/test` → `/docs`
 **対象**: `src/features/kiosk/utils/navigation.ts` / `tests/e2e/kiosk-procedure-list.spec.ts`

--- a/src/features/kiosk/utils/__tests__/navigation.spec.ts
+++ b/src/features/kiosk/utils/__tests__/navigation.spec.ts
@@ -56,5 +56,28 @@ describe('kiosk navigation utilities', () => {
       expect(params.get('userId')).toBe('active');
       expect(params.get('slotId')).toBe('123');
     });
+
+    it('handles empty or malformed search queries safely', () => {
+      const resultEmpty = appendKioskSearchParams('/kiosk/users', '');
+      expect(resultEmpty).toBe('/kiosk/users');
+
+      const resultMalformed = appendKioskSearchParams('/kiosk/users', 'no-question-mark=true&userId=stale');
+      const params = new URLSearchParams(resultMalformed.split('?')[1]);
+      expect(params.get('no-question-mark')).toBe('true');
+      expect(params.has('userId')).toBe(false);
+    });
+
+    it('clears state params on exact /kiosk and subpaths starting with /kiosk', () => {
+      const current = '?userId=stale&highlight=active';
+      const exactResult = appendKioskSearchParams('/kiosk', current);
+      const exactParams = new URLSearchParams(exactResult.split('?')[1]);
+      expect(exactParams.get('highlight')).toBe('active');
+      expect(exactParams.has('userId')).toBe(false);
+
+      const subpathResult = appendKioskSearchParams('/kiosk/sub', current);
+      const subpathParams = new URLSearchParams(subpathResult.split('?')[1]);
+      expect(subpathParams.get('highlight')).toBe('active');
+      expect(subpathParams.has('userId')).toBe(false);
+    });
   });
 });

--- a/tests/e2e/kiosk-procedure-list.spec.ts
+++ b/tests/e2e/kiosk-procedure-list.spec.ts
@@ -113,4 +113,41 @@ test.describe('Kiosk Procedure List', () => {
     expect(searchParams.has('slotId')).toBe(false);
     expect(searchParams.has('step')).toBe(false);
   });
+
+  test('should preserve diagnostic params when navigating back to user selection from procedure list', async ({ page }) => {
+    test.setTimeout(120000);
+
+    // Boot directly to procedure list with diagnostic and state query parameters
+    await bootKiosk(page, {
+      route: '/kiosk/users/1/procedures?highlight=sp_bootstrap_blocked&list=Users_Master&userId=1&slotId=123&step=2',
+      userId: '1',
+    });
+
+    await expect(page.getByText('の支援手順')).toBeVisible({ timeout: 15000 });
+
+    const selector = '[data-testid="kiosk-procedure-list-back"]';
+
+    // Stabilization wait
+    await page.waitForTimeout(2000);
+
+    // Click "back" button to go back to user selection
+    await page.evaluate((sel) => {
+      const el = document.querySelector(sel) as HTMLElement;
+      if (el) el.click();
+    }, selector);
+
+    await expect(page).toHaveURL(/.*\/kiosk\/users.*/, { timeout: 30000 });
+
+    const url = new URL(page.url());
+    const searchParams = url.searchParams;
+
+    // Diagnostic params must be preserved
+    expect(searchParams.get('highlight')).toBe('sp_bootstrap_blocked');
+    expect(searchParams.get('list')).toBe('Users_Master');
+
+    // State params of the user must be cleared on transition back
+    expect(searchParams.has('userId')).toBe(false);
+    expect(searchParams.has('slotId')).toBe(false);
+    expect(searchParams.has('step')).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- Add unit coverage for kiosk navigation query handling.
- Add E2E coverage for preserving diagnostic params from user selection to procedure list.
- Record the verification in the AI operations log.

## Scope
- Test-only hardening for Kiosk diagnostic query propagation.
- Preserves `highlight` / `list`.
- Clears stale state params such as `userId`, `user`, `slotId`, and `step`.
- No SharePoint schema, persistence, workflow, or production logic changes.

## Verification
- `npx vitest run src/features/kiosk/utils/__tests__/navigation.spec.ts`
- `npx playwright test tests/e2e/kiosk-procedure-list.spec.ts`
- `npm run typecheck`
- `git diff --check`

## Notes
This is a follow-up to the Kiosk diagnostic query boot coverage and keeps investigation/report artifacts out of git.
