### PR TITLE
fix(sp): add throttle cooldown to shared list discovery

### DIFF
--- a/src/features/daily/repositories/sharepoint/activityDiary/__tests__/ActivityDiarySchemaResolver.spec.ts
+++ b/src/features/daily/repositories/sharepoint/activityDiary/__tests__/ActivityDiarySchemaResolver.spec.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import type { SpFetchFn } from '@/lib/sp/spLists';
-import { ActivityDiarySchemaResolver } from '../modules/SchemaResolver';
+import {
+  ActivityDiarySchemaResolver,
+  __clearActivityDiaryAvailableTitlesCooldownsForTests
+} from '../modules/SchemaResolver';
+import { SpThrottleRedirectError } from '@/lib/sp/spFetch';
 
 const jsonResponse = (value: unknown): Response =>
   new Response(JSON.stringify(value), {
@@ -9,6 +13,14 @@ const jsonResponse = (value: unknown): Response =>
   });
 
 describe('ActivityDiarySchemaResolver', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    __clearActivityDiaryAvailableTitlesCooldownsForTests();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
   it('resolves drifted essential fields and fills optional fields with primary candidates', async () => {
     const spFetch = vi.fn(async (path: string) => {
       if (path.startsWith('lists?$select=Title&$top=5000')) {
@@ -92,5 +104,71 @@ describe('ActivityDiarySchemaResolver', () => {
 
     expect(result).toBeTruthy();
     expect(result?.listPath).toBe("lists/getbytitle('ActivityDiary')");
+  });
+
+  it('triggers cooldown and skips catalog queries on SpThrottleRedirectError', async () => {
+    let isCatalogThrottled = true;
+    let isFieldsAvailable = false;
+    const spFetch = vi.fn(async (path: string) => {
+      if (path.startsWith('lists?$select=Title')) {
+        if (isCatalogThrottled) {
+          throw new SpThrottleRedirectError('Throttled');
+        }
+        return jsonResponse({ value: [{ Title: 'ActivityDiary' }] });
+      }
+      if (path.includes("lists/getbytitle('ActivityDiary')/fields")) {
+        if (isFieldsAvailable) {
+          return jsonResponse({
+            value: [
+              { InternalName: 'UserID' },
+              { InternalName: 'Date' },
+              { InternalName: 'Shift' },
+              { InternalName: 'Category' },
+            ],
+          });
+        }
+      }
+      const err = new Error('Not Found') as any;
+      err.status = 404;
+      throw err;
+    });
+
+    const resolver = new ActivityDiarySchemaResolver(spFetch as unknown as SpFetchFn, 'ActivityDiary');
+
+    // Perform resolution, triggers throttle cooldown
+    const firstResult = await resolver.resolve();
+    expect(firstResult).toBeNull();
+    // Catalog call + direct fallback probes for candidates
+    expect(spFetch).toHaveBeenCalled();
+    expect(spFetch.mock.calls[0][0]).toBe('lists?$select=Title&$top=5000');
+
+    const totalCallsAfterFirst = spFetch.mock.calls.length;
+
+    // Second call: Within 30 seconds cooldown, list catalog search should be skipped
+    const resolver2 = new ActivityDiarySchemaResolver(spFetch as unknown as SpFetchFn, 'ActivityDiary');
+
+    const secondResult = await resolver2.resolve();
+    expect(secondResult).toBeNull();
+
+    // The lists?$select=Title fetch should NOT be in any calls after the first resolve
+    const postFirstCalls = spFetch.mock.calls.slice(totalCallsAfterFirst);
+    const hasCatalogCall = postFirstCalls.some(call => call[0].startsWith('lists?$select=Title'));
+    expect(hasCatalogCall).toBe(false);
+
+    // Advance time by 31 seconds to clear cooldown
+    vi.advanceTimersByTime(31000);
+    isCatalogThrottled = false;
+    isFieldsAvailable = true;
+
+    // Third call: Cooldown expired, catalog lookup succeeds
+    const resolver3 = new ActivityDiarySchemaResolver(spFetch as unknown as SpFetchFn, 'ActivityDiary');
+    const thirdResult = await resolver3.resolve();
+    expect(thirdResult).toBeTruthy();
+    expect(thirdResult?.listPath).toBe("lists/getbytitle('ActivityDiary')");
+
+    // Catalog call was re-invoked
+    const finalCalls = spFetch.mock.calls.slice(totalCallsAfterFirst + postFirstCalls.length);
+    const hasCatalogCallAgain = finalCalls.some(call => call[0].startsWith('lists?$select=Title'));
+    expect(hasCatalogCallAgain).toBe(true);
   });
 });

--- a/src/features/daily/repositories/sharepoint/activityDiary/modules/SchemaResolver.ts
+++ b/src/features/daily/repositories/sharepoint/activityDiary/modules/SchemaResolver.ts
@@ -1,4 +1,5 @@
 import type { SpFetchFn } from '@/lib/sp/spLists';
+import { isSharePointThrottleError } from '@/lib/sp';
 import { ACTIVITY_DIARY_CANDIDATES, ACTIVITY_DIARY_ESSENTIALS } from '@/sharepoint/fields/activityDiaryFields';
 import { resolveInternalNamesDetailed, areEssentialFieldsResolved } from '@/lib/sp/helpers';
 import { auditLog } from '@/lib/debugLogger';
@@ -10,6 +11,13 @@ import {
   suggestListTitles,
 } from '../../utils/Helpers';
 import type { ADFieldKey, ADMapping } from '../constants';
+
+let activityDiaryAvailableTitlesCooldowns = new WeakMap<SpFetchFn, number>();
+
+/** @internal - For testing only */
+export function __clearActivityDiaryAvailableTitlesCooldownsForTests(): void {
+  activityDiaryAvailableTitlesCooldowns = new WeakMap<SpFetchFn, number>();
+}
 
 export class ActivityDiarySchemaResolver {
   private resolvedListPath: string | null = null;
@@ -95,8 +103,13 @@ export class ActivityDiarySchemaResolver {
     this.resolutionFailed = true;
     return null;
   }
-
   private async getAvailableListTitles(): Promise<string[] | null> {
+    const cooldownUntil = activityDiaryAvailableTitlesCooldowns.get(this.spFetch) ?? 0;
+    if (Date.now() < cooldownUntil) {
+      console.info('[ActivityDiarySchemaResolver] getAvailableListTitles suppressed due to throttle cooldown.');
+      return null;
+    }
+
     try {
       const response = await this.spFetch('lists?$select=Title&$top=5000');
       const payload = (await response.json()) as { value?: Array<{ Title?: string }> };
@@ -104,6 +117,11 @@ export class ActivityDiarySchemaResolver {
         .map((item) => item.Title?.trim())
         .filter((title): title is string => Boolean(title));
     } catch (error) {
+      if (isSharePointThrottleError(error)) {
+        activityDiaryAvailableTitlesCooldowns.set(this.spFetch, Date.now() + 30000);
+        console.warn('[ActivityDiarySchemaResolver] getAvailableListTitles throttled. Cooldown set.');
+        return null;
+      }
       if (getHttpStatus(error) === 404) return null;
       throw error;
     }

--- a/src/lib/sp/__tests__/spListSchema.cooldown.spec.ts
+++ b/src/lib/sp/__tests__/spListSchema.cooldown.spec.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { 
+  getExistingListTitlesAndIds, 
+  __clearGetExistingListTitlesCooldownsForTests 
+} from '../spListSchema';
+import { SpThrottleRedirectError } from '../spFetch';
+
+describe('getExistingListTitlesAndIds throttle cooldown and cache preservation', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    __clearGetExistingListTitlesCooldownsForTests();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('successfully returns list titles and caches the result on first successful fetch', async () => {
+    const mockJson = {
+      value: [
+        { Title: 'ListA', Id: '{11111111-1111-1111-1111-111111111111}' },
+        { Title: 'ListB', Id: '{22222222-2222-2222-2222-222222222222}' },
+      ]
+    };
+    
+    const spFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => mockJson,
+    } as Response);
+
+    const result = await getExistingListTitlesAndIds(spFetch);
+    
+    expect(spFetch).toHaveBeenCalledTimes(1);
+    expect(result).toBeInstanceOf(Set);
+    expect(result.has('ListA')).toBe(true);
+    expect(result.has('ListB')).toBe(true);
+    expect(result.has('11111111-1111-1111-1111-111111111111')).toBe(true);
+  });
+
+  it('triggers cooldown and returns the last successful cached result on SpThrottleRedirectError', async () => {
+    const mockJson = {
+      value: [
+        { Title: 'ListCached', Id: '{99999999-9999-9999-9999-999999999999}' }
+      ]
+    };
+
+    const spFetch = vi.fn();
+    
+    // First call: Success
+    spFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockJson,
+    } as Response);
+
+    // Fetch once to populate successful cache
+    const initialResult = await getExistingListTitlesAndIds(spFetch);
+    expect(initialResult.has('ListCached')).toBe(true);
+    expect(spFetch).toHaveBeenCalledTimes(1);
+
+    // Second call: Throttle Error
+    const throttleError = new SpThrottleRedirectError('Throttled for testing');
+    spFetch.mockRejectedValueOnce(throttleError);
+
+    // Fetch again, which triggers throttle error and sets 30s cooldown
+    const errorResult = await getExistingListTitlesAndIds(spFetch);
+    expect(spFetch).toHaveBeenCalledTimes(2);
+    // Should still return last successful cache
+    expect(errorResult.has('ListCached')).toBe(true);
+
+    // Third call: Should be immediately suppressed due to cooldown, returning cached result
+    const suppressedResult = await getExistingListTitlesAndIds(spFetch);
+    // spFetch is NOT called again
+    expect(spFetch).toHaveBeenCalledTimes(2);
+    expect(suppressedResult.has('ListCached')).toBe(true);
+
+    // Advance time by 31 seconds (exceeding the 30-second cooldown)
+    vi.advanceTimersByTime(31000);
+
+    // Fourth call: Cooldown expired, should query SharePoint again
+    spFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ value: [{ Title: 'ListNew', Id: '{12345678-1234-1234-1234-123456789012}' }] }),
+    } as Response);
+
+    const expiredResult = await getExistingListTitlesAndIds(spFetch);
+    expect(spFetch).toHaveBeenCalledTimes(3);
+    expect(expiredResult.has('ListNew')).toBe(true);
+    expect(expiredResult.has('ListCached')).toBe(false);
+  });
+
+  it('returns empty Set on SpThrottleRedirectError if no successful cache exists', async () => {
+    const spFetch = vi.fn().mockRejectedValue(new SpThrottleRedirectError('Throttled immediately'));
+
+    const result = await getExistingListTitlesAndIds(spFetch);
+    expect(spFetch).toHaveBeenCalledTimes(1);
+    expect(result).toBeInstanceOf(Set);
+    expect(result.size).toBe(0);
+
+    // Subsequent call should be suppressed by cooldown
+    const secondResult = await getExistingListTitlesAndIds(spFetch);
+    expect(spFetch).toHaveBeenCalledTimes(1);
+    expect(secondResult.size).toBe(0);
+  });
+
+  it('does NOT trigger cooldown and retries immediately on standard network errors', async () => {
+    const spFetch = vi.fn();
+    
+    // First call: Standard error
+    spFetch.mockRejectedValueOnce(new Error('Network disconnected'));
+    const firstResult = await getExistingListTitlesAndIds(spFetch);
+    expect(spFetch).toHaveBeenCalledTimes(1);
+    expect(firstResult.size).toBe(0);
+
+    // Second call: Cooldown should NOT be active, so it calls spFetch again
+    spFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ value: [{ Title: 'RecoveredList', Id: '{55555555-5555-5555-5555-555555555555}' }] })
+    } as Response);
+
+    const secondResult = await getExistingListTitlesAndIds(spFetch);
+    expect(spFetch).toHaveBeenCalledTimes(2);
+    expect(secondResult.has('RecoveredList')).toBe(true);
+  });
+});

