### PR TITLE
fix(billing): remove redundant hub landing from billing route

### DIFF
--- a/src/app/hubs/__tests__/HubLanding.spec.tsx
+++ b/src/app/hubs/__tests__/HubLanding.spec.tsx
@@ -30,7 +30,7 @@ describe('HubLanding', () => {
     expect(screen.getByTestId('hub-landing-section-secondary-planning')).toBeInTheDocument();
   });
 
-  it('shows reception entries with primary/secondary/coming soon sections', () => {
+  it('shows reception entries with primary/secondary sections', () => {
     mockRole = 'reception';
 
     render(
@@ -41,14 +41,12 @@ describe('HubLanding', () => {
 
     const primary = screen.getByTestId('hub-landing-section-primary-billing');
     const secondary = screen.getByTestId('hub-landing-section-secondary-billing');
-    const comingSoon = screen.getByTestId('hub-landing-section-comingSoon-billing');
 
     expect(within(primary).getByText('請求処理')).toBeInTheDocument();
     expect(within(secondary).getByText('サービス提供実績記録')).toBeInTheDocument();
-    expect(within(comingSoon).getByText('精算ダッシュボード')).toBeInTheDocument();
     expect(within(primary).getByText('請求画面を開く')).toBeInTheDocument();
-    expect(screen.getByText('準備中')).toBeInTheDocument();
-    expect(within(comingSoon).getAllByText('Coming Soon').length).toBeGreaterThan(0);
+    expect(screen.queryByTestId('hub-landing-section-comingSoon-billing')).not.toBeInTheDocument();
+    expect(screen.queryByText('精算ダッシュボード')).not.toBeInTheDocument();
   });
 
   it('shows dictionary-driven empty state when no entry is visible for role', () => {

--- a/src/app/hubs/__tests__/hubDefinitions.spec.ts
+++ b/src/app/hubs/__tests__/hubDefinitions.spec.ts
@@ -75,7 +75,7 @@ describe('hubDefinitions', () => {
     const billingReception = resolveHubVisibleEntries('billing', 'reception');
     expect(billingReception.primary.map((entry) => entry.id)).toEqual(['billing-main']);
     expect(billingReception.secondary.map((entry) => entry.id)).toEqual(['billing-service-record']);
-    expect(billingReception.comingSoon.map((entry) => entry.id)).toEqual(['billing-reconciliation']);
+    expect(billingReception.comingSoon.map((entry) => entry.id)).toEqual([]);
 
     const billingViewer = resolveHubVisibleEntries('billing', 'viewer');
     expect(billingViewer.primary).toHaveLength(0);

--- a/src/app/hubs/hubDefinitions.ts
+++ b/src/app/hubs/hubDefinitions.ts
@@ -458,16 +458,6 @@ export const HUB_DEFINITIONS: Record<HubId, HubDefinition> = {
         kpiWeight: 82,
         usagePriority: 2,
       },
-      {
-        id: 'billing-reconciliation',
-        title: '精算ダッシュボード',
-        description: '請求後の精算状況を確認',
-        requiredRole: 'reception',
-        status: 'comingSoon',
-        badge: '準備中',
-        kpiWeight: 40,
-        usagePriority: 3,
-      },
     ],
   },
   master: {

--- a/src/app/routes/recordRoutes.tsx
+++ b/src/app/routes/recordRoutes.tsx
@@ -68,9 +68,7 @@ export const recordRoutes: RouteObject[] = [
     element: (
       withHubAudienceGuard(
         'billing',
-        <HubLanding hubId="billing">
-          <SuspendedBillingPage />
-        </HubLanding>,
+        <SuspendedBillingPage />,
       )
     ),
   },

--- a/src/pages/BillingPage.tsx
+++ b/src/pages/BillingPage.tsx
@@ -35,7 +35,6 @@ import {
   AccountCircle as AccountCircleIcon,
   Check as CheckIcon,
 } from '@mui/icons-material';
-import { PageHeader } from '@/components/PageHeader';
 import { useBillingSummary } from '@/features/billing/hooks/useBillingSummary';
 
 type ActiveTab = '利用者' | '職員' | 'ゲスト' | 'すべて';
@@ -156,16 +155,11 @@ export default function BillingPage() {
       <Box sx={{ '@media print': { display: 'none' } }}>
         <Stack
           direction={{ xs: 'column', md: 'row' }}
-          justifyContent="space-between"
+          justifyContent="flex-end"
           alignItems={{ xs: 'stretch', md: 'center' }}
           spacing={2}
           sx={{ mb: 4 }}
         >
-          <PageHeader
-            title="請求管理ダッシュボード"
-            subtitle="コーヒー注文履歴から月次請求データを集計・精算管理します"
-          />
-
           {/* コントロールパネル */}
           <Stack direction="row" spacing={1.5} alignItems="center">
             <FormControl size="small" sx={{ minWidth: 140 }}>


### PR DESCRIPTION
## Summary
- Render `BillingPage` directly for `/billing` instead of wrapping it in `HubLanding hubId="billing"`.
- Remove the redundant billing hub cards that were displayed above the actual billing dashboard.
- Keep the existing route audience guard in place.
- Remove the redundant `請求管理ダッシュボード` page header and right-align the billing page controls.

## Verification
- npm run typecheck
- npx eslint
- npx vitest run src/app/hubs/__tests__ src/features/billing
- git diff --check

## Notes
- This PR only changes the `/billing` route presentation and related hub tests.
- It does not change Billing aggregation, SharePoint schema, Worker env/proxy logic, or settlement persistence.
