### PR TITLE
test(record-quality): cover human review queue summary safety

### DIFF
--- a/src/features/record-quality/components/__tests__/HumanReviewQueueSummary.spec.tsx
+++ b/src/features/record-quality/components/__tests__/HumanReviewQueueSummary.spec.tsx
@@ -2,7 +2,9 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  acceptRecordQualityReviewDraft,
   createRecordQualityReviewDraft,
+  discardRecordQualityReviewDraft,
   reviseRecordQualityReviewDraft,
   type RecordQualityReviewDraft,
 } from '@/domain/supportRecord/recordQualityReview';
@@ -78,6 +80,85 @@ describe('HumanReviewQueueSummary', () => {
     expect(screen.queryByText('元の支援記録本文')).not.toBeInTheDocument();
     expect(screen.queryByText('本人の反応などの本文')).not.toBeInTheDocument();
     expect(screen.queryByText('original text')).not.toBeInTheDocument();
+  });
+
+  it('keeps accepted and discarded reviews out of the read-only summary', async () => {
+    const reviewRepository = new InMemoryRecordQualityReviewRepository([
+      createReview('record-draft', '2026-06-11T00:00:00.000Z'),
+      reviseRecordQualityReviewDraft(
+        createReview('record-revised', '2026-06-11T01:00:00.000Z'),
+        {
+          notes: ['人間レビューで修正済みだが再確認する'],
+          updatedAt: '2026-06-11T02:00:00.000Z',
+        },
+      ),
+      acceptRecordQualityReviewDraft(
+        createReview('record-accepted', '2026-06-11T03:00:00.000Z'),
+        '2026-06-11T04:00:00.000Z',
+      ),
+      discardRecordQualityReviewDraft(
+        createReview('record-discarded', '2026-06-11T05:00:00.000Z'),
+        '2026-06-11T06:00:00.000Z',
+      ),
+    ]);
+    const queueRepository = new InMemoryRecordQualityHumanReviewQueueRepository(
+      reviewRepository,
+    );
+
+    render(<HumanReviewQueueSummary repository={queueRepository} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('record-quality-human-review-count')).toHaveTextContent(
+        '要確認 2件',
+      ),
+    );
+
+    expect(screen.getByText('record-draft')).toBeInTheDocument();
+    expect(screen.getByText('record-revised')).toBeInTheDocument();
+    expect(screen.queryByText('record-accepted')).not.toBeInTheDocument();
+    expect(screen.queryByText('record-discarded')).not.toBeInTheDocument();
+  });
+
+  it('does not render decision action controls yet', async () => {
+    const reviewRepository = new InMemoryRecordQualityReviewRepository([
+      createReview('record-draft', '2026-06-11T00:00:00.000Z'),
+    ]);
+    const queueRepository = new InMemoryRecordQualityHumanReviewQueueRepository(
+      reviewRepository,
+    );
+
+    render(<HumanReviewQueueSummary repository={queueRepository} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('record-quality-human-review-count')).toHaveTextContent(
+        '要確認 1件',
+      ),
+    );
+
+    expect(screen.queryByRole('button', { name: /accept|承認/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /revise|修正/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /discard|破棄/i })).not.toBeInTheDocument();
+  });
+
+  it('depends only on the injected queue repository boundary', async () => {
+    const queueRepository = {
+      listActiveQueue: vi.fn().mockResolvedValue(
+        buildRecordQualityHumanReviewQueue([
+          createReview('record-draft', '2026-06-11T00:00:00.000Z'),
+        ]),
+      ),
+    } satisfies RecordQualityHumanReviewQueueRepository;
+
+    render(<HumanReviewQueueSummary repository={queueRepository} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('record-quality-human-review-count')).toHaveTextContent(
+        '要確認 1件',
+      ),
+    );
+
+    expect(queueRepository.listActiveQueue).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('record-draft')).toBeInTheDocument();
   });
 
   it('renders an empty state when the active queue is empty', async () => {


### PR DESCRIPTION
## Summary

Adds safety coverage for the read-only Record Quality human review queue summary UI.

This keeps the next step focused on display boundaries before any decision actions are introduced.

## Scope

- Test accepted and discarded reviews stay out of the summary
- Test draft and revised reviews remain visible
- Test queue count display remains aligned with active review metadata
- Test original support record body/content/original text is not rendered
- Test accept/revise/discard controls are not present yet
- Test the component depends only on the injected queue repository boundary

## Safety

- Test-only change
- No UI feature changes
- No operation buttons
- No SharePoint write
- No Graph or spFetch dependency
- No workflow connection
- No AI connection
- Does not mutate, store, or expose original support record body/content/original text

## Tests

- npx vitest run src/features/record-quality/components/__tests__/HumanReviewQueueSummary.spec.tsx src/features/record-quality/hooks/__tests__/useRecordQualityHumanReviewQueue.spec.ts src/domain/supportRecord/recordQualityHumanReviewQueueUseCase.spec.ts src/domain/supportRecord/recordQualityHumanReviewQueue.spec.ts src/domain/supportRecord/recordQualityReviewRepository.spec.ts src/domain/supportRecord/recordQualityReviewDecisionReadModel.spec.ts src/domain/supportRecord/recordQualityReviewPersistenceMapper.spec.ts src/domain/supportRecord/recordQualityReview.spec.ts src/domain/supportRecord/recordQuality.spec.ts
- npm run typecheck
- npm run lint
- git diff --check