### PR TITLE
test(record-quality): cover human review queue hook boundary

### DIFF
--- a/src/features/record-quality/hooks/__tests__/useRecordQualityHumanReviewQueue.spec.ts
+++ b/src/features/record-quality/hooks/__tests__/useRecordQualityHumanReviewQueue.spec.ts
@@ -1,0 +1,125 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createRecordQualityReviewDraft,
+  reviseRecordQualityReviewDraft,
+  type RecordQualityReviewDraft,
+} from '@/domain/supportRecord/recordQualityReview';
+import {
+  InMemoryRecordQualityHumanReviewQueueRepository,
+  type RecordQualityHumanReviewQueueRepository,
+} from '@/domain/supportRecord/recordQualityHumanReviewQueue';
+import { InMemoryRecordQualityReviewRepository } from '@/domain/supportRecord/recordQualityReviewRepository';
+import { useRecordQualityHumanReviewQueue } from '../useRecordQualityHumanReviewQueue';
+
+function createReview(recordId: string, createdAt: string): RecordQualityReviewDraft {
+  return createRecordQualityReviewDraft({
+    recordId,
+    suggestedCategories: [
+      {
+        categoryId: 'staffSupportActions',
+        matchedSignals: ['職員', '声かけ'],
+        source: 'rule',
+      },
+    ],
+    missingInformationHints: [
+      {
+        code: 'userResponseAfterSupport',
+        label: '支援後の本人の反応',
+        source: 'rule',
+      },
+    ],
+    notes: ['人間レビューで確認する'],
+    createdAt,
+  });
+}
+
+describe('useRecordQualityHumanReviewQueue', () => {
+  it('loads active queue items from the injected use case boundary', async () => {
+    const draftWithOriginalText = {
+      ...createReview('record-draft', '2026-06-11T00:00:00.000Z'),
+      body: '元の支援記録本文',
+      content: '本人の反応などの本文',
+      originalText: 'original text',
+    } as RecordQualityReviewDraft & {
+      body: string;
+      content: string;
+      originalText: string;
+    };
+    const reviewRepository = new InMemoryRecordQualityReviewRepository([
+      reviseRecordQualityReviewDraft(
+        createReview('record-revised', '2026-06-11T01:00:00.000Z'),
+        {
+          notes: ['人間レビューで修正済みだが再確認する'],
+          updatedAt: '2026-06-11T02:00:00.000Z',
+        },
+      ),
+      draftWithOriginalText,
+    ]);
+    const queueRepository = new InMemoryRecordQualityHumanReviewQueueRepository(
+      reviewRepository,
+    );
+
+    const { result } = renderHook(() =>
+      useRecordQualityHumanReviewQueue(queueRepository),
+    );
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.queue.totalCount).toBe(2);
+    expect(result.current.queue.items.map(item => item.recordId)).toEqual([
+      'record-draft',
+      'record-revised',
+    ]);
+    expect(result.current.queue.items.every(item => item.requiresHumanReview)).toBe(true);
+    expect(result.current.queue.items.some(item => 'body' in item)).toBe(false);
+    expect(result.current.queue.items.some(item => 'content' in item)).toBe(false);
+    expect(result.current.queue.items.some(item => 'originalText' in item)).toBe(false);
+  });
+
+  it('returns an empty loaded state when no queue items are active', async () => {
+    const queueRepository = {
+      listActiveQueue: vi.fn().mockResolvedValue({
+        items: [],
+        totalCount: 0,
+        oldestUpdatedAt: undefined,
+      }),
+    } satisfies RecordQualityHumanReviewQueueRepository;
+
+    const { result } = renderHook(() =>
+      useRecordQualityHumanReviewQueue(queueRepository),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.queue).toEqual({
+      items: [],
+      totalCount: 0,
+      oldestUpdatedAt: undefined,
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it('returns an empty queue and error state when loading fails', async () => {
+    const queueRepository = {
+      listActiveQueue: vi.fn().mockRejectedValue(new Error('queue failed')),
+    } satisfies RecordQualityHumanReviewQueueRepository;
+
+    const { result } = renderHook(() =>
+      useRecordQualityHumanReviewQueue(queueRepository),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.queue).toEqual({
+      items: [],
+      totalCount: 0,
+      oldestUpdatedAt: undefined,
+    });
+    expect(result.current.error?.message).toBe('queue failed');
+  });
+});

--- a/src/features/record-quality/hooks/useRecordQualityHumanReviewQueue.ts
+++ b/src/features/record-quality/hooks/useRecordQualityHumanReviewQueue.ts
@@ -1,0 +1,53 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import type {
+  RecordQualityHumanReviewQueue,
+  RecordQualityHumanReviewQueueRepository,
+} from '@/domain/supportRecord/recordQualityHumanReviewQueue';
+import { listRecordQualityHumanReviewQueue } from '@/domain/supportRecord/recordQualityHumanReviewQueueUseCase';
+
+const emptyQueue: RecordQualityHumanReviewQueue = {
+  items: [],
+  totalCount: 0,
+  oldestUpdatedAt: undefined,
+};
+
+export type UseRecordQualityHumanReviewQueueResult = {
+  readonly queue: RecordQualityHumanReviewQueue;
+  readonly isLoading: boolean;
+  readonly error: Error | null;
+  readonly reload: () => Promise<void>;
+};
+
+export function useRecordQualityHumanReviewQueue(
+  repository: RecordQualityHumanReviewQueueRepository,
+): UseRecordQualityHumanReviewQueueResult {
+  const [queue, setQueue] = useState<RecordQualityHumanReviewQueue>(emptyQueue);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const reload = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      setQueue(await listRecordQualityHumanReviewQueue({ repository }));
+    } catch (caught) {
+      setQueue(emptyQueue);
+      setError(caught instanceof Error ? caught : new Error(String(caught)));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [repository]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  return {
+    queue,
+    isLoading,
+    error,
+    reload,
+  };
+}


### PR DESCRIPTION
## Summary

Adds the Record Quality human review queue hook boundary before introducing UI screens.

The hook delegates to the existing read-only use case/repository boundary and exposes loading, empty, and error states for future UI integration.

## Scope

- Add useRecordQualityHumanReviewQueue hook
- Cover loading state while queue data is being fetched
- Cover empty loaded state
- Cover repository/load error state
- Confirm active queue items come from review metadata only
- Confirm queue items do not expose original support record body/content/original text

## Safety

- No UI screen added
- No SharePoint write
- No Graph or spFetch dependency
- No workflow connection
- No AI connection
- Does not mutate, store, or expose original support record body/content/original text

## Tests

- npx vitest run src/features/record-quality/hooks/__tests__/useRecordQualityHumanReviewQueue.spec.ts src/domain/supportRecord/recordQualityHumanReviewQueueUseCase.spec.ts src/domain/supportRecord/recordQualityHumanReviewQueue.spec.ts src/domain/supportRecord/recordQualityReviewRepository.spec.ts src/domain/supportRecord/recordQualityReviewDecisionReadModel.spec.ts src/domain/supportRecord/recordQualityReviewPersistenceMapper.spec.ts src/domain/supportRecord/recordQualityReview.spec.ts src/domain/supportRecord/recordQuality.spec.ts
- npm run typecheck
- npm run lint
- git diff --check