### PR TITLE
feat(record-quality): add human review queue model

### DIFF
--- a/src/domain/supportRecord/recordQualityHumanReviewQueue.spec.ts
+++ b/src/domain/supportRecord/recordQualityHumanReviewQueue.spec.ts
@@ -7,7 +7,7 @@ import {
   reviseRecordQualityReviewDraft,
   type RecordQualityReviewDraft,
 } from './recordQualityReview';
-import { buildRecordQualityHumanReviewQueue } from './recordQualityReviewDecisionReadModel';
+import { buildRecordQualityHumanReviewQueue } from './recordQualityHumanReviewQueue';
 
 function createReview(recordId: string, createdAt: string): RecordQualityReviewDraft {
   return createRecordQualityReviewDraft({
@@ -59,12 +59,14 @@ describe('record quality human review queue sorting and filters', () => {
       oldestDraft,
     ]);
 
-    expect(queue.map(item => item.recordId)).toEqual([
+    expect(queue.totalCount).toBe(3);
+    expect(queue.oldestUpdatedAt).toBe('2026-06-11T00:00:00.000Z');
+    expect(queue.items.map(item => item.recordId)).toEqual([
       'record-oldest-draft',
       'record-newer-draft',
       'record-revised',
     ]);
-    expect(queue.map(item => item.status)).toEqual(['draft', 'draft', 'revised']);
+    expect(queue.items.map(item => item.status)).toEqual(['draft', 'draft', 'revised']);
   });
 
   it('excludes accepted and discarded reviews from the pending queue', () => {
@@ -75,8 +77,8 @@ describe('record quality human review queue sorting and filters', () => {
       revised,
     ]);
 
-    expect(queue.map(item => item.recordId)).not.toContain('record-accepted');
-    expect(queue.map(item => item.recordId)).not.toContain('record-discarded');
+    expect(queue.items.map(item => item.recordId)).not.toContain('record-accepted');
+    expect(queue.items.map(item => item.recordId)).not.toContain('record-discarded');
   });
 
   it('keeps queue items limited to review metadata and source record references', () => {
@@ -91,7 +93,7 @@ describe('record quality human review queue sorting and filters', () => {
       originalText: string;
     };
 
-    const [item] = buildRecordQualityHumanReviewQueue([draftWithOriginalText]);
+    const [item] = buildRecordQualityHumanReviewQueue([draftWithOriginalText]).items;
 
     expect(item.sourceOfTruth).toBe('original_record');
     expect(item.outputKind).toBe('review_metadata');
@@ -100,5 +102,15 @@ describe('record quality human review queue sorting and filters', () => {
     expect('body' in item).toBe(false);
     expect('content' in item).toBe(false);
     expect('originalText' in item).toBe(false);
+  });
+
+  it('returns an empty queue model when no review requires action', () => {
+    const queue = buildRecordQualityHumanReviewQueue([accepted, discarded]);
+
+    expect(queue).toEqual({
+      items: [],
+      totalCount: 0,
+      oldestUpdatedAt: undefined,
+    });
   });
 });

--- a/src/domain/supportRecord/recordQualityHumanReviewQueue.ts
+++ b/src/domain/supportRecord/recordQualityHumanReviewQueue.ts
@@ -1,0 +1,29 @@
+import type { RecordQualityReviewDraft } from './recordQualityReview';
+import {
+  toRecordQualityReviewDecision,
+  type RecordQualityReviewDecision,
+} from './recordQualityReviewDecisionReadModel';
+
+export type RecordQualityHumanReviewQueueItem = RecordQualityReviewDecision;
+
+export type RecordQualityHumanReviewQueue = {
+  readonly items: readonly RecordQualityHumanReviewQueueItem[];
+  readonly totalCount: number;
+  readonly oldestUpdatedAt?: string;
+};
+
+export function buildRecordQualityHumanReviewQueue(
+  reviews: readonly RecordQualityReviewDraft[],
+): RecordQualityHumanReviewQueue {
+  const items = reviews
+    .filter(review => review.requiresHumanReview)
+    .filter(review => review.status === 'draft' || review.status === 'revised')
+    .map(toRecordQualityReviewDecision)
+    .sort((a, b) => a.updatedAt.localeCompare(b.updatedAt));
+
+  return {
+    items,
+    totalCount: items.length,
+    oldestUpdatedAt: items[0]?.updatedAt,
+  };
+}

--- a/src/domain/supportRecord/recordQualityReviewDecisionReadModel.ts
+++ b/src/domain/supportRecord/recordQualityReviewDecisionReadModel.ts
@@ -35,16 +35,6 @@ export function toRecordQualityReviewDecision(
   };
 }
 
-export function buildRecordQualityHumanReviewQueue(
-  reviews: readonly RecordQualityReviewDraft[],
-): RecordQualityReviewDecision[] {
-  return reviews
-    .filter(review => review.requiresHumanReview)
-    .filter(review => review.status === 'draft' || review.status === 'revised')
-    .map(toRecordQualityReviewDecision)
-    .sort((a, b) => a.updatedAt.localeCompare(b.updatedAt));
-}
-
 function labelForStatus(status: RecordQualityReviewStatus): string {
   switch (status) {
     case 'draft':


### PR DESCRIPTION
## Summary

Adds a minimal Record Quality human review queue model.

The queue model keeps review decisions focused on human-review metadata by selecting pending review states, preserving the read model boundaries, and exposing queue-level metadata for downstream use.

## Scope

- Add a dedicated human review queue model
- Include draft and revised review metadata that still requires human review
- Exclude accepted and discarded review decisions from the active queue
- Sort queue items by oldest updated review first
- Expose queue item count and oldest update timestamp

## Safety

- No SharePoint write
- No Graph or spFetch changes
- No UI changes
- No workflow changes
- No AI connection
- Does not store, mutate, or expose original support record body/content
- Keeps sourceOfTruth as original_record and outputKind as review_metadata through the decision read model

## Tests

- npx vitest run src/domain/supportRecord/recordQualityHumanReviewQueue.spec.ts src/domain/supportRecord/recordQualityReviewDecisionReadModel.spec.ts src/domain/supportRecord/recordQualityReviewRepository.spec.ts src/domain/supportRecord/recordQualityReviewPersistenceMapper.spec.ts src/domain/supportRecord/recordQualityReview.spec.ts
- npm run typecheck
- npm run lint
- git diff --check