### PR TITLE
test(kiosk-toilet): cover correction e2e smoke

### DIFF
--- a/tests/e2e/kiosk-home-smoke.spec.ts
+++ b/tests/e2e/kiosk-home-smoke.spec.ts
@@ -165,6 +165,36 @@ test.describe('Kiosk Home Smoke (memory provider for local kiosk flow checks)', 
       await expect(page.getByTestId('toilet-history-user-I005')).toContainText('1件');
     });
 
+    test('should correct a toilet record and refresh the displayed latest record', async ({ page }) => {
+      await page.getByTestId('kiosk-nav-toilet').click();
+
+      await expect(page).toHaveURL(/\/kiosk\/toilet(\?.*provider=memory.*)?/);
+      await expect(page.getByTestId('toilet-daily-board')).toBeVisible();
+
+      await page.getByTestId('toilet-record-button-I005').click();
+      await expect(page.getByRole('heading', { name: /石渡 由喜子さんのトイレ記録/ })).toBeVisible();
+      await page.getByTestId('toilet-record-save').click();
+
+      await expect(page.getByTestId('toilet-user-latest-I005')).toContainText('排尿 普通');
+
+      await page.locator('[data-testid^="toilet-correction-button-"]').first().click();
+      await expect(page.getByRole('heading', { name: /石渡 由喜子さんのトイレ記録を訂正/ })).toBeVisible();
+      await expect(page.getByLabel('利用者')).toHaveValue('石渡 由喜子');
+      await expect(page.getByRole('textbox', { name: '記録日', exact: true })).toBeEditable({ editable: false });
+      await expect(page.getByRole('textbox', { name: '記録日時', exact: true })).toBeEditable({ editable: false });
+
+      await page.getByRole('combobox', { name: '種類' }).click();
+      await page.getByRole('option', { name: '排便' }).click();
+      await page.getByRole('combobox', { name: '量' }).click();
+      await page.getByRole('option', { name: '多量' }).click();
+      await page.getByLabel('メモ').fill('E2E訂正メモ');
+      await page.getByTestId('toilet-correction-save').click();
+
+      await expect(page.getByRole('heading', { name: /石渡 由喜子さんのトイレ記録を訂正/ })).toHaveCount(0);
+      await expect(page.getByTestId('toilet-user-latest-I005')).toContainText('排便 多量');
+      await expect(page.getByTestId('toilet-history-user-I005')).toContainText('E2E訂正メモ');
+    });
+
     test('should keep schedule navigation active after schedule route redirects', async ({ page }) => {
       await bootKiosk(page, { route: '/kiosk?kiosk=1' });
 


### PR DESCRIPTION
## Summary
- Add a kiosk memory-provider E2E smoke for toilet record correction
- Cover create -> open correction dialog -> update type/amount/note -> refreshed latest record display
- Assert readonly correction fields for record date and occurred time remain non-editable

## Scope
- test-only
- One changed file: tests/e2e/kiosk-home-smoke.spec.ts
- No UI implementation changes
- No repository/SharePoint/env changes
- No delete/user/date/time correction behavior changes
- docs/roadmaps/ remains untracked and excluded

## Verification
- npx playwright test tests/e2e/kiosk-home-smoke.spec.ts --project=chromium --grep "should correct a toilet record" --reporter=line
- npx playwright test tests/e2e/kiosk-home-smoke.spec.ts --project=chromium --grep "toilet board|correct a toilet record" --reporter=line
- npm run typecheck
- git diff --check HEAD~1..HEAD
- git diff --name-only HEAD~1..HEAD