### PR TITLE
fix(kiosk-toilet): respect selected date query on daily board

### DIFF
--- a/src/features/kiosk/toilet/ToiletDailyBoard.tsx
+++ b/src/features/kiosk/toilet/ToiletDailyBoard.tsx
@@ -23,7 +23,7 @@ import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
-import { Link as RouterLink, useLocation } from 'react-router-dom';
+import { Link as RouterLink, useLocation, useSearchParams } from 'react-router-dom';
 import { toLocalDateISO } from '@/utils/getNow';
 import { useUsers } from '@/features/users/useUsers';
 import type { IUserMaster } from '@/features/users/types';
@@ -66,9 +66,21 @@ const findLatestRecord = (records: ToiletRecord[], userId: string): ToiletRecord
 
 export const ToiletDailyBoard: React.FC = () => {
   const location = useLocation();
+  const [searchParams] = useSearchParams();
+  const dateParam = searchParams.get('date');
   const todayIso = toLocalDateISO(new Date());
+
+  const isValidDateOnly = (val: string | null | undefined): val is string => {
+    if (!val) return false;
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(val)) return false;
+    const date = new Date(val);
+    return !isNaN(date.getTime());
+  };
+
+  const selectedDateIso = isValidDateOnly(dateParam) ? dateParam : todayIso;
+
   const { data: users, isLoading: isUsersLoading, status: usersStatus } = useUsers({ selectMode: 'core' });
-  const { records, create, refresh: refreshRecords, isLoading: isRecordsLoading, error: recordsError } = useToiletRecords(todayIso);
+  const { records, create, refresh: refreshRecords, isLoading: isRecordsLoading, error: recordsError } = useToiletRecords(selectedDateIso);
   const isLoading = isUsersLoading || isRecordsLoading;
   const hasRecordsError = Boolean(recordsError);
   const [selectedUser, setSelectedUser] = React.useState<IUserMaster | null>(null);
@@ -110,12 +122,20 @@ export const ToiletDailyBoard: React.FC = () => {
     return grouped;
   }, [records]);
 
+  const getInitialOccurredAt = (dateIso: string): string => {
+    const now = new Date();
+    const [yyyy, mm, dd] = dateIso.split('-').map(Number);
+    const date = new Date(now);
+    date.setFullYear(yyyy, mm - 1, dd);
+    return toMinuteInputValue(date);
+  };
+
   const openForm = (user: IUserMaster) => {
     setSelectedUser(user);
     setSaveError(null);
     setIsSaving(false);
     setForm({
-      occurredAt: toMinuteInputValue(new Date()),
+      occurredAt: getInitialOccurredAt(selectedDateIso),
       toiletType: 'urination',
       amount: 'normal',
       memo: '',
@@ -161,7 +181,7 @@ export const ToiletDailyBoard: React.FC = () => {
             本日のトイレ確認
           </Typography>
           <Typography variant="body2" color="text.secondary">
-            {todayIso}
+            {selectedDateIso}
           </Typography>
         </Box>
         <Chip

--- a/src/features/kiosk/toilet/__tests__/ToiletDailyBoard.spec.tsx
+++ b/src/features/kiosk/toilet/__tests__/ToiletDailyBoard.spec.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { IUserMaster } from '@/features/users/types';
+import { toLocalDateISO } from '@/utils/getNow';
 import { ToiletDailyBoard } from '../ToiletDailyBoard';
 
 const { mockUseUsers, mockUseToiletRecords, mockRefreshRecords, mockCreateRecord } = vi.hoisted(() => ({
@@ -98,4 +99,70 @@ describe('ToiletDailyBoard', () => {
     expect(screen.getByText('トイレ誘導対象の利用者がいません')).toBeInTheDocument();
     expect(screen.queryByText('トイレ記録の読み込みに失敗しました')).not.toBeInTheDocument();
   });
+
+  it("uses today's local date by default (without query parameter)", () => {
+    renderBoard();
+    const today = toLocalDateISO(new Date());
+    expect(mockUseToiletRecords).toHaveBeenCalledWith(today);
+  });
+
+  it('uses the specified date from date query parameter if it is a valid YYYY-MM-DD string', () => {
+    render(
+      <MemoryRouter initialEntries={['/kiosk/toilet?date=2026-06-12']}>
+        <ToiletDailyBoard />
+      </MemoryRouter>,
+    );
+    expect(mockUseToiletRecords).toHaveBeenCalledWith('2026-06-12');
+  });
+
+  it("falls back to today's date if the date query parameter is invalid", () => {
+    render(
+      <MemoryRouter initialEntries={['/kiosk/toilet?date=invalid-date']}>
+        <ToiletDailyBoard />
+      </MemoryRouter>,
+    );
+    const today = toLocalDateISO(new Date());
+    expect(mockUseToiletRecords).toHaveBeenCalledWith(today);
+  });
+
+  it('creates new records with the selected date', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-12T12:00:00'));
+
+    try {
+      mockUseToiletRecords.mockReturnValue({
+        records: [],
+        create: mockCreateRecord,
+        refresh: mockRefreshRecords,
+        isLoading: false,
+        error: null,
+      });
+
+      render(
+        <MemoryRouter initialEntries={['/kiosk/toilet?date=2026-06-12']}>
+          <ToiletDailyBoard />
+        </MemoryRouter>,
+      );
+
+      // Click on "記録する" button for the user
+      fireEvent.click(screen.getByTestId('toilet-record-button-user-1'));
+
+      // Check that the dialog is shown
+      expect(screen.getByText('支援 花子さんのトイレ記録')).toBeInTheDocument();
+
+      // Click save
+      fireEvent.click(screen.getByTestId('toilet-record-save'));
+
+      // Check that create was called with occurredAt containing the selected date
+      expect(mockCreateRecord).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'user-1',
+          occurredAt: expect.stringContaining('2026-06-12'),
+        })
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
+


### PR DESCRIPTION
## Summary

- Use the `date=YYYY-MM-DD` query parameter on the kiosk toilet daily board
- Keep fallback behavior to today's local date when no valid date query is provided
- Stabilize selected-date record creation tests with a fixed system time

## Verification

- npx vitest run src/features/kiosk/toilet/__tests__/ToiletDailyBoard.spec.tsx
- npm run test:ci:required