### PR TITLE
feat(kiosk): add coffee billing shortcut to footer navigation

### DIFF
--- a/src/app/components/KioskNavigation.tsx
+++ b/src/app/components/KioskNavigation.tsx
@@ -11,6 +11,7 @@ import HistoryIcon from '@mui/icons-material/History';
 import PhoneInTalkIcon from '@mui/icons-material/PhoneInTalk';
 import EditNoteIcon from '@mui/icons-material/EditNote';
 import WcIcon from '@mui/icons-material/Wc';
+import CoffeeIcon from '@mui/icons-material/Coffee';
 import { appendKioskSearchParams } from '@/features/kiosk/utils/navigation';
 
 type KioskNavItem =
@@ -88,6 +89,14 @@ export const KioskNavigation: React.FC = () => {
       testId: 'kiosk-nav-toilet',
       kind: 'link',
       activeMatch: (pathname) => pathname.startsWith('/kiosk/toilet'),
+    },
+    {
+      label: 'コーヒー精算',
+      icon: <CoffeeIcon />,
+      path: '/billing',
+      testId: 'kiosk-nav-billing',
+      kind: 'link',
+      activeMatch: (pathname) => pathname.startsWith('/billing'),
     },
     {
       label: '受電ログ',

--- a/src/features/kiosk/utils/__tests__/navigation.spec.ts
+++ b/src/features/kiosk/utils/__tests__/navigation.spec.ts
@@ -57,6 +57,16 @@ describe('kiosk navigation utilities', () => {
       expect(params.get('slotId')).toBe('123');
     });
 
+    it('does not clear state params for /billing path', () => {
+      const current = '?userId=active&slotId=123&kiosk=1';
+      const result = appendKioskSearchParams('/billing', current);
+
+      const params = new URLSearchParams(result.split('?')[1]);
+      expect(params.get('userId')).toBe('active');
+      expect(params.get('slotId')).toBe('123');
+      expect(params.get('kiosk')).toBe('1');
+    });
+
     it('handles empty or malformed search queries safely', () => {
       const resultEmpty = appendKioskSearchParams('/kiosk/users', '');
       expect(resultEmpty).toBe('/kiosk/users');

--- a/tests/e2e/kiosk-home-smoke.spec.ts
+++ b/tests/e2e/kiosk-home-smoke.spec.ts
@@ -111,6 +111,7 @@ test.describe('Kiosk Home Smoke (memory provider for local kiosk flow checks)', 
       await expect(page.getByTestId('kiosk-nav-activity')).toBeVisible({ timeout: 15000 });
       await expect(page.getByTestId('kiosk-nav-procedures')).toBeVisible({ timeout: 15000 });
       await expect(page.getByTestId('kiosk-nav-toilet')).toBeVisible({ timeout: 15000 });
+      await expect(page.getByTestId('kiosk-nav-billing')).toBeVisible({ timeout: 15000 });
       await expect(page.getByTestId('kiosk-nav-calllog')).toBeVisible({ timeout: 15000 });
       await expect(page.getByTestId('kiosk-nav-handoff')).toBeVisible({ timeout: 15000 });
     });
@@ -131,6 +132,19 @@ test.describe('Kiosk Home Smoke (memory provider for local kiosk flow checks)', 
     test('should navigate to records from navigation and maintain params', async ({ page }) => {
       await page.getByTestId('kiosk-nav-activity').click();
       await expect(page).toHaveURL(/\/daily\/table(\?.*provider=memory.*)?/);
+    });
+
+    test('should navigate to coffee billing from navigation and maintain params', async ({ page }) => {
+      await page.getByTestId('kiosk-nav-billing').click();
+      await expect(page).toHaveURL(/\/billing(\?.*provider=memory.*)?/);
+    });
+
+    test('should keep coffee billing navigation active on /billing route', async ({ page }) => {
+      await bootKiosk(page, { route: '/kiosk?kiosk=1' });
+      const billingNav = page.getByTestId('kiosk-nav-billing');
+      await billingNav.click();
+      await expect(page).toHaveURL(/\/billing/);
+      await expect(billingNav).toHaveAttribute('aria-current', 'page');
     });
 
     test('should navigate to toilet board and mark a target user recorded', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Add a `コーヒー精算` shortcut to the kiosk footer navigation.
- Link the shortcut to the existing `/billing` monthly coffee billing and settlement page.
- Keep the change limited to navigation and tests only.

## Verification
- npm run typecheck
- npx eslint src/app/components/KioskNavigation.tsx src/features/kiosk/utils/navigation.ts src/features/kiosk/utils/__tests__/navigation.spec.ts
- npx vitest run src/features/kiosk/utils/__tests__/navigation.spec.ts
- npx playwright test tests/e2e/kiosk-home-smoke.spec.ts --project=chromium
- git diff --check

## Notes
- `/billing` already connects to production `/sites/2/List3` and displays monthly coffee billing data.
- This PR does not change Billing aggregation, SharePoint field candidates, Worker env/proxy logic, or settlement persistence.
- The remaining settlement persistence warning is out of scope for this PR.
