### PR TITLE
docs: document SharePoint drift inventory

### DIFF
--- a/docs/sharepoint/drift-inventory.md
+++ b/docs/sharepoint/drift-inventory.md
@@ -1,0 +1,151 @@
+# SharePoint drift inventory (docs-only baseline)
+
+## Scope
+- 調査対象: `src/sharepoint/**`, `src/lib/**`, `src/domain/**`, `tests/**`, `docs/**`, worker/api/route 周辺
+- 実装変更なし、テスト変更なし、環境変数や `.env` への変更なし
+- 既存未コミット差分を触らない前提（事前確認: clean state）
+
+## 1. 取得できた SharePoint List 一覧
+
+### Registry 由来（`SP_LIST_REGISTRY`）
+- `support_cases`
+- `support_case_documents`
+- `support_case_documents` の参照/関連項目
+- `support_case_events`
+- `support_case_restricted_documents`
+- `schedule_events`
+- `support_procedure_results`
+- `approval_logs`
+- `survey_tokusei`
+- `survey_tokusei_v2`
+- `nurse_observations`
+- `official_forms`
+- `billing_orders`
+- `billing_summary`
+- `pdf_output_log`
+- `call_logs`
+- `toilet_records`
+- `meeting_sessions`
+- `meeting_steps`
+- `meeting_minutes`
+- `monitoring_meetings`
+- `users_master`
+- `user_feature_flags`
+- `user_transport_settings`
+- `user_benefit_profile`
+- `user_benefit_profile_ext`
+- `staff_master`
+- `org_master`
+- `holiday_master`
+- `daily_attendance`
+- `attendance_users`
+- `attendance_daily`
+- `staff_attendance`
+- `transport_log`
+- `compliance_check_rules`
+- `diagnostics_reports`
+- `drift_events_log`
+- `remediation_audit_log`
+- `support_record_daily`
+- `support_procedure_record_daily`
+- `support_record_rows`
+- `daily_activity_records`
+- `service_provision_records`
+- `abc_behavior_records`
+- `handoff`
+- `support_templates`
+- `plan_goals`
+- `support_plans`
+- `iceberg_pdca`
+- `iceberg_analysis`
+- `isp_master`
+- `planning_sheet_master`
+- `behavior_monitoring_master`
+- `planning_sheet_reassessment_master`
+
+### 補足
+- 上記は `spListRegistry` 系で参照されるリストキー集合（`tests/unit/spListHealthCheck.spec.ts` にも長さが固定化）  
+- 一部リストは drift 対象外/実験的扱い（`supportCase` 系など）で、運用上の除外ルールあり
+
+## 2. 取得できた Field 一覧（drift 関連）
+- 共通: `ID`, `Title`（drift 生成/補完ロジックが `Id`, `Title` を自動付加して比較）
+- `supportCaseFields` 系:
+  - `support_case_*` 参照で `support_cases` と関連ドキュメント・イベントの整合確認が実装側で利用
+- `staffFields` 系:
+  - `users_master`, `staff_master` のユーザー系キーと `ID` 系のキー名
+- `buildListSpecs` 由来で補完される必須フィールド:
+  - `buildListSpecs()` が内部で各 ListSpec に対して必須/比較対象を再構築
+  - `skipTitleEssential` の例外扱いあり（特定リストでは Title が未指定時も許容）
+- `drift` では “display name がない/曖昧な項目” が増えるため、`InternalName` と `DisplayName` を一致判定せずに運用している箇所がある
+
+## 3. InternalName / DisplayName の揺れ
+- `support_case_documents` や診断レポート系で、UI 表示名と OData 対象名の分離（`getFieldInternalName` / `fieldTitleMap` 系）を前提とする実装が散見される
+- 既存コード内には日本語 display と内部名が混在しうる想定コメントがあり、同一 List 内でも `internal=title` 系の扱いが一貫しない箇所がある
+- 証拠:
+  - `src/sharepoint/spListConfig.ts`
+  - `src/sharepoint/fields/fieldUtils.ts`
+  - `src/sharepoint/fields/staffFields.ts`
+  - `src/sharepoint/fields/supportCaseFields.ts`
+
+## 4. OData 利用箇所
+- `$select` / `$filter` / `$expand` / `$orderby` の利用箇所:
+  - `src/lib/sp/spListRead.ts`
+  - `src/sharepoint/query/builders.ts`
+  - health/diff 周辺: `src/pages/admin/DataIntegrityPage.tsx`, `src/features/diagnostics/health/*`, `src/pages/HealthPage.tsx`
+- `queryGuard` はクエリ安全性を検査しつつ、`throwOnHighRisk` が失敗停止に必ず寄与しない構成（既定 false かつ fail-open 特性の説明が必要）
+  - `src/lib/sp/queryGuard.ts`
+
+## 5. 環境変数依存
+- 主要:
+  - `VITE_SP_LIST_BILLING_ORDERS_SITE_RELATIVE`
+  - `VITE_FEATURE_SUPPORT_CASE_SHAREPOINT_DIAGNOSTICS`
+  - `VITE_SP_SITE_RELATIVE`, `VITE_SP_SITE_URL`
+  - `VITE_SP_BULK_READ_BATCH_SIZE` など読み取り挙動の安全域に効く設定
+- 依存箇所:
+  - `src/lib/sp/config.ts`
+  - `src/lib/sp/spListRead.ts`
+  - `src/sharepoint/spListRegistry.ts`
+  - `src/sharepoint/spListConfig.ts`
+  - `src/pages/admin/DataIntegrityPage.tsx`
+
+## 6. driftProbeTargets / driftProbeRegistry 設計意図
+- `getDriftProbeTargets()`:
+  - `lifecycle === required | optional` のみを driftProbe 対象に含める設計
+  - support_case 系は `experimental` をデフォルト扱い
+  - `billing_orders` は site 相対パス差異がある場合は `cross-site` で除外
+- `driftProbeRegistry`:
+  - 実データ監査に直結する targets 供給を責務
+  - `getDriftProbeTargets` の結果を UI 側（DataIntegrity）・診断ページ側で再利用
+- 根拠:
+  - `src/sharepoint/driftProbeRegistry.ts`
+  - `src/sharepoint/supportCaseDiagnosticsPreflight.ts`
+  - `src/sharepoint/__tests__/driftProbeRegistry.spec.ts`
+
+## 7. tests で固定された仕様
+- `SP_LIST_REGISTRY` 件数固定（`54`）と title/guid 変換仕様のテスト固定
+  - `tests/unit/spListHealthCheck.spec.ts`
+- `getDriftProbeTargets()` の lifecycle/追加条件
+  - `src/sharepoint/__tests__/driftProbeRegistry.spec.ts`
+  - `src/sharepoint/__tests__/supportCaseDiagnosticsPreflight.spec.ts`
+- `supportCaseFields` と `buildSupportCaseSchema` の形状仕様
+  - `src/sharepoint/fields/__tests__/supportCaseFields.spec.ts`
+  - `tests/unit/spListConfig.spec.ts`
+
+## 8. 触ってはいけない実装領域（初期方針）
+- `src/sharepoint/spListRegistry.ts` / `src/sharepoint/spListConfig.ts` の核ロジック
+- `src/lib/sp/spListRead.ts` の Query 生成と safety path
+- `src/lib/sp/queryGuard.ts`（リスク扱いの仕様変更は監査対象）
+- `src/sharepoint/driftProbeRegistry.ts`（drift 対象定義の挙動）
+- `src/pages/admin/DataIntegrityPage.tsx`（運用上の診断 UI）
+
+## 9. 未テストまたは高リスク領域
+- `queryGuard` の high-risk 判定と fail-open 挙動の監査
+- `display name` と `internal name` の完全一致前提での運用
+- environment-based 分岐（site relative）を含む cross-site drift の境界
+- List ごとの `select` / `expand` 追加時の権限/パフォーマンス/コスト監査
+
+## 10. 人間確認が必要な事項
+- SharePoint 側での実体 list title / field internalName の最終確定照合
+- drift 対象 54 リストと実運用環境の差分（特に `support_cases` と `billing_orders`）
+- `spListHealthCheck` のコメント「全24リスト」など説明文と実装整合
+- `queryGuard` の既定値を継続する判断（fail-open 継続か）

