### PR TITLE
test(record-quality): guard human review terminal transitions

### DIFF
--- a/src/domain/supportRecord/recordQualityReview.spec.ts
+++ b/src/domain/supportRecord/recordQualityReview.spec.ts
@@ -157,4 +157,77 @@ describe('recordQualityReview draft model', () => {
       'overwrite_original_record',
     ]);
   });
+
+  it.each([
+    {
+      label: 'accept',
+      transition: (draft: ReturnType<typeof createRecordQualityReviewDraft>) =>
+        acceptRecordQualityReviewDraft(draft, '2026-06-10T01:00:00.000Z'),
+      expectedStatus: 'accepted',
+    },
+    {
+      label: 'revise',
+      transition: (draft: ReturnType<typeof createRecordQualityReviewDraft>) =>
+        reviseRecordQualityReviewDraft(draft, {
+          notes: ['人間レビューで確認観点だけを修正する'],
+          updatedAt: '2026-06-10T01:00:00.000Z',
+        }),
+      expectedStatus: 'revised',
+    },
+    {
+      label: 'discard',
+      transition: (draft: ReturnType<typeof createRecordQualityReviewDraft>) =>
+        discardRecordQualityReviewDraft(draft, '2026-06-10T01:00:00.000Z'),
+      expectedStatus: 'discarded',
+    },
+  ])('allows draft -> $expectedStatus by $label action', ({ transition, expectedStatus }) => {
+    const draft = createRecordQualityReviewDraft({
+      recordId: 'record-1',
+      createdAt: '2026-06-10T00:00:00.000Z',
+    });
+
+    const decided = transition(draft);
+
+    expect(decided.status).toBe(expectedStatus);
+    expect(decided.updatedAt).toBe('2026-06-10T01:00:00.000Z');
+  });
+
+  it.each([
+    {
+      label: 'accepted -> accepted',
+      createCurrent: (draft: ReturnType<typeof createRecordQualityReviewDraft>) =>
+        acceptRecordQualityReviewDraft(draft, '2026-06-10T01:00:00.000Z'),
+      transition: (current: ReturnType<typeof createRecordQualityReviewDraft>) =>
+        acceptRecordQualityReviewDraft(current, '2026-06-10T02:00:00.000Z'),
+      expectedMessage: 'Cannot transition record quality review from accepted to accepted',
+    },
+    {
+      label: 'discarded -> accepted',
+      createCurrent: (draft: ReturnType<typeof createRecordQualityReviewDraft>) =>
+        discardRecordQualityReviewDraft(draft, '2026-06-10T01:00:00.000Z'),
+      transition: (current: ReturnType<typeof createRecordQualityReviewDraft>) =>
+        acceptRecordQualityReviewDraft(current, '2026-06-10T02:00:00.000Z'),
+      expectedMessage: 'Cannot transition record quality review from discarded to accepted',
+    },
+    {
+      label: 'accepted -> discarded',
+      createCurrent: (draft: ReturnType<typeof createRecordQualityReviewDraft>) =>
+        acceptRecordQualityReviewDraft(draft, '2026-06-10T01:00:00.000Z'),
+      transition: (current: ReturnType<typeof createRecordQualityReviewDraft>) =>
+        discardRecordQualityReviewDraft(current, '2026-06-10T02:00:00.000Z'),
+      expectedMessage: 'Cannot transition record quality review from accepted to discarded',
+    },
+  ])('rejects invalid human review transition: $label', ({
+    createCurrent,
+    transition,
+    expectedMessage,
+  }) => {
+    const draft = createRecordQualityReviewDraft({
+      recordId: 'record-1',
+      createdAt: '2026-06-10T00:00:00.000Z',
+    });
+    const current = createCurrent(draft);
+
+    expect(() => transition(current)).toThrow(expectedMessage);
+  });
 });

