### PR TITLE
chore(billing): register billing order provisioning fields

### DIFF
--- a/src/sharepoint/__tests__/driftProbeRegistry.spec.ts
+++ b/src/sharepoint/__tests__/driftProbeRegistry.spec.ts
@@ -59,4 +59,40 @@ describe('DriftProbeRegistry / Dynamic Discovery', () => {
     expect(entry?.essentialFields).toEqual(['ListName', 'FieldName', 'DetectedAt', 'DriftType']);
     expect(entry?.essentialFields).not.toContain('Severity');
   });
+
+  it('registers BillingOrders fields used by coffee order billing and settlement', () => {
+    const entry = SP_LIST_REGISTRY.find(e => e.key === 'billing_orders');
+    const fields = entry?.provisioningFields ?? [];
+    const fieldMap = new Map(fields.map(field => [field.internalName, field]));
+
+    expect(entry).toBeDefined();
+    expect(Array.from(fieldMap.keys())).toEqual(expect.arrayContaining([
+      'Title',
+      'OrdererCode',
+      'OrdererName',
+      'OrderCount',
+      'Item',
+      'Served',
+      'Sugar',
+      'Milk',
+      'DrinkPrice',
+      'PaymentStatus',
+      'PaidAt',
+      'PaidBy',
+    ]));
+    expect(fieldMap.get('PaymentStatus')).toMatchObject({
+      type: 'Choice',
+      choices: ['未精算', '精算済み'],
+      default: '未精算',
+    });
+    expect(fieldMap.get('PaidAt')).toMatchObject({
+      type: 'DateTime',
+      dateTimeFormat: 'DateTime',
+    });
+    expect(fieldMap.get('PaidBy')).toMatchObject({ type: 'Text' });
+    expect(fieldMap.get('DrinkPrice')).toMatchObject({
+      type: 'Number',
+      candidates: ['DrinkPrice', 'DRINK_PRICE'],
+    });
+  });
 });

--- a/src/sharepoint/definitions/other.ts
+++ b/src/sharepoint/definitions/other.ts
@@ -132,6 +132,13 @@ export const otherListEntries: readonly SpListEntry[] = [
       { internalName: 'OrdererName', type: 'Text', displayName: 'Orderer Name', governance: 'allow', isSilent: true, candidates: ['OrdererName', 'Orderer_x0020_Name'] },
       { internalName: 'OrderCount', type: 'Number', displayName: 'Order Count', governance: 'allow', isSilent: true, candidates: ['OrderCount', 'Order_x0020_Count'] },
       { internalName: 'Item', type: 'Text', displayName: 'Item', governance: 'allow' },
+      { internalName: 'Served', type: 'Text', displayName: 'Served', governance: 'allow', isSilent: true },
+      { internalName: 'Sugar', type: 'Text', displayName: 'Sugar', governance: 'allow', isSilent: true, candidates: ['Sugar', 'SugarOption'] },
+      { internalName: 'Milk', type: 'Text', displayName: 'Milk', governance: 'allow', isSilent: true, candidates: ['Milk', 'MilkOption'] },
+      { internalName: 'DrinkPrice', type: 'Number', displayName: 'Drink Price', governance: 'allow', isSilent: true, candidates: ['DrinkPrice', 'DRINK_PRICE'] },
+      { internalName: 'PaymentStatus', type: 'Choice', displayName: 'Payment Status', choices: ['未精算', '精算済み'], default: '未精算', governance: 'allow', candidates: ['PaymentStatus', 'Payment_x0020_Status'] },
+      { internalName: 'PaidAt', type: 'DateTime', displayName: 'Paid At', dateTimeFormat: 'DateTime', governance: 'allow', isSilent: true, candidates: ['PaidAt', 'Paid_x0020_At', 'PaymentDate'] },
+      { internalName: 'PaidBy', type: 'Text', displayName: 'Paid By', governance: 'allow', isSilent: true, candidates: ['PaidBy', 'Paid_x0020_By', 'PaymentHandler'] },
     ],
   },
   {


### PR DESCRIPTION
## Summary
- Register BillingOrders provisioning fields used by List3 coffee order billing
- Include served/order option fields and settlement persistence fields in the SharePoint registry
- Add a registry regression test for BillingOrders provisioning fields

## Verification
- npx vitest run src/sharepoint/__tests__/driftProbeRegistry.spec.ts --reporter=verbose --no-file-parallelism
- npm run typecheck

## Notes
- Runtime files such as .env and public/env.runtime.json are intentionally not changed.
- stash@{0} was used only as reference material and was not applied.
