### PR TITLE
feat(record-quality): split skipped review reasons

### DIFF
--- a/docs/runbooks/record-quality-review-observability.md
+++ b/docs/runbooks/record-quality-review-observability.md
@@ -2,7 +2,7 @@
 
 Record Quality Review の下書き作成を Daily record save 後に確認するための runbook。
 
-この runbook は、レビュー下書きが安全に作られ、件数を追える状態を運用契約として固定する。AI評価ロジック、現場画面の警告表示、skip reason の詳細分離は対象外とする。
+この runbook は、レビュー下書きが安全に作られ、件数とスキップ理由を追える状態を運用契約として固定する。AI評価ロジック、現場画面の警告表示、Queue UI、SharePoint 診断は対象外とする。
 
 ## Daily save observability
 
@@ -11,7 +11,12 @@ Record Quality Review の下書き作成を Daily record save 後に確認する
 - `createdReviewCount`
   - Number of new Record Quality Review draft records created.
 - `skippedReviewCount`
-  - Number of user rows skipped because they were not review targets or already had a review draft.
+  - Total number of skipped user rows.
+  - Derivable from `emptyTextSkippedReviewCount + existingReviewSkippedReviewCount`.
+- `emptyTextSkippedReviewCount`
+  - Number of user rows skipped because no reviewable support text was present.
+- `existingReviewSkippedReviewCount`
+  - Number of user rows skipped because a review draft already existed.
 - `userRowCount`
   - Number of user rows included in the Daily save operation.
 - No original support record body is stored in logs or review metadata.
@@ -27,14 +32,14 @@ Record Quality Review の下書き作成を Daily record save 後に確認する
 ## Operational Contract
 
 - `createdReviewCount` tracks new review drafts only.
-- `skippedReviewCount` is an aggregate skip count until skip reason metrics are split.
+- `skippedReviewCount` remains the aggregate skip count for compatibility.
+- `emptyTextSkippedReviewCount` and `existingReviewSkippedReviewCount` are the skip reason counters.
 - `userRowCount` is the denominator for Daily save review draft creation.
 - Daily save must remain successful when a row is skipped for an empty review target or an existing review draft.
 - Review metadata must reference the source support record by ID and must not copy the original body.
 
 ## Out of Scope
 
-- Splitting `skippedReviewCount` by skip reason.
 - Queue summary safety display.
 - SharePoint diagnostics for the Record Quality Review persistence lane.
 - AI evaluation or automatic support-record judgment.

--- a/src/features/daily/__tests__/useTableDailyRecordViewModel.spec.ts
+++ b/src/features/daily/__tests__/useTableDailyRecordViewModel.spec.ts
@@ -28,6 +28,8 @@ const mocks = vi.hoisted(() => {
       savedDailyRecord: true,
       createdReviewCount: 1,
       skippedReviewCount: 0,
+      emptyTextSkippedReviewCount: 0,
+      existingReviewSkippedReviewCount: 0,
     }),
   };
 });
@@ -77,6 +79,8 @@ describe('useTableDailyRecordViewModel', () => {
       savedDailyRecord: true,
       createdReviewCount: 1,
       skippedReviewCount: 0,
+      emptyTextSkippedReviewCount: 0,
+      existingReviewSkippedReviewCount: 0,
     });
     vi.mocked(toast.error).mockClear();
   });

