### PR TITLE
feat: add record quality review draft model

### DIFF
--- a/src/domain/supportRecord/recordQualityReview.spec.ts
+++ b/src/domain/supportRecord/recordQualityReview.spec.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  acceptRecordQualityReviewDraft,
+  createRecordQualityReviewDraft,
+  discardRecordQualityReviewDraft,
+  RECORD_QUALITY_REVIEW_STATUSES,
+  reviseRecordQualityReviewDraft,
+  type RecordQualityMissingInformationHint,
+  type RecordQualitySuggestedCategory,
+} from './recordQualityReview';
+
+const category: RecordQualitySuggestedCategory = {
+  categoryId: 'mealsHydration',
+  matchedSignals: ['昼食', '水分'],
+  source: 'rule',
+};
+
+const missingInformationHint: RecordQualityMissingInformationHint = {
+  code: 'staffSupportAction',
+  label: '職員の支援内容',
+  source: 'rule',
+};
+
+describe('recordQualityReview draft model', () => {
+  it('creating a draft sets status to draft', () => {
+    const draft = createRecordQualityReviewDraft({
+      recordId: 'record-1',
+      createdAt: '2026-06-10T00:00:00.000Z',
+    });
+
+    expect(draft.status).toBe('draft');
+  });
+
+  it('creating a draft sets sourceOfTruth to original_record', () => {
+    const draft = createRecordQualityReviewDraft({
+      recordId: 'record-1',
+      createdAt: '2026-06-10T00:00:00.000Z',
+    });
+
+    expect(draft.sourceOfTruth).toBe('original_record');
+    expect(draft.originalRecord).toEqual({ recordId: 'record-1' });
+  });
+
+  it('creating a draft sets outputKind to review_metadata', () => {
+    const draft = createRecordQualityReviewDraft({
+      recordId: 'record-1',
+      createdAt: '2026-06-10T00:00:00.000Z',
+    });
+
+    expect(draft.outputKind).toBe('review_metadata');
+  });
+
+  it('creating a draft requires human review', () => {
+    const draft = createRecordQualityReviewDraft({
+      recordId: 'record-1',
+      createdAt: '2026-06-10T00:00:00.000Z',
+    });
+
+    expect(draft.requiresHumanReview).toBe(true);
+  });
+
+  it('preserves suggested categories and missing information hints', () => {
+    const draft = createRecordQualityReviewDraft({
+      recordId: 'record-1',
+      suggestedCategories: [category],
+      missingInformationHints: [missingInformationHint],
+      notes: ['人間レビューで確認する'],
+      createdAt: '2026-06-10T00:00:00.000Z',
+    });
+
+    expect(draft.suggestedCategories).toEqual([category]);
+    expect(draft.missingInformationHints).toEqual([missingInformationHint]);
+    expect(draft.notes).toEqual(['人間レビューで確認する']);
+  });
+
+  it('accepting a draft changes status to accepted', () => {
+    const draft = createRecordQualityReviewDraft({
+      recordId: 'record-1',
+      createdAt: '2026-06-10T00:00:00.000Z',
+    });
+
+    const accepted = acceptRecordQualityReviewDraft(draft, '2026-06-10T01:00:00.000Z');
+
+    expect(accepted.status).toBe('accepted');
+    expect(accepted.recordId).toBe('record-1');
+  });
+
+  it('revising a draft changes status to revised and preserves source-of-truth metadata', () => {
+    const draft = createRecordQualityReviewDraft({
+      recordId: 'record-1',
+      suggestedCategories: [category],
+      createdAt: '2026-06-10T00:00:00.000Z',
+    });
+
+    const revised = reviseRecordQualityReviewDraft(draft, {
+      missingInformationHints: [missingInformationHint],
+      notes: ['表現を具体化してから採用する'],
+      updatedAt: '2026-06-10T01:30:00.000Z',
+    });
+
+    expect(revised.status).toBe('revised');
+    expect(revised.recordId).toBe('record-1');
+    expect(revised.sourceOfTruth).toBe('original_record');
+    expect(revised.outputKind).toBe('review_metadata');
+    expect(revised.requiresHumanReview).toBe(true);
+    expect(revised.suggestedCategories).toEqual([category]);
+    expect(revised.missingInformationHints).toEqual([missingInformationHint]);
+  });
+
+  it('discarding a draft changes status to discarded', () => {
+    const draft = createRecordQualityReviewDraft({
+      recordId: 'record-1',
+      createdAt: '2026-06-10T00:00:00.000Z',
+    });
+
+    const discarded = discardRecordQualityReviewDraft(draft, '2026-06-10T02:00:00.000Z');
+
+    expect(discarded.status).toBe('discarded');
+    expect(discarded.recordId).toBe('record-1');
+  });
+
+  it('does not store or rewrite original record text', () => {
+    const draft = createRecordQualityReviewDraft({
+      recordId: 'record-1',
+      notes: ['原文の要約ではなく確認観点のみ'],
+      createdAt: '2026-06-10T00:00:00.000Z',
+    });
+
+    expect('originalText' in draft).toBe(false);
+    expect(draft.originalRecord).toEqual({ recordId: 'record-1' });
+  });
+
+  it('does not expose diagnostic or judgmental status values', () => {
+    expect(RECORD_QUALITY_REVIEW_STATUSES).toEqual([
+      'draft',
+      'accepted',
+      'revised',
+      'discarded',
+    ]);
+    expect(RECORD_QUALITY_REVIEW_STATUSES).not.toContain('diagnosed');
+    expect(RECORD_QUALITY_REVIEW_STATUSES).not.toContain('evaluated');
+    expect(RECORD_QUALITY_REVIEW_STATUSES).not.toContain('policyDetermined');
+  });
+
+  it('fixes prohibited safety actions on every transition', () => {
+    const draft = createRecordQualityReviewDraft({
+      recordId: 'record-1',
+      createdAt: '2026-06-10T00:00:00.000Z',
+    });
+    const accepted = acceptRecordQualityReviewDraft(draft, '2026-06-10T01:00:00.000Z');
+
+    expect(accepted.prohibitedActions).toEqual([
+      'diagnose_users',
+      'judge_behavior',
+      'determine_support_policy',
+      'overwrite_original_record',
+    ]);
+  });
+});

