### PR TITLE
feat(record-quality): add review decision read model

### DIFF
--- a/src/domain/supportRecord/recordQualityReviewDecisionReadModel.spec.ts
+++ b/src/domain/supportRecord/recordQualityReviewDecisionReadModel.spec.ts
@@ -8,6 +8,7 @@ import {
   type RecordQualityReviewDraft,
   type RecordQualityReviewStatus,
 } from './recordQualityReview';
+import { toRecordQualityReviewDecision } from './recordQualityReviewDecisionReadModel';
 
 type ReviewDecisionFixture = {
   readonly label: string;
@@ -87,25 +88,47 @@ describe('record quality review decision read model fixtures', () => {
   });
 
   it.each(decisionFixtures)('keeps %s metadata tied to the original record reference', fixture => {
-    expect(fixture.review.status).toBe(fixture.expectedStatus);
-    expect(fixture.review.recordId).toBe('support-record-1');
-    expect(fixture.review.originalRecord).toEqual({ recordId: 'support-record-1' });
-    expect(fixture.review.sourceOfTruth).toBe('original_record');
-    expect(fixture.review.outputKind).toBe('review_metadata');
-    expect(fixture.review.requiresHumanReview).toBe(true);
+    const decision = toRecordQualityReviewDecision(fixture.review);
+
+    expect(decision.status).toBe(fixture.expectedStatus);
+    expect(decision.recordId).toBe('support-record-1');
+    expect(decision.sourceRecordId).toBe('support-record-1');
+    expect(decision.label).toBe(fixture.label);
+    expect(decision.sourceOfTruth).toBe('original_record');
+    expect(decision.outputKind).toBe('review_metadata');
+    expect(decision.requiresHumanReview).toBe(true);
   });
 
   it.each(decisionFixtures)('does not expose original support record text for %s', fixture => {
-    expect('body' in fixture.review).toBe(false);
-    expect('content' in fixture.review).toBe(false);
-    expect('originalText' in fixture.review).toBe(false);
-    expect('originalRecordText' in fixture.review).toBe(false);
+    const decision = toRecordQualityReviewDecision(fixture.review);
+
+    expect('body' in decision).toBe(false);
+    expect('content' in decision).toBe(false);
+    expect('originalText' in decision).toBe(false);
+    expect('originalRecordText' in decision).toBe(false);
+  });
+
+  it('summarizes metadata counts without exposing review detail arrays', () => {
+    const decision = toRecordQualityReviewDecision(draftReview);
+
+    expect(decision.suggestedCategoryCount).toBe(1);
+    expect(decision.missingInformationHintCount).toBe(1);
+    expect(decision.noteCount).toBe(1);
+    expect('suggestedCategories' in decision).toBe(false);
+    expect('missingInformationHints' in decision).toBe(false);
+    expect('notes' in decision).toBe(false);
   });
 
   it('keeps accepted, revised, and discarded fixture timestamps monotonic', () => {
-    expect(draftReview.updatedAt).toBe(createdAt);
-    expect(acceptedReview.updatedAt).toBe('2026-06-11T01:00:00.000Z');
-    expect(revisedReview.updatedAt).toBe('2026-06-11T02:00:00.000Z');
-    expect(discardedReview.updatedAt).toBe('2026-06-11T03:00:00.000Z');
+    expect(toRecordQualityReviewDecision(draftReview).updatedAt).toBe(createdAt);
+    expect(toRecordQualityReviewDecision(acceptedReview).updatedAt).toBe(
+      '2026-06-11T01:00:00.000Z',
+    );
+    expect(toRecordQualityReviewDecision(revisedReview).updatedAt).toBe(
+      '2026-06-11T02:00:00.000Z',
+    );
+    expect(toRecordQualityReviewDecision(discardedReview).updatedAt).toBe(
+      '2026-06-11T03:00:00.000Z',
+    );
   });
 });

--- a/src/domain/supportRecord/recordQualityReviewDecisionReadModel.ts
+++ b/src/domain/supportRecord/recordQualityReviewDecisionReadModel.ts
@@ -1,0 +1,49 @@
+import type {
+  RecordQualityReviewDraft,
+  RecordQualityReviewStatus,
+} from './recordQualityReview';
+
+export type RecordQualityReviewDecision = {
+  readonly recordId: string;
+  readonly sourceRecordId: string;
+  readonly status: RecordQualityReviewStatus;
+  readonly label: string;
+  readonly suggestedCategoryCount: number;
+  readonly missingInformationHintCount: number;
+  readonly noteCount: number;
+  readonly updatedAt: string;
+  readonly sourceOfTruth: 'original_record';
+  readonly outputKind: 'review_metadata';
+  readonly requiresHumanReview: true;
+};
+
+export function toRecordQualityReviewDecision(
+  review: RecordQualityReviewDraft,
+): RecordQualityReviewDecision {
+  return {
+    recordId: review.recordId,
+    sourceRecordId: review.originalRecord.recordId,
+    status: review.status,
+    label: labelForStatus(review.status),
+    suggestedCategoryCount: review.suggestedCategories.length,
+    missingInformationHintCount: review.missingInformationHints.length,
+    noteCount: review.notes.length,
+    updatedAt: review.updatedAt,
+    sourceOfTruth: 'original_record',
+    outputKind: 'review_metadata',
+    requiresHumanReview: true,
+  };
+}
+
+function labelForStatus(status: RecordQualityReviewStatus): string {
+  switch (status) {
+    case 'draft':
+      return 'pending human review';
+    case 'accepted':
+      return 'accepted by human reviewer';
+    case 'revised':
+      return 'revised by human reviewer';
+    case 'discarded':
+      return 'discarded by human reviewer';
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds a minimal Record Quality review decision read model.

It projects review metadata into a small decision summary while keeping the original support record referenced by ID only.

## Scope

Small domain-only feature.

Included:

* `toRecordQualityReviewDecision` pure mapper
* Decision fields for status, label, source record id, metadata counts, updated timestamp, and safety metadata
* Fixture spec updated to assert the read model covers `draft`, `accepted`, `revised`, and `discarded`
* Assertions that original support record `body` / `content` and review detail arrays are not exposed by the read model

Out of scope:

* No SharePoint write path
* No Graph / `spFetch`
* No UI
* No workflow connection
* No AI connection
* No original support record body/content mutation or exposure

## Safety

The read model is derived from review metadata only. It preserves:

* `sourceOfTruth: original_record`
* `outputKind: review_metadata`
* `requiresHumanReview: true`

It stores `sourceRecordId` as a reference and does not copy the original support record body/content.

## Tests

Validation performed:

* `npx vitest run src/domain/supportRecord/recordQualityReviewDecisionReadModel.spec.ts src/domain/supportRecord/recordQualityReviewRepository.spec.ts src/domain/supportRecord/recordQualityReviewPersistenceMapper.spec.ts src/domain/supportRecord/recordQualityReview.spec.ts`
* `npm run typecheck`
* `npm run lint`
* `git diff --check`
* commit hook: `lint`, `typecheck`, `lint:cookies`, lint-staged eslint
* pre-push hook: changed-file eslint
