### PR TITLE
feat(nvidia-nim): add receive boundary for apply-approved plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **AI Review Handoff Boundary（受け取り限定）**
+  - `nvidia-nim` 受け取り境界の schema validator を追加（`schemaVersion`, `items`, `warnings`, `summary` の検証）。
+  - `parseApplyApprovedPlanJson` / `validateApplyApprovedPlan` を追加し、JSON 破損・未定義 `schemaVersion` を明示的に拒否。
+  - fixture ベースの受け取り検証テストを追加し、`tests/unit/domain/nvidiaNim.applyApprovedReceive.spec.ts` と `tests/fixtures/nvidia-nim/*` で境界を固定。
+  - docs/runbooks に受け取り境界手順を追加（実適用・SharePoint 反映は対象外）。
+
 - **シグナルガバナンスとライフサイクル管理 (ADR-016〜019)**
   - シグナルライフサイクル管理の実装: `open` → `acknowledged` (対応中) → `resolved` (手動解消)
   - `acknowledgedMap` および `resolvedMap` による「対応中/解消」状態の永続化 (localStorage v2)

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Support Operations OS is built on **10 design principles** that ensure human-in-
 > 📖 詳細: **[設計原則 10 箇条](docs/product/principles.md)** ｜ [UI 設計規約](docs/product/ui-conventions.md) ｜ [プロダクトロードマップ](docs/product/roadmap.md) ｜ **[OS Architecture](docs/product/support-operations-os-architecture.md)** ｜ [ISP-Driven Model](docs/model/isp-driven-operations-model.md) ｜ [ADR Index](docs/adr/README.md)
 >
 > 🧑‍💻 開発者: [Developer Onboarding](docs/dev/onboarding.md) ｜ [モジュール硬化テンプレート](docs/guides/module-hardening-template.md)
+>
+> 🤖 AI 連携: [AI Review Handoff Boundary (受け取り専用)](docs/runbooks/ai-review-handoff-boundary.md)
 
 ---
 

--- a/docs/runbooks/ai-review-handoff-boundary.md
+++ b/docs/runbooks/ai-review-handoff-boundary.md
@@ -1,0 +1,64 @@
+# AI Review Handoff Boundary (receive-only)
+
+## 目的
+
+`ai-derived-artifact-core` から渡される `apply-approved` 出力を `audit-management-system-mvp` が
+**受け取る前提で検証**できる最小境界を定義する。
+
+- ここでは「実適用」は行わない。
+- SharePoint 書き込み、レコード更新、`write` 系 API 呼び出しは **未実装**。
+- 受け取り側の責務は: **JSON 受領の妥当性検証 + 受け取り対象の可視化**。
+
+## 受け取り契約（固定）
+
+対象ファイル: `apply-approved` write/plan の受け取り JSON。
+
+### 必須フィールド
+
+- `schemaVersion`: `nvidia-nim-apply-approved-dry-run/1.0`
+- `generatedAt`: string（発行日時）
+- `inputPath`: string（元入力 path）
+- `summary.total`: number (integer >= 0)
+- `summary.approved`: number (integer >= 0)
+- `summary.failed`: number (integer >= 0)
+- `items[]`: 承認対象候補配列
+- `warnings[]`: warning 配列（空配列可）
+
+### `items[]` 必須キー
+
+- `artifactId`
+- `path`
+- `suggestedTitle`
+- `labels` (string[])
+- `reason`
+
+### `warnings[]` 形式（提案）
+
+- `type`
+- `line`（非負整数）
+- `message`
+- `raw`（任意）
+
+## 実装境界
+
+- `src/domain/nvidiaNim/applyApprovedReceive.ts`
+  - `validateApplyApprovedPlan(raw)`
+  - `parseApplyApprovedPlanJson(text)`
+  - `schemaVersion` と payload 形状を厳格検証
+- `tests/unit/domain/nvidiaNim.applyApprovedReceive.spec.ts`
+  - valid/invalid fixture を使った受け取り検証のみ
+  - JSON 破損/スキーマ差分時は `success: false`
+
+## 受け取り前提の運用ルール
+
+1. まず `apply-approved` 出力を fixture として保管
+2. 上記バリデータで `schemaVersion` + `items` + `summary` を検証
+3. 失敗時は `audit-management-system-mvp` 側で適用を開始しない
+4. テスト付きで境界を固定し、実適用フェーズは別 PR で管理
+
+## 未実装項目（今回対象外）
+
+- SharePoint への反映
+- Records への書き込み
+- `--write` 実行や dry-run から先の自動適用
+

