### PR TITLE
fix(kiosk): disable regulatory real-data fetches on kiosk routes

### DIFF
--- a/src/features/regulatory/ComplianceBadgeProvider.tsx
+++ b/src/features/regulatory/ComplianceBadgeProvider.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
 import { useUsers } from '@/features/users/useUsers';
 import { useStaff } from '@/features/staff/store';
 import { usePlanningSheetRepositories } from '@/features/planning-sheet/hooks/usePlanningSheetRepositories';
@@ -16,6 +17,9 @@ interface ComplianceBadgeContextValue {
 const ComplianceBadgeContext = createContext<ComplianceBadgeContextValue | null>(null);
 
 export const ComplianceBadgeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const location = useLocation();
+  const isKiosk = location.pathname.startsWith('/kiosk');
+
   const { data: users, status: usersStatus, error: usersError } = useUsers({ selectMode: 'full' });
   const { staff, isLoading: staffLoading, error: staffError } = useStaff();
   
@@ -33,7 +37,9 @@ export const ComplianceBadgeProvider: React.FC<{ children: React.ReactNode }> = 
     dataError,
     planningSheetRepo,
     procedureRecordRepo,
-    monitoringMeetingRepo
+    monitoringMeetingRepo,
+    undefined,
+    { enabled: !isKiosk }
   );
 
   const { input: addonInput, isLoading: addonLoading } = useSevereAddonRealData(
@@ -43,7 +49,9 @@ export const ComplianceBadgeProvider: React.FC<{ children: React.ReactNode }> = 
     dataError,
     planningSheetRepo,
     null, // observation repo not used for count for now
-    null  // qualification repo not used for count for now
+    null, // qualification repo not used for count for now
+    undefined,
+    { enabled: !isKiosk }
   );
 
   const addonFindingCount = useMemo(() => {
@@ -58,8 +66,8 @@ export const ComplianceBadgeProvider: React.FC<{ children: React.ReactNode }> = 
 
   const value = useMemo(() => ({
     totalCount,
-    isLoading: findingsLoading || addonLoading || dataLoading,
-  }), [totalCount, findingsLoading, addonLoading, dataLoading]);
+    isLoading: isKiosk ? false : (findingsLoading || addonLoading || dataLoading),
+  }), [totalCount, findingsLoading, addonLoading, dataLoading, isKiosk]);
 
   return (
     <ComplianceBadgeContext.Provider value={value}>

--- a/src/features/regulatory/__tests__/useRegulatoryRealDataDedupe.spec.tsx
+++ b/src/features/regulatory/__tests__/useRegulatoryRealDataDedupe.spec.tsx
@@ -89,6 +89,97 @@ describe('regulatory real-data hook dedupe', () => {
     });
   });
 
