### PR TITLE
test(billing): cover useBillingOrders list error propagation

### DIFF
--- a/src/features/billing/hooks/useBillingOrders.spec.ts
+++ b/src/features/billing/hooks/useBillingOrders.spec.ts
@@ -53,4 +53,25 @@ describe('useBillingOrders', () => {
     await expect(capturedQueryFn!()).resolves.toEqual(rows);
     expect(repo.list).toHaveBeenCalledTimes(1);
   });
+
+  it('queryFn propagates list() rejection', async () => {
+    const boom = new Error('list failed');
+    const repo = {
+      list: vi.fn().mockRejectedValue(boom),
+      isPersistenceColumnsResolved: vi.fn(),
+      updatePaymentStatus: vi.fn(),
+      bulkUpdatePaymentStatus: vi.fn(),
+    };
+
+    let capturedQueryFn: (() => Promise<unknown[]>) | null = null;
+    mockUseQuery.mockImplementation((options: { queryFn: () => Promise<unknown[]> }) => {
+      capturedQueryFn = options.queryFn;
+      return { data: [], isLoading: false };
+    });
+
+    useBillingOrders(repo);
+
+    expect(capturedQueryFn).not.toBeNull();
+    await expect(capturedQueryFn!()).rejects.toBe(boom);
+  });
 });


### PR DESCRIPTION
### Summary
- Add one boundary test to src/features/billing/hooks/useBillingOrders.spec.ts.
- Verify that when repository list() rejects, the query function returned to react-query also rejects with the same error.
- Existing implementation is unchanged; this is a regression test-only fix.

### Tests
- npx vitest run src/features/billing/hooks/useBillingOrders.spec.ts
- npm run typecheck
- npm run lint
- git diff --check

### Scope
- test-only (1 file)
- No implementation, docs, or environment changes.