### PR TITLE
docs(support-case): record SupportCaseDocuments creation attempt

### DIFF
--- a/docs/reports/support-case-app-test-supportcase-documents-list-creation-attempt-2026-06-10.md
+++ b/docs/reports/support-case-app-test-supportcase-documents-list-creation-attempt-2026-06-10.md
@@ -1,0 +1,106 @@
+# SupportCase App-Test SupportCaseDocuments List Creation Attempt - 2026-06-10
+
+## Scope
+
+This report records the attempted app-test `SupportCaseDocuments` list creation after explicit approval.
+
+The operation stopped during the pre-creation metadata check. No SharePoint list was created, no fields were created, no permissions were changed, and no production resource was touched.
+
+## Preconditions
+
+- Branch before execution: `main`.
+- Working tree before execution: clean.
+- `HEAD` and `origin/main` were aligned before execution.
+- Target site: `https://isogokatudouhome.sharepoint.com/sites/app-test`
+- Explicit approval existed for creating the next single app-test resource:
+
+```txt
+app-test に SupportCaseDocuments list を作成してよい
+```
+
+## Target
+
+| Property | Value |
+|---|---|
+| SharePoint site | `https://isogokatudouhome.sharepoint.com/sites/app-test` |
+| Resource key | `support_case_documents` |
+| Display title | `SupportCaseDocuments` |
+| Expected internal URL name | `SupportCaseDocuments` |
+| Type | List |
+| BaseTemplate | `100` |
+
+## Execution Result
+
+The creation script confirmed the target site and target resource:
+
+- Target site: `https://isogokatudouhome.sharepoint.com/sites/app-test`
+- Create target: `SupportCaseDocuments`
+- Non-target resources: `SupportCaseEvents`, `SupportCaseRestrictedDocuments`
+
+The script then attempted the required pre-creation metadata check for `SupportCaseDocuments`.
+
+Result:
+
+| Check | Result |
+|---|---|
+| `SupportCaseDocuments` metadata precheck | HTTP `429` |
+| Request digest requested | no |
+| List creation attempted | no |
+| Field creation attempted | no |
+| Readback attempted | no |
+
+The operation stopped because the precheck did not return the expected HTTP `404`. A `429` response makes the existence state ambiguous for this safety gate, so the script refused to create the list.
+
+## Boundaries Confirmed
+
+- Production touched: no.
+- Permission changed: no.
+- `SupportCaseDocuments` created: no.
+- `SupportCaseEvents` created: no.
+- `SupportCaseRestrictedDocuments` created: no.
+- Document library created: no.
+- Restricted library created: no.
+- UI connected: no.
+- Migration run: no.
+- Graph API or `spFetch` implementation changed: no.
+- `SupportCaseRepository` changed: no.
+
+## Planned Fields Not Applied
+
+No fields were created. The planned `SUPPORT_CASE_DOCUMENTS_PROVISIONING_FIELDS` remain unapplied in app-test.
+
+Important boundary fields remain pending:
+
+- `DocumentId`
+- `TenantId`
+- `SupportCaseId`
+- `Category`
+- `StoragePolicy`
+- `LibraryTarget`
+- `Sensitivity`
+- `AuditLogRequired`
+
+## Stop Condition
+
+Stop condition reached:
+
+- `SupportCaseDocuments` pre-creation metadata check returned HTTP `429`.
+
+Do not retry creation automatically in the same operation. Before any retry:
+
+- Confirm app-test is still the target site.
+- Confirm production is excluded.
+- Confirm the previous response was throttling or another transient condition.
+- Confirm `SupportCaseDocuments` still does not exist, or classify the existing resource before proceeding.
+- Confirm the retry will still create only `SupportCaseDocuments`.
+
+## Recommended Next Action
+
+Keep `SupportCaseDocuments` creation paused.
+
+Recommended follow-up:
+
+- Re-run only the read-only pre-creation metadata check after the throttling window has cleared.
+- Proceed to creation only if the precheck returns the expected absent-resource result and the operation is still explicitly limited to `SupportCaseDocuments`.
+
+No additional SupportCase resources should be created until this stopped attempt is reviewed.


### PR DESCRIPTION
## Summary
- Attempted the approved app-test SupportCaseDocuments list creation
- Stopped during the pre-creation metadata check because SupportCaseDocuments returned HTTP 429 instead of the expected absent-resource response
- Recorded that no list, fields, permissions, production resources, or other SupportCase resources were created

## Scope
- app-test only
- SupportCaseDocuments pre-creation check only
- docs-only stopped-attempt record in this PR

## Out of scope
- No production changes
- No permission changes
- No SupportCaseDocuments creation
- No SupportCaseEvents creation
- No SupportCaseRestrictedDocuments creation
- No document library creation
- No restricted library creation
- No UI integration
- No migration
- No Graph API or spFetch changes
- No SupportCaseRepository changes

## Verification
- git diff --check
- npm run lint:docs
- npm run typecheck