### PR TITLE
docs: generalize PR merge safety runbook placeholders

### DIFF
--- a/docs/runbooks/pr-merge-safety.md
+++ b/docs/runbooks/pr-merge-safety.md
@@ -1,6 +1,6 @@
 # PR Merge Safety Runbook
 
-> ⚠️ この runbook は **PR #76 以降の標準手順**です  
+> ⚠️ この runbook は **現在の標準手順**です
 > 数字が 0 でも **pendingChecks / failingChecks が空であること**を必ず確認してください
 
 ## Daily small PR scope guard
@@ -15,7 +15,7 @@ SharePoint list/field candidates や `src/sharepoint/contracts/driftProbeTargets
 
 ```bash
 # failed / pending のカウントと、実際のチェック名を可視化
-gh pr view 76 --json statusCheckRollup -q '
+gh pr view <PR_NUMBER> --json statusCheckRollup -q '
 {
   failed: ([.statusCheckRollup[]|select(.conclusion=="FAILURE")]|length),
   pending: ([.statusCheckRollup[]|select(.status=="IN_PROGRESS")]|length),
@@ -38,7 +38,7 @@ gh pr view 76 --json statusCheckRollup -q '
 
 ```bash
 # failed/pending が 0 でなければ exit 1 → マージ不可
-gh pr view 76 --json statusCheckRollup \
+gh pr view <PR_NUMBER> --json statusCheckRollup \
   -q '([.statusCheckRollup[]|select(.conclusion=="FAILURE" or .status=="IN_PROGRESS")]|length)' \
 | grep -qx 0
 ```
@@ -49,7 +49,7 @@ gh pr view 76 --json statusCheckRollup \
 ### 3) Review 承認確認
 
 ```bash
-gh pr view 76 --json reviewDecision -q '.reviewDecision'
+gh pr view <PR_NUMBER> --json reviewDecision -q '.reviewDecision'
 # 期待値: APPROVED
 ```
 
@@ -57,7 +57,7 @@ gh pr view 76 --json reviewDecision -q '.reviewDecision'
 
 ```bash
 # Squash merge + ブランチ削除
-gh pr merge 76 --squash --delete-branch
+gh pr merge <PR_NUMBER> --squash --delete-branch
 ```
 
 ## C. main の同期と確認
@@ -101,7 +101,7 @@ gh run download "$RUN_ID"
 
 ```bash
 # マージ済みブランチの削除
-git branch -d copilot/update-org-filter-e2e-test
+git branch -d <BRANCH_NAME>
 
 # リモート追跡ブランチの削除（既に --delete-branch で削除済み）
 git fetch --prune
@@ -211,7 +211,7 @@ test.describe('Org Filter: URL Contract', () => {
 
 ```bash
 # 進行中のチェックを確認
-gh pr view 76 --json statusCheckRollup \
+gh pr view <PR_NUMBER> --json statusCheckRollup \
   -q '.statusCheckRollup[]|select(.status=="IN_PROGRESS")|.name'
 ```
 


### PR DESCRIPTION
## Summary
- Generalize fixed PR references in the PR merge safety runbook
- Replace PR-specific commands with PR_NUMBER placeholders
- Replace the hard-coded cleanup branch with BRANCH_NAME
- Update the opening note from a PR-specific standard to the current standard procedure

## Verification
- git diff --check
- git status --short

## Out of scope
- Source code changes
- Workflow changes
- Dependency changes
- SharePoint list or field candidate changes