### PR TITLE
test(sharepoint): cover daily query boundary cases

### DIFF
--- a/src/features/daily/repositories/sharepoint/activityDiary/modules/DataAccess.spec.ts
+++ b/src/features/daily/repositories/sharepoint/activityDiary/modules/DataAccess.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ActivityDiaryDataAccess } from './DataAccess';
+import type { ADMapping } from '../constants';
+import type { SpFetchFn } from '@/lib/sp/spLists';
+
+describe('ActivityDiaryDataAccess', () => {
+  const defaultMapping: ADMapping = {
+    userId: 'UserID',
+    date: 'Date',
+    shift: 'Shift',
+    category: 'Category',
+    lunchAmount: 'LunchAmount',
+    mealMain: 'MealMain',
+    mealSide: 'MealSide',
+    problemBehavior: 'ProblemBehavior',
+    behaviorType: 'BehaviorType',
+    behaviorNote: 'BehaviorNote',
+    seizure: 'Seizure',
+    seizureAt: 'SeizureAt',
+    goals: 'Goals',
+    notes: 'Notes',
+  };
+
+  it('loads a date with field mapping and normalized filters', async () => {
+    const response = {
+      value: [
+        { Id: 101, Title: 'entry-101' },
+        { Id: 102, Title: 'entry-102' },
+      ],
+    };
+    const spFetch = vi.fn(async () => ({ ok: true, json: async () => response })) as SpFetchFn;
+    const access = new ActivityDiaryDataAccess(spFetch);
+
+    const result = await access.loadByDate(
+      '2026-06-10',
+      "OU''Neil",
+      'lists/ActivityDiary',
+      defaultMapping,
+    );
+
+    expect(result).toEqual(response.value);
+    const [url] = spFetch.mock.calls[0]!;
+    const parsed = new URL(url as string, 'https://example.invalid');
+    expect(parsed.pathname).toBe('/lists/ActivityDiary/items');
+    const filter = parsed.searchParams.get('$filter');
+    expect(filter).toContain("Date eq '2026-06-10'");
+    expect(filter).toContain("UserID eq 'OU''''Neil'");
+    expect(parsed.searchParams.get('$orderby')).toBe('Id desc');
+    expect(parsed.searchParams.get('$select')).toContain('LunchAmount');
+    expect(parsed.searchParams.get('$orderby')).toBe('Id desc');
+    expect(parsed.searchParams.get('$top')).toBeNull();
+  });
+
+  it('lists with date range and default top', async () => {
+    const spFetch = vi.fn(async () => ({ ok: true, json: async () => ({ value: [{ Id: 1 }, { Id: 2 }] }) })) as SpFetchFn;
+    const access = new ActivityDiaryDataAccess(spFetch);
+
+    await access.list('2026-06-01', '2026-06-30', 'lists/ActivityDiary', defaultMapping);
+
+    const [url] = spFetch.mock.calls[0]!;
+    const parsed = new URL(url as string, 'https://example.invalid');
+    expect(parsed.pathname).toBe('/lists/ActivityDiary/items');
+    expect(parsed.searchParams.get('$top')).toBe('5000');
+    expect(parsed.searchParams.get('$filter')).toContain("Date ge '2026-06-01'");
+    expect(parsed.searchParams.get('$filter')).toContain("Date le '2026-06-30'");
+  });
+});

