### PR TITLE
fix(toilet-records): include false records in SharePoint date query

### DIFF
--- a/src/features/kiosk/toilet/SharePointToiletRecordRepository.ts
+++ b/src/features/kiosk/toilet/SharePointToiletRecordRepository.ts
@@ -86,17 +86,13 @@ export class SharePointToiletRecordRepository implements IToiletRecordRepository
     const recordDateField = this.rfFallback('recordDate');
     const isDeletedField = this.rfFallback('isDeleted');
 
-    // Convert dateIso (YYYY-MM-DD) to JST UTC range (since welfare records operate in JST/UTC+9)
-    const parts = dateIso.split('-');
-    const year = parseInt(parts[0], 10);
-    const month = parseInt(parts[1], 10) - 1;
-    const day = parseInt(parts[2], 10);
-    const startMs = Date.UTC(year, month, day, 0, 0, 0) - 9 * 60 * 60 * 1000;
-    const endMs = startMs + 24 * 60 * 60 * 1000;
-    const startUtc = new Date(startMs).toISOString().replace('.000Z', 'Z');
-    const endUtc = new Date(endMs).toISOString().replace('.000Z', 'Z');
+    // Calculate the next day's date string (e.g. "2026-05-29" -> "2026-05-30")
+    // Simple local-date OData range query (e.g. ge '2026-05-29' and lt '2026-05-30')
+    const date = new Date(dateIso);
+    date.setDate(date.getDate() + 1);
+    const nextDateIso = date.toISOString().slice(0, 10);
 
-    const filter = `(${recordDateField} ge '${startUtc}') and (${recordDateField} lt '${endUtc}') and (${isDeletedField} ne true)`;
+    const filter = `(${recordDateField} ge '${dateIso}') and (${recordDateField} lt '${nextDateIso}') and (${isDeletedField} eq false or ${isDeletedField} eq null)`;
     
     // OData query
     const select = [

--- a/src/features/kiosk/toilet/__tests__/toiletRecordRepository.spec.ts
+++ b/src/features/kiosk/toilet/__tests__/toiletRecordRepository.spec.ts
@@ -137,12 +137,12 @@ describe('ToiletRecord Repository & Factory Tests', () => {
       // 1. Should not use exact date equality filter
       expect(decodedUrl).not.toContain("RecordDate eq '2026-05-26'");
 
-      // 2. Should use local-day UTC range query
-      expect(decodedUrl).toContain("RecordDate ge '2026-05-25T15:00:00Z'");
-      expect(decodedUrl).toContain("RecordDate lt '2026-05-26T15:00:00Z'");
+      // 2. Should use YYYY-MM-DD date range query
+      expect(decodedUrl).toContain("RecordDate ge '2026-05-26'");
+      expect(decodedUrl).toContain("RecordDate lt '2026-05-27'");
 
-      // 4. IsDeleted condition should be preserved
-      expect(decodedUrl).toContain("IsDeleted ne true");
+      // 4. IsDeleted condition should be eq false or eq null
+      expect(decodedUrl).toContain("IsDeleted eq false or IsDeleted eq null");
 
       // 3. SharePoint '2026-05-25T15:00:00Z' maps back to JST local date '2026-05-26'
       expect(records).toHaveLength(1);


### PR DESCRIPTION
## Summary
- Fix ToiletRecords SharePoint list query so newly created records with `IsDeleted=false` are returned.
- Simplify date filtering to `YYYY-MM-DD` range comparison.
- Update repository tests for the new OData filter.

## Scope
- Repository query/filter fix only.
- No SharePoint schema changes.
- No model changes.
- No UI changes.
- `ToiletDailyBoard.tsx` error display improvement is intentionally stashed/separated.

## Root cause
`ToiletRecords` records were saved successfully, but the post-save fetch returned `value: []` because the OData filter used `Is_x0020_Deleted ne true`.

Direct SharePoint query verification showed that this condition did not return newly created records where `Is_x0020_Deleted=false`. Replacing it with:

`(Is_x0020_Deleted eq false or Is_x0020_Deleted eq null)`

returns both newly created false records and legacy null records.

## Verification
- Final SharePoint filter was directly verified against `/sites/welfare` and returned Id 67.
- `npx vitest src/features/kiosk/toilet/__tests__/toiletRecordRepository.spec.ts --run` (PASS)
- `npx vitest src/features/kiosk/toilet/__tests__/useToiletRecords.spec.ts --run` (PASS)
- `npm run typecheck` (PASS)
- `git diff --check` (PASS)
