### PR TITLE
docs: mark billing hook as covered in missing-test candidates

### DIFF
--- a/docs/testing/missing-test-candidates.md
+++ b/docs/testing/missing-test-candidates.md
@@ -19,7 +19,6 @@
   - 同名テストでの直接照合で `-by-name` では不一致（現時点）
 
 ### H-2. Billing
-- `src/features/billing/hooks/useBillingOrderRepository.ts`
 - `src/features/billing/infra/InMemoryBillingOrderRepository.ts`
 - `src/features/billing/useBillingOrders.ts`
 - 根拠:


### PR DESCRIPTION
### Summary
- docs/testing/missing-test-candidates.md の H-2 Billing 未テスト候補から、既に対応済みの src/features/billing/hooks/useBillingOrderRepository.ts を削除しました。
- 候補一覧を現状の実施状況に合わせて更新し、未カバレッジ監査の精度を上げます。

### Tests
- 
pm run typecheck
- 
pm run lint
- git diff --check

### Scope
- Docs-only 更新（1ファイル）
- 実装コード・既存テスト・環境変数には手を付けていません。