### PR TITLE
fix(kiosk): suppress throttled SharePoint request amplification

### DIFF
--- a/src/features/kiosk/components/KioskProcedureListScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureListScreen.tsx
@@ -362,6 +362,10 @@ export const KioskProcedureListScreen: React.FC = () => {
         const maxLookupAttempts = Number.POSITIVE_INFINITY;
 
         for (let index = 0; index < procedures.length; index += 1) {
+          if (!active) {
+            abortProcedureLookups = true;
+            break;
+          }
           const procedureKeys = buildProcedureMatchKeys(procedures[index], index);
           if (procedureKeys.some((key) => matchedKeys.has(key))) continue;
 
@@ -369,6 +373,10 @@ export const KioskProcedureListScreen: React.FC = () => {
           const lookupKeys = buildProcedureLookupKeys(procedures[index], index);
           for (const candidateUserId of queryUserIds) {
             for (const scheduleItemId of lookupKeys) {
+              if (!active) {
+                abortProcedureLookups = true;
+                break;
+              }
               if (lookupAttempts >= maxLookupAttempts) {
                 abortProcedureLookups = true;
                 break;

--- a/src/features/kiosk/toilet/SharePointToiletRecordRepository.ts
+++ b/src/features/kiosk/toilet/SharePointToiletRecordRepository.ts
@@ -126,6 +126,25 @@ export class SharePointToiletRecordRepository implements IToiletRecordRepository
     const data = await response.json();
     const items = (data.value || data.d?.results || []) as JsonRecord[];
 
+    if (items.length === 0) {
+      console.info(`[SharePointToiletRecordRepo] Primary range query returned 0 items. Triggering fallback query for date: ${dateIso}`);
+      const fallbackFilter = `(${isDeletedField} ne true)`;
+      const fallbackUrl = `/lists/getbytitle('${encodeURIComponent(listTitle)}')/items?$filter=${encodeURIComponent(fallbackFilter)}&$select=${selectQuery}&$orderby=Created desc&$top=500`;
+
+      const fallbackResponse = await this.spFetch(fallbackUrl);
+      if (!fallbackResponse.ok) {
+        throw new Error(`[SharePointToiletRecordRepo] Fallback query failed: ${fallbackResponse.statusText}`);
+      }
+
+      const fallbackData = await fallbackResponse.json();
+      const fallbackItems = (fallbackData.value || fallbackData.d?.results || []) as JsonRecord[];
+
+      return fallbackItems
+        .map((item) => this.mapToDomain(item))
+        .filter((record) => record.recordDate === dateIso && !record.isDeleted)
+        .sort((a, b) => b.occurredAt.localeCompare(a.occurredAt));
+    }
+
     return items
       .map((item) => this.mapToDomain(item))
       .sort((a, b) => b.occurredAt.localeCompare(a.occurredAt));

--- a/src/features/kiosk/toilet/__tests__/toiletRecordRepository.spec.ts
+++ b/src/features/kiosk/toilet/__tests__/toiletRecordRepository.spec.ts
@@ -206,6 +206,137 @@ describe('ToiletRecord Repository & Factory Tests', () => {
       expect(record.userId).toBe('I022');
       expect(record.recordDate).toBe('2026-05-26');
     });
+
+    it('should NOT execute fallback query when primary range query returns items', async () => {
+      const mockSpFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          value: [
+            {
+              Id: 101,
+              Title: 'toilet-1',
+              UserId: 'I005',
+              RecordDate: '2026-05-25T15:00:00Z',
+              OccurredAt: '2026-05-26T10:00:00Z',
+              ToiletType: 'urination',
+              Amount: 'normal',
+              Memo: 'sp test',
+              RecorderName: 'kiosk',
+              IsDeleted: false,
+              Created: '2026-05-26T10:05:00Z',
+              Modified: '2026-05-26T10:05:00Z',
+            },
+          ],
+        }),
+      });
+
+      const mockGetFields = vi.fn().mockResolvedValue(new Set([
+        'UserId', 'RecordDate', 'OccurredAt', 'ToiletType', 'Amount', 'Memo', 'RecorderName', 'Source', 'IsDeleted'
+      ]));
+
+      const repo = new SharePointToiletRecordRepository(mockSpFetch, mockGetFields);
+      const records = await repo.listByDate('2026-05-26');
+
+      expect(mockSpFetch).toHaveBeenCalledTimes(1);
+      expect(records).toHaveLength(1);
+      expect(records[0].id).toBe('toilet-1');
+    });
+
+    it('should execute fallback query when primary range query returns 0 items and filter client-side', async () => {
+      let callCount = 0;
+      const mockSpFetch = vi.fn().mockImplementation(async (_url) => {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            ok: true,
+            json: async () => ({ value: [] })
+          };
+        }
+        return {
+          ok: true,
+          json: async () => ({
+            value: [
+              {
+                Id: 50,
+                Title: 'toilet-fallback-1',
+                UserId: 'I005',
+                RecordDate: '2026-05-28T15:00:00Z', // 2026-05-29 00:00:00 JST -> target date
+                OccurredAt: '2026-05-29T10:00:00Z',
+                ToiletType: 'urination',
+                Amount: 'normal',
+                Memo: 'should match',
+                IsDeleted: false,
+                Created: '2026-05-29T10:05:00Z',
+              },
+              {
+                Id: 51,
+                Title: 'toilet-fallback-2',
+                UserId: 'I005',
+                RecordDate: '2026-05-27T15:00:00Z', // 2026-05-28 00:00:00 JST -> other date, should filter out
+                OccurredAt: '2026-05-28T10:00:00Z',
+                ToiletType: 'urination',
+                Amount: 'normal',
+                Memo: 'other date',
+                IsDeleted: false,
+                Created: '2026-05-28T10:05:00Z',
+              },
+              {
+                Id: 52,
+                Title: 'toilet-fallback-3',
+                UserId: 'I005',
+                RecordDate: '2026-05-28T15:00:00Z', // 2026-05-29 00:00:00 JST -> target date, but IsDeleted: true, should filter out
+                OccurredAt: '2026-05-29T11:00:00Z',
+                ToiletType: 'urination',
+                Amount: 'normal',
+                Memo: 'deleted record',
+                IsDeleted: true,
+                Created: '2026-05-29T11:05:00Z',
+              },
+              {
+                Id: 53,
+                Title: 'toilet-fallback-4',
+                UserId: 'I005',
+                RecordDate: '2026-05-28T15:00:00Z', // 2026-05-29 00:00:00 JST -> target date, occurredAt: 09:00:00Z (earlier)
+                OccurredAt: '2026-05-29T09:00:00Z',
+                ToiletType: 'urination',
+                Amount: 'normal',
+                Memo: 'should match earlier',
+                IsDeleted: false,
+                Created: '2026-05-29T09:05:00Z',
+              }
+            ]
+          })
+        };
+      });
+
+      const mockGetFields = vi.fn().mockResolvedValue(new Set([
+        'UserId', 'RecordDate', 'OccurredAt', 'ToiletType', 'Amount', 'Memo', 'RecorderName', 'Source', 'IsDeleted'
+      ]));
+
+      const repo = new SharePointToiletRecordRepository(mockSpFetch, mockGetFields);
+      const records = await repo.listByDate('2026-05-29');
+
+      expect(mockSpFetch).toHaveBeenCalledTimes(2);
+
+      // Verify the URL for the fallback query
+      const [firstCallUrl] = mockSpFetch.mock.calls[0];
+      const [secondCallUrl] = mockSpFetch.mock.calls[1];
+      const decodedFirstUrl = decodeURIComponent(firstCallUrl);
+      const decodedSecondUrl = decodeURIComponent(secondCallUrl);
+      expect(decodedFirstUrl).toContain('RecordDate ge');
+      expect(decodedSecondUrl).not.toContain('RecordDate ge');
+      expect(decodedSecondUrl).toContain('orderby=Created desc');
+      expect(decodedSecondUrl).toContain('top=500');
+
+      // Verify the filtered & sorted results:
+      // - toilet-fallback-1 (10:00:00) and toilet-fallback-4 (09:00:00) match target date '2026-05-29'
+      // - toilet-fallback-2 is filtered out (wrong date)
+      // - toilet-fallback-3 is filtered out (deleted)
+      // - Ordered by occurredAt desc -> fallback-1 (10:00) then fallback-4 (09:00)
+      expect(records).toHaveLength(2);
+      expect(records[0].id).toBe('toilet-fallback-1');
+      expect(records[1].id).toBe('toilet-fallback-4');
+    });
   });
 
   // ── 3. toiletRepositoryFactory ──


### PR DESCRIPTION
This PR introduces a robust client-side date-filtering fallback for SharePoint toilet records and active unmount cleanup guards in KioskProcedureListScreen.