### PR TITLE
feat(kiosk): add absence release and conflict guards

### DIFF
--- a/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
@@ -20,6 +20,7 @@ import {
   serializeKioskProcedureMemo,
 } from '../domain/kioskProcedureMemo';
 import { resolveProcedureUserQueryCandidates } from '../utils/resolveProcedureUserQuery';
+import { useKioskAttendance } from '../hooks/useKioskAttendance';
 
 const MOOD_CHIPS = ['落ち着いていた', '不安そう', '拒否あり', '興奮あり', '切り替え困難'];
 const ACTION_CHIPS = ['見守り', '声かけ', '環境調整', '活動変更', '距離を取る', 'クールダウン'];
@@ -148,6 +149,12 @@ export const KioskProcedureDetailScreen: React.FC = () => {
     fallbackUserIds,
   );
   
+  const { isAbsent } = useKioskAttendance(
+    resolvedUserId,
+    selectedDateIso,
+    historyUserIds
+  );
+
   const [isSaving, setIsSaving] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -306,7 +313,7 @@ export const KioskProcedureDetailScreen: React.FC = () => {
                 },
               })
             }
-            disabled={!abcSlotId}
+            disabled={!abcSlotId || isAbsent}
             sx={{ fontWeight: 'bold', borderRadius: 3 }}
             data-testid="kiosk-procedure-detail-abc-record"
           >
@@ -329,6 +336,21 @@ export const KioskProcedureDetailScreen: React.FC = () => {
           )}
         </Stack>
       </Box>
+
+      {isAbsent && (
+        <Alert
+          severity="warning"
+          sx={{ mb: 4, borderRadius: 2 }}
+          data-testid="kiosk-procedure-detail-absence-alert"
+        >
+          <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+            本日は欠席として処理されています。
+          </Typography>
+          <Typography variant="body2">
+            欠席日のため、この手順の保存・取消・ABC記録はできません。欠席を解除する場合は、利用者選択画面から操作してください。
+          </Typography>
+        </Alert>
+      )}
 
       {/* メインコンテンツ */}
       <Grid container spacing={4} sx={{ flexGrow: 1, mb: 4 }}>