--- a/docs/sharepoint/drift-risk-report.md
+++ b/docs/sharepoint/drift-risk-report.md
@@ -1,0 +1,71 @@
+# SharePoint drift risk report (High/Medium/Low)
+
+## High
+- Query guard の fail-open 特性
+  - 根拠: `src/lib/sp/queryGuard.ts`, `src/lib/sp/spListRead.ts`
+  - 概要: high-risk クエリに対し例外が上位で致命扱いしない運用
+  - 影響: 大量取得・権限超過・意図外リスト参照の潜在的増大
+  - 対応: docs-only では監査対象を明示し、実装変更は次イテレーションへ
+
+- `DisplayName` / `InternalName` 混在
+  - 根拠: `src/sharepoint/fields/fieldUtils.ts`, `src/sharepoint/fields/supportCaseFields.ts`, `src/lib/sp/spListRead.ts`
+  - 概要: 表示名と内部名の混在により OData 指定が想定外に失敗し得る
+  - 影響: false negative / false positive 的な drift 検知
+  - 対応: field-mapping を固定表化し、docs に drift 判定前提を明示
+
+- 環境変数依存の境界分岐
+  - 根拠: `src/lib/sp/config.ts`, `src/sharepoint/spListConfig.ts`, `src/sharepoint/spListRegistry.ts`
+  - 概要: `VITE_SP_LIST_BILLING_ORDERS_SITE_RELATIVE` 分岐により drift 対象可否が変化
+  - 影響: 監査結果の再現性低下（環境差）
+  - 対応: 人間レビュー項目として環境値の運用合意を docs 化
+
+## Medium
+- drift対象リスト説明と実体実装の乖離
+  - 根拠: `src/sharepoint/spListHealthCheck.ts`, `tests/unit/spListHealthCheck.spec.ts`
+  - 根拠コメントと実装対象範囲の一致性確認が必要
+  - 影響: 意図と実装のずれによる監査運用誤解
+
+- support case の実験的扱い
+  - 根拠: `src/sharepoint/driftProbeRegistry.ts`, `src/sharepoint/supportCaseDiagnosticsPreflight.ts`
+  - 概要: opt-in フラグに依存した取り込み条件
+  - 影響: 本番で drift が観測されても対象外扱いとなる場合がある
+
+- `skipTitleEssential` の例外
+  - 根拠: `src/sharepoint/spListConfig.ts`, `tests/unit/spListConfig.spec.ts`
+  - 概要: list により Title 補完を省く例外分岐が存在
+  - 影響: drift 判定で必須比較が漏れる可能性
+
+## Low
+- ドキュメント内説明文の断片（既知リスク）
+  - 既存 docs と実装整合の観点で説明更新のみで低リスク
+  - 根拠: `docs/sharepoint/*` 既存資料
+
+- UI 警告表示の閾値固定
+  - 根拠: `src/pages/admin/DataIntegrityPage.tsx`
+  - 影響: 上限到達時の表示だけで、core drift ロジック自体を変えない
+
+## 触ってはいけない実装領域（初期運用）
+- `src/sharepoint/spListRegistry.ts`
+- `src/sharepoint/spListConfig.ts`
+- `src/lib/sp/queryGuard.ts`
+- `src/lib/sp/spListRead.ts`
+- `src/sharepoint/driftProbeRegistry.ts`
+- `src/pages/admin/DataIntegrityPage.tsx`
+- `src/features/diagnostics/health/*`
+
+## 監査根拠（path list）
+- `src/sharepoint/__tests__/driftProbeRegistry.spec.ts`
+- `src/sharepoint/__tests__/supportCaseDiagnosticsPreflight.spec.ts`
+- `src/sharepoint/fields/__tests__/supportCaseFields.spec.ts`
+- `tests/unit/spListHealthCheck.spec.ts`
+- `tests/unit/spListConfig.spec.ts`
+- `src/sharepoint/spListHealthCheck.ts`
+- `src/pages/HealthPage.tsx`
+- `src/features/diagnostics/health/useHealthChecks.ts`
+- `src/sharepoint/query/builders.ts`
+
+## 人間レビューで確定すべき項目
+- `queryGuard` の high-risk 取扱いを監査方針として固定するか
+- `supportCases` / `billingOrders` の対象外条件を運用ポリシーとして承認するか
+- `drift` の対象リスト定義を環境ごとに freeze するか
+- SharePoint 側の実体スキーマを基準版として `field-mapping-notes` を更新するか

