### PR TITLE
feat(record-quality): show reviewed queue summary counts

### DIFF
--- a/src/domain/supportRecord/recordQualityHumanReviewQueue.spec.ts
+++ b/src/domain/supportRecord/recordQualityHumanReviewQueue.spec.ts
@@ -9,6 +9,7 @@ import {
 } from './recordQualityReview';
 import {
   buildRecordQualityHumanReviewQueue,
+  emptyRecordQualityHumanReviewQueueSummary,
   InMemoryRecordQualityHumanReviewQueueRepository,
 } from './recordQualityHumanReviewQueue';
 import { InMemoryRecordQualityReviewRepository } from './recordQualityReviewRepository';
@@ -68,6 +69,14 @@ describe('record quality human review queue repository', () => {
       'record-revised',
     ]);
     expect(queue.items.map(item => item.status)).toEqual(['draft', 'revised']);
+    expect(queue.summary).toEqual({
+      draftCount: 1,
+      revisedCount: 1,
+      acceptedCount: 1,
+      discardedCount: 1,
+      pendingTotalCount: 2,
+      reviewedTotalCount: 2,
+    });
     expect(queue.items.every(item => item.requiresHumanReview)).toBe(true);
     expect(queue.items.some(item => 'body' in item)).toBe(false);
     expect(queue.items.some(item => 'content' in item)).toBe(false);
@@ -111,6 +120,14 @@ describe('record quality human review queue sorting and filters', () => {
       'record-revised',
     ]);
     expect(queue.items.map(item => item.status)).toEqual(['draft', 'draft', 'revised']);
+    expect(queue.summary).toEqual({
+      draftCount: 2,
+      revisedCount: 1,
+      acceptedCount: 1,
+      discardedCount: 1,
+      pendingTotalCount: 3,
+      reviewedTotalCount: 2,
+    });
   });
 
   it('excludes accepted and discarded reviews from the pending queue', () => {
@@ -155,6 +172,12 @@ describe('record quality human review queue sorting and filters', () => {
       items: [],
       totalCount: 0,
       oldestUpdatedAt: undefined,
+      summary: {
+        ...emptyRecordQualityHumanReviewQueueSummary,
+        acceptedCount: 1,
+        discardedCount: 1,
+        reviewedTotalCount: 2,
+      },
     });
   });
 });

--- a/src/domain/supportRecord/recordQualityHumanReviewQueue.ts
+++ b/src/domain/supportRecord/recordQualityHumanReviewQueue.ts
@@ -7,10 +7,29 @@ import type { RecordQualityReviewRepository } from './recordQualityReviewReposit
 
 export type RecordQualityHumanReviewQueueItem = RecordQualityReviewDecision;
 
