### PR TITLE
fix(sp): surface throttle circuit breaker status in kiosk and admin

### DIFF
--- a/src/features/diagnostics/health/components/SpTelemetryPanel.tsx
+++ b/src/features/diagnostics/health/components/SpTelemetryPanel.tsx
@@ -1,23 +1,35 @@
-import { Box, Divider, Paper, Stack, Typography } from "@mui/material";
+import { Box, Divider, Paper, Stack, Typography, Chip } from "@mui/material";
 import { StatusChip } from "./StatusChip";
 import { spTelemetryStore } from "@/lib/telemetry/spTelemetryStore";
+import { getSharePointThrottleCircuitBreakerState } from "@/lib/sp";
 import React from "react";
 
 /**
  * 🌐 SP通信状態パネル
  *
- * spTelemetryStore を 2 秒間隔でポーリングし、
- * Throttled / Retry / Failed / Duration / Top Endpoints を表示する。
+ * spTelemetryStore と circuit breaker を 1 秒間隔でポーリングし、
+ * 通信統計情報とサーキットブレーカーの稼働状況を表示する。
  */
 export function SpTelemetryPanel() {
   const [spSnapshot, setSpSnapshot] = React.useState(() => spTelemetryStore.getSnapshot());
+  const [breakerState, setBreakerState] = React.useState(() => getSharePointThrottleCircuitBreakerState());
 
   React.useEffect(() => {
     const timer = setInterval(() => {
       setSpSnapshot(spTelemetryStore.getSnapshot());
-    }, 2000);
+      setBreakerState(getSharePointThrottleCircuitBreakerState());
+    }, 1000);
     return () => clearInterval(timer);
   }, []);
+
+  const formatTime = (timestamp: number) => {
+    if (!timestamp) return "なし";
+    try {
+      return new Date(timestamp).toLocaleTimeString("ja-JP");
+    } catch {
+      return "なし";
+    }
+  };
 
   return (
     <Paper variant="outlined" sx={{ p: 2 }}>
@@ -55,6 +67,32 @@ export function SpTelemetryPanel() {
           </Box>
         </Box>
       )}
+
+      <Divider sx={{ my: 1.5 }} />
+      <Box sx={{ mt: 1.5 }}>
+        <Stack direction="row" spacing={1.5} alignItems="center" sx={{ mb: 1 }} data-testid="sp-telemetry-breaker-section">
+          <Typography variant="body2" sx={{ fontWeight: "bold" }}>
+            🛑 サーキットブレーカー:
+          </Typography>
+          <Chip
+            size="small"
+            label={breakerState.isOpen ? "動作中 (OPEN)" : "待機中 (CLOSED)"}
+            color={breakerState.isOpen ? "error" : "success"}
+            data-testid="sp-telemetry-breaker-chip"
+          />
+        </Stack>
+        <Typography variant="body2" color="text.secondary">
+          {breakerState.isOpen ? (
+            <>
+              発生時刻: {formatTime(breakerState.openedAt)}
+              <br />
+              解除までの時間: <strong style={{ color: "#d32f2f" }}>残り {Math.ceil(breakerState.remainingMs / 1000)} 秒</strong>
+            </>
+          ) : (
+            "現在、サーキットブレーカーは動作していません。"
+          )}
+        </Typography>
+      </Box>
     </Paper>
   );
 }

--- a/src/features/kiosk/components/KioskProcedureListScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureListScreen.tsx
@@ -7,7 +7,7 @@ import { useNavigate, useParams, useLocation, Link as RouterLink } from 'react-r
 import { appendKioskSearchParams } from '../utils/navigation';
 import { useUser } from '@/features/users/useUsers';
 import { useUsersQuery } from '@/features/users/hooks/useUsersQuery';
-import { isSharePointThrottleError, isThrottleCircuitOpen } from '@/lib/sp';
+import { isSharePointThrottleError, isThrottleCircuitOpen, getSharePointThrottleCircuitBreakerState } from '@/lib/sp';
 import { useProcedureData } from '@/features/daily/hooks/useProcedureData';
 import { useExecutionData } from '@/features/daily/hooks/useExecutionData';
 import { formatDateJapanese } from '@/lib/dateFormat';
