### PR TITLE
docs(record-quality): document daily save observability

### DIFF
--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -23,6 +23,7 @@
 - [Corrective-Action Telemetry Review](./corrective-action-telemetry-review.md)
 - [ExceptionCenter Horizontal Rollout](./exception-center-horizontal-rollout.md)
 - [ExceptionCenter Priority Week-1 Review](./exception-center-priority-week1-review.md)
+- [Record Quality Review Observability](./record-quality-review-observability.md)
 - [Transport Assignment Page Spec (Phase 1)](./transport-assignment-page-spec.md)
 - [Transport Nightly Critical E2E](./transport-nightly-critical-e2e.md)
 - [TransportCourse Migration](./transport-course-migration.md)

--- a/docs/runbooks/record-quality-review-observability.md
+++ b/docs/runbooks/record-quality-review-observability.md
@@ -1,0 +1,41 @@
+# Record Quality Review Observability
+
+Record Quality Review の下書き作成を Daily record save 後に確認するための runbook。
+
+この runbook は、レビュー下書きが安全に作られ、件数を追える状態を運用契約として固定する。AI評価ロジック、現場画面の警告表示、skip reason の詳細分離は対象外とする。
+
+## Daily save observability
+
+`record-quality:daily-save` logs review draft creation counts after Daily record save.
+
+- `createdReviewCount`
+  - Number of new Record Quality Review draft records created.
+- `skippedReviewCount`
+  - Number of user rows skipped because they were not review targets or already had a review draft.
+- `userRowCount`
+  - Number of user rows included in the Daily save operation.
+- No original support record body is stored in logs or review metadata.
+
+## Review Procedure
+
+1. Save a Daily record.
+2. Find the `record-quality:daily-save` log entry.
+3. Confirm `userRowCount` matches the Daily save target user rows.
+4. Confirm `createdReviewCount + skippedReviewCount` is explainable from the Daily save target rows.
+5. Confirm logs and review metadata do not include original support record body text.
+
+## Operational Contract
+
+- `createdReviewCount` tracks new review drafts only.
+- `skippedReviewCount` is an aggregate skip count until skip reason metrics are split.
+- `userRowCount` is the denominator for Daily save review draft creation.
+- Daily save must remain successful when a row is skipped for an empty review target or an existing review draft.
+- Review metadata must reference the source support record by ID and must not copy the original body.
+
+## Out of Scope
+
+- Splitting `skippedReviewCount` by skip reason.
+- Queue summary safety display.
+- SharePoint diagnostics for the Record Quality Review persistence lane.
+- AI evaluation or automatic support-record judgment.
+- Field-screen warning display.


### PR DESCRIPTION
## Summary

- Add a runbook for Record Quality Review observability during Daily record save.
- Document the operational meaning of `createdReviewCount`, `skippedReviewCount`, and `userRowCount`.
- Link the new runbook from the runbooks README.

## Observability contract

`record-quality:daily-save` records count-level metadata after Daily record save.

- `createdReviewCount`: number of new Record Quality Review draft records created.
- `skippedReviewCount`: number of user rows skipped because they were not review targets, empty, or already had a review draft.
- `userRowCount`: number of user rows included in the Daily save operation.

## Privacy boundary

Original support-record body text is not copied into logs or review metadata.  
This observability contract tracks counts only.

## Verification

- `npx vitest run src/features/record-quality/application/saveDailyRecordWithQualityReview.spec.ts`
- `npm run typecheck`
- `npm run lint:docs`

## Out of scope

- Splitting `skippedReviewCount` into detailed skip reasons.
- Human Review Queue summary UI changes.
- SharePoint persistence diagnostics.
- AI scoring or advanced review logic.
- Monthly report automation.
