### PR TITLE
feat(support-case): add repository port and in-memory implementation

### DIFF
--- a/docs/model/generic-support-case-data-model.md
+++ b/docs/model/generic-support-case-data-model.md
@@ -1,0 +1,91 @@
+# 他事業所向け最小支援ケースデータモデル
+
+> ステータス: Draft
+> 作成日: 2026-06-07
+> 対象: SharePointをバックエンドとする事業所共通モデル
+
+## 目的
+
+SharePointの文書フォルダ構成を、そのままアプリのデータ本体にせず、既存のISP三層モデルと共存できる共通索引へ変換する。
+
+## 最小エンティティ
+
+| エンティティ | 責務 | 主な参照先 |
+|---|---|---|
+| `SupportCase` | 事業所と利用者を結ぶ支援ケース | `Users_Master` |
+| `CaseRecord` | 7分類を横断検索する業務記録索引 | 各専門モジュールのレコード |
+| `CaseDocument` | SharePoint文書のメタデータと保管先参照 | ドキュメントライブラリ |
+| `CaseAccessPolicy` | 分類単位の閲覧・更新・出力・監査要件 | Entra ID / SharePoint権限 |
+
+`CaseRecord`は内容本体を持たない。個別支援計画は`ISP_Master`、モニタリングは`MonitoringMeetings`など、既存の専門モジュールをSSOTとして`sourceModule`と`sourceRecordId`で参照する。
+
+## 7分類の対応
+
+| SharePoint分類 | `CaseRecord.category` | 内容のSSOT候補 |
+|---|---|---|
+| 個別支援計画 | `individual_support_plan` | `ISP_Master` |
+| 計画の進捗と見直し | `monitoring_review` | `MonitoringMeetings` |
+| 利用者・家族の意見 | `user_family_intention` | ISPまたは専用意向記録 |
+| サービス担当者会議 | `service_team_meeting` | 会議録モジュール |
+| アセスメント記録 | `assessment` | アセスメントモジュール |
+| 個人情報書類 | `personal_information` | 隔離ドキュメントライブラリ |
+| テンプレート・承諾書 | `template_consent` | `SupportTemplates`と文書ライブラリ |
+
+## 関係
+
+```mermaid
+erDiagram
+  TENANT ||--o{ SUPPORT_CASE : owns
+  USER ||--o{ SUPPORT_CASE : receives
+  SUPPORT_CASE ||--o{ CASE_RECORD : contains
+  SUPPORT_CASE ||--o{ CASE_DOCUMENT : references
+  CASE_RECORD ||--o{ CASE_DOCUMENT : attaches
+  SUPPORT_CASE ||--o{ CASE_ACCESS_POLICY : governs
+  CASE_RECORD }o--|| DOMAIN_RECORD : points_to
+```
+
+## 個人情報書類の境界
+
+`personal_information`は次の条件を必須とする。
+
+1. ファイル本体を標準ライブラリへ置かない。
+2. 共通モデルにはファイル内容や個人番号等を複製しない。
+3. `restricted_library`への不透明な参照だけを保持する。
+4. 閲覧・更新は`privacy_officers`に限定する。
+5. 標準エクスポートを無効化する。
+6. 閲覧、更新、ダウンロードを監査ログへ記録する。
+
+## SharePoint実装時の最小構成
+
+| 保存先 | 用途 |
+|---|---|
+| `SupportCases`リスト | `SupportCase` |
+| `CaseRecordIndex`リスト | `CaseRecord` |
+| `CaseDocumentIndex`リスト | `CaseDocument` |
+| 標準ドキュメントライブラリ | 通常文書と事業所テンプレート |
+| 制限付きドキュメントライブラリ | 個人情報書類 |
+
+初期段階では`CaseAccessPolicy`をアプリ設定として管理し、事業所別の例外が必要になった時点でリスト化する。SharePointフォルダ名は表示・移行用情報として扱い、業務上の識別子には使用しない。
+
+## SharePoint反映前のRepository境界
+
+ドメイン層は`SupportCaseRepository`だけに依存し、SharePoint REST API、Graph API、リスト名、列名を参照しない。最初のAdapterは`InMemorySupportCaseRepository`とし、同じ契約テストを将来のSharePoint Adapterにも適用する。
+
+Repositoryの全操作は`tenantId`を境界に含める。別事業所の`caseId`が判明しても取得・更新できないことをAdapter共通の契約とする。
+
+文書追加経路は次の2つに分離する。
+
+| メソッド | 許可する文書 | Repositoryが保証すること |
+|---|---|---|
+| `addDocumentReference` | 個人情報書類以外 | 標準ライブラリへの参照のみ |
+| `addRestrictedPersonalDocument` | 個人情報書類のみ | 隔離ライブラリ、`restricted`、監査ログ必須を強制 |
+
+通常追加メソッドの型から`personal_information`を除外し、実行時にも拒否する。個人情報書類用メソッドでは、呼び出し側が保管区分、機密区分、監査要件を指定できない。これにより、型キャストや外部入力で通常経路へ混入した場合も保存を防止する。
+
+この段階では以下を実施しない。
+
+- SharePointリスト・ライブラリの作成
+- SharePointまたはGraph Adapterの実装
+- 既存文書の移行
+- UIの追加
+- SharePoint権限の自動設定