--- a/docs/sharepoint/field-mapping-notes.md
+++ b/docs/sharepoint/field-mapping-notes.md
@@ -1,0 +1,56 @@
+# SharePoint field mapping notes
+
+## 対象
+- `SupportCase` 系と `Staff/User` 系を中心に、内部名と表示名の差異が drift 判定に与える影響を整理
+- 根拠ソース: 既存のフィールド定義ファイル、診断/比較ロジック、既存テスト
+
+## 1. InternalName / DisplayName の現状
+
+### 設計上の前提
+- SharePoint 比較は「表示名の完全一致」を基本前提にしない
+- 利用箇所では `fieldTitleMap` や内部名補助関数を経由して比較するケースがあり、両者がズレると一致しない前提で耐性を持たせる必要がある
+- `buildListSpecs` の後段で `Title/Id` が追加されるため、定義側と API 側のキー解像度差を吸収
+
+### 典型的な揺れ
+- `support_case_*` 系の関連リスト:
+  - `support_cases` と `support_case_documents/support_case_events` の関連キーが UI 名称で確認されがちで、内部参照は ID 系の不一致が起きやすい
+- `staff_master` / `users_master` 系:
+- ユーザーの識別キー（`Id` 系）と名称表示（`Title` 系）が非対称なリクエストで混在
+
+## 2. ファイル別マッピング参照
+
+### `src/sharepoint/fields/fieldUtils.ts`
+- `getFieldInternalName` / `normalize` 系を通じ、UI 名から内部名へ寄せる変換責務
+- ここで解決されない場合、drift 比較で誤検知/未検知が増える
+
+### `src/sharepoint/fields/staffFields.ts`
+- スタッフ系・ユーザー系の共通フィールドを定義
+- `Id` 系との比較が必要な箇所はここを通して `listSpecs` で参照される想定
+
+### `src/sharepoint/fields/supportCaseFields.ts`
+- サポートケース関連のフィールド定義
+- 主要イベント/ドキュメントを含む関連取得で、`expand` 対象の識別子とフィールド指定が一致しない場合、drift レベル差分に影響
+
+### `src/sharepoint/query/builders.ts` / `src/lib/sp/spListRead.ts`
+- OData クエリ生成は内部名依存。display name へ展開してから送る場合の解像度差はここで検知が必要
+
+## 3. 今回確認した不一致リスク
+- 重大:
+  - display name と internal name が混在したまま query/select/filter に渡される
+  - `support_case` 関連で関連先キー混在
+- 中:
+  - `Title` 補完の既定動作を前提にしたまま、カスタム表示名を追加した場合
+- 低:
+  - docs 側コメント/現状の実装説明の不一致（例: 対象リスト数の説明）
+
+## 4. 追跡すべき恒久チェック項目（docs + test連動）
+- `Field mapping` を list/field 単位で固定表として管理
+- listSpec と実装 field list の差分検知を単体テスト化
+- `buildListCheckPath` の title/guid 変換と list-specific field 変換との整合確認
+- `Id` と `Title` の自動付与対象から外すことがないかを監査
+
+## 5. 追加調査が必要なリスト（人間レビュー推奨）
+- `support_case_documents`, `support_case_events` の関連キー
+- `billing_orders`（site 依存分岐）
+- `diagnostics_reports`, `drift_events_log`（運用ログ性質のため表示名差分の検知対象要否）
+