+  it('does not start per-user fetch when enabled option is false', async () => {
+    const listCurrentByUser = vi.fn().mockResolvedValue([]);
+    const listByUser = vi.fn().mockResolvedValue([]);
+    const planningRepo = createPlanningSheetRepo(listCurrentByUser);
+    const monitoringRepo = createMonitoringMeetingRepo(listByUser);
+    const procedureRepo = createProcedureRecordRepo();
+    const users = buildUsers();
+
+    const { result } = renderHook(() =>
+      useRegulatoryFindingsRealData(
+        users,
+        [],
+        false,
+        null,
+        planningRepo,
+        procedureRepo,
+        monitoringRepo,
+        true,
+        { enabled: false },
+      ),
+    );
+
+    await waitFor(() => {
+      expect(listCurrentByUser).toHaveBeenCalledTimes(0);
+      expect(listByUser).toHaveBeenCalledTimes(0);
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.findings).toEqual([]);
+  });
+
+  it('does not start per-user fetch in severe addon hook when enabled is false', async () => {
+    const listCurrentByUser = vi.fn().mockResolvedValue([]);
+    const planningRepo = createPlanningSheetRepo(listCurrentByUser);
+    const users = buildUsers();
+
+    const { result } = renderHook(() =>
+      useSevereAddonRealData(
+        users,
+        [],
+        false,
+        null,
+        planningRepo,
+        null,
+        null,
+        true,
+        { enabled: false },
+      ),
+    );
+
+    await waitFor(() => {
+      expect(listCurrentByUser).toHaveBeenCalledTimes(0);
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.input).toBeNull();
+  });
+
+  it('filters out user-hc- synthetic users from fetching', async () => {
+    const listCurrentByUser = vi.fn().mockResolvedValue([]);
+    const listByUser = vi.fn().mockResolvedValue([]);
+    const planningRepo = createPlanningSheetRepo(listCurrentByUser);
+    const monitoringRepo = createMonitoringMeetingRepo(listByUser);
+    const procedureRepo = createProcedureRecordRepo();
+    const users = [
+      { Id: 1, UserID: 'U001', FullName: 'Real User', IsActive: true },
+      { Id: 2, UserID: 'user-hc-12345', FullName: 'Synthetic Health Check', IsActive: true },
+    ] as IUserMaster[];
+
+    renderHook(() =>
+      useRegulatoryFindingsRealData(
+        users,
+        [],
+        false,
+        null,
+        planningRepo,
+        procedureRepo,
+        monitoringRepo,
+        true,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(listCurrentByUser).toHaveBeenCalledTimes(1);
+      expect(listCurrentByUser).toHaveBeenCalledWith('U001');
+      expect(listCurrentByUser).not.toHaveBeenCalledWith('user-hc-12345');
+    });
+  });
+
   it('suppresses repeated AUTH_REQUIRED warnings per user and treats as auth skip', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     const listCurrentByUser = vi.fn().mockRejectedValue(new AuthRequiredError());

--- a/src/features/regulatory/hooks/useRegulatoryFindingsRealData.ts
+++ b/src/features/regulatory/hooks/useRegulatoryFindingsRealData.ts
@@ -78,10 +78,12 @@ export function useRegulatoryFindingsRealData(
   procedureRecordRepo?: ProcedureRecordRepository | null,
   monitoringMeetingRepo?: MonitoringMeetingRepository | null,
   authReadyOverride?: boolean,
+  options?: { enabled?: boolean },
 ): RegulatoryFindingsRealDataResult {
   const { isAuthReady } = useAuth();
   const authReady = authReadyOverride ?? isAuthReady;
   const authSkipLoggedRef = useRef(false);
+  const enabled = options?.enabled !== false;
 
   const isAuthRequiredError = useCallback((err: unknown): boolean => {
     if (err instanceof AuthRequiredError) return true;
@@ -117,11 +119,12 @@ export function useRegulatoryFindingsRealData(
 
   // 有効な利用者IDリスト（安定参照）
   const activeUserIds = useMemo(() => {
-    if (isLoading || error || users.length === 0) return [];
+    if (!enabled || isLoading || error || users.length === 0) return [];
     return users
       .filter(u => u.IsActive !== false)
-      .map(u => u.UserID ?? `user-${u.Id}`);
-  }, [users, isLoading, error]);
+      .map(u => u.UserID ?? `user-${u.Id}`)
+      .filter(id => !id.startsWith('user-hc-'));
+  }, [users, isLoading, error, enabled]);
   const activeUserIdsKey = useMemo(() => activeUserIds.join('|'), [activeUserIds]);
   const planningFetchStateRef = useRef<{ inFlightKey: string | null; completedKey: string | null }>({
     inFlightKey: null,
@@ -134,6 +137,11 @@ export function useRegulatoryFindingsRealData(
 
   // ── Phase 1: PlanningSheet 取得 ──
   const fetchPlanningSheets = useCallback(async () => {
+    if (!enabled) {
+      setSheetsByUser(new Map());
+      planningFetchStateRef.current = { inFlightKey: null, completedKey: null };
+      return;
+    }
     if (!authReady) {
       logAuthSkipOnce();
       setSheetsByUser(new Map());
@@ -194,7 +202,7 @@ export function useRegulatoryFindingsRealData(
       }
       setSheetsLoading(false);
     }
-  }, [planningSheetRepo, activeUserIds, activeUserIdsKey, authReady, isAuthRequiredError, logAuthSkipOnce]);
+  }, [planningSheetRepo, activeUserIds, activeUserIdsKey, authReady, isAuthRequiredError, logAuthSkipOnce, enabled]);
 
   useEffect(() => {
     fetchPlanningSheets();
@@ -202,6 +210,10 @@ export function useRegulatoryFindingsRealData(
 
   // ── Phase 2: ProcedureRecord 取得（PlanningSheet 確定後） ──
   const fetchProcedureRecords = useCallback(async () => {
+    if (!enabled) {
+      setRecordsBySheet(new Map());
+      return;
+    }
     if (!authReady) {
       logAuthSkipOnce();
       setRecordsBySheet(new Map());
@@ -236,12 +248,12 @@ export function useRegulatoryFindingsRealData(
           const records: ProcedureRecordListItem[] =
             await procedureRecordRepo.listByPlanningSheet(sheetId);
           results.set(
-            sheetId,
-            records.map(r => ({
-              id: r.id,
-              planningSheetId: r.planningSheetId,
-              recordDate: r.recordDate,
-            })),
+              sheetId,
+              records.map(r => ({
+                id: r.id,
+                planningSheetId: r.planningSheetId,
+                recordDate: r.recordDate,
+              })),
           );
         } catch (err) {
           if (isAuthRequiredError(err)) {
@@ -259,7 +271,7 @@ export function useRegulatoryFindingsRealData(
     } finally {
       setRecordsLoading(false);
     }
-  }, [procedureRecordRepo, sheetsByUser, sheetsLoading, authReady, isAuthRequiredError, logAuthSkipOnce]);
+  }, [procedureRecordRepo, sheetsByUser, sheetsLoading, authReady, isAuthRequiredError, logAuthSkipOnce, enabled]);
 
   useEffect(() => {
     fetchProcedureRecords();
@@ -267,6 +279,11 @@ export function useRegulatoryFindingsRealData(
 
   // ── Phase 3: MonitoringMeeting 取得 ──
   const fetchMonitoringMeetings = useCallback(async () => {
+    if (!enabled) {
+      setMeetingsByUser(new Map());
+      meetingFetchStateRef.current = { inFlightKey: null, completedKey: null };
+      return;
+    }
     if (!authReady) {
       logAuthSkipOnce();
       setMeetingsByUser(new Map());
@@ -315,19 +332,19 @@ export function useRegulatoryFindingsRealData(
       }
       setMeetingsLoading(false);
     }
-  }, [monitoringMeetingRepo, activeUserIds, activeUserIdsKey, authReady, isAuthRequiredError, logAuthSkipOnce]);
+  }, [monitoringMeetingRepo, activeUserIds, activeUserIdsKey, authReady, isAuthRequiredError, logAuthSkipOnce, enabled]);
 
   useEffect(() => {
     fetchMonitoringMeetings();
   }, [fetchMonitoringMeetings]);
 
   // ── 統合状態 ──
-  const combinedLoading = isLoading || (authReady && (sheetsLoading || recordsLoading || meetingsLoading));
-  const combinedError = error || sheetsError;
+  const combinedLoading = enabled && (isLoading || (authReady && (sheetsLoading || recordsLoading || meetingsLoading)));
+  const combinedError = enabled ? (error || sheetsError) : null;
 
   // ── findings 構築 ──
   const result = useMemo<{ findings: AuditFinding[]; inputs: AuditCheckInput[] }>(() => {
-    if (combinedLoading || combinedError) return { findings: [], inputs: [] };
+    if (!enabled || combinedLoading || combinedError) return { findings: [], inputs: [] };
     if (users.length === 0) return { findings: [], inputs: [] };
 
     const today = new Date().toISOString().slice(0, 10);
@@ -350,15 +367,15 @@ export function useRegulatoryFindingsRealData(
     }
 
     return { findings, inputs };
-  }, [users, staff, sheetsByUser, recordsBySheet, meetingsByUser, combinedLoading, combinedError]);
+  }, [users, staff, sheetsByUser, recordsBySheet, meetingsByUser, combinedLoading, combinedError, enabled]);
 
-  const isRealData = !combinedLoading && !combinedError && users.length > 0;
+  const isRealData = enabled && !combinedLoading && !combinedError && users.length > 0;
 
   return {
     findings: result.findings,
     inputs: result.inputs,
     isLoading: combinedLoading,
     error: combinedError,
-    dataSourceLabel: isRealData ? '実データ' : 'デモデータ',
+    dataSourceLabel: isRealData ? '実データ' : (enabled ? 'デモデータ' : '無効'),
   };
 }

--- a/src/features/regulatory/hooks/useSevereAddonRealData.ts
+++ b/src/features/regulatory/hooks/useSevereAddonRealData.ts
@@ -168,10 +168,12 @@ export function useSevereAddonRealData(
   weeklyObsRepo?: WeeklyObservationRepository | null,
   assignmentRepo?: QualificationAssignmentRepository | null,
   authReadyOverride?: boolean,
+  options?: { enabled?: boolean },
 ): SevereAddonRealDataResult {
   const { isAuthReady } = useAuth();
   const authReady = authReadyOverride ?? isAuthReady;
   const authSkipLoggedRef = useRef(false);
+  const enabled = options?.enabled !== false;
 
   const isAuthRequiredError = useCallback((err: unknown): boolean => {
     if (err instanceof AuthRequiredError) return true;
@@ -199,11 +201,12 @@ export function useSevereAddonRealData(
 
   // 候補利用者の userId リスト（stable reference）
   const activeUserIds = useMemo(() => {
-    if (isLoading || error || users.length === 0) return [];
+    if (!enabled || isLoading || error || users.length === 0) return [];
     return users
       .filter(u => u.IsActive !== false)
-      .map(u => u.UserID ?? `user-${u.Id}`);
-  }, [users, isLoading, error]);
+      .map(u => u.UserID ?? `user-${u.Id}`)
+      .filter(id => !id.startsWith('user-hc-'));
+  }, [users, isLoading, error, enabled]);
   const activeUserIdsKey = useMemo(() => activeUserIds.join('|'), [activeUserIds]);
   const planningFetchStateRef = useRef<{ inFlightKey: string | null; completedKey: string | null }>({
     inFlightKey: null,
@@ -211,6 +214,11 @@ export function useSevereAddonRealData(
   });
 
   const fetchPlanningSheets = useCallback(async () => {
+    if (!enabled) {
+      setSheetsByUser(new Map());
+      planningFetchStateRef.current = { inFlightKey: null, completedKey: null };
+      return;
+    }
     if (!authReady) {
       logAuthSkipOnce();
       setSheetsByUser(new Map());
@@ -274,7 +282,7 @@ export function useSevereAddonRealData(
       }
       setSheetsLoading(false);
     }
-  }, [planningSheetRepo, activeUserIds, activeUserIdsKey, authReady, isAuthRequiredError, logAuthSkipOnce]);
+  }, [planningSheetRepo, activeUserIds, activeUserIdsKey, authReady, isAuthRequiredError, logAuthSkipOnce, enabled]);
 
   useEffect(() => {
     fetchPlanningSheets();
@@ -286,6 +294,10 @@ export function useSevereAddonRealData(
   const [obsError, setObsError] = useState<Error | null>(null);
 
   const fetchObservations = useCallback(async () => {
+    if (!enabled) {
+      setAllObservations([]);
+      return;
+    }
     if (!authReady) {
       logAuthSkipOnce();
       setAllObservations([]);
@@ -330,7 +342,7 @@ export function useSevereAddonRealData(
     } finally {
       setObsLoading(false);
     }
-  }, [weeklyObsRepo, activeUserIds, authReady, isAuthRequiredError, logAuthSkipOnce]);
+  }, [weeklyObsRepo, activeUserIds, authReady, isAuthRequiredError, logAuthSkipOnce, enabled]);
 
   useEffect(() => {
     fetchObservations();
@@ -342,6 +354,10 @@ export function useSevereAddonRealData(
   const [assignError, setAssignError] = useState<Error | null>(null);
 
   const fetchAssignments = useCallback(async () => {
+    if (!enabled) {
+      setAllAssignments([]);
+      return;
+    }
     if (!authReady) {
       logAuthSkipOnce();
       setAllAssignments([]);
@@ -377,18 +393,18 @@ export function useSevereAddonRealData(
     } finally {
       setAssignLoading(false);
     }
-  }, [assignmentRepo, activeUserIds, authReady, isAuthRequiredError, logAuthSkipOnce]);
+  }, [assignmentRepo, activeUserIds, authReady, isAuthRequiredError, logAuthSkipOnce, enabled]);
 
   useEffect(() => {
     fetchAssignments();
   }, [fetchAssignments]);
 
   // ── メイン BulkInput 構築 ──
-  const combinedLoading = isLoading || (authReady && (sheetsLoading || obsLoading || assignLoading));
-  const combinedError = error || sheetsError || obsError || assignError;
+  const combinedLoading = enabled && (isLoading || (authReady && (sheetsLoading || obsLoading || assignLoading)));
+  const combinedError = enabled ? (error || sheetsError || obsError || assignError) : null;
 
   const input = useMemo<SevereAddonBulkInput | null>(() => {
-    if (combinedLoading || combinedError) return null;
+    if (!enabled || combinedLoading || combinedError) return null;
     if (users.length === 0 && staff.length === 0) return null;
 
     const today = new Date().toISOString().slice(0, 10);
@@ -444,12 +460,12 @@ export function useSevereAddonRealData(
       usersWithoutAssignmentQualification,
       today,
     };
-  }, [users, staff, combinedLoading, combinedError, sheetsByUser, allObservations, allAssignments, weeklyObsRepo, assignmentRepo]);
+  }, [users, staff, combinedLoading, combinedError, sheetsByUser, allObservations, allAssignments, weeklyObsRepo, assignmentRepo, enabled]);
 
   return {
     input,
     isLoading: combinedLoading,
     error: combinedError,
-    dataSourceLabel: input ? '実データ' : 'デモデータ',
+    dataSourceLabel: input ? '実データ' : (enabled ? 'デモデータ' : '無効'),
   };
 }


### PR DESCRIPTION
Summary:
- Bypass compliance badge data loading entirely on `/kiosk/*` routes.
- Refactor `ComplianceBadgeProvider` so kiosk routes do not mount the data-loading child component (`ComplianceBadgeLoader`), preventing `useUsers` and `useStaff` hooks from initializing.
- Add `enabled` options to `useRegulatoryFindingsRealData` and `useSevereAddonRealData` to support hook suppression.
- Exclude synthetic `user-hc-*` health-check users from regulatory fetch targets.
- Keep compliance badge loading behavior unchanged on non-kiosk routes.

Reason:
- Kiosk procedure screens were triggering compliance/regulatory background fetches through `ComplianceBadgeProvider`.
- These background fetches included `Users_Master`, `Staff_Master`, and `MonitoringMeetings`, increasing SharePoint request volume.
- In live SharePoint, this contributed to `Throttle.htm#17` / `SpThrottleRedirectError` noise.
- Kiosk screens do not need compliance badge aggregation, so the safest fix is to skip the provider's data-loading branch on `/kiosk/*`.

Verification:
- `npm run typecheck` (PASS)
- `git diff --check` (PASS)
- `npx vitest run src/features/regulatory/__tests__/useRegulatoryRealDataDedupe.spec.tsx` (PASS)
- `npx vitest run src/features/kiosk/` (PASS)
- `npx vitest run src/app/__tests__/AppShell.navigation.spec.tsx src/app/AppShell.role-sync.spec.tsx src/app/AppShell.kiosk-route.spec.tsx src/app/AppShell.hub-meta.spec.tsx` (PASS)
- Temporary Playwright verification:
  - `/kiosk/users/23/procedures/1`: no `Users_Master`, `Staff_Master`, or `MonitoringMeetings` requests (PASS)
  - `/dashboard`: `Users_Master` and `Staff_Master` requests still occur as expected (PASS)

Note:
This confirms app-side kiosk-route suppression. Final SharePoint-backed verification remains required after merge/deploy.
