### PR TITLE
feat(billing): persist coffee settlement status to SharePoint

### DIFF
--- a/src/features/billing/infra/__tests__/DataProviderBillingOrderRepository.spec.ts
+++ b/src/features/billing/infra/__tests__/DataProviderBillingOrderRepository.spec.ts
@@ -81,4 +81,33 @@ describe('DataProviderBillingOrderRepository', () => {
       })
     );
   });
+
+  describe('isPersistenceColumnsResolved', () => {
+    it('returns true when PaymentStatus field exists in data provider', async () => {
+      const provider = createProvider();
+      vi.mocked(provider.getFieldInternalNames).mockResolvedValue(new Set([
+        'ID',
+        'OrderDateTime',
+        'RequesterCode',
+        'PaymentStatus',
+      ]));
+      const repository = new DataProviderBillingOrderRepository(provider, 'List3');
+
+      const isResolved = await repository.isPersistenceColumnsResolved();
+      expect(isResolved).toBe(true);
+    });
+
+    it('returns false when PaymentStatus field is missing in data provider', async () => {
+      const provider = createProvider();
+      vi.mocked(provider.getFieldInternalNames).mockResolvedValue(new Set([
+        'ID',
+        'OrderDateTime',
+        'RequesterCode',
+      ]));
+      const repository = new DataProviderBillingOrderRepository(provider, 'List3');
+
+      const isResolved = await repository.isPersistenceColumnsResolved();
+      expect(isResolved).toBe(false);
+    });
+  });
 });

--- a/src/sharepoint/definitions/other.ts
+++ b/src/sharepoint/definitions/other.ts
@@ -136,9 +136,9 @@ export const otherListEntries: readonly SpListEntry[] = [
       { internalName: 'Sugar', type: 'Text', displayName: 'Sugar', governance: 'allow', isSilent: true, candidates: ['Sugar', 'SugarOption'] },
       { internalName: 'Milk', type: 'Text', displayName: 'Milk', governance: 'allow', isSilent: true, candidates: ['Milk', 'MilkOption'] },
       { internalName: 'DrinkPrice', type: 'Number', displayName: 'Drink Price', governance: 'allow', isSilent: true, candidates: ['DrinkPrice', 'DRINK_PRICE'] },
-      { internalName: 'PaymentStatus', type: 'Choice', displayName: 'Payment Status', choices: ['未精算', '精算済み'], default: '未精算', governance: 'allow', candidates: ['PaymentStatus', 'Payment_x0020_Status'] },
-      { internalName: 'PaidAt', type: 'DateTime', displayName: 'Paid At', dateTimeFormat: 'DateTime', governance: 'allow', isSilent: true, candidates: ['PaidAt', 'Paid_x0020_At', 'PaymentDate'] },
-      { internalName: 'PaidBy', type: 'Text', displayName: 'Paid By', governance: 'allow', isSilent: true, candidates: ['PaidBy', 'Paid_x0020_By', 'PaymentHandler'] },
+      { internalName: 'PaymentStatus', type: 'Choice', displayName: 'Payment Status', choices: ['未精算', '精算済み'], default: '未精算', governance: 'allow', forceCreate: true, candidates: ['PaymentStatus', 'Payment_x0020_Status'] },
+      { internalName: 'PaidAt', type: 'DateTime', displayName: 'Paid At', dateTimeFormat: 'DateTime', governance: 'allow', isSilent: true, forceCreate: true, candidates: ['PaidAt', 'Paid_x0020_At', 'PaymentDate'] },
+      { internalName: 'PaidBy', type: 'Text', displayName: 'Paid By', governance: 'allow', isSilent: true, forceCreate: true, candidates: ['PaidBy', 'Paid_x0020_By', 'PaymentHandler'] },
     ],
   },
   {


### PR DESCRIPTION
## Summary
- Add `forceCreate: true` to `PaymentStatus`, `PaidAt`, and `PaidBy` in the `billing_orders` list definitions.
- This ensures the dynamic creation (self-healing) of these columns on the SharePoint list at runtime when missing.
- Add unit tests verifying `isPersistenceColumnsResolved` returns true when columns exist and false when columns are missing.

## Verification
- npx vitest run src/features/billing
- npm run typecheck
- npm run sp:audit
- git diff --check
