### PR TITLE
feat(kiosk): show daily absence state on procedure list

### DIFF
--- a/src/features/kiosk/components/KioskProcedureListScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureListScreen.tsx
@@ -692,7 +692,7 @@ export const KioskProcedureListScreen: React.FC = () => {
           <Typography variant="body2">
             {recordedCount > 0
               ? 'すでに登録済みの記録は維持されますが、未記録の手順は記録対象外となります。'
-              : 'この日の支援手順は未実施ではなく、欠席／記録対象外として扱います。'
+              : 'この日は未実施ではなく、欠席／記録対象外として扱います。'
             }
             {absenceState.reason && `（理由: ${absenceState.reason}）`}
           </Typography>

--- a/src/features/kiosk/components/KioskProcedureListScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureListScreen.tsx
@@ -29,6 +29,7 @@ import { useCurrentPlanningSheet } from '@/features/planning-sheet/hooks/useCurr
 import { resolveSupportStartDateDetailed } from '@/features/planning-sheet/monitoringSchedule';
 import { resolveProcedureUserQueryCandidates } from '../utils/resolveProcedureUserQuery';
 import { isAuthRequiredError } from '@/lib/errors';
+import { useKioskAttendance } from '../hooks/useKioskAttendance';
 
 const buildProcedureMatchKeys = (
   procedure: { id?: unknown; rowNo?: unknown },
@@ -265,6 +266,12 @@ export const KioskProcedureListScreen: React.FC = () => {
   const [isThrottleActive, setIsThrottleActive] = useState(() => isThrottleCircuitOpen());
   const [throttleRemaining, setThrottleRemaining] = useState(0);
   const [retryCount, setRetryCount] = useState(0);
+  const absenceState = useKioskAttendance(
+    queryUserId || undefined,
+    selectedDateIso || '',
+    executionUserIdCandidates,
+    retryCount
+  );
 
   // Monitor circuit breaker status and remaining cooldown seconds (read-only)
   useEffect(() => {
@@ -652,21 +659,48 @@ export const KioskProcedureListScreen: React.FC = () => {
         {/* 進捗サマリー */}
         <Box sx={{ minWidth: 200, textAlign: 'right' }}>
           <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-            実施状況: {recordedCount} / {totalCount}
+            {absenceState.isAbsent ? '実施状況: 欠席（記録対象外）' : `実施状況: ${recordedCount} / ${totalCount}`}
           </Typography>
-          <LinearProgress
-            variant="determinate"
-            value={progress}
-            sx={{ height: 12, borderRadius: 6, mb: 1, bgcolor: 'action.hover' }}
-          />
-          <Box sx={{ display: 'flex', gap: 1, justifyContent: 'flex-end' }}>
-            <Chip icon={<CheckCircleIcon />} label={`${doneCount} 完了`} color="success" size="small" variant={doneCount > 0 ? "filled" : "outlined"} sx={{ fontWeight: 'bold' }} />
-          </Box>
+          {!absenceState.isAbsent && (
+            <>
+              <LinearProgress
+                variant="determinate"
+                value={progress}
+                sx={{ height: 12, borderRadius: 6, mb: 1, bgcolor: 'action.hover' }}
+              />
+              <Box sx={{ display: 'flex', gap: 1, justifyContent: 'flex-end' }}>
+                <Chip icon={<CheckCircleIcon />} label={`${doneCount} 完了`} color="success" size="small" variant={doneCount > 0 ? "filled" : "outlined"} sx={{ fontWeight: 'bold' }} />
+              </Box>
+            </>
+          )}
         </Box>
       </Box>
 
+      {/* 欠席バナー */}
+      {absenceState.isAbsent && (
+        <Alert
+          severity="info"
+          sx={{ mb: 3, borderRadius: 2 }}
+          data-testid="kiosk-absence-banner"
+        >
+          <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+            {recordedCount > 0
+              ? '本日は欠席として処理されていますが、本日の実施記録が存在します'
+              : '本日は欠席として処理されています'
+            }
+          </Typography>
+          <Typography variant="body2">
+            {recordedCount > 0
+              ? 'すでに登録済みの記録は維持されますが、未記録の手順は記録対象外となります。'
+              : 'この日の支援手順は未実施ではなく、欠席／記録対象外として扱います。'
+            }
+            {absenceState.reason && `（理由: ${absenceState.reason}）`}
+          </Typography>
+        </Alert>
+      )}
+
       {/* サーキットブレーカー / エラー警告バナー */}
-      {(isThrottleActive || fetchFailed) && (
+      {(isThrottleActive || fetchFailed || absenceState.isError) && (
         <Alert
           severity={isThrottleActive ? "warning" : "error"}
           sx={{ mb: 3, borderRadius: 2 }}
@@ -698,6 +732,8 @@ export const KioskProcedureListScreen: React.FC = () => {
               <br />
               しばらくしてから再試行してください。
             </>
+          ) : absenceState.isError && !fetchFailed ? (
+            "出欠情報の取得に失敗しました。再試行ボタンを押してデータを読み込んでください。"
           ) : (
             "一時的な接続エラーが発生しました。再試行ボタンを押してデータを読み込んでください。"
           )}
@@ -709,13 +745,17 @@ export const KioskProcedureListScreen: React.FC = () => {
         {procedures.map((step, index) => {
           const recordedRecord = recordedRecordsByProcedure[index];
           const isRecorded = Boolean(recordedRecord);
-          const isLoadFailed = fetchFailed || isThrottleActive;
+          const isLoadFailed = fetchFailed || isThrottleActive || absenceState.isError;
 
-          let statusType: 'recorded' | 'unrecorded' | 'uncertain' | 'uncertain_local' = 'unrecorded';
-          if (isLoadFailed) {
-            statusType = isRecorded ? 'uncertain_local' : 'uncertain';
+          let statusType: 'recorded' | 'unrecorded' | 'uncertain' | 'uncertain_local' | 'absent' = 'unrecorded';
+          if (isRecorded) {
+            statusType = isLoadFailed ? 'uncertain_local' : 'recorded';
+          } else if (absenceState.isAbsent) {
+            statusType = 'absent';
+          } else if (isLoadFailed) {
+            statusType = 'uncertain';
           } else {
-            statusType = isRecorded ? 'recorded' : 'unrecorded';
+            statusType = 'unrecorded';
           }
 
           const borderLeftColor = (() => {
@@ -723,6 +763,7 @@ export const KioskProcedureListScreen: React.FC = () => {
               case 'recorded': return 'success.main';
               case 'uncertain_local': return 'warning.light';
               case 'uncertain': return 'text.disabled';
+              case 'absent': return 'text.disabled';
               case 'unrecorded':
               default: return 'divider';
             }
@@ -733,6 +774,7 @@ export const KioskProcedureListScreen: React.FC = () => {
               case 'recorded': return 'success.lighter';
               case 'uncertain_local': return 'warning.lighter';
               case 'uncertain': return 'action.hover';
+              case 'absent': return 'action.hover';
               case 'unrecorded':
               default: return 'background.paper';
             }
@@ -743,6 +785,7 @@ export const KioskProcedureListScreen: React.FC = () => {
               case 'recorded': return 0.8;
               case 'uncertain_local': return 0.9;
               case 'uncertain': return 0.7;
+              case 'absent': return 0.6;
               case 'unrecorded':
               default: return 1;
             }
@@ -754,6 +797,7 @@ export const KioskProcedureListScreen: React.FC = () => {
               case 'recorded': return 'success.dark';
               case 'uncertain_local': return 'warning.dark';
               case 'uncertain': return 'text.secondary';
+              case 'absent': return 'text.secondary';
               case 'unrecorded':
               default: return 'text.primary';
             }
@@ -868,6 +912,21 @@ export const KioskProcedureListScreen: React.FC = () => {
                                   borderStyle: 'dashed'
                                 }}
                                 data-testid={`kiosk-uncertain-chip-${index}`}
+                              />
+                            );
+                          case 'absent':
+                            return (
+                              <Chip
+                                label="欠席のため記録対象外"
+                                variant="outlined"
+                                color="default"
+                                sx={{
+                                  borderRadius: 2,
+                                  color: 'text.secondary',
+                                  borderColor: 'divider',
+                                  borderStyle: 'dashed'
+                                }}
+                                data-testid={`kiosk-absent-chip-${index}`}
                               />
                             );
                           case 'unrecorded':

--- a/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
@@ -28,6 +28,16 @@ vi.mock('react-router-dom', async () => {
   };
 });
 
+let mockKioskAttendance = {
+  isAbsent: false,
+  reason: undefined as string | undefined,
+  isLoading: false,
+  isError: false,
+};
+vi.mock('../../hooks/useKioskAttendance', () => ({
+  useKioskAttendance: () => mockKioskAttendance,
+}));
+
 const mockUseUser = vi.fn(() => ({ data: { FullName: '田中 太郎', ServiceStartDate: undefined as string | undefined } as unknown as Record<string, unknown>, status: 'success' }));
 const mockUseUsers = vi.fn(() => ({ data: [], status: 'success' as const }));
 vi.mock('@/features/users/useUsers', () => ({
@@ -123,6 +133,12 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
     mockUseCurrentPlanningSheet.mockReturnValue({ currentSheet: null, allCurrentSheets: [], isLoading: false, error: null });
     mockGetRecords.mockResolvedValue([]);
     mockGetRecord.mockResolvedValue(undefined);
+    mockKioskAttendance = {
+      isAbsent: false,
+      reason: undefined,
+      isLoading: false,
+      isError: false,
+    };
   });
 
   afterEach(() => {
@@ -1296,6 +1312,95 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
       await waitFor(() => {
         expect(screen.getByTestId('kiosk-uncertain-local-chip-0')).toBeInTheDocument();
         expect(screen.getByTestId('kiosk-uncertain-chip-1')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Daily absence read and display (PR1)', () => {
+    it('renders absence banner, "欠席のため記録対象外" chips, and hides progress bar when user is absent', async () => {
+      mockKioskAttendance = {
+        isAbsent: true,
+        reason: '体調不良のためお休みします',
+        isLoading: false,
+        isError: false,
+      };
+
+      render(
+        <MemoryRouter>
+          <KioskProcedureListScreen />
+        </MemoryRouter>
+      );
+
+      // Verify banner
+      await waitFor(() => {
+        expect(screen.getByTestId('kiosk-absence-banner')).toBeInTheDocument();
+        expect(screen.getByText('本日は欠席として処理されています')).toBeInTheDocument();
+        expect(screen.getByText(/体調不良のためお休みします/)).toBeInTheDocument();
+      });
+
+      // Verify unrecorded cards are absent
+      expect(screen.getByTestId('kiosk-absent-chip-0')).toBeInTheDocument();
+      expect(screen.getByTestId('kiosk-absent-chip-1')).toBeInTheDocument();
+      expect(screen.queryByText('未実施')).toBeNull();
+
+      // Verify progress summary
+      expect(screen.getByText('実施状況: 欠席（記録対象外）')).toBeInTheDocument();
+      expect(screen.queryByRole('progressbar')).toBeNull();
+    });
+
+    it('displays warning banner and keeps "recorded" status for existing executions when absent', async () => {
+      mockKioskAttendance = {
+        isAbsent: true,
+        reason: '当日欠席',
+        isLoading: false,
+        isError: false,
+      };
+      // Mock one completed record
+      mockGetRecords.mockResolvedValue([
+        { scheduleItemId: '1', status: 'completed' },
+      ]);
+
+      render(
+        <MemoryRouter>
+          <KioskProcedureListScreen />
+        </MemoryRouter>
+      );
+
+      // Verify banner warning
+      await waitFor(() => {
+        expect(screen.getByTestId('kiosk-absence-banner')).toBeInTheDocument();
+        expect(screen.getByText('本日は欠席として処理されていますが、本日の実施記録が存在します')).toBeInTheDocument();
+      });
+
+      // Verify first card is recorded, second card is absent
+      expect(screen.getByText('記録済み')).toBeInTheDocument();
+      expect(screen.getByTestId('kiosk-absent-chip-1')).toBeInTheDocument();
+      expect(screen.queryByText('未実施')).toBeNull();
+
+      // Verify progress summary still indicates absence
+      expect(screen.getByText('実施状況: 欠席（記録対象外）')).toBeInTheDocument();
+      expect(screen.queryByRole('progressbar')).toBeNull();
+    });
+
+    it('falls back to "出欠状態未確認" (uncertain) when attendance load fails', async () => {
+      mockKioskAttendance = {
+        isAbsent: false,
+        reason: undefined,
+        isLoading: false,
+        isError: true,
+      };
+
+      render(
+        <MemoryRouter>
+          <KioskProcedureListScreen />
+        </MemoryRouter>
+      );
+
+      // Verify that error is integrated and unrecorded cards show "状態未確認" (uncertain) instead of "未実施"
+      await waitFor(() => {
+        expect(screen.getByTestId('kiosk-uncertain-chip-0')).toBeInTheDocument();
+        expect(screen.getByTestId('kiosk-uncertain-chip-1')).toBeInTheDocument();
+        expect(screen.queryByText('未実施')).toBeNull();
       });
     });
   });

--- a/src/features/kiosk/hooks/useKioskAttendance.ts
+++ b/src/features/kiosk/hooks/useKioskAttendance.ts
@@ -1,0 +1,99 @@
+import { useState, useEffect } from 'react';
+import { useAttendanceRepository } from '@/features/attendance/repositoryFactory';
+
+export function normalizeAttendanceStatus(status: unknown): string {
+  if (!status) return '';
+  if (typeof status === 'string') return status.trim();
+  if (typeof status === 'object' && status !== null) {
+    const obj = status as Record<string, unknown>;
+    const val = obj.Value ?? obj.value ?? obj.label ?? obj.Title ?? obj.title;
+    if (typeof val === 'string') return val.trim();
+  }
+  return String(status).trim();
+}
+
+export function isAbsentStatus(normalizedStatus: string): boolean {
+  const s = normalizedStatus.toLowerCase();
+  return s === '当日欠席' || s === '欠席' || s === 'absent';
+}
+
+export type KioskAbsenceState = {
+  isAbsent: boolean;
+  reason?: string;
+  isLoading: boolean;
+  isError: boolean;
+};
+
+export function useKioskAttendance(
+  userId: string | undefined,
+  selectedDateIso: string,
+  userCandidates: string[],
+  refreshTrigger?: number
+): KioskAbsenceState {
+  const [state, setState] = useState<KioskAbsenceState>({
+    isAbsent: false,
+    isLoading: true,
+    isError: false,
+  });
+
+  const repository = useAttendanceRepository();
+
+  useEffect(() => {
+    if (!userId || !selectedDateIso || userCandidates.length === 0) {
+      setState({ isAbsent: false, isLoading: false, isError: false });
+      return;
+    }
+
+    let active = true;
+    setState((prev) => ({ ...prev, isLoading: true, isError: false }));
+
+    const fetchAttendance = async () => {
+      try {
+        const dailyItems = await repository.getDailyByDate({ recordDate: selectedDateIso });
+        if (!active) return;
+
+        // 候補ユーザーID群のいずれかに合致するレコードを検索
+        const candidatesUpper = userCandidates.map((c) => c.trim().toUpperCase());
+        const userDailyRecord = dailyItems.find((item) => {
+          const itemUserUpper = String(item.UserCode ?? '').trim().toUpperCase();
+          return candidatesUpper.includes(itemUserUpper);
+        });
+
+        if (userDailyRecord) {
+          const normalized = normalizeAttendanceStatus(userDailyRecord.Status);
+          const isAbsent = isAbsentStatus(normalized);
+          setState({
+            isAbsent,
+            reason: userDailyRecord.AbsentReason || userDailyRecord.EveningNote || undefined,
+            isLoading: false,
+            isError: false,
+          });
+        } else {
+          // レコードが存在しない場合は「欠席していない（未）」として扱う
+          setState({
+            isAbsent: false,
+            isLoading: false,
+            isError: false,
+          });
+        }
+      } catch (error) {
+        console.error('[useKioskAttendance] Failed to fetch daily attendance:', error);
+        if (active) {
+          setState({
+            isAbsent: false,
+            isLoading: false,
+            isError: true,
+          });
+        }
+      }
+    };
+
+    void fetchAttendance();
+
+    return () => {
+      active = false;
+    };
+  }, [userId, selectedDateIso, userCandidates, repository, refreshTrigger]);
+
+  return state;
+}

--- a/tests/e2e/kiosk-procedure-detail.spec.ts
+++ b/tests/e2e/kiosk-procedure-detail.spec.ts
@@ -5,8 +5,8 @@ import { toLocalDateISO } from '../../src/utils/getNow';
 
 test.describe('Kiosk Procedure Detail', () => {
   test.beforeEach(async ({ page }) => {
-    // 直接 ID: 1 の利用者の最初の手順詳細に遷移する
-    await bootKiosk(page, { route: '/kiosk/users/1/procedures/0', userId: '1' });
+    // 直接 ID: 3 の利用者の最初の手順詳細に遷移する
+    await bootKiosk(page, { route: '/kiosk/users/3/procedures/0', userId: '3' });
     
     // 詳細画面が表示されるのを待つ
     await expect(page.getByText('本人のすること')).toBeVisible({ timeout: 10000 });
@@ -14,7 +14,7 @@ test.describe('Kiosk Procedure Detail', () => {
 
   test('should display procedure details and navigate back', async ({ page }) => {
     // 利用者名が表示されているか
-    await expect(page.locator('h1')).toContainText('桂川 進太朗');
+    await expect(page.locator('h1')).toContainText('塩田 裕貴');
     
     // 本人と支援者のセクションがあるか
     await expect(page.getByText('本人のすること')).toBeVisible();
@@ -40,7 +40,7 @@ test.describe('Kiosk Procedure Detail', () => {
 
     // 成功メッセージが表示されるのを待つ（タイムアウトに注意）
     await expect(page.getByText('記録を保存しました')).toBeVisible({ timeout: 5000 });
-    await expect(page).toHaveURL(/.*\/kiosk\/users\/1\/procedures\/?(\?.*)?/);
+    await expect(page).toHaveURL(/.*\/kiosk\/users\/3\/procedures\/?(\?.*)?/);
 
     const firstCard = page.locator('[data-testid="kiosk-procedure-card-0"]');
     await expect(firstCard.getByText('記録済み')).toBeVisible();
@@ -48,15 +48,15 @@ test.describe('Kiosk Procedure Detail', () => {
   });
 
   test('should propagate date URL parameter to detail and back on save', async ({ page }) => {
-    await bootKiosk(page, { route: '/kiosk/users/1/procedures/0?date=2026-05-07', userId: '1' });
+    await bootKiosk(page, { route: '/kiosk/users/3/procedures/0?date=2026-05-07', userId: '3' });
     await expect(page.getByText('本人のすること')).toBeVisible({ timeout: 10000 });
-    await expect(page).toHaveURL(/\/kiosk\/users\/1\/procedures\/0\?date=2026-05-07/);
+    await expect(page).toHaveURL(/\/kiosk\/users\/3\/procedures\/0\?date=2026-05-07/);
 
     await page.getByTestId('kiosk-observation-memo').fill('E2E過去日保存確認');
     await page.getByTestId('kiosk-observation-submit').click();
 
     await expect(page.getByText('記録を保存しました')).toBeVisible({ timeout: 5000 });
-    await expect(page).toHaveURL(/\/kiosk\/users\/1\/procedures\?date=2026-05-07/);
+    await expect(page).toHaveURL(/\/kiosk\/users\/3\/procedures\?date=2026-05-07/);
     await expect(page.getByText('2026年5月7日 の支援手順')).toBeVisible({ timeout: 10000 });
   });
 


### PR DESCRIPTION
## 概要
本日欠席ステータスの読み取り・表示機能（PR1）の実装。

## PR1 の詳細
- PR1 は読み取り・表示のみ
- AttendanceDaily / SupportRecord_Daily を SSOT として利用
- Status='当日欠席' 等の欠席表記揺れを normalizeAttendanceStatus で吸収
- 欠席時も既存 ExecutionRecord は recorded 表示を優先
- 未記録カードのみ「欠席のため記録対象外」と表示
- Attendance 読み込み失敗時は「出欠状態未確認」に倒し、未実施とは断定しない
- 書き込み、欠席解除、競合ガードは後続PRへ分離