### PR TITLE
test(planning-sheet): stabilize async support planning specs

### DIFF
--- a/src/features/assessment/hooks/__tests__/useTokuseiSurveyResponses.spec.ts
+++ b/src/features/assessment/hooks/__tests__/useTokuseiSurveyResponses.spec.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { renderHook } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 import { useTokuseiSurveyResponses } from '../useTokuseiSurveyResponses';
 
 const mockEnv = {
@@ -51,7 +51,7 @@ describe('useTokuseiSurveyResponses Hook', () => {
 
     const { result } = renderHook(() => useTokuseiSurveyResponses());
 
-    await vi.waitFor(() => {
+    await waitFor(() => {
       expect(result.current.status).toBe('success');
     });
 
@@ -64,7 +64,7 @@ describe('useTokuseiSurveyResponses Hook', () => {
 
     const { result } = renderHook(() => useTokuseiSurveyResponses());
 
-    await vi.waitFor(() => {
+    await waitFor(() => {
       expect(result.current.status).toBe('success');
     });
 
@@ -77,7 +77,7 @@ describe('useTokuseiSurveyResponses Hook', () => {
 
     const { result } = renderHook(() => useTokuseiSurveyResponses());
 
-    await vi.waitFor(() => {
+    await waitFor(() => {
       expect(result.current.status).toBe('success');
     });
 

--- a/src/pages/support-planning-sheet/__tests__/SupportPlanningSheetReflection.spec.tsx
+++ b/src/pages/support-planning-sheet/__tests__/SupportPlanningSheetReflection.spec.tsx
@@ -15,6 +15,10 @@ vi.mock('@/infra/abc/useAbcRecordRepository', () => ({
   useAbcRecordRepository: vi.fn().mockReturnValue(mockAbcRecordRepo),
 }));
 
+vi.mock('@/features/ibd/analysis/pdca/components/AbcEvidencePanel', () => ({
+  AbcEvidencePanel: () => 'まだ十分な分析データがありません',
+}));
+
 import { SupportPlanningSheetView } from '../SupportPlanningSheetView';
 import { MemoryRouter } from 'react-router-dom';
 import { SupportPlanningSheetViewModel, SupportPlanningSheetActionHandlers } from '../types';
@@ -159,7 +163,7 @@ describe('SupportPlanningSheetReflection UI Interaction', () => {
     
     expect(mockHandlers.onOpenReflectPreview).toHaveBeenCalled();
 
-    await screen.findByText('まだ十分な分析データがありません');
+    expect(await screen.findByText('まだ十分な分析データがありません')).toBeInTheDocument();
   });
 
   it('reflectPreviewOpen が true の場合、プレビューダイアログが表示されること', async () => {
@@ -183,7 +187,7 @@ describe('SupportPlanningSheetReflection UI Interaction', () => {
     expect(screen.getByText('既存の行動')).toBeInTheDocument();
     expect(screen.getByText('新しい行動')).toBeInTheDocument();
 
-    await screen.findByText('まだ十分な分析データがありません');
+    expect(await screen.findByText('まだ十分な分析データがありません')).toBeInTheDocument();
   });
 
   it('ダイアログの「反映する」をクリックすると onConfirmReflect が呼ばれること', async () => {
@@ -206,6 +210,6 @@ describe('SupportPlanningSheetReflection UI Interaction', () => {
     
     expect(mockHandlers.onConfirmReflect).toHaveBeenCalled();
 
-    await screen.findByText('まだ十分な分析データがありません');
+    expect(await screen.findByText('まだ十分な分析データがありません')).toBeInTheDocument();
   });
 });

--- a/src/pages/support-planning-sheet/__tests__/SupportPlanningSheetView.regression.spec.tsx
+++ b/src/pages/support-planning-sheet/__tests__/SupportPlanningSheetView.regression.spec.tsx
@@ -20,6 +20,10 @@ vi.mock('@/infra/abc/useAbcRecordRepository', () => ({
   useAbcRecordRepository: vi.fn().mockReturnValue(mockAbcRecordRepo),
 }));
 
+vi.mock('@/features/ibd/analysis/pdca/components/AbcEvidencePanel', () => ({
+  AbcEvidencePanel: () => 'まだ十分な分析データがありません',
+}));
+
 import { SupportPlanningSheetView } from '../SupportPlanningSheetView';
 import { SupportPlanningSheetViewModel, SupportPlanningSheetActionHandlers } from '../types';
 import { TESTIDS } from '@/testids';
@@ -142,8 +146,7 @@ describe('SupportPlanningSheetView Regression Tests', () => {
     expect(screen.getByText('追加: 自傷行為')).toBeInTheDocument();
     expect(screen.getByText('要検討: 騒音')).toBeInTheDocument();
 
-    // Wait for AbcEvidencePanel's async load to complete and flush state updates
-    await screen.findByText('まだ十分な分析データがありません');
+    expect(await screen.findByText('まだ十分な分析データがありません')).toBeInTheDocument();
   });
 
   it('差分がない場合、警告バーが表示されないこと', async () => {
@@ -156,7 +159,6 @@ describe('SupportPlanningSheetView Regression Tests', () => {
 
     expect(screen.queryByTestId(TESTIDS.DIFFERENCE_INSIGHT_BAR)).not.toBeInTheDocument();
 
-    // Wait for AbcEvidencePanel's async load to complete and flush state updates
-    await screen.findByText('まだ十分な分析データがありません');
+    expect(await screen.findByText('まだ十分な分析データがありません')).toBeInTheDocument();
   });
 });

--- a/src/pages/support-planning-sheet/hooks/__tests__/useSupportPlanningSheetOrchestrator.spec.tsx
+++ b/src/pages/support-planning-sheet/hooks/__tests__/useSupportPlanningSheetOrchestrator.spec.tsx
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { useSupportPlanningSheetOrchestrator } from '../useSupportPlanningSheetOrchestrator';
 import { MemoryRouter } from 'react-router-dom';
@@ -159,7 +159,9 @@ describe('useSupportPlanningSheetOrchestrator', () => {
     expect(result.current.handlers.onEdit).toBeDefined();
     expect(result.current.handlers.onSave).toBeDefined();
     
-    result.current.handlers.onEdit();
+    act(() => {
+      result.current.handlers.onEdit();
+    });
     expect(mockUiActions.setIsEditing).toHaveBeenCalledWith(true);
   });
 });


### PR DESCRIPTION
## Scope
- Mock the async ABC evidence panel in SupportPlanningSheet regression and reflection specs
- Wrap orchestrator handler invocation in `act()`
- Wrap Tokusei survey hook async waits in `act()`/`waitFor`

## Out of scope
- No production code changes
- No SupportCase SharePoint definitions
- No SharePoint provisioning or UI behavior changes

## Verification
- `npm run typecheck`
- `npx eslint src/features/assessment/hooks/__tests__/useTokuseiSurveyResponses.spec.ts src/pages/support-planning-sheet/__tests__/SupportPlanningSheetReflection.spec.tsx src/pages/support-planning-sheet/__tests__/SupportPlanningSheetView.regression.spec.tsx src/pages/support-planning-sheet/hooks/__tests__/useSupportPlanningSheetOrchestrator.spec.tsx --max-warnings=0`
- `npx vitest run src/features/assessment/hooks/__tests__/useTokuseiSurveyResponses.spec.ts src/pages/support-planning-sheet/__tests__/SupportPlanningSheetReflection.spec.tsx src/pages/support-planning-sheet/__tests__/SupportPlanningSheetView.regression.spec.tsx src/pages/support-planning-sheet/hooks/__tests__/useSupportPlanningSheetOrchestrator.spec.tsx` (11 passed)
- `git diff --check`