--- a/src/domain/nvidiaNim/applyApprovedReceive.ts
+++ b/src/domain/nvidiaNim/applyApprovedReceive.ts
@@ -1,0 +1,93 @@
+import { z } from 'zod';
+
+export const NVIDIA_APPLY_APPROVED_DRYRUN_SCHEMA_VERSION = 'nvidia-nim-apply-approved-dry-run/1.0';
+
+const schemaLabel = 'apply-approved-dry-run payload schema';
+
+export const nvidiaApplyApprovedItemSchema = z.object({
+  artifactId: z.string().min(1),
+  path: z.string().min(1),
+  suggestedTitle: z.string(),
+  labels: z.array(z.string()),
+  reason: z.string(),
+}).strict();
+
+export const nvidiaApplyApprovedWarningSchema = z.object({
+  type: z.string().min(1),
+  line: z.number().int().nonnegative(),
+  message: z.string().min(1),
+  raw: z.unknown().optional(),
+}).strict();
+
+const summarySchema = z.object({
+  total: z.number().int().nonnegative(),
+  approved: z.number().int().nonnegative(),
+  failed: z.number().int().nonnegative(),
+});
+
+export const nvidiaApplyApprovedPlanSchema = z
+  .object({
+    schemaVersion: z.literal(NVIDIA_APPLY_APPROVED_DRYRUN_SCHEMA_VERSION),
+    generatedAt: z.string().min(1),
+    inputPath: z.string().min(1),
+    summary: summarySchema,
+    items: z.array(nvidiaApplyApprovedItemSchema),
+    warnings: z.array(nvidiaApplyApprovedWarningSchema).default([]),
+    preflight: z.record(z.string(), z.unknown()).optional(),
+  })
+  .strict();
+
+export type NvidiaApplyApprovedItem = z.infer<typeof nvidiaApplyApprovedItemSchema>;
+export type NvidiaApplyApprovedWarning = z.infer<typeof nvidiaApplyApprovedWarningSchema>;
+export type NvidiaApplyApprovedPlanSummary = z.infer<typeof summarySchema>;
+export type NvidiaApplyApprovedPlan = z.infer<typeof nvidiaApplyApprovedPlanSchema>;
+
+export type ValidateApplyApprovedPlanResult =
+  | {
+      success: true;
+      payload: NvidiaApplyApprovedPlan;
+      errors: string[];
+    }
+  | {
+      success: false;
+      payload: null;
+      errors: string[];
+    };
+
+function formatZodError(error: z.ZodError): string[] {
+  return error.issues.map((issue) => {
+    const path = issue.path.length > 0 ? issue.path.join('.') : schemaLabel;
+    return `${path}: ${issue.message}`;
+  });
+}
+
+export function validateApplyApprovedPlan(raw: unknown): ValidateApplyApprovedPlanResult {
+  const result = nvidiaApplyApprovedPlanSchema.safeParse(raw);
+
+  if (!result.success) {
+    return {
+      success: false,
+      payload: null,
+      errors: formatZodError(result.error),
+    };
+  }
+
+  return {
+    success: true,
+    payload: result.data,
+    errors: [],
+  };
+}
+
+export function parseApplyApprovedPlanJson(text: string): ValidateApplyApprovedPlanResult {
+  try {
+    const parsed = JSON.parse(text);
+    return validateApplyApprovedPlan(parsed);
+  } catch {
+    return {
+      success: false,
+      payload: null,
+      errors: ['payload: invalid JSON'],
+    };
+  }
+}

--- a/tests/fixtures/nvidia-nim/apply-approved-receive-invalid-item.json
+++ b/tests/fixtures/nvidia-nim/apply-approved-receive-invalid-item.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": "nvidia-nim-apply-approved-dry-run/1.0",
+  "generatedAt": "2026-06-10T00:00:00.000Z",
+  "inputPath": "tmp/review/apply-plan.json",
+  "summary": {
+    "total": 1,
+    "approved": 0,
+    "failed": 1
+  },
+  "items": [
+    {
+      "artifactId": "art-003",
+      "path": "/support-plans/p3.json",
+      "suggestedTitle": "夜間加算",
+      "labels": ["risk"]
+    }
+  ],
+  "warnings": []
+}

--- a/tests/fixtures/nvidia-nim/apply-approved-receive-invalid-schema-version.json
+++ b/tests/fixtures/nvidia-nim/apply-approved-receive-invalid-schema-version.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": "nvidia-nim-old-version/0.1",
+  "generatedAt": "2026-06-10T00:00:00.000Z",
+  "inputPath": "tmp/review/apply-plan.json",
+  "summary": {
+    "total": 1,
+    "approved": 1,
+    "failed": 0
+  },
+  "items": [],
+  "warnings": []
+}

