### PR TITLE
docs(support-case): record SupportCaseDocuments read-only precheck retry

### DIFF
--- a/docs/reports/support-case-documents-read-only-precheck-retry-2026-06-11.md
+++ b/docs/reports/support-case-documents-read-only-precheck-retry-2026-06-11.md
@@ -1,0 +1,93 @@
+# SupportCaseDocuments Read-Only Precheck Retry - 2026-06-11
+
+## Scope
+
+This report records a single approved read-only metadata precheck retry for the app-test `SupportCaseDocuments` list.
+
+This was not a diagnostics rerun. It did not create SharePoint resources, request a form digest, create fields, change permissions, read fields, read items, connect UI, migrate documents, or change `SupportCaseRepository` behavior.
+
+## Approval
+
+The retry was explicitly approved with this scope:
+
+```txt
+app-test に対して SupportCaseDocuments の read-only metadata GET を1回だけ実行してよい。
+作成・権限変更・diagnostics 再実行・field check には進まない。
+```
+
+## Preconditions
+
+- Branch before execution: `main`.
+- Working tree before execution: clean.
+- `HEAD` and `origin/main` were aligned before execution.
+- Target site: `https://isogokatudouhome.sharepoint.com/sites/app-test`
+- Request scope: one read-only metadata GET for `SupportCaseDocuments`.
+
+## Request
+
+| Property | Value |
+|---|---|
+| SharePoint site | `https://isogokatudouhome.sharepoint.com/sites/app-test` |
+| Resource | `SupportCaseDocuments` |
+| Request type | Read-only metadata GET |
+| Field check | Not run |
+| Item read | Not run |
+| Form digest requested | No |
+| Create/provision/ensure request | No |
+
+## Result
+
+| Check | Result |
+|---|---|
+| `SupportCaseDocuments` metadata GET | HTTP `404` |
+| Request ID | `0b611ca2-80ef-7000-c05a-c69eba8e6c52` |
+| `Retry-After` header | Not present |
+
+The response body indicated that list `SupportCaseDocuments` does not exist at the app-test site.
+
+Interpretation:
+
+- The prior HTTP `429` condition did not recur on this single retry.
+- `SupportCaseDocuments` appears absent from app-test by metadata GET.
+- This result does not create the list and does not approve creation.
+- Creation still requires a separate explicit operation and must remain limited to `SupportCaseDocuments`.
+
+## Boundaries Confirmed
+
+- Production touched: no.
+- Permission changed: no.
+- `SupportCaseDocuments` created: no.
+- `SupportCaseEvents` created: no.
+- `SupportCaseRestrictedDocuments` created: no.
+- Document library created: no.
+- Restricted library created: no.
+- Diagnostics rerun: no.
+- Field check: no.
+- Item read: no.
+- UI connected: no.
+- Migration run: no.
+- Graph API or `spFetch` implementation changed: no.
+- `SupportCaseRepository` changed: no.
+
+## Stop Conditions Before Creation
+
+Do not proceed to creation automatically from this report.
+
+Before any later `SupportCaseDocuments` creation attempt:
+
+- Reconfirm the target site is app-test.
+- Reconfirm production is excluded.
+- Reconfirm `SupportCaseDocuments` is the only creation target.
+- Reconfirm no permission change is part of the operation.
+- Reconfirm the creation approval is still valid.
+- Record the creation result separately.
+
+## Next Step
+
+Keep `SupportCaseDocuments` creation paused until a human explicitly asks for the creation operation.
+
+Required creation wording:
+
+```txt
+app-test に SupportCaseDocuments list を作成してよい
+```


### PR DESCRIPTION
## Summary
- Ran the approved single read-only metadata GET for SupportCaseDocuments in app-test
- Recorded that the retry returned HTTP 404 and the prior 429 did not recur
- Kept creation, permission changes, diagnostics rerun, field checks, and item reads out of scope

## Scope
- app-test only
- SupportCaseDocuments metadata GET only
- docs-only result record in this PR

## Out of scope
- No SharePoint creation/provisioning/ensure call
- No permission changes
- No diagnostics rerun
- No field check
- No item read
- No SupportCaseDocuments creation
- No SupportCaseEvents creation
- No SupportCaseRestrictedDocuments creation
- No production changes
- No UI integration
- No migration
- No Graph API or spFetch changes
- No SupportCaseRepository changes

## Verification
- git diff --check
- npm run lint:docs
- npm run typecheck