### PR TITLE
fix(ci): harden smoke playwright install

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -183,8 +183,40 @@ jobs:
           node-version: 24
           cache: npm
       - run: npm ci
+
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(npx playwright --version | cut -d' ' -f2)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}-
+            ${{ runner.os }}-playwright-
+
       - name: Playwright install (preview server)
+        id: playwright-install
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 8
+        continue-on-error: true
         run: npx playwright install --with-deps chromium
+
+      - name: Playwright install retry (preview server)
+        if: steps.playwright-cache.outputs.cache-hit != 'true' && steps.playwright-install.outcome == 'failure'
+        timeout-minutes: 8
+        run: |
+          npx playwright install-deps chromium
+          npx playwright install chromium
+
+      - name: Playwright system dependencies (preview server)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        timeout-minutes: 8
+        run: npx playwright install-deps chromium
+
       - name: Build (preview server)
         run: VITE_E2E='1' VITE_E2E_MSAL_MOCK='1' VITE_FEATURE_SCHEDULES='1' VITE_SKIP_LOGIN='1' VITE_SKIP_SHAREPOINT='1' VITE_DEMO_MODE='1' npm run build --if-present
       - name: Start preview server


### PR DESCRIPTION
This PR only hardens the E2E Smoke Playwright browser install step. It does not change application behavior. The smoke workflow now follows the existing cached install / step-timeout pattern used by the stable E2E workflows to prevent hanging indefinitely during browser installation.

## Changes
- Adds a Playwright version-aware browser cache to `smoke.yml`.
- Adds step-level timeouts around the smoke Playwright install path.
- Adds an explicit retry/fallback path when the initial `--with-deps` install fails.
- Uses `install-deps chromium` when the browser cache is restored.

## Validation
- `git diff --check`
- Commit hook: `lint`, `typecheck`, `lint:cookies`
- `actionlint .github/workflows/smoke.yml` was run; it reports existing ShellCheck warnings in unrelated summary-generation blocks, not in the new Playwright install block.
