### PR TITLE
feat(record-quality): register review schema provisioning

### DIFF
--- a/src/lib/data/dataOSResourceRegistry.ts
+++ b/src/lib/data/dataOSResourceRegistry.ts
@@ -23,6 +23,10 @@ import {
   PLAN_GOAL_LIST_TITLE,
   PLAN_GOAL_ENSURE_FIELDS,
 } from '@/sharepoint/fields/planGoalFields';
+import {
+  RECORD_QUALITY_REVIEW_LIST_TITLE,
+  RECORD_QUALITY_REVIEW_PROVISIONING_FIELDS,
+} from '@/sharepoint/fields/recordQualityReviewFields';
 import type { SpFieldDef } from '@/lib/sp/types';
 
 export interface ResourceDefinition {
@@ -80,5 +84,10 @@ export const DATA_OS_RESOURCE_REGISTRY: Record<string, ResourceDefinition> = {
     resourceName: 'PlanGoal',
     defaultListTitle: PLAN_GOAL_LIST_TITLE,
     fields: [...PLAN_GOAL_ENSURE_FIELDS] as unknown as SpFieldDef[],
+  },
+  RecordQualityReview: {
+    resourceName: 'RecordQualityReview',
+    defaultListTitle: RECORD_QUALITY_REVIEW_LIST_TITLE,
+    fields: [...RECORD_QUALITY_REVIEW_PROVISIONING_FIELDS] as SpFieldDef[],
   },
 };

--- a/src/sharepoint/definitions/recordQuality.ts
+++ b/src/sharepoint/definitions/recordQuality.ts
@@ -1,0 +1,21 @@
+import {
+  RECORD_QUALITY_REVIEW_ESSENTIAL_FIELDS,
+  RECORD_QUALITY_REVIEW_LIST_TITLE,
+  RECORD_QUALITY_REVIEW_PROVISIONING_FIELDS,
+} from '@/sharepoint/fields/recordQualityReviewFields';
+import { envOr } from '../spListRegistry.shared';
+import type { SpListEntry } from '../spListRegistry.shared';
+
+export const recordQualityListEntries: readonly SpListEntry[] = [
+  {
+    key: 'record_quality_review',
+    displayName: '記録品質レビュー',
+    resolve: () =>
+      envOr('VITE_SP_LIST_RECORD_QUALITY_REVIEW', RECORD_QUALITY_REVIEW_LIST_TITLE),
+    operations: ['R', 'W'],
+    category: 'other',
+    lifecycle: 'optional',
+    essentialFields: RECORD_QUALITY_REVIEW_ESSENTIAL_FIELDS,
+    provisioningFields: RECORD_QUALITY_REVIEW_PROVISIONING_FIELDS,
+  },
+];

