### PR TITLE
test(billing): cover in-memory billing empty init fallback

### DIFF
--- a/src/features/billing/infra/__tests__/InMemoryBillingOrderRepository.spec.ts
+++ b/src/features/billing/infra/__tests__/InMemoryBillingOrderRepository.spec.ts
@@ -51,6 +51,19 @@ describe('InMemoryBillingOrderRepository', () => {
     expect(rows.every((row) => !!row.orderDate)).toBe(true);
   });
 
+  it('falls back to default mock data when an explicit empty array is passed', async () => {
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
+    try {
+      const rows = await new InMemoryBillingOrderRepository([]).list();
+      const defaultRows = await new InMemoryBillingOrderRepository().list();
+
+      expect(rows.length).toBeGreaterThan(0);
+      expect(rows).toEqual(defaultRows);
+    } finally {
+      randomSpy.mockRestore();
+    }
+  });
+
   it('isPersistenceColumnsResolved は常に true を返す', async () => {
     const repo = new InMemoryBillingOrderRepository(createBaseOrders());
 


### PR DESCRIPTION
### Summary
- src/features/billing/infra/__tests__/InMemoryBillingOrderRepository.spec.ts に1ケース追加しました。
- 
ew InMemoryBillingOrderRepository([]) がデフォルトのモックデータを使用する境界を検証します。
- 既存仕様の変更はありません。

### Tests
- 
px vitest run src/features/billing/infra/__tests__/InMemoryBillingOrderRepository.spec.ts
- 
pm run typecheck
- 
pm run lint
- git diff --check

### Scope
- test-only（1ファイル）
- 実装コード・ドキュメント・.env は変更していません。