+export type RecordQualityHumanReviewQueueSummary = {
+  readonly draftCount: number;
+  readonly revisedCount: number;
+  readonly acceptedCount: number;
+  readonly discardedCount: number;
+  readonly pendingTotalCount: number;
+  readonly reviewedTotalCount: number;
+};
+
+export const emptyRecordQualityHumanReviewQueueSummary: RecordQualityHumanReviewQueueSummary = {
+  draftCount: 0,
+  revisedCount: 0,
+  acceptedCount: 0,
+  discardedCount: 0,
+  pendingTotalCount: 0,
+  reviewedTotalCount: 0,
+};
+
 export type RecordQualityHumanReviewQueue = {
   readonly items: readonly RecordQualityHumanReviewQueueItem[];
   readonly totalCount: number;
   readonly oldestUpdatedAt?: string;
+  readonly summary: RecordQualityHumanReviewQueueSummary;
 };
 
 export interface RecordQualityHumanReviewQueueRepository {
@@ -32,6 +51,7 @@ export class InMemoryRecordQualityHumanReviewQueueRepository
 export function buildRecordQualityHumanReviewQueue(
   reviews: readonly RecordQualityReviewDraft[],
 ): RecordQualityHumanReviewQueue {
+  const summary = buildRecordQualityHumanReviewQueueSummary(reviews);
   const items = reviews
     .filter(review => review.requiresHumanReview)
     .filter(review => review.status === 'draft' || review.status === 'revised')
@@ -42,5 +62,26 @@ export function buildRecordQualityHumanReviewQueue(
     items,
     totalCount: items.length,
     oldestUpdatedAt: items[0]?.updatedAt,
+    summary,
+  };
+}
+
+export function buildRecordQualityHumanReviewQueueSummary(
+  reviews: readonly RecordQualityReviewDraft[],
+): RecordQualityHumanReviewQueueSummary {
+  const reviewMetadata = reviews.filter(review => review.requiresHumanReview);
+  const draftCount = reviewMetadata.filter(review => review.status === 'draft').length;
+  const revisedCount = reviewMetadata.filter(review => review.status === 'revised').length;
+  const acceptedCount = reviewMetadata.filter(review => review.status === 'accepted').length;
+  const discardedCount = reviewMetadata.filter(review => review.status === 'discarded').length;
+
+  return {
+    ...emptyRecordQualityHumanReviewQueueSummary,
+    draftCount,
+    revisedCount,
+    acceptedCount,
+    discardedCount,
+    pendingTotalCount: draftCount + revisedCount,
+    reviewedTotalCount: acceptedCount + discardedCount,
   };
 }

--- a/src/domain/supportRecord/recordQualityHumanReviewQueueUseCase.spec.ts
+++ b/src/domain/supportRecord/recordQualityHumanReviewQueueUseCase.spec.ts
@@ -8,6 +8,7 @@ import {
   type RecordQualityReviewDraft,
 } from './recordQualityReview';
 import {
+  emptyRecordQualityHumanReviewQueueSummary,
   InMemoryRecordQualityHumanReviewQueueRepository,
   type RecordQualityHumanReviewQueueRepository,
 } from './recordQualityHumanReviewQueue';
@@ -71,6 +72,14 @@ describe('listRecordQualityHumanReviewQueue', () => {
       'record-revised',
     ]);
     expect(queue.items.map(item => item.status)).toEqual(['draft', 'revised']);
+    expect(queue.summary).toEqual({
+      draftCount: 1,
+      revisedCount: 1,
+      acceptedCount: 1,
+      discardedCount: 1,
+      pendingTotalCount: 2,
+      reviewedTotalCount: 2,
+    });
     expect(queue.items.every(item => item.requiresHumanReview)).toBe(true);
     expect(queue.items.some(item => 'body' in item)).toBe(false);
     expect(queue.items.some(item => 'content' in item)).toBe(false);
@@ -84,6 +93,7 @@ describe('listRecordQualityHumanReviewQueue', () => {
           items: [],
           totalCount: 0,
           oldestUpdatedAt: undefined,
+          summary: emptyRecordQualityHumanReviewQueueSummary,
         };
       },
     } satisfies RecordQualityHumanReviewQueueRepository;
@@ -94,6 +104,7 @@ describe('listRecordQualityHumanReviewQueue', () => {
       items: [],
       totalCount: 0,
       oldestUpdatedAt: undefined,
+      summary: emptyRecordQualityHumanReviewQueueSummary,
     });
   });
 });

