### PR TITLE
docs(handoff): record completion history

### DIFF
--- a/docs/architecture/handoff-structure-report.md
+++ b/docs/architecture/handoff-structure-report.md
@@ -117,6 +117,14 @@ stateDiagram-v2
 2. test-only: 終端状態/持越遷移の状態機械をテスト追加
 3. test-only / analysis-only: 制度系監査証跡のテスト追加
 
+## 8. Handoff 完了履歴
+
+- 2026-06-09
+  - `#2137` docs-only: Handoff 構造レポート追加
+  - `#2139` test-only: 状態遷移（`normal/evening/morning` / 終端 / `reopen`）の固定
+  - `#2141` test-only: 制度系監査証跡（`ResolvedBy` / `ResolvedAt` / `ResolutionNote`）検証追加
+  - `#2143` test + small behavior fix: CarryOverDate 補完の優先順位・終端ステータス時の再適用防止
+
 ---
 
 最終更新: 2026-06-09


### PR DESCRIPTION
## Summary

This PR records the Handoff follow-up completion history in architecture documentation.

- #2137 docs-only: Handoff structure report
- #2139 test-only: state machine transition coverage
- #2141 test-only: regulatory resolution trail requirements
- #2143 test + small behavior fix: CarryOverDate fallback precedence and terminal-status guard

## Scope

Docs-only.

No runtime code, tests, SharePoint definitions, workflow files, or environment files are changed.

### 変更内容 (JP)

- `docs/architecture/handoff-structure-report.md` に Handoff 完了履歴を追記
- 既存の 4本 PR を完了履歴として固定

## Validation

- [x] `git diff --check`
- [x] `docs/architecture/handoff-structure-report.md` のみが変更されている
