### PR TITLE
feat(support-case): add SharePoint repository adapter

### DIFF
--- a/docs/model/generic-support-case-data-model.md
+++ b/docs/model/generic-support-case-data-model.md
@@ -112,3 +112,26 @@ SharePoint投影層は、ドメインモデルをSharePoint列名へ変換する
 各mapperは入力ドメインスキーマと出力投影スキーマの両方を検証する。`tenantId`、`supportCaseId`、保管ポリシー、監査ログ要件が欠落した値は、SharePoint Adapterへ到達する前に拒否する。
 
 この投影層にもSharePoint REST API、Graph client、実リスト作成、権限設定、UI、既存文書移行は含めない。
+
+## SharePoint Repository Adapter
+
+`SharePointSupportCaseRepository`は`SupportCaseRepository` Portを`IDataProvider`上で実装する。SharePoint列への変換は投影mapperへ委譲し、Adapter自身は検索、作成、更新、エラー境界を担当する。
+
+Adapterは次の安全条件を持つ。
+
+1. すべてのケース検索・更新を`tenantId + caseId`で絞り込む。
+2. 文書索引の追加前に、同一テナントの支援ケースが存在することを確認する。
+3. 個人情報文書は制限付き投影mapperだけを使用する。
+4. 個人情報文書の索引追加時に`SupportCaseEvents`へ監査イベントを記録する。
+5. 監査イベント保存に失敗した場合は、作成済み文書索引を削除する補償処理を行う。
+6. SharePointエラーを成功や空配列へ変換せず、`SupportCaseRepositoryError`として呼び出し元へ返す。
+7. `ensureListExists`を呼ばず、リスト作成・列追加・権限設定を行わない。
+
+このAdapterが保存するのはケースと文書参照メタデータであり、ドキュメントライブラリへのファイルアップロードは行わない。
+
+この段階にも次の処理は含めない。
+
+- 本番SharePointリスト・ライブラリの作成
+- 権限プロビジョニング
+- 既存フォルダ・文書の移行
+- UI接続

--- a/src/domain/supportCase/SharePointSupportCaseRepository.ts
+++ b/src/domain/supportCase/SharePointSupportCaseRepository.ts
@@ -91,7 +91,10 @@ export class SharePointSupportCaseRepository implements SupportCaseRepository {
           orderby: 'OpenedOn desc',
         },
       );
-      return rows.map((row) => toSupportCaseSummary(this.mapCaseRow(row)));
+      return rows
+        .map((row) => this.mapCaseRow(row))
+        .filter((supportCase) => supportCase.tenantId === tenantId)
+        .map(toSupportCaseSummary);
     } catch (error) {
       throw new SupportCaseRepositoryError('listCases', error);
     }
@@ -110,7 +113,10 @@ export class SharePointSupportCaseRepository implements SupportCaseRepository {
           top: 1,
         },
       );
-      return rows[0] ? this.mapCaseRow(rows[0]) : null;
+      const supportCase = rows[0] ? this.mapCaseRow(rows[0]) : null;
+      return supportCase?.tenantId === tenantId && supportCase.id === caseId
+        ? supportCase
+        : null;
     } catch (error) {
       throw new SupportCaseRepositoryError('getCase', error);
     }
@@ -184,7 +190,13 @@ export class SharePointSupportCaseRepository implements SupportCaseRepository {
           orderby: 'CreatedAt desc',
         },
       );
-      return rows.map((row) => this.mapDocumentRow(row));
+      return rows
+        .map((row) => this.mapDocumentRow(row))
+        .filter(
+          (document) =>
+            document.tenantId === tenantId &&
+            document.supportCaseId === caseId,
+        );
     } catch (error) {
       throw new SupportCaseRepositoryError('listDocumentReferences', error);
     }
