### PR TITLE
feat(record-quality): add human review decision actions

### DIFF
--- a/src/domain/supportRecord/recordQualityReviewDecisionActions.spec.ts
+++ b/src/domain/supportRecord/recordQualityReviewDecisionActions.spec.ts
@@ -2,12 +2,14 @@ import { describe, expect, it } from 'vitest';
 
 import { buildRecordQualityHumanReviewQueue } from './recordQualityHumanReviewQueue';
 import {
-  acceptRecordQualityReviewDraft,
   createRecordQualityReviewDraft,
-  discardRecordQualityReviewDraft,
-  reviseRecordQualityReviewDraft,
   type RecordQualityReviewDraft,
 } from './recordQualityReview';
+import {
+  acceptRecordQualityReviewDecision,
+  discardRecordQualityReviewDecision,
+  reviseRecordQualityReviewDecision,
+} from './recordQualityReviewDecisionActions';
 import { InMemoryRecordQualityReviewRepository } from './recordQualityReviewRepository';
 
 const timestamp = '2026-06-11T00:00:00.000Z';
@@ -45,9 +47,11 @@ describe('record quality human review decision actions', () => {
     const originalSnapshot = structuredClone(originalSupportRecord);
     const saved = await repository.saveReview(createReview(originalSupportRecord.id));
 
-    const accepted = await repository.updateReview(
-      acceptRecordQualityReviewDraft(saved, '2026-06-11T01:00:00.000Z'),
-    );
+    const accepted = await acceptRecordQualityReviewDecision({
+      repository,
+      recordId: saved.recordId,
+      updatedAt: '2026-06-11T01:00:00.000Z',
+    });
     const queue = buildRecordQualityHumanReviewQueue(await repository.listReviews());
 
     expect(originalSupportRecord).toEqual(originalSnapshot);
@@ -70,12 +74,12 @@ describe('record quality human review decision actions', () => {
     const repository = new InMemoryRecordQualityReviewRepository();
     const saved = await repository.saveReview(createReview('record-revised'));
 
-    const revised = await repository.updateReview(
-      reviseRecordQualityReviewDraft(saved, {
-        notes: ['人間レビューで確認観点だけを修正する'],
-        updatedAt: '2026-06-11T02:00:00.000Z',
-      }),
-    );
+    const revised = await reviseRecordQualityReviewDecision({
+      repository,
+      recordId: saved.recordId,
+      notes: ['人間レビューで確認観点だけを修正する'],
+      updatedAt: '2026-06-11T02:00:00.000Z',
+    });
     const queue = buildRecordQualityHumanReviewQueue(await repository.listReviews());
 
     expect(revised).toMatchObject({
@@ -105,9 +109,11 @@ describe('record quality human review decision actions', () => {
     const repository = new InMemoryRecordQualityReviewRepository();
     const saved = await repository.saveReview(createReview('record-discarded'));
 
-    const discarded = await repository.updateReview(
-      discardRecordQualityReviewDraft(saved, '2026-06-11T03:00:00.000Z'),
-    );
+    const discarded = await discardRecordQualityReviewDecision({
+      repository,
+      recordId: saved.recordId,
+      updatedAt: '2026-06-11T03:00:00.000Z',
+    });
     const stored = await repository.getReview('record-discarded');
     const queue = buildRecordQualityHumanReviewQueue(await repository.listReviews());
 
@@ -128,5 +134,18 @@ describe('record quality human review decision actions', () => {
       'overwrite_original_record',
     ]);
     expect(queue.items.map(item => item.recordId)).not.toContain('record-discarded');
+  });
+
+  it('rejects actions for missing review metadata without creating a new review', async () => {
+    const repository = new InMemoryRecordQualityReviewRepository();
+
+    await expect(
+      acceptRecordQualityReviewDecision({
+        repository,
+        recordId: 'missing-record',
+        updatedAt: '2026-06-11T04:00:00.000Z',
+      }),
+    ).rejects.toThrow('Record quality review not found');
+    await expect(repository.listReviews()).resolves.toEqual([]);
   });
 });

--- a/src/domain/supportRecord/recordQualityReviewDecisionActions.ts
+++ b/src/domain/supportRecord/recordQualityReviewDecisionActions.ts
@@ -1,0 +1,65 @@
+import {
+  acceptRecordQualityReviewDraft,
+  discardRecordQualityReviewDraft,
+  reviseRecordQualityReviewDraft,
+  type RecordQualityReviewDraft,
+  type ReviseRecordQualityReviewDraftInput,
+} from './recordQualityReview';
+import type {
+  RecordQualityReviewRecordId,
+  RecordQualityReviewRepository,
+} from './recordQualityReviewRepository';
+
+export type RecordQualityReviewDecisionActionInput = {
+  readonly repository: RecordQualityReviewRepository;
+  readonly recordId: RecordQualityReviewRecordId;
+  readonly updatedAt: string;
+};
+
+export type ReviseRecordQualityReviewDecisionInput =
+  RecordQualityReviewDecisionActionInput &
+    Omit<ReviseRecordQualityReviewDraftInput, 'updatedAt'>;
+
+export async function acceptRecordQualityReviewDecision(
+  input: RecordQualityReviewDecisionActionInput,
+): Promise<RecordQualityReviewDraft> {
+  const review = await getExistingReview(input.repository, input.recordId);
+  return input.repository.updateReview(
+    acceptRecordQualityReviewDraft(review, input.updatedAt),
+  );
+}
+
+export async function reviseRecordQualityReviewDecision(
+  input: ReviseRecordQualityReviewDecisionInput,
+): Promise<RecordQualityReviewDraft> {
+  const review = await getExistingReview(input.repository, input.recordId);
+  return input.repository.updateReview(
+    reviseRecordQualityReviewDraft(review, {
+      suggestedCategories: input.suggestedCategories,
+      missingInformationHints: input.missingInformationHints,
+      notes: input.notes,
+      updatedAt: input.updatedAt,
+    }),
+  );
+}
+
+export async function discardRecordQualityReviewDecision(
+  input: RecordQualityReviewDecisionActionInput,
+): Promise<RecordQualityReviewDraft> {
+  const review = await getExistingReview(input.repository, input.recordId);
+  return input.repository.updateReview(
+    discardRecordQualityReviewDraft(review, input.updatedAt),
+  );
+}
+
+async function getExistingReview(
+  repository: RecordQualityReviewRepository,
+  recordId: RecordQualityReviewRecordId,
+): Promise<RecordQualityReviewDraft> {
+  const review = await repository.getReview(recordId);
+  if (!review) {
+    throw new Error(`Record quality review not found: ${recordId}`);
+  }
+
+  return review;
+}


### PR DESCRIPTION
## Summary

Adds minimal Record Quality human review decision action use cases.

The actions accept, revise, or discard existing review metadata through the injected review repository. They do not create a new persistence path and do not touch original support record body/content.

## Scope

- Add acceptRecordQualityReviewDecision
- Add reviseRecordQualityReviewDecision
- Add discardRecordQualityReviewDecision
- Require existing review metadata before applying an action
- Keep accepted and discarded reviews out of the active human review queue
- Keep revised reviews in the active human review queue
- Preserve sourceOfTruth, outputKind, requiresHumanReview, and prohibitedActions

## Safety

- No UI action controls
- No SharePoint write
- No Graph or spFetch dependency
- No workflow connection
- No AI connection
- Does not mutate, store, or expose original support record body/content/original text

## Tests

- npx vitest run src/domain/supportRecord/recordQualityReviewDecisionActions.spec.ts src/domain/supportRecord/recordQualityHumanReviewQueueUseCase.spec.ts src/domain/supportRecord/recordQualityHumanReviewQueue.spec.ts src/domain/supportRecord/recordQualityReviewRepository.spec.ts src/domain/supportRecord/recordQualityReviewDecisionReadModel.spec.ts src/domain/supportRecord/recordQualityReviewPersistenceMapper.spec.ts src/domain/supportRecord/recordQualityReview.spec.ts src/domain/supportRecord/recordQuality.spec.ts
- npm run typecheck
- npm run lint
- git diff --check