### PR TITLE
fix(kiosk): show uncertain procedure status when records fail to load

### DIFF
--- a/src/features/kiosk/components/KioskProcedureListScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureListScreen.tsx
@@ -139,7 +139,7 @@ export const KioskProcedureListScreen: React.FC = () => {
   );
   const procedureRepo = useProcedureData();
   const executionRepo = useExecutionData();
-  
+
   const selectedDateIso = React.useMemo(() => resolveKioskRecordDate(location.search), [location.search]);
   const selectedDateStr = formatDateJapanese(selectedDateIso);
   const deepLinkUserId = React.useMemo(() => {
@@ -255,7 +255,7 @@ export const KioskProcedureListScreen: React.FC = () => {
     return Array.from(deduped.values());
   }, [executionUserIdCandidates, getStoreRecords, selectedDateIso]);
   const executionRepositoryKind = getCurrentExecutionRepositoryKind();
-  
+
   const [records, setRecords] = useState<ExecutionRecord[]>([]);
   const [hasFetchedRecords, setHasFetchedRecords] = useState(false);
   const [fetchFailed, setFetchFailed] = useState(false);
@@ -626,7 +626,7 @@ export const KioskProcedureListScreen: React.FC = () => {
       {/* ヘッダーセクション */}
       <Box sx={{ mb: 4, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
         <Box sx={{ display: 'flex', alignItems: 'center' }}>
-          <IconButton 
+          <IconButton
             component={RouterLink}
             to={appendKioskSearchParams('/kiosk/users', location.search)}
             sx={{ mr: 2, bgcolor: 'action.hover' }}
@@ -654,10 +654,10 @@ export const KioskProcedureListScreen: React.FC = () => {
           <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
             実施状況: {recordedCount} / {totalCount}
           </Typography>
-          <LinearProgress 
-            variant="determinate" 
-            value={progress} 
-            sx={{ height: 12, borderRadius: 6, mb: 1, bgcolor: 'action.hover' }} 
+          <LinearProgress
+            variant="determinate"
+            value={progress}
+            sx={{ height: 12, borderRadius: 6, mb: 1, bgcolor: 'action.hover' }}
           />
           <Box sx={{ display: 'flex', gap: 1, justifyContent: 'flex-end' }}>
             <Chip icon={<CheckCircleIcon />} label={`${doneCount} 完了`} color="success" size="small" variant={doneCount > 0 ? "filled" : "outlined"} sx={{ fontWeight: 'bold' }} />
@@ -709,17 +709,66 @@ export const KioskProcedureListScreen: React.FC = () => {
         {procedures.map((step, index) => {
           const recordedRecord = recordedRecordsByProcedure[index];
           const isRecorded = Boolean(recordedRecord);
-          
+          const isLoadFailed = fetchFailed || isThrottleActive;
+
+          let statusType: 'recorded' | 'unrecorded' | 'uncertain' | 'uncertain_local' = 'unrecorded';
+          if (isLoadFailed) {
+            statusType = isRecorded ? 'uncertain_local' : 'uncertain';
+          } else {
+            statusType = isRecorded ? 'recorded' : 'unrecorded';
+          }
+
+          const borderLeftColor = (() => {
+            switch (statusType) {
+              case 'recorded': return 'success.main';
+              case 'uncertain_local': return 'warning.light';
+              case 'uncertain': return 'text.disabled';
+              case 'unrecorded':
+              default: return 'divider';
+            }
+          })();
+
+          const bgcolor = (() => {
+            switch (statusType) {
+              case 'recorded': return 'success.lighter';
+              case 'uncertain_local': return 'warning.lighter';
+              case 'uncertain': return 'action.hover';
+              case 'unrecorded':
+              default: return 'background.paper';
+            }
+          })();
+
+          const opacity = (() => {
+            switch (statusType) {
+              case 'recorded': return 0.8;
+              case 'uncertain_local': return 0.9;
+              case 'uncertain': return 0.7;
+              case 'unrecorded':
+              default: return 1;
+            }
+          })();
+
+          const textDecoration = statusType === 'recorded' ? 'line-through' : 'none';
+          const titleColor = (() => {
+            switch (statusType) {
+              case 'recorded': return 'success.dark';
+              case 'uncertain_local': return 'warning.dark';
+              case 'uncertain': return 'text.secondary';
+              case 'unrecorded':
+              default: return 'text.primary';
+            }
+          })();
+
           return (
             <Grid key={index} size={12}>
-              <Card 
-                sx={{ 
+              <Card
+                sx={{
                   borderRadius: 3,
                   boxShadow: '0 2px 8px rgba(0,0,0,0.05)',
                   borderLeft: '6px solid',
-                  borderLeftColor: 'divider',
-                  bgcolor: isRecorded ? 'success.lighter' : 'background.paper',
-                  opacity: isRecorded ? 0.8 : 1,
+                  borderLeftColor: borderLeftColor,
+                  bgcolor: bgcolor,
+                  opacity: opacity,
                   transition: 'all 0.2s',
                   '&:hover': {
                     transform: 'translateY(-2px)',
@@ -742,16 +791,23 @@ export const KioskProcedureListScreen: React.FC = () => {
                 >
                   <Grid container alignItems="center" spacing={2}>
                     <Grid size={2} sx={{ textAlign: 'center' }}>
-                      <Typography variant="h5" sx={{ fontWeight: 'bold', color: isRecorded ? 'success.main' : 'text.secondary' }}>
+                      <Typography variant="h5" sx={{
+                        fontWeight: 'bold',
+                        color: statusType === 'recorded'
+                          ? 'success.main'
+                          : statusType === 'uncertain_local'
+                          ? 'warning.main'
+                          : 'text.secondary'
+                      }}>
                         {step.time}
                       </Typography>
                     </Grid>
                     <Grid size={7}>
-                      <Typography variant="h6" sx={{ 
-                        fontWeight: 'bold', 
+                      <Typography variant="h6" sx={{
+                        fontWeight: 'bold',
                         mb: 0.5,
-                        color: isRecorded ? 'success.dark' : 'text.primary',
-                        textDecoration: isRecorded ? 'line-through' : 'none'
+                        color: titleColor,
+                        textDecoration: textDecoration
                       }}>
                         {step.activity}
                       </Typography>
@@ -777,21 +833,55 @@ export const KioskProcedureListScreen: React.FC = () => {
                       >
                         この手順でABC記録
                       </Button>
-                      {isRecorded ? (
-                        <Chip 
-                          icon={<CheckCircleIcon />} 
-                          label="記録済み" 
-                          color="success"
-                          sx={{ borderRadius: 2, fontWeight: 'bold' }}
-                        />
-                      ) : (
-                        <Chip 
-                          icon={<AccessTimeIcon />} 
-                          label="未実施" 
-                          variant="outlined" 
-                          sx={{ borderRadius: 2, color: 'text.disabled', borderColor: 'divider' }}
-                        />
-                      )}
+                      {(() => {
+                        switch (statusType) {
+                          case 'recorded':
+                            return (
+                              <Chip
+                                icon={<CheckCircleIcon />}
+                                label="記録済み"
+                                color="success"
+                                sx={{ borderRadius: 2, fontWeight: 'bold' }}
+                              />
+                            );
+                          case 'uncertain_local':
+                            return (
+                              <Chip
+                                icon={<CheckCircleIcon color="warning" />}
+                                label="同期状態未確認"
+                                color="warning"
+                                variant="outlined"
+                                sx={{ borderRadius: 2, fontWeight: 'bold' }}
+                                data-testid={`kiosk-uncertain-local-chip-${index}`}
+                              />
+                            );
+                          case 'uncertain':
+                            return (
+                              <Chip
+                                label="状態未確認"
+                                variant="outlined"
+                                color="default"
+                                sx={{
+                                  borderRadius: 2,
+                                  color: 'text.secondary',
+                                  borderColor: 'divider',
+                                  borderStyle: 'dashed'
+                                }}
+                                data-testid={`kiosk-uncertain-chip-${index}`}
+                              />
+                            );
+                          case 'unrecorded':
+                          default:
+                            return (
+                              <Chip
+                                icon={<AccessTimeIcon />}
+                                label="未実施"
+                                variant="outlined"
+                                sx={{ borderRadius: 2, color: 'text.disabled', borderColor: 'divider' }}
+                              />
+                            );
+                        }
+                      })()}
                     </Grid>
                   </Grid>
                 </Box>

--- a/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
@@ -418,7 +418,8 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
 
     await waitFor(() => {
       const firstCard = screen.getByTestId('kiosk-procedure-card-0');
-      expect(within(firstCard).getByText('記録済み')).toBeInTheDocument();
+      expect(within(firstCard).getByText('同期状態未確認')).toBeInTheDocument();
+      expect(within(firstCard).queryByText('記録済み')).toBeNull();
       expect(within(firstCard).queryByText('未実施')).toBeNull();
       expect(screen.getByText('実施状況: 1 / 2')).toBeInTheDocument();
       expect(screen.getByText('記録の取得に失敗しました。再読み込みしてください。')).toBeInTheDocument();
@@ -1134,7 +1135,7 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
       data: { FullName: '田中 太郎', UserID: 'U001' } as any,
       status: 'success',
     };
-    
+
     // Trigger rerender to simulate useUser state update
     rerender(
       <MemoryRouter initialEntries={['/kiosk/users/17/procedures']}>
@@ -1229,6 +1230,72 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
       vi.advanceTimersByTime(20000);
       await waitFor(() => {
         expect(screen.queryByTestId('kiosk-throttle-alert')).toBeNull();
+      });
+    });
+  });
+
+  describe('SharePoint load failure representation', () => {
+    it('shows "状態未確認" Chip and styling when SharePoint load fails and no local cache is available', async () => {
+      mockGetRecords.mockRejectedValue(new Error('SharePoint fetch failed'));
+      mockGetStoreRecords.mockReturnValue([]);
+
+      render(
+        <MemoryRouter>
+          <KioskProcedureListScreen />
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('kiosk-uncertain-chip-0')).toBeInTheDocument();
+        expect(screen.getByTestId('kiosk-uncertain-chip-1')).toBeInTheDocument();
+        expect(screen.queryByText('未実施')).toBeNull();
+        expect(screen.queryByText('記録済み')).toBeNull();
+      });
+    });
+
+    it('shows "同期状態未確認" Chip for slots with local cache and "状態未確認" for others when SharePoint load fails', async () => {
+      mockGetRecords.mockRejectedValue(new Error('SharePoint fetch failed'));
+      mockGetStoreRecords.mockReturnValue([
+        { scheduleItemId: '1', status: 'completed', recordedAt: '2026-05-08T10:00:00Z' }
+      ]);
+
+      render(
+        <MemoryRouter>
+          <KioskProcedureListScreen />
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('kiosk-uncertain-local-chip-0')).toBeInTheDocument();
+        expect(screen.getByTestId('kiosk-uncertain-chip-1')).toBeInTheDocument();
+        expect(screen.queryByText('未実施')).toBeNull();
+        expect(screen.queryByText('記録済み')).toBeNull();
+      });
+    });
+
+    it('robustly matches local cache records with ID/userId variations (prefixed, canonical, trailing match)', async () => {
+      // routeUserId is mockRouteUserId = 'U001' (buildExecutionUserIdCandidates creates U001, 1, U1, U-001, etc)
+      mockGetRecords.mockRejectedValue(new Error('SharePoint fetch failed'));
+
+      // Store record has U-001 as userId (variation) and procedure match keys are evaluated
+      mockGetStoreRecords.mockImplementation((_date, userId) => {
+        if (userId === 'U-001') {
+          return [
+            { scheduleItemId: 'procedure-1', status: 'completed', recordedAt: '2026-05-08T10:00:00Z' }
+          ];
+        }
+        return [];
+      });
+
+      render(
+        <MemoryRouter>
+          <KioskProcedureListScreen />
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('kiosk-uncertain-local-chip-0')).toBeInTheDocument();
+        expect(screen.getByTestId('kiosk-uncertain-chip-1')).toBeInTheDocument();
       });
     });
   });


### PR DESCRIPTION
## Summary
- Show "状態未確認" on kiosk procedure list when SharePoint record loading fails and no matching local cache exists
- Show "同期状態未確認" when a matching local cache exists but SharePoint state could not be confirmed
- Strengthen regression coverage for local cache matching with userId / scheduleItemId / rowKey variations
- Update stale-cache expectations from "recorded" to "sync state unconfirmed"

## Scope
- Kiosk procedure list only
- No offline write mode
- No changes to `useExecutionRecord.ts` save behavior
- No SharePoint schema changes
- No repository contract changes
- No billing changes
- No history drawer changes

## Verification
- `npx vitest run src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx`
- `npm run typecheck`
- `npx eslint src/features/kiosk/components/KioskProcedureListScreen.tsx src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx`
- `git diff --check`