@@ -249,6 +249,43 @@ export const KioskProcedureListScreen: React.FC = () => {
   const [showFetchError, setShowFetchError] = useState(false);
   const procedureLookupThrottleKeyRef = React.useRef('');
 
+  const [isThrottleActive, setIsThrottleActive] = useState(() => isThrottleCircuitOpen());
+  const [throttleRemaining, setThrottleRemaining] = useState(0);
+  const [retryCount, setRetryCount] = useState(0);
+
+  // Monitor circuit breaker status and remaining cooldown seconds (read-only)
+  useEffect(() => {
+    const checkThrottle = () => {
+      const active = isThrottleCircuitOpen();
+      setIsThrottleActive(active);
+      if (active) {
+        const state = getSharePointThrottleCircuitBreakerState();
+        setThrottleRemaining(Math.max(0, Math.ceil(state.remainingMs / 1000)));
+      } else {
+        setThrottleRemaining(0);
+      }
+    };
+
+    checkThrottle();
+    const timer = setInterval(checkThrottle, 1000);
+    return () => {
+      clearInterval(timer);
+    };
+  }, []);
+
+  // When breaker closes, automatically reset states and trigger a fresh fetch
+  const prevThrottleActiveRef = React.useRef(isThrottleActive);
+  useEffect(() => {
+    if (!isThrottleActive && prevThrottleActiveRef.current) {
+      setFetchFailed(false);
+      setHasFetchedRecords(false);
+      setShowFetchError(false);
+      setRecords([]);
+      setRetryCount((prev) => prev + 1);
+    }
+    prevThrottleActiveRef.current = isThrottleActive;
+  }, [isThrottleActive]);
+
   // Synchronously reset records state when the active user or date changes
   // to prevent rendering stale records from the previous context.
   const currentQueryId = executionUserIdCandidates.join('|');
@@ -289,7 +326,8 @@ export const KioskProcedureListScreen: React.FC = () => {
       if (isThrottleCircuitOpen()) {
         console.warn('[Kiosk] Circuit breaker is open. Aborting execution record fetch to suppress storm.');
         if (active) {
-          setShowFetchError(true);
+          setShowFetchError(false);
+          setIsThrottleActive(true);
           setFetchFailed(true);
           setHasFetchedRecords(true);
         }
@@ -329,7 +367,12 @@ export const KioskProcedureListScreen: React.FC = () => {
         const error = failedResults[0]?.reason ?? new Error('No execution record fetches completed');
         if (active) {
           console.error('Failed to fetch execution records:', error);
-          setShowFetchError(true);
+          if (isSharePointThrottleError(error)) {
+            setShowFetchError(false);
+            setIsThrottleActive(true);
+          } else {
+            setShowFetchError(true);
+          }
           setFetchFailed(true);
           setHasFetchedRecords(true);
         }
@@ -452,6 +495,7 @@ export const KioskProcedureListScreen: React.FC = () => {
     userId,
     location.key,
     location.search,
+    retryCount,
   ]);
 
   const hasRecordInput = React.useCallback((record: ExecutionRecord | undefined): boolean => {
@@ -576,6 +620,45 @@ export const KioskProcedureListScreen: React.FC = () => {
           </Box>
         </Box>
       </Box>
+
+      {/* サーキットブレーカー / エラー警告バナー */}
+      {(isThrottleActive || fetchFailed) && (
+        <Alert
+          severity={isThrottleActive ? "warning" : "error"}
+          sx={{ mb: 3, borderRadius: 2 }}
+          data-testid="kiosk-throttle-alert"
+          action={
+            <Button
+              color="inherit"
+              size="small"
+              disabled={isThrottleActive}
+              onClick={() => {
+                setFetchFailed(false);
+                setHasFetchedRecords(false);
+                setShowFetchError(false);
+                setRecords([]);
+                setRetryCount((prev) => prev + 1);
+              }}
+            >
+              {isThrottleActive ? `再試行（${throttleRemaining}秒）` : '再試行する'}
+            </Button>
+          }
+        >
+          {isThrottleActive ? (
+            <>
+              SharePointが一時的に混み合っています。
+              <br />
+              安全のため、サーバーへの再接続を少し待っています。
+              <br />
+              表示できる範囲のローカル情報を表示しています。
+              <br />
+              しばらくしてから再試行してください。
+            </>
+          ) : (
+            "一時的な接続エラーが発生しました。再試行ボタンを押してデータを読み込んでください。"
+          )}
+        </Alert>
+      )}
 
       {/* 手順一覧 */}
       <Grid container spacing={2}>

--- a/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { KioskProcedureListScreen } from '../KioskProcedureListScreen';
+import { openThrottleCircuit, __clearSharePointThrottleCircuitBreakerForTests } from '@/lib/sp';
 import { MemoryRouter } from 'react-router-dom';
 import type { SupportPlanningSheet, PlanningSheetListItem } from '@/domain/isp/schema';
 
@@ -108,6 +109,7 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
     vi.useFakeTimers({ toFake: ['Date'] });
     vi.setSystemTime(new Date(2026, 4, 8));
     vi.clearAllMocks();
+    __clearSharePointThrottleCircuitBreakerForTests();
     mockRouteUserId = 'U001';
     mockLocationSearch = null;
     mockLocationKey = null;
@@ -357,7 +359,7 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
         recordedAt: '2026-05-07T23:50:00+09:00',
       },
     ]);
-    mockGetRecords.mockRejectedValue(new Error('SharePoint throttled'));
+    mockGetRecords.mockRejectedValue(new Error('Connection failed'));
 
     render(
       <MemoryRouter>
@@ -1143,5 +1145,42 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
       expect(within(card).getByText('未実施')).toBeInTheDocument();
       expect(within(card).queryByText('記録済み')).toBeNull();
     }
+  });
+
+  describe('SharePoint Throttle Circuit Breaker UX Alert', () => {
+    it('shows inline warning Alert with countdown and disabled button when circuit breaker is active', async () => {
+      // Open the circuit breaker manually at t=0
+      const startTime = Date.now();
+      openThrottleCircuit(startTime);
+
+      render(
+        <MemoryRouter>
+          <KioskProcedureListScreen />
+        </MemoryRouter>
+      );
+
+      // Verify the alert is rendered with appropriate styling and text
+      const alert = await screen.findByTestId('kiosk-throttle-alert');
+      expect(alert).toBeInTheDocument();
+      expect(screen.getByText(/SharePointが一時的に混み合っています。/)).toBeInTheDocument();
+      expect(screen.getByText(/安全のため、サーバーへの再接続を少し待っています。/)).toBeInTheDocument();
+
+      // Verify the button is disabled and displays the countdown (30 seconds initially)
+      const button = within(alert).getByRole('button');
+      expect(button).toBeDisabled();
+      expect(button).toHaveTextContent('再試行（30秒）');
+
+      // Advance time by 10 seconds - countdown should decrease
+      vi.advanceTimersByTime(10000);
+      await waitFor(() => {
+        expect(button).toHaveTextContent('再試行（20秒）');
+      });
+
+      // Advance time by 20 more seconds (total 30 seconds) - breaker should close and alert should auto-hide/trigger refetch
+      vi.advanceTimersByTime(20000);
+      await waitFor(() => {
+        expect(screen.queryByTestId('kiosk-throttle-alert')).toBeNull();
+      });
+    });
   });
 });