--- a/docs/sharepoint/recommended-small-prs.md
+++ b/docs/sharepoint/recommended-small-prs.md
@@ -1,0 +1,53 @@
+# Recommended next small PRs (docs/test scope first)
+
+## 方針
+- まずは docs-only / test-only を優先し、実装変更は最小限の監査合意後に段階実施
+- drift リスクの見える化を先行し、環境再現性を上げる
+
+## 候補1: docs-only（最優先）
+- docs: normalize drift intent and glossary
+- 対象ファイル:
+  - `docs/sharepoint/drift-inventory.md`
+  - `docs/sharepoint/field-mapping-notes.md`
+  - `docs/sharepoint/drift-risk-report.md`
+  - `docs/sharepoint/recommended-small-prs.md`
+- 目的:
+  - list/field 一覧、例外、根拠ファイル、環境依存、運用手順を1か所に集約
+  - `High risk` を人間レビューに先回し
+
+## 候補2: test-only（docs実装に対する補助）
+- docs: clarify existing behavior contracts with tests
+- 対象ファイル候補:
+  - `src/sharepoint/__tests__/driftProbeRegistry.spec.ts`
+  - `tests/unit/spListHealthCheck.spec.ts`
+- 目的:
+  - 既存仕様（`lifecycle`、`billing_orders` の除外条件、`buildListCheckPath`）の固定を維持
+  - 新規仕様は入れず、監査要件との不一致箇所を明確化するテストケースを追加
+- 注意:
+  - 本タスクではテスト変更は行わない（次回イテレーション）
+
+## 候補3: docs-only（運用手順）
+- `docs/sharepoint/drift-inventory.md` に環境別確認手順を追加
+  - local/prod の `VITE_*` 差分確認
+  - supportCase 診断 flag のオン/オフ影響確認
+  - drift 対象リストの snapshot 差分取り方
+
+## 候補4: docs-only（監査レポート雛形）
+- `docs/sharepoint/daily-drift-review-checklist.md` の新規追加（任意）
+- 計測項目:
+  - 対象 List/Field 増減有無
+  - 誤検知/未検知の再現手順
+  - 監査者承認ポイント
+- ※命名・テンプレートは既存 docs 規約に合わせる
+
+## 切り出し条件（小PRとしての安全基準）
+- 差分は docs のみ
+- `.env` を一切触らない
+- 既存未コミット差分に干渉しない
+- 1 PR あたり 1 ドメイン（例: risk, mapping, operations）
+
+## Human review required
+- drift 対象外リスト（`support cases` と関連）の運用方針
+- queryGuard の fail-open 継続判断
+- `billing_orders` のsite分岐除外を監査要件で許容するか
+- ListSpec 生成 (`buildListSpecs`) の必要最小ルールの固定

