### PR TITLE
feat(kiosk): add toilet record correction repository contract

### DIFF
--- a/src/features/kiosk/toilet/SharePointToiletRecordRepository.ts
+++ b/src/features/kiosk/toilet/SharePointToiletRecordRepository.ts
@@ -1,4 +1,9 @@
-import type { ToiletRecord, ToiletRecordInput, IToiletRecordRepository } from './types';
+import type {
+  ToiletRecord,
+  ToiletRecordCorrectionPatch,
+  ToiletRecordInput,
+  IToiletRecordRepository,
+} from './types';
 import type { SpFetchFn } from '@/lib/sp/spLists';
 import { findListEntry } from '@/sharepoint/spListRegistry';
 import { TOILET_RECORD_CANDIDATES } from '@/sharepoint/fields/toiletRecordFields';
@@ -77,6 +82,10 @@ export class SharePointToiletRecordRepository implements IToiletRecordRepository
       }
     }
     return activePayload;
+  }
+
+  private escapeODataString(value: string): string {
+    return value.replace(/'/g, "''");
   }
 
   async listByDate(dateIso: string): Promise<ToiletRecord[]> {
@@ -184,6 +193,68 @@ export class SharePointToiletRecordRepository implements IToiletRecordRepository
 
     const result = await response.json();
     return this.mapToDomain(result.d || result);
+  }
+
+  async update(recordId: string, patch: ToiletRecordCorrectionPatch): Promise<ToiletRecord> {
+    const listTitle = this.resolveListTitle();
+    await this.initFields(listTitle);
+
+    const select = [
+      'Id',
+      'Title',
+      'Created',
+      'Modified',
+      this.rfFallback('userId'),
+      this.rfFallback('recordDate'),
+      this.rfFallback('occurredAt'),
+      this.rfFallback('toiletType'),
+      this.rfFallback('amount'),
+      this.rfFallback('memo'),
+      this.rfFallback('recorderName'),
+      this.rfFallback('source'),
+      this.rfFallback('isDeleted'),
+    ];
+    const filter = `Title eq '${this.escapeODataString(recordId)}'`;
+    const lookupUrl = `/lists/getbytitle('${encodeURIComponent(listTitle)}')/items?$filter=${encodeURIComponent(filter)}&$select=${select.join(',')}&$top=1`;
+    const lookupResponse = await this.spFetch(lookupUrl);
+    if (!lookupResponse.ok) {
+      throw new Error(`[SharePointToiletRecordRepo] update lookup failed: ${lookupResponse.statusText}`);
+    }
+
+    const lookupData = await lookupResponse.json();
+    const item = ((lookupData.value || lookupData.d?.results || []) as JsonRecord[])[0];
+    if (!item) {
+      throw new Error(`[SharePointToiletRecordRepo] record not found: ${recordId}`);
+    }
+
+    const rawPayload: Record<string, unknown> = {};
+    if (patch.toiletType !== undefined) rawPayload[this.rfFallback('toiletType')] = patch.toiletType;
+    if (patch.amount !== undefined) rawPayload[this.rfFallback('amount')] = patch.amount;
+    if (patch.memo !== undefined) rawPayload[this.rfFallback('memo')] = patch.memo.trim();
+
+    const body = this.filterPayload(rawPayload);
+    const itemId = item.Id;
+    const updateUrl = `/lists/getbytitle('${encodeURIComponent(listTitle)}')/items(${itemId})`;
+    const updateResponse = await this.spFetch(updateUrl, {
+      method: 'POST',
+      headers: {
+        'X-HTTP-Method': 'MERGE',
+        'If-Match': '*',
+        'Content-Type': 'application/json;odata=nometadata',
+        'Accept': 'application/json;odata=nometadata',
+      },
+      body: JSON.stringify(body),
+    });
+    if (!updateResponse.ok) {
+      throw new Error(`[SharePointToiletRecordRepo] update failed: ${updateResponse.statusText}`);
+    }
+
+    const result = await updateResponse.json().catch(() => ({}));
+    return this.mapToDomain({
+      ...item,
+      ...body,
+      ...(result.d || result),
+    });
   }
 
   private mapToDomain(item: JsonRecord): ToiletRecord {

--- a/src/features/kiosk/toilet/__tests__/toiletRecordRepository.spec.ts
+++ b/src/features/kiosk/toilet/__tests__/toiletRecordRepository.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { LocalStorageToiletRecordRepository } from '../toiletRecordRepository';
 import { SharePointToiletRecordRepository } from '../SharePointToiletRecordRepository';
 import { getToiletRepository } from '../toiletRepositoryFactory';
-import type { ToiletRecordInput } from '../types';
+import type { ToiletRecord, ToiletRecordInput } from '../types';
 import * as env from '@/lib/env';
 import * as factory from '@/lib/createRepositoryFactory';
 
@@ -13,6 +13,16 @@ vi.mock('@/sharepoint/spListRegistry', () => ({
     resolve: () => 'ToiletRecords',
   })),
 }));
