### PR TITLE
docs: mark billing useBillingOrders as covered

### DIFF
--- a/docs/testing/missing-test-candidates.md
+++ b/docs/testing/missing-test-candidates.md
@@ -19,7 +19,7 @@
   - 同名テストでの直接照合で `-by-name` では不一致（現時点）
 
 ### H-2. Billing
-- `src/features/billing/useBillingOrders.ts`
+- `src/features/billing/useBillingOrders.ts` はテスト追加済み（#2217）
 - 根拠:
   - 既存テストが薄く、リポジトリ分岐と表示ロジックの連携を持つ
   - フィールド階層が SharePoint 仕様変更に追従しやすい場所


### PR DESCRIPTION
### Summary
- Update docs/testing/missing-test-candidates.md H-2 to reflect that src/features/billing/useBillingOrders.ts has completed coverage via merged PR #2217.

### Tests
- Not applicable (docs-only).

### Scope
- docs-only
