### PR TITLE
fix(kiosk): add retry and cache guard for procedure history

### DIFF
--- a/src/features/daily/hooks/__tests__/useHistoricalRecords.spec.ts
+++ b/src/features/daily/hooks/__tests__/useHistoricalRecords.spec.ts
@@ -1,7 +1,8 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { renderHook, waitFor, act } from '@testing-library/react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { useHistoricalRecords } from '../useHistoricalRecords';
+import { useHistoricalRecords, _testCache } from '../useHistoricalRecords';
 import type { ExecutionRecord } from '../../domain/legacy/executionRecordTypes';
+
 
 const mockGetHistoricalRecords = vi.fn<(...args: unknown[]) => Promise<ExecutionRecord[]>>();
 const mockGetRecordsInRange = vi.fn<(...args: unknown[]) => Promise<ExecutionRecord[]>>();
@@ -31,6 +32,7 @@ describe('useHistoricalRecords', () => {
     mockGetHistoricalRecords.mockReset();
     mockGetRecordsInRange.mockReset();
     mockGetRecordsInRange.mockResolvedValue([]);
+    _testCache.clear();
   });
 
   it('merges results across schedule candidates instead of stopping at first hit', async () => {
@@ -233,5 +235,99 @@ describe('useHistoricalRecords', () => {
 
     // 再フェッチの無限ループに入らず、コール数が1回で止まっていること
     expect(mockGetHistoricalRecords.mock.calls.length).toBe(1);
+  });
+
+  it('serves records from cache within CACHE_DURATION and sets isCached=true', async () => {
+    mockGetHistoricalRecords.mockResolvedValue([record('r-1', '2026-05-13', '1')]);
+
+    const { result } = renderHook(() =>
+      useHistoricalRecords('U001', '1', [], []),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.records.map((r) => r.id)).toEqual(['r-1']);
+    expect(result.current.isCached).toBe(false);
+
+    const initialCalls = mockGetHistoricalRecords.mock.calls.length;
+
+    const { result: cachedResult } = renderHook(() =>
+      useHistoricalRecords('U001', '1', [], []),
+    );
+
+    await waitFor(() => {
+      expect(cachedResult.current.isLoading).toBe(false);
+    });
+    expect(cachedResult.current.records.map((r) => r.id)).toEqual(['r-1']);
+    expect(cachedResult.current.isCached).toBe(true);
+    expect(mockGetHistoricalRecords.mock.calls.length).toBe(initialCalls);
+  });
+
+  it('bypasses cache and updates on force refresh', async () => {
+    let fetchCount = 0;
+    mockGetHistoricalRecords.mockImplementation(async (userId) => {
+      if (userId === 'U001') {
+        fetchCount++;
+      }
+      if (fetchCount <= 1) {
+        return userId === 'U001' ? [record('r-1', '2026-05-13', '1')] : [];
+      }
+      return userId === 'U001' ? [record('r-2', '2026-05-13', '1')] : [];
+    });
+
+    const { result } = renderHook(() =>
+      useHistoricalRecords('U001', '1', [], []),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.records.map((r) => r.id)).toEqual(['r-1']);
+
+    await act(async () => {
+      await result.current.refresh({ force: true });
+    });
+
+    await waitFor(() => {
+      expect(result.current.records.map((r) => r.id)).toEqual(['r-2']);
+    });
+    expect(result.current.isCached).toBe(false);
+  });
+
+  it('keeps stale cache on refresh failure instead of clearing it', async () => {
+    let fetchCount = 0;
+    mockGetHistoricalRecords.mockImplementation(async (userId) => {
+      if (userId === 'U001') {
+        fetchCount++;
+      }
+      if (fetchCount <= 1) {
+        return userId === 'U001' ? [record('r-1', '2026-05-13', '1')] : [];
+      }
+      throw new Error('SharePoint Throttle');
+    });
+
+    const { result } = renderHook(() =>
+      useHistoricalRecords('U001', '1', [], []),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.records.map((r) => r.id)).toEqual(['r-1']);
+
+    await act(async () => {
+      try {
+        await result.current.refresh({ force: true });
+      } catch {
+        // ignore thrown error during refresh
+      }
+    });
+
+    await waitFor(() => {
+      expect(result.current.error).not.toBeNull();
+    });
+    expect(result.current.records.map((r) => r.id)).toEqual(['r-1']);
+    expect(result.current.isCached).toBe(true);
   });
 });

