### PR TITLE
fix(kiosk): prevent viewport overflow with write-disabled banner

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import { RemediationAuditMonitor } from '@/features/sp/health/remediation/Remedi
 import { DemoProcedureSeeder } from '@/features/demo/DemoProcedureSeeder';
 
 import { isSharePointThrottleError } from '@/lib/sp';
+import Box from '@mui/material/Box';
 
 const hydrationHudEnabled = readBool('VITE_FEATURE_HYDRATION_HUD', false);
 const queryClient = new QueryClient({
@@ -77,18 +78,24 @@ function App() {
         <SettingsProvider>
           <ThemeRoot>
             <CssBaseline />
-            <DataLayerStatusBanner />
-            <WriteDisabledBanner />
-            <ToastProvider>
-              {!isKiosk && <DriftMonitor />}
-              {!isKiosk && <RemediationAuditMonitor />}
-              <SpInitBridge />
-              <DemoProcedureSeeder />
-              <ToastNotifierBridge />
-              <DataLayerGuard>
-                <RouterProvider router={router} future={routerFutureFlags} />
-              </DataLayerGuard>
-            </ToastProvider>
+            <Box sx={{ height: '100dvh', display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+              <Box sx={{ flexShrink: 0 }}>
+                <DataLayerStatusBanner />
+                <WriteDisabledBanner />
+              </Box>
+              <Box sx={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
+                <ToastProvider>
+                  {!isKiosk && <DriftMonitor />}
+                  {!isKiosk && <RemediationAuditMonitor />}
+                  <SpInitBridge />
+                  <DemoProcedureSeeder />
+                  <ToastNotifierBridge />
+                  <DataLayerGuard>
+                    <RouterProvider router={router} future={routerFutureFlags} />
+                  </DataLayerGuard>
+                </ToastProvider>
+              </Box>
+            </Box>
             {hydrationHudEnabled && <HydrationHud />}
           </ThemeRoot>
         </SettingsProvider>

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -115,7 +115,6 @@ const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) => {
     <RouteHydrationListener>
       <LiveAnnouncer>
         <div data-testid="app-shell" data-kiosk={isKioskMode || undefined}>
-          <KioskBackToToday />
           <AppShellV2
             header={headerContent}
             sidebar={sidebarContent}
@@ -123,11 +122,13 @@ const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) => {
             sidebarWidth={showDesktopSidebar ? currentDrawerWidth : 0}
             contentPaddingX={isFocusMode ? 0 : 16}
             contentPaddingY={isKioskMode ? 0 : contentPaddingY}
-            contentPaddingBottom={isKioskMode ? 160 : undefined}
+            contentPaddingBottom={isKioskMode ? 240 : undefined}
+            viewportHeight="100%"
             viewportMode={viewportMode}
           >
             {/* Global Connection Readiness Linkage */}
             <ConnectionDegradedBanner />
+            <KioskBackToToday />
             {children}
           </AppShellV2>
 

--- a/src/components/DataLayerGuard.tsx
+++ b/src/components/DataLayerGuard.tsx
@@ -22,7 +22,8 @@ export const DataLayerGuard: React.FC<{ children: React.ReactNode }> = ({ childr
           flexDirection: 'column',
           alignItems: 'center',
           justifyContent: 'center',
-          height: '100vh',
+          height: '100%',
+          minHeight: 0,
           bgcolor: 'background.default',
           color: 'text.secondary',
         }}
@@ -43,7 +44,7 @@ export const DataLayerGuard: React.FC<{ children: React.ReactNode }> = ({ childr
     <Box 
       id="app-main-container" 
       data-provider={currentProvider}
-      sx={{ height: '100vh', display: 'flex', flexDirection: 'column' }}
+      sx={{ height: '100%', minHeight: 0, display: 'flex', flexDirection: 'column' }}
     >
       {children}
     </Box>

--- a/src/components/layout/AppShellV2.tsx
+++ b/src/components/layout/AppShellV2.tsx
@@ -22,6 +22,7 @@ type Props = {
   contentPaddingX?: number; // default 16
   contentPaddingY?: number; // default 16
   contentPaddingBottom?: number;
+  viewportHeight?: string;
   viewportMode?: ShellViewportMode;
 };
 
@@ -37,6 +38,7 @@ export function AppShellV2({
   contentPaddingX = 16,
   contentPaddingY = 16,
   contentPaddingBottom,
+  viewportHeight = '100dvh',
   viewportMode = 'fixed',
   mainId = 'app-main-content',
 }: Props) {
@@ -61,7 +63,7 @@ export function AppShellV2({
     <Box
       sx={{
         '--bottom-nav-height': '88px', // CSS variable for LandscapeFab positioning
-        ...(viewportMode === 'fixed' ? { height: '100dvh' } : { minHeight: '100dvh' }),
+        ...(viewportMode === 'fixed' ? { height: viewportHeight } : { minHeight: viewportHeight }),
         overflow: 'hidden',
         display: 'grid',
         gridTemplateAreas: `


### PR DESCRIPTION
## Summary

キオスク画面で、上部の書き込み無効バナー表示時に AppShell 側の高さ計算がずれ、下部ナビやメイン領域のスクロールがビューポート外へはみ出す問題を修正しました。

## Changes

- App root をバナー + アプリ本体の縦 flex 構成に変更
- DataLayerGuard の `100vh` 固定をやめ、親要素の `100%` に追従
- AppShellV2 で親から高さ制御できるよう調整
- キオスク時の下余白を調整し、戻るバーをメイン領域内へ移動

## Verification

```powershell
npx eslint src/App.tsx src/app/AppShell.tsx src/components/DataLayerGuard.tsx src/components/layout/AppShellV2.tsx
npm run typecheck
git diff --check
```

All passed.

Playwright でも、`body` の余計な縦スクロールが消え、メイン領域がビューポート内に収まることを確認済みです。

## Notes

既存の `.env` 差分は本PRに含めていません。
