### PR TITLE
test(billing): keep provided mock orders in in-memory repository

### DIFF
--- a/src/features/billing/infra/__tests__/InMemoryBillingOrderRepository.spec.ts
+++ b/src/features/billing/infra/__tests__/InMemoryBillingOrderRepository.spec.ts
@@ -151,4 +151,22 @@ describe('InMemoryBillingOrderRepository', () => {
       });
     });
   });
+
+  it('uses provided initial data as-is when initialData is non-empty', async () => {
+    const repo = new InMemoryBillingOrderRepository(createBaseOrders());
+
+    const rows = await repo.list();
+    expect(rows).toEqual([
+      expect.objectContaining({
+        id: 1,
+        ordererCode: 'U-001',
+        orderCount: 1,
+      }),
+      expect.objectContaining({
+        id: 2,
+        ordererCode: 'G-001',
+        orderCount: 2,
+      }),
+    ]);
+  });
 });


### PR DESCRIPTION
### Summary
- Add a minimal boundary case to `src/features/billing/infra/__tests__/InMemoryBillingOrderRepository.spec.ts` ensuring constructor uses non-empty initial data directly.

### Tests
- `npx vitest run src/features/billing/infra/__tests__/InMemoryBillingOrderRepository.spec.ts` (pass: 1 file, 8 tests)
- `npm run typecheck` (pass)
- `npm run lint` (pass)
- `git diff --check` (pass)

### Scope
- test-only