### PR TITLE
feat(record-quality): add in-memory human review queue repository

### DIFF
--- a/src/domain/supportRecord/recordQualityHumanReviewQueue.spec.ts
+++ b/src/domain/supportRecord/recordQualityHumanReviewQueue.spec.ts
@@ -7,7 +7,11 @@ import {
   reviseRecordQualityReviewDraft,
   type RecordQualityReviewDraft,
 } from './recordQualityReview';
-import { buildRecordQualityHumanReviewQueue } from './recordQualityHumanReviewQueue';
+import {
+  buildRecordQualityHumanReviewQueue,
+  InMemoryRecordQualityHumanReviewQueueRepository,
+} from './recordQualityHumanReviewQueue';
+import { InMemoryRecordQualityReviewRepository } from './recordQualityReviewRepository';
 
 function createReview(recordId: string, createdAt: string): RecordQualityReviewDraft {
   return createRecordQualityReviewDraft({
@@ -30,6 +34,46 @@ function createReview(recordId: string, createdAt: string): RecordQualityReviewD
     createdAt,
   });
 }
+
+describe('record quality human review queue repository', () => {
+  it('lists active queue items from stored review metadata', async () => {
+    const reviewRepository = new InMemoryRecordQualityReviewRepository([
+      createReview('record-oldest-draft', '2026-06-11T00:00:00.000Z'),
+      acceptRecordQualityReviewDraft(
+        createReview('record-accepted', '2026-06-11T01:00:00.000Z'),
+        '2026-06-11T02:00:00.000Z',
+      ),
+      reviseRecordQualityReviewDraft(
+        createReview('record-revised', '2026-06-11T03:00:00.000Z'),
+        {
+          notes: ['人間レビューで修正済みだが再確認する'],
+          updatedAt: '2026-06-11T04:00:00.000Z',
+        },
+      ),
+      discardRecordQualityReviewDraft(
+        createReview('record-discarded', '2026-06-11T05:00:00.000Z'),
+        '2026-06-11T06:00:00.000Z',
+      ),
+    ]);
+    const queueRepository = new InMemoryRecordQualityHumanReviewQueueRepository(
+      reviewRepository,
+    );
+
+    const queue = await queueRepository.listActiveQueue();
+
+    expect(queue.totalCount).toBe(2);
+    expect(queue.oldestUpdatedAt).toBe('2026-06-11T00:00:00.000Z');
+    expect(queue.items.map(item => item.recordId)).toEqual([
+      'record-oldest-draft',
+      'record-revised',
+    ]);
+    expect(queue.items.map(item => item.status)).toEqual(['draft', 'revised']);
+    expect(queue.items.every(item => item.requiresHumanReview)).toBe(true);
+    expect(queue.items.some(item => 'body' in item)).toBe(false);
+    expect(queue.items.some(item => 'content' in item)).toBe(false);
+    expect(queue.items.some(item => 'originalText' in item)).toBe(false);
+  });
+});
 
 describe('record quality human review queue sorting and filters', () => {
   const oldestDraft = createReview('record-oldest-draft', '2026-06-11T00:00:00.000Z');

--- a/src/domain/supportRecord/recordQualityHumanReviewQueue.ts
+++ b/src/domain/supportRecord/recordQualityHumanReviewQueue.ts
@@ -3,6 +3,7 @@ import {
   toRecordQualityReviewDecision,
   type RecordQualityReviewDecision,
 } from './recordQualityReviewDecisionReadModel';
+import type { RecordQualityReviewRepository } from './recordQualityReviewRepository';
 
 export type RecordQualityHumanReviewQueueItem = RecordQualityReviewDecision;
 
@@ -11,6 +12,22 @@ export type RecordQualityHumanReviewQueue = {
   readonly totalCount: number;
   readonly oldestUpdatedAt?: string;
 };
+
+export interface RecordQualityHumanReviewQueueRepository {
+  listActiveQueue(): Promise<RecordQualityHumanReviewQueue>;
+}
+
+export class InMemoryRecordQualityHumanReviewQueueRepository
+  implements RecordQualityHumanReviewQueueRepository
+{
+  constructor(
+    private readonly reviewRepository: Pick<RecordQualityReviewRepository, 'listReviews'>,
+  ) {}
+
+  async listActiveQueue(): Promise<RecordQualityHumanReviewQueue> {
+    return buildRecordQualityHumanReviewQueue(await this.reviewRepository.listReviews());
+  }
+}
 
 export function buildRecordQualityHumanReviewQueue(
   reviews: readonly RecordQualityReviewDraft[],


### PR DESCRIPTION
## Summary

Adds a minimal in-memory Record Quality human review queue repository.

The repository builds the active queue from the existing RecordQualityReviewRepository listReviews contract, so queue data remains derived from review metadata instead of introducing a new persistence path.

## Scope

- Add a RecordQualityHumanReviewQueueRepository port
- Add InMemoryRecordQualityHumanReviewQueueRepository
- Build the active queue from stored review metadata
- Keep draft and revised reviews in the active queue
- Exclude accepted and discarded reviews
- Preserve deterministic oldest-updated-first ordering
- Keep queue items limited to review metadata and source record references

## Safety

- No SharePoint write
- No Graph or spFetch changes
- No UI changes
- No workflow changes
- No AI connection
- Does not mutate, store, or expose original support record body/content/original text

## Tests

- npx vitest run src/domain/supportRecord/recordQualityHumanReviewQueue.spec.ts src/domain/supportRecord/recordQualityReviewRepository.spec.ts src/domain/supportRecord/recordQualityReviewDecisionReadModel.spec.ts src/domain/supportRecord/recordQualityReviewPersistenceMapper.spec.ts src/domain/supportRecord/recordQualityReview.spec.ts src/domain/supportRecord/recordQuality.spec.ts
- npm run typecheck
- npm run lint
- git diff --check