@@ -522,7 +544,7 @@ export const KioskProcedureDetailScreen: React.FC = () => {
                   color="error"
                   onClick={() => setDeleteDialogOpen(true)}
                   sx={{ py: 1.5, px: 3, borderRadius: 3, fontSize: '1.1rem', mr: 'auto' }}
-                  disabled={isSaving || isDeleting || isRecordStatusUnknown}
+                  disabled={isSaving || isDeleting || isRecordStatusUnknown || isAbsent}
                   data-testid="kiosk-observation-revert"
                 >
                   記録を取り消す
@@ -542,7 +564,7 @@ export const KioskProcedureDetailScreen: React.FC = () => {
                 color="primary"
                 onClick={handleSave}
                 sx={{ py: 1.5, px: 4, borderRadius: 3, fontSize: '1.1rem', fontWeight: 'bold' }}
-                disabled={isSaving || isDeleting || isRecordStatusUnknown}
+                disabled={isSaving || isDeleting || isRecordStatusUnknown || isAbsent}
                 data-testid="kiosk-observation-submit"
               >
                 記録を保存する

--- a/src/features/kiosk/components/KioskUserSelectScreen.tsx
+++ b/src/features/kiosk/components/KioskUserSelectScreen.tsx
@@ -41,6 +41,11 @@ export const KioskUserSelectScreen: React.FC = () => {
   const [hasExistingRecords, setHasExistingRecords] = useState<boolean | null>(null);
   const [checkingRecords, setCheckingRecords] = useState(false);
 
+  // 欠席解除ダイアログ用
+  const [isCancelDialogOpen, setIsCancelDialogOpen] = useState(false);
+  const [isCanceling, setIsCanceling] = useState(false);
+  const [cancelError, setCancelError] = useState<string | null>(null);
+
   // スナックバー用
   const [isSnackbarOpen, setIsSnackbarOpen] = useState(false);
   const [snackbarMessage, setSnackbarMessage] = useState('');
@@ -102,6 +107,66 @@ export const KioskUserSelectScreen: React.FC = () => {
       setHasExistingRecords(false);
     } finally {
       setCheckingRecords(false);
+    }
+  };
+
+  const handleOpenCancelDialog = async () => {
+    if (!menuUser) return;
+    const targetUser = menuUser;
+    handleCloseMenu();
+    setDialogUser(targetUser);
+    setCancelError(null);
+    setIsCancelDialogOpen(true);
+    setCheckingRecords(true);
+
+    try {
+      const userCode = targetUser.UserID || String(targetUser.Id);
+      const records = await executionRepo.getRecords(selectedDateIso, userCode);
+      setHasExistingRecords(records.length > 0);
+    } catch (err) {
+      console.error('[KioskUserSelectScreen] Failed to check existing records:', err);
+      setHasExistingRecords(false);
+    } finally {
+      setCheckingRecords(false);
+    }
+  };
+
+  const handleCancelAbsence = async () => {
+    if (!dialogUser || isCanceling) return;
+    setIsCanceling(true);
+    setCancelError(null);
+
+    const userCode = dialogUser.UserID || String(dialogUser.Id);
+    const key = `${userCode}|${selectedDateIso}`;
+
+    const dailyItem: AttendanceDailyItem = {
+      Key: key,
+      UserCode: userCode,
+      RecordDate: selectedDateIso,
+      Status: '未',
+      CntAttendIn: 0,
+      CntAttendOut: 0,
+      TransportTo: false,
+      TransportFrom: false,
+      ProvidedMinutes: 0,
+      IsEarlyLeave: false,
+      IsAbsenceAddonClaimable: false,
+      CheckInAt: null,
+      CheckOutAt: null,
+      UserConfirmedAt: null,
+    };
+
+    try {
+      await attendanceRepo.upsertDailyByKey(dailyItem);
+      setSnackbarMessage(`${dialogUser.FullName}様の本日欠席処理を解除しました`);
+      setIsSnackbarOpen(true);
+      setIsCancelDialogOpen(false);
+      setRefreshTrigger((prev) => prev + 1);
+    } catch (err) {
+      console.error('[KioskUserSelectScreen] Failed to cancel daily absence:', err);
+      setCancelError('欠席処理の解除に失敗しました。しばらくしてから再試行してください。');
+    } finally {
+      setIsCanceling(false);
     }
   };
 
@@ -320,9 +385,15 @@ export const KioskUserSelectScreen: React.FC = () => {
         onClose={handleCloseMenu}
         data-testid="kiosk-user-option-menu"
       >
-        <MenuItem onClick={handleOpenDialog} data-testid="kiosk-user-menu-absent">
-          本日欠席として処理
-        </MenuItem>
+        {menuUser && getAbsenceState(menuUser) ? (
+          <MenuItem onClick={handleOpenCancelDialog} data-testid="kiosk-user-menu-cancel-absent">
+            欠席処理を解除する
+          </MenuItem>
+        ) : (
+          <MenuItem onClick={handleOpenDialog} data-testid="kiosk-user-menu-absent">
+            本日欠席として処理
+          </MenuItem>
+        )}
       </Menu>
 
       {/* 欠席登録ダイアログ */}
@@ -400,6 +471,60 @@ export const KioskUserSelectScreen: React.FC = () => {
             data-testid="kiosk-absent-dialog-submit"
           >
             {isSaving ? <CircularProgress size={20} color="inherit" /> : '欠席として処理する'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* 欠席解除確認ダイアログ */}
+      <Dialog
+        open={isCancelDialogOpen}
+        onClose={() => !isCanceling && setIsCancelDialogOpen(false)}
+        maxWidth="xs"
+        fullWidth
+        data-testid="kiosk-cancel-absent-dialog"
+      >
+        <DialogTitle sx={{ fontWeight: 'bold' }}>
+          欠席処理を解除しますか？
+        </DialogTitle>
+        <DialogContent dividers>
+          {checkingRecords ? (
+            <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
+              <CircularProgress size={24} />
+            </Box>
+          ) : hasExistingRecords ? (
+            <Alert severity="warning" sx={{ mb: 2 }} data-testid="kiosk-cancel-absent-dialog-warning">
+              本日の実施記録が存在します。欠席処理を解除すると、既存の実施記録が通常の記録として扱われます。解除してよろしいですか？
+            </Alert>
+          ) : null}
+
+          {cancelError && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              {cancelError}
+            </Alert>
+          )}
+
+          <Typography variant="body1">
+            {dialogUser?.FullName} 様の本日欠席処理を解除します。
+            解除すると、手順記録の登録や変更ができるようになります。
+          </Typography>
+        </DialogContent>
+        <DialogActions sx={{ p: 2, gap: 1 }}>
+          <Button
+            onClick={() => setIsCancelDialogOpen(false)}
+            disabled={isCanceling}
+            variant="outlined"
+            color="inherit"
+          >
+            キャンセル
+          </Button>
+          <Button
+            onClick={handleCancelAbsence}
+            color="primary"
+            variant="contained"
+            disabled={isCanceling || checkingRecords}
+            data-testid="kiosk-cancel-absent-dialog-submit"
+          >
+            {isCanceling ? <CircularProgress size={20} color="inherit" /> : '解除する'}
           </Button>
         </DialogActions>
       </Dialog>

--- a/src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx
@@ -67,6 +67,16 @@ vi.mock('@/features/daily/hooks/useExecutionRecord', () => ({
   ) => mockUseExecutionRecord(date, userId, scheduleItemId, fallbackScheduleItemIds, fallbackUserIds),
 }));
 
+const mockUseKioskAttendance = vi.fn();
+vi.mock('../../hooks/useKioskAttendance', () => ({
+  useKioskAttendance: (
+    userId: string | undefined,
+    selectedDateIso: string,
+    userCandidates: string[],
+    refreshTrigger?: number,
+  ) => mockUseKioskAttendance(userId, selectedDateIso, userCandidates, refreshTrigger),
+}));
+
 describe('KioskProcedureDetailScreen (memory provider URL for local UI behavior tests)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -79,6 +89,12 @@ describe('KioskProcedureDetailScreen (memory provider URL for local UI behavior 
       isLoading: false,
       error: null,
       refresh: mockRefreshRecord,
+    });
+    mockUseKioskAttendance.mockReturnValue({
+      isAbsent: false,
+      reason: undefined,
+      isLoading: false,
+      isError: false,
     });
   });
 