--- a/src/domain/supportRecord/recordQualityReview.ts
+++ b/src/domain/supportRecord/recordQualityReview.ts
@@ -122,6 +122,8 @@ function transitionRecordQualityReviewDraft(
   status: RecordQualityReviewStatus,
   input: ReviseRecordQualityReviewDraftInput,
 ): RecordQualityReviewDraft {
+  assertRecordQualityReviewTransitionAllowed(draft.status, status);
+
   return {
     ...draft,
     ...RECORD_QUALITY_REVIEW_SAFETY_METADATA,
@@ -134,4 +136,15 @@ function transitionRecordQualityReviewDraft(
     createdAt: draft.createdAt,
     updatedAt: input.updatedAt,
   };
+}
+
+function assertRecordQualityReviewTransitionAllowed(
+  currentStatus: RecordQualityReviewStatus,
+  nextStatus: RecordQualityReviewStatus,
+): void {
+  if (currentStatus === 'accepted' || currentStatus === 'discarded') {
+    throw new Error(
+      `Cannot transition record quality review from ${currentStatus} to ${nextStatus}`,
+    );
+  }
 }

--- a/src/domain/supportRecord/recordQualityReviewDecisionReadModel.spec.ts
+++ b/src/domain/supportRecord/recordQualityReviewDecisionReadModel.spec.ts
@@ -45,12 +45,12 @@ const acceptedReview = acceptRecordQualityReviewDraft(
   draftReview,
   '2026-06-11T01:00:00.000Z',
 );
-const revisedReview = reviseRecordQualityReviewDraft(acceptedReview, {
+const revisedReview = reviseRecordQualityReviewDraft(createBaseReview(), {
   notes: ['確認観点を修正した'],
   updatedAt: '2026-06-11T02:00:00.000Z',
 });
 const discardedReview = discardRecordQualityReviewDraft(
-  revisedReview,
+  createBaseReview(),
   '2026-06-11T03:00:00.000Z',
 );
 

--- a/src/domain/supportRecord/recordQualityReviewRepository.spec.ts
+++ b/src/domain/supportRecord/recordQualityReviewRepository.spec.ts
@@ -104,7 +104,7 @@ const runRecordQualityReviewRepositoryContract = (
 
     it('keeps statuses limited to draft, accepted, revised, and discarded', async () => {
       const repository = factory();
-      const saved = await repository.saveReview(createDraft());
+      const saved = await repository.saveReview(createDraft('record-draft'));
 
       expect(saved.status).toBe('draft');
 
@@ -116,7 +116,8 @@ const runRecordQualityReviewRepositoryContract = (
         requiresHumanReview: true,
       });
 
-      const revised = reviseRecordQualityReviewDraft(accepted, {
+      const savedForRevision = await repository.saveReview(createDraft('record-revised'));
+      const revised = reviseRecordQualityReviewDraft(savedForRevision, {
         notes: ['確認観点を修正する'],
         updatedAt: '2026-06-11T02:00:00.000Z',
       });
@@ -127,8 +128,9 @@ const runRecordQualityReviewRepositoryContract = (
         requiresHumanReview: true,
       });
 
+      const savedForDiscard = await repository.saveReview(createDraft('record-discarded'));
       const discarded = discardRecordQualityReviewDraft(
-        revised,
+        savedForDiscard,
         '2026-06-11T03:00:00.000Z',
       );
       await expect(repository.updateReview(discarded)).resolves.toMatchObject({
@@ -176,18 +178,22 @@ const runRecordQualityReviewRepositoryContract = (
       const accepted = await repository.updateReview(
         acceptRecordQualityReviewDraft(saved, '2026-06-11T01:00:00.000Z'),
       );
+      const savedForRevision = await repository.saveReview(createDraft('record-2'));
       const revised = await repository.updateReview(
-        reviseRecordQualityReviewDraft(accepted, {
+        reviseRecordQualityReviewDraft(savedForRevision, {
           notes: ['本文ではなくレビュー観点だけを修正する'],
           updatedAt: '2026-06-11T02:00:00.000Z',
         }),
       );
+      const savedForDiscard = await repository.saveReview(createDraft('record-3'));
       const discarded = await repository.updateReview(
-        discardRecordQualityReviewDraft(revised, '2026-06-11T03:00:00.000Z'),
+        discardRecordQualityReviewDraft(savedForDiscard, '2026-06-11T03:00:00.000Z'),
       );
 
       expect(originalSupportRecord).toEqual(originalSnapshot);
-      expect(discarded.originalRecord).toEqual({ recordId: originalSupportRecord.id });
+      expect(accepted.originalRecord).toEqual({ recordId: originalSupportRecord.id });
+      expect(revised.originalRecord).toEqual({ recordId: 'record-2' });
+      expect(discarded.originalRecord).toEqual({ recordId: 'record-3' });
       expect('body' in discarded).toBe(false);
       expect('content' in discarded).toBe(false);
       expect(discarded.sourceOfTruth).toBe('original_record');


### PR DESCRIPTION
- Fix draft -> accepted / revised / discarded domain transitions
- Reject repeated decisions from terminal statuses
- Align existing fixtures with terminal transition rules
- Keep domain, read model, and repository specs consistent