### PR TITLE
fix(kiosk): gate compliance badge loader on kiosk routes

### DIFF
--- a/src/features/regulatory/ComplianceBadgeProvider.tsx
+++ b/src/features/regulatory/ComplianceBadgeProvider.tsx
@@ -16,10 +16,7 @@ interface ComplianceBadgeContextValue {
 
 const ComplianceBadgeContext = createContext<ComplianceBadgeContextValue | null>(null);
 
-export const ComplianceBadgeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const location = useLocation();
-  const isKiosk = location.pathname.startsWith('/kiosk');
-
+const ComplianceBadgeLoader: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { data: users, status: usersStatus, error: usersError } = useUsers({ selectMode: 'full' });
   const { staff, isLoading: staffLoading, error: staffError } = useStaff();
   
@@ -39,7 +36,7 @@ export const ComplianceBadgeProvider: React.FC<{ children: React.ReactNode }> = 
     procedureRecordRepo,
     monitoringMeetingRepo,
     undefined,
-    { enabled: !isKiosk }
+    { enabled: true }
   );
 
   const { input: addonInput, isLoading: addonLoading } = useSevereAddonRealData(
@@ -51,7 +48,7 @@ export const ComplianceBadgeProvider: React.FC<{ children: React.ReactNode }> = 
     null, // observation repo not used for count for now
     null, // qualification repo not used for count for now
     undefined,
-    { enabled: !isKiosk }
+    { enabled: true }
   );
 
   const addonFindingCount = useMemo(() => {
@@ -66,14 +63,34 @@ export const ComplianceBadgeProvider: React.FC<{ children: React.ReactNode }> = 
 
   const value = useMemo(() => ({
     totalCount,
-    isLoading: isKiosk ? false : (findingsLoading || addonLoading || dataLoading),
-  }), [totalCount, findingsLoading, addonLoading, dataLoading, isKiosk]);
+    isLoading: findingsLoading || addonLoading || dataLoading,
+  }), [totalCount, findingsLoading, addonLoading, dataLoading]);
 
   return (
     <ComplianceBadgeContext.Provider value={value}>
       {children}
     </ComplianceBadgeContext.Provider>
   );
+};
+
+export const ComplianceBadgeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const location = useLocation();
+  const isKiosk = location.pathname.startsWith('/kiosk');
+
+  const emptyValue = useMemo(() => ({
+    totalCount: 0,
+    isLoading: false,
+  }), []);
+
+  if (isKiosk) {
+    return (
+      <ComplianceBadgeContext.Provider value={emptyValue}>
+        {children}
+      </ComplianceBadgeContext.Provider>
+    );
+  }
+
+  return <ComplianceBadgeLoader>{children}</ComplianceBadgeLoader>;
 };
 
 export const useComplianceBadge = () => {


### PR DESCRIPTION
## Summary

- Gate compliance badge data loader on kiosk routes by splitting the hooks into a child loader component (`ComplianceBadgeLoader`).
- Render the child loader only on non-kiosk routes, preventing `useUsers` and `useStaff` hooks from mounting/initializing and triggering unwanted background fetches on `/kiosk/*` pages.

## Reason

- Unconditional calls to `useUsers({ selectMode: 'full' })` and `useStaff()` at the top-level of `ComplianceBadgeProvider` were triggering background SharePoint fetches for `Users_Master` and `Staff_Master` list items.
- On kiosk routes, these background requests (including regulatory findings and monitoring meetings fetches) increased request amplification, risking throttle redirect errors.
- Gating them behind a child component pattern ensures no background compliance queries run on kiosk routes.

## Verification

- All kiosk-related E2E tests in Playwright pass cleanly (15 passed).
- TypeScript compile (`npm run typecheck`) and ESLint pass without warnings.
- Clean working directory state.