### PR TITLE
[codex] fix(kiosk): prevent SharePoint request amplification on procedure list

### DIFF
--- a/src/features/kiosk/components/KioskProcedureListScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureListScreen.tsx
@@ -341,7 +341,10 @@ export const KioskProcedureListScreen: React.FC = () => {
       }
 
       const procedureLookupKey = `${dateStr}|${queryUserIds.join('|')}`;
+      const shouldRunProcedureLevelLookup = executionRepositoryKind !== 'sharepoint';
+
       if (
+        shouldRunProcedureLevelLookup &&
         procedures.length > 0 &&
         deduped.size < procedures.length &&
         typeof executionRepo.getRecord === 'function' &&
@@ -356,7 +359,7 @@ export const KioskProcedureListScreen: React.FC = () => {
 
         let lookupAttempts = 0;
         let abortProcedureLookups = false;
-        const maxLookupAttempts = executionRepositoryKind === 'sharepoint' ? 12 : Number.POSITIVE_INFINITY;
+        const maxLookupAttempts = Number.POSITIVE_INFINITY;
 
         for (let index = 0; index < procedures.length; index += 1) {
           const procedureKeys = buildProcedureMatchKeys(procedures[index], index);

--- a/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
@@ -997,12 +997,6 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
         activity: '通所・朝の準備',
         instruction: '送迎担当と引継ぎ',
       },
-      {
-        id: 'official-sheet-1809-2',
-        time: '10:00頃',
-        activity: '体操',
-        instruction: '見守り',
-      },
     ]);
     mockGetRecords.mockResolvedValue([]);
     mockGetRecord.mockImplementation(async (_date, _userId, scheduleItemId) => {
@@ -1019,14 +1013,14 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
     );
 
     await waitFor(() => {
-      expect(screen.getByText('実施状況: 1 / 2')).toBeInTheDocument();
+      expect(screen.getByText('実施状況: 1 / 1')).toBeInTheDocument();
       const firstCard = screen.getByTestId('kiosk-procedure-card-0');
       expect(within(firstCard).getByText('記録済み')).toBeInTheDocument();
       expect(within(firstCard).queryByText('未実施')).toBeNull();
     });
   });
 
-  it('stops procedure-level lookups when SharePoint throttle/CORS is detected', async () => {
+  it('skips procedure-level lookups for SharePoint after bulk lookup completes', async () => {
     mockGetByUser.mockReturnValue([
       {
         id: 'official-sheet-1809-1',
@@ -1043,7 +1037,8 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
     ]);
     mockGetCurrentExecutionRepositoryKind.mockReturnValue('sharepoint');
     mockGetRecords.mockResolvedValue([]);
-    mockGetRecord.mockRejectedValue(new Error('[SharePoint] Throttled: redirected to Throttle.htm.'));
+    mockGetRecord.mockResolvedValue({ scheduleItemId: '1', status: 'completed', memo: 'saved row 1' });
+    const callsBeforeRender = mockGetRecord.mock.calls.length;
 
     render(
       <MemoryRouter initialEntries={['/kiosk/users/U001/procedures']}>
@@ -1054,9 +1049,7 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
     await waitFor(() => {
       expect(screen.getByText('実施状況: 0 / 2')).toBeInTheDocument();
     });
-    const u001Calls = mockGetRecord.mock.calls.filter((call) => call[1] === 'U001');
-    expect(u001Calls.length).toBeLessThanOrEqual(2);
-    expect(mockGetRecord).toHaveBeenCalledWith(expect.any(String), 'U001', '1');
+    expect(mockGetRecord.mock.calls.slice(callsBeforeRender)).toHaveLength(0);
   });
 
   it('waits for user to load before fetching route and master user ID candidates', async () => {


### PR DESCRIPTION
## Summary

- Skip per-card `getRecord` fallback lookups on `KioskProcedureListScreen` when using the SharePoint execution adapter.
- Rely on the batched `getRecords(date, user)` result as the source of truth for SharePoint-backed procedure list status.
- Keep non-SharePoint fallback behavior unchanged.
- Add regression coverage to ensure procedure-level lookups are not executed in SharePoint mode.

## Reason

Production `/kiosk/users/23/procedures?debugRecords=1` showed repeated SharePoint proxy requests and `429 Too Many Requests` while rendering the procedure list.

The procedure list has 17 cards. After the batched record fetch, the per-card fallback lookup could amplify requests and trigger throttling. This also made it harder to determine whether a missing completed status was caused by missing data or by failed fallback lookups.

This PR isolates the first problem: stopping request amplification. After this lands, production verification can focus on whether `procedure-1` exists in the batched `DailyRecordRows` response and whether matching works correctly.

## Verification

- `npm run typecheck`
- `npx vitest run src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx src/features/daily/repositories/sharepoint/__tests__/SharePointExecutionRecordRepository.spec.ts --reporter=dot --no-file-parallelism --silent`

Result:

- 3 files passed
- 80 tests passed

## Scope Note

This PR only stops SharePoint request amplification from per-card fallback lookups. It does not attempt to resolve the remaining production data mismatch directly; after this lands, production verification should check whether procedure-1 exists in the batched DailyRecordRows response.
