### PR TITLE
fix(billing): normalize served values and derive available months

### DIFF
--- a/src/features/billing/hooks/__tests__/useBillingSummary.spec.ts
+++ b/src/features/billing/hooks/__tests__/useBillingSummary.spec.ts
@@ -66,7 +66,7 @@ const mockOrders = [
     ordererCode: 'STF001',
     ordererName: 'テスト職員',
     orderCount: 1,
-    served: 'true',
+    served: true,
     item: 'カフェラテ',
     sugar: 'なし',
     milk: 'なし',
@@ -81,7 +81,7 @@ const mockOrders = [
     ordererCode: 'G-999',
     ordererName: 'ゲスト氏',
     orderCount: 1,
-    served: 'false', // 提供されていないため除外されるべき
+    served: false, // 提供されていないため除外されるべき
     item: 'コーヒー',
     sugar: 'なし',
     milk: 'なし',
@@ -195,6 +195,7 @@ describe('useBillingSummary', () => {
     // KPI 集計の検証
     expect(result.current.totalServedCount).toBe(5);
     expect(result.current.totalServedAmount).toBe(800);
+    expect(result.current.availableMonths).toEqual(['2026-05', '2026-04']);
   });
 
   it('個別の精算トグル状態が SharePoint の repository に送られ、query invalidation が走ること', async () => {

--- a/src/features/billing/hooks/useBillingSummary.ts
+++ b/src/features/billing/hooks/useBillingSummary.ts
@@ -18,6 +18,7 @@ export interface AggregatedBillingRecord {
 
 export interface BillingSummary {
   records: AggregatedBillingRecord[];
+  availableMonths: string[];
   totalServedCount: number;
   totalServedAmount: number;
   totalPaidCount: number;
@@ -30,6 +31,15 @@ export interface BillingSummary {
   bulkSettle: (category: '利用者' | '職員' | 'ゲスト' | 'すべて') => Promise<void>;
   exportCsv: (category: '利用者' | '職員' | 'ゲスト' | 'すべて') => void;
 }
+
+export const isServedOrder = (served: unknown): boolean => {
+  if (served === true) return true;
+  if (typeof served === 'number') return served === 1;
+  if (typeof served !== 'string') return false;
+
+  const normalized = served.trim().toLowerCase();
+  return normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'served' || normalized === '提供済み';
+};
 
 export function useBillingSummary(selectedMonth: string): BillingSummary {
   const repository = useBillingOrderRepository();
@@ -51,6 +61,17 @@ export function useBillingSummary(selectedMonth: string): BillingSummary {
     if (username) return username;
     return 'unknown';
   }, [account?.name, account?.username]);
+
+  const availableMonths = useMemo(() => {
+    const months = new Set<string>();
+    rawOrders.forEach((order) => {
+      const month = order.orderDate?.slice(0, 7);
+      if (/^\d{4}-\d{2}$/.test(month)) {
+        months.add(month);
+      }
+    });
+    return Array.from(months).sort((a, b) => b.localeCompare(a));
+  }, [rawOrders]);
 
   // 1. スキーマ存在チェック
   useEffect(() => {
@@ -99,7 +120,7 @@ export function useBillingSummary(selectedMonth: string): BillingSummary {
     // 1. 月フィルタ & 提供済みフィルタ
     const filtered = rawOrders.filter((order) => {
       const orderMonth = order.orderDate.slice(0, 7);
-      return orderMonth === selectedMonth && order.served === 'true';
+      return orderMonth === selectedMonth && isServedOrder(order.served);
     });
 
     // 2. 個人ごとに集計
@@ -313,6 +334,7 @@ export function useBillingSummary(selectedMonth: string): BillingSummary {
 
   return {
     records,
+    availableMonths,
     ...summary,
     isLoading,
     isError: !!ordersError,

--- a/src/pages/BillingPage.tsx
+++ b/src/pages/BillingPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   Box,
   Container,
@@ -40,13 +40,39 @@ import { useBillingSummary } from '@/features/billing/hooks/useBillingSummary';
 
 type ActiveTab = '利用者' | '職員' | 'ゲスト' | 'すべて';
 
+const toMonthKey = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  return `${year}-${month}`;
+};
+
+const addMonths = (monthKey: string, offset: number): string => {
+  const [year, month] = monthKey.split('-').map(Number);
+  return toMonthKey(new Date(year, month - 1 + offset, 1));
+};
+
+const buildMonthOptions = (availableMonths: string[], selectedMonth: string): string[] => {
+  const currentMonth = toMonthKey(new Date());
+  const months = new Set([selectedMonth, currentMonth, ...availableMonths]);
+
+  for (let offset = -24; offset <= 3; offset += 1) {
+    months.add(addMonths(currentMonth, offset));
+  }
+
+  return Array.from(months)
+    .filter((month) => /^\d{4}-\d{2}$/.test(month))
+    .sort((a, b) => b.localeCompare(a));
+};
+
 export default function BillingPage() {
-  const [selectedMonth, setSelectedMonth] = useState('2026-05');
+  const [selectedMonth, setSelectedMonth] = useState(() => toMonthKey(new Date()));
+  const [hasUserSelectedMonth, setHasUserSelectedMonth] = useState(false);
   const [activeTab, setActiveTab] = useState<ActiveTab>('利用者');
 
   // カスタムフックから集計データとコントロール関数を取得
   const {
     records,
+    availableMonths,
     totalServedCount,
     totalServedAmount,
     totalPaidCount,
@@ -59,6 +85,16 @@ export default function BillingPage() {
     bulkSettle,
     exportCsv,
   } = useBillingSummary(selectedMonth);
+
+  useEffect(() => {
+    if (!hasUserSelectedMonth && availableMonths.length > 0 && !availableMonths.includes(selectedMonth)) {
+      setSelectedMonth(availableMonths[0]);
+    }
+  }, [availableMonths, hasUserSelectedMonth, selectedMonth]);
+
+  const monthOptions = useMemo(() => {
+    return buildMonthOptions(availableMonths, selectedMonth);
+  }, [availableMonths, selectedMonth]);
 
   // 表示対象のレコードをタブでフィルタ
   const filteredRecords = React.useMemo(() => {
@@ -138,7 +174,10 @@ export default function BillingPage() {
                 labelId="month-select-label"
                 value={selectedMonth}
                 label="対象月"
-                onChange={(e) => setSelectedMonth(e.target.value)}
+                onChange={(e) => {
+                  setHasUserSelectedMonth(true);
+                  setSelectedMonth(e.target.value);
+                }}
                 sx={{
                   bgcolor: 'rgba(255, 255, 255, 0.8)',
                   borderRadius: 2,
@@ -151,9 +190,14 @@ export default function BillingPage() {
                   },
                 }}
               >
-                <MenuItem value="2026-06">2026年6月</MenuItem>
-                <MenuItem value="2026-05">2026年5月</MenuItem>
-                <MenuItem value="2026-04">2026年4月</MenuItem>
+                {monthOptions.map((month) => {
+                  const [year, monthNumber] = month.split('-');
+                  return (
+                    <MenuItem key={month} value={month}>
+                      {year}年{Number(monthNumber)}月
+                    </MenuItem>
+                  );
+                })}
               </Select>
             </FormControl>
 


### PR DESCRIPTION
## Summary
- Normalize BillingOrders Served values so boolean true, numeric 1, and string truthy values count as served
- Derive available billing months from loaded order data
- Replace hard-coded billing month options with derived month options while preserving current-month fallback

## Verification
- npx vitest run src/features/billing/hooks/__tests__/useBillingSummary.spec.ts --reporter=verbose --no-file-parallelism
- npm run typecheck

## Notes
- stash@{0} was used only as reference material and was not applied.
- Page-size and health drift follow-ups remain separate candidates.