+
+type ToiletRecordCorrectionPatch = Partial<
+  Pick<ToiletRecordInput, 'userId' | 'occurredAt' | 'toiletType' | 'amount' | 'memo'>
+> & {
+  recordDate?: string;
+};
+
+type ToiletRecordRepositoryWithUpdate = {
+  update(id: string, patch: ToiletRecordCorrectionPatch): Promise<ToiletRecord>;
+};
 
 describe('ToiletRecord Repository & Factory Tests', () => {
   beforeEach(() => {
@@ -94,6 +104,52 @@ describe('ToiletRecord Repository & Factory Tests', () => {
 
       const records = await repo.listByDate('2026-05-26');
       expect(records).toHaveLength(0); // matching date but deleted
+    });
+
+    it('should correct only toiletType, amount, and memo while keeping identity/date fields immutable', async () => {
+      const created = await repo.create({
+        userId: 'I005',
+        occurredAt: '2026-05-26T10:00:00.000Z',
+        toiletType: 'urination',
+        amount: 'normal',
+        memo: 'original memo',
+        recorderName: 'kiosk',
+      });
+
+      const updated = await (repo as LocalStorageToiletRecordRepository & ToiletRecordRepositoryWithUpdate).update(
+        created.id,
+        {
+          toiletType: 'bowel',
+          amount: 'large',
+          memo: 'corrected memo',
+          userId: 'I999',
+          occurredAt: '2026-05-27T11:00:00.000Z',
+          recordDate: '2026-05-27',
+        },
+      );
+
+      expect(updated).toMatchObject({
+        id: created.id,
+        userId: 'I005',
+        recordDate: '2026-05-26',
+        occurredAt: '2026-05-26T10:00:00.000Z',
+        toiletType: 'bowel',
+        amount: 'large',
+        memo: 'corrected memo',
+      });
+      expect(updated.updatedAt).not.toBe(created.updatedAt);
+
+      const originalDateRecords = await repo.listByDate('2026-05-26');
+      expect(originalDateRecords).toHaveLength(1);
+      expect(originalDateRecords[0]).toMatchObject({
+        id: created.id,
+        toiletType: 'bowel',
+        amount: 'large',
+        memo: 'corrected memo',
+      });
+
+      const movedDateRecords = await repo.listByDate('2026-05-27');
+      expect(movedDateRecords).toHaveLength(0);
     });
   });
 
@@ -336,6 +392,107 @@ describe('ToiletRecord Repository & Factory Tests', () => {
       expect(records).toHaveLength(2);
       expect(records[0].id).toBe('toilet-fallback-1');
       expect(records[1].id).toBe('toilet-fallback-4');
+    });
+
+    it('should send a SharePoint MERGE correction with only toiletType, amount, and memo fields', async () => {
+      const mockSpFetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+        if (url.includes('/items?$filter=') && init === undefined) {
+          return {
+            ok: true,
+            json: async () => ({
+              value: [
+                {
+                  Id: 101,
+                  Title: 'toilet-1',
+                  UserId: 'I005',
+                  RecordDate: '2026-05-26',
+                  OccurredAt: '2026-05-26T10:00:00.000Z',
+                  ToiletType: 'urination',
+                  Amount: 'normal',
+                  Memo: 'original memo',
+                  RecorderName: 'kiosk',
+                  Source: 'kiosk',
+                  IsDeleted: false,
+                  Created: '2026-05-26T10:01:00.000Z',
+                  Modified: '2026-05-26T10:01:00.000Z',
+                },
+              ],
+            }),
+          };
+        }
+        if (url.includes('/items(101)') && init?.method === 'POST') {
+          return {
+            ok: true,
+            json: async () => ({
+              Id: 101,
+              Title: 'toilet-1',
+              UserId: 'I005',
+              RecordDate: '2026-05-26',
+              OccurredAt: '2026-05-26T10:00:00.000Z',
+              ToiletType: 'bowel',
+              Amount: 'large',
+              Memo: 'corrected memo',
+              RecorderName: 'kiosk',
+              Source: 'kiosk',
+              IsDeleted: false,
+              Created: '2026-05-26T10:01:00.000Z',
+              Modified: '2026-05-26T10:05:00.000Z',
+            }),
+          };
+        }
+        return { ok: true, json: async () => ({ value: [] }) };
+      });
+
+      const mockGetFields = vi.fn().mockResolvedValue(new Set([
+        'UserId',
+        'RecordDate',
+        'OccurredAt',
+        'ToiletType',
+        'Amount',
+        'Memo',
+        'RecorderName',
+        'Source',
+        'IsDeleted',
+      ]));
+
+      const repo = new SharePointToiletRecordRepository(mockSpFetch, mockGetFields);
+      const updated = await (repo as SharePointToiletRecordRepository & ToiletRecordRepositoryWithUpdate).update(
+        'toilet-1',
+        {
+          toiletType: 'bowel',
+          amount: 'large',
+          memo: 'corrected memo',
+          userId: 'I999',
+          occurredAt: '2026-05-27T11:00:00.000Z',
+          recordDate: '2026-05-27',
+        },
+      );
+
+      const updateCall = mockSpFetch.mock.calls.find((call) =>
+        String(call[0]).includes("/lists/getbytitle('ToiletRecords')/items(101)"),
+      );
+      expect(updateCall).toBeDefined();
+      expect(updateCall?.[1]?.headers).toMatchObject({
+        'X-HTTP-Method': 'MERGE',
+        'If-Match': '*',
+      });
+
+      const body = JSON.parse(updateCall?.[1]?.body as string);
+      expect(body).toEqual({
+        ToiletType: 'bowel',
+        Amount: 'large',
+        Memo: 'corrected memo',
+      });
+
+      expect(updated).toMatchObject({
+        id: 'toilet-1',
+        userId: 'I005',
+        recordDate: '2026-05-26',
+        occurredAt: '2026-05-26T10:00:00.000Z',
+        toiletType: 'bowel',
+        amount: 'large',
+        memo: 'corrected memo',
+      });
     });
   });
 