--- a/src/lib/sp/__tests__/spFetch.circuitbreaker.spec.ts
+++ b/src/lib/sp/__tests__/spFetch.circuitbreaker.spec.ts
@@ -3,6 +3,7 @@ import {
   createSpFetch,
   SpThrottleRedirectError,
   isThrottleCircuitOpen,
+  getSharePointThrottleCircuitBreakerState,
   __clearSharePointThrottleCircuitBreakerForTests,
   __getSharePointThrottleCircuitBreakerStateForTests,
 } from '../spFetch';
@@ -185,5 +186,48 @@ describe('spFetch Throttle Circuit Breaker', () => {
     // Subsequent request should pass through
     const res = await spFetch('/lists');
     expect(res.ok).toBe(true);
+  });
+
+  describe('getSharePointThrottleCircuitBreakerState', () => {
+    it('should return correct initial values', () => {
+      const state = getSharePointThrottleCircuitBreakerState();
+      expect(state.isOpen).toBe(false);
+      expect(state.openUntil).toBe(0);
+      expect(state.openedAt).toBe(0);
+      expect(state.remainingMs).toBe(0);
+    });
+
+    it('should reflect correct openedAt and remainingMs when circuit is open', async () => {
+      const spFetch = createSpFetch(defaultDeps);
+
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 302,
+        url: 'https://tenant.sharepoint.com/sites/test/_layouts/15/Throttle.htm',
+        headers: new Headers(),
+      });
+      vi.stubGlobal('fetch', mockFetch);
+
+      const startTime = Date.now();
+      await expect(spFetch('/lists')).rejects.toThrow(SpThrottleRedirectError);
+
+      const state = getSharePointThrottleCircuitBreakerState();
+      expect(state.isOpen).toBe(true);
+      expect(state.openedAt).toBeGreaterThanOrEqual(startTime);
+      expect(state.openUntil).toBe(state.openedAt + 30000);
+      expect(state.remainingMs).toBeCloseTo(30000, -3); // ±1000ms is acceptable
+
+      // After 10 seconds
+      vi.advanceTimersByTime(10000);
+      const stateAfter10 = getSharePointThrottleCircuitBreakerState();
+      expect(stateAfter10.isOpen).toBe(true);
+      expect(stateAfter10.remainingMs).toBeCloseTo(20000, -3);
+
+      // After 30 seconds
+      vi.advanceTimersByTime(20000);
+      const stateAfter30 = getSharePointThrottleCircuitBreakerState();
+      expect(stateAfter30.isOpen).toBe(false);
+      expect(stateAfter30.remainingMs).toBe(0);
+    });
   });
 });

