### PR TITLE
docs: reflect drift event bus test coverage

### DIFF
--- a/docs/testing/missing-test-candidates.md
+++ b/docs/testing/missing-test-candidates.md
@@ -12,7 +12,7 @@
 - `src/features/daily/repositories/sharepoint/activityDiary/modules/Saver.ts`
 - `src/features/daily/repositories/sharepoint/activityDiary/SharePointActivityDiaryRepository.ts`
 - `src/features/daily/repositories/sharepoint/modules/RowAggregateAccess.ts`
-- `src/features/diagnostics/drift/domain/DriftEventBus.ts`
+- `src/features/diagnostics/drift/domain/DriftEventBus.ts はテスト追加済み（#2220）`
 - `src/features/diagnostics/drift/domain/driftLogic.ts`
 - 根拠:
   - SharePoint 操作＋ドリフト監査の境界が厚い


### PR DESCRIPTION
### Summary
- Update `docs/testing/missing-test-candidates.md` to reflect that `src/features/diagnostics/drift/domain/DriftEventBus.ts` is now covered by test PR `#2220`.

### Tests
- `npm run typecheck`
- `npm run lint`
- `git diff --check`

### Scope
- docs-only