### PR TITLE
feat(record-quality): add human review workflow summary actions

### DIFF
--- a/src/features/record-quality/components/HumanReviewWorkflowSummary.tsx
+++ b/src/features/record-quality/components/HumanReviewWorkflowSummary.tsx
@@ -1,0 +1,184 @@
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import EditNoteIcon from '@mui/icons-material/EditNote';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Chip from '@mui/material/Chip';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+
+import type { RecordQualityHumanReviewQueueRepository } from '@/domain/supportRecord/recordQualityHumanReviewQueue';
+import type { RecordQualityReviewRepository } from '@/domain/supportRecord/recordQualityReviewRepository';
+import { useRecordQualityHumanReviewWorkflow } from '../hooks/useRecordQualityHumanReviewWorkflow';
+
+type HumanReviewWorkflowSummaryProps = {
+  readonly reviewRepository: RecordQualityReviewRepository;
+  readonly queueRepository: RecordQualityHumanReviewQueueRepository;
+  readonly maxItems?: number;
+  readonly getUpdatedAt?: () => string;
+};
+
+export function HumanReviewWorkflowSummary({
+  reviewRepository,
+  queueRepository,
+  maxItems = 5,
+  getUpdatedAt = () => new Date().toISOString(),
+}: HumanReviewWorkflowSummaryProps) {
+  const {
+    queue,
+    isLoading,
+    error,
+    isDeciding,
+    decisionError,
+    accept,
+    revise,
+    discard,
+  } = useRecordQualityHumanReviewWorkflow({ reviewRepository, queueRepository });
+  const visibleItems = queue.items.slice(0, maxItems);
+
+  return (
+    <Card
+      variant="outlined"
+      sx={{ borderRadius: 1 }}
+      data-testid="record-quality-human-review-workflow-summary"
+    >
+      <CardContent>
+        <Stack spacing={2}>
+          <Box>
+            <Typography variant="h6" component="h2">
+              記録品質レビュー
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              要確認のレビュー状況
+            </Typography>
+          </Box>
+
+          {isLoading && (
+            <Typography role="status" variant="body2" color="text.secondary">
+              要人間レビューを読み込み中
+            </Typography>
+          )}
+
+          {!isLoading && error && (
+            <Alert severity="error" data-testid="record-quality-human-review-error">
+              要人間レビューを読み込めませんでした
+            </Alert>
+          )}
+
+          {!isLoading && decisionError && (
+            <Alert severity="error" data-testid="record-quality-human-review-decision-error">
+              レビュー判断を保存できませんでした
+            </Alert>
+          )}
+
+          {!isLoading && !error && queue.totalCount === 0 && (
+            <Alert severity="success" data-testid="record-quality-human-review-empty">
+              要人間レビューはありません
+            </Alert>
+          )}
+
+          {!isLoading && !error && queue.totalCount > 0 && (
+            <Stack spacing={1.5}>
+              <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+                <Chip
+                  label={`要確認 ${queue.totalCount}件`}
+                  color="warning"
+                  size="small"
+                  data-testid="record-quality-human-review-count"
+                />
+                {queue.oldestUpdatedAt && (
+                  <Typography variant="caption" color="text.secondary">
+                    最古更新 {queue.oldestUpdatedAt}
+                  </Typography>
+                )}
+              </Stack>
+
+              <List dense disablePadding data-testid="record-quality-human-review-list">
+                {visibleItems.map(item => (
+                  <ListItem
+                    key={item.recordId}
+                    disableGutters
+                    divider
+                    data-testid={`record-quality-human-review-item-${item.recordId}`}
+                  >
+                    <Stack spacing={1} sx={{ width: '100%' }}>
+                      <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+                        <Typography variant="body2" sx={{ fontWeight: 700 }}>
+                          {item.sourceRecordId}
+                        </Typography>
+                        <Chip label={item.label} size="small" variant="outlined" />
+                      </Stack>
+                      <Typography variant="caption" color="text.secondary">
+                        候補 {item.suggestedCategoryCount}件 / 不足情報{' '}
+                        {item.missingInformationHintCount}件 / ノート {item.noteCount}件
+                      </Typography>
+                      <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                        <Button
+                          type="button"
+                          size="small"
+                          variant="outlined"
+                          color="success"
+                          disableRipple
+                          startIcon={<CheckCircleOutlineIcon fontSize="small" />}
+                          disabled={isDeciding}
+                          onClick={() =>
+                            void accept({
+                              recordId: item.recordId,
+                              updatedAt: getUpdatedAt(),
+                            })
+                          }
+                        >
+                          採用
+                        </Button>
+                        <Button
+                          type="button"
+                          size="small"
+                          variant="outlined"
+                          color="info"
+                          disableRipple
+                          startIcon={<EditNoteIcon fontSize="small" />}
+                          disabled={isDeciding}
+                          onClick={() =>
+                            void revise({
+                              recordId: item.recordId,
+                              notes: ['人間レビューで確認観点を修正済み'],
+                              updatedAt: getUpdatedAt(),
+                            })
+                          }
+                        >
+                          修正済み
+                        </Button>
+                        <Button
+                          type="button"
+                          size="small"
+                          variant="outlined"
+                          color="error"
+                          disableRipple
+                          startIcon={<DeleteOutlineIcon fontSize="small" />}
+                          disabled={isDeciding}
+                          onClick={() =>
+                            void discard({
+                              recordId: item.recordId,
+                              updatedAt: getUpdatedAt(),
+                            })
+                          }
+                        >
+                          破棄
+                        </Button>
+                      </Stack>
+                    </Stack>
+                  </ListItem>
+                ))}
+              </List>
+            </Stack>
+          )}
+        </Stack>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/record-quality/components/__tests__/HumanReviewWorkflowSummary.spec.tsx
+++ b/src/features/record-quality/components/__tests__/HumanReviewWorkflowSummary.spec.tsx
@@ -1,0 +1,199 @@
+import { act, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createRecordQualityReviewDraft,
+  type RecordQualityReviewDraft,
+} from '@/domain/supportRecord/recordQualityReview';
+import {
+  buildRecordQualityHumanReviewQueue,
+  InMemoryRecordQualityHumanReviewQueueRepository,
+  type RecordQualityHumanReviewQueueRepository,
+} from '@/domain/supportRecord/recordQualityHumanReviewQueue';
+import {
+  InMemoryRecordQualityReviewRepository,
+  type RecordQualityReviewRepository,
+} from '@/domain/supportRecord/recordQualityReviewRepository';
+import { HumanReviewWorkflowSummary } from '../HumanReviewWorkflowSummary';
+
+function createReview(recordId: string, createdAt: string): RecordQualityReviewDraft {
+  return createRecordQualityReviewDraft({
+    recordId,
+    suggestedCategories: [
+      {
+        categoryId: 'staffSupportActions',
+        matchedSignals: ['職員', '声かけ'],
+        source: 'rule',
+      },
+    ],
+    missingInformationHints: [
+      {
+        code: 'userResponseAfterSupport',
+        label: '支援後の本人の反応',
+        source: 'rule',
+      },
+    ],
+    notes: ['人間レビューで確認する'],
+    createdAt,
+  });
+}
+
+function createRepositories(seed: readonly RecordQualityReviewDraft[]) {
+  const reviewRepository = new InMemoryRecordQualityReviewRepository(seed);
+  const queueRepository = new InMemoryRecordQualityHumanReviewQueueRepository(
+    reviewRepository,
+  );
+
+  return { reviewRepository, queueRepository };
+}
+
+async function clickAndFlush(
+  user: ReturnType<typeof userEvent.setup>,
+  button: HTMLElement,
+) {
+  await act(async () => {
+    await user.click(button);
+    await Promise.resolve();
+  });
+}
+
+describe('HumanReviewWorkflowSummary', () => {
+  it('accepts a review from the action controls and removes it from the active queue', async () => {
+    const user = userEvent.setup();
+    const repositories = createRepositories([
+      createReview('record-accepted', '2026-06-11T00:00:00.000Z'),
+    ]);
+
+    render(
+      <HumanReviewWorkflowSummary
+        {...repositories}
+        getUpdatedAt={() => '2026-06-11T01:00:00.000Z'}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('record-quality-human-review-count')).toHaveTextContent(
+        '要確認 1件',
+      ),
+    );
+
+    await clickAndFlush(user, screen.getByRole('button', { name: '採用' }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('record-quality-human-review-empty')).toHaveTextContent(
+        '要人間レビューはありません',
+      ),
+    );
+    await expect(repositories.reviewRepository.getReview('record-accepted')).resolves.toMatchObject({
+      status: 'accepted',
+      updatedAt: '2026-06-11T01:00:00.000Z',
+      sourceOfTruth: 'original_record',
+      outputKind: 'review_metadata',
+      requiresHumanReview: true,
+    });
+  });
+
+  it('revises a review from the action controls and keeps it visible as active review metadata', async () => {
+    const user = userEvent.setup();
+    const repositories = createRepositories([
+      createReview('record-revised', '2026-06-11T00:00:00.000Z'),
+    ]);
+
+    render(
+      <HumanReviewWorkflowSummary
+        {...repositories}
+        getUpdatedAt={() => '2026-06-11T02:00:00.000Z'}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('record-quality-human-review-count')).toHaveTextContent(
+        '要確認 1件',
+      ),
+    );
+
+    await clickAndFlush(user, screen.getByRole('button', { name: '修正済み' }));
+
+    const item = await screen.findByTestId(
+      'record-quality-human-review-item-record-revised',
+    );
+    expect(within(item).getByText('revised by human reviewer')).toBeInTheDocument();
+    expect(within(item).queryByText('元の支援記録本文')).not.toBeInTheDocument();
+    await expect(repositories.reviewRepository.getReview('record-revised')).resolves.toMatchObject({
+      status: 'revised',
+      notes: ['人間レビューで確認観点を修正済み'],
+      updatedAt: '2026-06-11T02:00:00.000Z',
+    });
+  });
+
+  it('discards a review from the action controls and removes it from the active queue', async () => {
+    const user = userEvent.setup();
+    const repositories = createRepositories([
+      createReview('record-discarded', '2026-06-11T00:00:00.000Z'),
+    ]);
+
+    render(
+      <HumanReviewWorkflowSummary
+        {...repositories}
+        getUpdatedAt={() => '2026-06-11T03:00:00.000Z'}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('record-quality-human-review-count')).toHaveTextContent(
+        '要確認 1件',
+      ),
+    );
+
+    await clickAndFlush(user, screen.getByRole('button', { name: '破棄' }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('record-quality-human-review-empty')).toBeInTheDocument(),
+    );
+    await expect(repositories.reviewRepository.getReview('record-discarded')).resolves.toMatchObject({
+      status: 'discarded',
+      updatedAt: '2026-06-11T03:00:00.000Z',
+      originalRecord: { recordId: 'record-discarded' },
+    });
+  });
+
+  it('keeps decision failures in a safe UI error without exposing the raw backend message', async () => {
+    const user = userEvent.setup();
+    const reviewRepository = {
+      getReview: vi.fn().mockRejectedValue(new Error('raw decision failure')),
+      saveReview: vi.fn(),
+      updateReview: vi.fn(),
+      listReviews: vi.fn(),
+    } satisfies RecordQualityReviewRepository;
+    const queueRepository = {
+      listActiveQueue: vi.fn().mockResolvedValue(
+        buildRecordQualityHumanReviewQueue([
+          createReview('record-failed', '2026-06-11T00:00:00.000Z'),
+        ]),
+      ),
+    } satisfies RecordQualityHumanReviewQueueRepository;
+
+    render(
+      <HumanReviewWorkflowSummary
+        reviewRepository={reviewRepository}
+        queueRepository={queueRepository}
+        getUpdatedAt={() => '2026-06-11T04:00:00.000Z'}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText('record-failed')).toBeInTheDocument());
+
+    await clickAndFlush(user, screen.getByRole('button', { name: '採用' }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByTestId('record-quality-human-review-decision-error'),
+      ).toHaveTextContent('レビュー判断を保存できませんでした'),
+    );
+    expect(screen.queryByText('raw decision failure')).not.toBeInTheDocument();
+    expect(screen.getByText('record-failed')).toBeInTheDocument();
+    expect(queueRepository.listActiveQueue).toHaveBeenCalledTimes(1);
+    expect(reviewRepository.updateReview).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
- Add a workflow summary component with accept / revise / discard action controls
- Keep the existing read-only summary component unchanged
- Route UI actions through the feature workflow hook and injected repositories
- Hide raw decision errors behind a safe UI message
- Keep original support record text out of the workflow summary

Positioning:
#2218 application workflow boundary -> this PR: human review UI workflow -> next: route/application integration or persistence adapter boundary