--- a/src/sharepoint/fields/__tests__/recordQualityReviewFields.spec.ts
+++ b/src/sharepoint/fields/__tests__/recordQualityReviewFields.spec.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import { DATA_OS_RESOURCE_REGISTRY } from '@/lib/data/dataOSResourceRegistry';
+import {
+  RECORD_QUALITY_REVIEW_FIELDS,
+} from '@/domain/supportRecord/dataProviderRecordQualityReviewPersistenceStore';
+import { findListEntry } from '@/sharepoint/spListRegistry';
+import {
+  RECORD_QUALITY_REVIEW_CANDIDATES,
+  RECORD_QUALITY_REVIEW_ESSENTIAL_FIELDS,
+  RECORD_QUALITY_REVIEW_LIST_TITLE,
+  RECORD_QUALITY_REVIEW_PROVISIONING_FIELDS,
+} from '../recordQualityReviewFields';
+
+describe('RecordQualityReview SharePoint definitions', () => {
+  it('registers the review list for optional self-healing provisioning', () => {
+    const entry = findListEntry('record_quality_review');
+
+    expect(entry).toBeDefined();
+    expect(entry?.resolve()).toBe(RECORD_QUALITY_REVIEW_LIST_TITLE);
+    expect(entry?.lifecycle).toBe('optional');
+    expect(entry?.operations).toEqual(['R', 'W']);
+    expect(entry?.essentialFields).toEqual(RECORD_QUALITY_REVIEW_ESSENTIAL_FIELDS);
+    expect(entry?.provisioningFields).toBe(RECORD_QUALITY_REVIEW_PROVISIONING_FIELDS);
+  });
+
+  it('keeps every persistence adapter field in the provisioning contract', () => {
+    const fieldNames = new Set(
+      RECORD_QUALITY_REVIEW_PROVISIONING_FIELDS.map((field) => field.internalName),
+    );
+
+    expect(fieldNames).toEqual(
+      new Set([
+        RECORD_QUALITY_REVIEW_FIELDS.recordId,
+        RECORD_QUALITY_REVIEW_FIELDS.sourceRecordId,
+        RECORD_QUALITY_REVIEW_FIELDS.status,
+        RECORD_QUALITY_REVIEW_FIELDS.reviewerId,
+        RECORD_QUALITY_REVIEW_FIELDS.reviewerName,
+        RECORD_QUALITY_REVIEW_FIELDS.suggestedCategoriesJson,
+        RECORD_QUALITY_REVIEW_FIELDS.missingInfoHintsJson,
+        RECORD_QUALITY_REVIEW_FIELDS.reviewerNotesJson,
+        RECORD_QUALITY_REVIEW_FIELDS.createdAt,
+        RECORD_QUALITY_REVIEW_FIELDS.updatedAt,
+      ]),
+    );
+  });
+
+  it('keeps original support record text out of the review schema', () => {
+    const fieldNames = RECORD_QUALITY_REVIEW_PROVISIONING_FIELDS.map(
+      (field) => field.internalName,
+    );
+
+    expect(fieldNames).not.toContain('Body');
+    expect(fieldNames).not.toContain('Content');
+    expect(fieldNames).not.toContain('OriginalRecordText');
+  });
+
+  it('defines indexed lookup fields used by the data provider store', () => {
+    const fields = new Map(
+      RECORD_QUALITY_REVIEW_PROVISIONING_FIELDS.map((field) => [
+        field.internalName,
+        field,
+      ]),
+    );
+
+    expect(fields.get(RECORD_QUALITY_REVIEW_FIELDS.recordId)).toMatchObject({
+      type: 'Text',
+      required: true,
+      indexed: true,
+    });
+    expect(fields.get(RECORD_QUALITY_REVIEW_FIELDS.updatedAt)).toMatchObject({
+      type: 'DateTime',
+      required: true,
+      indexed: true,
+      dateTimeFormat: 'DateTime',
+    });
+    expect(fields.get(RECORD_QUALITY_REVIEW_FIELDS.status)).toMatchObject({
+      type: 'Choice',
+      choices: ['draft', 'accepted', 'revised', 'discarded'],
+      default: 'draft',
+    });
+  });
+
+  it('registers the same schema in Data OS resource definitions', () => {
+    const definition = DATA_OS_RESOURCE_REGISTRY.RecordQualityReview;
+
+    expect(definition).toEqual({
+      resourceName: 'RecordQualityReview',
+      defaultListTitle: RECORD_QUALITY_REVIEW_LIST_TITLE,
+      fields: RECORD_QUALITY_REVIEW_PROVISIONING_FIELDS,
+    });
+  });
+
+  it('uses canonical names first and includes encoded SharePoint candidates', () => {
+    expect(RECORD_QUALITY_REVIEW_CANDIDATES.recordId[0]).toBe('RecordId');
+    expect(RECORD_QUALITY_REVIEW_CANDIDATES.recordId).toContain('Record_x0020_ID');
+    expect(RECORD_QUALITY_REVIEW_CANDIDATES.sourceRecordId[0]).toBe(
+      'SourceRecordId',
+    );
+    expect(RECORD_QUALITY_REVIEW_CANDIDATES.sourceRecordId).toContain(
+      'Source_x0020_Record_x0020_ID',
+    );
+    expect(RECORD_QUALITY_REVIEW_CANDIDATES.reviewerNotesJson).toContain(
+      'Reviewer_x0020_Notes_x0020_JSON',
+    );
+  });
+});

--- a/src/sharepoint/fields/index.ts
+++ b/src/sharepoint/fields/index.ts
@@ -135,6 +135,14 @@ export {
     SUPPORT_CASE_RESTRICTED_DOCUMENTS_PROVISIONING_FIELDS,
 } from './supportCaseFields';
 
