### PR TITLE
fix(billing): handle List3 cache and missing price

### DIFF
--- a/src/components/dev/DataLayerStatusBanner.tsx
+++ b/src/components/dev/DataLayerStatusBanner.tsx
@@ -6,9 +6,15 @@
  */
 import React from 'react';
 import { useDataProviderObservabilityStore } from '@/lib/data/dataProviderObservabilityStore';
+import { clearAllFieldsCache } from '@/lib/sp/helpers';
 
 export const DataLayerStatusBanner: React.FC = () => {
   const { resolutions, currentProvider } = useDataProviderObservabilityStore();
+
+  const handleReload = () => {
+    clearAllFieldsCache();
+    window.location.reload();
+  };
   
   const resList = Object.values(resolutions);
   const criticals = resList.filter(r => r.status === 'missing_required' || r.status === 'schema_mismatch');
@@ -61,7 +67,7 @@ export const DataLayerStatusBanner: React.FC = () => {
       </div>
       
       <button 
-        onClick={() => window.location.reload()}
+        onClick={handleReload}
         style={{ 
           border: '1px solid #d9d9d9', 
           background: '#fff', 

--- a/src/components/dev/__tests__/DataLayerStatusBanner.spec.tsx
+++ b/src/components/dev/__tests__/DataLayerStatusBanner.spec.tsx
@@ -1,0 +1,64 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useDataProviderObservabilityStore } from '@/lib/data/dataProviderObservabilityStore';
+import { clearAllFieldsCache } from '@/lib/sp/helpers';
+import { DataLayerStatusBanner } from '../DataLayerStatusBanner';
+
+vi.mock('@/lib/sp/helpers', () => ({
+  clearAllFieldsCache: vi.fn(),
+}));
+
+describe('DataLayerStatusBanner', () => {
+  const reload = vi.fn();
+
+  beforeEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: { reload },
+      writable: true,
+      configurable: true,
+    });
+
+    act(() => {
+      useDataProviderObservabilityStore.setState({
+        currentProvider: 'sharepoint',
+        resolutions: {
+          'BillingOrders:List3': {
+            resourceName: 'BillingOrders:List3',
+            status: 'schema_warning',
+            severity: 'warn',
+            resolvedTitle: 'List3',
+            fields: [
+              {
+                key: 'paymentStatus',
+                candidates: ['PaymentStatus'],
+                isEssential: false,
+                isResolved: false,
+                isSilent: false,
+              },
+            ],
+            lastAccessedAt: '2026-06-01T00:00:00.000Z',
+          },
+        },
+      });
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    act(() => {
+      useDataProviderObservabilityStore.setState({
+        currentProvider: null,
+        resolutions: {},
+      });
+    });
+  });
+
+  it('clears SharePoint field cache before reloading from a schema warning', () => {
+    render(<DataLayerStatusBanner />);
+
+    fireEvent.click(screen.getByRole('button', { name: '再読込' }));
+
+    expect(clearAllFieldsCache).toHaveBeenCalled();
+    expect(reload).toHaveBeenCalled();
+  });
+});

--- a/src/features/billing/domain/__tests__/billingLogic.spec.ts
+++ b/src/features/billing/domain/__tests__/billingLogic.spec.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { FIELD_MAP_BILLING_ORDERS as F } from '@/sharepoint/fields';
-import { mapToBillingOrder, safeParseNumber, safeParseString } from '../billingLogic';
+import {
+  BILLING_DEFAULT_DRINK_PRICE,
+  mapToBillingOrder,
+  parseBillingDrinkPrice,
+  safeParseNumber,
+  safeParseString,
+} from '../billingLogic';
 
 describe('billingLogic', () => {
   // ─── safeParseString ──────────────────────────────────────
@@ -40,6 +46,22 @@ describe('billingLogic', () => {
     it('現状仕様の観測固定: 負数は 0 に丸められずそのまま維持されること', () => {
       expect(safeParseNumber(-150)).toBe(-150);
       expect(safeParseNumber('-1')).toBe(-1);
+    });
+  });
+
+  // ─── parseBillingDrinkPrice ───────────────────────────────
+  describe('parseBillingDrinkPrice', () => {
+    it('有効な価格はそのまま使うこと', () => {
+      expect(parseBillingDrinkPrice(100)).toBe(100);
+      expect(parseBillingDrinkPrice('150')).toBe(150);
+    });
+
+    it('List3 の DRINK_PRICE が未設定の場合は固定50円へフォールバックすること', () => {
+      expect(parseBillingDrinkPrice(null)).toBe(BILLING_DEFAULT_DRINK_PRICE);
+      expect(parseBillingDrinkPrice(undefined)).toBe(BILLING_DEFAULT_DRINK_PRICE);
+      expect(parseBillingDrinkPrice('')).toBe(BILLING_DEFAULT_DRINK_PRICE);
+      expect(parseBillingDrinkPrice('abc')).toBe(BILLING_DEFAULT_DRINK_PRICE);
+      expect(parseBillingDrinkPrice(0)).toBe(BILLING_DEFAULT_DRINK_PRICE);
     });
   });
 
@@ -92,11 +114,27 @@ describe('billingLogic', () => {
 
       expect(result.id).toBe(0);
       expect(result.orderCount).toBe(0);
-      expect(result.drinkPrice).toBe(0);
       expect(result.orderDate).toBe('');
       expect(result.ordererName).toBe('');
       expect(result.item).toBe('');
       expect(result.sugar).toBe('');
+      expect(result.drinkPrice).toBe(BILLING_DEFAULT_DRINK_PRICE);
+    });
+
+    it('DRINK_PRICE が null の実データでも固定50円としてマッピングすること', () => {
+      const mockItem = {
+        [F.id]: 124,
+        [F.orderDate]: '2025-08-01T03:41:06Z',
+        [F.ordererCode]: 'I015',
+        [F.ordererName]: '真田　　滋久',
+        [F.orderCount]: 1,
+        [F.served]: true,
+        [F.drinkPrice]: null,
+      };
+
+      const result = mapToBillingOrder(mockItem, {});
+
+      expect(result.drinkPrice).toBe(BILLING_DEFAULT_DRINK_PRICE);
     });
   });
 });

