### PR TITLE
fix(sp): add global throttle circuit breaker to spFetch

### DIFF
--- a/src/features/kiosk/components/KioskProcedureListScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureListScreen.tsx
@@ -7,7 +7,7 @@ import { useNavigate, useParams, useLocation, Link as RouterLink } from 'react-r
 import { appendKioskSearchParams } from '../utils/navigation';
 import { useUser } from '@/features/users/useUsers';
 import { useUsersQuery } from '@/features/users/hooks/useUsersQuery';
-import { isSharePointThrottleError } from '@/lib/sp';
+import { isSharePointThrottleError, isThrottleCircuitOpen } from '@/lib/sp';
 import { useProcedureData } from '@/features/daily/hooks/useProcedureData';
 import { useExecutionData } from '@/features/daily/hooks/useExecutionData';
 import { formatDateJapanese } from '@/lib/dateFormat';
@@ -286,6 +286,15 @@ export const KioskProcedureListScreen: React.FC = () => {
     const fetchRecords = async () => {
       const dateStr = selectedDateIso;
       if (!dateStr) return;
+      if (isThrottleCircuitOpen()) {
+        console.warn('[Kiosk] Circuit breaker is open. Aborting execution record fetch to suppress storm.');
+        if (active) {
+          setShowFetchError(true);
+          setFetchFailed(true);
+          setHasFetchedRecords(true);
+        }
+        return;
+      }
       const isSharePoint = executionRepositoryKind === 'sharepoint';
       // Deduplicate user IDs that would produce the same SharePoint query candidates.
       // If not SharePoint, we keep all candidates to support local mock/Zustand stores.

--- a/src/lib/sp/__tests__/spFetch.circuitbreaker.spec.ts
+++ b/src/lib/sp/__tests__/spFetch.circuitbreaker.spec.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  createSpFetch,
+  SpThrottleRedirectError,
+  isThrottleCircuitOpen,
+  __clearSharePointThrottleCircuitBreakerForTests,
+  __getSharePointThrottleCircuitBreakerStateForTests,
+} from '../spFetch';
+import type { EnvRecord } from '@/lib/env';
+
+describe('spFetch Throttle Circuit Breaker', () => {
+  const mockAcquireToken = vi.fn().mockResolvedValue('mock-token');
+  const mockConfig: EnvRecord = {
+    VITE_SP_SITE_URL: 'https://tenant.sharepoint.com/sites/test',
+    VITE_SP_SITE_RELATIVE: '/sites/test',
+    VITE_SP_RESOURCE: 'https://tenant.sharepoint.com',
+    VITE_E2E_MSAL_MOCK: '0',
+    VITE_SKIP_SHAREPOINT: '0',
+  };
+
+  const defaultDeps = {
+    acquireToken: mockAcquireToken,
+    baseUrl: 'https://tenant.sharepoint.com/sites/test/_api/web',
+    config: mockConfig,
+    retrySettings: { maxAttempts: 1, baseDelay: 100, capDelay: 1000 },
+    debugEnabled: false,
+    spSiteLegacy: '/sites/test',
+    throwOnError: true,
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    __clearSharePointThrottleCircuitBreakerForTests();
+    mockAcquireToken.mockClear();
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    __clearSharePointThrottleCircuitBreakerForTests();
+  });
+
+  it('should not be open initially', () => {
+    expect(isThrottleCircuitOpen()).toBe(false);
+    const state = __getSharePointThrottleCircuitBreakerStateForTests();
+    expect(state.isOpen).toBe(false);
+    expect(state.openUntil).toBe(0);
+  });
+
+  it('should open circuit breaker for SpThrottleRedirectError and block subsequent requests', async () => {
+    const spFetch = createSpFetch(defaultDeps);
+
+    // Mock fetch to simulate a Throttle.htm redirect landing page
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 302,
+      url: 'https://tenant.sharepoint.com/sites/test/_layouts/15/Throttle.htm#17',
+      headers: new Headers(),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    // First request should hit mockFetch and trigger circuit breaker
+    await expect(spFetch('/lists')).rejects.toThrow(SpThrottleRedirectError);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(isThrottleCircuitOpen()).toBe(true);
+
+    // Second request should be blocked immediately without calling fetch
+    mockFetch.mockClear();
+    await expect(spFetch('/lists')).rejects.toThrow(SpThrottleRedirectError);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('should open circuit breaker for CORS/Redirect errors (Likely CORS failure due to 302 Throttle.htm redirect)', async () => {
+    const spFetch = createSpFetch(defaultDeps);
+
+    // Mock fetch to simulate a CORS/network error triggered by redirect
+    const mockFetch = vi.fn().mockRejectedValue(new Error('Failed to fetch (CORS block)'));
+    vi.stubGlobal('fetch', mockFetch);
+
+    // First request fails with CORS and triggers circuit breaker
+    await expect(spFetch('/lists')).rejects.toThrow(SpThrottleRedirectError);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(isThrottleCircuitOpen()).toBe(true);
+
+    // Second request blocked immediately
+    mockFetch.mockClear();
+    await expect(spFetch('/lists')).rejects.toThrow(SpThrottleRedirectError);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('should automatically close the circuit breaker after 30 seconds', async () => {
+    const spFetch = createSpFetch(defaultDeps);
+
+    // Trigger circuit breaker
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 302,
+        url: 'https://tenant.sharepoint.com/sites/test/_layouts/15/Throttle.htm',
+        headers: new Headers(),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        url: 'https://tenant.sharepoint.com/sites/test/_api/web/lists',
+        headers: new Headers(),
+        json: async () => ({ value: [] }),
+      });
+    vi.stubGlobal('fetch', mockFetch);
+
+    // Trigger
+    await expect(spFetch('/lists')).rejects.toThrow(SpThrottleRedirectError);
+    expect(isThrottleCircuitOpen()).toBe(true);
+
+    // Check blocked
+    await expect(spFetch('/lists')).rejects.toThrow(SpThrottleRedirectError);
+
+    // Advance time by 29 seconds - breaker should still be open
+    vi.advanceTimersByTime(29000);
+    expect(isThrottleCircuitOpen()).toBe(true);
+
+    // Advance time by 1 more second (total 30 seconds) - breaker should close
+    vi.advanceTimersByTime(1000);
+    expect(isThrottleCircuitOpen()).toBe(false);
+
+    // Request should now pass and call fetch
+    mockFetch.mockClear();
+    const res = await spFetch('/lists');
+    expect(res.ok).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not open circuit breaker for typical 500 errors', async () => {
+    const spFetch = createSpFetch(defaultDeps);
+
+    // Mock fetch to simulate a internal server error
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      url: 'https://tenant.sharepoint.com/sites/test/_api/web/lists',
+      headers: new Headers(),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    // First request should fail with normal HTTP error, NOT opening the breaker
+    await expect(spFetch('/lists')).rejects.toThrow();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(isThrottleCircuitOpen()).toBe(false);
+
+    // Second request should still hit fetch
+    mockFetch.mockClear();
+    await expect(spFetch('/lists')).rejects.toThrow();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('should be able to manually clear/reset circuit breaker using the test helper', async () => {
+    const spFetch = createSpFetch(defaultDeps);
+
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 302,
+        url: 'https://tenant.sharepoint.com/sites/test/_layouts/15/Throttle.htm',
+        headers: new Headers(),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        url: 'https://tenant.sharepoint.com/sites/test/_api/web/lists',
+        headers: new Headers(),
+        json: async () => ({ value: [] }),
+      });
+    vi.stubGlobal('fetch', mockFetch);
+
+    // Trigger breaker
+    await expect(spFetch('/lists')).rejects.toThrow(SpThrottleRedirectError);
+    expect(isThrottleCircuitOpen()).toBe(true);
+
+    // Clear breaker manually using helper
+    __clearSharePointThrottleCircuitBreakerForTests();
+    expect(isThrottleCircuitOpen()).toBe(false);
+
+    // Subsequent request should pass through
+    const res = await spFetch('/lists');
+    expect(res.ok).toBe(true);
+  });
+});

--- a/src/lib/sp/__tests__/spFetch.retry-guard.spec.ts
+++ b/src/lib/sp/__tests__/spFetch.retry-guard.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createSpFetch } from '../spFetch';
+import { createSpFetch, __clearSharePointThrottleCircuitBreakerForTests } from '../spFetch';
 import type { EnvRecord } from '@/lib/env';
 
 function createTestEnv(): EnvRecord {
@@ -43,12 +43,14 @@ function createProxyFetcher() {
 describe('spFetch retry guard for SharePoint throttle/cors', () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    __clearSharePointThrottleCircuitBreakerForTests();
   });
 
   afterEach(() => {
     vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
+    __clearSharePointThrottleCircuitBreakerForTests();
   });
 
   it('does not retry when redirected to Throttle.htm', async () => {

--- a/src/lib/sp/__tests__/spListSchema.cooldown.spec.ts
+++ b/src/lib/sp/__tests__/spListSchema.cooldown.spec.ts
@@ -3,12 +3,13 @@ import {
   getExistingListTitlesAndIds, 
   __clearGetExistingListTitlesCooldownsForTests 
 } from '../spListSchema';
-import { SpThrottleRedirectError } from '../spFetch';
+import { SpThrottleRedirectError, __clearSharePointThrottleCircuitBreakerForTests } from '../spFetch';
 
 describe('getExistingListTitlesAndIds throttle cooldown and cache preservation', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     __clearGetExistingListTitlesCooldownsForTests();
+    __clearSharePointThrottleCircuitBreakerForTests();
   });
 
   afterEach(() => {

--- a/src/lib/sp/index.ts
+++ b/src/lib/sp/index.ts
@@ -38,7 +38,7 @@ export { createListOperations } from './spLists';
 export type { NormalizePathFn, SpFetchFn, SpListOperations } from './spLists';
 
 // Fetch (HTTP fetch + retry + mock)
-export { createNormalizePath, createSpFetch, SpThrottleRedirectError, isSharePointThrottleError } from './spFetch';
+export { createNormalizePath, createSpFetch, SpThrottleRedirectError, isSharePointThrottleError, isThrottleCircuitOpen, openThrottleCircuit, __clearSharePointThrottleCircuitBreakerForTests } from './spFetch';
 export type { SpFetchDeps } from './spFetch';
 
 // Batch POST (retry-aware)

--- a/src/lib/sp/spFetch.ts
+++ b/src/lib/sp/spFetch.ts
@@ -232,6 +232,32 @@ export function isSharePointThrottleError(error: unknown): boolean {
   );
 }
 
+const THROTTLE_CIRCUIT_BREAKER_MS = 30_000;
+
+let throttleCircuitOpenUntil = 0;
+
+export function isThrottleCircuitOpen(now = Date.now()): boolean {
+  return throttleCircuitOpenUntil > now;
+}
+
+export function openThrottleCircuit(now = Date.now()): void {
+  throttleCircuitOpenUntil = Math.max(
+    throttleCircuitOpenUntil,
+    now + THROTTLE_CIRCUIT_BREAKER_MS,
+  );
+}
+
+export function __clearSharePointThrottleCircuitBreakerForTests(): void {
+  throttleCircuitOpenUntil = 0;
+}
+
+export function __getSharePointThrottleCircuitBreakerStateForTests(): { openUntil: number; isOpen: boolean } {
+  return {
+    openUntil: throttleCircuitOpenUntil,
+    isOpen: isThrottleCircuitOpen(),
+  };
+}
+
 let hasWarnedThrottleRedirect = false;
 let hasWarnedCorsOrRedirectFailure = false;
 
@@ -299,6 +325,11 @@ export function createSpFetch(deps: SpFetchDeps) {
   };
 
   return async function spFetch(path: string, init: import('./types').SpRequestInit = {}): Promise<Response> {
+    if (isThrottleCircuitOpen()) {
+      throw new SpThrottleRedirectError(
+        '[SharePoint] Throttled: circuit breaker is open. Request suppressed to avoid request storm.'
+      );
+    }
     const spOptions = init.spOptions || {};
     const resolvedPath = path; // normalizePath is applied BEFORE calling spFetch by createSpClient
     const method = (init.method ?? 'GET').toUpperCase();
@@ -449,6 +480,7 @@ export function createSpFetch(deps: SpFetchDeps) {
                 lane,
               });
             }
+            openThrottleCircuit();
             throw new SpThrottleRedirectError(responseUrl);
           }
 
@@ -598,6 +630,7 @@ export function createSpFetch(deps: SpFetchDeps) {
               message: error instanceof Error ? error.message : 'NetworkError',
             });
             span.error('SpThrottleRedirectError', attempt - 1);
+            openThrottleCircuit();
             throw new SpThrottleRedirectError(url);
           }
 