--- a/docs/testing/coverage-gap-report.md
+++ b/docs/testing/coverage-gap-report.md
@@ -1,0 +1,84 @@
+# Test Coverage Gap Analysis (Baseline)
+
+日付: 2026-06-11
+対象領域: SharePoint 関連・ドメイン周辺のテスト欠損棚卸し
+
+## 1. 前提
+- `spec` / `test` ファイルを `src` と `tests` 配下で全探索
+- `docs-only` / `test-only` 小PR運用を前提に、まずは「未テスト候補」を高・中・低に分けて列挙
+- ここでの「未テスト」は**厳密な網羅率計算ではなく、実行可能候補化のための高信頼推定**
+
+## 2. 収集結果（サマリ）
+- 総 `spec` / `test` 件数（探索時点）: 1,277
+- 検索対象の主カテゴリ別（src側ファイル/テスト名一致推定）
+  - Domain: 131中 63 が未テスト推定
+  - SharePoint: 143中 98 が未テスト推定
+  - Mapper: 49中 20 が未テスト推定
+  - Validation: 46中 22 が未テスト推定
+  - AI Safety: 3中 1 が未テスト推定
+  - Billing: 7中 4 が未テスト推定
+
+## 3. 根拠ファイル（カテゴリ別抜粋）
+
+### SharePoint
+- `src/sharepoint/**`
+- `src/features/*/sharepoint/**`
+- `src/features/*/sp/**`
+- `src/infra/sharepoint/**`
+- `src/features/diagnostics/drift/**`
+
+代表的な既存テスト
+- `src/sharepoint/__tests__/driftProbeRegistry.spec.ts`
+- `src/sharepoint/__tests__/supportCaseDiagnosticsPreflight.spec.ts`
+- `src/sharepoint/fields/__tests__/*`
+- `src/features/daily/repositories/sharepoint/__tests__/DailyRecordSchemaDrift.spec.ts`
+- `src/infra/sharepoint/repos/__tests__/SharePointAbcRecordRepository.spec.ts`
+- `src/features/diagnostics/drift/infra/__tests__/SharePointDriftEventRepository.spec.ts`
+
+### Mapper
+- `src/domain/**/*Mapper*.ts`
+- `src/features/**/*Mapper*.ts`
+- `src/features/**/*Map*.ts`
+- `src/sharepoint/**/*Mapper*.ts`
+
+代表的な既存テスト
+- `src/domain/supportCase/__tests__/sharePointMapper.spec.ts`
+- `src/domain/today/__tests__/planPatchToTodayActionMapper.spec.ts`
+- `src/features/daily/domain/__tests__/dailyTableMapper.spec.ts`
+- `src/features/meeting-minutes/sp/__tests__/mapItemToMinutes.spec.ts`
+- `src/sharepoint/__tests__/ispGoalMapper.spec.ts`
+- `src/features/` 配下に `Map` 系実装とテストを横断的に確認
+
+### Validation
+- `schema`, `contract`, `guard`, `validate` 系の実装
+
+代表的な既存テスト
+- `tests/unit/env.coercion.spec.ts`
+- `tests/unit/env.coercion.more.spec.ts`
+- `src/lib/sp/__tests__/spListSchema.cooldown.spec.ts`
+- `src/lib/sp/__tests__/spListSchema.fields-cache.spec.ts`
+- `tests/unit/contract.spec.ts`
+- `tests/unit/service-provision/schema.spec.ts`
+
+### Billing
+- `src/features/billing/**`
+- `src/sharepoint/fields/**billing*`
+
+代表的な既存テスト
+- `src/features/billing/__tests__/repositoryFactory.spec.ts`
+- `src/features/billing/domain/__tests__/billingLogic.spec.ts`
+- `src/features/billing/hooks/__tests__/useBillingSummary.spec.ts`
+- `src/features/billing/infra/__tests__/DataProviderBillingOrderRepository.spec.ts`
+
+## 4. ドキュメント化対象（次の1セット）
+- `docs/testing/coverage-gap-report.md`（本資料）
+- `docs/testing/missing-test-candidates.md`（未テスト候補）
+- `docs/testing/recommended-test-prs.md`（test-only PR候補）
+- `docs/testing/index.md` へ横断リンク追記
+
+## 5. 直近8時間での実行可能アクション
+- `Coverage -> Candidate`: 各カテゴリで「未テスト推定」を `docs/testing/missing-test-candidates.md` に昇格
+- `Candidate -> PR`: テスト追加/改善を `docs/testing/recommended-test-prs.md` の順で小PR化
+- `PR -> 実行`: まず `Billing` と `AI Safety` から開始（影響範囲が限定的なため）
+
+