@@ -328,6 +344,49 @@ describe('KioskProcedureDetailScreen (memory provider URL for local UI behavior 
 
       // Case 3: query parameter override is present
       expect(resolveProcedureUserQueryCandidates({ UserID: 'U-006' } as any, '7', 'override-id')).toBe('override-id');
+    });
+  });
+
+  describe('when the user is absent', () => {
+    beforeEach(() => {
+      mockUseKioskAttendance.mockReturnValue({
+        isAbsent: true,
+        reason: '風邪のため',
+        isLoading: false,
+        isError: false,
+      });
+    });
+
+    it('renders the absence warning alert and disables save/delete/abc actions', () => {
+      mockUseExecutionRecord.mockReturnValue({
+        record: {
+          id: 'rec-1',
+          status: 'completed',
+          memo: '【様子】落ち着いていた\n【対応】見守り\n【変化】改善した\n【メモ】テスト記録',
+        },
+        saveRecord: mockSaveRecord,
+        deleteRecord: mockDeleteRecord,
+        isLoading: false,
+        error: null,
+        refresh: mockRefreshRecord,
+      });
+
+      render(
+        <MemoryRouter>
+          <KioskProcedureDetailScreen />
+        </MemoryRouter>
+      );
+
+      // 1. 警告アラートが表示されているか
+      const alert = screen.getByTestId('kiosk-procedure-detail-absence-alert');
+      expect(alert).toBeInTheDocument();
+      expect(alert).toHaveTextContent('本日は欠席として処理されています。');
+      expect(alert).toHaveTextContent('欠席日のため、この手順の保存・取消・ABC記録はできません。');
+
+      // 2. ボタンが disabled か
+      expect(screen.getByTestId('kiosk-procedure-detail-abc-record')).toBeDisabled();
+      expect(screen.getByTestId('kiosk-observation-submit')).toBeDisabled();
+      expect(screen.getByTestId('kiosk-observation-revert')).toBeDisabled();
     });
   });
 });