--- a/tests/fixtures/nvidia-nim/apply-approved-receive-valid.json
+++ b/tests/fixtures/nvidia-nim/apply-approved-receive-valid.json
@@ -1,0 +1,37 @@
+{
+  "schemaVersion": "nvidia-nim-apply-approved-dry-run/1.0",
+  "generatedAt": "2026-06-10T00:00:00.000Z",
+  "inputPath": "tmp/review/apply-plan.json",
+  "summary": {
+    "total": 3,
+    "approved": 2,
+    "failed": 1
+  },
+  "items": [
+    {
+      "artifactId": "art-001",
+      "path": "/support-plans/p1.json",
+      "suggestedTitle": "夜間支援追加",
+      "labels": ["safety", "night"],
+      "reason": "critical flag and recurrence detected"
+    },
+    {
+      "artifactId": "art-002",
+      "path": "/support-plans/p2.json",
+      "suggestedTitle": "訪問頻度調整",
+      "labels": ["mobility"],
+      "reason": "review suggests lowering frequency"
+    }
+  ],
+  "warnings": [
+    {
+      "type": "line_mismatch",
+      "line": 12,
+      "message": "artifactId line differs from source",
+      "raw": {
+        "expected": "art-001",
+        "actual": "art-001-a"
+      }
+    }
+  ]
+}

--- a/tests/unit/domain/nvidiaNim.applyApprovedReceive.spec.ts
+++ b/tests/unit/domain/nvidiaNim.applyApprovedReceive.spec.ts
@@ -1,0 +1,68 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  parseApplyApprovedPlanJson,
+  validateApplyApprovedPlan,
+  NVIDIA_APPLY_APPROVED_DRYRUN_SCHEMA_VERSION,
+} from '@/domain/nvidiaNim/applyApprovedReceive';
+
+const fixturePath = (name: string): string =>
+  path.join(process.cwd(), 'tests', 'fixtures', 'nvidia-nim', name);
+
+const readFixture = (name: string): string =>
+  readFileSync(fixturePath(name), 'utf8');
+
+describe('validateApplyApprovedPlan', () => {
+  it('valid payload is accepted', () => {
+    const input = JSON.parse(readFixture('apply-approved-receive-valid.json'));
+    const result = validateApplyApprovedPlan(input);
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+
+    expect(result.payload.schemaVersion).toBe(NVIDIA_APPLY_APPROVED_DRYRUN_SCHEMA_VERSION);
+    expect(result.payload.summary.approved).toBe(2);
+    expect(result.payload.items).toHaveLength(2);
+    expect(result.payload.warnings).toHaveLength(1);
+  });
+
+  it('non-matching schemaVersion is rejected', () => {
+    const input = JSON.parse(readFixture('apply-approved-receive-invalid-schema-version.json'));
+    const result = validateApplyApprovedPlan(input);
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+
+    expect(result.errors.join('\n')).toContain('schemaVersion');
+    expect(result.errors.join('\n')).toContain('nvidia-nim-apply-approved-dry-run/1.0');
+  });
+
+  it('malformed JSON is rejected', () => {
+    const result = parseApplyApprovedPlanJson('{invalid-json');
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+
+    expect(result.errors).toEqual(['payload: invalid JSON']);
+  });
+
+  it('missing required item field is rejected', () => {
+    const input = JSON.parse(readFixture('apply-approved-receive-invalid-item.json'));
+    const result = parseApplyApprovedPlanJson(JSON.stringify(input));
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+
+    expect(result.errors.join('\n')).toContain('items.0.reason');
+    expect(result.errors.join('\n')).toContain('string');
+  });
+});


### PR DESCRIPTION
## Summary
- Add a receive-only boundary for `ai-derived-artifact-core` apply-approved plan payloads
- Add strict validation helpers for `schemaVersion`, `summary`, `items`, and `warnings`
- Add unit tests and fixtures for valid, schema mismatch, broken JSON, and required-field-missing cases
- Document the handoff boundary as receive-only / no-apply / no-write

## Verification
- `npm run -s test tests/unit/domain/nvidiaNim.applyApprovedReceive.spec.ts`
- `npm run -s typecheck`
- pre-push/husky eslint passed during commit

## Safety notes
- No SharePoint writes
- No records writes
- No real data added
- No apply-approved mutation path added
- This PR only validates and documents the receive boundary
