### PR TITLE
test(support-case): add coverage for restricted document projection guard

### DIFF
--- a/src/domain/supportCase/__tests__/sharePointMapper.spec.ts
+++ b/src/domain/supportCase/__tests__/sharePointMapper.spec.ts
@@ -139,6 +139,12 @@ describe('SharePoint document projection', () => {
     });
   });
 
+  it('prevents non-personal information from using the restricted projection', () => {
+    expect(() => toRestrictedDocumentListItem(standardDocument)).toThrow(
+      'personal information documents only',
+    );
+  });
+
   it.each([
     ['tenantId', { ...standardDocument, tenantId: '' }],
     ['caseId', { ...standardDocument, supportCaseId: null }],


### PR DESCRIPTION
## Summary
- Add coverage for the restricted support-case document projection guard.
- Verify that non-personal-information documents cannot use the restricted projection path.

## Verification
- npx vitest run src/domain/supportCase/__tests__/sharePointMapper.spec.ts --reporter=verbose
- npm run typecheck
- npm run lint
- git diff --check

## Risk
- Test-only change. No runtime behavior, SharePoint schema, dependency, or environment changes.
