### PR TITLE
test(support-case): add app-test diagnostics preflight checks

### DIFF
--- a/docs/runbooks/support-case-app-test-diagnostics.md
+++ b/docs/runbooks/support-case-app-test-diagnostics.md
@@ -35,11 +35,13 @@ git checkout main
 git pull --ff-only
 git status --short
 npm run sp:audit
+npx vitest run src/sharepoint/__tests__/supportCaseDiagnosticsPreflight.spec.ts
 ```
 
 Confirm all of the following before running diagnostics:
 
 - `git status --short` is empty.
+- The SupportCase app-test diagnostics preflight passes.
 - The current SharePoint environment is app-test, not production.
 - `SHAREPOINT_SITE`, `VITE_SP_SITE_URL`, or the runtime site configuration does not point to a production site.
 - SupportCase diagnostics opt-in is explicit for this command only.
@@ -129,6 +131,7 @@ Do not perform any of the following in this runbook or the docs-only PR that int
 Stop immediately and report the finding if any of the following is true:
 
 - The target site may be production.
+- The preflight check fails.
 - `support_case_*` appears in diagnostics without explicit opt-in.
 - Restricted documents are treated as the same list/resource as standard document metadata.
 - Essential fields are missing.

--- a/src/sharepoint/__tests__/supportCaseDiagnosticsPreflight.spec.ts
+++ b/src/sharepoint/__tests__/supportCaseDiagnosticsPreflight.spec.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+import type { DriftProbeTarget } from '../contracts/driftProbeTargets';
+import {
+  getDriftProbeTargets,
+  getSupportCaseExperimentalDriftProbeTargets,
+  SUPPORT_CASE_SHAREPOINT_DIAGNOSTICS_FLAG,
+} from '../driftProbeRegistry';
+import {
+  runSupportCaseDiagnosticsPreflight,
+  SUPPORT_CASE_DIAGNOSTIC_KEYS,
+} from '../supportCaseDiagnosticsPreflight';
+import { SP_LIST_REGISTRY } from '../spListRegistry';
+import type { SpListEntry } from '../spListRegistry';
+
+const optInEnv = {
+  [SUPPORT_CASE_SHAREPOINT_DIAGNOSTICS_FLAG]: '1',
+};
+
+const appTestInput = {
+  environmentName: 'app-test',
+  siteUrl: 'https://tenant.sharepoint.com/sites/app-test',
+  envOverride: optInEnv,
+};
+
+describe('SupportCase app-test diagnostics preflight', () => {
+  it('fails when the target looks like production', () => {
+    const result = runSupportCaseDiagnosticsPreflight({
+      environmentName: 'production',
+      siteUrl: 'https://tenant.sharepoint.com/sites/prod',
+      envOverride: optInEnv,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContain('production_site_suspected');
+  });
+
+  it('passes for app-test when diagnostics opt-in is explicit', () => {
+    const result = runSupportCaseDiagnosticsPreflight(appTestInput);
+
+    expect(result).toEqual({
+      ok: true,
+      failures: [],
+      warnings: [],
+    });
+  });
+
+  it('fails when SupportCase targets are present without opt-in', () => {
+    const defaultTargets: DriftProbeTarget[] = [
+      ...getDriftProbeTargets(),
+      {
+        key: 'support_cases',
+        displayName: '汎用支援ケース',
+        listTitle: 'SupportCases',
+        selectFields: ['Id', 'Title', 'CaseId'],
+      },
+    ];
+
+    const result = runSupportCaseDiagnosticsPreflight({
+      environmentName: 'app-test',
+      siteUrl: 'https://tenant.sharepoint.com/sites/app-test',
+      defaultTargets,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.failures).toEqual(
+      expect.arrayContaining([
+        'support_case_diagnostics_opt_in_missing',
+        'support_case_included_without_opt_in',
+      ]),
+    );
+  });
+
+  it('keeps SupportCase resources out of default target selection', () => {
+    const targetKeys = new Set(getDriftProbeTargets().map(target => target.key));
+
+    for (const key of SUPPORT_CASE_DIAGNOSTIC_KEYS) {
+      expect(targetKeys.has(key)).toBe(false);
+    }
+  });
+
+  it('includes SupportCase resources only in opt-in target selection', () => {
+    expect(getSupportCaseExperimentalDriftProbeTargets()).toEqual([]);
+
+    const targetKeys = getSupportCaseExperimentalDriftProbeTargets(optInEnv).map(
+      target => target.key,
+    );
+
+    expect(targetKeys).toEqual([...SUPPORT_CASE_DIAGNOSTIC_KEYS]);
+  });
+
+  it('fails when opt-in does not produce every SupportCase target', () => {
+    const result = runSupportCaseDiagnosticsPreflight({
+      ...appTestInput,
+      optInTargets: getSupportCaseExperimentalDriftProbeTargets(optInEnv).filter(
+        target => target.key !== 'support_case_events',
+      ),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContain('support_case_opt_in_targets_missing');
+  });
+
+  it('requires restricted documents to remain a document library', () => {
+    const restricted = getSupportCaseExperimentalDriftProbeTargets(optInEnv).find(
+      target => target.key === 'support_case_restricted_documents',
+    );
+
+    expect(restricted?.baseTemplate).toBe(101);
+
+    const registryEntries = SP_LIST_REGISTRY.map(entry =>
+      entry.key === 'support_case_restricted_documents'
+        ? ({ ...entry, baseTemplate: undefined } as SpListEntry)
+        : entry,
+    );
+
+    const result = runSupportCaseDiagnosticsPreflight({
+      ...appTestInput,
+      registryEntries,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContain('restricted_library_not_document_library');
+  });
+
+  it('requires restricted documents to stay separate from standard document metadata', () => {
+    const standard = SP_LIST_REGISTRY.find(
+      entry => entry.key === 'support_case_documents',
+    );
+    const registryEntries = SP_LIST_REGISTRY.map(entry =>
+      entry.key === 'support_case_restricted_documents' && standard
+        ? ({ ...entry, resolve: standard.resolve } as SpListEntry)
+        : entry,
+    );
+
+    const result = runSupportCaseDiagnosticsPreflight({
+      ...appTestInput,
+      registryEntries,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContain(
+      'restricted_library_mixed_with_standard_documents',
+    );
+  });
+
+  it('requires SupportCase resources to remain experimental', () => {
+    const registryEntries = SP_LIST_REGISTRY.map(entry =>
+      entry.key === 'support_cases'
+        ? ({ ...entry, lifecycle: 'optional' } as SpListEntry)
+        : entry,
+    );
+
+    const result = runSupportCaseDiagnosticsPreflight({
+      ...appTestInput,
+      registryEntries,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContain('support_case_lifecycle_not_experimental');
+  });
+});

--- a/src/sharepoint/supportCaseDiagnosticsPreflight.ts
+++ b/src/sharepoint/supportCaseDiagnosticsPreflight.ts
@@ -1,0 +1,153 @@
+import type { DriftProbeTarget } from './contracts/driftProbeTargets';
+import {
+  getDriftProbeTargets,
+  getSupportCaseExperimentalDriftProbeTargets,
+  isSupportCaseSharePointDiagnosticsEnabled,
+} from './driftProbeRegistry';
+import { SP_LIST_REGISTRY, type SpListEntry } from './spListRegistry';
+import type { EnvRecord } from '@/lib/env';
+
+export const SUPPORT_CASE_DIAGNOSTIC_KEYS = [
+  'support_cases',
+  'support_case_documents',
+  'support_case_events',
+  'support_case_restricted_documents',
+] as const;
+
+export type SupportCaseDiagnosticKey =
+  (typeof SUPPORT_CASE_DIAGNOSTIC_KEYS)[number];
+
+export type SupportCaseDiagnosticsPreflightFailure =
+  | 'production_site_suspected'
+  | 'app_test_target_missing'
+  | 'support_case_diagnostics_opt_in_missing'
+  | 'support_case_included_without_opt_in'
+  | 'support_case_opt_in_targets_missing'
+  | 'support_case_lifecycle_not_experimental'
+  | 'restricted_library_not_document_library'
+  | 'restricted_library_mixed_with_standard_documents';
+
+export type SupportCaseDiagnosticsPreflightWarning =
+  | 'site_url_missing'
+  | 'environment_name_missing';
+
+export interface SupportCaseDiagnosticsPreflightInput {
+  environmentName?: string;
+  siteUrl?: string;
+  envOverride?: EnvRecord;
+  defaultTargets?: readonly DriftProbeTarget[];
+  optInTargets?: readonly DriftProbeTarget[];
+  registryEntries?: readonly SpListEntry[];
+}
+
+export interface SupportCaseDiagnosticsPreflightResult {
+  ok: boolean;
+  failures: SupportCaseDiagnosticsPreflightFailure[];
+  warnings: SupportCaseDiagnosticsPreflightWarning[];
+}
+
+const SUPPORT_CASE_KEY_SET = new Set<string>(SUPPORT_CASE_DIAGNOSTIC_KEYS);
+const RESTRICTED_DOCUMENTS_KEY = 'support_case_restricted_documents';
+const STANDARD_DOCUMENTS_KEY = 'support_case_documents';
+
+const normalize = (value?: string): string =>
+  String(value ?? '').trim().toLowerCase();
+
+const hasAppTestMarker = (value: string): boolean =>
+  /(^|[^a-z0-9])(app[-_]?test|apptest)([^a-z0-9]|$)/i.test(value);
+
+const hasProductionMarker = (value: string): boolean =>
+  /(^|[^a-z0-9])(prod|production)([^a-z0-9]|$)/i.test(value);
+
+const includesSupportCaseTarget = (targets: readonly DriftProbeTarget[]): boolean =>
+  targets.some(target => SUPPORT_CASE_KEY_SET.has(target.key));
+
+const listSupportCaseTargetKeys = (
+  targets: readonly DriftProbeTarget[],
+): Set<string> =>
+  new Set(
+    targets
+      .filter(target => SUPPORT_CASE_KEY_SET.has(target.key))
+      .map(target => target.key),
+  );
+
+const addFailure = (
+  failures: SupportCaseDiagnosticsPreflightFailure[],
+  failure: SupportCaseDiagnosticsPreflightFailure,
+): void => {
+  if (!failures.includes(failure)) failures.push(failure);
+};
+
+const findEntry = (
+  registryEntries: readonly SpListEntry[],
+  key: SupportCaseDiagnosticKey,
+): SpListEntry | undefined => registryEntries.find(entry => entry.key === key);
+
+export function runSupportCaseDiagnosticsPreflight(
+  input: SupportCaseDiagnosticsPreflightInput,
+): SupportCaseDiagnosticsPreflightResult {
+  const registryEntries = input.registryEntries ?? SP_LIST_REGISTRY;
+  const defaultTargets = input.defaultTargets ?? getDriftProbeTargets(input.envOverride);
+  const optInTargets =
+    input.optInTargets ?? getSupportCaseExperimentalDriftProbeTargets(input.envOverride);
+  const optInEnabled = isSupportCaseSharePointDiagnosticsEnabled(input.envOverride);
+
+  const failures: SupportCaseDiagnosticsPreflightFailure[] = [];
+  const warnings: SupportCaseDiagnosticsPreflightWarning[] = [];
+  const environmentName = normalize(input.environmentName);
+  const siteUrl = normalize(input.siteUrl);
+  const targetLabel = `${environmentName} ${siteUrl}`.trim();
+
+  if (!environmentName) warnings.push('environment_name_missing');
+  if (!siteUrl) warnings.push('site_url_missing');
+
+  if (hasProductionMarker(targetLabel)) {
+    addFailure(failures, 'production_site_suspected');
+  }
+
+  if (!hasAppTestMarker(targetLabel)) {
+    addFailure(failures, 'app_test_target_missing');
+  }
+
+  if (!optInEnabled) {
+    addFailure(failures, 'support_case_diagnostics_opt_in_missing');
+  }
+
+  if (includesSupportCaseTarget(defaultTargets)) {
+    addFailure(failures, 'support_case_included_without_opt_in');
+  }
+
+  if (optInEnabled) {
+    const optInTargetKeys = listSupportCaseTargetKeys(optInTargets);
+    const hasAllSupportCaseTargets = SUPPORT_CASE_DIAGNOSTIC_KEYS.every(key =>
+      optInTargetKeys.has(key),
+    );
+
+    if (!hasAllSupportCaseTargets) {
+      addFailure(failures, 'support_case_opt_in_targets_missing');
+    }
+  }
+
+  for (const key of SUPPORT_CASE_DIAGNOSTIC_KEYS) {
+    if (findEntry(registryEntries, key)?.lifecycle !== 'experimental') {
+      addFailure(failures, 'support_case_lifecycle_not_experimental');
+    }
+  }
+
+  const restrictedEntry = findEntry(registryEntries, RESTRICTED_DOCUMENTS_KEY);
+  const standardEntry = findEntry(registryEntries, STANDARD_DOCUMENTS_KEY);
+
+  if (restrictedEntry?.baseTemplate !== 101) {
+    addFailure(failures, 'restricted_library_not_document_library');
+  }
+
+  if (restrictedEntry?.resolve() === standardEntry?.resolve()) {
+    addFailure(failures, 'restricted_library_mixed_with_standard_documents');
+  }
+
+  return {
+    ok: failures.length === 0,
+    failures,
+    warnings,
+  };
+}


### PR DESCRIPTION
## Scope
- Add preflight checks for app-test SupportCase diagnostics
- Validate app-test target, explicit opt-in, default exclusion, and restricted library boundaries
- Add unit tests and runbook notes for the preflight flow

## Out of scope
- No app-test list/library creation
- No production SharePoint changes
- No permission provisioning
- No UI integration
- No migration
- No Graph API or spFetch changes
- No SupportCaseRepository behavior changes

## Verification
- npm run typecheck
- npx eslint src/sharepoint src/lib/env.schema.ts tests/unit/spListHealthCheck.spec.ts --ext .ts,.tsx --max-warnings=0
- npx vitest run src/sharepoint/__tests__/driftProbeRegistry.spec.ts src/sharepoint/__tests__/supportCaseDiagnosticsPreflight.spec.ts tests/unit/spListHealthCheck.spec.ts
- npm run sp:audit
- git diff --check

Note: npm run sp:audit passed with existing manifest warnings for AbcBehaviorRecords, List2, and ToiletRecords.