### PR TITLE
docs: update billing candidate progress

### DIFF
--- a/docs/testing/missing-test-candidates.md
+++ b/docs/testing/missing-test-candidates.md
@@ -2,6 +2,8 @@
 
 ## Progress update
 - `src/domain/isp/dailyBridgeMapper.ts` は完了済み（PR #2198, #2200, #2201 で境界ケース固定）。
+- `src/features/billing/hooks/useBillingOrderRepository.ts` の境界（skip-sharepoint）を PR #2205 で固定。
+  （H-2 は `billing` 配下のうち未検証枠が残り、引き続き `useBillingOrders` と `InMemoryBillingOrderRepository` を順次追加）
 
 ## 1. High Priority（優先）
 


### PR DESCRIPTION
## Summary
- Update docs/testing/missing-test-candidates.md to record PR #2205 coverage for billing repository boundary.
- Keep remaining H-2 billing candidates for follow-up test-only PRs.

## Tests
- npm run typecheck
- npm run lint
- git diff --check

## Scope
- Docs-only change under docs/testing.
- No implementation or test code changes.