--- a/src/domain/supportRecord/recordQualityReview.ts
+++ b/src/domain/supportRecord/recordQualityReview.ts
@@ -1,0 +1,137 @@
+import type { MissingInformationCode, RecordQualityCategoryId } from './recordQuality';
+
+export type RecordQualityReviewStatus = 'draft' | 'accepted' | 'revised' | 'discarded';
+
+export type RecordQualityReviewSource = 'rule' | 'ai' | 'human';
+
+export type RecordQualityOriginalRecordReference = {
+  readonly recordId: string;
+};
+
+export type RecordQualitySuggestedCategory = {
+  readonly categoryId: RecordQualityCategoryId;
+  readonly matchedSignals: readonly string[];
+  readonly source: RecordQualityReviewSource;
+};
+
+export type RecordQualityMissingInformationHint = {
+  readonly code: MissingInformationCode;
+  readonly label: string;
+  readonly source: RecordQualityReviewSource;
+};
+
+export type RecordQualityReviewSafetyMetadata = {
+  readonly sourceOfTruth: 'original_record';
+  readonly outputKind: 'review_metadata';
+  readonly requiresHumanReview: true;
+  readonly prohibitedActions: readonly [
+    'diagnose_users',
+    'judge_behavior',
+    'determine_support_policy',
+    'overwrite_original_record',
+  ];
+};
+
+export type RecordQualityReviewDraft = RecordQualityReviewSafetyMetadata & {
+  readonly recordId: string;
+  readonly originalRecord: RecordQualityOriginalRecordReference;
+  readonly status: RecordQualityReviewStatus;
+  readonly suggestedCategories: readonly RecordQualitySuggestedCategory[];
+  readonly missingInformationHints: readonly RecordQualityMissingInformationHint[];
+  readonly notes: readonly string[];
+  readonly createdAt: string;
+  readonly updatedAt: string;
+};
+
+export type CreateRecordQualityReviewDraftInput = {
+  readonly recordId: string;
+  readonly suggestedCategories?: readonly RecordQualitySuggestedCategory[];
+  readonly missingInformationHints?: readonly RecordQualityMissingInformationHint[];
+  readonly notes?: readonly string[];
+  readonly createdAt: string;
+  readonly updatedAt?: string;
+};
+
+export type ReviseRecordQualityReviewDraftInput = {
+  readonly suggestedCategories?: readonly RecordQualitySuggestedCategory[];
+  readonly missingInformationHints?: readonly RecordQualityMissingInformationHint[];
+  readonly notes?: readonly string[];
+  readonly updatedAt: string;
+};
+
+export const RECORD_QUALITY_REVIEW_SAFETY_METADATA: RecordQualityReviewSafetyMetadata = {
+  sourceOfTruth: 'original_record',
+  outputKind: 'review_metadata',
+  requiresHumanReview: true,
+  prohibitedActions: [
+    'diagnose_users',
+    'judge_behavior',
+    'determine_support_policy',
+    'overwrite_original_record',
+  ],
+};
+
+export const RECORD_QUALITY_REVIEW_STATUSES = [
+  'draft',
+  'accepted',
+  'revised',
+  'discarded',
+] as const satisfies readonly RecordQualityReviewStatus[];
+
+export function createRecordQualityReviewDraft(
+  input: CreateRecordQualityReviewDraftInput,
+): RecordQualityReviewDraft {
+  return {
+    ...RECORD_QUALITY_REVIEW_SAFETY_METADATA,
+    recordId: input.recordId,
+    originalRecord: {
+      recordId: input.recordId,
+    },
+    status: 'draft',
+    suggestedCategories: [...(input.suggestedCategories ?? [])],
+    missingInformationHints: [...(input.missingInformationHints ?? [])],
+    notes: [...(input.notes ?? [])],
+    createdAt: input.createdAt,
+    updatedAt: input.updatedAt ?? input.createdAt,
+  };
+}
+
+export function acceptRecordQualityReviewDraft(
+  draft: RecordQualityReviewDraft,
+  updatedAt: string,
+): RecordQualityReviewDraft {
+  return transitionRecordQualityReviewDraft(draft, 'accepted', { updatedAt });
+}
+
+export function reviseRecordQualityReviewDraft(
+  draft: RecordQualityReviewDraft,
+  input: ReviseRecordQualityReviewDraftInput,
+): RecordQualityReviewDraft {
+  return transitionRecordQualityReviewDraft(draft, 'revised', input);
+}
+
+export function discardRecordQualityReviewDraft(
+  draft: RecordQualityReviewDraft,
+  updatedAt: string,
+): RecordQualityReviewDraft {
+  return transitionRecordQualityReviewDraft(draft, 'discarded', { updatedAt });
+}
+
+function transitionRecordQualityReviewDraft(
+  draft: RecordQualityReviewDraft,
+  status: RecordQualityReviewStatus,
+  input: ReviseRecordQualityReviewDraftInput,
+): RecordQualityReviewDraft {
+  return {
+    ...draft,
+    ...RECORD_QUALITY_REVIEW_SAFETY_METADATA,
+    recordId: draft.recordId,
+    originalRecord: draft.originalRecord,
+    status,
+    suggestedCategories: input.suggestedCategories ?? draft.suggestedCategories,
+    missingInformationHints: input.missingInformationHints ?? draft.missingInformationHints,
+    notes: input.notes ?? draft.notes,
+    createdAt: draft.createdAt,
+    updatedAt: input.updatedAt,
+  };
+}


### PR DESCRIPTION
## Summary

This PR adds a small domain model for Record Quality Agent review drafts.

It defines how record quality suggestions can be represented as review metadata while preserving the original support record as the source of truth.

## Scope

- Adds Record Quality review draft types
- Adds pure helpers for draft, accepted, revised, and discarded states
- Adds tests for source-of-truth metadata and human review requirements

## Safety

This PR does not add AI integration, UI, SharePoint writes, or external dependencies.

The model treats AI or rule-generated output as review metadata only. Original support records remain the source of truth, and human review is required before suggestions are accepted.

The model does not diagnose users, judge behavior, determine support policy, or overwrite original records.

## Tests

- `npm run typecheck`
- `npm run lint`
- `npx vitest run src/domain/supportRecord/recordQualityReview.spec.ts --reporter=verbose`
- `git diff --check`
- `git diff --cached --check`
- commit hook: `lint`, `typecheck`, `lint:cookies`, `lint-staged`