--- a/src/domain/supportCase/InMemorySupportCaseRepository.ts
+++ b/src/domain/supportCase/InMemorySupportCaseRepository.ts
@@ -1,0 +1,169 @@
+import type {
+  AddDocumentReferenceInput,
+  AddRestrictedPersonalDocumentInput,
+  CreateSupportCaseInput,
+  SupportCaseId,
+  SupportCaseRepository,
+  SupportCaseSummary,
+  UpdateSupportCaseInput,
+} from './repository';
+import { toSupportCaseSummary } from './repository';
+import {
+  caseDocumentSchema,
+  supportCaseSchema,
+  type CaseDocument,
+  type SupportCase,
+} from './schema';
+
+export interface InMemorySupportCaseRepositoryOptions {
+  now?: () => string;
+  createId?: (entity: 'case' | 'document') => string;
+}
+
+export interface InMemorySupportCaseRepositorySeed {
+  cases?: readonly SupportCase[];
+  documents?: readonly CaseDocument[];
+}
+
+const clone = <T>(value: T): T => structuredClone(value);
+
+const defaultCreateId = (entity: 'case' | 'document'): string =>
+  `${entity}-${globalThis.crypto.randomUUID()}`;
+
+export class InMemorySupportCaseRepository implements SupportCaseRepository {
+  private cases: SupportCase[];
+  private documents: CaseDocument[];
+  private readonly now: () => string;
+  private readonly createId: (entity: 'case' | 'document') => string;
+
+  constructor(
+    seed: InMemorySupportCaseRepositorySeed = {},
+    options: InMemorySupportCaseRepositoryOptions = {},
+  ) {
+    this.cases = (seed.cases ?? []).map((item) => supportCaseSchema.parse(clone(item)));
+    this.documents = (seed.documents ?? []).map((item) => caseDocumentSchema.parse(clone(item)));
+    this.now = options.now ?? (() => new Date().toISOString());
+    this.createId = options.createId ?? defaultCreateId;
+  }
+
+  async listCases(tenantId: string): Promise<SupportCaseSummary[]> {
+    return this.cases
+      .filter((item) => item.tenantId === tenantId)
+      .map(toSupportCaseSummary)
+      .map(clone);
+  }
+
+  async getCase(tenantId: string, caseId: SupportCaseId): Promise<SupportCase | null> {
+    const supportCase = this.findCase(tenantId, caseId);
+    return supportCase ? clone(supportCase) : null;
+  }
+
+  async createCase(input: CreateSupportCaseInput): Promise<SupportCase> {
+    const timestamp = this.now();
+    const created = supportCaseSchema.parse({
+      ...clone(input),
+      id: this.createId('case'),
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      updatedBy: input.createdBy,
+    });
+
+    if (this.cases.some((item) => item.id === created.id)) {
+      throw new Error(`Support case id already exists: ${created.id}`);
+    }
+
+    this.cases.push(created);
+    return clone(created);
+  }
+
+  async updateCase(
+    tenantId: string,
+    caseId: SupportCaseId,
+    patch: UpdateSupportCaseInput,
+  ): Promise<SupportCase> {
+    const index = this.cases.findIndex(
+      (item) => item.tenantId === tenantId && item.id === caseId,
+    );
+    if (index < 0) {
+      throw new Error(`Support case not found: ${caseId}`);
+    }
+
+    const updated = supportCaseSchema.parse({
+      ...this.cases[index],
+      ...clone(patch),
+      id: caseId,
+      tenantId,
+      updatedAt: this.now(),
+    });
+    this.cases[index] = updated;
+    return clone(updated);
+  }
+
+  async listDocumentReferences(
+    tenantId: string,
+    caseId: SupportCaseId,
+  ): Promise<CaseDocument[]> {
+    this.requireCase(tenantId, caseId);
+    return this.documents
+      .filter((item) => item.tenantId === tenantId && item.supportCaseId === caseId)
+      .map(clone);
+  }
+
+  async addDocumentReference(input: AddDocumentReferenceInput): Promise<CaseDocument> {
+    if ((input.category as string) === 'personal_information') {
+      throw new Error(
+        'Personal information documents must use addRestrictedPersonalDocument',
+      );
+    }
+    if (input.supportCaseId === null) {
+      throw new Error('Standard case documents require a support case id');
+    }
+
+    this.requireCase(input.tenantId, input.supportCaseId);
+    return this.storeDocument({
+      ...clone(input),
+      id: this.createId('document'),
+      createdAt: this.now(),
+    });
+  }
+
+  async addRestrictedPersonalDocument(
+    input: AddRestrictedPersonalDocumentInput,
+  ): Promise<CaseDocument> {
+    if (input.supportCaseId === null) {
+      throw new Error('Restricted personal documents require a support case id');
+    }
+
+    this.requireCase(input.tenantId, input.supportCaseId);
+    return this.storeDocument({
+      ...clone(input),
+      id: this.createId('document'),
+      category: 'personal_information',
+      storageClass: 'restricted_library',
+      sensitivity: 'restricted',
+      auditLoggingRequired: true,
+      createdAt: this.now(),
+    });
+  }
+
+  private findCase(tenantId: string, caseId: SupportCaseId): SupportCase | undefined {
+    return this.cases.find((item) => item.tenantId === tenantId && item.id === caseId);
+  }
+
+  private requireCase(tenantId: string, caseId: SupportCaseId): SupportCase {
+    const supportCase = this.findCase(tenantId, caseId);
+    if (!supportCase) {
+      throw new Error(`Support case not found: ${caseId}`);
+    }
+    return supportCase;
+  }
+
+  private storeDocument(document: unknown): CaseDocument {
+    const created = caseDocumentSchema.parse(document);
+    if (this.documents.some((item) => item.id === created.id)) {
+      throw new Error(`Case document id already exists: ${created.id}`);
+    }
+    this.documents.push(created);
+    return clone(created);
+  }
+}

