### PR TITLE
docs(support-case): record app-test diagnostics target confirmation

### DIFF
--- a/docs/runbooks/support-case-app-test-diagnostics.md
+++ b/docs/runbooks/support-case-app-test-diagnostics.md
@@ -208,6 +208,28 @@ Next required human confirmation before any SharePoint diagnostics command:
 - Confirm `VITE_FEATURE_SUPPORT_CASE_SHAREPOINT_DIAGNOSTICS=1` is intentional for the opt-in command.
 - Confirm the command remains read-only and does not create lists, libraries, permissions, folders, files, or items.
 
+### 2026-06-09 App-Test Target Confirmation
+
+Scope:
+
+- Human-provided target confirmation before any SharePoint diagnostics command.
+- No SharePoint diagnostics command was run in this step.
+- No app-test or production SharePoint resource was created, modified, or deleted.
+
+Confirmed target:
+
+- Tenant host: `isogokatudouhome.sharepoint.com`
+- Site path: `/sites/app-test`
+- Canonical diagnostics URL: `https://isogokatudouhome.sharepoint.com/sites/app-test`
+- Source URL query parameters were ignored for the confirmation record.
+
+Confirmation status:
+
+- Target includes the explicit `app-test` site path.
+- Target does not use a production site path.
+- Any future opt-in diagnostics command must set `VITE_FEATURE_SUPPORT_CASE_SHAREPOINT_DIAGNOSTICS=1` explicitly.
+- Any future diagnostics command must remain read-only and must not create lists, libraries, permissions, folders, files, or items.
+
 ## Conditions For The Next Phase
 
 Proceed to app-test resource verification only after all conditions are true:


### PR DESCRIPTION
## Scope
- Record human-confirmed app-test diagnostics target URL for SupportCase
- Document canonical app-test URL and that query parameters were ignored
- Document that no SharePoint diagnostics command was run in this step
- Keep app-test/production resource creation out of scope

## Out of scope
- No app-test list/library creation
- No production SharePoint changes
- No permission provisioning
- No UI integration
- No migration
- No runtime behavior changes
- No SupportCaseRepository changes
- No Graph API or spFetch changes

## Verification
- npm run lint:docs
- git diff --check
- npm run typecheck
