### PR TITLE
feat(record-quality): add data provider persistence store

### DIFF
--- a/src/domain/supportRecord/dataProviderRecordQualityReviewPersistenceStore.spec.ts
+++ b/src/domain/supportRecord/dataProviderRecordQualityReviewPersistenceStore.spec.ts
@@ -1,0 +1,205 @@
+import { beforeEach, describe, expect, it, vi, type Mocked } from 'vitest';
+import type { IDataProvider } from '@/lib/data/dataProvider.interface';
+import {
+  DataProviderRecordQualityReviewPersistenceStore,
+  RECORD_QUALITY_REVIEW_FIELDS,
+} from './dataProviderRecordQualityReviewPersistenceStore';
+import type {
+  RecordQualityReviewPersistenceItem,
+} from './recordQualityReviewPersistenceMapper';
+
+const listTitle = 'RecordQualityReview_Test';
+
+const item: RecordQualityReviewPersistenceItem = {
+  recordId: 'review-1',
+  sourceRecordId: 'support-record-1',
+  status: 'draft',
+  reviewerId: 'reviewer-1',
+  reviewerName: '山田 太郎',
+  suggestedCategoriesJson: JSON.stringify([
+    {
+      categoryId: 'meal',
+      matchedSignals: ['食事'],
+      source: 'rule',
+    },
+  ]),
+  missingInfoHintsJson: JSON.stringify([
+    {
+      code: 'time',
+      label: '時刻',
+      source: 'rule',
+    },
+  ]),
+  reviewerNotesJson: JSON.stringify(['確認待ち']),
+  createdAt: '2026-06-12T09:00:00+09:00',
+  updatedAt: '2026-06-12T09:00:00+09:00',
+};
+
+const makeProvider = (): Mocked<IDataProvider> => ({
+  listItems: vi.fn(),
+  getItemById: vi.fn(),
+  createItem: vi.fn(),
+  updateItem: vi.fn(),
+  deleteItem: vi.fn(),
+  getMetadata: vi.fn(),
+  getResourceNames: vi.fn(),
+  getFieldInternalNames: vi.fn(),
+  ensureListExists: vi.fn(),
+  seed: vi.fn(),
+});
+
+describe('DataProviderRecordQualityReviewPersistenceStore', () => {
+  let provider: Mocked<IDataProvider>;
+  let store: DataProviderRecordQualityReviewPersistenceStore;
+
+  beforeEach(() => {
+    provider = makeProvider();
+    store = new DataProviderRecordQualityReviewPersistenceStore({
+      provider,
+      listTitle,
+    });
+  });
+
+  it('lists persistence items from the configured data provider list', async () => {
+    provider.listItems.mockResolvedValue([toRow(item, 10)]);
+
+    const result = await store.list();
+
+    expect(provider.listItems).toHaveBeenCalledWith(
+      listTitle,
+      expect.objectContaining({
+        select: expect.arrayContaining([
+          RECORD_QUALITY_REVIEW_FIELDS.recordId,
+          RECORD_QUALITY_REVIEW_FIELDS.sourceRecordId,
+          RECORD_QUALITY_REVIEW_FIELDS.status,
+          RECORD_QUALITY_REVIEW_FIELDS.updatedAt,
+        ]),
+        orderby: `${RECORD_QUALITY_REVIEW_FIELDS.updatedAt} asc`,
+      }),
+    );
+    expect(result).toEqual([item]);
+  });
+
+  it('gets one item by record id without loading original record text', async () => {
+    provider.listItems.mockResolvedValue([
+      {
+        ...toRow(item, 10),
+        Body: '利用者の元支援記録本文',
+      },
+    ]);
+
+    const result = await store.get(item.recordId);
+
+    expect(provider.listItems).toHaveBeenCalledWith(
+      listTitle,
+      expect.objectContaining({
+        filter: `${RECORD_QUALITY_REVIEW_FIELDS.recordId} eq '${item.recordId}'`,
+        top: 1,
+      }),
+    );
+    expect(JSON.stringify(result)).not.toContain('元支援記録本文');
+    expect(result).toEqual(item);
+  });
+
+  it('creates a row payload from persistence metadata only', async () => {
+    provider.createItem.mockResolvedValue({ Id: 11 });
+
+    await store.create(item);
+
+    expect(provider.createItem).toHaveBeenCalledWith(
+      listTitle,
+      expect.objectContaining({
+        Title: item.recordId,
+        RecordId: item.recordId,
+        SourceRecordId: item.sourceRecordId,
+        ReviewStatus: item.status,
+        SuggestedCategoriesJson: item.suggestedCategoriesJson,
+        MissingInfoHintsJson: item.missingInfoHintsJson,
+        ReviewerNotesJson: item.reviewerNotesJson,
+      }),
+    );
+
+    const [, payload] = provider.createItem.mock.calls[0];
+    expect(payload).not.toHaveProperty('Body');
+    expect(payload).not.toHaveProperty('OriginalRecordText');
+  });
+
+  it('updates an existing row by SharePoint id', async () => {
+    provider.listItems.mockResolvedValue([toRow(item, 42)]);
+    provider.updateItem.mockResolvedValue({});
+
+    const updatedItem: RecordQualityReviewPersistenceItem = {
+      ...item,
+      status: 'accepted',
+      reviewerNotesJson: JSON.stringify(['承認済み']),
+      updatedAt: '2026-06-12T10:00:00+09:00',
+    };
+
+    await store.update(updatedItem);
+
+    expect(provider.listItems).toHaveBeenCalledWith(
+      listTitle,
+      expect.objectContaining({
+        select: expect.arrayContaining([
+          'Id',
+          RECORD_QUALITY_REVIEW_FIELDS.recordId,
+        ]),
+        filter: `${RECORD_QUALITY_REVIEW_FIELDS.recordId} eq '${item.recordId}'`,
+        top: 1,
+      }),
+    );
+    expect(provider.updateItem).toHaveBeenCalledWith(
+      listTitle,
+      42,
+      expect.objectContaining({
+        RecordId: updatedItem.recordId,
+        ReviewStatus: 'accepted',
+        ReviewerNotesJson: updatedItem.reviewerNotesJson,
+        UpdatedAt: updatedItem.updatedAt,
+      }),
+      { etag: '*' },
+    );
+  });
+
+  it('rejects update when the backing row is missing', async () => {
+    provider.listItems.mockResolvedValue([]);
+
+    await expect(store.update(item)).rejects.toThrow(
+      `Record quality review persistence item not found: ${item.recordId}`,
+    );
+    expect(provider.updateItem).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed rows before returning partial persistence metadata', async () => {
+    provider.listItems.mockResolvedValue([
+      {
+        Id: 1,
+        RecordId: item.recordId,
+      },
+    ]);
+
+    await expect(store.list()).rejects.toThrow(
+      'Record quality review persistence row field is missing',
+    );
+  });
+});
+
+function toRow(
+  source: RecordQualityReviewPersistenceItem,
+  id: number,
+): Record<string, unknown> {
+  return {
+    Id: id,
+    Title: source.recordId,
+    RecordId: source.recordId,
+    SourceRecordId: source.sourceRecordId,
+    ReviewStatus: source.status,
+    ReviewerId: source.reviewerId,
+    ReviewerName: source.reviewerName,
+    SuggestedCategoriesJson: source.suggestedCategoriesJson,
+    MissingInfoHintsJson: source.missingInfoHintsJson,
+    ReviewerNotesJson: source.reviewerNotesJson,
+    CreatedAt: source.createdAt,
+    UpdatedAt: source.updatedAt,
+  };
+}

