### PR TITLE
test(record-quality): cover human review decision actions

### DIFF
--- a/src/domain/supportRecord/recordQualityReviewDecisionActions.spec.ts
+++ b/src/domain/supportRecord/recordQualityReviewDecisionActions.spec.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildRecordQualityHumanReviewQueue } from './recordQualityHumanReviewQueue';
+import {
+  acceptRecordQualityReviewDraft,
+  createRecordQualityReviewDraft,
+  discardRecordQualityReviewDraft,
+  reviseRecordQualityReviewDraft,
+  type RecordQualityReviewDraft,
+} from './recordQualityReview';
+import { InMemoryRecordQualityReviewRepository } from './recordQualityReviewRepository';
+
+const timestamp = '2026-06-11T00:00:00.000Z';
+
+function createReview(recordId = 'record-1'): RecordQualityReviewDraft {
+  return createRecordQualityReviewDraft({
+    recordId,
+    suggestedCategories: [
+      {
+        categoryId: 'staffSupportActions',
+        matchedSignals: ['職員', '声かけ'],
+        source: 'rule',
+      },
+    ],
+    missingInformationHints: [
+      {
+        code: 'userResponseAfterSupport',
+        label: '支援後の本人の反応',
+        source: 'rule',
+      },
+    ],
+    notes: ['人間レビューで確認する'],
+    createdAt: timestamp,
+  });
+}
+
+describe('record quality human review decision actions', () => {
+  it('accepts review metadata without mutating the original support record', async () => {
+    const repository = new InMemoryRecordQualityReviewRepository();
+    const originalSupportRecord = {
+      id: 'record-accepted',
+      body: '元の支援記録本文',
+      content: '本人の反応などの本文',
+    };
+    const originalSnapshot = structuredClone(originalSupportRecord);
+    const saved = await repository.saveReview(createReview(originalSupportRecord.id));
+
+    const accepted = await repository.updateReview(
+      acceptRecordQualityReviewDraft(saved, '2026-06-11T01:00:00.000Z'),
+    );
+    const queue = buildRecordQualityHumanReviewQueue(await repository.listReviews());
+
+    expect(originalSupportRecord).toEqual(originalSnapshot);
+    expect(accepted).toMatchObject({
+      recordId: originalSupportRecord.id,
+      originalRecord: { recordId: originalSupportRecord.id },
+      status: 'accepted',
+      sourceOfTruth: 'original_record',
+      outputKind: 'review_metadata',
+      requiresHumanReview: true,
+      updatedAt: '2026-06-11T01:00:00.000Z',
+    });
+    expect('body' in accepted).toBe(false);
+    expect('content' in accepted).toBe(false);
+    expect('originalText' in accepted).toBe(false);
+    expect(queue.items.map(item => item.recordId)).not.toContain(originalSupportRecord.id);
+  });
+
+  it('revises review metadata and keeps the review in the active human review queue', async () => {
+    const repository = new InMemoryRecordQualityReviewRepository();
+    const saved = await repository.saveReview(createReview('record-revised'));
+
+    const revised = await repository.updateReview(
+      reviseRecordQualityReviewDraft(saved, {
+        notes: ['人間レビューで確認観点だけを修正する'],
+        updatedAt: '2026-06-11T02:00:00.000Z',
+      }),
+    );
+    const queue = buildRecordQualityHumanReviewQueue(await repository.listReviews());
+
+    expect(revised).toMatchObject({
+      recordId: 'record-revised',
+      originalRecord: { recordId: 'record-revised' },
+      status: 'revised',
+      notes: ['人間レビューで確認観点だけを修正する'],
+      sourceOfTruth: 'original_record',
+      outputKind: 'review_metadata',
+      requiresHumanReview: true,
+      updatedAt: '2026-06-11T02:00:00.000Z',
+    });
+    expect(queue.items.map(item => item.recordId)).toEqual(['record-revised']);
+    expect(queue.items[0]).toMatchObject({
+      status: 'revised',
+      sourceRecordId: 'record-revised',
+      sourceOfTruth: 'original_record',
+      outputKind: 'review_metadata',
+      requiresHumanReview: true,
+    });
+    expect('body' in queue.items[0]).toBe(false);
+    expect('content' in queue.items[0]).toBe(false);
+    expect('originalText' in queue.items[0]).toBe(false);
+  });
+
+  it('discards review metadata without deleting or overwriting the original record reference', async () => {
+    const repository = new InMemoryRecordQualityReviewRepository();
+    const saved = await repository.saveReview(createReview('record-discarded'));
+
+    const discarded = await repository.updateReview(
+      discardRecordQualityReviewDraft(saved, '2026-06-11T03:00:00.000Z'),
+    );
+    const stored = await repository.getReview('record-discarded');
+    const queue = buildRecordQualityHumanReviewQueue(await repository.listReviews());
+
+    expect(stored).toEqual(discarded);
+    expect(discarded).toMatchObject({
+      recordId: 'record-discarded',
+      originalRecord: { recordId: 'record-discarded' },
+      status: 'discarded',
+      sourceOfTruth: 'original_record',
+      outputKind: 'review_metadata',
+      requiresHumanReview: true,
+      updatedAt: '2026-06-11T03:00:00.000Z',
+    });
+    expect(discarded.prohibitedActions).toEqual([
+      'diagnose_users',
+      'judge_behavior',
+      'determine_support_policy',
+      'overwrite_original_record',
+    ]);
+    expect(queue.items.map(item => item.recordId)).not.toContain('record-discarded');
+  });
+});


### PR DESCRIPTION
## Summary

Adds test coverage for Record Quality human review decision actions before introducing action use cases or UI controls.

The tests lock down accept, revise, and discard behavior as review metadata transitions only.

## Scope

- Cover accept decision metadata update
- Cover revise decision metadata update
- Cover discard decision metadata update
- Confirm accepted and discarded reviews leave the active human review queue
- Confirm revised reviews remain in the active human review queue
- Confirm original support record body/content/original text is not stored, rendered, or mutated
- Confirm sourceOfTruth, outputKind, requiresHumanReview, and prohibitedActions stay intact

## Safety

- Test-only change
- No production code changes
- No UI action controls
- No SharePoint write
- No Graph or spFetch dependency
- No workflow connection
- No AI connection
- Does not mutate, store, or expose original support record body/content/original text

## Tests

- npx vitest run src/domain/supportRecord/recordQualityReviewDecisionActions.spec.ts src/domain/supportRecord/recordQualityHumanReviewQueueUseCase.spec.ts src/domain/supportRecord/recordQualityHumanReviewQueue.spec.ts src/domain/supportRecord/recordQualityReviewRepository.spec.ts src/domain/supportRecord/recordQualityReviewDecisionReadModel.spec.ts src/domain/supportRecord/recordQualityReviewPersistenceMapper.spec.ts src/domain/supportRecord/recordQualityReview.spec.ts src/domain/supportRecord/recordQuality.spec.ts
- npm run typecheck
- npm run lint
- git diff --check