### PR TITLE
test(handoff): cover carry-over date fallback precedence

### DIFF
--- a/src/features/handoff/__tests__/handoffApi.spec.ts
+++ b/src/features/handoff/__tests__/handoffApi.spec.ts
@@ -202,6 +202,55 @@ describe('HandoffApi', () => {
       expect(records).toEqual([]);
     });
 
+    it('SharePoint 側に CarryOverDate がある場合、ローカル補完値より優先される', async () => {
+      CarryOverDateStore.set(99, '2026-03-01');
+
+      const spItem = createSpItem({
+        Id: 99,
+        Status: '明日へ持越',
+        CarryOverDate: '2026-03-31',
+      });
+      mockSP.spFetch.mockResolvedValue(mockResponse({ value: [spItem] }));
+
+      const api = createHandoffApi(mockSP as never);
+      const records = await api.getHandoffRecords();
+
+      expect(records).toHaveLength(1);
+      expect(records[0].carryOverDate).toBe('2026-03-31');
+    });
+
+    it('SharePoint 側に CarryOverDate がない場合のみローカル補完値が使われる', async () => {
+      CarryOverDateStore.set(100, '2026-03-01');
+
+      const spItem = createSpItem({
+        Id: 100,
+        Status: '明日へ持越',
+      });
+      mockSP.spFetch.mockResolvedValue(mockResponse({ value: [spItem] }));
+
+      const api = createHandoffApi(mockSP as never);
+      const records = await api.getHandoffRecords();
+
+      expect(records).toHaveLength(1);
+      expect(records[0].carryOverDate).toBe('2026-03-01');
+    });
+
+    it('完了ステータスには古いローカル補完値を再適用しない', async () => {
+      CarryOverDateStore.set(101, '2026-02-28');
+
+      const spItem = createSpItem({
+        Id: 101,
+        Status: '完了',
+      });
+      mockSP.spFetch.mockResolvedValue(mockResponse({ value: [spItem] }));
+
+      const api = createHandoffApi(mockSP as never);
+      const records = await api.getHandoffRecords();
+
+      expect(records).toHaveLength(1);
+      expect(records[0].carryOverDate).toBeUndefined();
+    });
+
     it('フィールド一覧取得が権限エラーでも fallback select で継続する', async () => {
       const items = [createSpItem({ Id: 99, Title: 'fallback' })];
       mockSP.getListFieldInternalNames.mockRejectedValueOnce(

--- a/src/features/handoff/handoffApi.ts
+++ b/src/features/handoff/handoffApi.ts
@@ -179,7 +179,7 @@ class HandoffApi {
 
       // v3: CarryOverDateStore からのローカル補完マージ
       const mergedRecords = records.map(record => {
-        if (!record.carryOverDate) {
+        if (!record.carryOverDate && !isTerminalStatus(record.status)) {
           const localDate = CarryOverDateStore.get(record.id);
           if (localDate) {
             return { ...record, carryOverDate: localDate };
@@ -282,7 +282,7 @@ class HandoffApi {
       const updatedRecord = fromSpHandoffItem(data);
 
       // v3: ローカル補完マージ
-      if (!updatedRecord.carryOverDate) {
+      if (!updatedRecord.carryOverDate && !isTerminalStatus(updatedRecord.status)) {
         const localDate = CarryOverDateStore.get(id);
         if (localDate) {
           updatedRecord.carryOverDate = localDate;
@@ -469,7 +469,7 @@ class HandoffApi {
 
       // CarryOverDateStore からのローカル補完
       const mergedRecords = records.map(record => {
-        if (!record.carryOverDate) {
+        if (!record.carryOverDate && !isTerminalStatus(record.status)) {
           const localDate = CarryOverDateStore.get(record.id);
           if (localDate) {
             return { ...record, carryOverDate: localDate };


### PR DESCRIPTION
## Summary

This PR adds coverage and behavior hardening for CarryOverDate fallback precedence in Handoff API.

主な変更内容:

- 追加観点のテストを src/features/handoff/__tests__/handoffApi.spec.ts に追加
  - SharePoint 側 CarryOverDate の優先順位
  - SharePoint 側未設定時のローカル補完利用
  - 完了ステータス再取得時の古いローカル補完値の再適用防止
- CarryOverDate ローカル補完の適用先を terminal status では除外
  - getHandoffRecords
  - updateHandoffRecord（再取得結果の補完）
  - getHandoffRecordsForAnalysis

## Scope

- test + small behavior fix (no UI/SharePoint definition changes)

Changed files:

- src/features/handoff/__tests__/handoffApi.spec.ts
- src/features/handoff/handoffApi.ts

## Validation

- [x] npx vitest run src/features/handoff/__tests__/handoffApi.spec.ts --run
- [x] git diff --check
- [x] PR diff includes only CarryOverDate fallback-related files