--- a/src/features/billing/domain/billingLogic.ts
+++ b/src/features/billing/domain/billingLogic.ts
@@ -1,5 +1,7 @@
 import type { BillingOrder } from '../types';
 
+export const BILLING_DEFAULT_DRINK_PRICE = 50;
+
 /**
  * 外部の未知の値を安全に文字列として解釈する
  * - string型ならそのまま
@@ -22,6 +24,15 @@ export const safeParseNumber = (v: unknown): number => {
 };
 
 /**
+ * コーヒー請求は現行運用では1杯50円固定。
+ * SharePoint List3 の DRINK_PRICE が未設定でも月次請求額を算出できるようにする。
+ */
+export const parseBillingDrinkPrice = (v: unknown): number => {
+  const parsed = safeParseNumber(v);
+  return parsed > 0 ? parsed : BILLING_DEFAULT_DRINK_PRICE;
+};
+
+/**
  * SharePointの生アイテム(辞書)をアプリケーション内部のBillingOrderモデルに安全に変換する
  * @param item SharePointの行データ（DTO）
  * @param mapping 解決された内部名のマッピング
@@ -41,7 +52,7 @@ export function mapToBillingOrder(
     item: safeParseString(item[F.item ?? 'Item'] ?? item['item'] ?? ''),
     sugar: safeParseString(item[F.sugar ?? 'Sugar'] ?? item['sugar'] ?? ''),
     milk: safeParseString(item[F.milk ?? 'Milk'] ?? item['milk'] ?? ''),
-    drinkPrice: safeParseNumber(item[F.drinkPrice ?? 'DrinkPrice'] ?? item['drinkPrice'] ?? 0),
+    drinkPrice: parseBillingDrinkPrice(item[F.drinkPrice ?? 'DrinkPrice'] ?? item['drinkPrice']),
     paymentStatus: safeParseString(item[F.paymentStatus ?? 'PaymentStatus'] ?? item['paymentStatus'] ?? ''),
     paidAt: safeParseString(item[F.paidAt ?? 'PaidAt'] ?? item['paidAt'] ?? ''),
     paidBy: safeParseString(item[F.paidBy ?? 'PaidBy'] ?? item['paidBy'] ?? ''),

--- a/src/features/billing/infra/__tests__/DataProviderBillingOrderRepository.spec.ts
+++ b/src/features/billing/infra/__tests__/DataProviderBillingOrderRepository.spec.ts
@@ -4,6 +4,7 @@ import {
   BILLING_ORDERS_PAGE_SIZE,
   DataProviderBillingOrderRepository,
 } from '../DataProviderBillingOrderRepository';
+import { BILLING_DEFAULT_DRINK_PRICE } from '../../domain/billingLogic';
 
 const createProvider = (): IDataProvider => ({
   listItems: vi.fn().mockResolvedValue([]),
@@ -29,5 +30,55 @@ describe('DataProviderBillingOrderRepository', () => {
       expect.objectContaining({ top: BILLING_ORDERS_PAGE_SIZE })
     );
     expect(BILLING_ORDERS_PAGE_SIZE).toBe(5000);
+  });
+
+  it('maps List3 rows with null DRINK_PRICE to the fixed billing price', async () => {
+    const provider = createProvider();
+    vi.mocked(provider.getFieldInternalNames).mockResolvedValue(new Set([
+      'ID',
+      'OrderDateTime',
+      'RequesterCode',
+      'RequesterName',
+      'Count',
+      'Served',
+      'Item',
+      'DRINK_PRICE',
+      'PaymentStatus',
+      'PaidAt',
+      'PaidBy',
+    ]));
+    vi.mocked(provider.listItems).mockResolvedValue([
+      {
+        Id: 124,
+        OrderDateTime: '2025-08-01T03:41:06Z',
+        RequesterCode: 'I015',
+        RequesterName: '真田　　滋久',
+        Count: 1,
+        Served: true,
+        Item: 'コーヒー',
+        DRINK_PRICE: null,
+        PaymentStatus: null,
+        PaidAt: null,
+        PaidBy: null,
+      },
+    ]);
+    const repository = new DataProviderBillingOrderRepository(provider, 'List3');
+
+    const orders = await repository.list();
+
+    expect(orders[0]).toMatchObject({
+      id: 124,
+      orderDate: '2025-08-01T03:41:06Z',
+      ordererCode: 'I015',
+      orderCount: 1,
+      served: 'true',
+      drinkPrice: BILLING_DEFAULT_DRINK_PRICE,
+    });
+    expect(provider.listItems).toHaveBeenCalledWith(
+      'List3',
+      expect.objectContaining({
+        select: expect.arrayContaining(['OrderDateTime', 'Served', 'DRINK_PRICE', 'PaymentStatus']),
+      })
+    );
   });
 });

--- a/src/features/ibd/plans/isp-editor/hooks/__tests__/useISPComparisonEditor.spec.tsx
+++ b/src/features/ibd/plans/isp-editor/hooks/__tests__/useISPComparisonEditor.spec.tsx
@@ -5,6 +5,7 @@ import { useISPComparisonEditor } from '../useISPComparisonEditor';
 describe('useISPComparisonEditor', () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-01T00:00:00Z'));
   });
   afterEach(() => {
     vi.useRealTimers();

--- a/src/pages/health/__tests__/driftCandidates.spec.ts
+++ b/src/pages/health/__tests__/driftCandidates.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { buildListSpecs } from '../driftCandidates';
+
+describe('health driftCandidates', () => {
+  it('excludes cross-site BillingOrders from default-site health drift checks', () => {
+    const specs = buildListSpecs({
+      VITE_SP_SITE_RELATIVE: '/sites/welfare',
+      VITE_SP_LIST_BILLING_ORDERS_SITE_RELATIVE: '/sites/2',
+    });
+
+    expect(specs.some(spec => spec.key === 'billing_orders')).toBe(false);
+  });
+
+  it('keeps BillingOrders when no cross-site override is configured', () => {
+    const specs = buildListSpecs({
+      VITE_SP_SITE_RELATIVE: '/sites/welfare',
+    });
+
+    expect(specs.some(spec => spec.key === 'billing_orders')).toBe(true);
+  });
+
+  it('keeps BillingOrders when the override points to the default site', () => {
+    const specs = buildListSpecs({
+      VITE_SP_SITE_RELATIVE: '/sites/welfare',
+      VITE_SP_LIST_BILLING_ORDERS_SITE_RELATIVE: '/sites/welfare/',
+    });
+
+    expect(specs.some(spec => spec.key === 'billing_orders')).toBe(true);
+  });
+});

--- a/src/pages/health/driftCandidates.ts
+++ b/src/pages/health/driftCandidates.ts
@@ -1,4 +1,5 @@
 import { SP_LIST_REGISTRY } from "@/sharepoint/spListRegistry";
+import { type EnvRecord } from "@/lib/env";
 import { ListSpec, SpFieldSpec } from "../../features/diagnostics/health/types";
 import {
   DAILY_RECORD_CANONICAL_CANDIDATES,
@@ -38,6 +39,10 @@ import { MEETING_MINUTES_CANDIDATES } from "@/sharepoint/fields/meetingMinutesFi
 import { HANDOFF_CANDIDATES } from "@/sharepoint/fields/handoffFields";
 import { MEETING_SESSIONS_CANDIDATES } from "@/sharepoint/fields/meetingSessionFields";
 import { NURSE_OBS_CANDIDATES } from "@/sharepoint/fields/nurseObservationFields";
+import {
+  BILLING_ORDERS_REGISTRY_KEY,
+  shouldExcludeBillingOrdersFromDefaultSiteDrift,
+} from "@/sharepoint/crossSiteDrift";
 
 /**
  * リストキー → フィールド内部名 → drift 候補名[] のオーバーライドマップ
@@ -312,8 +317,12 @@ export const DRIFT_ESSENTIALS_BY_KEY: Record<string, readonly string[]> = {
   ),
 };
 
-export function buildListSpecs(): ListSpec[] {
-  return SP_LIST_REGISTRY.map((entry) => {
+export function buildListSpecs(envOverride?: EnvRecord): ListSpec[] {
+  const excludeBillingOrders = shouldExcludeBillingOrdersFromDefaultSiteDrift(envOverride);
+
+  return SP_LIST_REGISTRY
+    .filter((entry) => !(excludeBillingOrders && entry.key === BILLING_ORDERS_REGISTRY_KEY))
+    .map((entry) => {
     const effectiveEssentials = DRIFT_ESSENTIALS_BY_KEY[entry.key] ?? (entry.essentialFields || []);
     const essentialSet = new Set(DRIFT_ESSENTIALS_BY_KEY[entry.key] ?? (entry.essentialFields || []));
 

--- a/src/sharepoint/__tests__/driftProbeRegistry.spec.ts
+++ b/src/sharepoint/__tests__/driftProbeRegistry.spec.ts
@@ -48,6 +48,29 @@ describe('DriftProbeRegistry / Dynamic Discovery', () => {
     expect(keys.length).toBe(uniqueKeys.size);
   });
 
+  it('excludes cross-site BillingOrders from default-site drift probes', () => {
+    const activeRegistryCount = SP_LIST_REGISTRY.filter(
+      e => e.lifecycle === 'required' || e.lifecycle === 'optional'
+    ).length;
+
+    const targets = getDriftProbeTargets({
+      VITE_SP_SITE_RELATIVE: '/sites/welfare',
+      VITE_SP_LIST_BILLING_ORDERS_SITE_RELATIVE: '/sites/2',
+    });
+
+    expect(targets.some(t => t.key === 'billing_orders')).toBe(false);
+    expect(targets.length).toBe(activeRegistryCount - 1);
+  });
+
+  it('keeps BillingOrders in drift probes when it uses the default site', () => {
+    const targets = getDriftProbeTargets({
+      VITE_SP_SITE_RELATIVE: '/sites/welfare',
+      VITE_SP_LIST_BILLING_ORDERS_SITE_RELATIVE: '/sites/welfare/',
+    });
+
+    expect(targets.some(t => t.key === 'billing_orders')).toBe(true);
+  });
+
   it('does not mark drift_events_log Severity as essential', () => {
     // 診断契約と SharePointDriftEventRepository の実装契約を一致させるための回帰防止。
     // Severity は repository が任意扱い（fail-open）で、本リストは lifecycle: 'optional'。

--- a/src/sharepoint/crossSiteDrift.ts
+++ b/src/sharepoint/crossSiteDrift.ts
@@ -1,0 +1,21 @@
+import { readEnv, readOptionalEnv, type EnvRecord } from '@/lib/env';
+
+export const BILLING_ORDERS_REGISTRY_KEY = 'billing_orders';
+
+const normalizeSiteRelative = (value?: string): string | undefined => {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  const withLeadingSlash = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+  return withLeadingSlash.replace(/\/+$/, '').toLowerCase();
+};
+
+export const shouldExcludeBillingOrdersFromDefaultSiteDrift = (
+  envOverride?: EnvRecord,
+): boolean => {
+  const defaultSite = normalizeSiteRelative(readEnv('VITE_SP_SITE_RELATIVE', '', envOverride));
+  const billingSite = normalizeSiteRelative(
+    readOptionalEnv('VITE_SP_LIST_BILLING_ORDERS_SITE_RELATIVE', envOverride),
+  );
+
+  return Boolean(defaultSite && billingSite && billingSite !== defaultSite);
+};

--- a/src/sharepoint/driftProbeRegistry.ts
+++ b/src/sharepoint/driftProbeRegistry.ts
@@ -6,14 +6,22 @@
  */
 import { SP_LIST_REGISTRY } from './spListRegistry';
 import { type DriftProbeTarget } from './contracts/driftProbeTargets';