--- a/docs/testing/index.md
+++ b/docs/testing/index.md
@@ -18,6 +18,14 @@
 👉 **[Unit Test Boundary Guide](./unit-test-boundary-guide.md)**
 （repositoryFactory 境界ルール、判定フロー、モックパターン、コンプライアンス一覧）
 
+## Test Coverage Gap Analysis
+
+テスト不足棚卸しと、次に切り出せる test-only 候補を集約します。
+
+👉 **[Coverage Gap Report](./coverage-gap-report.md)**
+👉 **[Missing Test Candidates](./missing-test-candidates.md)**
+👉 **[Recommended Test PRs](./recommended-test-prs.md)**
+
 ## Schedule / Calendar E2E Tests
 
 Schedule（Day / Week / Month / Status / Quick Dialog）を扱う E2E テストのガイドラインと共通ヘルパーは以下に集約されています。

--- a/docs/testing/missing-test-candidates.md
+++ b/docs/testing/missing-test-candidates.md
@@ -1,0 +1,72 @@
+# Missing test candidates (SharePoint-aligned baseline)
+
+## 1. High Priority（優先）
+
+### H-1. SharePoint Drift / Diagnostics domain
+- `src/features/daily/repositories/sharepoint/activityDiary/modules/DataAccess.ts`
+- `src/features/daily/repositories/sharepoint/activityDiary/modules/Saver.ts`
+- `src/features/daily/repositories/sharepoint/activityDiary/SharePointActivityDiaryRepository.ts`
+- `src/features/daily/repositories/sharepoint/modules/RowAggregateAccess.ts`
+- `src/features/diagnostics/drift/domain/DriftEventBus.ts`
+- `src/features/diagnostics/drift/domain/driftLogic.ts`
+- 根拠:
+  - SharePoint 操作＋ドリフト監査の境界が厚い
+  - 同名テストでの直接照合で `-by-name` では不一致（現時点）
+
+### H-2. Billing
+- `src/features/billing/hooks/useBillingOrderRepository.ts`
+- `src/features/billing/infra/InMemoryBillingOrderRepository.ts`
+- `src/features/billing/useBillingOrders.ts`
+- 根拠:
+  - 既存テストが薄く、リポジトリ分岐と表示ロジックの連携を持つ
+  - フィールド階層が SharePoint 仕様変更に追従しやすい場所
+
+### H-3. Domain core with low discoverability
+- `src/domain/behavior/abc.ts`
+- `src/domain/isp/dailyBridgeMapper.ts`
+- `src/domain/isp/dailyBridge.ts`
+- 根拠:
+  - 名前ベースのテスト照合で未検出になりやすい
+  - `src/domain/isp` は影響範囲が大きく、再現性ある単体テスト追加が必要
+
+## 2. Medium Priority（中優先）
+
+### M-1. AI Safety（UI + ドメイン連携境界)
+- `src/features/safety/components/SafetyOperationsSummaryCard.tsx`
+- `src/domain/safety/__tests__` 既存テストはあるが、UI表示層との結線を追加する価値あり
+- 根拠:
+  - 安全性関連のリスクが高く、観測不能領域が残ると監査時の追跡困難
+
+### M-2. SharePoint mapper/validation 補助
+- `src/features/planning-sheet/tokuseiFieldMap.ts`
+- `src/features/callLogs/data/callLogFieldMap.ts`
+- `src/features/users/infra/migration/userBenefitProfileCutover/readMapper.ts`
+- `src/features/users/infra/migration/userBenefitProfileCutover/writeMapper.ts`
+
+### M-3. Validation utility drift
+- `src/domain/behavior/abc.schema.ts`
+- `src/domain/isp/schema/*` 各種
+- `src/features/schedules/data/spChildRowSchemas.ts`
+- `src/lib/sp/spListSchema.ts`
+- 根拠:
+  - スキーマの微修正は runtime 側で広域影響しうるため
+
+## 3. Low Priority（低優先）
+
+### L-1. Index / 接続レイヤ
+- `src/domain/*/index.ts`
+- `src/features/*/index.ts`
+- 明示的テスト化は価値が低いが、公開 API 変更時の監査ログとして追跡対象にする
+
+## 4. 除外（今回は対象外）
+- `*.spec.ts / *.test.ts` 自体
+- 自動生成資産・型定義のみ
+- UIの純粋なレイアウト差分のみ（監査対象ではないもの）
+
+## 5. 追加観点
+- ここでの未検出は「名前一致で見つからない」ものが混在する。
+  - したがって PR 化時は、以下順で確度を上げる:
+    1. 既存テストの呼び出し元を確認
+    2. 事象再現シナリオの fixture を小さく追加
+    3. エラーパス/境界値を1ケース以上含める
+

