### PR TITLE
test(record-quality): cover human review queue repository contract

### DIFF
--- a/src/domain/supportRecord/recordQualityReviewRepository.spec.ts
+++ b/src/domain/supportRecord/recordQualityReviewRepository.spec.ts
@@ -11,6 +11,7 @@ import {
   InMemoryRecordQualityReviewRepository,
   type RecordQualityReviewRepository,
 } from './recordQualityReviewRepository';
+import { buildRecordQualityHumanReviewQueue } from './recordQualityHumanReviewQueue';
 
 const timestamp = '2026-06-11T00:00:00.000Z';
 
@@ -192,6 +193,72 @@ const runRecordQualityReviewRepositoryContract = (
       expect(discarded.sourceOfTruth).toBe('original_record');
       expect(discarded.outputKind).toBe('review_metadata');
       expect(discarded.requiresHumanReview).toBe(true);
+    });
+
+    it('supports building an active human review queue from stored review metadata only', async () => {
+      const repository = factory();
+      const oldestDraft = await repository.saveReview(
+        createDraft('record-oldest-draft'),
+      );
+      const newerDraft = await repository.saveReview({
+        ...createDraft('record-newer-draft'),
+        createdAt: '2026-06-11T01:00:00.000Z',
+        updatedAt: '2026-06-11T01:00:00.000Z',
+      });
+      const accepted = await repository.saveReview({
+        ...createDraft('record-accepted'),
+        createdAt: '2026-06-11T02:00:00.000Z',
+        updatedAt: '2026-06-11T02:00:00.000Z',
+      });
+      const revised = await repository.saveReview({
+        ...createDraft('record-revised'),
+        createdAt: '2026-06-11T03:00:00.000Z',
+        updatedAt: '2026-06-11T03:00:00.000Z',
+      });
+      const discarded = await repository.saveReview({
+        ...createDraft('record-discarded'),
+        createdAt: '2026-06-11T04:00:00.000Z',
+        updatedAt: '2026-06-11T04:00:00.000Z',
+      });
+
+      await repository.updateReview(
+        acceptRecordQualityReviewDraft(accepted, '2026-06-11T05:00:00.000Z'),
+      );
+      await repository.updateReview(
+        reviseRecordQualityReviewDraft(revised, {
+          notes: ['人間レビューキューで再確認する'],
+          updatedAt: '2026-06-11T06:00:00.000Z',
+        }),
+      );
+      await repository.updateReview(
+        discardRecordQualityReviewDraft(discarded, '2026-06-11T07:00:00.000Z'),
+      );
+
+      const storedReviews = await repository.listReviews();
+      const queue = buildRecordQualityHumanReviewQueue(storedReviews);
+
+      expect(queue.totalCount).toBe(3);
+      expect(queue.oldestUpdatedAt).toBe(oldestDraft.updatedAt);
+      expect(queue.items.map(item => item.recordId)).toEqual([
+        oldestDraft.recordId,
+        newerDraft.recordId,
+        revised.recordId,
+      ]);
+      expect(queue.items.map(item => item.status)).toEqual(['draft', 'draft', 'revised']);
+      expect(queue.items).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            sourceOfTruth: 'original_record',
+            outputKind: 'review_metadata',
+            requiresHumanReview: true,
+          }),
+        ]),
+      );
+      expect(queue.items.map(item => item.recordId)).not.toContain(accepted.recordId);
+      expect(queue.items.map(item => item.recordId)).not.toContain(discarded.recordId);
+      expect(queue.items.some(item => 'body' in item)).toBe(false);
+      expect(queue.items.some(item => 'content' in item)).toBe(false);
+      expect(queue.items.some(item => 'originalText' in item)).toBe(false);
     });
   });
 };


### PR DESCRIPTION
## Summary

Adds repository contract coverage for building the Record Quality human review queue from stored review metadata.

## Scope

- Keeps the change test-only
- Covers active queue construction from repository listReviews output
- Confirms draft and revised reviews remain in the active queue
- Confirms accepted and discarded reviews are excluded
- Confirms deterministic oldest-updated-first queue ordering
- Confirms queue items expose review metadata and source record references only

## Safety

- No production code changes
- No SharePoint write
- No Graph or spFetch changes
- No UI changes
- No workflow changes
- No AI connection
- Does not mutate, store, or expose original support record body/content/original text

## Tests

- npx vitest run src/domain/supportRecord/recordQualityReviewRepository.spec.ts src/domain/supportRecord/recordQualityHumanReviewQueue.spec.ts src/domain/supportRecord/recordQualityReviewDecisionReadModel.spec.ts src/domain/supportRecord/recordQualityReviewPersistenceMapper.spec.ts src/domain/supportRecord/recordQualityReview.spec.ts src/domain/supportRecord/recordQuality.spec.ts
- npm run typecheck
- npm run lint
- git diff --check