### PR TITLE
feat(support-record): add record quality review persistence mapper

### DIFF
--- a/src/domain/supportRecord/recordQualityReviewPersistenceMapper.spec.ts
+++ b/src/domain/supportRecord/recordQualityReviewPersistenceMapper.spec.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  acceptRecordQualityReviewDraft,
+  createRecordQualityReviewDraft,
+  type RecordQualityReviewDraft,
+} from './recordQualityReview';
+import {
+  fromRecordQualityReviewPersistenceItem,
+  toRecordQualityReviewPersistenceItem,
+  type RecordQualityReviewPersistenceItem,
+} from './recordQualityReviewPersistenceMapper';
+
+const createDraft = (): RecordQualityReviewDraft =>
+  createRecordQualityReviewDraft({
+    recordId: 'record-1',
+    suggestedCategories: [
+      {
+        categoryId: 'mealsHydration',
+        matchedSignals: ['昼食', '水分'],
+        source: 'rule',
+      },
+      {
+        categoryId: 'staffSupportActions',
+        matchedSignals: ['職員', '提案'],
+        source: 'ai',
+      },
+    ],
+    missingInformationHints: [
+      {
+        code: 'userResponseAfterSupport',
+        label: '支援後の本人の反応',
+        source: 'rule',
+      },
+    ],
+    notes: ['人間レビューで確認する'],
+    createdAt: '2026-06-11T00:00:00.000Z',
+  });
+
+describe('recordQualityReviewPersistenceMapper', () => {
+  it('maps review draft metadata to a persistence item', () => {
+    const item = toRecordQualityReviewPersistenceItem({
+      ...createDraft(),
+      reviewerId: 'staff-1',
+      reviewerName: '山田 花子',
+    } as RecordQualityReviewDraft & {
+      reviewerId: string;
+      reviewerName: string;
+    });
+
+    expect(item).toMatchObject({
+      recordId: 'record-1',
+      sourceRecordId: 'record-1',
+      status: 'draft',
+      reviewerId: 'staff-1',
+      reviewerName: '山田 花子',
+      createdAt: '2026-06-11T00:00:00.000Z',
+      updatedAt: '2026-06-11T00:00:00.000Z',
+    });
+    expect(JSON.parse(item.suggestedCategoriesJson)).toEqual([
+      {
+        categoryId: 'mealsHydration',
+        matchedSignals: ['昼食', '水分'],
+        source: 'rule',
+      },
+      {
+        categoryId: 'staffSupportActions',
+        matchedSignals: ['職員', '提案'],
+        source: 'ai',
+      },
+    ]);
+    expect(JSON.parse(item.missingInfoHintsJson)).toEqual([
+      {
+        code: 'userResponseAfterSupport',
+        label: '支援後の本人の反応',
+        source: 'rule',
+      },
+    ]);
+    expect(JSON.parse(item.reviewerNotesJson)).toEqual(['人間レビューで確認する']);
+  });
+
+  it('maps persistence items back to repository-compatible review drafts', () => {
+    const accepted = acceptRecordQualityReviewDraft(createDraft(), '2026-06-11T01:00:00.000Z');
+    const restored = fromRecordQualityReviewPersistenceItem(
+      toRecordQualityReviewPersistenceItem(accepted),
+    );
+
+    expect(restored).toEqual(accepted);
+    expect(restored.originalRecord).toEqual({ recordId: 'record-1' });
+    expect(restored.sourceOfTruth).toBe('original_record');
+    expect(restored.outputKind).toBe('review_metadata');
+    expect(restored.requiresHumanReview).toBe(true);
+  });
+
+  it('does not include original record text in the persistence item', () => {
+    const draftWithText = {
+      ...createDraft(),
+      originalText: '元の支援記録本文は保存対象に含めない',
+      originalRecordText: '別名で紛れ込んだ本文も保存しない',
+    } as RecordQualityReviewDraft & {
+      originalText: string;
+      originalRecordText: string;
+    };
+
+    const item = toRecordQualityReviewPersistenceItem(draftWithText);
+
+    expect('originalText' in item).toBe(false);
+    expect('originalRecordText' in item).toBe(false);
+    expect(Object.keys(item)).toEqual([
+      'recordId',
+      'sourceRecordId',
+      'status',
+      'reviewerId',
+      'reviewerName',
+      'suggestedCategoriesJson',
+      'missingInfoHintsJson',
+      'reviewerNotesJson',
+      'createdAt',
+      'updatedAt',
+    ]);
+  });
+
+  it('preserves source record id separately from the persistence record id', () => {
+    const item: RecordQualityReviewPersistenceItem = {
+      ...toRecordQualityReviewPersistenceItem(createDraft()),
+      recordId: 'review-row-1',
+      sourceRecordId: 'support-record-1',
+    };
+
+    const restored = fromRecordQualityReviewPersistenceItem(item);
+
+    expect(restored.recordId).toBe('review-row-1');
+    expect(restored.originalRecord).toEqual({ recordId: 'support-record-1' });
+  });
+
+  it('rejects unsupported statuses and non-array JSON fields', () => {
+    const item = toRecordQualityReviewPersistenceItem(createDraft());
+
+    expect(() =>
+      fromRecordQualityReviewPersistenceItem({
+        ...item,
+        status: 'diagnosed' as RecordQualityReviewPersistenceItem['status'],
+      }),
+    ).toThrow('Unsupported record quality review status');
+
+    expect(() =>
+      fromRecordQualityReviewPersistenceItem({
+        ...item,
+        suggestedCategoriesJson: '{}',
+      }),
+    ).toThrow('Record quality review persistence field must be an array');
+  });
+});

