### PR TITLE
test(sp): cover ensureListExists policy boundary on create

### DIFF
--- a/src/lib/sp/__tests__/spListSchema.spec.ts
+++ b/src/lib/sp/__tests__/spListSchema.spec.ts
@@ -72,4 +72,36 @@ describe('ensureListExists boundaries', () => {
       title: 'BillingOrders',
     });
   });
+
+  it('preventPhysicalCreation が true の場合、リスト作成後にフィールド追加は行わない', async () => {
+    const spFetch = vi.fn()
+      .mockRejectedValueOnce({ status: 404 })
+      .mockResolvedValueOnce(jsonResponse({
+        Id: '{33333333-3333-3333-3333-333333333333}',
+        Title: 'QAList',
+      }));
+
+    const result = await ensureListExists(
+      spFetch,
+      'QAList',
+      [{ internalName: 'NewColumn', typeAsString: 'Text', required: true }],
+      { preventPhysicalCreation: true },
+    );
+
+    expect(spFetch).toHaveBeenCalledTimes(2);
+    expect(spFetch).toHaveBeenNthCalledWith(
+      2,
+      '/lists',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json;odata=verbose',
+        }),
+      }),
+    );
+    expect(result).toEqual({
+      listId: '33333333-3333-3333-3333-333333333333',
+      title: 'QAList',
+    });
+  });
 });


### PR DESCRIPTION
### Summary
- Add a minimal boundary test for `ensureListExists` when `preventPhysicalCreation: true` and the target list does not exist.
- Verifies list creation path is executed and field creation is skipped under policy mode.

### Tests
- `npx vitest run src/lib/sp/__tests__/spListSchema.spec.ts` (pass: 1 file, 3 tests)
- `npm run typecheck` (pass)
- `npm run lint` (pass)
- `git diff --check` (pass)

### Scope
- test-only