--- a/src/features/record-quality/application/saveDailyRecordWithQualityReview.spec.ts
+++ b/src/features/record-quality/application/saveDailyRecordWithQualityReview.spec.ts
@@ -38,6 +38,8 @@ describe('saveDailyRecordWithQualityReview', () => {
       savedDailyRecord: true,
       createdReviewCount: 2,
       skippedReviewCount: 0,
+      emptyTextSkippedReviewCount: 0,
+      existingReviewSkippedReviewCount: 0,
     });
     expect(auditLogInfo).toHaveBeenCalledWith(
       'record-quality:daily-save',
@@ -47,6 +49,8 @@ describe('saveDailyRecordWithQualityReview', () => {
         userRowCount: 2,
         createdReviewCount: 2,
         skippedReviewCount: 0,
+        emptyTextSkippedReviewCount: 0,
+        existingReviewSkippedReviewCount: 0,
       },
     );
     await expect(
@@ -121,6 +125,11 @@ describe('saveDailyRecordWithQualityReview', () => {
 
     expect(result.createdReviewCount).toBe(0);
     expect(result.skippedReviewCount).toBe(1);
+    expect(result.emptyTextSkippedReviewCount).toBe(1);
+    expect(result.existingReviewSkippedReviewCount).toBe(0);
+    expect(result.skippedReviewCount).toBe(
+      result.emptyTextSkippedReviewCount + result.existingReviewSkippedReviewCount,
+    );
     await expect(
       reviewRepository.getReview('daily:2026-06-12:empty-user'),
     ).resolves.toBeNull();
@@ -150,7 +159,80 @@ describe('saveDailyRecordWithQualityReview', () => {
       savedDailyRecord: true,
       createdReviewCount: 0,
       skippedReviewCount: 2,
+      emptyTextSkippedReviewCount: 0,
+      existingReviewSkippedReviewCount: 2,
     });
+  });
+
+  it('splits empty text and existing review skips without storing original body text', async () => {
+    const dailyRepository = createDailyRepository();
+    const reviewRepository = new InMemoryRecordQualityReviewRepository();
+    const sensitiveBody = '本文をログや戻り値に含めない。';
+    const input = {
+      ...createDailyRecordInput({ specialNotes: sensitiveBody }),
+      userRows: [
+        createDailyRecordInput({ specialNotes: sensitiveBody }).userRows[0],
+        {
+          userId: 'empty-user',
+          userName: '空欄 利用者',
+          amActivity: '',
+          pmActivity: '',
+          lunchAmount: '',
+          specialNotes: '',
+          problemBehavior: {
+            selfHarm: false,
+            otherInjury: false,
+            loudVoice: false,
+            pica: false,
+            other: false,
+          },
+          behaviorTags: [],
+        },
+      ],
+      userCount: 2,
+    };
+
+    await saveDailyRecordWithQualityReview({
+      dailyRepository,
+      reviewRepository,
+      input,
+      createdAt: '2026-06-12T09:00:00.000Z',
+    });
+
+    const result = await saveDailyRecordWithQualityReview({
+      dailyRepository,
+      reviewRepository,
+      input,
+      createdAt: '2026-06-12T10:00:00.000Z',
+    });
+
+    expect(dailyRepository.save).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({
+      savedDailyRecord: true,
+      createdReviewCount: 0,
+      skippedReviewCount: 2,
+      emptyTextSkippedReviewCount: 1,
+      existingReviewSkippedReviewCount: 1,
+    });
+    expect(result.skippedReviewCount).toBe(
+      result.emptyTextSkippedReviewCount + result.existingReviewSkippedReviewCount,
+    );
+    expect(auditLogInfo).toHaveBeenLastCalledWith(
+      'record-quality:daily-save',
+      'Review metadata creation completed',
+      {
+        date: '2026-06-12',
+        userRowCount: 2,
+        createdReviewCount: 0,
+        skippedReviewCount: 2,
+        emptyTextSkippedReviewCount: 1,
+        existingReviewSkippedReviewCount: 1,
+      },
+    );
+    const review = await reviewRepository.getReview('daily:2026-06-12:user-1');
+    expect(JSON.stringify(review)).not.toContain(sensitiveBody);
+    expect(JSON.stringify(result)).not.toContain(sensitiveBody);
+    expect(JSON.stringify(auditLogInfo.mock.calls)).not.toContain(sensitiveBody);
   });
 
   it('passes mutation params to the daily repository save boundary', async () => {

--- a/src/features/record-quality/application/saveDailyRecordWithQualityReview.ts
+++ b/src/features/record-quality/application/saveDailyRecordWithQualityReview.ts
@@ -22,6 +22,8 @@ export type SaveDailyRecordWithQualityReviewResult = {
   readonly savedDailyRecord: true;
   readonly createdReviewCount: number;
   readonly skippedReviewCount: number;
+  readonly emptyTextSkippedReviewCount: number;
+  readonly existingReviewSkippedReviewCount: number;
 };
 
 export async function saveDailyRecordWithQualityReview(
@@ -30,19 +32,20 @@ export async function saveDailyRecordWithQualityReview(
   await input.dailyRepository.save(input.input, input.mutationParams);
 
   let createdReviewCount = 0;
-  let skippedReviewCount = 0;
+  let emptyTextSkippedReviewCount = 0;
+  let existingReviewSkippedReviewCount = 0;
 
   for (const row of input.input.userRows) {
     const recordId = buildDailyRecordQualityReviewId(input.input.date, row.userId);
     const text = buildReviewableSupportRecordText(row);
     if (!text) {
-      skippedReviewCount += 1;
+      emptyTextSkippedReviewCount += 1;
       continue;
     }
 
     const existing = await input.reviewRepository.getReview(recordId);
     if (existing) {
-      skippedReviewCount += 1;
+      existingReviewSkippedReviewCount += 1;
       continue;
     }
 
@@ -55,17 +58,23 @@ export async function saveDailyRecordWithQualityReview(
     createdReviewCount += 1;
   }
 
+  const skippedReviewCount = emptyTextSkippedReviewCount + existingReviewSkippedReviewCount;
+
   auditLog.info('record-quality:daily-save', 'Review metadata creation completed', {
     date: input.input.date,
     userRowCount: input.input.userRows.length,
     createdReviewCount,
     skippedReviewCount,
+    emptyTextSkippedReviewCount,
+    existingReviewSkippedReviewCount,
   });
 
   return {
     savedDailyRecord: true,
     createdReviewCount,
     skippedReviewCount,
+    emptyTextSkippedReviewCount,
+    existingReviewSkippedReviewCount,
   };
 }
 


### PR DESCRIPTION
## Summary

- Split Daily save review skips into `emptyTextSkippedReviewCount` and `existingReviewSkippedReviewCount`.
- Keep `skippedReviewCount` as the aggregate compatibility count derived from the two skip reason counters.
- Update Record Quality observability runbook and related tests to document the new counters.

## Observability contract

`record-quality:daily-save` now records both aggregate and reason-level skip counts after Daily record save.

- `createdReviewCount`: number of new Record Quality Review draft records created.
- `skippedReviewCount`: aggregate skipped row count.
- `emptyTextSkippedReviewCount`: rows skipped because no reviewable support text was present.
- `existingReviewSkippedReviewCount`: rows skipped because a review draft already existed.
- `userRowCount`: number of user rows included in the Daily save operation.

`skippedReviewCount` remains derivable from `emptyTextSkippedReviewCount + existingReviewSkippedReviewCount`.

## Privacy boundary

Original support-record body text is still not copied into logs, returned result data, or review metadata.

## Verification

- `npx vitest run src/features/record-quality/application/saveDailyRecordWithQualityReview.spec.ts src/features/daily/__tests__/useTableDailyRecordViewModel.spec.ts`
- `npm run typecheck`
- `npm run lint:docs`
- `git diff --check`

## Out of scope

- Human Review Queue summary UI changes.
- SharePoint persistence diagnostics.
- AI scoring or advanced review logic.
- Monthly report automation.
