### PR TITLE
test(handoff): cover regulatory resolution trail requirements

### DIFF
--- a/src/features/handoff/__tests__/regulatoryResolution.spec.ts
+++ b/src/features/handoff/__tests__/regulatoryResolution.spec.ts
@@ -154,3 +154,64 @@ describe('buildResolutionPayload', () => {
     expect(result.resolutionNote).toBe('');
   });
 });
+
+// ── 監査対象外ロジック ──
+
+describe('regulatory audit scope', () => {
+  it('regulatory-finding / severe-addon-finding のみ制度系として扱われる', () => {
+    expect(isRegulatoryHandoff(createRecord({ sourceType: 'regulatory-finding' }))).toBe(true);
+    expect(isRegulatoryHandoff(createRecord({ sourceType: 'severe-addon-finding' }))).toBe(true);
+    expect(isRegulatoryHandoff(createRecord({ sourceType: 'meeting-minutes' }))).toBe(false);
+    expect(isRegulatoryHandoff(createRecord({}))).toBe(false);
+  });
+
+  it('制度系完了レコードの証跡欠損は監査未完了として検知', () => {
+    expect(
+      getRegulatoryResolutionStatus(
+        createRecord({
+          sourceType: 'regulatory-finding',
+          status: '対応済',
+        }),
+      ),
+    ).toBe('closed_no_trail');
+    expect(
+      getRegulatoryResolutionStatus(
+        createRecord({
+          sourceType: 'severe-addon-finding',
+          status: '完了',
+          resolvedBy: '田中太郎',
+        }),
+      ),
+    ).toBe('closed_no_trail');
+  });
+
+  it('制度系完了レコードで証跡が揃うと resolved 扱いになる', () => {
+    expect(
+      getRegulatoryResolutionStatus(
+        createRecord({
+          sourceType: 'regulatory-finding',
+          status: '対応済',
+          resolvedBy: '田中太郎',
+          resolvedAt: '2026-03-14T08:00:00Z',
+          resolutionNote: '対応内容確認済み',
+        }),
+      ),
+    ).toBe('resolved');
+  });
+
+  it('通常申し送りは制度系監査ロジックの外側に置ける（対象外判定）', () => {
+    const manual = createRecord({
+      sourceType: undefined,
+      status: '完了',
+      resolvedBy: '田中太郎',
+      resolvedAt: '2026-03-14T08:00:00Z',
+      resolutionNote: '対応完了',
+    });
+
+    const isRegulatoryAuditRequired = isRegulatoryHandoff(manual)
+      && getRegulatoryResolutionStatus(manual) !== 'pending';
+
+    expect(isRegulatoryHandoff(manual)).toBe(false);
+    expect(isRegulatoryAuditRequired).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds test-only coverage for regulatory handoff audit trail requirements.

主な確認内容:

- regulatory-finding / severe-addon-finding の制度系判定
  - `isRegulatoryHandoff` の判定を明確化
- 制度系完了レコードの監査要件
  - terminal かつ証跡 (resolvedBy / resolvedAt) が不足している場合は `closed_no_trail`
  - terminal かつ証跡を満たす場合は `resolved`
- 通常申し送りは制度系監査対象外
  - `isRegulatoryHandoff` が false なら監査判定対象外として扱えることを明記

## Scope

- `src/features/handoff/__tests__/regulatoryResolution.spec.ts`

No runtime code or SharePoint definition changes are made.

## Validation

- [x] `npm test -- src/features/handoff/__tests__/regulatoryResolution.spec.ts --run`
- [x] Existing tests in the same file continue to pass
