### PR TITLE
feat(record-quality): wire review route to data provider

### DIFF
--- a/src/features/record-quality/routes/RecordQualityHumanReviewPage.tsx
+++ b/src/features/record-quality/routes/RecordQualityHumanReviewPage.tsx
@@ -5,64 +5,29 @@ import Typography from '@mui/material/Typography';
 import { useMemo } from 'react';
 
 import {
+  DataProviderRecordQualityReviewPersistenceStore,
+} from '@/domain/supportRecord/dataProviderRecordQualityReviewPersistenceStore';
+import {
   InMemoryRecordQualityHumanReviewQueueRepository,
 } from '@/domain/supportRecord/recordQualityHumanReviewQueue';
 import {
-  createRecordQualityReviewDraft,
-  reviseRecordQualityReviewDraft,
-  type RecordQualityReviewDraft,
-} from '@/domain/supportRecord/recordQualityReview';
-import {
-  InMemoryRecordQualityReviewRepository,
-} from '@/domain/supportRecord/recordQualityReviewRepository';
+  RecordQualityReviewPersistenceRepository,
+} from '@/domain/supportRecord/recordQualityReviewPersistenceRepository';
+import { useDataProvider } from '@/lib/data/useDataProvider';
 import { HumanReviewWorkflowSummary } from '../components/HumanReviewWorkflowSummary';
 
-function createReview(recordId: string, createdAt: string): RecordQualityReviewDraft {
-  return createRecordQualityReviewDraft({
-    recordId,
-    suggestedCategories: [
-      {
-        categoryId: 'staffSupportActions',
-        matchedSignals: ['職員', '声かけ'],
-        source: 'rule',
-      },
-    ],
-    missingInformationHints: [
-      {
-        code: 'userResponseAfterSupport',
-        label: '支援後の本人の反応',
-        source: 'rule',
-      },
-    ],
-    notes: ['人間レビューで確認する'],
-    createdAt,
-  });
-}
-
-function createInitialReviews(): RecordQualityReviewDraft[] {
-  return [
-    createReview('support-record-review-1', '2026-06-11T00:00:00.000Z'),
-    reviseRecordQualityReviewDraft(
-      createReview('support-record-review-2', '2026-06-11T01:00:00.000Z'),
-      {
-        notes: ['確認観点を修正済み'],
-        updatedAt: '2026-06-11T02:00:00.000Z',
-      },
-    ),
-  ];
-}
-
 export default function RecordQualityHumanReviewPage() {
+  const { provider } = useDataProvider();
   const repositories = useMemo(() => {
-    const reviewRepository = new InMemoryRecordQualityReviewRepository(
-      createInitialReviews(),
+    const reviewRepository = new RecordQualityReviewPersistenceRepository(
+      new DataProviderRecordQualityReviewPersistenceStore({ provider }),
     );
     const queueRepository = new InMemoryRecordQualityHumanReviewQueueRepository(
       reviewRepository,
     );
 
     return { reviewRepository, queueRepository };
-  }, []);
+  }, [provider]);
 
   return (
     <Container maxWidth="lg" sx={{ py: 3 }} data-testid="record-quality-human-review-page">

--- a/src/features/record-quality/routes/__tests__/RecordQualityHumanReviewPage.spec.tsx
+++ b/src/features/record-quality/routes/__tests__/RecordQualityHumanReviewPage.spec.tsx
@@ -1,8 +1,20 @@
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi, type Mocked } from 'vitest';
 
+import type { IDataProvider } from '@/lib/data/dataProvider.interface';
 import RecordQualityHumanReviewPage from '../RecordQualityHumanReviewPage';