--- a/src/domain/supportCase/__tests__/repository.spec.ts
+++ b/src/domain/supportCase/__tests__/repository.spec.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+import { InMemorySupportCaseRepository } from '../InMemorySupportCaseRepository';
+import type {
+  AddDocumentReferenceInput,
+  SupportCaseRepository,
+} from '../repository';
+
+const timestamp = '2026-06-07T12:00:00+09:00';
+
+const createRepository = (): SupportCaseRepository => {
+  let nextId = 1;
+  return new InMemorySupportCaseRepository(
+    {},
+    {
+      now: () => timestamp,
+      createId: (entity) => `${entity}-${nextId++}`,
+    },
+  );
+};
+
+const createCase = (repository: SupportCaseRepository, tenantId = 'office-1') =>
+  repository.createCase({
+    tenantId,
+    userId: 'U001',
+    serviceType: 'daily_life_care',
+    status: 'active',
+    openedOn: '2026-04-01',
+    closedOn: null,
+    primaryStaffId: 'staff-1',
+    createdBy: 'staff-1',
+  });
+
+const runSupportCaseRepositoryContract = (
+  name: string,
+  factory: () => SupportCaseRepository,
+): void => {
+  describe(name, () => {
+    it('creates, retrieves, lists, and updates cases within a tenant', async () => {
+      const repository = factory();
+      const created = await createCase(repository);
+
+      expect(await repository.getCase('office-1', created.id)).toEqual(created);
+      expect(await repository.getCase('office-2', created.id)).toBeNull();
+      expect(await repository.listCases('office-1')).toEqual([
+        expect.objectContaining({
+          id: created.id,
+          tenantId: 'office-1',
+          userId: 'U001',
+          status: 'active',
+        }),
+      ]);
+
+      const updated = await repository.updateCase('office-1', created.id, {
+        status: 'closed',
+        closedOn: '2026-06-07',
+        updatedBy: 'staff-2',
+      });
+
+      expect(updated.status).toBe('closed');
+      expect(updated.closedOn).toBe('2026-06-07');
+      expect(updated.updatedBy).toBe('staff-2');
+    });
+
+    it('does not expose mutable internal state', async () => {
+      const repository = factory();
+      const created = await createCase(repository);
+      created.primaryStaffId = 'tampered';
+
+      const stored = await repository.getCase('office-1', created.id);
+      expect(stored?.primaryStaffId).toBe('staff-1');
+    });
+
+    it('stores standard document references through the standard path', async () => {
+      const repository = factory();
+      const supportCase = await createCase(repository);
+
+      const document = await repository.addDocumentReference({
+        tenantId: 'office-1',
+        supportCaseId: supportCase.id,
+        caseRecordId: null,
+        category: 'assessment',
+        fileName: 'assessment.pdf',
+        storageClass: 'standard_library',
+        storageLocator: 'standard-drive-item-id',
+        sensitivity: 'confidential',
+        auditLoggingRequired: true,
+        templateKey: null,
+        templateVersion: null,
+        createdBy: 'staff-1',
+      });
+
+      expect(document.category).toBe('assessment');
+      expect(await repository.listDocumentReferences('office-1', supportCase.id))
+        .toEqual([document]);
+    });
+
+    it('rejects personal information sent through the standard document path', async () => {
+      const repository = factory();
+      const supportCase = await createCase(repository);
+      const invalidInput = {
+        tenantId: 'office-1',
+        supportCaseId: supportCase.id,
+        caseRecordId: null,
+        category: 'personal_information',
+        fileName: 'certificate.pdf',
+        storageClass: 'standard_library',
+        storageLocator: 'standard-drive-item-id',
+        sensitivity: 'confidential',
+        auditLoggingRequired: false,
+        templateKey: null,
+        templateVersion: null,
+        createdBy: 'staff-1',
+      } as unknown as AddDocumentReferenceInput;
+
+      await expect(repository.addDocumentReference(invalidInput)).rejects.toThrow(
+        'addRestrictedPersonalDocument',
+      );
+      expect(await repository.listDocumentReferences('office-1', supportCase.id))
+        .toEqual([]);
+    });
+
+    it('forces isolated storage and audit logging on restricted personal documents', async () => {
+      const repository = factory();
+      const supportCase = await createCase(repository);
+
+      const document = await repository.addRestrictedPersonalDocument({
+        tenantId: 'office-1',
+        supportCaseId: supportCase.id,
+        caseRecordId: null,
+        fileName: 'certificate.pdf',
+        storageLocator: 'restricted-drive-item-id',
+        templateKey: null,
+        templateVersion: null,
+        createdBy: 'privacy-officer-1',
+      });
+
+      expect(document).toMatchObject({
+        category: 'personal_information',
+        storageClass: 'restricted_library',
+        sensitivity: 'restricted',
+        auditLoggingRequired: true,
+      });
+    });
+  });
+};
+
+runSupportCaseRepositoryContract(
+  'InMemorySupportCaseRepository contract',
+  createRepository,
+);