--- a/src/lib/sp/spListSchema.ts
+++ b/src/lib/sp/spListSchema.ts
@@ -21,6 +21,7 @@ import {
 import { trackGuidResolution } from '@/lib/telemetry/spTelemetry';
 import type { SpFetchFn } from './spLists';
 import { buildFieldSchema, trimGuidBraces } from './spSchema';
+import { isSharePointThrottleError } from './spFetch';
 import type {
     EnsureListOptions,
     EnsureListResult,
@@ -111,12 +112,29 @@ export async function tryGetListMetadata(
   }
 }
 
+// Cache and cooldown mapping for list title discovery to prevent request storms on throttle
+let getExistingListTitlesCooldowns = new WeakMap<SpFetchFn, number>();
+let getExistingListTitlesCache = new WeakMap<SpFetchFn, Set<string>>();
+
+/** @internal - For testing only */
+export function __clearGetExistingListTitlesCooldownsForTests(): void {
+  // Clear map values by recreating WeakMaps (garbage collection handles cleanup)
+  getExistingListTitlesCooldowns = new WeakMap<SpFetchFn, number>();
+  getExistingListTitlesCache = new WeakMap<SpFetchFn, Set<string>>();
+}
+
 /**
  * Fetch all existing list titles and IDs once to avoid redundant 404 probes.
  */
 export async function getExistingListTitlesAndIds(
   spFetch: SpFetchFn,
 ): Promise<Set<string>> {
+  const cooldownUntil = getExistingListTitlesCooldowns.get(spFetch) ?? 0;
+  if (Date.now() < cooldownUntil) {
+    auditLog.info('sp:metadata', 'bulk_check_suppressed_cooldown');
+    return getExistingListTitlesCache.get(spFetch) ?? new Set<string>();
+  }
+
   const path = `lists?$select=Title,Id`;
   try {
     const res = await spFetch(path);
@@ -128,9 +146,18 @@ export async function getExistingListTitlesAndIds(
       if (list.Title) identifiers.add(list.Title);
       if (list.Id) identifiers.add(trimGuidBraces(list.Id));
     }
+    // Update successful cache
+    getExistingListTitlesCache.set(spFetch, identifiers);
     return identifiers;
   } catch (error) {
-    auditLog.warn('sp:metadata', 'bulk_check_failed', { error });
+    if (isSharePointThrottleError(error)) {
+      getExistingListTitlesCooldowns.set(spFetch, Date.now() + 30000);
+      auditLog.warn('sp:metadata', 'bulk_check_throttled_cooldown_set', { error });
+      // Return the last successful cache to avoid treating throttle as list absence
+      return getExistingListTitlesCache.get(spFetch) ?? new Set<string>();
+    } else {
+      auditLog.warn('sp:metadata', 'bulk_check_failed', { error });
+    }
     return new Set();
   }
 }


### PR DESCRIPTION
## Summary

Prevents SharePoint request storms and throttling amplification across other components (e.g., Attendance, MonitoringMeeting, and ActivityDiary) by introducing robust, non-negative-cache throttle cooldowns in shared list discovery/metadata resolution.

## Changes

### 1. Core SharePoint Metadata Layer (`spListSchema.ts`)
- **Throttle Cooldown & Cache Preservation**: Added a 30-second cooldown per `spFetch` instance inside `getExistingListTitlesAndIds()`.
- **Constraint Compliance**: Instead of returning an empty `Set` and marking list absence permanently, **the query prioritizes returning the last successful cached list titles** during cooldown or immediately after a throttle error. An empty `Set` is only returned if there is no pre-existing cache, ensuring transient throttle errors do not trigger incorrect list-provisioning/drift failures.
- Exported `__clearGetExistingListTitlesCooldownsForTests` to clear mapping cache during testing.

### 2. ActivityDiary Schema Resolution (`SchemaResolver.ts` in ActivityDiary)
- **Throttle Cooldown**: Added a 30-second throttle cooldown in `getAvailableListTitles()`.
- **Safe Fallback**: On cooldown or throttle error, it immediately returns `null` which safely hands over to direct probes candidate probing without throwing an exception or treating list discovery as permanent absence.
- Exported `__clearActivityDiaryAvailableTitlesCooldownsForTests` to clear the cache mapping.

### 3. Tests
- **`spListSchema.cooldown.spec.ts` [NEW]**: Verifies that `getExistingListTitlesAndIds` successfully caches results, triggers 30-second cooldowns, returns the last successful cache on throttle error, and does not suppress standard network errors.
- **`ActivityDiarySchemaResolver.spec.ts`**: Verifies that `ActivityDiarySchemaResolver` sets cooldowns, skips catalog queries during cooldown, falls back to direct probing on 404, and successfully resumes queries after the cooldown window.

## Architectural Statement

> [!NOTE]
> *This PR does not treat throttled list discovery as list absence. Throttle cooldown only suppresses repeated metadata calls temporarily; normal recovery remains possible after the cooldown window.*

## Verification

| Check | Result |
|---|---|
| `npx vitest run src/lib/sp/__tests__/spListSchema.cooldown.spec.ts` | ✅ 4/4 passed |
| `npx vitest run src/features/daily/repositories/sharepoint/activityDiary/__tests__/ActivityDiarySchemaResolver.spec.ts` | ✅ 4/4 passed |
| `npx vitest run src/features/daily` | ✅ 600/600 passed (74 files) |
| `npm run typecheck` | ✅ Clean |
| `npm run lint` | ✅ Clean |
| `git diff origin/main --check` | ✅ Clean |