### PR TITLE
fix(dev): restore react refresh and hmr configuration

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -56,7 +56,7 @@ export default defineConfig(({ mode }) => {
 
   return {
     define: {
-      'process.env': {},
+      'process.env.NODE_ENV': JSON.stringify(mode),
     },
     plugins: [
       react(),
@@ -116,9 +116,7 @@ export default defineConfig(({ mode }) => {
       port: 5173,
       strictPort: true,
       hmr: {
-        host: 'localhost',
-        protocol: 'ws',
-        clientPort: 5173,
+        host: '127.0.0.1',
       },
       headers: {
         'Cross-Origin-Opener-Policy': 'same-origin-allow-popups',


### PR DESCRIPTION
## Summary

- Fix React Fast Refresh crash by defining only `process.env.NODE_ENV` in Vite's `define` config
- Avoid global `process.env` object replacement that can break Vite/React runtime helpers
- Align Vite HMR host with the local dev server host (`127.0.0.1`)
- Remove hardcoded HMR protocol/clientPort so Vite can adapt to HTTP/HTTPS environments

## Verification

- `npm run typecheck` passed
- `npm run lint` passed
- `npm run build` passed
- Confirmed the React app boots without `RefreshRuntime.getRefreshReg is not a function`
- Confirmed HMR websocket connection succeeds