### PR TITLE
feat(record-quality): add human review route composition

### DIFF
--- a/src/app/routes/__tests__/recordRoutes.spec.tsx
+++ b/src/app/routes/__tests__/recordRoutes.spec.tsx
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+
+import { recordRoutes } from '../recordRoutes';
+
+describe('recordRoutes', () => {
+  it('exposes the record quality human review workflow route under records', () => {
+    const route = recordRoutes.find(item => item.path === 'records/quality-review');
+
+    expect(route).toBeDefined();
+    expect(route?.element).toBeTruthy();
+  });
+});

--- a/src/app/routes/lazyPages.tsx
+++ b/src/app/routes/lazyPages.tsx
@@ -11,6 +11,7 @@ import { createSuspended } from '../createSuspended';
 // ── React.lazy imports ─────────────────────────────────────────────────────
 
 const RecordList = React.lazy(() => import('@/features/records/RecordList'));
+const RecordQualityHumanReviewPage = React.lazy(() => import('@/features/record-quality/routes/RecordQualityHumanReviewPage'));
 const ChecklistPage = React.lazy(() => import('@/features/compliance-checklist/ChecklistPage'));
 const AuditPanel = React.lazy(() => import('@/features/audit/AuditPanel'));
 
@@ -126,6 +127,7 @@ export const SuspendedHealthObservationPage = createSuspended(HealthObservationP
 export const SuspendedStaffDashboardPage = createSuspended(StaffDashboardPage, 'ダッシュボードを読み込んでいます…');
 export const SuspendedAdminDashboardPage = createSuspended(AdminDashboardPage, '管理ダッシュボードを読み込んでいます…');
 export const SuspendedRecordList = createSuspended(RecordList, '記録ノートを読み込んでいます…');
+export const SuspendedRecordQualityHumanReviewPage = createSuspended(RecordQualityHumanReviewPage, '記録品質レビューを読み込んでいます…');
 export const SuspendedChecklistPage = createSuspended(ChecklistPage, '自己点検ページを読み込んでいます…');
 export const SuspendedAuditPanel = createSuspended(AuditPanel, '監査ログを読み込んでいます…');
 export const SuspendedSupportActivityMasterPage = createSuspended(SupportActivityMasterPage, '支援活動テンプレート管理を読み込んでいます…');

--- a/src/app/routes/recordRoutes.tsx
+++ b/src/app/routes/recordRoutes.tsx
@@ -15,6 +15,7 @@ import {
     SuspendedHandoffTimelinePage,
     SuspendedMonthlyRecordPage,
     SuspendedPersonalJournalPage,
+    SuspendedRecordQualityHumanReviewPage,
     SuspendedRecordList,
     SuspendedServiceProvisionFormPage,
 } from './lazyPages';
@@ -60,6 +61,14 @@ export const recordRoutes: RouteObject[] = [
     element: (
       <RequireAudience requiredRole="reception">
         <SuspendedServiceProvisionFormPage />
+      </RequireAudience>
+    ),
+  },
+  {
+    path: 'records/quality-review',
+    element: (
+      <RequireAudience requiredRole="viewer">
+        <SuspendedRecordQualityHumanReviewPage />
       </RequireAudience>
     ),
   },

--- a/src/features/record-quality/routes/RecordQualityHumanReviewPage.tsx
+++ b/src/features/record-quality/routes/RecordQualityHumanReviewPage.tsx
@@ -1,0 +1,83 @@
+import Box from '@mui/material/Box';
+import Container from '@mui/material/Container';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { useMemo } from 'react';
+
+import {
+  InMemoryRecordQualityHumanReviewQueueRepository,
+} from '@/domain/supportRecord/recordQualityHumanReviewQueue';
+import {
+  createRecordQualityReviewDraft,
+  reviseRecordQualityReviewDraft,
+  type RecordQualityReviewDraft,
+} from '@/domain/supportRecord/recordQualityReview';
+import {
+  InMemoryRecordQualityReviewRepository,
+} from '@/domain/supportRecord/recordQualityReviewRepository';
+import { HumanReviewWorkflowSummary } from '../components/HumanReviewWorkflowSummary';
+
+function createReview(recordId: string, createdAt: string): RecordQualityReviewDraft {
+  return createRecordQualityReviewDraft({
+    recordId,
+    suggestedCategories: [
+      {
+        categoryId: 'staffSupportActions',
+        matchedSignals: ['職員', '声かけ'],
+        source: 'rule',
+      },
+    ],
+    missingInformationHints: [
+      {
+        code: 'userResponseAfterSupport',
+        label: '支援後の本人の反応',
+        source: 'rule',
+      },
+    ],
+    notes: ['人間レビューで確認する'],
+    createdAt,
+  });
+}
+
+function createInitialReviews(): RecordQualityReviewDraft[] {
+  return [
+    createReview('support-record-review-1', '2026-06-11T00:00:00.000Z'),
+    reviseRecordQualityReviewDraft(
+      createReview('support-record-review-2', '2026-06-11T01:00:00.000Z'),
+      {
+        notes: ['確認観点を修正済み'],
+        updatedAt: '2026-06-11T02:00:00.000Z',
+      },
+    ),
+  ];
+}
+
+export default function RecordQualityHumanReviewPage() {
+  const repositories = useMemo(() => {
+    const reviewRepository = new InMemoryRecordQualityReviewRepository(
+      createInitialReviews(),
+    );
+    const queueRepository = new InMemoryRecordQualityHumanReviewQueueRepository(
+      reviewRepository,
+    );
+
+    return { reviewRepository, queueRepository };
+  }, []);
+
+  return (
+    <Container maxWidth="lg" sx={{ py: 3 }} data-testid="record-quality-human-review-page">
+      <Stack spacing={3}>
+        <Box>
+          <Typography variant="h5" component="h1" sx={{ fontWeight: 700 }}>
+            記録品質レビュー
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            支援記録の確認待ちレビュー
+          </Typography>
+        </Box>
+
+        <HumanReviewWorkflowSummary {...repositories} />
+      </Stack>
+    </Container>
+  );
+}

--- a/src/features/record-quality/routes/__tests__/RecordQualityHumanReviewPage.spec.tsx
+++ b/src/features/record-quality/routes/__tests__/RecordQualityHumanReviewPage.spec.tsx
@@ -1,0 +1,58 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+
+import RecordQualityHumanReviewPage from '../RecordQualityHumanReviewPage';
+
+async function clickAndFlush(
+  user: ReturnType<typeof userEvent.setup>,
+  button: HTMLElement,
+) {
+  await act(async () => {
+    await user.click(button);
+    await Promise.resolve();
+  });
+}
+
+describe('RecordQualityHumanReviewPage', () => {
+  it('composes the human review workflow summary with route-level repositories', async () => {
+    render(<RecordQualityHumanReviewPage />);
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: '記録品質レビュー' }),
+    ).toBeInTheDocument();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('record-quality-human-review-count')).toHaveTextContent(
+        '要確認 2件',
+      ),
+    );
+
+    expect(screen.getByText('support-record-review-1')).toBeInTheDocument();
+    expect(screen.getByText('support-record-review-2')).toBeInTheDocument();
+    expect(screen.queryByText('元の支援記録本文')).not.toBeInTheDocument();
+  });
+
+  it('keeps the route-level workflow interactive without persisting original record text', async () => {
+    const user = userEvent.setup();
+
+    render(<RecordQualityHumanReviewPage />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('record-quality-human-review-count')).toHaveTextContent(
+        '要確認 2件',
+      ),
+    );
+
+    await clickAndFlush(user, screen.getAllByRole('button', { name: '採用' })[0]);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('record-quality-human-review-count')).toHaveTextContent(
+        '要確認 1件',
+      ),
+    );
+    expect(screen.queryByText('support-record-review-1')).not.toBeInTheDocument();
+    expect(screen.getByText('support-record-review-2')).toBeInTheDocument();
+    expect(screen.queryByText('元の支援記録本文')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
- Add a records/quality-review route for the human review workflow
- Lazy-load the Record Quality human review page from record routes
- Compose workflow UI with in-memory review and queue repositories at route level
- Keep original support record text out of the page-level workflow
- Cover route registration and page-level interaction with focused tests

Positioning:
#2221 human review UI workflow -> this PR: route/application composition -> next: persistence adapter boundary