### PR TITLE
test(record-quality): cover human review queue sorting and filters

### DIFF
--- a/src/domain/supportRecord/recordQualityHumanReviewQueue.spec.ts
+++ b/src/domain/supportRecord/recordQualityHumanReviewQueue.spec.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  acceptRecordQualityReviewDraft,
+  createRecordQualityReviewDraft,
+  discardRecordQualityReviewDraft,
+  reviseRecordQualityReviewDraft,
+  type RecordQualityReviewDraft,
+} from './recordQualityReview';
+import { buildRecordQualityHumanReviewQueue } from './recordQualityReviewDecisionReadModel';
+
+function createReview(recordId: string, createdAt: string): RecordQualityReviewDraft {
+  return createRecordQualityReviewDraft({
+    recordId,
+    suggestedCategories: [
+      {
+        categoryId: 'staffSupportActions',
+        matchedSignals: ['職員', '声かけ'],
+        source: 'rule',
+      },
+    ],
+    missingInformationHints: [
+      {
+        code: 'userResponseAfterSupport',
+        label: '支援後の本人の反応',
+        source: 'rule',
+      },
+    ],
+    notes: ['人間レビューで確認する'],
+    createdAt,
+  });
+}
+
+describe('record quality human review queue sorting and filters', () => {
+  const oldestDraft = createReview('record-oldest-draft', '2026-06-11T00:00:00.000Z');
+  const newerDraft = createReview('record-newer-draft', '2026-06-11T01:00:00.000Z');
+  const accepted = acceptRecordQualityReviewDraft(
+    createReview('record-accepted', '2026-06-11T02:00:00.000Z'),
+    '2026-06-11T03:00:00.000Z',
+  );
+  const revised = reviseRecordQualityReviewDraft(
+    createReview('record-revised', '2026-06-11T04:00:00.000Z'),
+    {
+      notes: ['人間レビューで修正済みだが再確認する'],
+      updatedAt: '2026-06-11T05:00:00.000Z',
+    },
+  );
+  const discarded = discardRecordQualityReviewDraft(
+    createReview('record-discarded', '2026-06-11T06:00:00.000Z'),
+    '2026-06-11T07:00:00.000Z',
+  );
+
+  it('includes draft and revised reviews in the pending human review queue', () => {
+    const queue = buildRecordQualityHumanReviewQueue([
+      accepted,
+      revised,
+      discarded,
+      newerDraft,
+      oldestDraft,
+    ]);
+
+    expect(queue.map(item => item.recordId)).toEqual([
+      'record-oldest-draft',
+      'record-newer-draft',
+      'record-revised',
+    ]);
+    expect(queue.map(item => item.status)).toEqual(['draft', 'draft', 'revised']);
+  });
+
+  it('excludes accepted and discarded reviews from the pending queue', () => {
+    const queue = buildRecordQualityHumanReviewQueue([
+      accepted,
+      discarded,
+      oldestDraft,
+      revised,
+    ]);
+
+    expect(queue.map(item => item.recordId)).not.toContain('record-accepted');
+    expect(queue.map(item => item.recordId)).not.toContain('record-discarded');
+  });
+
+  it('keeps queue items limited to review metadata and source record references', () => {
+    const draftWithOriginalText = {
+      ...oldestDraft,
+      body: '元の支援記録本文',
+      content: '本人の反応などの本文',
+      originalText: 'original text',
+    } as RecordQualityReviewDraft & {
+      body: string;
+      content: string;
+      originalText: string;
+    };
+
+    const [item] = buildRecordQualityHumanReviewQueue([draftWithOriginalText]);
+
+    expect(item.sourceOfTruth).toBe('original_record');
+    expect(item.outputKind).toBe('review_metadata');
+    expect(item.requiresHumanReview).toBe(true);
+    expect(item.sourceRecordId).toBe('record-oldest-draft');
+    expect('body' in item).toBe(false);
+    expect('content' in item).toBe(false);
+    expect('originalText' in item).toBe(false);
+  });
+});

--- a/src/domain/supportRecord/recordQualityReviewDecisionReadModel.ts
+++ b/src/domain/supportRecord/recordQualityReviewDecisionReadModel.ts
@@ -35,6 +35,16 @@ export function toRecordQualityReviewDecision(
   };
 }
 
+export function buildRecordQualityHumanReviewQueue(
+  reviews: readonly RecordQualityReviewDraft[],
+): RecordQualityReviewDecision[] {
+  return reviews
+    .filter(review => review.requiresHumanReview)
+    .filter(review => review.status === 'draft' || review.status === 'revised')
+    .map(toRecordQualityReviewDecision)
+    .sort((a, b) => a.updatedAt.localeCompare(b.updatedAt));
+}
+
 function labelForStatus(status: RecordQualityReviewStatus): string {
   switch (status) {
     case 'draft':


### PR DESCRIPTION
## Summary

This PR fixes the Record Quality human review queue boundary with focused tests and a small pure helper.

It keeps the queue limited to review metadata and only includes reviews that still require human attention.

## Scope

Small domain-only change.

Included:

* `buildRecordQualityHumanReviewQueue` pure helper
* Queue includes `draft` and `revised` review metadata
* Queue excludes `accepted` and `discarded` reviews
* Queue sorts by `updatedAt` ascending
* Queue items keep `sourceOfTruth: original_record`, `outputKind: review_metadata`, and `requiresHumanReview: true`
* Tests confirm original support record `body` / `content` / original text are not exposed

Out of scope:

* No SharePoint write path
* No Graph / `spFetch`
* No UI
* No workflow connection
* No AI connection
* No original support record body/content storage or mutation

## Safety

The queue is derived from `RecordQualityReviewDraft` metadata only. It returns decision read model items that reference the source record by ID and do not copy original support record text.

## Tests

Validation performed:

* `npx vitest run src/domain/supportRecord/recordQualityHumanReviewQueue.spec.ts src/domain/supportRecord/recordQualityReviewDecisionReadModel.spec.ts src/domain/supportRecord/recordQualityReviewRepository.spec.ts src/domain/supportRecord/recordQualityReviewPersistenceMapper.spec.ts src/domain/supportRecord/recordQualityReview.spec.ts`
* `npm run typecheck`
* `npm run lint`
* `git diff --check`
* commit hook: `lint`, `typecheck`, `lint:cookies`, lint-staged eslint
* pre-push hook: changed-file eslint
