### PR TITLE
docs(runbook): add small PR scope guard

### DIFF
--- a/docs/runbooks/pr-merge-safety.md
+++ b/docs/runbooks/pr-merge-safety.md
@@ -3,6 +3,12 @@
 > ⚠️ この runbook は **PR #76 以降の標準手順**です  
 > 数字が 0 でも **pendingChecks / failingChecks が空であること**を必ず確認してください
 
+## Daily small PR scope guard
+
+mixed worktree で daily-task の小PRを作る場合は、既存の未コミット差分を巻き込まないことを最優先にします。`git status --short` と対象ファイルの diff を確認し、stage は対象ファイルだけに限定してください。`git add .` や `git add -A` は使わず、PR 本文には `Scope` / `Verification` / `Out of scope` を必ず明記します。
+
+SharePoint list/field candidates や `src/sharepoint/contracts/driftProbeTargets.ts` の差分は daily-task ではなく別枠差分として扱い、由来確認や採用判断が終わるまで小PRには含めません。
+
 ## A. マージ前の条件確認
 
 ### 1) CI Status の可視化


### PR DESCRIPTION
## Scope

- Add a daily small PR scope guard to `docs/runbooks/pr-merge-safety.md`.
- Document that mixed worktrees must avoid including existing uncommitted changes.
- Document that only the intended target file should be staged in mixed worktrees.
- Require PR bodies to include `Scope` / `Verification` / `Out of scope`.

## Verification

- `git diff --check` PASS
- `npm run typecheck` PASS
- `npm run lint` FAIL before isolating unrelated worktree changes due to an existing unstaged error in `src/sharepoint/driftProbeRegistry.ts`; PASS via normal pre-commit hook after temporarily stashing unrelated unstaged changes and committing only this docs file.

## Out of scope

- Existing uncommitted changes in these 7 files were not included or staged:
  - `docs/env-reference.md`
  - `src/lib/env.schema.ts`
  - `src/sharepoint/contracts/driftProbeTargets.ts`
  - `src/sharepoint/driftProbeRegistry.ts`
  - `src/sharepoint/fields/__tests__/supportCaseFields.spec.ts`
  - `tests/integration/diagnose.sharepoint.spec.ts`
  - `tests/unit/spListHealthCheck.spec.ts`
- SharePoint list/field candidates are out of scope.
- `src/sharepoint/contracts/driftProbeTargets.ts` is out of scope.
- env schema/reference changes are out of scope.