### PR TITLE
feat(billing): record paid by current signed-in user

### DIFF
--- a/src/features/billing/hooks/__tests__/useBillingSummary.spec.ts
+++ b/src/features/billing/hooks/__tests__/useBillingSummary.spec.ts
@@ -18,6 +18,17 @@ vi.mock('@/features/staff/store', () => ({
   }),
 }));
 
+const mockAuthAccount: { name?: string; username?: string } = {
+  name: '請求 太郎',
+  username: 'billing@example.com',
+};
+
+vi.mock('@/auth/useAuth', () => ({
+  useAuth: () => ({
+    account: mockAuthAccount,
+  }),
+}));
+
 const mockOrders = [
   {
     id: 1,
@@ -146,6 +157,8 @@ vi.mock('../useBillingOrderRepository', () => ({
 describe('useBillingSummary', () => {
   beforeEach(() => {
     localStorage.clear();
+    mockAuthAccount.name = '請求 太郎';
+    mockAuthAccount.username = 'billing@example.com';
     vi.spyOn(window, 'alert').mockImplementation(() => {});
     mockBulkUpdatePaymentStatus.mockClear();
     mockInvalidateQueries.mockClear();
@@ -202,7 +215,7 @@ describe('useBillingSummary', () => {
       [1, 2],
       '精算済み',
       expect.any(String),
-      '管理担当者'
+      '請求 太郎'
     );
 
     // キャッシュクリアが呼ばれたこと
@@ -227,7 +240,51 @@ describe('useBillingSummary', () => {
       [3],
       '精算済み',
       expect.any(String),
-      '管理担当者'
+      '請求 太郎'
+    );
+  });
+
+  it('ログインユーザー名が無い場合はメールアドレスを PaidBy に使うこと', async () => {
+    mockAuthAccount.name = '';
+    mockAuthAccount.username = 'billing.operator@example.com';
+    mockIsPersistenceColumnsResolved.mockResolvedValue(true);
+    const { result } = renderHook(() => useBillingSummary('2026-05'));
+
+    await vi.waitFor(() => {
+      expect(result.current.isPersistenceMissing).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.togglePaymentStatus('U-001');
+    });
+
+    expect(mockBulkUpdatePaymentStatus).toHaveBeenCalledWith(
+      [1, 2],
+      '精算済み',
+      expect.any(String),
+      'billing.operator@example.com'
+    );
+  });
+
+  it('ログインユーザー情報が取れない場合は PaidBy に unknown を使うこと', async () => {
+    mockAuthAccount.name = '';
+    mockAuthAccount.username = '';
+    mockIsPersistenceColumnsResolved.mockResolvedValue(true);
+    const { result } = renderHook(() => useBillingSummary('2026-05'));
+
+    await vi.waitFor(() => {
+      expect(result.current.isPersistenceMissing).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.bulkSettle('職員');
+    });
+
+    expect(mockBulkUpdatePaymentStatus).toHaveBeenCalledWith(
+      [3],
+      '精算済み',
+      expect.any(String),
+      'unknown'
     );
   });
 

--- a/src/features/billing/hooks/useBillingSummary.ts
+++ b/src/features/billing/hooks/useBillingSummary.ts
@@ -4,6 +4,7 @@ import { useBillingOrders, billingOrdersQueryKey } from '../useBillingOrders';
 import { useBillingOrderRepository } from './useBillingOrderRepository';
 import { useUsersStore } from '@/features/users/store';
 import { useStaffStore } from '@/features/staff/store';
+import { useAuth } from '@/auth/useAuth';
 
 export interface AggregatedBillingRecord {
   ordererCode: string;
@@ -33,6 +34,7 @@ export interface BillingSummary {
 export function useBillingSummary(selectedMonth: string): BillingSummary {
   const repository = useBillingOrderRepository();
   const queryClient = useQueryClient();
+  const { account } = useAuth();
   
   const { data: rawOrders = [], isLoading: ordersLoading, isError: ordersError } = useBillingOrders(repository);
   const { data: users = [], isLoading: usersLoading } = useUsersStore();
@@ -42,6 +44,13 @@ export function useBillingSummary(selectedMonth: string): BillingSummary {
   const [isPersistenceMissing, setIsPersistenceMissing] = useState(false);
 
   const isLoading = ordersLoading || usersLoading || staffLoading;
+  const paidByActor = useMemo(() => {
+    const name = account?.name?.trim();
+    if (name) return name;
+    const username = account?.username?.trim();
+    if (username) return username;
+    return 'unknown';
+  }, [account?.name, account?.username]);
 
   // 1. スキーマ存在チェック
   useEffect(() => {
@@ -201,7 +210,7 @@ export function useBillingSummary(selectedMonth: string): BillingSummary {
 
     const nextStatus = targetRecord.isPaid ? '未精算' : '精算済み';
     const paidAt = nextStatus === '精算済み' ? new Date().toISOString() : '';
-    const paidBy = nextStatus === '精算済み' ? '管理担当者' : '';
+    const paidBy = nextStatus === '精算済み' ? paidByActor : '';
 
     setIsMutating(true);
     try {
@@ -224,7 +233,7 @@ export function useBillingSummary(selectedMonth: string): BillingSummary {
     } finally {
       setIsMutating(false);
     }
-  }, [records, isPersistenceMissing, repository, queryClient, selectedMonth]);
+  }, [records, isPersistenceMissing, repository, queryClient, selectedMonth, paidByActor]);
 
   // 一括精算 (対象カテゴリ・対象月のみ)
   const bulkSettle = useCallback(async (targetCategory: '利用者' | '職員' | 'ゲスト' | 'すべて') => {
@@ -241,7 +250,7 @@ export function useBillingSummary(selectedMonth: string): BillingSummary {
     try {
       if (!isPersistenceMissing) {
         const paidAt = new Date().toISOString();
-        const paidBy = '管理担当者';
+        const paidBy = paidByActor;
         await repository.bulkUpdatePaymentStatus(
           allUnpaidIds,
           '精算済み',
@@ -267,7 +276,7 @@ export function useBillingSummary(selectedMonth: string): BillingSummary {
     } finally {
       setIsMutating(false);
     }
-  }, [records, isPersistenceMissing, repository, queryClient, selectedMonth, fallbackPaymentStates]);
+  }, [records, isPersistenceMissing, repository, queryClient, selectedMonth, fallbackPaymentStates, paidByActor]);
 
   // 日本語 Excel 対応 CSV 出力 (BOM 付き)
   const exportCsv = useCallback((targetCategory: '利用者' | '職員' | 'ゲスト' | 'すべて') => {


### PR DESCRIPTION
## Summary
- Use the current authenticated account for Billing PaidBy instead of the fixed 管理担当者 label
- Prefer MSAL display name, fall back to username/email, then unknown
- Cover individual settlement, bulk settlement, email fallback, and unknown fallback in billing hook tests

## Verification
- npm run lint -- --max-warnings=200
- npm run typecheck
- npx vitest run src/features/billing/hooks/__tests__/useBillingSummary.spec.ts --reporter=default