@@ -216,6 +228,7 @@ export class SharePointSupportCaseRepository implements SupportCaseRepository {
     input: AddRestrictedPersonalDocumentInput,
   ): Promise<CaseDocument> {
     let createdItemId: string | number | null = null;
+    let createdDocument: CaseDocument | null = null;
 
     try {
       const supportCaseId = this.requireInputCaseId(input.supportCaseId);
@@ -230,6 +243,7 @@ export class SharePointSupportCaseRepository implements SupportCaseRepository {
         auditLoggingRequired: true,
         createdAt: timestamp,
       });
+      createdDocument = document;
 
       const created = await this.provider.createItem<Record<string, unknown>>(
         this.documentsListTitle,
@@ -259,21 +273,27 @@ export class SharePointSupportCaseRepository implements SupportCaseRepository {
       );
       return document;
     } catch (error) {
+      if (createdItemId === null && createdDocument !== null) {
+        try {
+          createdItemId = await this.findDocumentItemId(
+            createdDocument.tenantId,
+            createdDocument.id,
+          );
+        } catch (lookupError) {
+          throw new SupportCaseRepositoryError(
+            'addRestrictedPersonalDocument.rollbackLookup',
+            this.combineErrors(error, lookupError, 'Rollback lookup failed'),
+          );
+        }
+      }
+
       if (createdItemId !== null) {
         try {
           await this.provider.deleteItem(this.documentsListTitle, createdItemId);
         } catch (rollbackError) {
-          const originalMessage =
-            error instanceof Error ? error.message : String(error);
-          const rollbackMessage =
-            rollbackError instanceof Error
-              ? rollbackError.message
-              : String(rollbackError);
           throw new SupportCaseRepositoryError(
             'addRestrictedPersonalDocument.rollback',
-            new Error(
-              `Audit write failed: ${originalMessage}; rollback failed: ${rollbackMessage}`,
-            ),
+            this.combineErrors(error, rollbackError, 'Rollback failed'),
           );
         }
       }
@@ -296,7 +316,39 @@ export class SharePointSupportCaseRepository implements SupportCaseRepository {
         top: 1,
       },
     );
-    return rows[0] ?? null;
+    return (
+      rows.find((row) => {
+        const parsed = supportCaseListItemSchema.safeParse(row);
+        return (
+          parsed.success &&
+          parsed.data.TenantId === tenantId &&
+          parsed.data.CaseId === caseId
+        );
+      }) ?? null
+    );
+  }
+
+  private async findDocumentItemId(
+    tenantId: string,
+    documentId: string,
+  ): Promise<string | number | null> {
+    const rows = await this.provider.listItems<Record<string, unknown>>(
+      this.documentsListTitle,
+      {
+        select: ['Id', 'TenantId', 'DocumentId'],
+        filter: joinAnd([
+          buildEq('TenantId', tenantId),
+          buildEq('DocumentId', documentId),
+        ]),
+        top: 1,
+      },
+    );
+    const row = rows.find(
+      (item) =>
+        item.TenantId === tenantId &&
+        item.DocumentId === documentId,
+    );
+    return row ? this.optionalSharePointId(row) : null;
   }
 
   private async requireCase(
@@ -370,5 +422,19 @@ export class SharePointSupportCaseRepository implements SupportCaseRepository {
   private optionalSharePointId(row: Record<string, unknown>): string | number | null {
     const id = row.Id ?? row.ID ?? row.id;
     return typeof id === 'string' || typeof id === 'number' ? id : null;
+  }
+
+  private combineErrors(
+    original: unknown,
+    secondary: unknown,
+    label: string,
+  ): Error {
+    const originalMessage =
+      original instanceof Error ? original.message : String(original);
+    const secondaryMessage =
+      secondary instanceof Error ? secondary.message : String(secondary);
+    return new Error(
+      `Original failure: ${originalMessage}; ${label}: ${secondaryMessage}`,
+    );
   }
 }

--- a/src/domain/supportCase/SharePointSupportCaseRepository.ts
+++ b/src/domain/supportCase/SharePointSupportCaseRepository.ts
@@ -1,0 +1,374 @@
+import type { IDataProvider } from '@/lib/data/dataProvider.interface';
+import { buildEq, joinAnd } from '@/sharepoint/query/builders';
+import type {
+  AddDocumentReferenceInput,
+  AddRestrictedPersonalDocumentInput,
+  CreateSupportCaseInput,
+  SupportCaseId,
+  SupportCaseRepository,
+  SupportCaseSummary,
+  UpdateSupportCaseInput,
+} from './repository';
+import { toSupportCaseSummary } from './repository';
+import {
+  caseDocumentSchema,
+  supportCaseSchema,
+  type CaseDocument,
+  type SupportCase,
+} from './schema';
+import {
+  toRestrictedDocumentListItem,
+  toStandardDocumentListItem,
+  toSupportCaseEventListItem,
+  toSupportCaseListItem,
+} from './sharePointMapper';
+import {
+  SUPPORT_CASE_DOCUMENTS_LIST_TITLE,
+  SUPPORT_CASE_EVENTS_LIST_TITLE,
+  SUPPORT_CASES_LIST_TITLE,
+  supportCaseDocumentListItemSchema,
+  supportCaseListItemSchema,
+  type SupportCaseAuditEvent,
+} from './sharePointProjection';
+
+type EntityKind = 'case' | 'document' | 'event';
+
+export interface SharePointSupportCaseRepositoryOptions {
+  provider: IDataProvider;
+  now?: () => string;
+  createId?: (entity: EntityKind) => string;
+  listTitles?: {
+    cases?: string;
+    documents?: string;
+    events?: string;
+  };
+}
+
+export class SupportCaseRepositoryError extends Error {
+  readonly operation: string;
+  readonly causeValue: unknown;
+
+  constructor(operation: string, causeValue: unknown) {
+    const message = causeValue instanceof Error ? causeValue.message : String(causeValue);
+    super(`SupportCase repository ${operation} failed: ${message}`);
+    this.name = 'SupportCaseRepositoryError';
+    this.operation = operation;
+    this.causeValue = causeValue;
+  }
+}
+
+const defaultCreateId = (entity: EntityKind): string =>
+  `${entity}-${globalThis.crypto.randomUUID()}`;
+
+const CASE_SELECT = Object.keys(supportCaseListItemSchema.shape);
+const DOCUMENT_SELECT = Object.keys(supportCaseDocumentListItemSchema.shape);
+
+export class SharePointSupportCaseRepository implements SupportCaseRepository {
+  private readonly provider: IDataProvider;
+  private readonly now: () => string;
+  private readonly createId: (entity: EntityKind) => string;
+  private readonly casesListTitle: string;
+  private readonly documentsListTitle: string;
+  private readonly eventsListTitle: string;
+
+  constructor(options: SharePointSupportCaseRepositoryOptions) {
+    this.provider = options.provider;
+    this.now = options.now ?? (() => new Date().toISOString());
+    this.createId = options.createId ?? defaultCreateId;
+    this.casesListTitle = options.listTitles?.cases ?? SUPPORT_CASES_LIST_TITLE;
+    this.documentsListTitle =
+      options.listTitles?.documents ?? SUPPORT_CASE_DOCUMENTS_LIST_TITLE;
+    this.eventsListTitle = options.listTitles?.events ?? SUPPORT_CASE_EVENTS_LIST_TITLE;
+  }
+
+  async listCases(tenantId: string): Promise<SupportCaseSummary[]> {
+    try {
+      const rows = await this.provider.listItems<Record<string, unknown>>(
+        this.casesListTitle,
+        {
+          select: CASE_SELECT,
+          filter: buildEq('TenantId', tenantId),
+          orderby: 'OpenedOn desc',
+        },
+      );
+      return rows.map((row) => toSupportCaseSummary(this.mapCaseRow(row)));
+    } catch (error) {
+      throw new SupportCaseRepositoryError('listCases', error);
+    }
+  }
+
+  async getCase(
+    tenantId: string,
+    caseId: SupportCaseId,
+  ): Promise<SupportCase | null> {
+    try {
+      const rows = await this.provider.listItems<Record<string, unknown>>(
+        this.casesListTitle,
+        {
+          select: CASE_SELECT,
+          filter: this.caseFilter(tenantId, caseId),
+          top: 1,
+        },
+      );
+      return rows[0] ? this.mapCaseRow(rows[0]) : null;
+    } catch (error) {
+      throw new SupportCaseRepositoryError('getCase', error);
+    }
+  }
+
+  async createCase(input: CreateSupportCaseInput): Promise<SupportCase> {
+    const timestamp = this.now();
+    const supportCase = supportCaseSchema.parse({
+      ...input,
+      id: this.createId('case'),
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      updatedBy: input.createdBy,
+    });
+
+    try {
+      await this.provider.createItem(
+        this.casesListTitle,
+        toSupportCaseListItem(supportCase),
+      );
+      return supportCase;
+    } catch (error) {
+      throw new SupportCaseRepositoryError('createCase', error);
+    }
+  }
+
+  async updateCase(
+    tenantId: string,
+    caseId: SupportCaseId,
+    patch: UpdateSupportCaseInput,
+  ): Promise<SupportCase> {
+    try {
+      const row = await this.findCaseRow(tenantId, caseId);
+      if (!row) throw new Error(`Support case not found: ${caseId}`);
+
+      const current = this.mapCaseRow(row);
+      const updated = supportCaseSchema.parse({
+        ...current,
+        ...patch,
+        id: caseId,
+        tenantId,
+        updatedAt: this.now(),
+      });
+
+      await this.provider.updateItem(
+        this.casesListTitle,
+        this.requireSharePointId(row, 'support case'),
+        toSupportCaseListItem(updated),
+        { etag: '*' },
+      );
+      return updated;
+    } catch (error) {
+      throw new SupportCaseRepositoryError('updateCase', error);
+    }
+  }
+
+  async listDocumentReferences(
+    tenantId: string,
+    caseId: SupportCaseId,
+  ): Promise<CaseDocument[]> {
+    try {
+      await this.requireCase(tenantId, caseId);
+      const rows = await this.provider.listItems<Record<string, unknown>>(
+        this.documentsListTitle,
+        {
+          select: DOCUMENT_SELECT,
+          filter: joinAnd([
+            buildEq('TenantId', tenantId),
+            buildEq('SupportCaseId', caseId),
+          ]),
+          orderby: 'CreatedAt desc',
+        },
+      );
+      return rows.map((row) => this.mapDocumentRow(row));
+    } catch (error) {
+      throw new SupportCaseRepositoryError('listDocumentReferences', error);
+    }
+  }
+
+  async addDocumentReference(
+    input: AddDocumentReferenceInput,
+  ): Promise<CaseDocument> {
+    try {
+      const supportCaseId = this.requireInputCaseId(input.supportCaseId);
+      await this.requireCase(input.tenantId, supportCaseId);
+      const document = caseDocumentSchema.parse({
+        ...input,
+        id: this.createId('document'),
+        createdAt: this.now(),
+      });
+
+      await this.provider.createItem(
+        this.documentsListTitle,
+        toStandardDocumentListItem(document),
+      );
+      return document;
+    } catch (error) {
+      throw new SupportCaseRepositoryError('addDocumentReference', error);
+    }
+  }
+
+  async addRestrictedPersonalDocument(
+    input: AddRestrictedPersonalDocumentInput,
+  ): Promise<CaseDocument> {
+    let createdItemId: string | number | null = null;
+
+    try {
+      const supportCaseId = this.requireInputCaseId(input.supportCaseId);
+      await this.requireCase(input.tenantId, supportCaseId);
+      const timestamp = this.now();
+      const document = caseDocumentSchema.parse({
+        ...input,
+        id: this.createId('document'),
+        category: 'personal_information',
+        storageClass: 'restricted_library',
+        sensitivity: 'restricted',
+        auditLoggingRequired: true,
+        createdAt: timestamp,
+      });
+
+      const created = await this.provider.createItem<Record<string, unknown>>(
+        this.documentsListTitle,
+        toRestrictedDocumentListItem(document),
+      );
+      createdItemId = this.optionalSharePointId(created);
+
+      const event: SupportCaseAuditEvent = {
+        id: this.createId('event'),
+        tenantId: document.tenantId,
+        supportCaseId,
+        targetType: 'case_document',
+        targetId: document.id,
+        action: 'created',
+        actorId: document.createdBy,
+        occurredAt: timestamp,
+        auditLogRequired: true,
+        detailJson: JSON.stringify({
+          category: document.category,
+          storagePolicy: document.storageClass,
+        }),
+      };
+
+      await this.provider.createItem(
+        this.eventsListTitle,
+        toSupportCaseEventListItem(event),
+      );
+      return document;
+    } catch (error) {
+      if (createdItemId !== null) {
+        try {
+          await this.provider.deleteItem(this.documentsListTitle, createdItemId);
+        } catch (rollbackError) {
+          const originalMessage =
+            error instanceof Error ? error.message : String(error);
+          const rollbackMessage =
+            rollbackError instanceof Error
+              ? rollbackError.message
+              : String(rollbackError);
+          throw new SupportCaseRepositoryError(
+            'addRestrictedPersonalDocument.rollback',
+            new Error(
+              `Audit write failed: ${originalMessage}; rollback failed: ${rollbackMessage}`,
+            ),
+          );
+        }
+      }
+      throw new SupportCaseRepositoryError(
+        'addRestrictedPersonalDocument',
+        error,
+      );
+    }
+  }
+
+  private async findCaseRow(
+    tenantId: string,
+    caseId: SupportCaseId,
+  ): Promise<Record<string, unknown> | null> {
+    const rows = await this.provider.listItems<Record<string, unknown>>(
+      this.casesListTitle,
+      {
+        select: ['Id', ...CASE_SELECT],
+        filter: this.caseFilter(tenantId, caseId),
+        top: 1,
+      },
+    );
+    return rows[0] ?? null;
+  }
+
+  private async requireCase(
+    tenantId: string,
+    caseId: SupportCaseId,
+  ): Promise<SupportCase> {
+    const row = await this.findCaseRow(tenantId, caseId);
+    if (!row) throw new Error(`Support case not found: ${caseId}`);
+    return this.mapCaseRow(row);
+  }
+
+  private caseFilter(tenantId: string, caseId: SupportCaseId): string {
+    return joinAnd([
+      buildEq('TenantId', tenantId),
+      buildEq('CaseId', caseId),
+    ]);
+  }
+
+  private mapCaseRow(row: Record<string, unknown>): SupportCase {
+    const item = supportCaseListItemSchema.parse(row);
+    return supportCaseSchema.parse({
+      id: item.CaseId,
+      tenantId: item.TenantId,
+      userId: item.UserId,
+      serviceType: item.ServiceType,
+      status: item.Status,
+      openedOn: item.OpenedOn,
+      closedOn: item.ClosedOn,
+      primaryStaffId: item.PrimaryStaffId,
+      createdAt: item.CreatedAt,
+      createdBy: item.CreatedByKey,
+      updatedAt: item.UpdatedAt,
+      updatedBy: item.UpdatedByKey,
+    });
+  }
+
+  private mapDocumentRow(row: Record<string, unknown>): CaseDocument {
+    const item = supportCaseDocumentListItemSchema.parse(row);
+    return caseDocumentSchema.parse({
+      id: item.DocumentId,
+      tenantId: item.TenantId,
+      supportCaseId: item.SupportCaseId,
+      caseRecordId: item.CaseRecordId,
+      category: item.Category,
+      fileName: item.FileName,
+      storageClass: item.StoragePolicy,
+      storageLocator: item.StorageLocator,
+      sensitivity: item.Sensitivity,
+      auditLoggingRequired: item.AuditLogRequired,
+      templateKey: item.TemplateKey,
+      templateVersion: item.TemplateVersion,
+      createdAt: item.CreatedAt,
+      createdBy: item.CreatedByKey,
+    });
+  }
+
+  private requireInputCaseId(caseId: string | null): string {
+    if (!caseId) throw new Error('Support case id is required');
+    return caseId;
+  }
+
+  private requireSharePointId(
+    row: Record<string, unknown>,
+    entity: string,
+  ): string | number {
+    const id = this.optionalSharePointId(row);
+    if (id === null) throw new Error(`SharePoint ${entity} item id is missing`);
+    return id;
+  }
+
+  private optionalSharePointId(row: Record<string, unknown>): string | number | null {
+    const id = row.Id ?? row.ID ?? row.id;
+    return typeof id === 'string' || typeof id === 'number' ? id : null;
+  }
+}

--- a/src/domain/supportCase/__tests__/SharePointSupportCaseRepository.spec.ts
+++ b/src/domain/supportCase/__tests__/SharePointSupportCaseRepository.spec.ts
@@ -1,0 +1,309 @@
+import { beforeEach, describe, expect, it, vi, type Mocked } from 'vitest';
+import type { IDataProvider } from '@/lib/data/dataProvider.interface';
+import {
+  SharePointSupportCaseRepository,
+  SupportCaseRepositoryError,
+} from '../SharePointSupportCaseRepository';
+import {
+  SUPPORT_CASE_DOCUMENTS_LIST_TITLE,
+  SUPPORT_CASE_EVENTS_LIST_TITLE,
+  SUPPORT_CASES_LIST_TITLE,
+} from '../sharePointProjection';
+
+const timestamp = '2026-06-07T12:00:00+09:00';
+
+const caseRow = {
+  Id: 10,
+  Title: 'U001:case-1',
+  CaseId: 'case-1',
+  TenantId: 'office-1',
+  UserId: 'U001',
+  ServiceType: 'daily_life_care',
+  Status: 'active',
+  OpenedOn: '2026-04-01',
+  ClosedOn: null,
+  PrimaryStaffId: 'staff-1',
+  CreatedAt: timestamp,
+  CreatedByKey: 'staff-1',
+  UpdatedAt: timestamp,
+  UpdatedByKey: 'staff-1',
+};
+
+const documentRow = {
+  Id: 20,
+  Title: 'assessment.pdf',
+  DocumentId: 'document-1',
+  TenantId: 'office-1',
+  SupportCaseId: 'case-1',
+  CaseRecordId: null,
+  Category: 'assessment',
+  FileName: 'assessment.pdf',
+  StoragePolicy: 'standard_library',
+  LibraryTarget: 'standard_documents',
+  StorageLocator: 'standard-drive-item-id',
+  Sensitivity: 'confidential',
+  AuditLogRequired: true,
+  TemplateKey: null,
+  TemplateVersion: null,
+  CreatedAt: timestamp,
+  CreatedByKey: 'staff-1',
+};
+
+const makeProvider = (): Mocked<IDataProvider> => ({
+  listItems: vi.fn(),
+  getItemById: vi.fn(),
+  createItem: vi.fn(),
+  updateItem: vi.fn(),
+  deleteItem: vi.fn(),
+  getMetadata: vi.fn(),
+  getResourceNames: vi.fn(),
+  getFieldInternalNames: vi.fn(),
+  ensureListExists: vi.fn(),
+  seed: vi.fn(),
+});
+
+describe('SharePointSupportCaseRepository', () => {
+  let provider: Mocked<IDataProvider>;
+  let repository: SharePointSupportCaseRepository;
+  let nextId: number;
+
+  beforeEach(() => {
+    provider = makeProvider();
+    nextId = 1;
+    repository = new SharePointSupportCaseRepository({
+      provider,
+      now: () => timestamp,
+      createId: (entity) => `${entity}-${nextId++}`,
+    });
+  });
+
+  it('lists cases within the tenant boundary', async () => {
+    provider.listItems.mockResolvedValue([caseRow]);
+
+    const result = await repository.listCases('office-1');
+
+    expect(provider.listItems).toHaveBeenCalledWith(
+      SUPPORT_CASES_LIST_TITLE,
+      expect.objectContaining({
+        filter: expect.stringContaining("TenantId eq 'office-1'"),
+      }),
+    );
+    expect(result).toEqual([
+      expect.objectContaining({
+        id: 'case-1',
+        tenantId: 'office-1',
+        userId: 'U001',
+      }),
+    ]);
+  });
+
+  it('creates a case with the projection mapper', async () => {
+    provider.createItem.mockResolvedValue({ Id: 11 });
+
+    const created = await repository.createCase({
+      tenantId: 'office-1',
+      userId: 'U002',
+      serviceType: 'daily_life_care',
+      status: 'active',
+      openedOn: '2026-06-01',
+      closedOn: null,
+      primaryStaffId: 'staff-2',
+      createdBy: 'staff-2',
+    });
+
+    expect(provider.createItem).toHaveBeenCalledWith(
+      SUPPORT_CASES_LIST_TITLE,
+      expect.objectContaining({
+        CaseId: 'case-1',
+        TenantId: 'office-1',
+        UserId: 'U002',
+      }),
+    );
+    expect(created.id).toBe('case-1');
+  });
+
+  it('updates only a case matched by tenantId and caseId', async () => {
+    provider.listItems.mockResolvedValue([caseRow]);
+    provider.updateItem.mockResolvedValue({});
+
+    const updated = await repository.updateCase('office-1', 'case-1', {
+      status: 'closed',
+      closedOn: '2026-06-07',
+      updatedBy: 'staff-2',
+    });
+
+    expect(provider.listItems).toHaveBeenCalledWith(
+      SUPPORT_CASES_LIST_TITLE,
+      expect.objectContaining({
+        filter: expect.stringContaining("TenantId eq 'office-1'"),
+      }),
+    );
+    expect(provider.updateItem).toHaveBeenCalledWith(
+      SUPPORT_CASES_LIST_TITLE,
+      10,
+      expect.objectContaining({
+        CaseId: 'case-1',
+        Status: 'closed',
+        ClosedOn: '2026-06-07',
+      }),
+      { etag: '*' },
+    );
+    expect(updated.status).toBe('closed');
+  });
+
+  it('maps document list rows back to domain references', async () => {
+    provider.listItems
+      .mockResolvedValueOnce([caseRow])
+      .mockResolvedValueOnce([documentRow]);
+
+    const documents = await repository.listDocumentReferences(
+      'office-1',
+      'case-1',
+    );
+
+    expect(documents).toEqual([
+      expect.objectContaining({
+        id: 'document-1',
+        category: 'assessment',
+        storageClass: 'standard_library',
+      }),
+    ]);
+  });
+
+  it('stores a standard document without creating a restricted audit event', async () => {
+    provider.listItems.mockResolvedValue([caseRow]);
+    provider.createItem.mockResolvedValue({ Id: 21 });
+
+    const document = await repository.addDocumentReference({
+      tenantId: 'office-1',
+      supportCaseId: 'case-1',
+      caseRecordId: null,
+      category: 'assessment',
+      fileName: 'assessment.pdf',
+      storageClass: 'standard_library',
+      storageLocator: 'standard-drive-item-id',
+      sensitivity: 'confidential',
+      auditLoggingRequired: true,
+      templateKey: null,
+      templateVersion: null,
+      createdBy: 'staff-1',
+    });
+
+    expect(provider.createItem).toHaveBeenCalledTimes(1);
+    expect(provider.createItem).toHaveBeenCalledWith(
+      SUPPORT_CASE_DOCUMENTS_LIST_TITLE,
+      expect.objectContaining({
+        Category: 'assessment',
+        LibraryTarget: 'standard_documents',
+      }),
+    );
+    expect(document.category).toBe('assessment');
+  });
+
+  it('stores restricted document metadata and its audit event', async () => {
+    provider.listItems.mockResolvedValue([caseRow]);
+    provider.createItem
+      .mockResolvedValueOnce({ Id: 22 })
+      .mockResolvedValueOnce({ Id: 23 });
+
+    const document = await repository.addRestrictedPersonalDocument({
+      tenantId: 'office-1',
+      supportCaseId: 'case-1',
+      caseRecordId: null,
+      fileName: 'certificate.pdf',
+      storageLocator: 'restricted-drive-item-id',
+      templateKey: null,
+      templateVersion: null,
+      createdBy: 'privacy-officer-1',
+    });
+
+    expect(provider.createItem).toHaveBeenNthCalledWith(
+      1,
+      SUPPORT_CASE_DOCUMENTS_LIST_TITLE,
+      expect.objectContaining({
+        Category: 'personal_information',
+        LibraryTarget: 'restricted_personal_documents',
+        AuditLogRequired: true,
+      }),
+    );
+    expect(provider.createItem).toHaveBeenNthCalledWith(
+      2,
+      SUPPORT_CASE_EVENTS_LIST_TITLE,
+      expect.objectContaining({
+        TargetType: 'case_document',
+        TargetId: 'document-1',
+        Action: 'created',
+        AuditLogRequired: true,
+      }),
+    );
+    expect(document.storageClass).toBe('restricted_library');
+  });
+
+  it('rolls back restricted metadata when audit event persistence fails', async () => {
+    provider.listItems.mockResolvedValue([caseRow]);
+    provider.createItem
+      .mockResolvedValueOnce({ Id: 24 })
+      .mockRejectedValueOnce(new Error('events list unavailable'));
+    provider.deleteItem.mockResolvedValue();
+
+    await expect(
+      repository.addRestrictedPersonalDocument({
+        tenantId: 'office-1',
+        supportCaseId: 'case-1',
+        caseRecordId: null,
+        fileName: 'certificate.pdf',
+        storageLocator: 'restricted-drive-item-id',
+        templateKey: null,
+        templateVersion: null,
+        createdBy: 'privacy-officer-1',
+      }),
+    ).rejects.toMatchObject({
+      operation: 'addRestrictedPersonalDocument',
+    });
+
+    expect(provider.deleteItem).toHaveBeenCalledWith(
+      SUPPORT_CASE_DOCUMENTS_LIST_TITLE,
+      24,
+    );
+  });
+
+  it('does not write a document when the tenant-scoped case does not exist', async () => {
+    provider.listItems.mockResolvedValue([]);
+
+    await expect(
+      repository.addDocumentReference({
+        tenantId: 'office-2',
+        supportCaseId: 'case-1',
+        caseRecordId: null,
+        category: 'assessment',
+        fileName: 'assessment.pdf',
+        storageClass: 'standard_library',
+        storageLocator: 'standard-drive-item-id',
+        sensitivity: 'confidential',
+        auditLoggingRequired: true,
+        templateKey: null,
+        templateVersion: null,
+        createdBy: 'staff-1',
+      }),
+    ).rejects.toBeInstanceOf(SupportCaseRepositoryError);
+
+    expect(provider.createItem).not.toHaveBeenCalled();
+  });
+
+  it('fails safely when SharePoint read operations reject', async () => {
+    provider.listItems.mockRejectedValue(new Error('SharePoint unavailable'));
+
+    await expect(repository.listCases('office-1')).rejects.toMatchObject({
+      name: 'SupportCaseRepositoryError',
+      operation: 'listCases',
+    });
+  });
+
+  it('never provisions SharePoint lists from the repository adapter', async () => {
+    provider.listItems.mockResolvedValue([]);
+
+    await repository.listCases('office-1');
+
+    expect(provider.ensureListExists).not.toHaveBeenCalled();
+  });
+});

--- a/src/domain/supportCase/__tests__/SharePointSupportCaseRepository.spec.ts
+++ b/src/domain/supportCase/__tests__/SharePointSupportCaseRepository.spec.ts
@@ -78,7 +78,10 @@ describe('SharePointSupportCaseRepository', () => {
   });
 
   it('lists cases within the tenant boundary', async () => {
-    provider.listItems.mockResolvedValue([caseRow]);
+    provider.listItems.mockResolvedValue([
+      caseRow,
+      { ...caseRow, Id: 11, CaseId: 'case-2', TenantId: 'office-2' },
+    ]);
 
     const result = await repository.listCases('office-1');
 
@@ -154,7 +157,10 @@ describe('SharePointSupportCaseRepository', () => {
   it('maps document list rows back to domain references', async () => {
     provider.listItems
       .mockResolvedValueOnce([caseRow])
-      .mockResolvedValueOnce([documentRow]);
+      .mockResolvedValueOnce([
+        documentRow,
+        { ...documentRow, Id: 21, DocumentId: 'document-2', TenantId: 'office-2' },
+      ]);
 
     const documents = await repository.listDocumentReferences(
       'office-1',
@@ -264,6 +270,50 @@ describe('SharePointSupportCaseRepository', () => {
     expect(provider.deleteItem).toHaveBeenCalledWith(
       SUPPORT_CASE_DOCUMENTS_LIST_TITLE,
       24,
+    );
+  });
+
+  it('finds restricted metadata by tenant and document id when create omits Id', async () => {
+    provider.listItems
+      .mockResolvedValueOnce([caseRow])
+      .mockResolvedValueOnce([
+        {
+          Id: 25,
+          TenantId: 'office-1',
+          DocumentId: 'document-1',
+        },
+      ]);
+    provider.createItem
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(new Error('events list unavailable'));
+    provider.deleteItem.mockResolvedValue();
+
+    await expect(
+      repository.addRestrictedPersonalDocument({
+        tenantId: 'office-1',
+        supportCaseId: 'case-1',
+        caseRecordId: null,
+        fileName: 'certificate.pdf',
+        storageLocator: 'restricted-drive-item-id',
+        templateKey: null,
+        templateVersion: null,
+        createdBy: 'privacy-officer-1',
+      }),
+    ).rejects.toMatchObject({
+      operation: 'addRestrictedPersonalDocument',
+    });
+
+    expect(provider.listItems).toHaveBeenNthCalledWith(
+      2,
+      SUPPORT_CASE_DOCUMENTS_LIST_TITLE,
+      expect.objectContaining({
+        filter: expect.stringContaining("TenantId eq 'office-1'"),
+        top: 1,
+      }),
+    );
+    expect(provider.deleteItem).toHaveBeenCalledWith(
+      SUPPORT_CASE_DOCUMENTS_LIST_TITLE,
+      25,
     );
   });
 

--- a/src/domain/supportCase/index.ts
+++ b/src/domain/supportCase/index.ts
@@ -88,3 +88,12 @@ export {
   toSupportCaseListItem,
   toSupportCaseRecordListItem,
 } from './sharePointMapper';
+
+export {
+  SharePointSupportCaseRepository,
+  SupportCaseRepositoryError,
+} from './SharePointSupportCaseRepository';
+
+export type {
+  SharePointSupportCaseRepositoryOptions,
+} from './SharePointSupportCaseRepository';


### PR DESCRIPTION
## Summary
- Add `SharePointSupportCaseRepository` implementing the existing `SupportCaseRepository` port through `IDataProvider`
- Reuse the SharePoint projection mappers for case and document read/write operations
- Enforce tenant-scoped case lookup before updates and document writes
- Persist a `SupportCaseEvents` audit event when restricted personal-document metadata is created
- Roll back restricted document metadata when audit-event persistence fails
- Surface SharePoint failures as `SupportCaseRepositoryError` instead of returning false success or empty data
- Add mocked transport tests for case CRUD, document mapping, tenant isolation, audit persistence, rollback, and API failure

## Scope boundary
This PR adds the repository adapter only. It does not provision SharePoint lists or libraries, upload document files, configure permissions, connect UI, or migrate existing content.

## Out of scope
- Production SharePoint list or document library creation
- Permission provisioning
- Document file upload
- Existing folder or document migration
- UI integration

## Verification
- `npx vitest run src/domain/supportCase`: 36 passed
- `npm run typecheck`: passed
- `npx eslint src/domain/supportCase --ext .ts --max-warnings=0`: passed
- Commit hooks: repository lint and typecheck passed
- `git diff --check origin/main..HEAD`: passed
