### PR TITLE
fix(worker): allowlist billing SharePoint runtime env vars

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -9,6 +9,8 @@ interface Env {
   };
   VITE_SP_RESOURCE?: string;
   VITE_SP_SITE_RELATIVE?: string;
+  VITE_SP_LIST_BILLING_ORDERS?: string;
+  VITE_SP_LIST_BILLING_ORDERS_SITE_RELATIVE?: string;
   ALLOWED_TENANT_ID?: string;
   ORG_ID_OVERRIDE?: string;
   GOOGLE_SERVICE_ACCOUNT_JSON?: string;
@@ -72,6 +74,8 @@ const RUNTIME_ENV_ALLOWLIST = new Set([
   'VITE_SP_RESOURCE',
   'VITE_SP_SITE_RELATIVE',
   'VITE_SP_USE_PROXY',
+  'VITE_SP_LIST_BILLING_ORDERS',
+  'VITE_SP_LIST_BILLING_ORDERS_SITE_RELATIVE',
 ]);
 
 const pickRuntimeEnvFromBindings = (env: Env): Record<string, string> => {


### PR DESCRIPTION
Resolve Iceberg-PDCA diagnostic FAIL [lists] on production by allowlisting VITE_SP_LIST_BILLING_ORDERS and VITE_SP_LIST_BILLING_ORDERS_SITE_RELATIVE in the Cloudflare Worker runtime environment allowlist.

Verification:
- npm run typecheck
- npx eslint src/worker.ts
- git diff --check

Manual verification after deploy:
- Open /admin/status
- Confirm FAIL [lists] no longer validates BillingOrders against /sites/welfare
- Confirm BillingOrders/List3 is checked under /sites/2