--- a/src/lib/sp/index.ts
+++ b/src/lib/sp/index.ts
@@ -38,7 +38,7 @@ export { createListOperations } from './spLists';
 export type { NormalizePathFn, SpFetchFn, SpListOperations } from './spLists';
 
 // Fetch (HTTP fetch + retry + mock)
-export { createNormalizePath, createSpFetch, SpThrottleRedirectError, isSharePointThrottleError, isThrottleCircuitOpen, openThrottleCircuit, __clearSharePointThrottleCircuitBreakerForTests } from './spFetch';
+export { createNormalizePath, createSpFetch, SpThrottleRedirectError, isSharePointThrottleError, isThrottleCircuitOpen, openThrottleCircuit, getSharePointThrottleCircuitBreakerState, __clearSharePointThrottleCircuitBreakerForTests } from './spFetch';
 export type { SpFetchDeps } from './spFetch';
 
 // Batch POST (retry-aware)

--- a/src/lib/sp/spFetch.ts
+++ b/src/lib/sp/spFetch.ts
@@ -235,20 +235,41 @@ export function isSharePointThrottleError(error: unknown): boolean {
 const THROTTLE_CIRCUIT_BREAKER_MS = 30_000;
 
 let throttleCircuitOpenUntil = 0;
+let throttleCircuitOpenedAt = 0;
 
 export function isThrottleCircuitOpen(now = Date.now()): boolean {
   return throttleCircuitOpenUntil > now;
 }
 
 export function openThrottleCircuit(now = Date.now()): void {
+  if (throttleCircuitOpenUntil <= now) {
+    throttleCircuitOpenedAt = now;
+  }
   throttleCircuitOpenUntil = Math.max(
     throttleCircuitOpenUntil,
     now + THROTTLE_CIRCUIT_BREAKER_MS,
   );
 }
 
+export function getSharePointThrottleCircuitBreakerState(now = Date.now()): {
+  isOpen: boolean;
+  openUntil: number;
+  openedAt: number;
+  remainingMs: number;
+} {
+  const isOpen = throttleCircuitOpenUntil > now;
+  const remainingMs = isOpen ? Math.max(0, throttleCircuitOpenUntil - now) : 0;
+  return {
+    isOpen,
+    openUntil: throttleCircuitOpenUntil,
+    openedAt: throttleCircuitOpenedAt,
+    remainingMs,
+  };
+}
+
 export function __clearSharePointThrottleCircuitBreakerForTests(): void {
   throttleCircuitOpenUntil = 0;
+  throttleCircuitOpenedAt = 0;
 }
 
 export function __getSharePointThrottleCircuitBreakerStateForTests(): { openUntil: number; isOpen: boolean } {


### PR DESCRIPTION
## Summary

Surfaces the SharePoint throttle circuit breaker state to operators and admins.

## Changes

- Adds an operator-facing Kiosk alert when the SharePoint throttle circuit breaker is open.
- Shows a safe cooldown countdown without triggering additional SharePoint fetches.
- Disables retry while the breaker is open and re-enables it after cooldown.
- Adds admin/status telemetry for the SharePoint circuit breaker state, including active/inactive status and remaining cooldown time.
- Keeps circuit breaker state read-only from the UI.

## Verification

| Check | Result |
|---|---|
| src/lib/sp tests | ✅ 55/55 passed |
| src/features/kiosk tests | ✅ 105/105 passed |
| diagnostics/health tests | ✅ 39/39 passed |
| Playwright kiosk procedure detail | ✅ 4/4 passed |
| typecheck / lint / diff --check | ✅ passed |

## Design Notes

The UI does not open or close the circuit breaker. It only reads the current state and presents a safe operator/admin status. Countdown updates are local UI state only and do not trigger SharePoint refetches.