### PR TITLE
docs(support-case): record app-test admin verification result

### DIFF
--- a/docs/reports/support-case-app-test-admin-verification-result-2026-06-10.md
+++ b/docs/reports/support-case-app-test-admin-verification-result-2026-06-10.md
@@ -1,0 +1,133 @@
+# SupportCase App-Test Admin Verification Result - 2026-06-10
+
+## Scope
+
+This report records administrator confirmation after the SupportCase app-test diagnostics returned 404/403 outcomes.
+
+No app-test or production SharePoint list, library, permission, folder, file, item, migration, UI integration, Graph API change, `spFetch` change, or `SupportCaseRepository` change was made.
+
+## Review Metadata
+
+- Review date: 2026-06-10
+- App-test site URL: `https://isogokatudouhome.sharepoint.com/sites/app-test`
+- Production site excluded: yes
+- Related diagnostics report: `docs/reports/support-case-app-test-diagnostics-result-2026-06-09.md`
+- Related 404/403 classification report: `docs/reports/support-case-app-test-diagnostics-404-403-classification-2026-06-09.md`
+- Related admin checklist: `docs/reports/support-case-app-test-admin-verification-checklist-2026-06-09.md`
+- Related result template: `docs/reports/support-case-app-test-admin-verification-result-template.md`
+
+## App-Test Site Confirmation
+
+- Confirmed app-test site exists: yes
+- Confirmed app-test site URL: `https://isogokatudouhome.sharepoint.com/sites/app-test`
+- Tenant host: `isogokatudouhome.sharepoint.com`
+- Site path: `/sites/app-test`
+- Production URL or production site involved: no
+
+## Azure App Registration Context
+
+The Azure app registration exists and is treated as identity/context information only.
+
+Safe recorded attributes:
+
+- Display name: `磯子区障害者地域活動ホーム業務システム`
+- Account type: accounts in this organizational directory only.
+- Client credentials: certificate credential exists; no client secret recorded.
+- SPA/public client redirect URI configuration exists.
+
+Not recorded in this report:
+
+- Application ID.
+- Object ID.
+- Tenant ID.
+- Certificate contents.
+- Private key.
+- Client secret.
+- Tokens.
+
+## Resource Inventory Result
+
+Administrator confirmation: SupportCase app-test lists/libraries do not exist yet.
+
+| Resource key | Expected title | Exists? | Actual display title | Internal URL name | List/library ID | Type | BaseTemplate | Unique permissions? | Diagnostics identity can read metadata? | Notes |
+|---|---|---|---|---|---|---|---:|---|---|---|
+| `support_cases` | `SupportCases` | no | not created | not created | none | List candidate | n/a | n/a | n/a | Not present in app-test. |
+| `support_case_documents` | `SupportCaseDocuments` | no | not created | not created | none | List candidate | n/a | n/a | n/a | Not present in app-test. |
+| `support_case_events` | `SupportCaseEvents` | no | not created | not created | none | List candidate | n/a | n/a | n/a | Not present in app-test. |
+| `support_case_restricted_documents` | `SupportCaseRestrictedDocuments` | no | not created | not created | none | Document library candidate | n/a | n/a | n/a | Not present in app-test. |
+
+## 404/403 Outcome Classification
+
+| Resource key | Observed status | Reviewed classification | Evidence | Follow-up needed |
+|---|---:|---|---|---|
+| `support_cases` | 404 | Missing app-test resource. | Admin confirmation says SupportCase lists/libraries do not exist yet. | Separate app-test creation plan, if explicitly approved later. |
+| `support_case_documents` | 403 | Existence was not confirmable by diagnostics; admin confirmation says not created yet. | Admin confirmation says SupportCase lists/libraries do not exist yet. | Separate app-test creation plan and permission model review, if explicitly approved later. |
+| `support_case_events` | 403 | Existence was not confirmable by diagnostics; admin confirmation says not created yet. | Admin confirmation says SupportCase lists/libraries do not exist yet. | Separate app-test creation plan and permission model review, if explicitly approved later. |
+| `support_case_restricted_documents` | 403 | Existence was not confirmable by diagnostics; admin confirmation says not created yet. | Admin confirmation says SupportCase lists/libraries do not exist yet. | Separate restricted document library creation and permission plan, if explicitly approved later. |
+
+## Naming Alignment Result
+
+Because the SupportCase app-test resources do not exist yet, there are no actual SharePoint display titles, internal URL names, or IDs to compare against the registry targets.
+
+Expected names remain:
+
+- `VITE_SP_LIST_SUPPORT_CASES` / `SupportCases`
+- `VITE_SP_LIST_SUPPORT_CASE_DOCUMENTS` / `SupportCaseDocuments`
+- `VITE_SP_LIST_SUPPORT_CASE_EVENTS` / `SupportCaseEvents`
+- `VITE_SP_LIBRARY_SUPPORT_CASE_RESTRICTED_DOCUMENTS` / `SupportCaseRestrictedDocuments`
+
+Recommended follow-up category: separate app-test resource creation plan, only after explicit approval.
+
+## Restricted Library Boundary Result
+
+- `SupportCaseRestrictedDocuments` confirmed separate from `SupportCaseDocuments`: planned boundary only; not created yet.
+- Confirmed document library: no app-test resource exists yet.
+- Confirmed `BaseTemplate=101`: not confirmable until a document library exists.
+- Unique permissions expected: to be reviewed before any creation plan.
+- Diagnostics identity should read metadata: to be reviewed before any permission plan.
+- Permission policy reviewed by administrator: not finalized in this result.
+
+Stop if restricted documents could be mixed with ordinary document metadata.
+
+## Stop Condition Review
+
+| Stop condition | Status | Notes |
+|---|---|---|
+| App-test administrator confirmation is missing. | cleared | App-test site exists and SupportCase resources are not created yet. |
+| Resource existence or title is unknown. | cleared | The four SupportCase resources are confirmed not created yet. |
+| `SupportCaseRestrictedDocuments` type is unknown or not a document library. | open | No resource exists yet, so type cannot be confirmed from SharePoint. |
+| Restricted library permission model is not reviewed. | open | Permission model must be reviewed before any creation plan. |
+| Diagnostics identity metadata-read access is not approved. | open | Access policy must be reviewed before any permission plan. |
+| Production/app-test boundary is ambiguous. | cleared | App-test site was confirmed; production is excluded. |
+| Next step would combine creation with permission changes. | open | Any future step must keep creation and permission changes separately reviewed unless explicitly approved. |
+| Next step would include UI, migration, Graph API changes, `spFetch` changes, or `SupportCaseRepository` changes. | cleared | Those remain out of scope for the next planning step. |
+
+Because stop conditions remain open, do not proceed beyond documentation and review.
+
+## Recommended Next-Step Decision
+
+Recommended next step:
+
+- Prepare a separate app-test resource creation plan only if explicit approval is given.
+
+Required rationale:
+
+```txt
+The app-test site exists, but the SupportCase lists/libraries do not exist yet.
+The next safe step is not direct creation. It is a reviewed creation plan that
+keeps list/library creation separate from permissions, UI integration, migration,
+Graph API/spFetch changes, and SupportCaseRepository behavior changes.
+```
+
+## Out Of Scope For This Result Record
+
+- App-test list or library creation.
+- Production SharePoint changes.
+- Permission provisioning or permission changes.
+- Diagnostics re-run.
+- UI integration.
+- Existing folder or document migration.
+- Graph API or `spFetch` communication changes.
+- `SupportCaseRepository` changes.
+- File upload.
+- Provisioning, bootstrap, setup, migration, create, ensure, or delete commands.


### PR DESCRIPTION
## Scope
- Record app-test administrator verification result for SupportCase diagnostics findings
- Document that the app-test site exists and SupportCase lists/libraries do not exist yet
- Record safe Azure app registration context without secrets or IDs
- Keep app-test/production resource creation and permission changes out of scope

## Out of scope
- No app-test list/library creation
- No production SharePoint changes
- No permission provisioning or permission changes
- No diagnostics re-run
- No UI integration
- No migration
- No Graph API or spFetch changes
- No SupportCaseRepository changes
- No runtime behavior changes

## Verification
- npm run lint:docs
- git diff --check
- npm run typecheck