--- a/src/features/daily/repositories/sharepoint/modules/RowAggregateAccess.spec.ts
+++ b/src/features/daily/repositories/sharepoint/modules/RowAggregateAccess.spec.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+import { RowAggregateAccess } from './RowAggregateAccess';
+import type { RowAggregateSource } from '../constants';
+import type { SpFetchFn } from '@/lib/sp/spLists';
+
+describe('RowAggregateAccess', () => {
+  it('aggregates rows by date and merges duplicate users', async () => {
+    const source: RowAggregateSource = {
+      listPath: 'lists/DailyRows',
+      listTitle: 'DailyRows',
+      dateField: 'cr013_date',
+      selectFields: ['Id', 'cr013_personId', 'Title', 'cr013_date', 'cr013_payload', 'cr013_kind'],
+    };
+
+    const spFetch = vi.fn(async (url: string) => {
+      if (url.startsWith('lists/DailyRows/items?')) {
+        return {
+          ok: true,
+          json: async () => ({
+            value: [
+              {
+                Id: 1,
+                cr013_personId: 'U-001',
+                Title: 'Alice',
+                cr013_date: '2026-06-10',
+                cr013_kind: 'A',
+                cr013_payload: JSON.stringify({
+                  amActivities: ['walk'],
+                  pmActivities: ['study'],
+                  specialNotes: 'first',
+                }),
+              },
+              {
+                Id: 2,
+                cr013_personId: 'U-001',
+                Title: 'Alice',
+                cr013_date: '2026-06-10',
+                cr013_kind: 'A',
+                cr013_payload: JSON.stringify({
+                  pmActivities: ['rest'],
+                  specialNotes: 'second',
+                }),
+              },
+              {
+                Id: 3,
+                cr013_personId: 'U-002',
+                Title: 'Bob',
+                cr013_date: '2026-06-11',
+                cr013_kind: 'A',
+                cr013_payload: JSON.stringify({
+                  amActivities: ['meal'],
+                  specialNotes: 'single',
+                }),
+              },
+              {
+                Id: 4,
+                cr013_personId: 'U-003',
+                Title: 'Carol',
+                cr013_date: '2026-05-31',
+                cr013_kind: 'A',
+                cr013_payload: JSON.stringify({
+                  amActivities: ['skip'],
+                }),
+              },
+            ],
+          }),
+        };
+      }
+      return { ok: true, json: async () => ({ value: [] }) };
+    }) as SpFetchFn;
+
+    const access = new RowAggregateAccess(spFetch);
+    const result = await access.list(source, { range: { startDate: '2026-06-10', endDate: '2026-06-11' } });
+
+    expect(result).toHaveLength(2);
+    expect(result[0].date).toBe('2026-06-11');
+    expect(result[0].userRows).toHaveLength(1);
+    expect(result[0].userRows[0]).toMatchObject({ userId: 'U-002', userName: 'Bob', specialNotes: 'single' });
+
+    expect(result[1].date).toBe('2026-06-10');
+    expect(result[1].userRows).toHaveLength(1);
+    expect(result[1].userRows[0]).toMatchObject({ userId: 'U-001', userName: 'Alice', amActivity: 'walk', pmActivity: 'study' });
+    expect(result[1].userRows[0].specialNotes).toBe('first\nsecond');
+  });
+
+  it('respects SP top and date-range sorting order', async () => {
+    const source: RowAggregateSource = {
+      listPath: 'lists/DailyRows',
+      listTitle: 'DailyRows',
+      dateField: 'cr013_date',
+      selectFields: ['Id', 'cr013_personId', 'Title', 'cr013_date', 'cr013_payload', 'cr013_kind'],
+    };
+
+    const spFetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ value: [] }),
+    })) as SpFetchFn;
+
+    const access = new RowAggregateAccess(spFetch);
+    await access.list(source, { range: { startDate: '2026-01-01', endDate: '2026-01-31' }, limit: 2 });
+
+    const [url] = spFetch.mock.calls[0]!;
+    const parsed = new URL(url as string, 'https://example.invalid');
+    expect(parsed.pathname).toBe('/lists/DailyRows/items');
+    expect(parsed.searchParams.get('$top')).toBe('2');
+    expect(parsed.searchParams.get('$orderby')).toBe('Id desc');
+  });
+});


### PR DESCRIPTION
## Summary
- Recreate PR 2-B on a main-based branch to keep test-only scope strictly to 2 files.
- Covers daily SharePoint query boundary behavior for activity diary and row aggregate access modules only.
- Intentionally separated from #2177 (drift/integrity boundary tests) to keep review scope minimal.