+
+const provider = vi.hoisted(() => ({
+  current: null as Mocked<IDataProvider> | null,
+}));
+
+vi.mock('@/lib/data/useDataProvider', () => ({
+  useDataProvider: () => ({
+    provider: provider.current,
+    type: 'sharepoint',
+  }),
+}));
 
 async function clickAndFlush(
   user: ReturnType<typeof userEvent.setup>,
@@ -15,7 +27,34 @@ async function clickAndFlush(
 }
 
 describe('RecordQualityHumanReviewPage', () => {
-  it('composes the human review workflow summary with route-level repositories', async () => {
+  beforeEach(() => {
+    provider.current = makeProvider([
+      createRow({
+        id: 1,
+        recordId: 'review-1',
+        sourceRecordId: 'support-record-review-1',
+        status: 'draft',
+        updatedAt: '2026-06-11T00:00:00.000Z',
+      }),
+      createRow({
+        id: 2,
+        recordId: 'review-2',
+        sourceRecordId: 'support-record-review-2',
+        status: 'revised',
+        notes: ['確認観点を修正済み'],
+        updatedAt: '2026-06-11T02:00:00.000Z',
+      }),
+      createRow({
+        id: 3,
+        recordId: 'review-3',
+        sourceRecordId: 'support-record-review-3',
+        status: 'accepted',
+        updatedAt: '2026-06-11T03:00:00.000Z',
+      }),
+    ]);
+  });
+
+  it('composes the human review workflow summary with the data provider repository', async () => {
     render(<RecordQualityHumanReviewPage />);
 
     expect(
@@ -30,10 +69,18 @@ describe('RecordQualityHumanReviewPage', () => {
 
     expect(screen.getByText('support-record-review-1')).toBeInTheDocument();
     expect(screen.getByText('support-record-review-2')).toBeInTheDocument();
+    expect(screen.queryByText('support-record-review-3')).not.toBeInTheDocument();
     expect(screen.queryByText('元の支援記録本文')).not.toBeInTheDocument();
+
+    expect(provider.current?.listItems).toHaveBeenCalledWith(
+      'RecordQualityReview',
+      expect.objectContaining({
+        orderby: 'UpdatedAt asc',
+      }),
+    );
   });
 
-  it('keeps the route-level workflow interactive without persisting original record text', async () => {
+  it('keeps the data provider workflow interactive without persisting original record text', async () => {
     const user = userEvent.setup();
 
     render(<RecordQualityHumanReviewPage />);
@@ -54,5 +101,113 @@ describe('RecordQualityHumanReviewPage', () => {
     expect(screen.queryByText('support-record-review-1')).not.toBeInTheDocument();
     expect(screen.getByText('support-record-review-2')).toBeInTheDocument();
     expect(screen.queryByText('元の支援記録本文')).not.toBeInTheDocument();
+
+    expect(provider.current?.updateItem).toHaveBeenCalledWith(
+      'RecordQualityReview',
+      1,
+      expect.objectContaining({
+        RecordId: 'review-1',
+        SourceRecordId: 'support-record-review-1',
+        ReviewStatus: 'accepted',
+      }),
+      { etag: '*' },
+    );
+    const [, , payload] = provider.current?.updateItem.mock.calls[0] ?? [];
+    expect(payload).not.toHaveProperty('Body');
+    expect(payload).not.toHaveProperty('OriginalRecordText');
   });
 });
+
+type RecordQualityReviewRow = {
+  Id: number;
+  Title: string;
+  RecordId: string;
+  SourceRecordId: string;
+  ReviewStatus: string;
+  ReviewerId: string | null;
+  ReviewerName: string | null;
+  SuggestedCategoriesJson: string;
+  MissingInfoHintsJson: string;
+  ReviewerNotesJson: string;
+  CreatedAt: string;
+  UpdatedAt: string;
+};
+
+function makeProvider(seed: RecordQualityReviewRow[]): Mocked<IDataProvider> {
+  let rows = seed.map(row => ({ ...row }));
+  const mockProvider: Mocked<IDataProvider> = {
+    listItems: vi.fn(async (_resourceName, options) => {
+      if (options?.filter?.includes('RecordId eq')) {
+        const match = options.filter.match(/RecordId eq '([^']+)'/);
+        const recordId = match?.[1];
+        return rows.filter(row => row.RecordId === recordId);
+      }
+
+      return rows;
+    }),
+    getItemById: vi.fn(),
+    createItem: vi.fn(),
+    updateItem: vi.fn(async (_resourceName, id, payload) => {
+      rows = rows.map(row =>
+        row.Id === id
+          ? {
+              ...row,
+              ...payload,
+            }
+          : row,
+      );
+      return rows.find(row => row.Id === id) ?? {};
+    }),
+    deleteItem: vi.fn(),
+    getMetadata: vi.fn(),
+    getResourceNames: vi.fn(),
+    getFieldInternalNames: vi.fn(),
+    ensureListExists: vi.fn(),
+    seed: vi.fn(),
+  };
+
+  return mockProvider;
+}
+
+function createRow({
+  id,
+  recordId,
+  sourceRecordId,
+  status,
+  notes = ['人間レビューで確認する'],
+  updatedAt,
+}: {
+  readonly id: number;
+  readonly recordId: string;
+  readonly sourceRecordId: string;
+  readonly status: string;
+  readonly notes?: readonly string[];
+  readonly updatedAt: string;
+}): RecordQualityReviewRow {
+  return {
+    Id: id,
+    Title: recordId,
+    RecordId: recordId,
+    SourceRecordId: sourceRecordId,
+    ReviewStatus: status,
+    ReviewerId: null,
+    ReviewerName: null,
+    SuggestedCategoriesJson: JSON.stringify([
+      {
+        categoryId: 'staffSupportActions',
+        matchedSignals: ['職員', '声かけ'],
+        source: 'rule',
+      },
+    ]),
+    MissingInfoHintsJson: JSON.stringify([
+      {
+        code: 'userResponseAfterSupport',
+        label: '支援後の本人の反応',
+        source: 'rule',
+      },
+    ]),
+    ReviewerNotesJson: JSON.stringify(notes),
+    CreatedAt: '2026-06-11T00:00:00.000Z',
+    UpdatedAt: updatedAt,
+  };
+}


### PR DESCRIPTION
- Replace route-level fixture repository with the DataProvider-backed persistence repository
- Compose the human review queue from persisted review metadata at the route boundary
- Keep accept/revise/discard actions flowing through the persistence store update path
- Keep original support record text out of route rendering and update payloads
- Cover route wiring with a mocked IDataProvider

Positioning:
#2229 review schema provisioning
-> this PR: route wiring to data provider
-> next: workflow boundary / review creation path