--- a/src/features/kiosk/components/__tests__/KioskUserSelectScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskUserSelectScreen.spec.tsx
@@ -62,6 +62,12 @@ describe('KioskUserSelectScreen', () => {
 
     fireEvent.click(screen.getByRole('button', { name: '再読み込み' }));
     expect(mockRefresh).toHaveBeenCalledTimes(1);
+
+    // 再読み込みによって開始されるローディング表示とその完了を待機し、テスト外での非同期状態更新（act警告）を防ぐ
+    await screen.findByRole('progressbar');
+    await waitFor(() => {
+      expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    });
   });
 
   it('keeps the empty target-user state for a successful load with no target users', async () => {
@@ -201,5 +207,97 @@ describe('KioskUserSelectScreen', () => {
 
     const submitBtn = screen.getByTestId('kiosk-absent-dialog-submit');
     expect(submitBtn).toBeDisabled();
+  });
+
+  it('shows "cancel absence" menu for an absent user and releases absence successfully', async () => {
+    mockUseUsersQuery.mockReturnValue({
+      data: [
+        {
+          Id: 4,
+          UserID: 'user-4',
+          FullName: '解除 太郎',
+          IsActive: true,
+          IsSupportProcedureTarget: true,
+          IsHighIntensitySupportTarget: false,
+        } as unknown as IUserMaster,
+      ],
+      status: 'success',
+      refresh: mockRefresh,
+    });
+
+    mockGetDailyByDate.mockResolvedValue([
+      {
+        Key: 'user-4|2026-06-03',
+        UserCode: 'user-4',
+        RecordDate: '2026-06-03',
+        Status: '当日欠席',
+      },
+    ]);
+    mockGetRecords.mockResolvedValue([]); // 既存実績なし
+
+    renderScreen();
+
+    const trigger = await screen.findByTestId('kiosk-user-menu-trigger-4');
+    fireEvent.click(trigger);
+
+    const menuItem = await screen.findByTestId('kiosk-user-menu-cancel-absent');
+    expect(menuItem).toBeInTheDocument();
+    fireEvent.click(menuItem);
+
+    const dialogTitle = await screen.findByText(/欠席処理を解除しますか？/);
+    expect(dialogTitle).toBeInTheDocument();
+    expect(screen.queryByTestId('kiosk-cancel-absent-dialog-warning')).toBeNull();
+
+    const submitBtn = screen.getByTestId('kiosk-cancel-absent-dialog-submit');
+    fireEvent.click(submitBtn);
+
+    await waitFor(() => {
+      expect(mockUpsertDailyByKey).toHaveBeenCalledWith(expect.objectContaining({
+        UserCode: 'user-4',
+        Status: '未',
+      }));
+    });
+  });
+
+  it('shows warning alert in cancellation dialog when there are existing records', async () => {
+    mockUseUsersQuery.mockReturnValue({
+      data: [
+        {
+          Id: 5,
+          UserID: 'user-5',
+          FullName: '矛盾 次郎',
+          IsActive: true,
+          IsSupportProcedureTarget: true,
+          IsHighIntensitySupportTarget: false,
+        } as unknown as IUserMaster,
+      ],
+      status: 'success',
+      refresh: mockRefresh,
+    });
+
+    mockGetDailyByDate.mockResolvedValue([
+      {
+        Key: 'user-5|2026-06-03',
+        UserCode: 'user-5',
+        RecordDate: '2026-06-03',
+        Status: '当日欠席',
+      },
+    ]);
+    mockGetRecords.mockResolvedValue([{ id: 'rec-2', status: 'completed' }]); // 既存実績あり
+
+    renderScreen();
+
+    const trigger = await screen.findByTestId('kiosk-user-menu-trigger-5');
+    fireEvent.click(trigger);
+
+    const menuItem = await screen.findByTestId('kiosk-user-menu-cancel-absent');
+    fireEvent.click(menuItem);
+
+    const warningAlert = await screen.findByTestId('kiosk-cancel-absent-dialog-warning');
+    expect(warningAlert).toBeInTheDocument();
+    expect(warningAlert).toHaveTextContent(/本日の実施記録が存在します/);
+
+    const submitBtn = screen.getByTestId('kiosk-cancel-absent-dialog-submit');
+    expect(submitBtn).not.toBeDisabled(); // 解除は許可されるため、disabled にならない
   });
 });


### PR DESCRIPTION
## 概要
Daily Absence Handling PR3 として、欠席解除と欠席状態に関する競合ガードを追加します。

## 変更内容
- 欠席済み利用者のメニューに「欠席処理を解除する」を追加
- 欠席解除時は既存の出欠状態へ戻し、欠席理由・補足メモをクリア
- 欠席状態 + 既存実施記録ありの場合は注意表示を出した上で解除可能
- 欠席済み日の手順詳細画面では、保存・取消・ABC記録をブロック
- KioskUserSelectScreen / KioskProcedureDetailScreen の回帰テストを追加・更新

## 検証
- npx vitest run src/features/kiosk/components/__tests__/KioskUserSelectScreen.spec.tsx
- npx vitest run src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx
- npx vitest run src/features/kiosk
- npm run typecheck
- git diff --check

## 備考
- PR1 #2109: 欠席状態の読み取り・表示
- PR2 #2110: 欠席登録UI
- 本PRは PR3 として、欠席解除と競合ガードを扱います。
