### PR TITLE
fix(kiosk): preserve multiple flow preview records during store sync

### DIFF
--- a/src/features/daily/stores/__tests__/executionStore.spec.ts
+++ b/src/features/daily/stores/__tests__/executionStore.spec.ts
@@ -307,4 +307,67 @@ describe('executionStore', () => {
 
     expect(result.current.getRecord('2025-04-01', 'I001', '1')?.status).toBe('completed');
   });
+
+  // -----------------------------------------------------------------------
+  // regression: consecutive / synchronous batch upsert record preservation
+  // -----------------------------------------------------------------------
+
+  it('preserves all records when multiple records are upserted synchronously in the same call stack', () => {
+    const { result } = renderHook(() => useExecutionStore());
+
+    const recordA = {
+      ...createEmptyRecord('2025-04-01', 'I001', 'base-0900'),
+      status: 'completed' as const,
+      recordedAt: '2025-04-01T10:00:00Z',
+    };
+    const recordB = {
+      ...createEmptyRecord('2025-04-01', 'I001', 'base-1000'),
+      status: 'completed' as const,
+      recordedAt: '2025-04-01T10:01:00Z',
+    };
+    const recordC = {
+      ...createEmptyRecord('2025-04-01', 'I001', 'base-1100'),
+      status: 'completed' as const,
+      recordedAt: '2025-04-01T10:02:00Z',
+    };
+
+    act(() => {
+      // Simulate consecutive synchronous upsert loop (as performed in repositories during SharePoint sync)
+      [recordA, recordB, recordC].forEach((rec) => {
+        result.current.upsertRecord(rec);
+      });
+    });
+
+    const records = result.current.getRecords('2025-04-01', 'I001');
+    expect(records).toHaveLength(3);
+
+    const scheduleItemIds = records.map((r) => r.scheduleItemId);
+    expect(scheduleItemIds).toContain('base-0900');
+    expect(scheduleItemIds).toContain('base-1000');
+    expect(scheduleItemIds).toContain('base-1100');
+  });
+
+  it('preserves all range records in getRecordsInRange during synchronous updates', () => {
+    const { result } = renderHook(() => useExecutionStore());
+
+    const recordA = {
+      ...createEmptyRecord('2025-04-01', 'I001', 'base-0900'),
+      status: 'completed' as const,
+      recordedAt: '2025-04-01T10:00:00Z',
+    };
+    const recordB = {
+      ...createEmptyRecord('2025-04-02', 'I001', 'base-1000'),
+      status: 'completed' as const,
+      recordedAt: '2025-04-02T10:01:00Z',
+    };
+
+    act(() => {
+      [recordA, recordB].forEach((rec) => {
+        result.current.upsertRecord(rec);
+      });
+    });
+
+    const rangeRecords = result.current.getRecordsInRange('I001', '2025-04-01', '2025-04-03');
+    expect(rangeRecords).toHaveLength(2);
+  });
 });

--- a/src/features/daily/stores/executionStore.ts
+++ b/src/features/daily/stores/executionStore.ts
@@ -104,7 +104,9 @@ export function __resetStore() {
 // ---------------------------------------------------------------------------
 
 export function useExecutionStore() {
-  const snapshot = useExecutionStoreBase((s) => s.store);
+  // Subscribe to store changes to trigger React re-renders, but read values
+  // via getState().store to prevent stale closures during synchronous batch upserts.
+  useExecutionStoreBase((s) => s.store);
 
   /** 日付×ユーザーの記録集合が store 側で確定済みかを判定 */
   const hasInitializedRecords = useCallback(
@@ -112,15 +114,16 @@ export function useExecutionStore() {
       const normalizedDate = normalizeExecutionDate(date);
       const normalizedUserId = normalizeExecutionUserId(userId);
       const key = makeDailyUserKey(normalizedDate, normalizedUserId);
-      if (snapshot[key]) return true;
+      const currentStore = useExecutionStoreBase.getState().store;
+      if (currentStore[key]) return true;
 
       // Legacy fallback: scan keys and compare normalized date/userId
-      return Object.values(snapshot).some((daily) => (
+      return Object.values(currentStore).some((daily) => (
         normalizeExecutionDate(daily.date) === normalizedDate &&
         normalizeExecutionUserId(daily.userId) === normalizedUserId
       ));
     },
-    [snapshot],
+    [],
   );
 
   /** 日付×ユーザーの全記録を取得 */
@@ -129,11 +132,12 @@ export function useExecutionStore() {
       const normalizedDate = normalizeExecutionDate(date);
       const normalizedUserId = normalizeExecutionUserId(userId);
       const key = makeDailyUserKey(normalizedDate, normalizedUserId);
-      const direct = snapshot[key]?.records;
+      const currentStore = useExecutionStoreBase.getState().store;
+      const direct = currentStore[key]?.records;
       if (direct) return direct;
 
       // Legacy fallback: scan keys and compare normalized date/userId
-      for (const daily of Object.values(snapshot)) {
+      for (const daily of Object.values(currentStore)) {
         if (
           normalizeExecutionDate(daily.date) === normalizedDate &&
           normalizeExecutionUserId(daily.userId) === normalizedUserId
@@ -143,7 +147,7 @@ export function useExecutionStore() {
       }
       return [];
     },
-    [snapshot],
+    [],
   );
 
   /** scheduleItemId で特定の1レコードを取得 */
@@ -245,8 +249,9 @@ export function useExecutionStore() {
       const normalizedFrom = normalizeExecutionDate(from);
       const normalizedTo = normalizeExecutionDate(to);
       const results: ExecutionRecord[] = [];
+      const currentStore = useExecutionStoreBase.getState().store;
 
-      for (const daily of Object.values(snapshot)) {
+      for (const daily of Object.values(currentStore)) {
         if (normalizeExecutionUserId(daily.userId) === normalizedUserId) {
           const date = normalizeExecutionDate(daily.date);
           if (date >= normalizedFrom && date <= normalizedTo) {
@@ -256,7 +261,7 @@ export function useExecutionStore() {
       }
       return results;
     },
-    [snapshot],
+    [],
   );
 
   return useMemo(() => ({


### PR DESCRIPTION
## Summary

Fixes a Zustand execution store sync bug where multiple execution records inserted in the same call stack could collapse into only the last record, causing the daily flow preview to show some existing records as 未記録.

## Changes

- Updates `useExecutionStore` read methods to use the latest Zustand state via `useExecutionStoreBase.getState().store` instead of a render-time snapshot.
- Applies the direct state read to:
  - `getRecords`
  - `getRecordsInRange`
  - `hasInitializedRecords`
- Adds a regression test ensuring multiple synchronous `upsertRecord` calls preserve all records.
- Keeps the existing subscription behavior for React re-rendering.
- Does not change `spFetch`, throttle circuit breaker, SharePoint write behavior, or Kiosk UI rendering logic.

## Verification

- `npx vitest run src/features/daily/stores` — 25/25 passed
- `npx vitest run src/features/kiosk` — 108/108 passed
- `npm run typecheck` — passed
- `npm run lint -- --max-warnings=200` — passed
- `git diff --check` — passed
