### PR TITLE
fix(integration): stabilize staff and dailyops SharePoint integration tests

### DIFF
--- a/tests/integration/dailyOpsSignals.sp.integration.spec.ts
+++ b/tests/integration/dailyOpsSignals.sp.integration.spec.ts
@@ -12,7 +12,6 @@ runListIntegration({
   keyField: 'date',
   selectFields: [
     'Title',
-    'date',
     'targetType',
     'targetId',
     'kind',

--- a/tests/integration/staffMaster.sp.integration.spec.ts
+++ b/tests/integration/staffMaster.sp.integration.spec.ts
@@ -2,23 +2,24 @@ import { runListIntegration } from './_shared/runListIntegration';
 import { resolveSharePointSiteUrl } from './_shared/resolveSiteUrl';
 
 const siteUrl = resolveSharePointSiteUrl();
+const isAppTest = siteUrl.includes('app-test');
 
-runListIntegration({
-  name: 'Staff_Master',
-  siteUrl,
-  listTitle: 'Staff_Master',
-  keyField: 'StaffID',
-  selectFields: [
-    'Title',
-    'FullName',
-    'Role',
-    'IsActive',
-    'Department',
-    'HireDate',
-    'Email',
-  ],
-  fixedKeyValue: 'E2E_INTEGRATION_STAFF_0001',
-  makeUpsertPayload: (key) => ({
+const keyField = isAppTest ? 'Staff_x0020_ID' : 'StaffID';
+const fullNameField = isAppTest ? 'Full_x0020_Name' : 'FullName';
+
+const selectFields = isAppTest
+  ? ['Title', fullNameField]
+  : ['Title', 'FullName', 'Role', 'IsActive', 'Department', 'HireDate', 'Email'];
+
+const makeUpsertPayload = (key: string) => {
+  if (isAppTest) {
+    return {
+      Staff_x0020_ID: key,
+      Title: `E2E Staff ${key}`,
+      Full_x0020_Name: 'E2E Staff FullName',
+    };
+  }
+  return {
     StaffID: key,
     Title: `E2E Staff ${key}`,
     FullName: 'E2E Staff FullName',
@@ -26,6 +27,20 @@ runListIntegration({
     Department: 'E2E',
     Email: 'e2e.staff@example.com',
     IsActive: true,
-  }),
-  deactivate: { field: 'IsActive', value: false },
+  };
+};
+
+const deactivate = isAppTest
+  ? undefined
+  : { field: 'IsActive', value: false };
+
+runListIntegration({
+  name: 'Staff_Master',
+  siteUrl,
+  listTitle: 'Staff_Master',
+  keyField,
+  selectFields,
+  fixedKeyValue: 'E2E_INTEGRATION_STAFF_0001',
+  makeUpsertPayload,
+  deactivate,
 });

--- a/tests/integration/staffMaster.sp.integration.spec.ts
+++ b/tests/integration/staffMaster.sp.integration.spec.ts
@@ -10,7 +10,6 @@ runListIntegration({
   keyField: 'StaffID',
   selectFields: [
     'Title',
-    'StaffID',
     'FullName',
     'Role',
     'IsActive',

--- a/tests/integration/usersMaster.sp.integration.spec.ts
+++ b/tests/integration/usersMaster.sp.integration.spec.ts
@@ -8,7 +8,7 @@ runListIntegration({
   siteUrl,
   listTitle: 'Users_Master',
   keyField: 'UserID',
-  selectFields: ['Title', 'UserID', 'FullName', 'IsActive', 'Modified'],
+  selectFields: ['Title', 'FullName', 'IsActive', 'Modified'],
   fixedKeyValue: 'E2E_INTEGRATION_USER_0001',
   makeUpsertPayload: (key) => ({
     UserID: key,


### PR DESCRIPTION
## Summary
- Refreshes the GitHub Actions Playwright storage state via updated `PW_STORAGE_STATE_B64`
- Fixes duplicate OData select fields in SharePoint integration tests
- Makes the `Staff_Master` integration test environment-aware for `welfare` and `app-test` schema differences

## Verification
- `integration (dailyops)` passed on GitHub Actions
- `integration (staff)` passed on GitHub Actions
- Confirmed previous `403 UnauthorizedAccessException` is resolved
- Confirmed previous `400 Bad Request` from duplicate/incorrect OData select fields is resolved

## Notes
- No `storageState.json` or Base64 credential material is committed
- `integration (users)` was not the original Nightly Patrol blocker; it may be tracked separately if needed