### PR TITLE
fix(kiosk): harden procedure record key consistency

### DIFF
--- a/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
+++ b/src/features/daily/repositories/sharepoint/SharePointExecutionRecordRepository.ts
@@ -17,6 +17,7 @@ import {
   normalizeExecutionDate,
   normalizeExecutionUserId,
   buildExecutionUserIdCandidates,
+  extractProcedureRowKey,
 } from '@/features/daily/utils/normalizeExecutionLookup';
 
 type SharePointExecutionRecordRepositoryOptions = {
@@ -423,7 +424,15 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
       [rf.recordedAt]: mergedRecord.recordedAt,
     };
     
-    if (rf.rowNo) rawBody[rf.rowNo] = mergedRecord.scheduleItemId;
+    if (rf.rowNo) {
+      const rawRowNo = extractProcedureRowKey(mergedRecord.scheduleItemId);
+      if (rawRowNo) {
+        rawBody[rf.rowNo] = Number.parseInt(rawRowNo, 10);
+      } else {
+        const fallbackNum = Number.parseInt(mergedRecord.scheduleItemId, 10);
+        rawBody[rf.rowNo] = Number.isNaN(fallbackNum) ? mergedRecord.scheduleItemId : fallbackNum;
+      }
+    }
     if (rf.memo) rawBody[rf.memo] = mergedRecord.memo;
     if (rf.staffName) rawBody[rf.staffName] = mergedRecord.recordedBy;
     if (rf.bipsJSON) rawBody[rf.bipsJSON] = JSON.stringify(mergedRecord.triggeredBipIds);
@@ -617,65 +626,62 @@ export class SharePointExecutionRecordRepository implements ExecutionRecordRepos
 
     let date = title.slice(0, 10);
     const userId = readSharePointText(item[rf.userId]);
-    let scheduleItemId = rf.rowNo ? normalizeScheduleItemId(readSharePointText(item[rf.rowNo])) : '';
+    let scheduleItemId = '';
 