--- a/src/features/kiosk/toilet/toiletRecordRepository.ts
+++ b/src/features/kiosk/toilet/toiletRecordRepository.ts
@@ -1,4 +1,9 @@
-import type { ToiletRecord, ToiletRecordInput, IToiletRecordRepository } from './types';
+import type {
+  ToiletRecord,
+  ToiletRecordCorrectionPatch,
+  ToiletRecordInput,
+  IToiletRecordRepository,
+} from './types';
 import { toLocalDateISO } from '@/utils/getNow';
 
 const STORAGE_KEY = 'kiosk.toiletRecords.v1';
@@ -29,6 +34,15 @@ const writeStorage = (shape: StorageShape): void => {
   window.localStorage.setItem(STORAGE_KEY, JSON.stringify(shape));
 };
 
+const nextUpdatedAt = (currentUpdatedAt: string): string => {
+  const now = new Date();
+  const current = Date.parse(currentUpdatedAt);
+  if (!Number.isNaN(current) && now.getTime() <= current) {
+    return new Date(current + 1).toISOString();
+  }
+  return now.toISOString();
+};
+
 export class LocalStorageToiletRecordRepository implements IToiletRecordRepository {
   async listByDate(dateIso: string): Promise<ToiletRecord[]> {
     return readStorage().records
@@ -56,5 +70,28 @@ export class LocalStorageToiletRecordRepository implements IToiletRecordReposito
     const storage = readStorage();
     writeStorage({ version: 1, records: [record, ...storage.records] });
     return record;
+  }
+
+  async update(recordId: string, patch: ToiletRecordCorrectionPatch): Promise<ToiletRecord> {
+    const storage = readStorage();
+    const index = storage.records.findIndex((record) => record.id === recordId && !record.isDeleted);
+    if (index < 0) {
+      throw new Error(`[ToiletRecordRepo] record not found: ${recordId}`);
+    }
+
+    const current = storage.records[index];
+    const updated: ToiletRecord = {
+      ...current,
+      toiletType: patch.toiletType ?? current.toiletType,
+      amount: patch.amount ?? current.amount,
+      memo: patch.memo?.trim() ?? current.memo,
+      updatedAt: nextUpdatedAt(current.updatedAt),
+    };
+
+    writeStorage({
+      version: 1,
+      records: storage.records.map((record, recordIndex) => (recordIndex === index ? updated : record)),
+    });
+    return updated;
   }
 }

--- a/src/features/kiosk/toilet/types.ts
+++ b/src/features/kiosk/toilet/types.ts
@@ -25,6 +25,12 @@ export type ToiletRecordInput = {
   recorderName?: string;
 };
 
+export type ToiletRecordCorrectionPatch = {
+  toiletType?: ToiletType;
+  amount?: ToiletAmount;
+  memo?: string;
+};
+
 export const TOILET_TYPE_LABELS: Record<ToiletType, string> = {
   urination: '排尿',
   bowel: '排便',
@@ -42,4 +48,5 @@ export const TOILET_AMOUNT_LABELS: Record<ToiletAmount, string> = {
 export interface IToiletRecordRepository {
   listByDate(dateIso: string): Promise<ToiletRecord[]>;
   create(input: ToiletRecordInput): Promise<ToiletRecord>;
+  update(recordId: string, patch: ToiletRecordCorrectionPatch): Promise<ToiletRecord>;
 }


### PR DESCRIPTION
## Summary
- add repository-level correction specs for kiosk toilet records
- add the repository update contract and minimal LocalStorage/SharePoint implementations
- allow only toiletType, amount, and memo to change during correction
- keep userId, occurredAt, recordDate, and record id immutable

## Scope
- repository contract and repository implementations only
- no UI implementation
- no SharePoint list definition changes
- no env changes
- no delete behavior added
- docs/roadmaps remains untracked and excluded

## Verification
- npm test -- src/features/kiosk/toilet/__tests__/toiletRecordRepository.spec.ts
- npm run typecheck
- git diff --check
- git diff --name-only
- gh pr view 2252 --json changedFiles,files,isDraft,mergeable,mergeStateStatus