### PR TITLE
fix(kiosk): prevent misrecognition when records fail to load

### DIFF
--- a/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
@@ -140,7 +140,7 @@ export const KioskProcedureDetailScreen: React.FC = () => {
   // isUserLoading 中は空文字を渡し、確定前の userId が saveRecord のクロージャに
   // 束縛されて Zustand に誤ったキーで保存されるのを防ぐ
   const resolvedUserId = isUserLoading ? '' : deepLinkUserId;
-  const { record, saveRecord, deleteRecord, isLoading } = useExecutionRecord(
+  const { record, saveRecord, deleteRecord, isLoading, error: recordLoadError, refresh: refreshRecord } = useExecutionRecord(
     selectedDateIso,
     resolvedUserId,
     scheduleItemId,
@@ -192,7 +192,7 @@ export const KioskProcedureDetailScreen: React.FC = () => {
   };
 
   const handleSave = async () => {
-    if (!userId || isUserLoading || !resolvedUserId) return;
+    if (!userId || isUserLoading || !resolvedUserId || recordLoadError) return;
     const finalMemo = serializeMemo();
     if (!finalMemo.trim()) {
       setShowValidationError(true);
@@ -214,6 +214,7 @@ export const KioskProcedureDetailScreen: React.FC = () => {
   };
 
   const handleDelete = async () => {
+    if (recordLoadError) return;
     setIsDeleting(true);
     try {
       await deleteRecord();
@@ -270,6 +271,7 @@ export const KioskProcedureDetailScreen: React.FC = () => {
   const staffTask = procedure.instructionDetail || parts.slice(1).join('。') || '適宜見守り、必要に応じて声掛けを行います';
 
   const isCompleted = record?.status === 'completed';
+  const isRecordStatusUnknown = Boolean(recordLoadError);
 
   return (
     <Box sx={{ p: 4, height: '100%', display: 'flex', flexDirection: 'column' }}>
@@ -321,6 +323,9 @@ export const KioskProcedureDetailScreen: React.FC = () => {
           </Button>
           {isCompleted && (
             <Chip label="実施済み" color="success" icon={<CheckCircleOutlineIcon />} sx={{ fontWeight: 'bold' }} />
+          )}
+          {isRecordStatusUnknown && (
+            <Chip label="保存状態未確認" color="error" sx={{ fontWeight: 'bold' }} />
           )}
         </Stack>
       </Box>
@@ -376,6 +381,25 @@ export const KioskProcedureDetailScreen: React.FC = () => {
           </Paper>
         </Grid>
       </Grid>
+
+      {isRecordStatusUnknown && (
+        <Alert
+          severity="error"
+          action={
+            <Button color="inherit" size="small" onClick={() => void refreshRecord()}>
+              再読み込み
+            </Button>
+          }
+          sx={{ mb: 4, borderRadius: 2, alignItems: 'center' }}
+        >
+          <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+            実施記録の読み込みに失敗しました
+          </Typography>
+          <Typography variant="body2">
+            保存済みかどうかを確認できません。再読み込みするまで記録の保存・取消はできません。
+          </Typography>
+        </Alert>
+      )}
 
       {/* 観察記録の入力パネル */}
       {showObservations && (
@@ -498,7 +522,7 @@ export const KioskProcedureDetailScreen: React.FC = () => {
                   color="error"
                   onClick={() => setDeleteDialogOpen(true)}
                   sx={{ py: 1.5, px: 3, borderRadius: 3, fontSize: '1.1rem', mr: 'auto' }}
-                  disabled={isSaving || isDeleting}
+                  disabled={isSaving || isDeleting || isRecordStatusUnknown}
                   data-testid="kiosk-observation-revert"
                 >
                   記録を取り消す
@@ -518,7 +542,7 @@ export const KioskProcedureDetailScreen: React.FC = () => {
                 color="primary"
                 onClick={handleSave}
                 sx={{ py: 1.5, px: 4, borderRadius: 3, fontSize: '1.1rem', fontWeight: 'bold' }}
-                disabled={isSaving || isDeleting}
+                disabled={isSaving || isDeleting || isRecordStatusUnknown}
                 data-testid="kiosk-observation-submit"
               >
                 記録を保存する

--- a/src/features/kiosk/components/KioskUserSelectScreen.tsx
+++ b/src/features/kiosk/components/KioskUserSelectScreen.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
-import { Box, Typography, Grid, Card, CardActionArea, CardContent, IconButton, CircularProgress, Chip } from '@mui/material';
+import { Box, Typography, Grid, Card, CardActionArea, CardContent, IconButton, CircularProgress, Chip, Alert, Button } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import RefreshIcon from '@mui/icons-material/Refresh';
 import { useLocation, Link as RouterLink } from 'react-router-dom';
 import { appendKioskSearchParams } from '../utils/navigation';
 import { useUsersQuery } from '@/features/users/hooks/useUsersQuery';
 
 export const KioskUserSelectScreen: React.FC = () => {
   const location = useLocation();
-  const { data: users, status } = useUsersQuery({ selectMode: 'core' });
+  const { data: users, status, refresh } = useUsersQuery({ selectMode: 'core' });
   const isLoading = status === 'loading';
+  const hasLoadError = status === 'error';
 
   // キオスクモードでは「支援手順対象」または「強度行動障害支援対象」の利用者を表示。
   // IsActive が明示的に false の場合は除外する。
@@ -37,6 +39,23 @@ export const KioskUserSelectScreen: React.FC = () => {
         <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', flexGrow: 1 }}>
           <CircularProgress size={48} />
         </Box>
+      ) : hasLoadError ? (
+        <Alert
+          severity="error"
+          action={
+            <Button color="inherit" size="small" startIcon={<RefreshIcon />} onClick={() => void refresh()}>
+              再読み込み
+            </Button>
+          }
+          sx={{ borderRadius: 2, alignItems: 'center' }}
+        >
+          <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+            利用者の読み込みに失敗しました
+          </Typography>
+          <Typography variant="body2">
+            対象者なしではありません。通信状態または認証状態を確認して再読み込みしてください。
+          </Typography>
+        </Alert>
       ) : (
         <Grid container spacing={2}>
           {activeUsers.map((user) => (

--- a/src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx
@@ -41,6 +41,8 @@ vi.mock('@/features/daily/hooks/useProcedureData', () => ({
 }));
 
 const mockSaveRecord = vi.fn().mockResolvedValue(undefined);
+const mockDeleteRecord = vi.fn().mockResolvedValue(undefined);
+const mockRefreshRecord = vi.fn();
 const mockUseExecutionRecord = vi.fn((
   _date?: string,
   _userId?: string,
@@ -50,7 +52,10 @@ const mockUseExecutionRecord = vi.fn((
 ) => ({
   record: null,
   saveRecord: mockSaveRecord,
+  deleteRecord: mockDeleteRecord,
   isLoading: false,
+  error: null,
+  refresh: mockRefreshRecord,
 }));
 vi.mock('@/features/daily/hooks/useExecutionRecord', () => ({
   useExecutionRecord: (
@@ -70,7 +75,10 @@ describe('KioskProcedureDetailScreen (memory provider URL for local UI behavior 
     mockUseExecutionRecord.mockReturnValue({
       record: null,
       saveRecord: mockSaveRecord,
+      deleteRecord: mockDeleteRecord,
       isLoading: false,
+      error: null,
+      refresh: mockRefreshRecord,
     });
   });
 
@@ -221,6 +229,32 @@ describe('KioskProcedureDetailScreen (memory provider URL for local UI behavior 
     await waitFor(() => {
       expect(screen.getByText('手順記録の内容を1つ以上入力してください。')).toBeInTheDocument();
     });
+    expect(mockSaveRecord).not.toHaveBeenCalled();
+  });
+
+  it('shows unknown saved-state feedback and blocks save when the execution record cannot be loaded', () => {
+    mockUseExecutionRecord.mockReturnValue({
+      record: null,
+      saveRecord: mockSaveRecord,
+      deleteRecord: mockDeleteRecord,
+      isLoading: false,
+      error: new Error('failed to load execution record'),
+      refresh: mockRefreshRecord,
+    });
+
+    render(
+      <MemoryRouter>
+        <KioskProcedureDetailScreen />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('保存状態未確認')).toBeInTheDocument();
+    expect(screen.getByText('実施記録の読み込みに失敗しました')).toBeInTheDocument();
+    expect(screen.getByText(/保存済みかどうかを確認できません/)).toBeInTheDocument();
+    expect(screen.getByTestId('kiosk-observation-submit')).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('button', { name: '再読み込み' }));
+    expect(mockRefreshRecord).toHaveBeenCalledTimes(1);
     expect(mockSaveRecord).not.toHaveBeenCalled();
   });
 

--- a/src/features/kiosk/components/__tests__/KioskUserSelectScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskUserSelectScreen.spec.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { IUserMaster } from '@/features/users/types';
+import { KioskUserSelectScreen } from '../KioskUserSelectScreen';
+
+const { mockUseUsersQuery, mockRefresh } = vi.hoisted(() => ({
+  mockUseUsersQuery: vi.fn(),
+  mockRefresh: vi.fn(),
+}));
+
+vi.mock('@/features/users/hooks/useUsersQuery', () => ({
+  useUsersQuery: mockUseUsersQuery,
+}));
+
+const renderScreen = () =>
+  render(
+    <MemoryRouter initialEntries={['/kiosk/users']}>
+      <KioskUserSelectScreen />
+    </MemoryRouter>,
+  );
+
+describe('KioskUserSelectScreen', () => {
+  beforeEach(() => {
+    mockRefresh.mockReset();
+    mockUseUsersQuery.mockReset();
+  });
+
+  it('shows a load failure instead of the empty target-user state when users cannot be loaded', () => {
+    mockUseUsersQuery.mockReturnValue({
+      data: [],
+      status: 'error',
+      refresh: mockRefresh,
+    });
+
+    renderScreen();
+
+    expect(screen.getByText('利用者の読み込みに失敗しました')).toBeInTheDocument();
+    expect(screen.getByText(/対象者なしではありません/)).toBeInTheDocument();
+    expect(screen.queryByText('対象の利用者がいません')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '再読み込み' }));
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the empty target-user state for a successful load with no target users', () => {
+    mockUseUsersQuery.mockReturnValue({
+      data: [
+        {
+          Id: 1,
+          UserID: 'user-1',
+          FullName: '対象外 太郎',
+          IsActive: true,
+          IsSupportProcedureTarget: false,
+          IsHighIntensitySupportTarget: false,
+        } as unknown as IUserMaster,
+      ],
+      status: 'success',
+      refresh: mockRefresh,
+    });
+
+    renderScreen();
+
+    expect(screen.getByText('対象の利用者がいません')).toBeInTheDocument();
+    expect(screen.queryByText('利用者の読み込みに失敗しました')).not.toBeInTheDocument();
+  });
+});

--- a/src/features/kiosk/toilet/ToiletDailyBoard.tsx
+++ b/src/features/kiosk/toilet/ToiletDailyBoard.tsx
@@ -68,8 +68,9 @@ export const ToiletDailyBoard: React.FC = () => {
   const location = useLocation();
   const todayIso = toLocalDateISO(new Date());
   const { data: users, isLoading: isUsersLoading, status: usersStatus } = useUsers({ selectMode: 'core' });
-  const { records, create, isLoading: isRecordsLoading } = useToiletRecords(todayIso);
+  const { records, create, refresh: refreshRecords, isLoading: isRecordsLoading, error: recordsError } = useToiletRecords(todayIso);
   const isLoading = isUsersLoading || isRecordsLoading;
+  const hasRecordsError = Boolean(recordsError);
   const [selectedUser, setSelectedUser] = React.useState<IUserMaster | null>(null);
   const [isSaving, setIsSaving] = React.useState(false);
   const [saveError, setSaveError] = React.useState<string | null>(null);
@@ -99,6 +100,7 @@ export const ToiletDailyBoard: React.FC = () => {
 
   const recordedCount = rows.filter((row) => row.recorded).length;
   const unrecordedCount = rows.length - recordedCount;
+  const summaryLabel = hasRecordsError ? '記録状態を確認できません' : `未記録 ${unrecordedCount}名 / 記録済み ${recordedCount}名`;
   const recordsByUserKey = React.useMemo(() => {
     const grouped = new Map<string, ToiletRecord[]>();
     records.forEach((record) => {
@@ -164,8 +166,8 @@ export const ToiletDailyBoard: React.FC = () => {
         </Box>
         <Chip
           data-testid="toilet-board-summary"
-          color={unrecordedCount > 0 ? 'warning' : 'success'}
-          label={`未記録 ${unrecordedCount}名 / 記録済み ${recordedCount}名`}
+          color={hasRecordsError ? 'error' : unrecordedCount > 0 ? 'warning' : 'success'}
+          label={summaryLabel}
           sx={{ height: 40, borderRadius: 2, fontWeight: 800, fontSize: '0.95rem' }}
         />
       </Stack>
@@ -203,7 +205,36 @@ export const ToiletDailyBoard: React.FC = () => {
               </Grid>
             )}
 
-            {usersStatus !== 'error' && rows.map(({ user, latestRecord, recorded }) => (
+            {usersStatus !== 'error' && hasRecordsError && (
+              <Grid size={12}>
+                <Paper
+                  variant="outlined"
+                  sx={{
+                    p: 3,
+                    borderRadius: 2,
+                    borderColor: 'error.light',
+                    bgcolor: 'rgba(211, 47, 47, 0.05)',
+                  }}
+                >
+                  <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems={{ xs: 'stretch', sm: 'center' }}>
+                    <ErrorOutlineIcon color="error" sx={{ fontSize: 32 }} />
+                    <Box sx={{ flex: 1, minWidth: 0 }}>
+                      <Typography variant="subtitle1" sx={{ fontWeight: 900, color: 'error.main' }}>
+                        トイレ記録の読み込みに失敗しました
+                      </Typography>
+                      <Typography variant="body2" color="text.secondary">
+                        記録済み/未記録の判定ができません。通信状態または ToiletRecords リストを確認して再読み込みしてください。
+                      </Typography>
+                    </Box>
+                    <Button variant="outlined" color="error" onClick={() => void refreshRecords()} sx={{ minHeight: 44, fontWeight: 900 }}>
+                      再読み込み
+                    </Button>
+                  </Stack>
+                </Paper>
+              </Grid>
+            )}
+
+            {usersStatus !== 'error' && !hasRecordsError && rows.map(({ user, latestRecord, recorded }) => (
               <Grid key={user.Id} size={12}>
                 <Paper
                   data-testid={`toilet-user-row-${resolveUserKey(user)}`}
@@ -247,7 +278,7 @@ export const ToiletDailyBoard: React.FC = () => {
               </Grid>
             ))}
 
-            {usersStatus !== 'error' && rows.length === 0 && (
+            {usersStatus !== 'error' && !hasRecordsError && rows.length === 0 && (
               <Grid size={12}>
                 <Paper variant="outlined" sx={{ p: 5, textAlign: 'center', borderRadius: 2 }}>
                   <Typography color="text.secondary">トイレ誘導対象の利用者がいません</Typography>
@@ -256,65 +287,67 @@ export const ToiletDailyBoard: React.FC = () => {
             )}
           </Grid>
 
-          <Paper data-testid="toilet-record-history" variant="outlined" sx={{ p: { xs: 1.5, md: 2 }, borderRadius: 2 }}>
-            <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1.5 }}>
-              <Typography variant="h6" component="h2" sx={{ fontWeight: 900 }}>
-                本日の全記録（個人別）
-              </Typography>
-              <Chip label={`${records.length}件`} size="small" sx={{ borderRadius: 1, fontWeight: 800 }} />
-            </Stack>
-            <Stack spacing={1.25}>
-              {targetUsers.map((user) => {
-                const userKey = resolveUserKey(user);
-                const userRecords = recordsByUserKey.get(userKey) ?? [];
+          {!hasRecordsError && (
+            <Paper data-testid="toilet-record-history" variant="outlined" sx={{ p: { xs: 1.5, md: 2 }, borderRadius: 2 }}>
+              <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1.5 }}>
+                <Typography variant="h6" component="h2" sx={{ fontWeight: 900 }}>
+                  本日の全記録（個人別）
+                </Typography>
+                <Chip label={`${records.length}件`} size="small" sx={{ borderRadius: 1, fontWeight: 800 }} />
+              </Stack>
+              <Stack spacing={1.25}>
+                {targetUsers.map((user) => {
+                  const userKey = resolveUserKey(user);
+                  const userRecords = recordsByUserKey.get(userKey) ?? [];
 
-                return (
-                  <Box
-                    key={userKey}
-                    data-testid={`toilet-history-user-${userKey}`}
-                    sx={{
-                      p: 1.25,
-                      border: '1px solid',
-                      borderColor: 'divider',
-                      borderRadius: 1.5,
-                    }}
-                  >
-                    <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: userRecords.length > 0 ? 1 : 0 }}>
-                      <Typography sx={{ fontWeight: 900 }}>{user.FullName}</Typography>
-                      <Chip label={`${userRecords.length}件`} size="small" variant="outlined" sx={{ borderRadius: 1, fontWeight: 800 }} />
-                    </Stack>
-
-                    {userRecords.length === 0 ? (
-                      <Typography color="text.secondary">記録なし</Typography>
-                    ) : (
-                      <Stack spacing={0.75}>
-                        {userRecords.map((record) => (
-                          <Box
-                            key={record.id}
-                            data-testid={`toilet-history-record-${record.id}`}
-                            sx={{
-                              display: 'grid',
-                              gridTemplateColumns: { xs: '1fr', sm: '96px 120px 120px 1fr' },
-                              gap: { xs: 0.5, sm: 1.5 },
-                              alignItems: 'center',
-                              p: 1,
-                              borderRadius: 1.25,
-                              bgcolor: 'action.hover',
-                            }}
-                          >
-                            <Typography sx={{ fontWeight: 900 }}>{formatRecordTime(record.occurredAt)}</Typography>
-                            <Typography color="text.secondary">{TOILET_TYPE_LABELS[record.toiletType]}</Typography>
-                            <Typography color="text.secondary">{TOILET_AMOUNT_LABELS[record.amount]}</Typography>
-                            <Typography color="text.secondary">{record.memo || 'メモなし'}</Typography>
-                          </Box>
-                        ))}
+                  return (
+                    <Box
+                      key={userKey}
+                      data-testid={`toilet-history-user-${userKey}`}
+                      sx={{
+                        p: 1.25,
+                        border: '1px solid',
+                        borderColor: 'divider',
+                        borderRadius: 1.5,
+                      }}
+                    >
+                      <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: userRecords.length > 0 ? 1 : 0 }}>
+                        <Typography sx={{ fontWeight: 900 }}>{user.FullName}</Typography>
+                        <Chip label={`${userRecords.length}件`} size="small" variant="outlined" sx={{ borderRadius: 1, fontWeight: 800 }} />
                       </Stack>
-                    )}
-                  </Box>
-                );
-              })}
-            </Stack>
-          </Paper>
+
+                      {userRecords.length === 0 ? (
+                        <Typography color="text.secondary">記録なし</Typography>
+                      ) : (
+                        <Stack spacing={0.75}>
+                          {userRecords.map((record) => (
+                            <Box
+                              key={record.id}
+                              data-testid={`toilet-history-record-${record.id}`}
+                              sx={{
+                                display: 'grid',
+                                gridTemplateColumns: { xs: '1fr', sm: '96px 120px 120px 1fr' },
+                                gap: { xs: 0.5, sm: 1.5 },
+                                alignItems: 'center',
+                                p: 1,
+                                borderRadius: 1.25,
+                                bgcolor: 'action.hover',
+                              }}
+                            >
+                              <Typography sx={{ fontWeight: 900 }}>{formatRecordTime(record.occurredAt)}</Typography>
+                              <Typography color="text.secondary">{TOILET_TYPE_LABELS[record.toiletType]}</Typography>
+                              <Typography color="text.secondary">{TOILET_AMOUNT_LABELS[record.amount]}</Typography>
+                              <Typography color="text.secondary">{record.memo || 'メモなし'}</Typography>
+                            </Box>
+                          ))}
+                        </Stack>
+                      )}
+                    </Box>
+                  );
+                })}
+              </Stack>
+            </Paper>
+          )}
         </Stack>
       )}
 

--- a/src/features/kiosk/toilet/__tests__/ToiletDailyBoard.spec.tsx
+++ b/src/features/kiosk/toilet/__tests__/ToiletDailyBoard.spec.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IUserMaster } from '@/features/users/types';
+import { ToiletDailyBoard } from '../ToiletDailyBoard';
+
+const { mockUseUsers, mockUseToiletRecords, mockRefreshRecords, mockCreateRecord } = vi.hoisted(() => ({
+  mockUseUsers: vi.fn(),
+  mockUseToiletRecords: vi.fn(),
+  mockRefreshRecords: vi.fn(),
+  mockCreateRecord: vi.fn(),
+}));
+
+vi.mock('@/features/users/useUsers', () => ({
+  useUsers: mockUseUsers,
+}));
+
+vi.mock('../useToiletRecords', () => ({
+  useToiletRecords: mockUseToiletRecords,
+}));
+
+const toiletTargetUser = {
+  Id: 1,
+  UserID: 'user-1',
+  FullName: '支援 花子',
+  IsActive: true,
+  RequiresToiletGuidance: true,
+} as unknown as IUserMaster;
+
+const renderBoard = () =>
+  render(
+    <MemoryRouter initialEntries={['/kiosk/toilet']}>
+      <ToiletDailyBoard />
+    </MemoryRouter>,
+  );
+
+describe('ToiletDailyBoard', () => {
+  beforeEach(() => {
+    mockUseUsers.mockReset();
+    mockUseToiletRecords.mockReset();
+    mockRefreshRecords.mockReset();
+    mockCreateRecord.mockReset();
+
+    mockUseUsers.mockReturnValue({
+      data: [toiletTargetUser],
+      isLoading: false,
+      status: 'success',
+    });
+
+    mockUseToiletRecords.mockReturnValue({
+      records: [],
+      create: mockCreateRecord,
+      refresh: mockRefreshRecords,
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  it('shows a record load failure instead of treating every target user as unrecorded', () => {
+    mockUseToiletRecords.mockReturnValue({
+      records: [],
+      create: mockCreateRecord,
+      refresh: mockRefreshRecords,
+      isLoading: false,
+      error: new Error('failed to load ToiletRecords'),
+    });
+
+    renderBoard();
+
+    expect(screen.getByText('トイレ記録の読み込みに失敗しました')).toBeInTheDocument();
+    expect(screen.getByText(/記録済み\/未記録の判定ができません/)).toBeInTheDocument();
+    expect(screen.getByTestId('toilet-board-summary')).toHaveTextContent('記録状態を確認できません');
+    expect(screen.queryByTestId('toilet-user-row-user-1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('toilet-record-history')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '再読み込み' }));
+    expect(mockRefreshRecords).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the no-target-users state for a successful load with no toilet guidance targets', () => {
+    mockUseUsers.mockReturnValue({
+      data: [
+        {
+          Id: 2,
+          UserID: 'user-2',
+          FullName: '対象外 太郎',
+          IsActive: true,
+          RequiresToiletGuidance: false,
+        } as unknown as IUserMaster,
+      ],
+      isLoading: false,
+      status: 'success',
+    });
+
+    renderBoard();
+
+    expect(screen.getByText('トイレ誘導対象の利用者がいません')).toBeInTheDocument();
+    expect(screen.queryByText('トイレ記録の読み込みに失敗しました')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

* Show an explicit load failure state on `/kiosk/users` instead of showing an empty-user message when Users loading fails
* Prevent `/kiosk/toilet` from treating unknown ToiletRecords state as unrecorded, and suppress row/history display when record state cannot be confirmed
* Show "保存状態未確認" on procedure detail when execution record loading fails, and block save/cancel actions until the state is confirmed
* Add regression coverage for the three misrecognition guard cases

## Scope

* Kiosk misrecognition guard only
* No SharePoint schema changes
* No repository contract changes
* No billing changes
* No new feature behavior beyond safer failure-state presentation

## Verification

* `npx vitest run src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx src/features/kiosk/components/__tests__/KioskUserSelectScreen.spec.tsx src/features/kiosk/toilet/__tests__/ToiletDailyBoard.spec.tsx --reporter=verbose --no-file-parallelism`
  * 15 tests passed
* `npm run typecheck`
* `npx eslint src/features/kiosk/components/KioskProcedureDetailScreen.tsx src/features/kiosk/components/KioskUserSelectScreen.tsx src/features/kiosk/toilet/ToiletDailyBoard.tsx src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx src/features/kiosk/components/__tests__/KioskUserSelectScreen.spec.tsx src/features/kiosk/toilet/__tests__/ToiletDailyBoard.spec.tsx --max-warnings=0`
* `git diff --check main..HEAD`
* commit hook:
  * `npm run lint`
  * `npm run typecheck`
  * `npm run lint:cookies`
* pre-push hook:
  * eslint on changed files vs `origin/main`