+// ── RecordQualityReview ──
+export {
+    RECORD_QUALITY_REVIEW_CANDIDATES,
+    RECORD_QUALITY_REVIEW_ESSENTIAL_FIELDS,
+    RECORD_QUALITY_REVIEW_LIST_TITLE,
+    RECORD_QUALITY_REVIEW_PROVISIONING_FIELDS,
+} from './recordQualityReviewFields';
+
 // ── Iceberg ──
 export {
     buildIcebergPdcaSelectFields, FIELD_MAP_ICEBERG_ANALYSIS,

--- a/src/sharepoint/fields/recordQualityReviewFields.ts
+++ b/src/sharepoint/fields/recordQualityReviewFields.ts
@@ -1,0 +1,128 @@
+import type { SpFieldDef } from '@/lib/sp/types';
+import {
+  RECORD_QUALITY_REVIEW_FIELDS,
+  RECORD_QUALITY_REVIEW_LIST_TITLE,
+} from '@/domain/supportRecord/dataProviderRecordQualityReviewPersistenceStore';
+
+export { RECORD_QUALITY_REVIEW_LIST_TITLE };
+
+export const RECORD_QUALITY_REVIEW_CANDIDATES = {
+  recordId: [RECORD_QUALITY_REVIEW_FIELDS.recordId, 'Record_x0020_ID'],
+  sourceRecordId: [
+    RECORD_QUALITY_REVIEW_FIELDS.sourceRecordId,
+    'Source_x0020_Record_x0020_ID',
+  ],
+  status: [RECORD_QUALITY_REVIEW_FIELDS.status, 'Review_x0020_Status'],
+  reviewerId: [RECORD_QUALITY_REVIEW_FIELDS.reviewerId, 'Reviewer_x0020_ID'],
+  reviewerName: [
+    RECORD_QUALITY_REVIEW_FIELDS.reviewerName,
+    'Reviewer_x0020_Name',
+  ],
+  suggestedCategoriesJson: [
+    RECORD_QUALITY_REVIEW_FIELDS.suggestedCategoriesJson,
+    'Suggested_x0020_Categories_x0020_JSON',
+  ],
+  missingInfoHintsJson: [
+    RECORD_QUALITY_REVIEW_FIELDS.missingInfoHintsJson,
+    'Missing_x0020_Info_x0020_Hints_x0020_JSON',
+  ],
+  reviewerNotesJson: [
+    RECORD_QUALITY_REVIEW_FIELDS.reviewerNotesJson,
+    'Reviewer_x0020_Notes_x0020_JSON',
+  ],
+  createdAt: [RECORD_QUALITY_REVIEW_FIELDS.createdAt, 'Created_x0020_At'],
+  updatedAt: [RECORD_QUALITY_REVIEW_FIELDS.updatedAt, 'Updated_x0020_At'],
+} as const;
+
+export const RECORD_QUALITY_REVIEW_ESSENTIAL_FIELDS = [
+  RECORD_QUALITY_REVIEW_FIELDS.recordId,
+  RECORD_QUALITY_REVIEW_FIELDS.sourceRecordId,
+  RECORD_QUALITY_REVIEW_FIELDS.status,
+  RECORD_QUALITY_REVIEW_FIELDS.suggestedCategoriesJson,
+  RECORD_QUALITY_REVIEW_FIELDS.missingInfoHintsJson,
+  RECORD_QUALITY_REVIEW_FIELDS.reviewerNotesJson,
+  RECORD_QUALITY_REVIEW_FIELDS.createdAt,
+  RECORD_QUALITY_REVIEW_FIELDS.updatedAt,
+] as const;
+
+export const RECORD_QUALITY_REVIEW_PROVISIONING_FIELDS = [
+  {
+    internalName: RECORD_QUALITY_REVIEW_FIELDS.recordId,
+    type: 'Text',
+    displayName: 'Record ID',
+    required: true,
+    indexed: true,
+    candidates: RECORD_QUALITY_REVIEW_CANDIDATES.recordId,
+  },
+  {
+    internalName: RECORD_QUALITY_REVIEW_FIELDS.sourceRecordId,
+    type: 'Text',
+    displayName: 'Source Record ID',
+    required: true,
+    indexed: true,
+    candidates: RECORD_QUALITY_REVIEW_CANDIDATES.sourceRecordId,
+  },
+  {
+    internalName: RECORD_QUALITY_REVIEW_FIELDS.status,
+    type: 'Choice',
+    displayName: 'Review Status',
+    required: true,
+    indexed: true,
+    choices: ['draft', 'accepted', 'revised', 'discarded'],
+    default: 'draft',
+    candidates: RECORD_QUALITY_REVIEW_CANDIDATES.status,
+  },
+  {
+    internalName: RECORD_QUALITY_REVIEW_FIELDS.reviewerId,
+    type: 'Text',
+    displayName: 'Reviewer ID',
+    candidates: RECORD_QUALITY_REVIEW_CANDIDATES.reviewerId,
+  },
+  {
+    internalName: RECORD_QUALITY_REVIEW_FIELDS.reviewerName,
+    type: 'Text',
+    displayName: 'Reviewer Name',
+    candidates: RECORD_QUALITY_REVIEW_CANDIDATES.reviewerName,
+  },
+  {
+    internalName: RECORD_QUALITY_REVIEW_FIELDS.suggestedCategoriesJson,
+    type: 'Note',
+    displayName: 'Suggested Categories JSON',
+    required: true,
+    richText: false,
+    candidates: RECORD_QUALITY_REVIEW_CANDIDATES.suggestedCategoriesJson,
+  },
+  {
+    internalName: RECORD_QUALITY_REVIEW_FIELDS.missingInfoHintsJson,
+    type: 'Note',
+    displayName: 'Missing Info Hints JSON',
+    required: true,
+    richText: false,
+    candidates: RECORD_QUALITY_REVIEW_CANDIDATES.missingInfoHintsJson,
+  },
+  {
+    internalName: RECORD_QUALITY_REVIEW_FIELDS.reviewerNotesJson,
+    type: 'Note',
+    displayName: 'Reviewer Notes JSON',
+    required: true,
+    richText: false,
+    candidates: RECORD_QUALITY_REVIEW_CANDIDATES.reviewerNotesJson,
+  },
+  {
+    internalName: RECORD_QUALITY_REVIEW_FIELDS.createdAt,
+    type: 'DateTime',
+    displayName: 'Created At',
+    required: true,
+    dateTimeFormat: 'DateTime',
+    candidates: RECORD_QUALITY_REVIEW_CANDIDATES.createdAt,
+  },
+  {
+    internalName: RECORD_QUALITY_REVIEW_FIELDS.updatedAt,
+    type: 'DateTime',
+    displayName: 'Updated At',
+    required: true,
+    indexed: true,
+    dateTimeFormat: 'DateTime',
+    candidates: RECORD_QUALITY_REVIEW_CANDIDATES.updatedAt,
+  },
+] as const satisfies readonly SpFieldDef[];

--- a/src/sharepoint/spListRegistry.definitions.ts
+++ b/src/sharepoint/spListRegistry.definitions.ts
@@ -8,6 +8,7 @@ import { handoffListEntries } from './definitions/handoff';
 import { complianceListEntries } from './definitions/compliance';
 import { otherListEntries } from './definitions/other';
 import { supportCaseListEntries } from './definitions/supportCase';
+import { recordQualityListEntries } from './definitions/recordQuality';
 
 export {
   masterListEntries,
@@ -19,6 +20,7 @@ export {
   complianceListEntries,
   otherListEntries,
   supportCaseListEntries,
+  recordQualityListEntries,
 };
 
 /** 全リスト定義の統合（参照等価性を維持するため） */
@@ -32,4 +34,5 @@ export const listDefinitions: readonly SpListEntry[] = [
   ...complianceListEntries,
   ...otherListEntries,
   ...supportCaseListEntries,
+  ...recordQualityListEntries,
 ];


### PR DESCRIPTION
- Add RecordQualityReview SharePoint field definitions
- Register the review list in SP_LIST_REGISTRY for optional self-healing provisioning
- Register the same schema in DATA_OS_RESOURCE_REGISTRY
- Keep provisioning fields aligned with the data provider persistence store
- Guard that original support record text is not part of the review schema

Positioning:
#2227 data provider persistence store adapter
-> this PR: review schema provisioning
-> next: route wiring to real provider / workflow boundary