--- a/docs/testing/recommended-test-prs.md
+++ b/docs/testing/recommended-test-prs.md
@@ -1,0 +1,58 @@
+# Recommended test-only PR candidates
+
+## 方針
+- 小さく安全に回すため、1 PR は単一責務
+- まず検知価値が高い箇所から着手し、失敗時の切り戻しコストを最小化
+- ここでは `test-only` を基本とし、必要に応じて docs-only を併記
+
+## PR Candidate 1: Billing Coverage - Core hooks + repository
+- 目標: Billing フローの最小リスク高の未カバー領域を埋める
+- docs-only 追加: `docs/testing/missing-test-candidates.md` への更新
+- test-only 追加候補:
+  - `src/features/billing/hooks/useBillingOrderRepository.spec.ts`（新規）
+  - `src/features/billing/infra/InMemoryBillingOrderRepository.spec.ts`（新規）
+  - `src/features/billing/useBillingOrders.spec.ts`（新規）
+- 期待: `repository / hook / use*` の境界欠損を1セットで補完
+
+## PR Candidate 2: SharePoint Diagnostics Drift + Health
+- 目標: Drift 監査境界（data access / drift orchestration）を再現
+- test-only 追加候補:
+  - `src/features/daily/repositories/sharepoint/modules/IntegrityScanner.spec.ts`（既存は存在するが、補強推奨）
+  - `src/features/daily/repositories/sharepoint/activityDiary/modules/DataAccess.spec.ts`（新規）
+  - `src/features/daily/repositories/sharepoint/modules/RowAggregateAccess.spec.ts`（新規）
+  - `src/features/diagnostics/drift/domain/driftLogic.spec.ts`（新規）
+- docs-only 追加: 失敗観測の再現手順追記
+
+## PR Candidate 3: SharePoint Mapper Regression Set
+- 目標: SharePoint 由来の Mapper（特に日報/行集約系）を網羅
+- test-only 追加候補:
+  - `src/features/daily/repositories/sharepoint/activityDiary/modules/Saver.spec.ts`（新規）
+  - `src/sharepoint/fields/__tests__/billingFields.spec.ts`（既存補強）
+  - `src/domain/today/__tests__/planPatchToTodayActionMapper.spec.ts` の連携ケース追加
+- 期待: `map` の境界ズレ（field名差異、欠落値）を単体で検知
+
+## PR Candidate 4: Validation Contract Matrix
+- 目標: schema/guard/contract の「成功/失敗対比」テストを追加
+- test-only 追加候補:
+  - `src/lib/sp/spListSchema.spec.ts`（新規）
+  - `src/domain/isp/schema/*` 既存ファイルに対する追加 fixture
+  - `src/lib/envGuards.spec.ts`（新規）
+- 期待: 設定変更時の不整合を早期検知
+
+## PR Candidate 5: AI Safety + Telemetry Boundary
+- 目標: safety 表示・集約の回帰を検知し、AI系の安全監査時点検を安定化
+- test-only 追加候補:
+  - `src/features/safety/components/SafetyOperationsSummaryCard.spec.tsx`（新規）
+  - `src/domain/safety/__tests__` の境界ケースを 1–2 ケース追加
+- 期待: 安全関連サマリ表示と監査ログ連鎖の見落とし防止
+
+## 実施順の推奨
+1. PR Candidate 1（Billing）
+2. PR Candidate 5（AI Safety）
+3. PR Candidate 4（Validation）
+4. PR Candidate 2（SharePoint Diagnostics）
+5. PR Candidate 3（SharePoint Mapper）
+
+## 次アクション
+- 各候補をレビュー前提の「1 PR 1 目的」で準備し、`docs/testing/coverage-gap-report.md` と `missing-test-candidates.md` の照合を継続
+