-    // Fallback: extract scheduleItemId and/or date from composite key if missing or empty
-    if (!scheduleItemId || !/^\d{4}-\d{2}-\d{2}/.test(date)) {
-      const keys = [title, readSharePointText(item[rf.rowKey])];
-      for (const key of keys) {
-        if (key.length > 11 && /^\d{4}-\d{2}-\d{2}-/.test(key)) {
-          const parsedDate = key.slice(0, 10);
-          const suffix = key.slice(11); // userId-scheduleItemId
+    // First attempt: extract scheduleItemId from Title or RowKey (composite keys)
+    const keys = [title, readSharePointText(item[rf.rowKey])].filter(Boolean) as string[];
+    for (const key of keys) {
+      if (key.length > 11 && /^\d{4}-\d{2}-\d{2}-/.test(key)) {
+        const parsedDate = key.slice(0, 10);
+        const suffix = key.slice(11); // userId-scheduleItemId
 
-          // Build user ID candidates including both current userId and any logical representations
-          const userCandidates = buildExecutionUserIdCandidates(userId);
-          let matchedCandidate: string | null = null;
+        // Build user ID candidates including both current userId and any logical representations
+        const userCandidates = buildExecutionUserIdCandidates(userId);
+        let matchedCandidate: string | null = null;
 
-          for (const candidate of userCandidates) {
-            if (suffix.startsWith(`${candidate}-`)) {
-              matchedCandidate = candidate;
-              break;
-            }
+        for (const candidate of userCandidates) {
+          if (suffix.startsWith(`${candidate}-`)) {
+            matchedCandidate = candidate;
+            break;
           }
+        }
 
-          if (matchedCandidate) {
+        if (matchedCandidate) {
+          if (!/^\d{4}-\d{2}-\d{2}/.test(date)) {
+            date = parsedDate;
+          }
+          scheduleItemId = normalizeScheduleItemId(suffix.slice(matchedCandidate.length + 1)) || '';
+          break;
+        } else {
+          // Secondary fallback: regex-based extraction if userId candidates didn't match
+          // Try matching with keyword prefix first
+          const kwMatch = suffix.match(/(?:^|.*[-_])(base|row|procedure|slot|step)[-_](\d+)$/i);
+          if (kwMatch) {
             if (!/^\d{4}-\d{2}-\d{2}/.test(date)) {
               date = parsedDate;
             }
-            if (!scheduleItemId) {
-              scheduleItemId = normalizeScheduleItemId(suffix.slice(matchedCandidate.length + 1));
-            }
+            const prefix = kwMatch[1];
+            const digits = kwMatch[2];
+            const separator = suffix.includes(`${prefix}_${digits}`) ? '_' : '-';
+            scheduleItemId = `${prefix}${separator}${digits}`;
             break;
-          } else {
-            // Secondary fallback: regex-based extraction if userId candidates didn't match
-            // Try matching with keyword prefix first
-            const kwMatch = suffix.match(/(?:^|.*[-_])(base|row|procedure|slot|step)[-_](\d+)$/i);
-            if (kwMatch) {
-              if (!/^\d{4}-\d{2}-\d{2}/.test(date)) {
-                date = parsedDate;
-              }
-              if (!scheduleItemId) {
-                const prefix = kwMatch[1];
-                const digits = kwMatch[2];
-                const separator = suffix.includes(`${prefix}_${digits}`) ? '_' : '-';
-                scheduleItemId = `${prefix}${separator}${digits}`;
-              }
-              break;
+          }
+          // Try matching digits only
+          const digitsMatch = suffix.match(/(?:^|.*[-_])(\d+)$/i);
+          if (digitsMatch) {
+            if (!/^\d{4}-\d{2}-\d{2}/.test(date)) {
+              date = parsedDate;
             }
-            // Try matching digits only
-            const digitsMatch = suffix.match(/(?:^|.*[-_])(\d+)$/i);
-            if (digitsMatch) {
-              if (!/^\d{4}-\d{2}-\d{2}/.test(date)) {
-                date = parsedDate;
-              }
-              if (!scheduleItemId) {
-                scheduleItemId = digitsMatch[1];
-              }
-              break;
-            }
+            scheduleItemId = digitsMatch[1];
+            break;
           }
         }
       }
+    }
+
+    // Fallback: use RowNo field if composite key parsing failed
+    if (!scheduleItemId && rf.rowNo) {
+      scheduleItemId = normalizeScheduleItemId(readSharePointText(item[rf.rowNo])) || '';
     }
 
     const rawStatus = String(item[rf.status] || '').trim();

--- a/src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts
+++ b/src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts
@@ -684,6 +684,43 @@ describe('SharePointExecutionRecordRepository', () => {
       expect(mapped.date).toBe('2026-05-26');
     });
 
+    it('correctly parses canonical prefixed scheduleItemId with hyphenated userId U-023', () => {
+      const rf = {
+        parentId: 'Parent_x0020_ID',
+        userId: 'User_x0020_ID',
+        version: 'Version',
+        status: 'Status',
+        payload: 'Payload',
+        recordedAt: 'Recorded_x0020_At',
+        rowKey: 'Title',
+        rowNo: 'RowNo',
+        memo: 'Memo',
+        staffName: 'StaffName',
+        bipsJSON: 'BipsJSON',
+      };
+
+      const testCases = [
+        { title: '2026-05-30-U-023-procedure-2', expected: 'procedure-2' },
+        { title: '2026-05-30-U-023-slot-2', expected: 'slot-2' },
+        { title: '2026-05-30-U-023-slot_2', expected: 'slot_2' },
+        { title: '2026-05-30-U-023-step-2', expected: 'step-2' },
+        { title: '2026-05-30-U-023-2', expected: '2' },
+      ];
+
+      for (const tc of testCases) {
+        const mockItem = {
+          Title: tc.title,
+          User_x0020_ID: 'U-023',
+          Status: 'completed',
+          Memo: 'Test memo',
+          Recorded_x0020_At: '2026-05-30T12:00:00Z',
+        };
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const mapped = (repo as any).mapToDomain(mockItem, rf);
+        expect(mapped.scheduleItemId).toBe(tc.expected);
+      }
+    });
+
     it('uses Memo when Memo has content', () => {
       const mockItem = {
         Title: '2026-05-08-4-1',

--- a/src/features/daily/utils/normalizeExecutionLookup.ts
+++ b/src/features/daily/utils/normalizeExecutionLookup.ts
@@ -81,4 +81,20 @@ export const buildExecutionUserIdCandidates = (...values: unknown[]): string[] =
   return out;
 };
 
+export const extractProcedureRowKey = (value: unknown): string => {
+  const normalized = normalizeScheduleItemId(value);
+  if (!normalized) return '';
+  if (/^\d+$/.test(normalized)) return String(Number.parseInt(normalized, 10));
+
+  const match = normalized.match(/(?:^|[-_])(row|base|procedure|slot|step)[-_]?(\d+)$/i);
+  if (match) return String(Number.parseInt(match[2], 10));
+
+  // Planning-sheet derived procedure IDs can be source-scoped, e.g.
+  // "official-<sheetId>-1". The final small numeric segment is the rowNo.
+  const tailNumber = normalized.match(/[-_](\d{1,2})$/);
+  if (!tailNumber) return '';
+  const rowNo = Number.parseInt(tailNumber[1], 10);
+  return rowNo >= 0 && rowNo <= 99 ? String(rowNo) : '';
+};
+
 export { normalizeScheduleItemId };

--- a/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
@@ -41,7 +41,8 @@ const buildScheduleItemIdCandidates = (
   const rowCandidates = [rowNo, indexPlusOne].filter(Boolean);
 
   push(procedure?.id);
-  push(slotKey);
+  // Do not add raw route-index based candidates.
+  // route index is 0-based and can collide with rowNo-based persisted records.
   for (const rowCandidate of rowCandidates) {
     push(rowCandidate);
     push(`base-${rowCandidate}`);
@@ -83,19 +84,21 @@ export const KioskProcedureDetailScreen: React.FC = () => {
     return procedures[index] || null;
   }, [userId, user, slotKey, procedureRepo]);
 
+  const slotIndex = Number.parseInt(String(slotKey ?? ''), 10);
+  const indexPlusOne = Number.isNaN(slotIndex) ? '' : String(slotIndex + 1);
+
   // rowNo is the canonical slot identity for kiosk procedure completion tracking.
   // Some procedure IDs can vary by source/runtime, so prefer rowNo for persistence keys.
   const scheduleItemId = normalizeScheduleItemId(procedure?.rowNo) ||
     normalizeScheduleItemId(procedure?.id) ||
-    normalizeScheduleItemId(slotKey);
+    normalizeScheduleItemId(indexPlusOne || slotKey);
   const historyScheduleItemIds = React.useMemo(() => {
     const indexValue = Number.parseInt(String(slotKey ?? ''), 10);
-    const indexPlusOne = Number.isNaN(indexValue) ? '' : normalizeScheduleItemId(indexValue + 1);
+    const idxPlusOne = Number.isNaN(indexValue) ? '' : normalizeScheduleItemId(indexValue + 1);
     return [
       normalizeScheduleItemId(procedure?.rowNo),
       normalizeScheduleItemId(procedure?.id),
-      normalizeScheduleItemId(slotKey),
-      indexPlusOne,
+      idxPlusOne,
     ].filter((value, idx, arr): value is string => Boolean(value) && arr.indexOf(value) === idx);
   }, [procedure?.id, procedure?.rowNo, slotKey]);
   const historyUserIds = React.useMemo(() => {

--- a/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
@@ -89,9 +89,8 @@ export const KioskProcedureDetailScreen: React.FC = () => {
 
   // rowNo is the canonical slot identity for kiosk procedure completion tracking.
   // Some procedure IDs can vary by source/runtime, so prefer rowNo for persistence keys.
-  const scheduleItemId = normalizeScheduleItemId(procedure?.rowNo) ||
-    normalizeScheduleItemId(procedure?.id) ||
-    normalizeScheduleItemId(indexPlusOne || slotKey);
+  const rawRowNo = normalizeScheduleItemId(procedure?.rowNo) || indexPlusOne;
+  const scheduleItemId = rawRowNo ? `procedure-${rawRowNo}` : normalizeScheduleItemId(procedure?.id || slotKey);
   const historyScheduleItemIds = React.useMemo(() => {
     const indexValue = Number.parseInt(String(slotKey ?? ''), 10);
     const idxPlusOne = Number.isNaN(indexValue) ? '' : normalizeScheduleItemId(indexValue + 1);

--- a/src/features/kiosk/components/KioskProcedureListScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureListScreen.tsx
@@ -16,6 +16,7 @@ import { ExecutionRecord } from '@/features/daily/domain/executionRecordTypes';
 import {
   buildExecutionUserIdCandidates,
   normalizeScheduleItemId,
+  extractProcedureRowKey,
 } from '@/features/daily/utils/normalizeExecutionLookup';
 import { useExecutionStore } from '@/features/daily/stores/executionStore';
 import { matchExecutionRecordsToProcedures } from '../domain/executionRecordMatching';
@@ -27,26 +28,9 @@ import { useCurrentPlanningSheet } from '@/features/planning-sheet/hooks/useCurr
 import { resolveSupportStartDateDetailed } from '@/features/planning-sheet/monitoringSchedule';
 import { resolveProcedureUserQueryCandidates } from '../utils/resolveProcedureUserQuery';
 
-const extractProcedureRowKey = (value: unknown): string => {
-  const normalized = normalizeScheduleItemId(value);
-  if (!normalized) return '';
-  if (/^\d+$/.test(normalized)) return String(Number.parseInt(normalized, 10));
-
-  const match = normalized.match(/(?:^|[-_])(row|base|procedure|slot|step)[-_]?(\d+)$/i);
-  if (match) return String(Number.parseInt(match[2], 10));
-
-  // Planning-sheet derived procedure IDs can be source-scoped, e.g.
-  // "official-<sheetId>-1". The final small numeric segment is the rowNo.
-  const tailNumber = normalized.match(/[-_](\d{1,2})$/);
-  if (!tailNumber) return '';
-  const rowNo = Number.parseInt(tailNumber[1], 10);
-  return rowNo >= 0 && rowNo <= 99 ? String(rowNo) : '';
-};
-
 const buildProcedureMatchKeys = (
   procedure: { id?: unknown; rowNo?: unknown },
   index: number,
-  allPrimaryScheduleKeys: Set<string>,
 ): string[] => {
   const keys = new Set<string>();
   const push = (value: string) => {
@@ -55,14 +39,23 @@ const buildProcedureMatchKeys = (
 
   const idKey = normalizeScheduleItemId(procedure.id);
   const rowNoKey = normalizeScheduleItemId(procedure.rowNo);
+  const rowNoVal = extractProcedureRowKey(procedure.rowNo);
+  const idRowVal = extractProcedureRowKey(procedure.id);
+  const indexPlusOne = String(index + 1);
+
   push(idKey);
   push(rowNoKey);
-  push(extractProcedureRowKey(procedure.id));
-  push(extractProcedureRowKey(procedure.rowNo));
+  push(rowNoVal);
+  push(idRowVal);
 
-  const indexKey = index.toString();
-  const canUseIndexFallback = !allPrimaryScheduleKeys.has(indexKey) || keys.has(indexKey);
-  if (canUseIndexFallback) push(indexKey);
+  // Add prefixed candidates based on rowNo or indexPlusOne
+  const rowCandidates = [rowNoKey, rowNoVal, indexPlusOne].filter(Boolean);
+  for (const rc of rowCandidates) {
+    push(`procedure-${rc}`);
+    push(`slot-${rc}`);
+    push(`slot_${rc}`);
+    push(`step-${rc}`);
+  }
 
   return Array.from(keys);
 };
@@ -73,13 +66,26 @@ const buildProcedureLookupKeys = (procedure: { id?: unknown; rowNo?: unknown }, 
     if (value) keys.add(value);
   };
 
-  // For SharePoint point lookups, prefer the physical row number first.
-  // Source-scoped planning IDs such as "official-<sheetId>-1" are not row keys.
-  push(extractProcedureRowKey(procedure.rowNo));
-  push(extractProcedureRowKey(procedure.id));
-  push(normalizeScheduleItemId(procedure.rowNo));
-  push(normalizeScheduleItemId(procedure.id));
-  push(index.toString());
+  const rowNoKey = normalizeScheduleItemId(procedure.rowNo);
+  const idKey = normalizeScheduleItemId(procedure.id);
+  const rowNoVal = extractProcedureRowKey(procedure.rowNo);
+  const idRowVal = extractProcedureRowKey(procedure.id);
+  const indexPlusOne = String(index + 1);
+
+  push(rowNoVal);
+  push(idRowVal);
+  push(rowNoKey);
+  push(idKey);
+
+  // Add prefixed candidates for robust SharePoint lookup
+  const rowCandidates = [rowNoKey, rowNoVal, indexPlusOne].filter(Boolean);
+  for (const rc of rowCandidates) {
+    push(`procedure-${rc}`);
+    push(`slot-${rc}`);
+    push(`slot_${rc}`);
+    push(`step-${rc}`);
+  }
+
   return Array.from(keys);
 };
 
@@ -352,7 +358,7 @@ export const KioskProcedureListScreen: React.FC = () => {
         const maxLookupAttempts = executionRepositoryKind === 'sharepoint' ? 12 : Number.POSITIVE_INFINITY;
 
         for (let index = 0; index < procedures.length; index += 1) {
-          const procedureKeys = buildProcedureMatchKeys(procedures[index], index, allPrimaryScheduleKeys);
+          const procedureKeys = buildProcedureMatchKeys(procedures[index], index);
           if (procedureKeys.some((key) => matchedKeys.has(key))) continue;
 
           let foundRecord: ExecutionRecord | undefined;

--- a/tests/e2e/kiosk-procedure-detail.spec.ts
+++ b/tests/e2e/kiosk-procedure-detail.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { bootKiosk } from './_helpers/bootKiosk';
+import { setupSharePointStubs } from './_helpers/setupSharePointStubs';
+import { toLocalDateISO } from '../../src/utils/getNow';
 
 test.describe('Kiosk Procedure Detail', () => {
   test.beforeEach(async ({ page }) => {
@@ -59,24 +61,84 @@ test.describe('Kiosk Procedure Detail', () => {
   });
 
   test('should save second procedure without colliding with first procedure record', async ({ page }) => {
-    // 1. 1番目の手順(scheduleItemId: '1')が完了した状態で2番目の手順(/procedures/1)の詳細画面に直接遷移する
+    const today = toLocalDateISO(new Date());
+
+    // 1. SharePoint stubsを登録
+    await setupSharePointStubs(page, {
+      currentUser: { status: 200, body: { Id: 12345, Title: 'Mock User' } },
+      fallback: { status: 200, body: { value: [] } },
+      lists: [
+        {
+          name: 'Users_Master',
+          items: [
+            { Id: 23, UserID: 'U-023', FullName: '桂川 進太朗' }
+          ]
+        },
+        {
+          name: 'SupportRecord_Daily',
+          items: [
+            {
+              Id: 1,
+              Title: `${today}-U-023`,
+              RecordDate: today,
+            }
+          ]
+        },
+        {
+          name: 'DailyRecordRows',
+          items: [
+            {
+              Id: 1,
+              Title: `${today}-U-023-1`,
+              Parent_x0020_ID: 1,
+              User_x0020_ID: 'U-023',
+              Status: 'completed',
+              Recorded_x0020_At: new Date().toISOString(),
+              RowNo: '1',
+            }
+          ]
+        }
+      ]
+    });
+
+    // 2. 1番目の手順(scheduleItemId: '1')が完了した状態で2番目の手順(/procedures/1)の詳細画面に直接遷移する
     await bootKiosk(page, {
-      route: '/kiosk/users/1/procedures/1',
-      userId: '1',
+      route: '/kiosk/users/23/procedures/1?provider=sharepoint',
+      userId: '23',
       records: [
         { scheduleItemId: '1', status: 'completed' }
-      ]
+      ],
+      envOverrides: {
+        VITE_SKIP_SHAREPOINT: '0',
+        VITE_FORCE_SHAREPOINT: '1'
+      }
     });
 
     await expect(page.getByText('本人のすること')).toBeVisible({ timeout: 10000 });
 
-    // 2. メモを入力して保存
+    // 3. メモを入力して保存
     await page.getByTestId('kiosk-observation-memo').fill('2番目の手順のメモ');
+
+    // 保存時のリクエストを傍受して、TitleとRowNoが正しいか検証する
+    let savedRequestPayload: any = null;
+    page.on('request', request => {
+      if (request.url().includes('items') && request.method() === 'POST') {
+        try {
+          const data = JSON.parse(request.postData() || '{}');
+          if (data.Title || data.RowNo || data.cr013_rowNo) {
+            savedRequestPayload = data;
+          }
+        } catch {
+          // ignore parsing error
+        }
+      }
+    });
+
     await page.getByTestId('kiosk-observation-submit').click();
 
-    // 3. 一覧画面に戻り、1番目と2番目の手順の両方が記録済みになっていることを確認する
+    // 4. 一覧画面に戻り、1番目と2番目の手順の両方が記録済みになっていることを確認する
     await expect(page.getByText('記録を保存しました')).toBeVisible({ timeout: 5000 });
-    await expect(page).toHaveURL(/.*\/kiosk\/users\/1\/procedures\/?(\?.*)?/);
+    await expect(page).toHaveURL(/.*\/kiosk\/users\/23\/procedures\/?(\?.*)?/);
 
     // 1番目と2番目のカードがともに記録済み
     const firstCard = page.locator('[data-testid="kiosk-procedure-card-0"]');
@@ -86,5 +148,23 @@ test.describe('Kiosk Procedure Detail', () => {
 
     // 進捗が 2 / 17 になっていることを確認
     await expect(page.getByText('実施状況: 2 / 17')).toBeVisible();
+
+    // 5. ページをリロードして、再取得後も記録済みが維持されることを確認
+    await page.reload();
+    await expect(page.getByText('の支援手順')).toBeVisible({ timeout: 10000 });
+    await expect(firstCard.getByText('記録済み')).toBeVisible();
+    await expect(secondCard.getByText('記録済み')).toBeVisible();
+    await expect(page.getByText('実施状況: 2 / 17')).toBeVisible();
+
+    // 6. 保存されたリクエストのTitleが期待通りかアサート
+    console.log('Saved Request Payload:', JSON.stringify(savedRequestPayload));
+    if (savedRequestPayload) {
+      expect(savedRequestPayload.Title).toContain('U-023-procedure-2');
+      expect(savedRequestPayload.User_x0020_ID).toBe('U-023');
+      const rowNoKey = Object.keys(savedRequestPayload).find(k => k.toLowerCase().includes('rowno'));
+      if (rowNoKey) {
+        expect(savedRequestPayload[rowNoKey]).toBe(2);
+      }
+    }
   });
 });

--- a/tests/e2e/kiosk-procedure-detail.spec.ts
+++ b/tests/e2e/kiosk-procedure-detail.spec.ts
@@ -57,4 +57,34 @@ test.describe('Kiosk Procedure Detail', () => {
     await expect(page).toHaveURL(/\/kiosk\/users\/1\/procedures\?date=2026-05-07/);
     await expect(page.getByText('2026年5月7日 の支援手順')).toBeVisible({ timeout: 10000 });
   });
+
+  test('should save second procedure without colliding with first procedure record', async ({ page }) => {
+    // 1. 1番目の手順(scheduleItemId: '1')が完了した状態で2番目の手順(/procedures/1)の詳細画面に直接遷移する
+    await bootKiosk(page, {
+      route: '/kiosk/users/1/procedures/1',
+      userId: '1',
+      records: [
+        { scheduleItemId: '1', status: 'completed' }
+      ]
+    });
+
+    await expect(page.getByText('本人のすること')).toBeVisible({ timeout: 10000 });
+
+    // 2. メモを入力して保存
+    await page.getByTestId('kiosk-observation-memo').fill('2番目の手順のメモ');
+    await page.getByTestId('kiosk-observation-submit').click();
+
+    // 3. 一覧画面に戻り、1番目と2番目の手順の両方が記録済みになっていることを確認する
+    await expect(page.getByText('記録を保存しました')).toBeVisible({ timeout: 5000 });
+    await expect(page).toHaveURL(/.*\/kiosk\/users\/1\/procedures\/?(\?.*)?/);
+
+    // 1番目と2番目のカードがともに記録済み
+    const firstCard = page.locator('[data-testid="kiosk-procedure-card-0"]');
+    const secondCard = page.locator('[data-testid="kiosk-procedure-card-1"]');
+    await expect(firstCard.getByText('記録済み')).toBeVisible();
+    await expect(secondCard.getByText('記録済み')).toBeVisible();
+
+    // 進捗が 2 / 17 になっていることを確認
+    await expect(page.getByText('実施状況: 2 / 17')).toBeVisible();
+  });
 });


### PR DESCRIPTION
## Summary

- Harden kiosk procedure record key consistency across detail save, list matching, SharePoint persistence, and reload.
- Use `procedure-${rowNo}` as the canonical `scheduleItemId`.
- Persist SharePoint `RowNo` as a numeric row number.
- Restore `scheduleItemId` from composite `Title` / `RowKey` before falling back to `RowNo`.
- Remove raw route-index based candidates from list/detail matching.
- Add E2E coverage for `/kiosk/users/23/procedures/1` save → list reflection → reload persistence.

## Reason

- `/procedures/1` is a 0-based route index for the second procedure.
- Raw route index and bare numeric keys could collide with rowNo-based records.
- SharePoint reload could previously restore `procedure-2` as `"2"`, causing duplicate records or shifted-match false positives.
- This caused detail saves to appear on the wrong card, disappear after reload, or mark another card as recorded.

## Changed Files

| File | Change |
|---|---|
| `KioskProcedureDetailScreen.tsx` | `procedure-${rowNo}` canonical key, no raw index |
| `KioskProcedureListScreen.tsx` | Shared `extractProcedureRowKey`, removed bare index candidates |
| `SharePointExecutionRecordRepository.ts` | Numeric RowNo upsert, Title-first mapToDomain |
| `normalizeExecutionLookup.ts` | Exported `extractProcedureRowKey` |
| `SharePointExecutionRecordRepository.spec.ts` | Unit test for prefix extraction with U-023 |
| `kiosk-procedure-detail.spec.ts` | E2E collision / reload test |

## Verification

```bash
npx playwright test tests/e2e/kiosk-procedure-detail.spec.ts tests/e2e/kiosk-procedure-list.spec.ts --project=chromium  # 13 passed
npx vitest run src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts  # 27 passed
npx vitest run src/features/kiosk/domain src/features/daily  # 612 passed
npm run typecheck  # PASS
git diff --check  # clean
```

## Remaining Risks (non-blocking)

1. **Legacy bare-numeric records** (`"2"`) matched via `isShiftedProcedureSlot` — backward compat, future cleanup candidate.
2. **`historyScheduleItemIds`** includes `indexPlusOne` for legacy search — acceptable fallback.
3. **`allPrimaryScheduleKeys`** in useEffect deps — functionally harmless, cleanup PR candidate.