### PR TITLE
feat(record-quality): show queue summary counts

### DIFF
--- a/src/features/record-quality/components/HumanReviewQueueSummary.tsx
+++ b/src/features/record-quality/components/HumanReviewQueueSummary.tsx
@@ -22,6 +22,8 @@ export function HumanReviewQueueSummary({
 }: HumanReviewQueueSummaryProps) {
   const { queue, isLoading, error } = useRecordQualityHumanReviewQueue(repository);
   const visibleItems = queue.items.slice(0, maxItems);
+  const draftCount = queue.items.filter(item => item.status === 'draft').length;
+  const revisedCount = queue.items.filter(item => item.status === 'revised').length;
 
   return (
     <Card
@@ -66,6 +68,18 @@ export function HumanReviewQueueSummary({
                   color="warning"
                   size="small"
                   data-testid="record-quality-human-review-count"
+                />
+                <Chip
+                  label={`未確認 ${draftCount}件`}
+                  size="small"
+                  variant="outlined"
+                  data-testid="record-quality-human-review-draft-count"
+                />
+                <Chip
+                  label={`修正済み ${revisedCount}件`}
+                  size="small"
+                  variant="outlined"
+                  data-testid="record-quality-human-review-revised-count"
                 />
                 {queue.oldestUpdatedAt && (
                   <Typography variant="caption" color="text.secondary">

--- a/src/features/record-quality/components/__tests__/HumanReviewQueueSummary.spec.tsx
+++ b/src/features/record-quality/components/__tests__/HumanReviewQueueSummary.spec.tsx
@@ -76,6 +76,12 @@ describe('HumanReviewQueueSummary', () => {
 
     expect(screen.getByText('record-draft')).toBeInTheDocument();
     expect(screen.getByText('record-revised')).toBeInTheDocument();
+    expect(screen.getByTestId('record-quality-human-review-draft-count')).toHaveTextContent(
+      '未確認 1件',
+    );
+    expect(screen.getByTestId('record-quality-human-review-revised-count')).toHaveTextContent(
+      '修正済み 1件',
+    );
     expect(screen.getByText('最古更新 2026-06-11T00:00:00.000Z')).toBeInTheDocument();
     expect(screen.queryByText('元の支援記録本文')).not.toBeInTheDocument();
     expect(screen.queryByText('本人の反応などの本文')).not.toBeInTheDocument();
@@ -167,6 +173,12 @@ describe('HumanReviewQueueSummary', () => {
     expect(screen.getByText('record-oldest-draft')).toBeInTheDocument();
     expect(screen.queryByText('record-newer-draft')).not.toBeInTheDocument();
     expect(screen.queryByText('record-revised')).not.toBeInTheDocument();
+    expect(screen.getByTestId('record-quality-human-review-draft-count')).toHaveTextContent(
+      '未確認 2件',
+    );
+    expect(screen.getByTestId('record-quality-human-review-revised-count')).toHaveTextContent(
+      '修正済み 1件',
+    );
   });
 
   it('renders safe draft and revised status labels without exposing source body text', async () => {


### PR DESCRIPTION
## Summary

- Show active Human Review Queue status counts in the Record Quality queue summary.
- Add separate count chips for draft (`未確認`) and revised (`修正済み`) review metadata.
- Keep the existing total queue count and item list behavior unchanged.

## Scope

This PR implements the summary display covered by #2243. It only updates the existing `HumanReviewQueueSummary` component and its tests.

## Safety boundary

- Counts are derived from active queue metadata only.
- `maxItems` still limits rendered list rows only, not summary totals.
- Original support-record body/content/originalText are not displayed.
- No decision action controls, SharePoint diagnostics, or AI scoring are added.

## Verification

- `npx vitest run src/features/record-quality/components/__tests__/HumanReviewQueueSummary.spec.tsx src/features/record-quality/routes/__tests__/RecordQualityHumanReviewPage.spec.tsx`
- `npm run typecheck`
- `git diff --check`

## Out of scope

- accepted/discarded trend metrics.
- Monthly quality reporting.
- SharePoint persistence diagnostics.
- AI scoring or advanced review logic.