--- a/src/domain/supportCase/__tests__/schema.spec.ts
+++ b/src/domain/supportCase/__tests__/schema.spec.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import {
+  caseAccessPolicySchema,
+  caseDocumentSchema,
+  caseRecordCategoryValues,
+  supportCaseSchema,
+} from '../schema';
+
+const auditFields = {
+  createdAt: '2026-06-07T01:00:00+09:00',
+  createdBy: 'staff-1',
+};
+
+describe('supportCaseSchema', () => {
+  it('requires a closed date when the case is closed', () => {
+    const result = supportCaseSchema.safeParse({
+      id: 'case-1',
+      tenantId: 'office-1',
+      userId: 'U001',
+      serviceType: 'daily_life_care',
+      status: 'closed',
+      openedOn: '2026-04-01',
+      closedOn: null,
+      primaryStaffId: 'staff-1',
+      ...auditFields,
+      updatedAt: auditFields.createdAt,
+      updatedBy: auditFields.createdBy,
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
+describe('caseRecordCategorySchema', () => {
+  it('covers the seven SharePoint folder classifications', () => {
+    expect(caseRecordCategoryValues).toEqual([
+      'individual_support_plan',
+      'monitoring_review',
+      'user_family_intention',
+      'service_team_meeting',
+      'assessment',
+      'personal_information',
+      'template_consent',
+    ]);
+  });
+});
+
+describe('caseDocumentSchema', () => {
+  it('accepts a personal information reference only with isolated storage and audit logging', () => {
+    const result = caseDocumentSchema.safeParse({
+      id: 'doc-1',
+      tenantId: 'office-1',
+      supportCaseId: 'case-1',
+      caseRecordId: null,
+      category: 'personal_information',
+      fileName: 'certificate.pdf',
+      storageClass: 'restricted_library',
+      storageLocator: 'drive-item-id',
+      sensitivity: 'restricted',
+      auditLoggingRequired: true,
+      ...auditFields,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects personal information stored in the standard library', () => {
+    const result = caseDocumentSchema.safeParse({
+      id: 'doc-1',
+      tenantId: 'office-1',
+      supportCaseId: 'case-1',
+      caseRecordId: null,
+      category: 'personal_information',
+      fileName: 'certificate.pdf',
+      storageClass: 'standard_library',
+      storageLocator: 'drive-item-id',
+      sensitivity: 'confidential',
+      auditLoggingRequired: false,
+      ...auditFields,
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('caseAccessPolicySchema', () => {
+  it('prevents broad access and export for personal information', () => {
+    const result = caseAccessPolicySchema.safeParse({
+      tenantId: 'office-1',
+      supportCaseId: 'case-1',
+      category: 'personal_information',
+      readScope: 'case_team',
+      writeScope: 'case_team',
+      exportAllowed: true,
+      auditLoggingRequired: false,
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/domain/supportCase/index.ts
+++ b/src/domain/supportCase/index.ts
@@ -1,0 +1,53 @@
+export {
+  CASE_RECORD_CATEGORY_LABELS,
+  accessScopeSchema,
+  accessScopeValues,
+  caseAccessPolicySchema,
+  caseDocumentSchema,
+  caseRecordCategorySchema,
+  caseRecordCategoryValues,
+  caseRecordSchema,
+  caseRecordStatusSchema,
+  caseRecordStatusValues,
+  documentSensitivitySchema,
+  documentSensitivityValues,
+  documentStorageClassSchema,
+  documentStorageClassValues,
+  supportCaseSchema,
+  supportCaseStatusSchema,
+  supportCaseStatusValues,
+} from './schema';
+
+export type {
+  CaseAccessPolicy,
+  CaseDocument,
+  CaseRecord,
+  CaseRecordCategory,
+  DocumentSensitivity,
+  SupportCase,
+  SupportCaseStatus,
+} from './schema';
+
+export {
+  isOpenSupportCaseStatus,
+  toSupportCaseSummary,
+} from './repository';
+
+export type {
+  AddDocumentReferenceInput,
+  AddRestrictedPersonalDocumentInput,
+  CreateSupportCaseInput,
+  SupportCaseId,
+  SupportCaseRepository,
+  SupportCaseSummary,
+  UpdateSupportCaseInput,
+} from './repository';
+
+export {
+  InMemorySupportCaseRepository,
+} from './InMemorySupportCaseRepository';
+
+export type {
+  InMemorySupportCaseRepositoryOptions,
+  InMemorySupportCaseRepositorySeed,
+} from './InMemorySupportCaseRepository';

--- a/src/domain/supportCase/repository.ts
+++ b/src/domain/supportCase/repository.ts
@@ -1,0 +1,83 @@
+import type {
+  CaseDocument,
+  CaseRecordCategory,
+  SupportCase,
+  SupportCaseStatus,
+} from './schema';
+
+export type SupportCaseId = string;
+
+export type SupportCaseSummary = Pick<
+  SupportCase,
+  'id' | 'tenantId' | 'userId' | 'serviceType' | 'status' | 'openedOn' | 'closedOn' | 'primaryStaffId'
+>;
+
+export type CreateSupportCaseInput = Pick<
+  SupportCase,
+  'tenantId' | 'userId' | 'serviceType' | 'status' | 'openedOn' | 'closedOn' | 'primaryStaffId' | 'createdBy'
+>;
+
+export type UpdateSupportCaseInput = Partial<
+  Pick<SupportCase, 'serviceType' | 'status' | 'openedOn' | 'closedOn' | 'primaryStaffId'>
+> & {
+  updatedBy: string;
+};
+
+type NonRestrictedDocumentCategory = Exclude<CaseRecordCategory, 'personal_information'>;
+
+type DocumentReferenceInputBase = Pick<
+  CaseDocument,
+  | 'tenantId'
+  | 'supportCaseId'
+  | 'caseRecordId'
+  | 'fileName'
+  | 'storageLocator'
+  | 'templateKey'
+  | 'templateVersion'
+  | 'createdBy'
+>;
+
+/** Input accepted by the standard document path. Personal information is excluded. */
+export type AddDocumentReferenceInput = DocumentReferenceInputBase & {
+  category: NonRestrictedDocumentCategory;
+  storageClass: 'standard_library';
+  sensitivity: 'standard' | 'confidential';
+  auditLoggingRequired: boolean;
+};
+
+/**
+ * Input accepted only by the restricted document path.
+ * Security fields are assigned by the repository and cannot be weakened by callers.
+ */
+export type AddRestrictedPersonalDocumentInput = DocumentReferenceInputBase;
+
+export interface SupportCaseRepository {
+  listCases(tenantId: string): Promise<SupportCaseSummary[]>;
+  getCase(tenantId: string, caseId: SupportCaseId): Promise<SupportCase | null>;
+  createCase(input: CreateSupportCaseInput): Promise<SupportCase>;
+  updateCase(
+    tenantId: string,
+    caseId: SupportCaseId,
+    patch: UpdateSupportCaseInput,
+  ): Promise<SupportCase>;
+
+  listDocumentReferences(tenantId: string, caseId: SupportCaseId): Promise<CaseDocument[]>;
+  addDocumentReference(input: AddDocumentReferenceInput): Promise<CaseDocument>;
+  addRestrictedPersonalDocument(
+    input: AddRestrictedPersonalDocumentInput,
+  ): Promise<CaseDocument>;
+}
+
+export const toSupportCaseSummary = (supportCase: SupportCase): SupportCaseSummary => ({
+  id: supportCase.id,
+  tenantId: supportCase.tenantId,
+  userId: supportCase.userId,
+  serviceType: supportCase.serviceType,
+  status: supportCase.status,
+  openedOn: supportCase.openedOn,
+  closedOn: supportCase.closedOn,
+  primaryStaffId: supportCase.primaryStaffId,
+});
+
+export const isOpenSupportCaseStatus = (status: SupportCaseStatus): boolean =>
+  status !== 'closed';

--- a/src/domain/supportCase/schema.ts
+++ b/src/domain/supportCase/schema.ts
@@ -1,0 +1,194 @@
+import { z } from 'zod';
+
+const isoDate = z.string().date();
+const isoDateTime = z.string().datetime({ offset: true });
+
+export const supportCaseStatusValues = ['active', 'suspended', 'closed'] as const;
+export const supportCaseStatusSchema = z.enum(supportCaseStatusValues);
+export type SupportCaseStatus = z.infer<typeof supportCaseStatusSchema>;
+
+/**
+ * A tenant-scoped container that ties existing welfare modules to one service user.
+ * Detailed user attributes remain in Users_Master and are not duplicated here.
+ */
+export const supportCaseSchema = z.object({
+  id: z.string().min(1),
+  tenantId: z.string().min(1),
+  userId: z.string().min(1),
+  serviceType: z.string().min(1),
+  status: supportCaseStatusSchema,
+  openedOn: isoDate,
+  closedOn: isoDate.nullable().default(null),
+  primaryStaffId: z.string().min(1),
+  createdAt: isoDateTime,
+  createdBy: z.string().min(1),
+  updatedAt: isoDateTime,
+  updatedBy: z.string().min(1),
+}).superRefine((value, ctx) => {
+  if (value.status === 'closed' && value.closedOn === null) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['closedOn'],
+      message: '終了したケースには終了日が必要です',
+    });
+  }
+  if (value.status !== 'closed' && value.closedOn !== null) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['closedOn'],
+      message: '終了日を設定できるのは終了したケースのみです',
+    });
+  }
+});
+
+export type SupportCase = z.infer<typeof supportCaseSchema>;
+
+export const caseRecordCategoryValues = [
+  'individual_support_plan',
+  'monitoring_review',
+  'user_family_intention',
+  'service_team_meeting',
+  'assessment',
+  'personal_information',
+  'template_consent',
+] as const;
+
+export const caseRecordCategorySchema = z.enum(caseRecordCategoryValues);
+export type CaseRecordCategory = z.infer<typeof caseRecordCategorySchema>;
+
+export const CASE_RECORD_CATEGORY_LABELS: Record<CaseRecordCategory, string> = {
+  individual_support_plan: '個別支援計画',
+  monitoring_review: '計画の進捗と見直し',
+  user_family_intention: '利用者・家族の意見',
+  service_team_meeting: 'サービス担当者会議',
+  assessment: 'アセスメント記録',
+  personal_information: '個人情報書類',
+  template_consent: 'テンプレート・承諾書',
+};
+
+export const caseRecordStatusValues = ['draft', 'final', 'superseded', 'archived'] as const;
+export const caseRecordStatusSchema = z.enum(caseRecordStatusValues);
+
+/**
+ * Cross-module index entry. The actual domain payload remains in its owning module.
+ * For example, an ISP record points to ISP_Master through sourceRecordId.
+ */
+export const caseRecordSchema = z.object({
+  id: z.string().min(1),
+  tenantId: z.string().min(1),
+  supportCaseId: z.string().min(1),
+  userId: z.string().min(1),
+  category: caseRecordCategorySchema,
+  title: z.string().min(1).max(200),
+  occurredOn: isoDate,
+  status: caseRecordStatusSchema,
+  sourceModule: z.string().min(1),
+  sourceRecordId: z.string().min(1),
+  relatedPlanId: z.string().min(1).nullable().default(null),
+  createdAt: isoDateTime,
+  createdBy: z.string().min(1),
+  updatedAt: isoDateTime,
+  updatedBy: z.string().min(1),
+});
+
+export type CaseRecord = z.infer<typeof caseRecordSchema>;
+
+export const documentSensitivityValues = ['standard', 'confidential', 'restricted'] as const;
+export const documentSensitivitySchema = z.enum(documentSensitivityValues);
+export type DocumentSensitivity = z.infer<typeof documentSensitivitySchema>;
+
+export const documentStorageClassValues = ['standard_library', 'restricted_library'] as const;
+export const documentStorageClassSchema = z.enum(documentStorageClassValues);
+
+/**
+ * Metadata-only document reference. File bodies stay in SharePoint document libraries.
+ */
+export const caseDocumentSchema = z.object({
+  id: z.string().min(1),
+  tenantId: z.string().min(1),
+  supportCaseId: z.string().min(1).nullable(),
+  caseRecordId: z.string().min(1).nullable(),
+  category: caseRecordCategorySchema,
+  fileName: z.string().min(1),
+  storageClass: documentStorageClassSchema,
+  storageLocator: z.string().min(1),
+  sensitivity: documentSensitivitySchema,
+  auditLoggingRequired: z.boolean(),
+  templateKey: z.string().min(1).nullable().default(null),
+  templateVersion: z.string().min(1).nullable().default(null),
+  createdAt: isoDateTime,
+  createdBy: z.string().min(1),
+}).superRefine((value, ctx) => {
+  if (value.supportCaseId === null && value.category !== 'template_consent') {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['supportCaseId'],
+      message: '利用者文書には支援ケースIDが必要です',
+    });
+  }
+
+  if (value.category === 'personal_information') {
+    if (value.sensitivity !== 'restricted') {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['sensitivity'],
+        message: '個人情報書類はrestrictedに分類してください',
+      });
+    }
+    if (value.storageClass !== 'restricted_library') {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['storageClass'],
+        message: '個人情報書類は隔離ライブラリに保管してください',
+      });
+    }
+    if (!value.auditLoggingRequired) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['auditLoggingRequired'],
+        message: '個人情報書類には監査ログが必要です',
+      });
+    }
+  }
+});
+
+export type CaseDocument = z.infer<typeof caseDocumentSchema>;
+
+export const accessScopeValues = ['tenant', 'case_team', 'privacy_officers'] as const;
+export const accessScopeSchema = z.enum(accessScopeValues);
+
+export const caseAccessPolicySchema = z.object({
+  tenantId: z.string().min(1),
+  supportCaseId: z.string().min(1),
+  category: caseRecordCategorySchema,
+  readScope: accessScopeSchema,
+  writeScope: accessScopeSchema,
+  exportAllowed: z.boolean(),
+  auditLoggingRequired: z.boolean(),
+}).superRefine((value, ctx) => {
+  if (value.category !== 'personal_information') return;
+
+  if (value.readScope !== 'privacy_officers' || value.writeScope !== 'privacy_officers') {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['readScope'],
+      message: '個人情報書類は個人情報取扱権限に限定してください',
+    });
+  }
+  if (value.exportAllowed) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['exportAllowed'],
+      message: '個人情報書類の標準エクスポートは許可できません',
+    });
+  }
+  if (!value.auditLoggingRequired) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['auditLoggingRequired'],
+      message: '個人情報書類には監査ログが必要です',
+    });
+  }
+});
+
+export type CaseAccessPolicy = z.infer<typeof caseAccessPolicySchema>;


### PR DESCRIPTION
## Summary
- Add the generic `SupportCase` domain model and seven-category case record index
- Add the `SupportCaseRepository` port
- Add `InMemorySupportCaseRepository`
- Separate normal document references from restricted personal documents
- Enforce tenant boundaries, isolated storage policy, and audit-log requirements through repository contract tests
- Document the generic support case data model and the pre-SharePoint repository boundary

## Out of scope
- SharePoint list creation
- SharePoint or Graph repository implementation
- UI integration
- Existing document migration
- Permission provisioning automation

## Verification
- Repository and schema tests: 10 passed
- TypeScript typecheck: passed
- ESLint for `src/domain/supportCase`: passed
- Commit hooks: repository lint and typecheck passed
- `git diff --check origin/main..HEAD`: passed

## Scope boundary
This PR intentionally stops at the domain/repository boundary. SharePoint projection, SharePoint repository implementation, UI integration, and migration are out of scope and will be handled in follow-up PRs.