--- a/src/domain/supportRecord/dataProviderRecordQualityReviewPersistenceStore.ts
+++ b/src/domain/supportRecord/dataProviderRecordQualityReviewPersistenceStore.ts
@@ -1,0 +1,199 @@
+import type { IDataProvider } from '@/lib/data/dataProvider.interface';
+import { buildEq } from '@/sharepoint/query/builders';
+import type {
+  RecordQualityReviewRecordId,
+} from './recordQualityReviewRepository';
+import type {
+  RecordQualityReviewPersistenceItem,
+} from './recordQualityReviewPersistenceMapper';
+import type {
+  RecordQualityReviewPersistenceStore,
+} from './recordQualityReviewPersistenceRepository';
+
+export const RECORD_QUALITY_REVIEW_LIST_TITLE = 'RecordQualityReview';
+
+export const RECORD_QUALITY_REVIEW_FIELDS = {
+  title: 'Title',
+  recordId: 'RecordId',
+  sourceRecordId: 'SourceRecordId',
+  status: 'ReviewStatus',
+  reviewerId: 'ReviewerId',
+  reviewerName: 'ReviewerName',
+  suggestedCategoriesJson: 'SuggestedCategoriesJson',
+  missingInfoHintsJson: 'MissingInfoHintsJson',
+  reviewerNotesJson: 'ReviewerNotesJson',
+  createdAt: 'CreatedAt',
+  updatedAt: 'UpdatedAt',
+} as const;
+
+type RecordQualityReviewRow = {
+  readonly Id?: number;
+  readonly id?: number | string;
+  readonly Title?: string;
+  readonly RecordId?: string;
+  readonly SourceRecordId?: string;
+  readonly ReviewStatus?: RecordQualityReviewPersistenceItem['status'];
+  readonly ReviewerId?: string | null;
+  readonly ReviewerName?: string | null;
+  readonly SuggestedCategoriesJson?: string;
+  readonly MissingInfoHintsJson?: string;
+  readonly ReviewerNotesJson?: string;
+  readonly CreatedAt?: string;
+  readonly UpdatedAt?: string;
+};
+
+export type DataProviderRecordQualityReviewPersistenceStoreOptions = {
+  readonly provider: IDataProvider;
+  readonly listTitle?: string;
+};
+
+export class DataProviderRecordQualityReviewPersistenceStore
+  implements RecordQualityReviewPersistenceStore
+{
+  private readonly provider: IDataProvider;
+  private readonly listTitle: string;
+
+  constructor(options: DataProviderRecordQualityReviewPersistenceStoreOptions) {
+    this.provider = options.provider;
+    this.listTitle = options.listTitle ?? RECORD_QUALITY_REVIEW_LIST_TITLE;
+  }
+
+  async list(): Promise<readonly RecordQualityReviewPersistenceItem[]> {
+    const rows = await this.provider.listItems<RecordQualityReviewRow>(this.listTitle, {
+      select: selectFields,
+      orderby: `${RECORD_QUALITY_REVIEW_FIELDS.updatedAt} asc`,
+    });
+
+    return rows.map(fromRow);
+  }
+
+  async get(
+    recordId: RecordQualityReviewRecordId,
+  ): Promise<RecordQualityReviewPersistenceItem | null> {
+    const rows = await this.provider.listItems<RecordQualityReviewRow>(this.listTitle, {
+      select: selectFields,
+      filter: buildEq(RECORD_QUALITY_REVIEW_FIELDS.recordId, recordId),
+      top: 1,
+    });
+
+    return rows[0] ? fromRow(rows[0]) : null;
+  }
+
+  async create(
+    item: RecordQualityReviewPersistenceItem,
+  ): Promise<RecordQualityReviewPersistenceItem> {
+    await this.provider.createItem(this.listTitle, toRow(item));
+    return item;
+  }
+
+  async update(
+    item: RecordQualityReviewPersistenceItem,
+  ): Promise<RecordQualityReviewPersistenceItem> {
+    const row = await this.findRow(item.recordId);
+    if (!row) {
+      throw new Error(`Record quality review persistence item not found: ${item.recordId}`);
+    }
+
+    await this.provider.updateItem(
+      this.listTitle,
+      readSharePointId(row),
+      toRow(item),
+      { etag: '*' },
+    );
+    return item;
+  }
+
+  private async findRow(
+    recordId: RecordQualityReviewRecordId,
+  ): Promise<RecordQualityReviewRow | null> {
+    const rows = await this.provider.listItems<RecordQualityReviewRow>(this.listTitle, {
+      select: ['Id', ...selectFields],
+      filter: buildEq(RECORD_QUALITY_REVIEW_FIELDS.recordId, recordId),
+      top: 1,
+    });
+
+    return rows[0] ?? null;
+  }
+}
+
+const selectFields = [
+  RECORD_QUALITY_REVIEW_FIELDS.recordId,
+  RECORD_QUALITY_REVIEW_FIELDS.sourceRecordId,
+  RECORD_QUALITY_REVIEW_FIELDS.status,
+  RECORD_QUALITY_REVIEW_FIELDS.reviewerId,
+  RECORD_QUALITY_REVIEW_FIELDS.reviewerName,
+  RECORD_QUALITY_REVIEW_FIELDS.suggestedCategoriesJson,
+  RECORD_QUALITY_REVIEW_FIELDS.missingInfoHintsJson,
+  RECORD_QUALITY_REVIEW_FIELDS.reviewerNotesJson,
+  RECORD_QUALITY_REVIEW_FIELDS.createdAt,
+  RECORD_QUALITY_REVIEW_FIELDS.updatedAt,
+];
+
+function toRow(
+  item: RecordQualityReviewPersistenceItem,
+): Record<string, unknown> {
+  return {
+    [RECORD_QUALITY_REVIEW_FIELDS.title]: item.recordId,
+    [RECORD_QUALITY_REVIEW_FIELDS.recordId]: item.recordId,
+    [RECORD_QUALITY_REVIEW_FIELDS.sourceRecordId]: item.sourceRecordId,
+    [RECORD_QUALITY_REVIEW_FIELDS.status]: item.status,
+    [RECORD_QUALITY_REVIEW_FIELDS.reviewerId]: item.reviewerId ?? null,
+    [RECORD_QUALITY_REVIEW_FIELDS.reviewerName]: item.reviewerName ?? null,
+    [RECORD_QUALITY_REVIEW_FIELDS.suggestedCategoriesJson]: item.suggestedCategoriesJson,
+    [RECORD_QUALITY_REVIEW_FIELDS.missingInfoHintsJson]: item.missingInfoHintsJson,
+    [RECORD_QUALITY_REVIEW_FIELDS.reviewerNotesJson]: item.reviewerNotesJson,
+    [RECORD_QUALITY_REVIEW_FIELDS.createdAt]: item.createdAt,
+    [RECORD_QUALITY_REVIEW_FIELDS.updatedAt]: item.updatedAt,
+  };
+}
+
+function fromRow(row: RecordQualityReviewRow): RecordQualityReviewPersistenceItem {
+  return {
+    recordId: requireString(row.RecordId, RECORD_QUALITY_REVIEW_FIELDS.recordId),
+    sourceRecordId: requireString(
+      row.SourceRecordId,
+      RECORD_QUALITY_REVIEW_FIELDS.sourceRecordId,
+    ),
+    status: requireString(
+      row.ReviewStatus,
+      RECORD_QUALITY_REVIEW_FIELDS.status,
+    ) as RecordQualityReviewPersistenceItem['status'],
+    reviewerId: readOptionalString(row.ReviewerId),
+    reviewerName: readOptionalString(row.ReviewerName),
+    suggestedCategoriesJson: requireString(
+      row.SuggestedCategoriesJson,
+      RECORD_QUALITY_REVIEW_FIELDS.suggestedCategoriesJson,
+    ),
+    missingInfoHintsJson: requireString(
+      row.MissingInfoHintsJson,
+      RECORD_QUALITY_REVIEW_FIELDS.missingInfoHintsJson,
+    ),
+    reviewerNotesJson: requireString(
+      row.ReviewerNotesJson,
+      RECORD_QUALITY_REVIEW_FIELDS.reviewerNotesJson,
+    ),
+    createdAt: requireString(row.CreatedAt, RECORD_QUALITY_REVIEW_FIELDS.createdAt),
+    updatedAt: requireString(row.UpdatedAt, RECORD_QUALITY_REVIEW_FIELDS.updatedAt),
+  };
+}
+
+function readSharePointId(row: RecordQualityReviewRow): string | number {
+  const id = row.Id ?? row.id;
+  if (typeof id !== 'string' && typeof id !== 'number') {
+    throw new Error('Record quality review persistence row is missing SharePoint id');
+  }
+
+  return id;
+}
+
+function requireString(value: unknown, fieldName: string): string {
+  if (typeof value !== 'string') {
+    throw new Error(`Record quality review persistence row field is missing: ${fieldName}`);
+  }
+
+  return value;
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value ? value : undefined;
+}


### PR DESCRIPTION
- Add an IDataProvider-backed RecordQualityReviewPersistenceStore
- Map record quality review metadata to RecordQualityReview list rows
- Look up rows by RecordId and update them by SharePoint Id with etag
- Keep original support record text out of persistence payloads
- Cover list, get, create, update, missing row, and malformed row boundaries

Positioning:
#2225 persistence repository boundary
-> this PR: data provider persistence store adapter
-> next: route wiring to real provider / list schema provisioning