### PR TITLE
fix(billing): increase BillingOrders page size for monthly aggregation

### DIFF
--- a/src/features/billing/infra/DataProviderBillingOrderRepository.ts
+++ b/src/features/billing/infra/DataProviderBillingOrderRepository.ts
@@ -15,6 +15,8 @@ import type { BillingOrderRepository } from '../repository';
 import type { BillingOrder } from '../types';
 import { mapToBillingOrder } from '../domain/billingLogic';
 
+export const BILLING_ORDERS_PAGE_SIZE = 5000;
+
 /**
  * DataProviderBillingOrderRepository
  * 
@@ -75,7 +77,7 @@ export class DataProviderBillingOrderRepository implements BillingOrderRepositor
       const selectFields = Object.values(mapping).filter((v): v is string => !!v);
 
       const items = await this.provider.listItems<Record<string, unknown>>(this.listId, {
-        top: 500,
+        top: BILLING_ORDERS_PAGE_SIZE,
         select: selectFields.length > 0 ? ['Id', 'Title', ...selectFields] : undefined,
       });
 

--- a/src/features/billing/infra/__tests__/DataProviderBillingOrderRepository.spec.ts
+++ b/src/features/billing/infra/__tests__/DataProviderBillingOrderRepository.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { IDataProvider } from '@/lib/data/dataProvider.interface';
+import {
+  BILLING_ORDERS_PAGE_SIZE,
+  DataProviderBillingOrderRepository,
+} from '../DataProviderBillingOrderRepository';
+
+const createProvider = (): IDataProvider => ({
+  listItems: vi.fn().mockResolvedValue([]),
+  getItemById: vi.fn(),
+  createItem: vi.fn(),
+  updateItem: vi.fn(),
+  deleteItem: vi.fn(),
+  getMetadata: vi.fn(),
+  getResourceNames: vi.fn(),
+  getFieldInternalNames: vi.fn().mockResolvedValue(new Set(['Id', 'Title', 'OrdererCode'])),
+  ensureListExists: vi.fn(),
+});
+
+describe('DataProviderBillingOrderRepository', () => {
+  it('requests enough BillingOrders rows for monthly aggregation', async () => {
+    const provider = createProvider();
+    const repository = new DataProviderBillingOrderRepository(provider, 'List3');
+
+    await repository.list();
+
+    expect(provider.listItems).toHaveBeenCalledWith(
+      'List3',
+      expect.objectContaining({ top: BILLING_ORDERS_PAGE_SIZE })
+    );
+    expect(BILLING_ORDERS_PAGE_SIZE).toBe(5000);
+  });
+});


### PR DESCRIPTION
## Summary
- Increase BillingOrders list fetch size from 500 to 5000 for monthly aggregation
- Keep the change scoped to the billing SharePoint repository
- Add a regression test for the BillingOrders page size

## Verification
- npx vitest run src/features/billing/infra/__tests__/DataProviderBillingOrderRepository.spec.ts --reporter=verbose --no-file-parallelism
- npm run typecheck

## Notes
- stash@{0} was used only as reference material and was not applied.
- No env/runtime files are changed.