--- a/src/domain/supportRecord/recordQualityReviewPersistenceMapper.ts
+++ b/src/domain/supportRecord/recordQualityReviewPersistenceMapper.ts
@@ -1,0 +1,113 @@
+import {
+  RECORD_QUALITY_REVIEW_SAFETY_METADATA,
+  RECORD_QUALITY_REVIEW_STATUSES,
+  type RecordQualityMissingInformationHint,
+  type RecordQualityReviewDraft,
+  type RecordQualityReviewSource,
+  type RecordQualityReviewStatus,
+  type RecordQualitySuggestedCategory,
+} from './recordQualityReview';
+
+export type RecordQualityReviewPersistenceItem = {
+  readonly recordId: string;
+  readonly sourceRecordId: string;
+  readonly status: RecordQualityReviewStatus;
+  readonly reviewerId?: string;
+  readonly reviewerName?: string;
+  readonly suggestedCategoriesJson: string;
+  readonly missingInfoHintsJson: string;
+  readonly reviewerNotesJson: string;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+};
+
+export function toRecordQualityReviewPersistenceItem(
+  draft: RecordQualityReviewDraft,
+): RecordQualityReviewPersistenceItem {
+  return {
+    recordId: draft.recordId,
+    sourceRecordId: draft.originalRecord.recordId,
+    status: assertRecordQualityReviewStatus(draft.status),
+    reviewerId: readOptionalString(draft, 'reviewerId'),
+    reviewerName: readOptionalString(draft, 'reviewerName'),
+    suggestedCategoriesJson: JSON.stringify(draft.suggestedCategories.map(toSuggestedCategoryItem)),
+    missingInfoHintsJson: JSON.stringify(draft.missingInformationHints.map(toMissingInfoHintItem)),
+    reviewerNotesJson: JSON.stringify([...draft.notes]),
+    createdAt: draft.createdAt,
+    updatedAt: draft.updatedAt,
+  };
+}
+
+export function fromRecordQualityReviewPersistenceItem(
+  item: RecordQualityReviewPersistenceItem,
+): RecordQualityReviewDraft {
+  return {
+    ...RECORD_QUALITY_REVIEW_SAFETY_METADATA,
+    recordId: item.recordId,
+    originalRecord: {
+      recordId: item.sourceRecordId,
+    },
+    status: assertRecordQualityReviewStatus(item.status),
+    suggestedCategories: parseJsonArray<RecordQualitySuggestedCategory>(
+      item.suggestedCategoriesJson,
+      'suggestedCategoriesJson',
+    ),
+    missingInformationHints: parseJsonArray<RecordQualityMissingInformationHint>(
+      item.missingInfoHintsJson,
+      'missingInfoHintsJson',
+    ),
+    notes: parseJsonArray<string>(item.reviewerNotesJson, 'reviewerNotesJson'),
+    createdAt: item.createdAt,
+    updatedAt: item.updatedAt,
+  };
+}
+
+function toSuggestedCategoryItem(
+  category: RecordQualitySuggestedCategory,
+): RecordQualitySuggestedCategory {
+  return {
+    categoryId: category.categoryId,
+    matchedSignals: [...category.matchedSignals],
+    source: assertRecordQualityReviewSource(category.source),
+  };
+}
+
+function toMissingInfoHintItem(
+  hint: RecordQualityMissingInformationHint,
+): RecordQualityMissingInformationHint {
+  return {
+    code: hint.code,
+    label: hint.label,
+    source: assertRecordQualityReviewSource(hint.source),
+  };
+}
+
+function assertRecordQualityReviewStatus(status: string): RecordQualityReviewStatus {
+  if (!(RECORD_QUALITY_REVIEW_STATUSES as readonly string[]).includes(status)) {
+    throw new Error(`Unsupported record quality review status: ${status}`);
+  }
+
+  return status as RecordQualityReviewStatus;
+}
+
+function assertRecordQualityReviewSource(source: string): RecordQualityReviewSource {
+  if (!['rule', 'ai', 'human'].includes(source)) {
+    throw new Error(`Unsupported record quality review source: ${source}`);
+  }
+
+  return source as RecordQualityReviewSource;
+}
+
+function readOptionalString(source: object, key: string): string | undefined {
+  const value = (source as Record<string, unknown>)[key];
+  return typeof value === 'string' && value ? value : undefined;
+}
+
+function parseJsonArray<T>(value: string, fieldName: string): readonly T[] {
+  const parsed: unknown = JSON.parse(value);
+  if (!Array.isArray(parsed)) {
+    throw new Error(`Record quality review persistence field must be an array: ${fieldName}`);
+  }
+
+  return parsed as readonly T[];
+}


