### PR TITLE
docs: drop billing in-memory repo from missing candidates

### DIFF
--- a/docs/testing/missing-test-candidates.md
+++ b/docs/testing/missing-test-candidates.md
@@ -19,7 +19,6 @@
   - 同名テストでの直接照合で `-by-name` では不一致（現時点）
 
 ### H-2. Billing
-- `src/features/billing/infra/InMemoryBillingOrderRepository.ts`
 - `src/features/billing/useBillingOrders.ts`
 - 根拠:
   - 既存テストが薄く、リポジトリ分岐と表示ロジックの連携を持つ


### PR DESCRIPTION
### Summary
- docs/testing/missing-test-candidates.md の H-2 Billing から src/features/billing/infra/InMemoryBillingOrderRepository.ts を除外しました。
- #2214 の反映に合わせ、未カバレッジ候補リストを現状に同期します。

### Tests
- 
pm run typecheck
- 
pm run lint
- git diff --check

### Scope
- docs-only 更新（1ファイル）
- 実装・テスト・.env は変更しません。