### PR TITLE
docs(ops): document known admin-status schema drift warnings

### DIFF
--- a/docs/checklists/billing-pre-deployment-checklist.md
+++ b/docs/checklists/billing-pre-deployment-checklist.md
@@ -64,7 +64,7 @@
 ## 🛡️ データ整合性ステータス (`/admin/status`)
 
 *   `/admin/status` 画面において、ステータスが **FAIL** の項目が **0件** であることを確認してください。
-*   `Users_Master` / `ToiletRecords` の SharePoint 列名のゆらぎに起因する `drift WARN` については、#2092 の candidate マッピング補強により、既知 of 候補名として安全に処理され警告が整理されていることを確認済みです。
+*   `Users_Master` / `ToiletRecords` の SharePoint 列名のゆらぎに起因する `drift WARN` については、#2092 の candidate マッピング補強により、既知の候補名として安全に処理され警告が整理されていることを確認済みです。
 *   `BillingOrders` のクロスサイト（`/sites/2`）参照起因による不具合や FAIL が再発していないことを確認済みです。
 
 ---

--- a/docs/operations/sp-health-admin-runbook.md
+++ b/docs/operations/sp-health-admin-runbook.md
@@ -2,7 +2,7 @@
 
 **対象ページ**: `/admin/status`（管理者専用）  
 **診断実装**: `src/features/diagnostics/health/checks.ts`  
-**最終更新**: 2026-04-11
+**最終更新**: 2026-06-02
 
 ---
 
@@ -106,6 +106,27 @@ Provision を実行してリストを作成する
 3. 削除後、`/admin/status` で PASS に変わったことを確認する
 
 > ⚠️ 列削除はデータ損失リスクがあります。削除前に列に値が入っていないことを確認してください。
+
+### 既知 WARN — Users_Master / ToiletRecords
+
+2026-06-02 時点で、以下は `/admin/status` の既知 WARN として扱います。いずれも候補名解決で吸収済みの場合はアプリ継続可です。
+
+| 対象 | WARN 例 | 実害判定 | 運用アクション |
+|------|---------|----------|----------------|
+| `Users_Master` | `RequiresToiletGuidance -> RequiresToiletGuidance0` など | `/kiosk/toilet` で誘導対象者が表示され、利用者詳細でトイレ誘導フラグが読めるなら実害なし | Issue #2102 への追記は不要。新規対象者が表示されない場合のみ追記 |
+| `ToiletRecords` | `UserId`, `RecordDate`, `OccurredAt`, `ToiletType`, `Amount`, `IsDeleted` の内部名 drift | `/kiosk/toilet` で当日記録の読み込み・保存ができるなら実害なし | 保存失敗、当日記録 0 件誤表示、または `schema.fields.toilet_records` が FAIL 化した場合のみ Issue #2102 に追記 |
+
+**根拠**:
+- `Users_Master` の `RequiresToiletGuidance` / `ToiletGuidanceNote` は候補名に `RequiresToiletGuidance0`, `cr013_requiresToiletGuidance`, SharePoint エンコード名を含みます。
+- `ToiletRecords` は SharePoint repository が実列名を取得し、`TOILET_RECORD_CANDIDATES` で読み書き用の物理名を解決します。
+- `ToiletRecords` は optional list です。ただし `/kiosk/toilet` 運用中は保存先として重要なため、保存失敗や当日表示不整合は軽微ではありません。
+
+**小 PR が必要な条件**:
+1. WARN が候補外の実列名を指しており、読み書きで fallback できない
+2. `/kiosk/toilet` の対象者表示、当日記録表示、保存のいずれかに失敗する
+3. `schema.fields.users_master` または `schema.fields.toilet_records` が FAIL に変わる
+
+上記に該当しない場合は、WARN を既知 drift として受け入れ、列削除や rename は急がないでください。
 
 ### WARN (optional missing) — オプション列の欠落
 

--- a/docs/ops/post-deploy-status-checklist.md
+++ b/docs/ops/post-deploy-status-checklist.md
@@ -42,6 +42,17 @@ VITE_SP_LIST_BILLING_ORDERS=c4be5492-9803-4fc6-ac7e-82d10e95ff6d
 
 詳細は [billing-list3-live-verification.md](./billing-list3-live-verification.md) を参照する。
 
+## 既知 WARN 補足
+
+2026-06-02 時点で、以下の `/admin/status` WARN は既知 drift として扱う。候補名解決でアプリが読み書きできている場合は Ready 判定を妨げない。
+
+| 対象 | 既知 WARN | OK 条件 | NG 条件 |
+| --- | --- | --- | --- |
+| Users_Master | `RequiresToiletGuidance` の内部名 drift | `/kiosk/toilet` で誘導対象者が表示される | 対象者が欠落する、または利用者詳細でフラグが読めない |
+| ToiletRecords | 主要 6 列の内部名 drift | 当日記録の読み込み・保存ができる | 保存失敗、当日記録 0 件誤表示、または FAIL 化 |
+
+NG 条件に該当した場合のみ Issue #2102 に軽く追記し、小 PR の要否を判断する。
+
 ## 記録テンプレート
 
 ```text


### PR DESCRIPTION
## Summary
- Document known `/admin/status` WARN cases for Users_Master and ToiletRecords schema drift
- Clarify when these WARNs can be treated as non-blocking during `/billing` acceptance
- Add Day 2+ OK/NG criteria for post-deploy `/admin/status` checks
- Fix a typo in the billing pre-deployment checklist

## Review focus
- This PR is documentation-only.
- Please review whether the known `/admin/status` WARN handling is clear for Day 2+ `/billing` acceptance checks.
- No runtime code, SharePoint schema, repository, field resolver, route, auth, or permission changes are included.

## Scope
- Documentation only
- No SharePoint schema changes
- No repository or field resolver changes
- No runtime behavior changes

## Verification
- `git diff --name-only main..HEAD`
  - Confirmed expected 3 documentation files only
- `git diff --check main..HEAD`
- commit hook:
  - `npm run lint`
  - `npm run typecheck`
  - `npm run lint:cookies`
- Additional tests not run because this is docs-only
