### PR TITLE
fix(layout): restrict footer navigation to kiosk mode

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -111,6 +111,11 @@ const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) => {
     />
   ) : null;
 
+  const shouldShowFooterMenu =
+    (viewportMode as string) === 'kiosk' ||
+    (viewportMode as string) === 'mobile-kiosk' ||
+    isKioskMode;
+
   return (
     <RouteHydrationListener>
       <LiveAnnouncer>
@@ -127,7 +132,7 @@ const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) => {
           <AppShellV2
             header={headerContent}
             sidebar={sidebarContent}
-            footer={<FooterQuickActions onlyDialogs={isKioskMode} />}
+            footer={shouldShowFooterMenu ? <FooterQuickActions onlyDialogs={isKioskMode} /> : undefined}
             sidebarWidth={showDesktopSidebar ? currentDrawerWidth : 0}
             contentPaddingX={isFocusMode ? 0 : 16}
             contentPaddingY={isKioskMode ? 0 : contentPaddingY}

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -114,7 +114,16 @@ const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   return (
     <RouteHydrationListener>
       <LiveAnnouncer>
-        <div data-testid="app-shell" data-kiosk={isKioskMode || undefined}>
+        <div
+          data-testid="app-shell"
+          data-kiosk={isKioskMode || undefined}
+          style={{
+            height: '100%',
+            display: 'flex',
+            flexDirection: 'column',
+            minHeight: 0,
+          }}
+        >
           <AppShellV2
             header={headerContent}
             sidebar={sidebarContent}

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -111,10 +111,7 @@ const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) => {
     />
   ) : null;
 
-  const shouldShowFooterMenu =
-    (viewportMode as string) === 'kiosk' ||
-    (viewportMode as string) === 'mobile-kiosk' ||
-    isKioskMode;
+  const shouldShowFooterMenu = isKioskMode;
 
   return (
     <RouteHydrationListener>

--- a/src/app/__tests__/AppShell.kiosk-nav.spec.tsx
+++ b/src/app/__tests__/AppShell.kiosk-nav.spec.tsx
@@ -129,4 +129,24 @@ describe('AppShell Navigation OS integration (Logical Filtering)', () => {
     // Core staff functionality should remain
     expect(screen.getByText('日次記録')).toBeInTheDocument();
   });
+
+  it('renders kiosk-navigation and footer dialog registry in Kiosk mode', () => {
+    renderAppShell({ layoutMode: 'kiosk' });
+
+    // Kiosk navigation should be rendered
+    expect(screen.getByTestId('kiosk-navigation')).toBeInTheDocument();
+
+    // Footer (contentinfo) should be in the document (renders onlyDialogs)
+    expect(screen.getByRole('contentinfo')).toBeInTheDocument();
+  });
+
+  it('does not render kiosk-navigation or footer in Normal mode', () => {
+    renderAppShell({ layoutMode: 'normal' });
+
+    // Kiosk navigation should not be rendered
+    expect(screen.queryByTestId('kiosk-navigation')).not.toBeInTheDocument();
+
+    // Footer (contentinfo) should not be in the document
+    expect(screen.queryByRole('contentinfo')).not.toBeInTheDocument();
+  });
 });

--- a/tests/unit/AppShell.nav.spec.tsx
+++ b/tests/unit/AppShell.nav.spec.tsx
@@ -145,8 +145,8 @@ describe('AppShell navigation', () => {
     const hasComplianceLink = links.some(link => link.getAttribute('href')?.includes('/compliance'));
     expect(hasComplianceLink).toBe(false);
 
-    // AppShell footer is now enabled by default.
-    expect(screen.getByRole('contentinfo')).toBeInTheDocument();
+    // AppShell footer is now hidden by default in normal mode.
+    expect(screen.queryByRole('contentinfo')).not.toBeInTheDocument();
 
   });
 


### PR DESCRIPTION
## Summary

- Restore scrolling in the AppShell main content area
- Allow normal mode to use sidebar navigation only
- Restrict bottom footer/kiosk navigation to kiosk mode
- Add/update tests for normal and kiosk navigation visibility

## Verification

- npm run typecheck
- npm run lint
- npm run build
- npx vitest run tests/unit/AppShell.nav.spec.tsx src/app/__tests__/AppShell.kiosk-nav.spec.tsx
- Manually confirmed /today normal mode shows no bottom footer menu
- Manually confirmed /today normal mode uses sidebar navigation only
- Manually confirmed /today and /dashboard can scroll vertically
- Manually confirmed kiosk mode keeps the bottom kiosk navigation/footer