### PR DESCRIPTION
## Summary

This PR adds a pure persistence mapper for record quality review drafts.

It converts `RecordQualityReviewDraft` metadata to and from a storage item shape while keeping the original support record text out of persistence.

## Scope

Mapper-only change.

Included:

* `ReviewDraft -> persistence item` mapper
* `persistence item -> ReviewDraft` mapper
* Storage fields for status, reviewer metadata, suggested categories, missing information hints, reviewer notes, timestamps, and source record id
* Tests for round-trip behavior and repository-compatible review metadata
* Tests confirming original record text is not included in the persistence item

Out of scope:

* No SharePoint write implementation
* No Graph / `spFetch` usage
* No UI changes
* No AI connection
* No workflow connection
* No overwrite of the original support record body

## Safety

The mapper stores review metadata only. It preserves the existing safety metadata: `sourceOfTruth`, `outputKind`, `requiresHumanReview`, and prohibited actions.

The original record text is intentionally not represented in the persistence item.

## Tests

Validation performed:

* `git diff --check`
* `npm run typecheck`
* `npm run lint`
* `npx vitest run src/domain/supportRecord/recordQualityReviewPersistenceMapper.spec.ts src/domain/supportRecord/recordQualityReviewRepository.spec.ts src/domain/supportRecord/recordQualityReviewProjection.spec.ts src/domain/supportRecord/recordQualityReview.spec.ts`
* commit hook: `lint`, `typecheck`, `lint:cookies`, lint-staged eslint
* pre-push hook: changed-file eslint
