### PR TITLE
fix(billing): align BillingOrders with production List3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,5 +105,6 @@ VITE_SP_LIST_ACTIVITY_DIARY=ActivityDiary
 VITE_SP_LIST_DAILY=SupportRecord_Daily
 VITE_SP_LIST_PLAN_GOAL=PlanGoals
 VITE_SP_LIST_ISP_DECISIONS=IspRecommendationDecisions
+VITE_SP_LIST_BILLING_ORDERS=
 
 # Remove all placeholders (<yourtenant>, <SiteName>, __FILL_ME__) before running.

--- a/.env.local.example
+++ b/.env.local.example
@@ -35,3 +35,4 @@ VITE_SCHEDULES_TZ=Asia/Tokyo
 # Optional: override the SharePoint list name used for schedules
 # Default list name is "Schedules"
 VITE_SP_LIST_SCHEDULES=Schedules
+VITE_SP_LIST_BILLING_ORDERS=

--- a/.env.production
+++ b/.env.production
@@ -8,3 +8,6 @@ VITE_DAILY_BULK_ENTRY=1
 # 既存のナース機能フラグ（必要に応じて調整）
 # VITE_FEATURE_NURSE_UI=1
 # VITE_NURSE_BULK_ENTRY=1
+
+# SharePoint list overrides
+VITE_SP_LIST_BILLING_ORDERS=c4be5492-9803-4fc6-ac7e-82d10e95ff6d

--- a/src/sharepoint/fields/billingFields.ts
+++ b/src/sharepoint/fields/billingFields.ts
@@ -31,16 +31,17 @@ export const FIELD_MAP_BILLING_ORDERS = {
  */
 export const BILLING_ORDERS_CANDIDATES = {
   id: ['ID', 'Id'],
-  orderDate: ['Title', 'OrderDate', 'cr013_orderDate'],
-  ordererCode: ['Orderer_x0020_Code', 'OrdererCode', 'cr013_ordererCode'],
-  ordererName: ['Orderer_x0020_Name', 'OrdererName', 'cr013_ordererName'],
-  orderCount: ['Order_x0020_Count', 'OrderCount', 'cr013_orderCount'],
+  orderDate: ['OrderDateTime', 'Title', 'OrderDate', 'cr013_orderDate'],
+  ordererCode: ['RequesterCode', 'Orderer_x0020_Code', 'OrdererCode', 'cr013_ordererCode'],
+  ordererName: ['RequesterName', 'Orderer_x0020_Name', 'OrdererName', 'cr013_ordererName'],
+  orderCount: ['Count', 'Order_x0020_Count', 'OrderCount', 'cr013_orderCount'],
   served: ['Served', 'cr013_served'],
   item: ['Item', 'cr013_item'],
-  sugar: ['Sugar', 'cr013_sugar'],
-  milk: ['Milk', 'cr013_milk'],
-  drinkPrice: ['DrinkPrice', 'cr013_drinkPrice'],
+  sugar: ['SugarOption', 'Sugar', 'cr013_sugar'],
+  milk: ['MilkOption', 'Milk', 'cr013_milk'],
+  drinkPrice: ['DRINK_PRICE', 'DrinkPrice', 'cr013_drinkPrice'],
 } as const;
+
 
 export const BILLING_ORDERS_ESSENTIALS: (keyof typeof BILLING_ORDERS_CANDIDATES)[] = [
   'orderDate',


### PR DESCRIPTION
Summary:
- Map production SharePoint List3/BillingOrders internal field names.
- Add BillingOrders list GUID override examples.
- Preserve existing candidate names for local/dev compatibility.

Verification:
- npm run typecheck
- npm run test tests/unit/spListConfig.spec.ts

Notes:
- Live verification confirmed List3 resolves OrderDateTime, RequesterCode, RequesterName, Count, SugarOption, MilkOption, and DRINK_PRICE.