### PR TITLE
feat(record-quality): add human review queue use case

### DIFF
--- a/src/domain/supportRecord/recordQualityHumanReviewQueueUseCase.spec.ts
+++ b/src/domain/supportRecord/recordQualityHumanReviewQueueUseCase.spec.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  acceptRecordQualityReviewDraft,
+  createRecordQualityReviewDraft,
+  discardRecordQualityReviewDraft,
+  reviseRecordQualityReviewDraft,
+  type RecordQualityReviewDraft,
+} from './recordQualityReview';
+import {
+  InMemoryRecordQualityHumanReviewQueueRepository,
+  type RecordQualityHumanReviewQueueRepository,
+} from './recordQualityHumanReviewQueue';
+import { listRecordQualityHumanReviewQueue } from './recordQualityHumanReviewQueueUseCase';
+import { InMemoryRecordQualityReviewRepository } from './recordQualityReviewRepository';
+
+function createReview(recordId: string, createdAt: string): RecordQualityReviewDraft {
+  return createRecordQualityReviewDraft({
+    recordId,
+    suggestedCategories: [
+      {
+        categoryId: 'staffSupportActions',
+        matchedSignals: ['職員', '声かけ'],
+        source: 'rule',
+      },
+    ],
+    missingInformationHints: [
+      {
+        code: 'userResponseAfterSupport',
+        label: '支援後の本人の反応',
+        source: 'rule',
+      },
+    ],
+    notes: ['人間レビューで確認する'],
+    createdAt,
+  });
+}
+
+describe('listRecordQualityHumanReviewQueue', () => {
+  it('returns the active human review queue from review metadata only', async () => {
+    const reviewRepository = new InMemoryRecordQualityReviewRepository([
+      createReview('record-oldest-draft', '2026-06-11T00:00:00.000Z'),
+      acceptRecordQualityReviewDraft(
+        createReview('record-accepted', '2026-06-11T01:00:00.000Z'),
+        '2026-06-11T02:00:00.000Z',
+      ),
+      reviseRecordQualityReviewDraft(
+        createReview('record-revised', '2026-06-11T03:00:00.000Z'),
+        {
+          notes: ['人間レビューで修正済みだが再確認する'],
+          updatedAt: '2026-06-11T04:00:00.000Z',
+        },
+      ),
+      discardRecordQualityReviewDraft(
+        createReview('record-discarded', '2026-06-11T05:00:00.000Z'),
+        '2026-06-11T06:00:00.000Z',
+      ),
+    ]);
+    const queueRepository = new InMemoryRecordQualityHumanReviewQueueRepository(
+      reviewRepository,
+    );
+
+    const queue = await listRecordQualityHumanReviewQueue({
+      repository: queueRepository,
+    });
+
+    expect(queue.totalCount).toBe(2);
+    expect(queue.oldestUpdatedAt).toBe('2026-06-11T00:00:00.000Z');
+    expect(queue.items.map(item => item.recordId)).toEqual([
+      'record-oldest-draft',
+      'record-revised',
+    ]);
+    expect(queue.items.map(item => item.status)).toEqual(['draft', 'revised']);
+    expect(queue.items.every(item => item.requiresHumanReview)).toBe(true);
+    expect(queue.items.some(item => 'body' in item)).toBe(false);
+    expect(queue.items.some(item => 'content' in item)).toBe(false);
+    expect(queue.items.some(item => 'originalText' in item)).toBe(false);
+  });
+
+  it('delegates queue construction to the injected repository', async () => {
+    const queueRepository = {
+      async listActiveQueue() {
+        return {
+          items: [],
+          totalCount: 0,
+          oldestUpdatedAt: undefined,
+        };
+      },
+    } satisfies RecordQualityHumanReviewQueueRepository;
+
+    await expect(
+      listRecordQualityHumanReviewQueue({ repository: queueRepository }),
+    ).resolves.toEqual({
+      items: [],
+      totalCount: 0,
+      oldestUpdatedAt: undefined,
+    });
+  });
+});

--- a/src/domain/supportRecord/recordQualityHumanReviewQueueUseCase.ts
+++ b/src/domain/supportRecord/recordQualityHumanReviewQueueUseCase.ts
@@ -1,0 +1,14 @@
+import type {
+  RecordQualityHumanReviewQueue,
+  RecordQualityHumanReviewQueueRepository,
+} from './recordQualityHumanReviewQueue';
+
+export type ListRecordQualityHumanReviewQueueInput = {
+  readonly repository: RecordQualityHumanReviewQueueRepository;
+};
+
+export async function listRecordQualityHumanReviewQueue(
+  input: ListRecordQualityHumanReviewQueueInput,
+): Promise<RecordQualityHumanReviewQueue> {
+  return input.repository.listActiveQueue();
+}


### PR DESCRIPTION
## Summary

Adds a minimal Record Quality human review queue use case.

The use case delegates to the injected human review queue repository and keeps queue retrieval read-only and metadata-only.

## Scope

- Add listRecordQualityHumanReviewQueue use case
- Keep the use case repository-injected
- Return the active human review queue without introducing a new storage path
- Cover draft/revised active queue behavior through the in-memory queue repository
- Confirm accepted/discarded reviews stay out of the active queue
- Confirm queue items do not expose original support record body/content/original text

## Safety

- No SharePoint write
- No Graph or spFetch changes
- No UI changes
- No workflow changes
- No AI connection
- Does not mutate, store, or expose original support record body/content/original text

## Tests

- npx vitest run src/domain/supportRecord/recordQualityHumanReviewQueueUseCase.spec.ts src/domain/supportRecord/recordQualityHumanReviewQueue.spec.ts src/domain/supportRecord/recordQualityReviewRepository.spec.ts src/domain/supportRecord/recordQualityReviewDecisionReadModel.spec.ts src/domain/supportRecord/recordQualityReviewPersistenceMapper.spec.ts src/domain/supportRecord/recordQualityReview.spec.ts src/domain/supportRecord/recordQuality.spec.ts
- npm run typecheck
- npm run lint
- git diff --check