### PR TITLE
chore(deploy): configure production variables for billing in wrangler.toml

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -11,6 +11,8 @@ main = "src/worker.ts"
 VITE_SP_RESOURCE = "https://isogokatudouhome.sharepoint.com"
 VITE_SP_SITE_RELATIVE = "/sites/welfare"
 VITE_SP_USE_PROXY = "1"
+VITE_SP_LIST_BILLING_ORDERS = "c4be5492-9803-4fc6-ac7e-82d10e95ff6d"
+VITE_SP_LIST_BILLING_ORDERS_SITE_RELATIVE = "/sites/2"
 
 [assets]
 directory = "./dist"


### PR DESCRIPTION
## Summary
- Configure production variables for BillingOrders list and site relative path in wrangler.toml:
  - VITE_SP_LIST_BILLING_ORDERS = 'c4be5492-9803-4fc6-ac7e-82d10e95ff6d'
  - VITE_SP_LIST_BILLING_ORDERS_SITE_RELATIVE = '/sites/2'

## Verification
- Pre-deploy check is blocked if wrangler.toml has uncommitted changes, this PR merges the variables to main first.