+import { type EnvRecord } from '@/lib/env';
+import {
+  BILLING_ORDERS_REGISTRY_KEY,
+  shouldExcludeBillingOrdersFromDefaultSiteDrift,
+} from './crossSiteDrift';
 
 /**
  * Generates the list of probe targets based on the central SP_LIST_REGISTRY.
  * Filters out deprecated/experimental lists to ensure monitoring stability.
  */
-export function getDriftProbeTargets(): DriftProbeTarget[] {
+export function getDriftProbeTargets(envOverride?: EnvRecord): DriftProbeTarget[] {
+  const excludeBillingOrders = shouldExcludeBillingOrdersFromDefaultSiteDrift(envOverride);
+
   return SP_LIST_REGISTRY
     .filter(entry => entry.lifecycle === 'required' || entry.lifecycle === 'optional')
+    .filter(entry => !(excludeBillingOrders && entry.key === BILLING_ORDERS_REGISTRY_KEY))
     .map(entry => {
       // 1. Resolve actual list title (honoring environment variable overrides if any)
       const listTitle = entry.resolve();


### PR DESCRIPTION
## Summary
- Clear SharePoint field-name cache before reloading from the data warning banner
- Default missing or invalid BillingOrders DRINK_PRICE values to the current fixed 50 yen price
- Exclude cross-site BillingOrders from default-site health/drift probes when the dedicated site override is configured
- Add regression coverage for List3 null price mapping, warning-banner cache clearing, and cross-site drift exclusion

## Root Cause
- List3 fields exist with expected internal names, but the browser can keep a stale `sp.fieldsCache.v1` session cache after columns are added.
- 2025-08 List3 records have `Served: true`, but `DRINK_PRICE` is null for all checked rows, so billing amount needs the documented fixed-price fallback.
- `/admin/status` health checks were still probing `billing_orders` through the default SharePoint site, which can produce false drift warnings when `VITE_SP_LIST_BILLING_ORDERS_SITE_RELATIVE=/sites/2` is used.

## Live Check
- `/sites/2` List3 columns confirmed: `PaymentStatus`, `PaidAt`, `PaidBy`, `Served`, `RequesterCode`, `RequesterName`, `OrderDateTime`.
- 2025-08 List3 data: 376 rows, 374 served rows, expected fixed-price amount 18,700 yen.

## Verification
- npx vitest run src/sharepoint/__tests__/driftProbeRegistry.spec.ts src/pages/health/__tests__/driftCandidates.spec.ts --reporter=verbose --no-file-parallelism
- npx vitest run src/features/billing/domain/__tests__/billingLogic.spec.ts src/features/billing/infra/__tests__/DataProviderBillingOrderRepository.spec.ts src/components/dev/__tests__/DataLayerStatusBanner.spec.tsx src/features/billing/hooks/__tests__/useBillingSummary.spec.ts src/features/ibd/plans/isp-editor/hooks/__tests__/useISPComparisonEditor.spec.tsx --reporter=verbose --no-file-parallelism
- npm run typecheck
- pre-commit lint/typecheck hooks
- pre-push changed-file eslint hook

## Notes
- No runtime env files are changed in this PR.
- Live local verification requires `VITE_SP_LIST_BILLING_ORDERS_SITE_RELATIVE=/sites/2` and `VITE_SP_LIST_BILLING_ORDERS=c4be5492-9803-4fc6-ac7e-82d10e95ff6d` in the runtime environment.
- `stash@{0}` remains untouched.

## CI follow-up
- Fixed an unrelated date-dependent IBD test by freezing system time in the spec.
- This is test-only and does not affect production billing code.

