### PR TITLE
fix(kiosk): show auth required state instead of missing user

### DIFF
--- a/src/features/kiosk/components/KioskProcedureListScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureListScreen.tsx
@@ -28,6 +28,7 @@ import { usePlanningSheetData } from '@/features/planning-sheet/hooks/usePlannin
 import { useCurrentPlanningSheet } from '@/features/planning-sheet/hooks/useCurrentPlanningSheet';
 import { resolveSupportStartDateDetailed } from '@/features/planning-sheet/monitoringSchedule';
 import { resolveProcedureUserQueryCandidates } from '../utils/resolveProcedureUserQuery';
+import { isAuthRequiredError } from '@/lib/errors';
 
 const buildProcedureMatchKeys = (
   procedure: { id?: unknown; rowNo?: unknown },
@@ -109,8 +110,16 @@ export const KioskProcedureListScreen: React.FC = () => {
   }, [location.search]);
   const userLookupId = queryUserIdFromSearch || userId || '';
   const numericUserLookupId = Number.isFinite(Number(userLookupId)) ? Number(userLookupId) : undefined;
-  const { data: userByNumericId, status: numericUserStatus } = useUser(numericUserLookupId);
-  const { data: users, status: usersStatus } = useUsersQuery({ selectMode: 'core' });
+  const {
+    data: userByNumericId,
+    status: numericUserStatus,
+    error: numericUserError,
+  } = useUser(numericUserLookupId);
+  const {
+    data: users,
+    status: usersStatus,
+    error: usersError,
+  } = useUsersQuery({ selectMode: 'core' });
   const userByCode = React.useMemo(() => {
     const lookup = String(userLookupId).trim();
     if (!lookup) return null;
@@ -124,6 +133,10 @@ export const KioskProcedureListScreen: React.FC = () => {
   const isUserLoading = numericUserLookupId != null
     ? (numericUserStatus === 'loading' || numericUserStatus === 'idle')
     : (usersStatus === 'loading' || usersStatus === 'idle');
+  const isUserAuthRequired = React.useMemo(
+    () => isAuthRequiredError(numericUserError) || isAuthRequiredError(usersError),
+    [numericUserError, usersError],
+  );
   const procedureRepo = useProcedureData();
   const executionRepo = useExecutionData();
   
@@ -564,6 +577,37 @@ export const KioskProcedureListScreen: React.FC = () => {
 
   if (isUserLoading) {
     return <Box sx={{ p: 4 }}>読み込み中...</Box>;
+  }
+
+  if (!user && isUserAuthRequired) {
+    return (
+      <Box sx={{ p: 4, textAlign: 'center' }}>
+        <Alert
+          severity="warning"
+          sx={{ mb: 3, textAlign: 'left' }}
+          data-testid="kiosk-auth-required-alert"
+          action={
+            <Button
+              color="inherit"
+              size="small"
+              onClick={() => {
+                if (typeof window !== 'undefined') {
+                  window.sessionStorage.setItem('postLoginRedirect', `${location.pathname}${location.search}`);
+                }
+                navigate('/login');
+              }}
+            >
+              再ログイン
+            </Button>
+          }
+        >
+          Microsoft 365 の認証が必要です。再ログイン後にもう一度お試しください。
+        </Alert>
+        <IconButton onClick={() => navigate(appendKioskSearchParams('/kiosk/users', location.search))} sx={{ mt: 2 }}>
+          <ArrowBackIcon /> 戻る
+        </IconButton>
+      </Box>
+    );
   }
 
   if (!user) {

--- a/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
@@ -5,6 +5,7 @@ import { KioskProcedureListScreen } from '../KioskProcedureListScreen';
 import { openThrottleCircuit, __clearSharePointThrottleCircuitBreakerForTests } from '@/lib/sp';
 import { MemoryRouter } from 'react-router-dom';
 import type { SupportPlanningSheet, PlanningSheetListItem } from '@/domain/isp/schema';
+import { AuthRequiredError } from '@/lib/errors';
 
 // Mock dependencies
 let mockRouteUserId = 'U001';
@@ -36,8 +37,8 @@ vi.mock('@/features/users/useUsers', () => ({
 vi.mock('@/features/users/hooks/useUsersQuery', () => ({
   useUsersQuery: () => ({
     data: mockUseUsers().data,
-    status: mockUseUsers().status === 'success' ? 'success' : 'loading',
-    error: null,
+    status: mockUseUsers().status === 'success' ? 'success' : mockUseUsers().status === 'error' ? 'error' : 'loading',
+    error: mockUseUsers().error ?? null,
     refresh: vi.fn(),
   }),
 }));
@@ -113,8 +114,8 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
     mockRouteUserId = 'U001';
     mockLocationSearch = null;
     mockLocationKey = null;
-    mockUseUser.mockReturnValue({ data: { FullName: '田中 太郎' }, status: 'success' });
-    mockUseUsers.mockReturnValue({ data: [], status: 'success' });
+    mockUseUser.mockReturnValue({ data: { FullName: '田中 太郎' }, status: 'success', error: null });
+    mockUseUsers.mockReturnValue({ data: [], status: 'success', error: null });
     mockGetCurrentExecutionRepositoryKind.mockReturnValue('local');
     mockGetStoreRecords.mockReturnValue([]);
     mockGetByUser.mockReturnValue(mockProcedures);
@@ -148,6 +149,54 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
       expect(screen.getByText('実施状況: 1 / 2')).toBeInTheDocument();
       expect(screen.getByText('記録済み')).toBeInTheDocument();
     });
+  });
+
+  it('shows an auth-required alert instead of user-not-found when user lookup requires Microsoft 365 auth', async () => {
+    mockRouteUserId = '23';
+    mockUseUser.mockReturnValue({
+      data: null,
+      status: 'error',
+      error: new AuthRequiredError(),
+    });
+    mockUseUsers.mockReturnValue({
+      data: [],
+      status: 'error',
+      error: new AuthRequiredError(),
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/kiosk/users/23/procedures']}>
+        <KioskProcedureListScreen />
+      </MemoryRouter>
+    );
+
+    const alert = await screen.findByTestId('kiosk-auth-required-alert');
+    expect(alert).toHaveTextContent('Microsoft 365 の認証が必要です。再ログイン後にもう一度お試しください。');
+    expect(within(alert).getByRole('button', { name: '再ログイン' })).toBeInTheDocument();
+    expect(screen.queryByText('利用者が存在しません')).toBeNull();
+  });
+
+  it('keeps the user-not-found state when lookup succeeds without a matching user', async () => {
+    mockRouteUserId = '23';
+    mockUseUser.mockReturnValue({
+      data: null,
+      status: 'success',
+      error: null,
+    });
+    mockUseUsers.mockReturnValue({
+      data: [],
+      status: 'success',
+      error: null,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/kiosk/users/23/procedures']}>
+        <KioskProcedureListScreen />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('利用者が存在しません')).toBeInTheDocument();
+    expect(screen.queryByTestId('kiosk-auth-required-alert')).toBeNull();
   });
 
   it('shows "未実施" for procedures without records', async () => {

--- a/src/features/users/infra/DataProviderUserRepository.ts
+++ b/src/features/users/infra/DataProviderUserRepository.ts
@@ -2,6 +2,7 @@ import { sanitizeEnvValue, washRow } from '@/lib/sp/helpers';
 import { auditLog } from '@/lib/debugLogger';
 import { BaseRepository } from '@/lib/data/BaseRepository';
 import { getAppConfig, readEnv, isAuditDebugEnabled } from '@/lib/env';
+import { isAuthRequiredError } from '@/lib/errors';
 import type { AuditEvent } from '@/lib/audit';
 import {
   USER_TRANSPORT_SETTINGS_CANDIDATES,
@@ -170,6 +171,7 @@ export class DataProviderUserRepository extends BaseRepository implements UserRe
       return user;
     } catch (error) {
       auditLog.error('users', 'DataProviderUserRepository.getById_failed', { id, error: String(error) });
+      if (isAuthRequiredError(error)) throw error;
       return null;
     }
   }

--- a/src/features/users/infra/__tests__/DataProviderUserRepository.spec.ts
+++ b/src/features/users/infra/__tests__/DataProviderUserRepository.spec.ts
@@ -107,6 +107,21 @@ describe('DataProviderUserRepository Split Logic', () => {
     await expect(authRepo.getAll({ selectMode: 'core' })).rejects.toBe(authError);
   });
 
+  it('propagates AUTH_REQUIRED on getById instead of returning null', async () => {
+    const authError = new AuthRequiredError();
+    const throwingProvider = {
+      getFieldInternalNames: async () => {
+        throw authError;
+      },
+      getItemById: async () => null,
+      listItems: async () => [],
+    } as unknown as IDataProvider;
+
+    const authRepo = new DataProviderUserRepository({ provider: throwingProvider, listTitle: 'Users_Master' });
+
+    await expect(authRepo.getById(23, { selectMode: 'core' })).rejects.toBe(authError);
+  });
+
   it('propagates non-auth failures on getAll (instead of returning empty)', async () => {
     const listError = new Error('SP_LIST_READ_FAILED');
     const throwingProvider = {


### PR DESCRIPTION
## Summary

Fixes the Kiosk procedure list screen showing "利用者が存在しません" when SharePoint access fails with AUTH_REQUIRED.

## Changes

- Distinguishes AuthRequiredError from true user-not-found in KioskProcedureListScreen.
- Shows an authentication-required Alert and re-login action when Microsoft 365 authentication is required.
- Updates DataProviderUserRepository.getById so AUTH_REQUIRED is propagated instead of being collapsed to null.
- Keeps true user-not-found behavior unchanged.
- Does not modify spFetch or the throttle circuit breaker.

## Verification

- /kiosk/users/23/procedures now shows the authentication-required Alert.
- "利用者が存在しません" is no longer shown for AUTH_REQUIRED.
- Throttle.htm count remains 0.
- KioskProcedureListScreen tests passed.
- DataProviderUserRepository tests passed.
- src/features/kiosk tests passed.
- npm run typecheck passed.
- npm run lint -- --max-warnings=200 passed.