### PR TITLE
feat(support-case): add SharePoint projection model and mappers

### DIFF
--- a/docs/model/generic-support-case-data-model.md
+++ b/docs/model/generic-support-case-data-model.md
@@ -89,3 +89,26 @@ Repositoryの全操作は`tenantId`を境界に含める。別事業所の`caseI
 - 既存文書の移行
 - UIの追加
 - SharePoint権限の自動設定
+
+## SharePoint投影モデル
+
+SharePoint投影層は、ドメインモデルをSharePoint列名へ変換する純粋関数だけを持つ。通信、リスト存在確認、権限設定、ファイルアップロードは担当しない。
+
+| ドメイン入力 | 投影先 | Mapper |
+|---|---|---|
+| `SupportCase` | `SupportCases` | `toSupportCaseListItem` |
+| `CaseRecord` | `SupportCaseRecords` | `toSupportCaseRecordListItem` |
+| 通常`CaseDocument` | `SupportCaseDocuments`と通常ライブラリ | `toStandardDocumentListItem` |
+| 個人情報`CaseDocument` | `SupportCaseDocuments`と制限付きライブラリ | `toRestrictedDocumentListItem` |
+| `SupportCaseAuditEvent` | `SupportCaseEvents` | `toSupportCaseEventListItem` |
+
+通常文書と個人情報書類は、投影段階でも別経路とする。`personal_information`を`toStandardDocumentListItem`へ渡した場合は例外とし、制限付き投影では次の値を必須とする。
+
+- `StoragePolicy: restricted_library`
+- `LibraryTarget: restricted_personal_documents`
+- `Sensitivity: restricted`
+- `AuditLogRequired: true`
+
+各mapperは入力ドメインスキーマと出力投影スキーマの両方を検証する。`tenantId`、`supportCaseId`、保管ポリシー、監査ログ要件が欠落した値は、SharePoint Adapterへ到達する前に拒否する。
+
+この投影層にもSharePoint REST API、Graph client、実リスト作成、権限設定、UI、既存文書移行は含めない。

--- a/src/domain/supportCase/__tests__/sharePointMapper.spec.ts
+++ b/src/domain/supportCase/__tests__/sharePointMapper.spec.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from 'vitest';
+import type { CaseDocument, CaseRecord, SupportCase } from '../schema';
+import {
+  toRestrictedDocumentListItem,
+  toStandardDocumentListItem,
+  toSupportCaseEventListItem,
+  toSupportCaseListItem,
+  toSupportCaseRecordListItem,
+} from '../sharePointMapper';
+import type { SupportCaseAuditEvent } from '../sharePointProjection';
+
+const timestamp = '2026-06-07T12:00:00+09:00';
+
+const supportCase: SupportCase = {
+  id: 'case-1',
+  tenantId: 'office-1',
+  userId: 'U001',
+  serviceType: 'daily_life_care',
+  status: 'active',
+  openedOn: '2026-04-01',
+  closedOn: null,
+  primaryStaffId: 'staff-1',
+  createdAt: timestamp,
+  createdBy: 'staff-1',
+  updatedAt: timestamp,
+  updatedBy: 'staff-1',
+};
+
+const standardDocument: CaseDocument = {
+  id: 'doc-1',
+  tenantId: 'office-1',
+  supportCaseId: 'case-1',
+  caseRecordId: 'record-1',
+  category: 'assessment',
+  fileName: 'assessment.pdf',
+  storageClass: 'standard_library',
+  storageLocator: 'standard-drive-item-id',
+  sensitivity: 'confidential',
+  auditLoggingRequired: true,
+  templateKey: null,
+  templateVersion: null,
+  createdAt: timestamp,
+  createdBy: 'staff-1',
+};
+
+const restrictedDocument: CaseDocument = {
+  ...standardDocument,
+  id: 'doc-2',
+  caseRecordId: null,
+  category: 'personal_information',
+  fileName: 'certificate.pdf',
+  storageClass: 'restricted_library',
+  storageLocator: 'restricted-drive-item-id',
+  sensitivity: 'restricted',
+  auditLoggingRequired: true,
+};
+
+describe('SharePoint support case projection', () => {
+  it('maps SupportCase to the SupportCases list shape', () => {
+    expect(toSupportCaseListItem(supportCase)).toEqual({
+      Title: 'U001:case-1',
+      CaseId: 'case-1',
+      TenantId: 'office-1',
+      UserId: 'U001',
+      ServiceType: 'daily_life_care',
+      Status: 'active',
+      OpenedOn: '2026-04-01',
+      ClosedOn: null,
+      PrimaryStaffId: 'staff-1',
+      CreatedAt: timestamp,
+      CreatedByKey: 'staff-1',
+      UpdatedAt: timestamp,
+      UpdatedByKey: 'staff-1',
+    });
+  });
+
+  it('rejects a SupportCase projection without tenantId', () => {
+    const invalid = { ...supportCase, tenantId: '' };
+    expect(() => toSupportCaseListItem(invalid)).toThrow();
+  });
+});
+
+describe('SharePoint case record projection', () => {
+  it('maps the seven-category record index without embedding domain content', () => {
+    const record: CaseRecord = {
+      id: 'record-1',
+      tenantId: 'office-1',
+      supportCaseId: 'case-1',
+      userId: 'U001',
+      category: 'assessment',
+      title: '初回アセスメント',
+      occurredOn: '2026-04-01',
+      status: 'final',
+      sourceModule: 'assessment',
+      sourceRecordId: 'assessment-1',
+      relatedPlanId: null,
+      createdAt: timestamp,
+      createdBy: 'staff-1',
+      updatedAt: timestamp,
+      updatedBy: 'staff-1',
+    };
+
+    expect(toSupportCaseRecordListItem(record)).toMatchObject({
+      RecordId: 'record-1',
+      TenantId: 'office-1',
+      SupportCaseId: 'case-1',
+      Category: 'assessment',
+      SourceRecordId: 'assessment-1',
+    });
+  });
+});
+
+describe('SharePoint document projection', () => {
+  it('maps a standard document to the standard library target', () => {
+    expect(toStandardDocumentListItem(standardDocument)).toMatchObject({
+      DocumentId: 'doc-1',
+      TenantId: 'office-1',
+      SupportCaseId: 'case-1',
+      StoragePolicy: 'standard_library',
+      LibraryTarget: 'standard_documents',
+      AuditLogRequired: true,
+    });
+  });
+
+  it('prevents personal information from using the standard projection', () => {
+    expect(() => toStandardDocumentListItem(restrictedDocument)).toThrow(
+      'cannot be projected to the standard library',
+    );
+  });
+
+  it('maps personal information only to the restricted target', () => {
+    expect(toRestrictedDocumentListItem(restrictedDocument)).toMatchObject({
+      DocumentId: 'doc-2',
+      Category: 'personal_information',
+      StoragePolicy: 'restricted_library',
+      LibraryTarget: 'restricted_personal_documents',
+      Sensitivity: 'restricted',
+      AuditLogRequired: true,
+    });
+  });
+
+  it.each([
+    ['tenantId', { ...standardDocument, tenantId: '' }],
+    ['caseId', { ...standardDocument, supportCaseId: null }],
+    ['storagePolicy', { ...standardDocument, storageClass: undefined }],
+    ['auditLogRequired', { ...standardDocument, auditLoggingRequired: undefined }],
+  ])('rejects a standard projection without %s', (_field, invalid) => {
+    expect(() => toStandardDocumentListItem(invalid as CaseDocument)).toThrow();
+  });
+
+  it('rejects a restricted projection without auditLogRequired', () => {
+    const invalid = {
+      ...restrictedDocument,
+      auditLoggingRequired: false,
+    };
+    expect(() => toRestrictedDocumentListItem(invalid)).toThrow();
+  });
+});
+
+describe('SharePoint audit event projection', () => {
+  const event: SupportCaseAuditEvent = {
+    id: 'event-1',
+    tenantId: 'office-1',
+    supportCaseId: 'case-1',
+    targetType: 'case_document',
+    targetId: 'doc-2',
+    action: 'viewed',
+    actorId: 'privacy-officer-1',
+    occurredAt: timestamp,
+    auditLogRequired: true,
+    detailJson: null,
+  };
+
+  it('maps an audit event to SupportCaseEvents', () => {
+    expect(toSupportCaseEventListItem(event)).toEqual({
+      Title: 'viewed:case_document:doc-2',
+      EventId: 'event-1',
+      TenantId: 'office-1',
+      SupportCaseId: 'case-1',
+      TargetType: 'case_document',
+      TargetId: 'doc-2',
+      Action: 'viewed',
+      ActorId: 'privacy-officer-1',
+      OccurredAt: timestamp,
+      AuditLogRequired: true,
+      DetailJson: null,
+    });
+  });
+
+  it.each([
+    ['tenantId', { ...event, tenantId: '' }],
+    ['caseId', { ...event, supportCaseId: '' }],
+    ['auditLogRequired', { ...event, auditLogRequired: false }],
+  ])('rejects an audit event without a valid %s', (_field, invalid) => {
+    expect(() =>
+      toSupportCaseEventListItem(invalid as SupportCaseAuditEvent),
+    ).toThrow();
+  });
+});

--- a/src/domain/supportCase/index.ts
+++ b/src/domain/supportCase/index.ts
@@ -51,3 +51,40 @@ export type {
   InMemorySupportCaseRepositoryOptions,
   InMemorySupportCaseRepositorySeed,
 } from './InMemorySupportCaseRepository';
+
+export {
+  SUPPORT_CASE_DOCUMENTS_LIST_TITLE,
+  SUPPORT_CASE_EVENTS_LIST_TITLE,
+  SUPPORT_CASE_RECORDS_LIST_TITLE,
+  SUPPORT_CASES_LIST_TITLE,
+  documentLibraryTargetSchema,
+  documentLibraryTargetValues,
+  supportCaseAuditEventSchema,
+  supportCaseDocumentListItemSchema,
+  supportCaseEventActionSchema,
+  supportCaseEventActionValues,
+  supportCaseEventListItemSchema,
+  supportCaseEventTargetTypeSchema,
+  supportCaseEventTargetTypeValues,
+  supportCaseListItemSchema,
+  supportCaseRecordListItemSchema,
+} from './sharePointProjection';
+
+export type {
+  DocumentLibraryTarget,
+  SupportCaseAuditEvent,
+  SupportCaseDocumentListItem,
+  SupportCaseEventAction,
+  SupportCaseEventListItem,
+  SupportCaseEventTargetType,
+  SupportCaseListItem,
+  SupportCaseRecordListItem,
+} from './sharePointProjection';
+
+export {
+  toRestrictedDocumentListItem,
+  toStandardDocumentListItem,
+  toSupportCaseEventListItem,
+  toSupportCaseListItem,
+  toSupportCaseRecordListItem,
+} from './sharePointMapper';

--- a/src/domain/supportCase/sharePointMapper.ts
+++ b/src/domain/supportCase/sharePointMapper.ts
@@ -1,0 +1,152 @@
+import {
+  caseDocumentSchema,
+  caseRecordSchema,
+  supportCaseSchema,
+  type CaseDocument,
+  type CaseRecord,
+  type SupportCase,
+} from './schema';
+import {
+  supportCaseAuditEventSchema,
+  supportCaseDocumentListItemSchema,
+  supportCaseEventListItemSchema,
+  supportCaseListItemSchema,
+  supportCaseRecordListItemSchema,
+  type SupportCaseAuditEvent,
+  type SupportCaseDocumentListItem,
+  type SupportCaseEventListItem,
+  type SupportCaseListItem,
+  type SupportCaseRecordListItem,
+} from './sharePointProjection';
+
+export function toSupportCaseListItem(
+  value: SupportCase,
+): SupportCaseListItem {
+  const supportCase = supportCaseSchema.parse(value);
+  return supportCaseListItemSchema.parse({
+    Title: `${supportCase.userId}:${supportCase.id}`,
+    CaseId: supportCase.id,
+    TenantId: supportCase.tenantId,
+    UserId: supportCase.userId,
+    ServiceType: supportCase.serviceType,
+    Status: supportCase.status,
+    OpenedOn: supportCase.openedOn,
+    ClosedOn: supportCase.closedOn,
+    PrimaryStaffId: supportCase.primaryStaffId,
+    CreatedAt: supportCase.createdAt,
+    CreatedByKey: supportCase.createdBy,
+    UpdatedAt: supportCase.updatedAt,
+    UpdatedByKey: supportCase.updatedBy,
+  });
+}
+
+export function toSupportCaseRecordListItem(
+  value: CaseRecord,
+): SupportCaseRecordListItem {
+  const record = caseRecordSchema.parse(value);
+  return supportCaseRecordListItemSchema.parse({
+    Title: record.title,
+    RecordId: record.id,
+    TenantId: record.tenantId,
+    SupportCaseId: record.supportCaseId,
+    UserId: record.userId,
+    Category: record.category,
+    OccurredOn: record.occurredOn,
+    Status: record.status,
+    SourceModule: record.sourceModule,
+    SourceRecordId: record.sourceRecordId,
+    RelatedPlanId: record.relatedPlanId,
+    CreatedAt: record.createdAt,
+    CreatedByKey: record.createdBy,
+    UpdatedAt: record.updatedAt,
+    UpdatedByKey: record.updatedBy,
+  });
+}
+
+export function toStandardDocumentListItem(
+  value: CaseDocument,
+): SupportCaseDocumentListItem {
+  const document = caseDocumentSchema.parse(value);
+  if (document.category === 'personal_information') {
+    throw new Error(
+      'Personal information documents cannot be projected to the standard library',
+    );
+  }
+  if (document.supportCaseId === null) {
+    throw new Error('Standard document projection requires a support case id');
+  }
+  if (document.storageClass !== 'standard_library') {
+    throw new Error('Standard document projection requires standard_library');
+  }
+
+  return supportCaseDocumentListItemSchema.parse({
+    Title: document.fileName,
+    DocumentId: document.id,
+    TenantId: document.tenantId,
+    SupportCaseId: document.supportCaseId,
+    CaseRecordId: document.caseRecordId,
+    Category: document.category,
+    FileName: document.fileName,
+    StoragePolicy: document.storageClass,
+    LibraryTarget: 'standard_documents',
+    StorageLocator: document.storageLocator,
+    Sensitivity: document.sensitivity,
+    AuditLogRequired: document.auditLoggingRequired,
+    TemplateKey: document.templateKey,
+    TemplateVersion: document.templateVersion,
+    CreatedAt: document.createdAt,
+    CreatedByKey: document.createdBy,
+  });
+}
+
+export function toRestrictedDocumentListItem(
+  value: CaseDocument,
+): SupportCaseDocumentListItem {
+  const document = caseDocumentSchema.parse(value);
+  if (document.category !== 'personal_information') {
+    throw new Error(
+      'Restricted document projection accepts personal information documents only',
+    );
+  }
+  if (document.supportCaseId === null) {
+    throw new Error('Restricted document projection requires a support case id');
+  }
+
+  return supportCaseDocumentListItemSchema.parse({
+    Title: document.fileName,
+    DocumentId: document.id,
+    TenantId: document.tenantId,
+    SupportCaseId: document.supportCaseId,
+    CaseRecordId: document.caseRecordId,
+    Category: document.category,
+    FileName: document.fileName,
+    StoragePolicy: document.storageClass,
+    LibraryTarget: 'restricted_personal_documents',
+    StorageLocator: document.storageLocator,
+    Sensitivity: document.sensitivity,
+    AuditLogRequired: document.auditLoggingRequired,
+    TemplateKey: document.templateKey,
+    TemplateVersion: document.templateVersion,
+    CreatedAt: document.createdAt,
+    CreatedByKey: document.createdBy,
+  });
+}
+
+export function toSupportCaseEventListItem(
+  value: SupportCaseAuditEvent,
+): SupportCaseEventListItem {
+  const event = supportCaseAuditEventSchema.parse(value);
+  return supportCaseEventListItemSchema.parse({
+    Title: `${event.action}:${event.targetType}:${event.targetId}`,
+    EventId: event.id,
+    TenantId: event.tenantId,
+    SupportCaseId: event.supportCaseId,
+    TargetType: event.targetType,
+    TargetId: event.targetId,
+    Action: event.action,
+    ActorId: event.actorId,
+    OccurredAt: event.occurredAt,
+    AuditLogRequired: event.auditLogRequired,
+    DetailJson: event.detailJson,
+  });
+}

--- a/src/domain/supportCase/sharePointProjection.ts
+++ b/src/domain/supportCase/sharePointProjection.ts
@@ -1,0 +1,173 @@
+import { z } from 'zod';
+import {
+  caseRecordCategorySchema,
+  caseRecordStatusSchema,
+  documentSensitivitySchema,
+  supportCaseStatusSchema,
+} from './schema';
+
+const requiredText = z.string().min(1);
+const nullableText = requiredText.nullable();
+const isoDate = z.string().date();
+const isoDateTime = z.string().datetime({ offset: true });
+
+export const SUPPORT_CASES_LIST_TITLE = 'SupportCases' as const;
+export const SUPPORT_CASE_RECORDS_LIST_TITLE = 'SupportCaseRecords' as const;
+export const SUPPORT_CASE_DOCUMENTS_LIST_TITLE = 'SupportCaseDocuments' as const;
+export const SUPPORT_CASE_EVENTS_LIST_TITLE = 'SupportCaseEvents' as const;
+
+export const supportCaseListItemSchema = z.object({
+  Title: requiredText,
+  CaseId: requiredText,
+  TenantId: requiredText,
+  UserId: requiredText,
+  ServiceType: requiredText,
+  Status: supportCaseStatusSchema,
+  OpenedOn: isoDate,
+  ClosedOn: isoDate.nullable(),
+  PrimaryStaffId: requiredText,
+  CreatedAt: isoDateTime,
+  CreatedByKey: requiredText,
+  UpdatedAt: isoDateTime,
+  UpdatedByKey: requiredText,
+});
+
+export type SupportCaseListItem = z.infer<typeof supportCaseListItemSchema>;
+
+export const documentLibraryTargetValues = [
+  'standard_documents',
+  'restricted_personal_documents',
+] as const;
+
+export const documentLibraryTargetSchema = z.enum(documentLibraryTargetValues);
+export type DocumentLibraryTarget = z.infer<typeof documentLibraryTargetSchema>;
+
+export const supportCaseDocumentListItemSchema = z.object({
+  Title: requiredText,
+  DocumentId: requiredText,
+  TenantId: requiredText,
+  SupportCaseId: requiredText,
+  CaseRecordId: nullableText,
+  Category: caseRecordCategorySchema,
+  FileName: requiredText,
+  StoragePolicy: z.enum(['standard_library', 'restricted_library']),
+  LibraryTarget: documentLibraryTargetSchema,
+  StorageLocator: requiredText,
+  Sensitivity: documentSensitivitySchema,
+  AuditLogRequired: z.boolean(),
+  TemplateKey: nullableText,
+  TemplateVersion: nullableText,
+  CreatedAt: isoDateTime,
+  CreatedByKey: requiredText,
+}).superRefine((value, ctx) => {
+  if (value.Category === 'personal_information') {
+    if (value.StoragePolicy !== 'restricted_library') {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['StoragePolicy'],
+        message: '個人情報書類はrestricted_libraryへ投影してください',
+      });
+    }
+    if (value.LibraryTarget !== 'restricted_personal_documents') {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['LibraryTarget'],
+        message: '個人情報書類は制限付きライブラリへ投影してください',
+      });
+    }
+    if (!value.AuditLogRequired) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['AuditLogRequired'],
+        message: '個人情報書類の投影には監査ログが必要です',
+      });
+    }
+  }
+});
+
+export type SupportCaseDocumentListItem = z.infer<
+  typeof supportCaseDocumentListItemSchema
+>;
+
+export const supportCaseEventActionValues = [
+  'created',
+  'updated',
+  'viewed',
+  'downloaded',
+  'archived',
+] as const;
+
+export const supportCaseEventActionSchema = z.enum(supportCaseEventActionValues);
+export type SupportCaseEventAction = z.infer<typeof supportCaseEventActionSchema>;
+
+export const supportCaseEventTargetTypeValues = [
+  'support_case',
+  'case_record',
+  'case_document',
+] as const;
+
+export const supportCaseEventTargetTypeSchema = z.enum(
+  supportCaseEventTargetTypeValues,
+);
+export type SupportCaseEventTargetType = z.infer<
+  typeof supportCaseEventTargetTypeSchema
+>;
+
+export const supportCaseAuditEventSchema = z.object({
+  id: requiredText,
+  tenantId: requiredText,
+  supportCaseId: requiredText,
+  targetType: supportCaseEventTargetTypeSchema,
+  targetId: requiredText,
+  action: supportCaseEventActionSchema,
+  actorId: requiredText,
+  occurredAt: isoDateTime,
+  auditLogRequired: z.literal(true),
+  detailJson: z.string().nullable().default(null),
+});
+
+export type SupportCaseAuditEvent = z.infer<typeof supportCaseAuditEventSchema>;
+
+export const supportCaseEventListItemSchema = z.object({
+  Title: requiredText,
+  EventId: requiredText,
+  TenantId: requiredText,
+  SupportCaseId: requiredText,
+  TargetType: supportCaseEventTargetTypeSchema,
+  TargetId: requiredText,
+  Action: supportCaseEventActionSchema,
+  ActorId: requiredText,
+  OccurredAt: isoDateTime,
+  AuditLogRequired: z.literal(true),
+  DetailJson: z.string().nullable(),
+});
+
+export type SupportCaseEventListItem = z.infer<
+  typeof supportCaseEventListItemSchema
+>;
+
+/**
+ * Reserved projection for the seven-category record index.
+ * It is defined here so a future adapter does not need to invent field names.
+ */
+export const supportCaseRecordListItemSchema = z.object({
+  Title: requiredText,
+  RecordId: requiredText,
+  TenantId: requiredText,
+  SupportCaseId: requiredText,
+  UserId: requiredText,
+  Category: caseRecordCategorySchema,
+  OccurredOn: isoDate,
+  Status: caseRecordStatusSchema,
+  SourceModule: requiredText,
+  SourceRecordId: requiredText,
+  RelatedPlanId: nullableText,
+  CreatedAt: isoDateTime,
+  CreatedByKey: requiredText,
+  UpdatedAt: isoDateTime,
+  UpdatedByKey: requiredText,
+});
+
+export type SupportCaseRecordListItem = z.infer<
+  typeof supportCaseRecordListItemSchema
+>;


### PR DESCRIPTION
## Summary
- Add SharePoint projection schemas for `SupportCases`, `SupportCaseRecords`, `SupportCaseDocuments`, and `SupportCaseEvents`
- Add pure mappers from `SupportCase`, `CaseRecord`, `CaseDocument`, and support-case audit events
- Separate standard and restricted personal-document projection paths
- Reject personal information projected to the standard document library
- Validate tenant ID, case ID, storage policy, and audit-log requirements at the projection boundary
- Document the projection-only architecture and storage targets

## Scope boundary
This PR intentionally contains projection types and pure mapper functions only. It does not call SharePoint or Graph APIs and does not create lists, upload files, configure permissions, connect UI, or migrate existing documents.

## Out of scope
- SharePoint REST or Graph client implementation
- SharePoint list or document library creation
- Permission provisioning
- UI integration
- Existing document migration

## Verification
- `npx vitest run src/domain/supportCase`: 25 passed
- `npm run typecheck`: passed
- `npx eslint src/domain/supportCase --ext .ts --max-warnings=0`: passed
- Commit hooks: repository lint and typecheck passed
- `git diff --check origin/main..HEAD`: passed