### PR TITLE
test(kiosk-toilet): cover correction error UI boundary

### DIFF
--- a/src/features/kiosk/toilet/__tests__/ToiletDailyBoard.spec.tsx
+++ b/src/features/kiosk/toilet/__tests__/ToiletDailyBoard.spec.tsx
@@ -454,5 +454,7 @@ describe('ToiletDailyBoard', () => {
       expect(screen.getByText('訂正保存に失敗しました')).toBeInTheDocument();
     });
     expect(screen.getByText('支援 花子さんのトイレ記録を訂正')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '訂正を保存' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'キャンセル' })).toBeEnabled();
   });
 });


### PR DESCRIPTION
## Summary
- Cover kiosk toilet correction error UI recovery state
- Assert the correction dialog stays open and shows the error after save failure
- Assert save and cancel actions are re-enabled after the failed correction attempt

## Tests
- `npm run test -- src/features/kiosk/toilet/__tests__/ToiletDailyBoard.spec.tsx`
- `npm run typecheck`
- `npm run lint`
- `git diff --check`
- commit hook: `npm run lint`
- commit hook: `npm run typecheck`
- commit hook: `npm run lint:cookies`

## Scope notes
- Test-only PR
- Changed file: `src/features/kiosk/toilet/__tests__/ToiletDailyBoard.spec.tsx`
- No runtime behavior changes
- No routing changes
- No SharePoint list definition or schema candidate changes
- No repository implementation changes
- No env file changes
- Existing untracked `docs/roadmaps/` remains out of scope