### PR TITLE
feat(record-quality): show human review queue summary

### DIFF
--- a/src/features/record-quality/components/HumanReviewQueueSummary.tsx
+++ b/src/features/record-quality/components/HumanReviewQueueSummary.tsx
@@ -1,0 +1,106 @@
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Chip from '@mui/material/Chip';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+
+import type { RecordQualityHumanReviewQueueRepository } from '@/domain/supportRecord/recordQualityHumanReviewQueue';
+import { useRecordQualityHumanReviewQueue } from '../hooks/useRecordQualityHumanReviewQueue';
+
+type HumanReviewQueueSummaryProps = {
+  readonly repository: RecordQualityHumanReviewQueueRepository;
+  readonly maxItems?: number;
+};
+
+export function HumanReviewQueueSummary({
+  repository,
+  maxItems = 5,
+}: HumanReviewQueueSummaryProps) {
+  const { queue, isLoading, error } = useRecordQualityHumanReviewQueue(repository);
+  const visibleItems = queue.items.slice(0, maxItems);
+
+  return (
+    <Card
+      variant="outlined"
+      sx={{ borderRadius: 1 }}
+      data-testid="record-quality-human-review-summary"
+    >
+      <CardContent>
+        <Stack spacing={2}>
+          <Box>
+            <Typography variant="h6" component="h2">
+              記録品質レビュー
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              要確認のレビュー状況
+            </Typography>
+          </Box>
+
+          {isLoading && (
+            <Typography role="status" variant="body2" color="text.secondary">
+              要人間レビューを読み込み中
+            </Typography>
+          )}
+
+          {!isLoading && error && (
+            <Alert severity="error" data-testid="record-quality-human-review-error">
+              要人間レビューを読み込めませんでした
+            </Alert>
+          )}
+
+          {!isLoading && !error && queue.totalCount === 0 && (
+            <Alert severity="success" data-testid="record-quality-human-review-empty">
+              要人間レビューはありません
+            </Alert>
+          )}
+
+          {!isLoading && !error && queue.totalCount > 0 && (
+            <Stack spacing={1.5}>
+              <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+                <Chip
+                  label={`要確認 ${queue.totalCount}件`}
+                  color="warning"
+                  size="small"
+                  data-testid="record-quality-human-review-count"
+                />
+                {queue.oldestUpdatedAt && (
+                  <Typography variant="caption" color="text.secondary">
+                    最古更新 {queue.oldestUpdatedAt}
+                  </Typography>
+                )}
+              </Stack>
+
+              <List dense disablePadding data-testid="record-quality-human-review-list">
+                {visibleItems.map(item => (
+                  <ListItem
+                    key={item.recordId}
+                    disableGutters
+                    divider
+                    data-testid={`record-quality-human-review-item-${item.recordId}`}
+                  >
+                    <Stack spacing={0.5} sx={{ width: '100%' }}>
+                      <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+                        <Typography variant="body2" sx={{ fontWeight: 700 }}>
+                          {item.sourceRecordId}
+                        </Typography>
+                        <Chip label={item.label} size="small" variant="outlined" />
+                      </Stack>
+                      <Typography variant="caption" color="text.secondary">
+                        候補 {item.suggestedCategoryCount}件 / 不足情報{' '}
+                        {item.missingInformationHintCount}件 / ノート {item.noteCount}件
+                      </Typography>
+                    </Stack>
+                  </ListItem>
+                ))}
+              </List>
+            </Stack>
+          )}
+        </Stack>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/record-quality/components/__tests__/HumanReviewQueueSummary.spec.tsx
+++ b/src/features/record-quality/components/__tests__/HumanReviewQueueSummary.spec.tsx
@@ -1,0 +1,113 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createRecordQualityReviewDraft,
+  reviseRecordQualityReviewDraft,
+  type RecordQualityReviewDraft,
+} from '@/domain/supportRecord/recordQualityReview';
+import {
+  buildRecordQualityHumanReviewQueue,
+  InMemoryRecordQualityHumanReviewQueueRepository,
+  type RecordQualityHumanReviewQueueRepository,
+} from '@/domain/supportRecord/recordQualityHumanReviewQueue';
+import { InMemoryRecordQualityReviewRepository } from '@/domain/supportRecord/recordQualityReviewRepository';
+import { HumanReviewQueueSummary } from '../HumanReviewQueueSummary';
+
+function createReview(recordId: string, createdAt: string): RecordQualityReviewDraft {
+  return createRecordQualityReviewDraft({
+    recordId,
+    suggestedCategories: [
+      {
+        categoryId: 'staffSupportActions',
+        matchedSignals: ['職員', '声かけ'],
+        source: 'rule',
+      },
+    ],
+    missingInformationHints: [
+      {
+        code: 'userResponseAfterSupport',
+        label: '支援後の本人の反応',
+        source: 'rule',
+      },
+    ],
+    notes: ['人間レビューで確認する'],
+    createdAt,
+  });
+}
+
+describe('HumanReviewQueueSummary', () => {
+  it('renders loading and then active queue summary without original record text', async () => {
+    const draftWithOriginalText = {
+      ...createReview('record-draft', '2026-06-11T00:00:00.000Z'),
+      body: '元の支援記録本文',
+      content: '本人の反応などの本文',
+      originalText: 'original text',
+    } as RecordQualityReviewDraft & {
+      body: string;
+      content: string;
+      originalText: string;
+    };
+    const reviewRepository = new InMemoryRecordQualityReviewRepository([
+      reviseRecordQualityReviewDraft(
+        createReview('record-revised', '2026-06-11T01:00:00.000Z'),
+        {
+          notes: ['人間レビューで修正済みだが再確認する'],
+          updatedAt: '2026-06-11T02:00:00.000Z',
+        },
+      ),
+      draftWithOriginalText,
+    ]);
+    const queueRepository = new InMemoryRecordQualityHumanReviewQueueRepository(
+      reviewRepository,
+    );
+
+    render(<HumanReviewQueueSummary repository={queueRepository} />);
+
+    expect(screen.getByRole('status')).toHaveTextContent('要人間レビューを読み込み中');
+
+    await waitFor(() =>
+      expect(screen.getByTestId('record-quality-human-review-count')).toHaveTextContent(
+        '要確認 2件',
+      ),
+    );
+
+    expect(screen.getByText('record-draft')).toBeInTheDocument();
+    expect(screen.getByText('record-revised')).toBeInTheDocument();
+    expect(screen.getByText('最古更新 2026-06-11T00:00:00.000Z')).toBeInTheDocument();
+    expect(screen.queryByText('元の支援記録本文')).not.toBeInTheDocument();
+    expect(screen.queryByText('本人の反応などの本文')).not.toBeInTheDocument();
+    expect(screen.queryByText('original text')).not.toBeInTheDocument();
+  });
+
+  it('renders an empty state when the active queue is empty', async () => {
+    const queueRepository = {
+      listActiveQueue: vi.fn().mockResolvedValue(
+        buildRecordQualityHumanReviewQueue([]),
+      ),
+    } satisfies RecordQualityHumanReviewQueueRepository;
+
+    render(<HumanReviewQueueSummary repository={queueRepository} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('record-quality-human-review-empty')).toHaveTextContent(
+        '要人間レビューはありません',
+      ),
+    );
+  });
+
+  it('renders an error state without exposing the raw error message', async () => {
+    const queueRepository = {
+      listActiveQueue: vi.fn().mockRejectedValue(new Error('raw backend failure')),
+    } satisfies RecordQualityHumanReviewQueueRepository;
+
+    render(<HumanReviewQueueSummary repository={queueRepository} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('record-quality-human-review-error')).toHaveTextContent(
+        '要人間レビューを読み込めませんでした',
+      ),
+    );
+    expect(screen.queryByText('raw backend failure')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a read-only Record Quality human review queue summary component.

This is the first UI-facing step for the human review queue. It displays queue count, oldest update timestamp, loading, empty, error, and a small active review list without adding actions or persistence writes.

## Scope

- Add HumanReviewQueueSummary component
- Delegate data loading to useRecordQualityHumanReviewQueue
- Show loading, empty, and error states
- Show active queue count and minimal item list
- Keep the UI read-only
- Confirm original support record body/content/original text is not rendered

## Safety

- No accept/revise/discard actions
- No SharePoint write
- No Graph or spFetch changes
- No workflow connection
- No AI connection
- Does not mutate, store, or expose original support record body/content/original text

## Tests

- npx vitest run src/features/record-quality/components/__tests__/HumanReviewQueueSummary.spec.tsx src/features/record-quality/hooks/__tests__/useRecordQualityHumanReviewQueue.spec.ts src/domain/supportRecord/recordQualityHumanReviewQueueUseCase.spec.ts src/domain/supportRecord/recordQualityHumanReviewQueue.spec.ts src/domain/supportRecord/recordQualityReviewRepository.spec.ts src/domain/supportRecord/recordQualityReviewDecisionReadModel.spec.ts src/domain/supportRecord/recordQualityReviewPersistenceMapper.spec.ts src/domain/supportRecord/recordQualityReview.spec.ts src/domain/supportRecord/recordQuality.spec.ts
- npm run typecheck
- npm run lint
- git diff --check