### PR DESCRIPTION
### Summary
This PR suppresses physical SharePoint HTTP requests after a confirmed SpThrottleRedirectError. The circuit breaker is temporary and does not convert generic network/auth errors into throttle errors.

### Changes
- **spFetch.ts**: Implemented a global throttle circuit breaker. When SpThrottleRedirectError is detected (via 302 Throttle.htm redirect or CORS network failure), a 30s cooldown timer is started during which any physical HTTP fetch requests to SharePoint are blocked locally and immediately throw SpThrottleRedirectError.
- **KioskProcedureListScreen.tsx**: Integrated early fetch-abort guard to immediately exit fetch loops when throttled, significantly reducing local CPU/console logs storm.
- **spFetch.circuitbreaker.spec.ts**: Created comprehensive unit tests validating breaker trigger, suppression, automatic cooldown recovery, and test-safety isolation helper.
- **index.ts (sp barrel)**: Barrel exported new circuit breaker state check and test cleanup helper.
- **spec cleanup**: Protected spListSchema & spFetch retry-guard specs using the test reset helper.

### Verification
- Vitest: `src/lib/sp/__tests__/spFetch.circuitbreaker.spec.ts` (6/6 passed)
- Vitest: `src/lib/sp/__tests__/spFetch.retry-guard.spec.ts` (4/4 passed)
- Vitest: `src/features/kiosk` suite (104/104 passed)
- E2E Playwright: `tests/e2e/kiosk-procedure-detail.spec.ts` (4/4 passed)