### PR TITLE
test(kiosk-toilet): cover correction dialog patch fields

### DIFF
--- a/src/features/kiosk/toilet/__tests__/ToiletDailyBoard.spec.tsx
+++ b/src/features/kiosk/toilet/__tests__/ToiletDailyBoard.spec.tsx
@@ -240,6 +240,72 @@ describe('ToiletDailyBoard', () => {
     });
   });
 
+  it('saves corrected type and amount without changing readonly record fields', async () => {
+    mockCorrectRecord.mockResolvedValue({
+      id: 'toilet-1',
+      userId: 'user-1',
+      recordDate: '2026-06-12',
+      occurredAt: '2026-06-12T10:30:00.000+09:00',
+      toiletType: 'bowel',
+      amount: 'large',
+      memo: '記録メモ',
+      recorderName: 'kiosk',
+      source: 'kiosk',
+      isDeleted: false,
+      createdAt: '2026-06-12T10:30:00.000+09:00',
+      updatedAt: '2026-06-12T10:35:00.000+09:00',
+    });
+    mockUseToiletRecords.mockReturnValue({
+      records: [
+        {
+          id: 'toilet-1',
+          userId: 'user-1',
+          recordDate: '2026-06-12',
+          occurredAt: '2026-06-12T10:30:00.000+09:00',
+          toiletType: 'urination',
+          amount: 'normal',
+          memo: '記録メモ',
+          recorderName: 'kiosk',
+          source: 'kiosk',
+          isDeleted: false,
+          createdAt: '2026-06-12T10:30:00.000+09:00',
+          updatedAt: '2026-06-12T10:30:00.000+09:00',
+        },
+      ],
+      create: mockCreateRecord,
+      correct: mockCorrectRecord,
+      refresh: mockRefreshRecords,
+      isLoading: false,
+      error: null,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/kiosk/toilet?date=2026-06-12']}>
+        <ToiletDailyBoard />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByTestId('toilet-correction-button-toilet-1'));
+
+    expect(screen.getByLabelText('利用者')).toHaveAttribute('readonly');
+    expect(screen.getByLabelText('記録日')).toHaveAttribute('readonly');
+    expect(screen.getByLabelText('記録日時')).toHaveAttribute('readonly');
+
+    fireEvent.mouseDown(screen.getByRole('combobox', { name: '種類' }));
+    fireEvent.click(screen.getByRole('option', { name: '排便' }));
+    fireEvent.mouseDown(screen.getByRole('combobox', { name: '量' }));
+    fireEvent.click(screen.getByRole('option', { name: '多量' }));
+    fireEvent.click(screen.getByTestId('toilet-correction-save'));
+
+    await waitFor(() => {
+      expect(mockCorrectRecord).toHaveBeenCalledWith('toilet-1', {
+        toiletType: 'bowel',
+        amount: 'large',
+        memo: '記録メモ',
+      });
+    });
+  });
+
   it('keeps the correction dialog open and shows an error when correction save fails', async () => {
     mockCorrectRecord.mockRejectedValue(new Error('訂正保存に失敗しました'));
     mockUseToiletRecords.mockReturnValue({


### PR DESCRIPTION
## Summary
- Add test coverage for changing toilet correction type and amount from the dialog
- Assert the correction patch contains only toiletType, amount, and memo
- Assert readonly user/date/time fields remain readonly in the correction flow

## Scope
- test-only
- One changed file: ToiletDailyBoard.spec.tsx
- No UI implementation changes
- No repository/SharePoint/env changes
- No delete/user/date/time correction behavior changes
- docs/roadmaps/ remains untracked and excluded

## Verification
- npx vitest run src/features/kiosk/toilet/__tests__/ToiletDailyBoard.spec.tsx
- npm run typecheck
- git diff --check HEAD~1..HEAD
- git diff --name-only HEAD~1..HEAD