### PR TITLE
test: cover trimmed date-only ISO input

### DIFF
--- a/tests/unit/dateFormat.spec.ts
+++ b/tests/unit/dateFormat.spec.ts
@@ -314,6 +314,10 @@ describe('formatDateIso', () => {
     expect(formatDateIso(ts)).toBe('2025-12-31');
   });
 
+  it('keeps date-only strings valid when surrounded by whitespace', () => {
+    expect(formatDateIso(' 2025-01-15 ')).toBe('2025-01-15');
+  });
+
   it('returns empty string for null', () => {
     expect(formatDateIso(null)).toBe('');
   });


### PR DESCRIPTION
## Summary
- Add a regression test that keeps whitespace-surrounded date-only strings valid for `formatDateIso`
- Lock the public formatter behavior to use the existing safe string trimming path instead of falling back

## Verification
- npx vitest run tests/unit/dateFormat.spec.ts --reporter=verbose --no-file-parallelism
- git diff --check
- npm run lint
- npm run typecheck
- commit hook: guard:tz, lint, typecheck, lint:cookies, lint-staged

## Scope guard
- Test-only change
- No implementation changes
- No specification changes
- No dependency changes
- No SharePoint list / field candidates changes