### PR TITLE
feat(kiosk): add daily absence registration UI

### DIFF
--- a/src/features/kiosk/components/KioskUserSelectScreen.tsx
+++ b/src/features/kiosk/components/KioskUserSelectScreen.tsx
@@ -1,16 +1,171 @@
-import React from 'react';
-import { Box, Typography, Grid, Card, CardActionArea, CardContent, IconButton, CircularProgress, Chip, Alert, Button } from '@mui/material';
+import React, { useState, useEffect } from 'react';
+import { Box, Typography, Grid, Card, CardActionArea, CardContent, IconButton, CircularProgress, Chip, Alert, Button, Menu, MenuItem, Dialog, DialogTitle, DialogContent, DialogActions, FormControl, InputLabel, Select, TextField, Snackbar } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import RefreshIcon from '@mui/icons-material/Refresh';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
 import { useLocation, Link as RouterLink } from 'react-router-dom';
 import { appendKioskSearchParams } from '../utils/navigation';
 import { useUsersQuery } from '@/features/users/hooks/useUsersQuery';
+import type { IUserMaster } from '@/features/users/types';
+import { useAttendanceRepository } from '@/features/attendance/repositoryFactory';
+import { useExecutionData } from '@/features/daily/hooks/useExecutionData';
+import { resolveKioskRecordDate } from '../utils/kioskDate';
+import { normalizeAttendanceStatus, isAbsentStatus } from '../hooks/useKioskAttendance';
+import type { AttendanceDailyItem } from '@/features/attendance/infra/Legacy/attendanceDailyRepository';
 
 export const KioskUserSelectScreen: React.FC = () => {
   const location = useLocation();
-  const { data: users, status, refresh } = useUsersQuery({ selectMode: 'core' });
-  const isLoading = status === 'loading';
+  const { data: users, status, refresh: refreshUsers } = useUsersQuery({ selectMode: 'core' });
+  const isLoadingUsers = status === 'loading';
   const hasLoadError = status === 'error';
+
+  const attendanceRepo = useAttendanceRepository();
+  const executionRepo = useExecutionData();
+  const selectedDateIso = React.useMemo(() => resolveKioskRecordDate(location.search), [location.search]);
+
+  const [dailyItems, setDailyItems] = useState<AttendanceDailyItem[]>([]);
+  const [isDailyLoading, setIsDailyLoading] = useState(true);
+  const [refreshTrigger, setRefreshTrigger] = useState(0);
+
+  // オプションメニュー用
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const [menuUser, setMenuUser] = useState<IUserMaster | null>(null);
+
+  // 欠席ダイアログ用
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [dialogUser, setDialogUser] = useState<IUserMaster | null>(null);
+  const [absentReason, setAbsentReason] = useState('体調不良');
+  const [absentMemo, setAbsentMemo] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [hasExistingRecords, setHasExistingRecords] = useState<boolean | null>(null);
+  const [checkingRecords, setCheckingRecords] = useState(false);
+
+  // スナックバー用
+  const [isSnackbarOpen, setIsSnackbarOpen] = useState(false);
+  const [snackbarMessage, setSnackbarMessage] = useState('');
+
+  const isLoading = isLoadingUsers || isDailyLoading;
+
+  useEffect(() => {
+    let active = true;
+    setIsDailyLoading(true);
+    const fetchAttendance = async () => {
+      try {
+        const items = await attendanceRepo.getDailyByDate({ recordDate: selectedDateIso });
+        if (active) {
+          setDailyItems(items || []);
+          setIsDailyLoading(false);
+        }
+      } catch (err) {
+        console.error('[KioskUserSelectScreen] Failed to fetch daily attendance:', err);
+        if (active) {
+          setIsDailyLoading(false);
+        }
+      }
+    };
+    void fetchAttendance();
+    return () => {
+      active = false;
+    };
+  }, [selectedDateIso, refreshTrigger]);
+
+  const handleOpenMenu = (event: React.MouseEvent<HTMLButtonElement>, user: IUserMaster) => {
+    event.stopPropagation();
+    event.preventDefault();
+    setAnchorEl(event.currentTarget);
+    setMenuUser(user);
+  };
+
+  const handleCloseMenu = () => {
+    setAnchorEl(null);
+    setMenuUser(null);
+  };
+
+  const handleOpenDialog = async () => {
+    if (!menuUser) return;
+    const targetUser = menuUser;
+    handleCloseMenu();
+    setDialogUser(targetUser);
+    setAbsentReason('体調不良');
+    setAbsentMemo('');
+    setSaveError(null);
+    setIsDialogOpen(true);
+    setCheckingRecords(true);
+
+    try {
+      const userCode = targetUser.UserID || String(targetUser.Id);
+      const records = await executionRepo.getRecords(selectedDateIso, userCode);
+      setHasExistingRecords(records.length > 0);
+    } catch (err) {
+      console.error('[KioskUserSelectScreen] Failed to check existing records:', err);
+      setHasExistingRecords(false);
+    } finally {
+      setCheckingRecords(false);
+    }
+  };
+
+  const handleSaveAbsence = async () => {
+    if (!dialogUser || isSaving) return;
+    setIsSaving(true);
+    setSaveError(null);
+
+    const userCode = dialogUser.UserID || String(dialogUser.Id);
+    const key = `${userCode}|${selectedDateIso}`;
+
+    const dailyItem: AttendanceDailyItem = {
+      Key: key,
+      UserCode: userCode,
+      RecordDate: selectedDateIso,
+      Status: '当日欠席',
+      AbsentReason: absentReason,
+      AbsentSupportContent: absentMemo || undefined,
+      CntAttendIn: 0,
+      CntAttendOut: 0,
+      TransportTo: false,
+      TransportFrom: false,
+      ProvidedMinutes: 0,
+      IsEarlyLeave: false,
+      IsAbsenceAddonClaimable: false,
+      CheckInAt: null,
+      CheckOutAt: null,
+      UserConfirmedAt: null,
+    };
+
+    try {
+      await attendanceRepo.upsertDailyByKey(dailyItem);
+      setSnackbarMessage(`${dialogUser.FullName}様を本日欠席として処理しました`);
+      setIsSnackbarOpen(true);
+      setIsDialogOpen(false);
+      setRefreshTrigger((prev) => prev + 1);
+    } catch (err) {
+      console.error('[KioskUserSelectScreen] Failed to save daily absence:', err);
+      setSaveError('欠席処理の保存に失敗しました。しばらくしてから再試行してください。');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const getAbsenceState = (user: IUserMaster) => {
+    const userCode = String(user.UserID || '').trim().toUpperCase();
+    const fallbackId = String(user.Id || '').trim().toUpperCase();
+
+    const record = dailyItems.find((item) => {
+      const itemUserUpper = String(item.UserCode ?? '').trim().toUpperCase();
+      return itemUserUpper === userCode || itemUserUpper === fallbackId;
+    });
+
+    if (record) {
+      const normalized = normalizeAttendanceStatus(record.Status);
+      return isAbsentStatus(normalized);
+    }
+    return false;
+  };
+
+  const refreshAll = () => {
+    void refreshUsers();
+    setRefreshTrigger((prev) => prev + 1);
+  };
 
   // キオスクモードでは「支援手順対象」または「強度行動障害支援対象」の利用者を表示。
   // IsActive が明示的に false の場合は除外する。
@@ -43,7 +198,7 @@ export const KioskUserSelectScreen: React.FC = () => {
         <Alert
           severity="error"
           action={
-            <Button color="inherit" size="small" startIcon={<RefreshIcon />} onClick={() => void refresh()}>
+            <Button color="inherit" size="small" startIcon={<RefreshIcon />} onClick={refreshAll}>
               再読み込み
             </Button>
           }
@@ -58,59 +213,94 @@ export const KioskUserSelectScreen: React.FC = () => {
         </Alert>
       ) : (
         <Grid container spacing={2}>
-          {activeUsers.map((user) => (
-            <Grid key={user.Id} size={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
-              <Card 
-                sx={{ 
-                  height: '100%',
-                  borderRadius: 3,
-                  boxShadow: '0 4px 12px rgba(0,0,0,0.08)',
-                  '&:active': { transform: 'scale(0.98)' },
-                  transition: 'transform 0.1s'
-                }}
-                data-testid={`kiosk-user-card-${user.Id}`}
-              >
-                <CardActionArea 
-                  component={RouterLink}
-                  to={appendKioskSearchParams(`/kiosk/users/${user.Id}/procedures`, location.search)}
-                  sx={{ height: '100%', p: { xs: 2, md: 3 } }}
+          {activeUsers.map((user) => {
+            const isAbsent = getAbsenceState(user);
+            return (
+              <Grid key={user.Id} size={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
+                <Card
+                  sx={{
+                    height: '100%',
+                    borderRadius: 3,
+                    boxShadow: '0 4px 12px rgba(0,0,0,0.08)',
+                    '&:active': { transform: 'scale(0.98)' },
+                    transition: 'transform 0.1s',
+                    opacity: isAbsent ? 0.6 : 1,
+                    position: 'relative'
+                  }}
+                  data-testid={`kiosk-user-card-${user.Id}`}
                 >
-                  <CardContent sx={{ textAlign: 'center', p: 0 }}>
-                    <Typography 
-                      variant="body2" 
-                      color="text.secondary" 
-                      sx={{ mb: 0.5, letterSpacing: '0.05em' }}
-                    >
-                      {user.Furigana || '　'}
-                    </Typography>
-                    <Typography variant="h5" sx={{ fontWeight: 'bold', mb: 1 }}>
-                      {user.FullName}
-                    </Typography>
-                    <Box sx={{ display: 'flex', justifyContent: 'center', gap: 1, mt: 1, flexWrap: 'wrap' }}>
-                      {user.IsHighIntensitySupportTarget && (
-                        <Chip 
-                          label="強度行動障害支援対象" 
-                          size="small" 
-                          color="error" 
-                          variant="outlined"
-                          sx={{ fontWeight: 'bold', borderRadius: 1, fontSize: '0.75rem' }}
-                        />
-                      )}
-                      {user.IsSupportProcedureTarget && !user.IsHighIntensitySupportTarget && (
-                        <Chip 
-                          label="支援手順対象" 
-                          size="small" 
-                          color="primary" 
-                          variant="outlined"
-                          sx={{ fontWeight: 'bold', borderRadius: 1, fontSize: '0.75rem' }}
-                        />
-                      )}
-                    </Box>
-                  </CardContent>
-                </CardActionArea>
-              </Card>
-            </Grid>
-          ))}
+                  <IconButton
+                    onClick={(e) => handleOpenMenu(e, user)}
+                    sx={{
+                      position: 'absolute',
+                      top: 8,
+                      right: 8,
+                      zIndex: 2,
+                      color: 'text.secondary',
+                      bgcolor: 'background.paper',
+                      boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
+                      '&:hover': { bgcolor: 'action.hover' },
+                    }}
+                    data-testid={`kiosk-user-menu-trigger-${user.Id}`}
+                  >
+                    <MoreVertIcon fontSize="small" />
+                  </IconButton>
+                  <CardActionArea
+                    component={RouterLink}
+                    to={appendKioskSearchParams(`/kiosk/users/${user.Id}/procedures`, location.search)}
+                    sx={{ height: '100%', p: { xs: 2, md: 3 } }}
+                  >
+                    <CardContent sx={{ textAlign: 'center', p: 0 }}>
+                      <Typography
+                        variant="body2"
+                        color="text.secondary"
+                        sx={{ mb: 0.5, letterSpacing: '0.05em' }}
+                      >
+                        {user.Furigana || '　'}
+                      </Typography>
+                      <Typography variant="h5" sx={{ fontWeight: 'bold', mb: 1 }}>
+                        {user.FullName}
+                      </Typography>
+                      <Box sx={{ display: 'flex', justifyContent: 'center', gap: 1, mt: 1, flexWrap: 'wrap' }}>
+                        {isAbsent && (
+                          <Chip
+                            label="本日欠席"
+                            size="small"
+                            sx={{
+                              fontWeight: 'bold',
+                              borderRadius: 1,
+                              fontSize: '0.75rem',
+                              bgcolor: 'grey.400',
+                              color: 'common.white'
+                            }}
+                            data-testid={`kiosk-user-absent-chip-${user.Id}`}
+                          />
+                        )}
+                        {user.IsHighIntensitySupportTarget && (
+                          <Chip
+                            label="強度行動障害支援対象"
+                            size="small"
+                            color="error"
+                            variant="outlined"
+                            sx={{ fontWeight: 'bold', borderRadius: 1, fontSize: '0.75rem' }}
+                          />
+                        )}
+                        {user.IsSupportProcedureTarget && !user.IsHighIntensitySupportTarget && (
+                          <Chip
+                            label="支援手順対象"
+                            size="small"
+                            color="primary"
+                            variant="outlined"
+                            sx={{ fontWeight: 'bold', borderRadius: 1, fontSize: '0.75rem' }}
+                          />
+                        )}
+                      </Box>
+                    </CardContent>
+                  </CardActionArea>
+                </Card>
+              </Grid>
+            );
+          })}
           {activeUsers.length === 0 && (
             <Grid size={12}>
               <Box sx={{ p: 6, textAlign: 'center', bgcolor: 'action.hover', borderRadius: 4 }}>
@@ -122,6 +312,106 @@ export const KioskUserSelectScreen: React.FC = () => {
           )}
         </Grid>
       )}
+
+      {/* オプションメニュー */}
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleCloseMenu}
+        data-testid="kiosk-user-option-menu"
+      >
+        <MenuItem onClick={handleOpenDialog} data-testid="kiosk-user-menu-absent">
+          本日欠席として処理
+        </MenuItem>
+      </Menu>
+
+      {/* 欠席登録ダイアログ */}
+      <Dialog
+        open={isDialogOpen}
+        onClose={() => !isSaving && setIsDialogOpen(false)}
+        maxWidth="xs"
+        fullWidth
+        data-testid="kiosk-absent-dialog"
+      >
+        <DialogTitle sx={{ fontWeight: 'bold' }}>
+          本日欠席として処理 ({dialogUser?.FullName} 様)
+        </DialogTitle>
+        <DialogContent dividers>
+          {checkingRecords ? (
+            <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
+              <CircularProgress size={24} />
+            </Box>
+          ) : hasExistingRecords ? (
+            <Alert severity="warning" sx={{ mb: 2 }} data-testid="kiosk-absent-dialog-error">
+              本日の実施記録が既にあります。欠席処理は後続対応で扱うため、この画面では保存できません。
+            </Alert>
+          ) : null}
+
+          {saveError && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              {saveError}
+            </Alert>
+          )}
+
+          <FormControl fullWidth sx={{ mb: 2, mt: 1 }}>
+            <InputLabel id="absent-reason-label">欠席理由</InputLabel>
+            <Select
+              labelId="absent-reason-label"
+              value={absentReason}
+              label="欠席理由"
+              onChange={(e) => setAbsentReason(e.target.value)}
+              disabled={isSaving || hasExistingRecords === true}
+              inputProps={{ 'data-testid': 'kiosk-absent-dialog-reason' }}
+            >
+              <MenuItem value="体調不良">体調不良</MenuItem>
+              <MenuItem value="家庭都合">家庭都合</MenuItem>
+              <MenuItem value="予定欠席">予定欠席</MenuItem>
+              <MenuItem value="連絡なし">連絡なし</MenuItem>
+              <MenuItem value="その他">その他</MenuItem>
+            </Select>
+          </FormControl>
+
+          <TextField
+            fullWidth
+            label="補足メモ"
+            multiline
+            rows={3}
+            value={absentMemo}
+            onChange={(e) => setAbsentMemo(e.target.value)}
+            disabled={isSaving || hasExistingRecords === true}
+            placeholder="連絡手段や詳細などを入力（任意）"
+            inputProps={{ 'data-testid': 'kiosk-absent-dialog-memo' }}
+          />
+        </DialogContent>
+        <DialogActions sx={{ p: 2, gap: 1 }}>
+          <Button
+            onClick={() => setIsDialogOpen(false)}
+            disabled={isSaving}
+            variant="outlined"
+            color="inherit"
+          >
+            キャンセル
+          </Button>
+          <Button
+            onClick={handleSaveAbsence}
+            color="primary"
+            variant="contained"
+            disabled={isSaving || checkingRecords || hasExistingRecords === true}
+            data-testid="kiosk-absent-dialog-submit"
+          >
+            {isSaving ? <CircularProgress size={20} color="inherit" /> : '欠席として処理する'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* スナックバー */}
+      <Snackbar
+        open={isSnackbarOpen}
+        autoHideDuration={4000}
+        onClose={() => setIsSnackbarOpen(false)}
+        message={snackbarMessage}
+        data-testid="kiosk-absent-snackbar"
+      />
     </Box>
   );
 };

--- a/src/features/kiosk/components/__tests__/KioskUserSelectScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskUserSelectScreen.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import type { IUserMaster } from '@/features/users/types';
@@ -14,6 +14,22 @@ vi.mock('@/features/users/hooks/useUsersQuery', () => ({
   useUsersQuery: mockUseUsersQuery,
 }));
 
+const mockGetDailyByDate = vi.fn();
+const mockUpsertDailyByKey = vi.fn();
+vi.mock('@/features/attendance/repositoryFactory', () => ({
+  useAttendanceRepository: () => ({
+    getDailyByDate: mockGetDailyByDate,
+    upsertDailyByKey: mockUpsertDailyByKey,
+  }),
+}));
+
+const mockGetRecords = vi.fn();
+vi.mock('@/features/daily/hooks/useExecutionData', () => ({
+  useExecutionData: () => ({
+    getRecords: mockGetRecords,
+  }),
+}));
+
 const renderScreen = () =>
   render(
     <MemoryRouter initialEntries={['/kiosk/users']}>
@@ -25,18 +41,22 @@ describe('KioskUserSelectScreen', () => {
   beforeEach(() => {
     mockRefresh.mockReset();
     mockUseUsersQuery.mockReset();
+    mockGetDailyByDate.mockReset();
+    mockUpsertDailyByKey.mockReset();
+    mockGetRecords.mockReset();
   });
 
-  it('shows a load failure instead of the empty target-user state when users cannot be loaded', () => {
+  it('shows a load failure instead of the empty target-user state when users cannot be loaded', async () => {
     mockUseUsersQuery.mockReturnValue({
       data: [],
       status: 'error',
       refresh: mockRefresh,
     });
+    mockGetDailyByDate.mockResolvedValue([]);
 
     renderScreen();
 
-    expect(screen.getByText('利用者の読み込みに失敗しました')).toBeInTheDocument();
+    expect(await screen.findByText('利用者の読み込みに失敗しました')).toBeInTheDocument();
     expect(screen.getByText(/対象者なしではありません/)).toBeInTheDocument();
     expect(screen.queryByText('対象の利用者がいません')).not.toBeInTheDocument();
 
@@ -44,7 +64,7 @@ describe('KioskUserSelectScreen', () => {
     expect(mockRefresh).toHaveBeenCalledTimes(1);
   });
 
-  it('keeps the empty target-user state for a successful load with no target users', () => {
+  it('keeps the empty target-user state for a successful load with no target users', async () => {
     mockUseUsersQuery.mockReturnValue({
       data: [
         {
@@ -59,10 +79,127 @@ describe('KioskUserSelectScreen', () => {
       status: 'success',
       refresh: mockRefresh,
     });
+    mockGetDailyByDate.mockResolvedValue([]);
 
     renderScreen();
 
-    expect(screen.getByText('対象の利用者がいません')).toBeInTheDocument();
+    expect(await screen.findByText('対象の利用者がいません')).toBeInTheDocument();
     expect(screen.queryByText('利用者の読み込みに失敗しました')).not.toBeInTheDocument();
+  });
+
+  it('shows a [本日欠席] chip and sets opacity on absent user card', async () => {
+    mockUseUsersQuery.mockReturnValue({
+      data: [
+        {
+          Id: 1,
+          UserID: 'user-1',
+          FullName: '欠席 太郎',
+          IsActive: true,
+          IsSupportProcedureTarget: true,
+          IsHighIntensitySupportTarget: false,
+        } as unknown as IUserMaster,
+      ],
+      status: 'success',
+      refresh: mockRefresh,
+    });
+
+    mockGetDailyByDate.mockResolvedValue([
+      {
+        Key: 'user-1|2026-06-03',
+        UserCode: 'user-1',
+        RecordDate: '2026-06-03',
+        Status: '当日欠席',
+      },
+    ]);
+
+    renderScreen();
+
+    const chip = await screen.findByTestId('kiosk-user-absent-chip-1');
+    expect(chip).toBeInTheDocument();
+    expect(chip).toHaveTextContent('本日欠席');
+
+    const card = screen.getByTestId('kiosk-user-card-1');
+    expect(card).toHaveStyle('opacity: 0.6');
+  });
+
+  it('opens dialog, allows selecting reason, typing memo and saves absence', async () => {
+    mockUseUsersQuery.mockReturnValue({
+      data: [
+        {
+          Id: 2,
+          UserID: 'user-2',
+          FullName: '出席 花子',
+          IsActive: true,
+          IsSupportProcedureTarget: true,
+          IsHighIntensitySupportTarget: false,
+        } as unknown as IUserMaster,
+      ],
+      status: 'success',
+      refresh: mockRefresh,
+    });
+
+    mockGetDailyByDate.mockResolvedValue([]);
+    mockGetRecords.mockResolvedValue([]); // 既存実績なし
+
+    renderScreen();
+
+    const trigger = await screen.findByTestId('kiosk-user-menu-trigger-2');
+    fireEvent.click(trigger);
+
+    const menuItem = await screen.findByTestId('kiosk-user-menu-absent');
+    fireEvent.click(menuItem);
+
+    const dialogTitle = await screen.findByText(/本日欠席として処理/);
+    expect(dialogTitle).toBeInTheDocument();
+
+    const memoInput = screen.getByPlaceholderText(/連絡手段や詳細など/);
+    fireEvent.change(memoInput, { target: { value: '家庭都合で休みです' } });
+
+    const submitBtn = screen.getByTestId('kiosk-absent-dialog-submit');
+    fireEvent.click(submitBtn);
+
+    await waitFor(() => {
+      expect(mockUpsertDailyByKey).toHaveBeenCalledWith(expect.objectContaining({
+        UserCode: 'user-2',
+        Status: '当日欠席',
+        AbsentReason: '体調不良',
+        AbsentSupportContent: '家庭都合で休みです',
+      }));
+    });
+  });
+
+  it('blocks saving absence if there are existing records', async () => {
+    mockUseUsersQuery.mockReturnValue({
+      data: [
+        {
+          Id: 3,
+          UserID: 'user-3',
+          FullName: '実績あり 次郎',
+          IsActive: true,
+          IsSupportProcedureTarget: true,
+          IsHighIntensitySupportTarget: false,
+        } as unknown as IUserMaster,
+      ],
+      status: 'success',
+      refresh: mockRefresh,
+    });
+
+    mockGetDailyByDate.mockResolvedValue([]);
+    mockGetRecords.mockResolvedValue([{ id: 'rec-1', status: 'completed' }]); // 既存実績あり
+
+    renderScreen();
+
+    const trigger = await screen.findByTestId('kiosk-user-menu-trigger-3');
+    fireEvent.click(trigger);
+
+    const menuItem = await screen.findByTestId('kiosk-user-menu-absent');
+    fireEvent.click(menuItem);
+
+    const errorAlert = await screen.findByTestId('kiosk-absent-dialog-error');
+    expect(errorAlert).toBeInTheDocument();
+    expect(errorAlert).toHaveTextContent(/本日の実施記録が既にあります/);
+
+    const submitBtn = screen.getByTestId('kiosk-absent-dialog-submit');
+    expect(submitBtn).toBeDisabled();
   });
 });

--- a/src/features/kiosk/hooks/useKioskAttendance.ts
+++ b/src/features/kiosk/hooks/useKioskAttendance.ts
@@ -62,9 +62,13 @@ export function useKioskAttendance(
         if (userDailyRecord) {
           const normalized = normalizeAttendanceStatus(userDailyRecord.Status);
           const isAbsent = isAbsentStatus(normalized);
+          const reasonParts = [
+            userDailyRecord.AbsentReason,
+            userDailyRecord.AbsentSupportContent || userDailyRecord.EveningNote
+          ].filter(Boolean);
           setState({
             isAbsent,
-            reason: userDailyRecord.AbsentReason || userDailyRecord.EveningNote || undefined,
+            reason: reasonParts.length > 0 ? reasonParts.join(' - ') : undefined,
             isLoading: false,
             isError: false,
           });


### PR DESCRIPTION
## 概要
本日欠席処理の書き込みUI（PR2）の実装。

## 変更内容
- 利用者選択画面 (`KioskUserSelectScreen.tsx`) で、当日欠席の利用者に「本日欠席」Chipを表示し、カード全体の不透明度を `0.6` に調整（クリックは引き続き可能）。
- カード内に縦三点リーダーメニュー（︙）を配置し、「本日欠席として処理」ダイアログを開く機能を追加。
- ダイアログ内で「欠席理由」と「補足メモ（`AbsentSupportContent`）」を入力して `upsertDailyByKey` で `Status='当日欠席'` レコードを保存。
- 保存成功後にデータを再取得し、画面へ即座に反映。
- 当日の手順実施記録が既に存在する場合、欠席登録をブロックするエラー警告ガードを追加。
- `KioskUserSelectScreen.spec.tsx` で欠席登録の正常系および実施記録存在時のブロック仕様を網羅するテストを追加。
- `useKioskAttendance.ts` にて `AbsentSupportContent` も欠席理由／メモの取得元として参照するよう調整。