### PR TITLE
test(kiosk-toilet): cover correction success refresh behavior

### DIFF
--- a/src/features/kiosk/toilet/__tests__/useToiletRecords.spec.ts
+++ b/src/features/kiosk/toilet/__tests__/useToiletRecords.spec.ts
@@ -124,8 +124,9 @@ describe('useToiletRecords', () => {
       expect(result.current.isLoading).toBe(false);
     });
 
+    let returnedRecord: unknown;
     await act(async () => {
-      await result.current.correct('toilet-1', {
+      returnedRecord = await result.current.correct('toilet-1', {
         toiletType: 'bowel',
         amount: 'large',
         memo: 'corrected memo',
@@ -149,7 +150,9 @@ describe('useToiletRecords', () => {
       expect.any(Function),
       expect.any(Function),
     );
+    expect(returnedRecord).toBe(correctedRecord);
     expect(result.current.records).toEqual([correctedRecord]);
+    expect(result.current.error).toBeNull();
   });
 
   it('sets error when correction fails', async () => {


### PR DESCRIPTION
## Summary
- Cover kiosk toilet correction success refresh behavior in the hook boundary
- Assert `correct()` returns the corrected record from the repository update
- Assert successful correction refreshes the selected date records and leaves no error state behind

## Tests
- `npm run test -- src/features/kiosk/toilet/__tests__/useToiletRecords.spec.ts`
- `npm run typecheck`
- `npm run lint`
- `git diff --check`
- commit hook: `npm run lint`
- commit hook: `npm run typecheck`
- commit hook: `npm run lint:cookies`

## Scope notes
- Test-only PR
- Changed file: `src/features/kiosk/toilet/__tests__/useToiletRecords.spec.ts`
- No runtime behavior changes
- No UI implementation changes
- No routing changes
- No SharePoint list definition or schema candidate changes
- No repository implementation changes
- No env file changes
- Existing untracked `docs/roadmaps/` remains out of scope