### PR DESCRIPTION
## Summary
- Added SharePoint drift inventory documentation and risk/scope mapping as docs-only assets.
- Added follow-up test coverage-gap analysis for the same operational area: spec exploration and candidate test-only backlog.
- Added reusable links into the testing doc index.

## Scope
- Documentation updates only under `docs/sharepoint/*` and `docs/testing/*`.
- No implementation code changes.
- No test code changes.
- No `.env` file touched.

## Files changed
- docs/sharepoint/drift-inventory.md
- docs/sharepoint/field-mapping-notes.md
- docs/sharepoint/drift-risk-report.md
- docs/sharepoint/recommended-small-prs.md
- docs/testing/coverage-gap-report.md
- docs/testing/missing-test-candidates.md
- docs/testing/recommended-test-prs.md
- docs/testing/index.md

## Validation
- git diff --check
- git status --short (working tree clean)
- gh pr view 2171 --json ... (files + draft status)

## Out of scope
- 実装改修（SharePoint 接続・ドリフト検知ロジック）
- テスト追加・修正
- 本番監査の実行
- `.env` の編集・コミット

## Human review points
- Confirm SharePoint-side actual InternalName vs DisplayName mapping for each list/field.
- Validate environment variable values affecting drift targets (`VITE_SP_LIST_BILLING_ORDERS_SITE_RELATIVE`, feature flags).
- Validate coverage-gap assumptions (especially name-based test matching).
- Decide PR Candidate execution order for Billing / AI Safety / SharePoint diagnostics.