### PR TITLE
fix(kiosk): preserve history records in flow preview

### DIFF
--- a/src/features/kiosk/components/KioskDailyProcedureFlowPreview.tsx
+++ b/src/features/kiosk/components/KioskDailyProcedureFlowPreview.tsx
@@ -20,11 +20,13 @@ import BlockIcon from '@mui/icons-material/Block';
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 import { useDailyProcedureFlowPreview } from '../hooks/useDailyProcedureFlowPreview';
 import { formatDateShort } from '@/lib/dateFormat';
+import type { ExecutionRecord } from '@/features/daily/domain/legacy/executionRecordTypes';
 
 interface KioskDailyProcedureFlowPreviewProps {
   userId: string;
   userName: string;
   recordDate: string;
+  seedRecords?: ExecutionRecord[];
   onClose: () => void;
   onBack?: () => void; // Optional if navigated from another panel
 }
@@ -33,10 +35,11 @@ export const KioskDailyProcedureFlowPreview: React.FC<KioskDailyProcedureFlowPre
   userId,
   userName,
   recordDate,
+  seedRecords = [],
   onClose,
   onBack,
 }) => {
-  const { steps, isLoading, error } = useDailyProcedureFlowPreview(userId, recordDate);
+  const { steps, isLoading, error } = useDailyProcedureFlowPreview(userId, recordDate, seedRecords);
 
 
   const getStatusConfig = (status?: string) => {

--- a/src/features/kiosk/components/KioskProcedureHistoryPanel.tsx
+++ b/src/features/kiosk/components/KioskProcedureHistoryPanel.tsx
@@ -54,6 +54,11 @@ export const KioskProcedureHistoryPanel: React.FC<KioskProcedureHistoryPanelProp
     fallbackUserIds,
   );
 
+  const selectedFlowRecords = useMemo(() => {
+    if (!selectedFlowDate) return [];
+    return records.filter((record) => String(record.date ?? '').slice(0, 10) === selectedFlowDate);
+  }, [records, selectedFlowDate]);
+
   const handleViewChange = (
     _event: React.MouseEvent<HTMLElement>,
     nextView: ViewMode | null,
@@ -247,6 +252,7 @@ export const KioskProcedureHistoryPanel: React.FC<KioskProcedureHistoryPanelProp
         userId={userId}
         userName={userName}
         recordDate={selectedFlowDate}
+        seedRecords={selectedFlowRecords}
         onClose={onClose}
         onBack={() => setSelectedFlowDate(null)}
       />

--- a/src/features/kiosk/hooks/__tests__/useDailyProcedureFlowPreview.spec.ts
+++ b/src/features/kiosk/hooks/__tests__/useDailyProcedureFlowPreview.spec.ts
@@ -5,6 +5,7 @@ import { useExecutionData } from '@/features/daily/hooks/useExecutionData';
 import { useProcedureStore } from '@/features/daily/stores/procedureStore';
 import { useUser } from '@/features/users/useUsers';
 import { useExecutionStore } from '@/features/daily/stores/executionStore';
+import type { ExecutionRecord } from '@/features/daily/domain/legacy/executionRecordTypes';
 
 // Mock the hooks
 vi.mock('@/features/daily/hooks/useExecutionData', () => ({
@@ -180,5 +181,43 @@ describe('useDailyProcedureFlowPreview', () => {
 
     expect(result.current.steps).toHaveLength(1);
     expect(result.current.steps[0].record).toBeUndefined();
+  });
+
+  it('uses seeded history records when daily record fetch returns empty', async () => {
+    const mockSlots = [
+      { id: 'base-1', rowNo: 1, time: '09:30', activity: 'Morning Assembly', block: 'morning' },
+    ];
+    const seedRecords: ExecutionRecord[] = [
+      {
+        id: 'R-seed',
+        date: '2026-05-22',
+        userId: '6',
+        scheduleItemId: 'procedure-1',
+        status: 'completed',
+        memo: 'History record memo',
+        recordedAt: '2026-05-22T09:35:00Z',
+        recordedBy: 'Staff Seed',
+        triggeredBipIds: [],
+      },
+    ];
+
+    mockGetByUser.mockReturnValue(mockSlots);
+    mockGetRecords.mockResolvedValue([]);
+    mockGetStoreRecords.mockReturnValue([]);
+
+    const { result } = renderHook(() => (
+      useDailyProcedureFlowPreview('6', '2026-05-22', seedRecords)
+    ));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.steps).toHaveLength(1);
+    expect(result.current.steps[0].record).toEqual(expect.objectContaining({
+      status: 'completed',
+      memo: 'History record memo',
+      recordedBy: 'Staff Seed',
+    }));
   });
 });

--- a/src/features/kiosk/hooks/useDailyProcedureFlowPreview.ts
+++ b/src/features/kiosk/hooks/useDailyProcedureFlowPreview.ts
@@ -20,7 +20,8 @@ export interface UseDailyProcedureFlowPreviewResult {
 
 export function useDailyProcedureFlowPreview(
   userId: string,
-  recordDate: string
+  recordDate: string,
+  seedRecords: ExecutionRecord[] = [],
 ): UseDailyProcedureFlowPreviewResult {
   const { getRecords } = useExecutionData();
   const getRecordsRef = useRef(getRecords);
@@ -105,9 +106,12 @@ export function useDailyProcedureFlowPreview(
       deduped.set(key, r);
     };
     rawRecords.forEach(addRecord);
+    seedRecords
+      .filter((record) => String(record.date ?? '').slice(0, 10) === recordDate)
+      .forEach(addRecord);
     storeRecords.forEach(addRecord);
     return Array.from(deduped.values());
-  }, [hasInitializedStoreRecords, rawRecords, storeRecords]);
+  }, [hasInitializedStoreRecords, rawRecords, recordDate, seedRecords, storeRecords]);
 
   // Merge slots and actual execution records to build daily flow sequence
   const steps = useMemo(() => {


### PR DESCRIPTION
## Summary

Fixes the Kiosk daily flow preview showing entries as 未記録 when the history panel already resolved records for that date/procedure.

## Changes

- Passes the selected day records from `KioskProcedureHistoryPanel` into `KioskDailyProcedureFlowPreview`.
- Merges those seeded history records in `useDailyProcedureFlowPreview` when the daily aggregate fetch returns empty or misses them.
- Preserves the existing store-authoritative behavior after local deletion, so stale repository records are not revived.
- Does not change `spFetch`, the throttle circuit breaker, or SharePoint write behavior.

## Verification

- `npx vitest run src/features/kiosk/hooks/__tests__/useDailyProcedureFlowPreview.spec.ts src/features/kiosk/components/__tests__/KioskDailyProcedureFlowPreview.spec.tsx src/features/kiosk/components/__tests__/KioskProcedureHistoryPanel.spec.tsx src/features/kiosk/domain/__tests__/buildDailyProcedureFlowPreview.spec.ts`
- `npm run typecheck`
- `npm run lint -- --max-warnings=200`
- `git diff --check`

## Production symptom

Reported at `/kiosk/users/6/procedures/0`: the history drawer found an existing record, but the daily flow preview still rendered the selected row as 未記録. This PR keeps the already-resolved history record available to the preview so it is displayed as recorded even if the day-level fetch misses legacy/key-variant rows.
