### PR TITLE
test(billing): cover repository kind boundaries

### DIFF
--- a/src/features/billing/hooks/useBillingOrderRepository.spec.ts
+++ b/src/features/billing/hooks/useBillingOrderRepository.spec.ts
@@ -18,10 +18,15 @@ vi.mock('@/lib/env', () => ({
   isTestMode: () => envState.isTestMode,
   readBool: () => false,
   readEnv: () => '',
+  isE2eMsalMockEnabled: () => false,
   isDevMode: () => false,
   shouldSkipLogin: () => false,
+  skipSharePoint: () => envState.shouldSkipSharePoint,
   shouldSkipSharePoint: () => envState.shouldSkipSharePoint,
-  getAppConfig: () => ({ VITE_SP_RESOURCE: 'https://example.sharepoint.com/sites/test' }),
+  getAppConfig: () => ({
+    VITE_SP_RESOURCE: 'https://example.sharepoint.com',
+    VITE_SP_SITE_RELATIVE: '/sites/test',
+  }),
   readOptionalEnv: () => undefined,
 }));
 
@@ -80,5 +85,16 @@ describe('useBillingOrderRepository', () => {
 
     expect(result.current).toBe(inMemoryBillingOrderRepository);
     expect(getCurrentBillingOrderRepositoryKind()).toBe('demo');
+  });
+
+  it('uses real repository when sharepoint is allowed and test mode is disabled', () => {
+    envState.isTestMode = false;
+    envState.shouldSkipSharePoint = false;
+
+    const { result } = renderHook(() => useBillingOrderRepository());
+
+    expect(getCurrentBillingOrderRepositoryKind()).toBe('real');
+    expect(result.current).not.toBe(inMemoryBillingOrderRepository);
+    expect(typeof result.current).toBe('object');
   });
 });


### PR DESCRIPTION
### Summary
- src/features/billing/hooks/useBillingOrderRepository.spec.ts に1件追加しました。
- isTestMode=false かつ shouldSkipSharePoint=false のとき、Repository が real モードになる境界を検証します。
- 既存3ケースとの重複を避け、nv モックは既存テストの構成を維持した最小差分にしています。

### Tests
- 
px vitest run src/features/billing/hooks/useBillingOrderRepository.spec.ts
- 
pm run typecheck
- 
pm run lint
- git diff --check

### Scope
- test-only（1 ファイル更新）
- 実装コード・docs・.env は変更していません。