--- a/src/features/daily/hooks/useHistoricalRecords.ts
+++ b/src/features/daily/hooks/useHistoricalRecords.ts
@@ -3,8 +3,17 @@ import { useExecutionData } from './useExecutionData';
 import type { ExecutionRecord } from '../domain/legacy/executionRecordTypes';
 import { normalizeScheduleItemId } from '../utils/normalizeScheduleItemId';
 import { buildExecutionUserIdCandidates } from '../utils/normalizeExecutionLookup';
+import { toLocalDateISO } from '@/utils/getNow';
 
 const EMPTY_IDS: readonly string[] = [];
+
+interface CacheEntry {
+  records: ExecutionRecord[];
+  fetchedAt: number;
+}
+
+const historyCache = new Map<string, CacheEntry>();
+const CACHE_DURATION = 60_000; // 60秒
 
 export function useHistoricalRecords(
   userId: string,
@@ -27,32 +36,51 @@ export function useHistoricalRecords(
   const [records, setRecords] = useState<ExecutionRecord[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
+  const [isCached, setIsCached] = useState(false);
+  const [lastFetchedAt, setLastFetchedAt] = useState<number | null>(null);
 
   // 配列の参照揺れを防ぐため文字列キー化
   const fallbackScheduleKey = fallbackScheduleItemIds.join('\u0000');
   const fallbackUserKey = fallbackUserIds.join('\u0000');
 
-  const fetchHistory = useCallback(async () => {
+  const fetchHistory = useCallback(async (options?: { force?: boolean }) => {
     const requestSeq = ++requestSeqRef.current;
 
     if (!userId || !scheduleItemId) {
       setRecords([]);
       setError(null);
       setIsLoading(false);
+      setIsCached(false);
+      setLastFetchedAt(null);
       return;
+    }
+
+    const fallbackScheduleIds = fallbackScheduleKey
+      ? fallbackScheduleKey.split('\u0000')
+      : [];
+
+    const fallbackUsers = fallbackUserKey
+      ? fallbackUserKey.split('\u0000')
+      : [];
+
+    const cacheKey = `${userId}::${scheduleItemId}::${fallbackScheduleKey}::${fallbackUserKey}`;
+
+    // force refresh ではなく、キャッシュが有効期限内の場合はキャッシュを適用してAPI実行をスキップする
+    if (!options?.force) {
+      const cached = historyCache.get(cacheKey);
+      if (cached && Date.now() - cached.fetchedAt < CACHE_DURATION) {
+        setRecords(cached.records);
+        setError(null);
+        setIsLoading(false);
+        setIsCached(true);
+        setLastFetchedAt(cached.fetchedAt);
+        return;
+      }
     }
 
     setIsLoading(true);
     setError(null);
     try {
-      const fallbackScheduleIds = fallbackScheduleKey
-        ? fallbackScheduleKey.split('\u0000')
-        : [];
-
-      const fallbackUsers = fallbackUserKey
-        ? fallbackUserKey.split('\u0000')
-        : [];
-
       const userCandidates = buildExecutionUserIdCandidates(userId, ...fallbackUsers);
 
       const primaryId = normalizeScheduleItemId(scheduleItemId);
@@ -104,8 +132,8 @@ export function useHistoricalRecords(
       const to = new Date();
       const from = new Date();
       from.setDate(from.getDate() - 95);
-      const toStr = `${to.getFullYear()}-${String(to.getMonth() + 1).padStart(2, '0')}-${String(to.getDate()).padStart(2, '0')}`;
-      const fromStr = `${from.getFullYear()}-${String(from.getMonth() + 1).padStart(2, '0')}-${String(from.getDate()).padStart(2, '0')}`;
+      const toStr = toLocalDateISO(to);
+      const fromStr = toLocalDateISO(from);
       const scheduleSet = new Set(scheduleCandidates.map((id) => normalizeScheduleItemId(id)));
 
       const isScheduleMatch = (value: unknown): boolean => {
@@ -130,11 +158,27 @@ export function useHistoricalRecords(
         .slice(0, 150);
 
       if (requestSeq !== requestSeqRef.current) return;
+
+      const fetchedTime = Date.now();
+      // キャッシュを更新
+      historyCache.set(cacheKey, { records: history, fetchedAt: fetchedTime });
+
       setRecords(history);
+      setIsCached(false);
+      setLastFetchedAt(fetchedTime);
     } catch (err) {
       if (requestSeq !== requestSeqRef.current) return;
       console.error('[useHistoricalRecords] Failed to fetch history:', err);
       setError(err instanceof Error ? err : new Error('Failed to fetch history'));
+
+      // エラー発生時、期限切れキャッシュ（あるいは既存のキャッシュ）があれば
+      // それを records としてセットし、isCached を true にして lastFetchedAt をそのキャッシュの時刻にする。
+      const cached = historyCache.get(cacheKey);
+      if (cached) {
+        setRecords(cached.records);
+        setIsCached(true);
+        setLastFetchedAt(cached.fetchedAt);
+      }
     } finally {
       if (requestSeq === requestSeqRef.current) {
         setIsLoading(false);
@@ -146,5 +190,14 @@ export function useHistoricalRecords(
     void fetchHistory();
   }, [fetchHistory]);
 
-  return { records, isLoading, error, refresh: fetchHistory };
+  return {
+    records,
+    isLoading,
+    error,
+    refresh: useCallback((options?: { force?: boolean }) => fetchHistory(options), [fetchHistory]),
+    isCached,
+    lastFetchedAt,
+  };
 }
+
+export const _testCache = historyCache;

--- a/src/features/kiosk/components/KioskProcedureHistoryPanel.tsx
+++ b/src/features/kiosk/components/KioskProcedureHistoryPanel.tsx
@@ -23,6 +23,7 @@ import { formatDateShort } from '@/lib/dateFormat';
 import type { ExecutionRecord } from '@/features/daily/domain/legacy/executionRecordTypes';
 import { KioskDailyProcedureFlowPreview } from './KioskDailyProcedureFlowPreview';
 import { parseKioskProcedureMemo } from '../domain/kioskProcedureMemo';
+import { toLocalDateISO } from '@/utils/getNow';
 
 interface KioskProcedureHistoryPanelProps {
   userId: string;
@@ -47,7 +48,7 @@ export const KioskProcedureHistoryPanel: React.FC<KioskProcedureHistoryPanelProp
 }) => {
   const [viewMode, setViewMode] = useState<ViewMode>('daily');
   const [selectedFlowDate, setSelectedFlowDate] = useState<string | null>(null);
-  const { records, isLoading, error } = useHistoricalRecords(
+  const { records, isLoading, error, refresh, isCached, lastFetchedAt } = useHistoricalRecords(
     userId,
     scheduleItemId,
     fallbackScheduleItemIds,
@@ -71,15 +72,14 @@ export const KioskProcedureHistoryPanel: React.FC<KioskProcedureHistoryPanelProp
   const stats = useMemo(() => {
     if (!records.length) return null;
 
-    const getDaysAgo = (days: number) => {
-      const d = new Date();
-      d.setDate(d.getDate() - days);
-      return d;
-    };
-
     const filterByDays = (days: number) => {
-      const threshold = getDaysAgo(days);
-      return records.filter(r => new Date(r.date) >= threshold);
+      const targetDate = new Date();
+      targetDate.setDate(targetDate.getDate() - days);
+      const thresholdStr = toLocalDateISO(targetDate);
+      return records.filter(r => {
+        const recordDateStr = String(r.date ?? '').slice(0, 10);
+        return recordDateStr >= thresholdStr;
+      });
     };
 
     const calculateStats = (filteredRecords: ExecutionRecord[]) => {
@@ -117,10 +117,18 @@ export const KioskProcedureHistoryPanel: React.FC<KioskProcedureHistoryPanelProp
       );
     }
 
-    if (error) {
+    if (error && !records.length) {
       return (
         <Box sx={{ p: 4, textAlign: 'center' }}>
-          <Typography color="error">履歴の読み込みに失敗しました</Typography>
+          <Typography color="error" sx={{ mb: 2 }}>履歴の読み込みに失敗しました</Typography>
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={() => refresh({ force: true })}
+            sx={{ borderRadius: 2, fontWeight: 'bold' }}
+          >
+            再読み込み
+          </Button>
         </Box>
       );
     }
@@ -297,6 +305,39 @@ export const KioskProcedureHistoryPanel: React.FC<KioskProcedureHistoryPanelProp
           <ToggleButton value="3m">3ヶ月</ToggleButton>
         </ToggleButtonGroup>
       </Box>
+
+      {/* ステータスバナー (キャッシュ表示中、または取得エラー時のフォールバック表示) */}
+      {error && records.length > 0 && (
+        <Box sx={{ px: 2, py: 1, bgcolor: 'error.light', color: 'error.contrastText', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <Typography variant="caption" sx={{ fontWeight: 'bold' }}>
+            最新履歴の取得に失敗しました。前回取得分を表示しています。
+          </Typography>
+          <Button
+            size="small"
+            color="inherit"
+            onClick={() => refresh({ force: true })}
+            sx={{ py: 0, fontWeight: 'bold', textDecoration: 'underline' }}
+          >
+            再試行
+          </Button>
+        </Box>
+      )}
+
+      {!error && isCached && lastFetchedAt && (
+        <Box sx={{ px: 2, py: 0.75, bgcolor: 'action.hover', borderBottom: 1, borderColor: 'divider', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <Typography variant="caption" color="text.secondary">
+            前回取得分を表示中 ({new Date(lastFetchedAt).toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' })} 取得)
+          </Typography>
+          <Button
+            size="small"
+            color="primary"
+            onClick={() => refresh({ force: true })}
+            sx={{ py: 0, minWidth: 'auto', fontWeight: 'bold' }}
+          >
+            更新
+          </Button>
+        </Box>
+      )}
 
       {/* コンテンツエリア */}
       <Box sx={{ flexGrow: 1, overflowY: 'auto' }}>

--- a/src/features/kiosk/components/__tests__/KioskProcedureHistoryPanel.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureHistoryPanel.spec.tsx
@@ -38,7 +38,10 @@ describe('KioskProcedureHistoryPanel Integration', () => {
     mockUseHistoricalRecords.mockReturnValue({
       records: mockRecords,
       isLoading: false,
-      error: null
+      error: null,
+      refresh: vi.fn(),
+      isCached: false,
+      lastFetchedAt: null
     });
   });
 
@@ -71,5 +74,101 @@ describe('KioskProcedureHistoryPanel Integration', () => {
     fireEvent.click(screen.getByTestId('back-button'));
     expect(screen.queryByTestId('flow-preview')).toBeNull();
     expect(screen.getByText('5/11')).toBeInTheDocument();
+  });
+
+  it('renders cache warning status banner when isCached=true and lastFetchedAt is set', () => {
+    const mockRefresh = vi.fn();
+    mockUseHistoricalRecords.mockReturnValue({
+      records: mockRecords,
+      isLoading: false,
+      error: null,
+      refresh: mockRefresh,
+      isCached: true,
+      lastFetchedAt: new Date('2026-06-03T11:00:00Z').getTime(),
+    });
+
+    render(
+      <KioskProcedureHistoryPanel
+        userId="U001"
+        scheduleItemId="P001"
+        userName="田中 太郎"
+        procedureName="朝の作業"
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText(/前回取得分を表示中/)).toBeInTheDocument();
+
+    // 更新ボタンの動作検証
+    const updateButton = screen.getByRole('button', { name: '更新' });
+    expect(updateButton).toBeInTheDocument();
+    fireEvent.click(updateButton);
+    expect(mockRefresh).toHaveBeenCalledWith({ force: true });
+  });
+
+  it('renders only error message and reload button when fetch fails with no cache records', () => {
+    const mockRefresh = vi.fn();
+    mockUseHistoricalRecords.mockReturnValue({
+      records: [],
+      isLoading: false,
+      error: new Error('Network Error'),
+      refresh: mockRefresh,
+      isCached: false,
+      lastFetchedAt: null,
+    });
+
+    render(
+      <KioskProcedureHistoryPanel
+        userId="U001"
+        scheduleItemId="P001"
+        userName="田中 太郎"
+        procedureName="朝の作業"
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('履歴の読み込みに失敗しました')).toBeInTheDocument();
+
+    const reloadButton = screen.getByRole('button', { name: '再読み込み' });
+    expect(reloadButton).toBeInTheDocument();
+    fireEvent.click(reloadButton);
+    expect(mockRefresh).toHaveBeenCalledWith({ force: true });
+
+    // 「過去の記録はありません」などの文言が表示されていないことを確認
+    expect(screen.queryByText('過去の記録はありません')).toBeNull();
+  });
+
+  it('renders historical records and top error banner when fetch fails but stale cache is present', () => {
+    const mockRefresh = vi.fn();
+    mockUseHistoricalRecords.mockReturnValue({
+      records: mockRecords,
+      isLoading: false,
+      error: new Error('Network Error'),
+      refresh: mockRefresh,
+      isCached: true,
+      lastFetchedAt: new Date('2026-06-03T11:00:00Z').getTime(),
+    });
+
+    render(
+      <KioskProcedureHistoryPanel
+        userId="U001"
+        scheduleItemId="P001"
+        userName="田中 太郎"
+        procedureName="朝の作業"
+        onClose={vi.fn()}
+      />
+    );
+
+    // 履歴が表示されていること
+    expect(screen.getByText('5/11')).toBeInTheDocument();
+    expect(screen.getByText(/落ち着いていた/)).toBeInTheDocument();
+
+    // エラーバナーが表示されていること
+    expect(screen.getByText('最新履歴の取得に失敗しました。前回取得分を表示しています。')).toBeInTheDocument();
+
+    const retryButton = screen.getByRole('button', { name: '再試行' });
+    expect(retryButton).toBeInTheDocument();
+    fireEvent.click(retryButton);
+    expect(mockRefresh).toHaveBeenCalledWith({ force: true });
   });
 });


### PR DESCRIPTION
## Summary

* Add a 60-second in-memory cache to `useHistoricalRecords` to reduce repeated SharePoint history fetches during short drawer reopen cycles
* Add `refresh({ force: true })` so the history drawer can explicitly bypass cache and retry loading
* Keep stale cached history visible when refresh fails, while clearly showing that the latest fetch failed
* Add cached / stale / retry UI states to `KioskProcedureHistoryPanel`
* Replace timezone-sensitive date filtering with JST-safe `YYYY-MM-DD` string comparisons via `toLocalDateISO`
* Add regression coverage for cache reuse, force refresh, stale cache fallback, retry UI, and history load failure handling

## Scope

* Kiosk procedure history drawer only
* No offline write mode
* No background sync
* No changes to `useExecutionRecord.ts` save behavior
* No SharePoint schema changes
* No repository contract changes
* No kiosk procedure list changes
* No billing changes

## Verification

* `npx vitest run src/features/daily/hooks/__tests__/useHistoricalRecords.spec.ts src/features/kiosk/components/__tests__/KioskProcedureHistoryPanel.spec.tsx`

  * 14 tests passed
* `npm run typecheck`
* `npx eslint src/features/daily/hooks/useHistoricalRecords.ts src/features/kiosk/components/KioskProcedureHistoryPanel.tsx --max-warnings=0`
* `git diff --check`