--- a/src/features/record-quality/components/HumanReviewQueueSummary.tsx
+++ b/src/features/record-quality/components/HumanReviewQueueSummary.tsx
@@ -22,8 +22,8 @@ export function HumanReviewQueueSummary({
 }: HumanReviewQueueSummaryProps) {
   const { queue, isLoading, error } = useRecordQualityHumanReviewQueue(repository);
   const visibleItems = queue.items.slice(0, maxItems);
-  const draftCount = queue.items.filter(item => item.status === 'draft').length;
-  const revisedCount = queue.items.filter(item => item.status === 'revised').length;
+  const { summary } = queue;
+  const hasSummaryCounts = queue.totalCount > 0 || summary.reviewedTotalCount > 0;
 
   return (
     <Card
@@ -60,26 +60,44 @@ export function HumanReviewQueueSummary({
             </Alert>
           )}
 
-          {!isLoading && !error && queue.totalCount > 0 && (
+          {!isLoading && !error && hasSummaryCounts && (
             <Stack spacing={1.5}>
               <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
                 <Chip
-                  label={`要確認 ${queue.totalCount}件`}
+                  label={`要確認 ${summary.pendingTotalCount}件`}
                   color="warning"
                   size="small"
                   data-testid="record-quality-human-review-count"
                 />
                 <Chip
-                  label={`未確認 ${draftCount}件`}
+                  label={`未確認 ${summary.draftCount}件`}
                   size="small"
                   variant="outlined"
                   data-testid="record-quality-human-review-draft-count"
                 />
                 <Chip
-                  label={`修正済み ${revisedCount}件`}
+                  label={`修正済み ${summary.revisedCount}件`}
                   size="small"
                   variant="outlined"
                   data-testid="record-quality-human-review-revised-count"
+                />
+                <Chip
+                  label={`判断済み ${summary.reviewedTotalCount}件`}
+                  size="small"
+                  variant="outlined"
+                  data-testid="record-quality-human-review-reviewed-count"
+                />
+                <Chip
+                  label={`採用済み ${summary.acceptedCount}件`}
+                  size="small"
+                  variant="outlined"
+                  data-testid="record-quality-human-review-accepted-count"
+                />
+                <Chip
+                  label={`破棄 ${summary.discardedCount}件`}
+                  size="small"
+                  variant="outlined"
+                  data-testid="record-quality-human-review-discarded-count"
                 />
                 {queue.oldestUpdatedAt && (
                   <Typography variant="caption" color="text.secondary">
@@ -88,29 +106,31 @@ export function HumanReviewQueueSummary({
                 )}
               </Stack>
 
-              <List dense disablePadding data-testid="record-quality-human-review-list">
-                {visibleItems.map(item => (
-                  <ListItem
-                    key={item.recordId}
-                    disableGutters
-                    divider
-                    data-testid={`record-quality-human-review-item-${item.recordId}`}
-                  >
-                    <Stack spacing={0.5} sx={{ width: '100%' }}>
-                      <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
-                        <Typography variant="body2" sx={{ fontWeight: 700 }}>
-                          {item.sourceRecordId}
+              {queue.totalCount > 0 && (
+                <List dense disablePadding data-testid="record-quality-human-review-list">
+                  {visibleItems.map(item => (
+                    <ListItem
+                      key={item.recordId}
+                      disableGutters
+                      divider
+                      data-testid={`record-quality-human-review-item-${item.recordId}`}
+                    >
+                      <Stack spacing={0.5} sx={{ width: '100%' }}>
+                        <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+                          <Typography variant="body2" sx={{ fontWeight: 700 }}>
+                            {item.sourceRecordId}
+                          </Typography>
+                          <Chip label={item.label} size="small" variant="outlined" />
+                        </Stack>
+                        <Typography variant="caption" color="text.secondary">
+                          候補 {item.suggestedCategoryCount}件 / 不足情報{' '}
+                          {item.missingInformationHintCount}件 / ノート {item.noteCount}件
                         </Typography>
-                        <Chip label={item.label} size="small" variant="outlined" />
                       </Stack>
-                      <Typography variant="caption" color="text.secondary">
-                        候補 {item.suggestedCategoryCount}件 / 不足情報{' '}
-                        {item.missingInformationHintCount}件 / ノート {item.noteCount}件
-                      </Typography>
-                    </Stack>
-                  </ListItem>
-                ))}
-              </List>
+                    </ListItem>
+                  ))}
+                </List>
+              )}
             </Stack>
           )}
         </Stack>

--- a/src/features/record-quality/components/__tests__/HumanReviewQueueSummary.spec.tsx
+++ b/src/features/record-quality/components/__tests__/HumanReviewQueueSummary.spec.tsx
@@ -38,22 +38,6 @@ function createReview(recordId: string, createdAt: string): RecordQualityReviewD
   });
 }
 
-function buildExpectedReviewedSummary(reviews: readonly RecordQualityReviewDraft[]) {
-  const draftCount = reviews.filter(review => review.status === 'draft').length;
-  const revisedCount = reviews.filter(review => review.status === 'revised').length;
-  const acceptedCount = reviews.filter(review => review.status === 'accepted').length;
-  const discardedCount = reviews.filter(review => review.status === 'discarded').length;
-
-  return {
-    draftCount,
-    revisedCount,
-    acceptedCount,
-    discardedCount,
-    pendingTotalCount: draftCount + revisedCount,
-    reviewedTotalCount: acceptedCount + discardedCount,
-  };
-}
-
 describe('HumanReviewQueueSummary', () => {
   it('renders loading and then active queue summary without original record text', async () => {
     const draftWithOriginalText = {
@@ -98,6 +82,9 @@ describe('HumanReviewQueueSummary', () => {
     expect(screen.getByTestId('record-quality-human-review-revised-count')).toHaveTextContent(
       '修正済み 1件',
     );
+    expect(screen.getByTestId('record-quality-human-review-reviewed-count')).toHaveTextContent(
+      '判断済み 0件',
+    );
     expect(screen.getByText('最古更新 2026-06-11T00:00:00.000Z')).toBeInTheDocument();
     expect(screen.queryByText('元の支援記録本文')).not.toBeInTheDocument();
     expect(screen.queryByText('本人の反応などの本文')).not.toBeInTheDocument();
@@ -137,6 +124,15 @@ describe('HumanReviewQueueSummary', () => {
 
     expect(screen.getByText('record-draft')).toBeInTheDocument();
     expect(screen.getByText('record-revised')).toBeInTheDocument();
+    expect(screen.getByTestId('record-quality-human-review-reviewed-count')).toHaveTextContent(
+      '判断済み 2件',
+    );
+    expect(screen.getByTestId('record-quality-human-review-accepted-count')).toHaveTextContent(
+      '採用済み 1件',
+    );
+    expect(screen.getByTestId('record-quality-human-review-discarded-count')).toHaveTextContent(
+      '破棄 1件',
+    );
     expect(screen.queryByText('record-accepted')).not.toBeInTheDocument();
     expect(screen.queryByText('record-discarded')).not.toBeInTheDocument();
   });
@@ -237,7 +233,7 @@ describe('HumanReviewQueueSummary', () => {
     expect(screen.queryByText('original body text')).not.toBeInTheDocument();
   });
 
-  it('locks reviewed summary count expectations before rendering reviewed counts', async () => {
+  it('renders reviewed summary counts without exposing reviewed item rows or source body text', async () => {
     const draftWithOriginalText = {
       ...createReview('record-draft', '2026-06-11T00:00:00.000Z'),
       body: '元の支援記録本文',
@@ -279,19 +275,20 @@ describe('HumanReviewQueueSummary', () => {
       ),
     );
 
-    expect(buildExpectedReviewedSummary(reviews)).toEqual({
-      draftCount: 1,
-      revisedCount: 1,
-      acceptedCount: 1,
-      discardedCount: 1,
-      pendingTotalCount: 2,
-      reviewedTotalCount: 2,
-    });
     expect(screen.getByTestId('record-quality-human-review-draft-count')).toHaveTextContent(
       '未確認 1件',
     );
     expect(screen.getByTestId('record-quality-human-review-revised-count')).toHaveTextContent(
       '修正済み 1件',
+    );
+    expect(screen.getByTestId('record-quality-human-review-reviewed-count')).toHaveTextContent(
+      '判断済み 2件',
+    );
+    expect(screen.getByTestId('record-quality-human-review-accepted-count')).toHaveTextContent(
+      '採用済み 1件',
+    );
+    expect(screen.getByTestId('record-quality-human-review-discarded-count')).toHaveTextContent(
+      '破棄 1件',
     );
     expect(screen.getByText('record-draft')).toBeInTheDocument();
     expect(screen.queryByText('record-revised')).not.toBeInTheDocument();

--- a/src/features/record-quality/hooks/__tests__/useRecordQualityHumanReviewQueue.spec.ts
+++ b/src/features/record-quality/hooks/__tests__/useRecordQualityHumanReviewQueue.spec.ts
@@ -7,6 +7,7 @@ import {
   type RecordQualityReviewDraft,
 } from '@/domain/supportRecord/recordQualityReview';
 import {
+  emptyRecordQualityHumanReviewQueueSummary,
   InMemoryRecordQualityHumanReviewQueueRepository,
   type RecordQualityHumanReviewQueueRepository,
 } from '@/domain/supportRecord/recordQualityHumanReviewQueue';
@@ -71,6 +72,14 @@ describe('useRecordQualityHumanReviewQueue', () => {
 
     expect(result.current.error).toBeNull();
     expect(result.current.queue.totalCount).toBe(2);
+    expect(result.current.queue.summary).toEqual({
+      draftCount: 1,
+      revisedCount: 1,
+      acceptedCount: 0,
+      discardedCount: 0,
+      pendingTotalCount: 2,
+      reviewedTotalCount: 0,
+    });
     expect(result.current.queue.items.map(item => item.recordId)).toEqual([
       'record-draft',
       'record-revised',
@@ -87,6 +96,7 @@ describe('useRecordQualityHumanReviewQueue', () => {
         items: [],
         totalCount: 0,
         oldestUpdatedAt: undefined,
+        summary: emptyRecordQualityHumanReviewQueueSummary,
       }),
     } satisfies RecordQualityHumanReviewQueueRepository;
 
@@ -100,6 +110,7 @@ describe('useRecordQualityHumanReviewQueue', () => {
       items: [],
       totalCount: 0,
       oldestUpdatedAt: undefined,
+      summary: emptyRecordQualityHumanReviewQueueSummary,
     });
     expect(result.current.error).toBeNull();
   });
@@ -119,6 +130,7 @@ describe('useRecordQualityHumanReviewQueue', () => {
       items: [],
       totalCount: 0,
       oldestUpdatedAt: undefined,
+      summary: emptyRecordQualityHumanReviewQueueSummary,
     });
     expect(result.current.error?.message).toBe('queue failed');
   });

--- a/src/features/record-quality/hooks/useRecordQualityHumanReviewQueue.ts
+++ b/src/features/record-quality/hooks/useRecordQualityHumanReviewQueue.ts
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useState } from 'react';
 
-import type {
-  RecordQualityHumanReviewQueue,
-  RecordQualityHumanReviewQueueRepository,
+import {
+  emptyRecordQualityHumanReviewQueueSummary,
+  type RecordQualityHumanReviewQueue,
+  type RecordQualityHumanReviewQueueRepository,
 } from '@/domain/supportRecord/recordQualityHumanReviewQueue';
 import { listRecordQualityHumanReviewQueue } from '@/domain/supportRecord/recordQualityHumanReviewQueueUseCase';
 
@@ -10,6 +11,7 @@ const emptyQueue: RecordQualityHumanReviewQueue = {
   items: [],
   totalCount: 0,
   oldestUpdatedAt: undefined,
+  summary: emptyRecordQualityHumanReviewQueueSummary,
 };
 
 export type UseRecordQualityHumanReviewQueueResult = {


### PR DESCRIPTION
## Summary

- Add reviewed summary counts to the Record Quality Human Review Queue model.
- Show `判断済み`, `採用済み`, and `破棄` count chips in `HumanReviewQueueSummary`.
- Keep active queue rows limited to draft/revised review metadata.

## Scope

This implements the expectations locked by #2245. It updates the queue model, hook empty state, summary component, and focused tests.

## Safety boundary

- Counts are derived from review metadata only.
- `pendingTotalCount = draftCount + revisedCount`.
- `reviewedTotalCount = acceptedCount + discardedCount`.
- `maxItems` still limits visible active rows only.
- accepted/discarded records contribute to counts but are not rendered as list rows.
- Original support-record `body`, `content`, and `originalText` are not displayed.
- No decision actions, SharePoint diagnostics, or AI scoring are added.

## Verification

- `npx vitest run src/domain/supportRecord/recordQualityHumanReviewQueue.spec.ts src/domain/supportRecord/recordQualityHumanReviewQueueUseCase.spec.ts src/features/record-quality/hooks/__tests__/useRecordQualityHumanReviewQueue.spec.ts src/features/record-quality/components/__tests__/HumanReviewQueueSummary.spec.tsx src/features/record-quality/routes/__tests__/RecordQualityHumanReviewPage.spec.tsx`
- `npm run typecheck`
- `npx eslint src/domain/supportRecord/recordQualityHumanReviewQueue.ts src/domain/supportRecord/recordQualityHumanReviewQueue.spec.ts src/domain/supportRecord/recordQualityHumanReviewQueueUseCase.spec.ts src/features/record-quality/hooks/useRecordQualityHumanReviewQueue.ts src/features/record-quality/hooks/__tests__/useRecordQualityHumanReviewQueue.spec.ts src/features/record-quality/components/HumanReviewQueueSummary.tsx src/features/record-quality/components/__tests__/HumanReviewQueueSummary.spec.tsx`
- `git diff --check`

## Out of scope

- Monthly quality reporting.
- SharePoint persistence diagnostics.
- AI scoring or advanced review logic.
