### PR TITLE
test(e2e): stabilize home quick action activity locator

### DIFF
--- a/tests/e2e/home.tiles.spec.ts
+++ b/tests/e2e/home.tiles.spec.ts
@@ -35,7 +35,7 @@ test.describe('Dashboard smoke', () => {
       fallback: { status: 200, body: { value: [] } },
     });
 
-    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await page.goto('/dashboard', { waitUntil: 'domcontentloaded' });
     await page.waitForLoadState('networkidle', { timeout: 8_000 }).catch(() => undefined);
 
     const root = page.getByTestId(TESTIDS['dashboard-page']).or(page.getByTestId(TESTIDS.SCHEDULES_PAGE_ROOT));
@@ -57,20 +57,16 @@ test.describe('Dashboard smoke', () => {
     await expect(page.getByRole('heading', { name: /申し送りタイムライン|今日の予定/i }).first()).toBeVisible();
   });
 
-  test('quick action navigates to daily activity records', async ({ page }) => {
+  test('dashboard daily record navigation opens the daily record menu', async ({ page }) => {
     const root = page.getByTestId(TESTIDS['dashboard-page']).or(page.getByTestId(TESTIDS.SCHEDULES_PAGE_ROOT));
     await expect(root).toBeVisible({ timeout: 15_000 });
 
-    const quickAction = page
-      .getByTestId(TESTIDS.footer.dailyFooterActivity)
-      .or(page.getByRole('link', { name: /ケース記録入力|支援記録（ケース記録）入力/ }))
-      .or(page.locator('a[href="/daily/table"]'))
-      .or(page.locator('a[href="/daily/activity"]'))
-      .or(page.locator('a[href="/daily/activity/"]'));
+    const dailyNav = page.getByTestId(TESTIDS.nav.daily).first();
+    await expect(dailyNav).toBeVisible({ timeout: 15_000 });
+    await expect(dailyNav).toHaveAttribute('href', '/dailysupport');
+    await dailyNav.click();
 
-    await expect(quickAction.first()).toBeVisible({ timeout: 15_000 });
-    await quickAction.first().click();
-
-    await expect(page).toHaveURL(/\/(daily\/table|daily\/activity)/);
+    await expect(page).toHaveURL(/\/dailysupport/);
+    await expect(page.getByRole('heading', { level: 1, name: '日々の記録', exact: true })).toBeVisible({ timeout: 15_000 });
   });
 });


### PR DESCRIPTION
## Summary
- Replace the missing daily-footer-activity fallback in home.tiles.spec.ts with the dashboard shell daily record navigation contract.
- Navigate directly to /dashboard so the smoke test does not depend on landing redirects or kiosk footer visibility.
- Scope this PR to the E2E test only; kiosk/toilet correction code is untouched.

## Cause
- daily-footer-activity exists in footer config, but the dashboard fast-lane path does not render that footer link: normal dashboard mode has no footer quick actions, and kiosk mode renders footer dialogs only.
- The stable visible daily-record route from the dashboard shell is TESTIDS.nav.daily -> /dailysupport.

## Tests
- npm run e2e:home-tiles
- npm test -- tests/smoke/router.flags.spec.tsx
- npm run typecheck
- npm run lint
- git diff --check

## Scope notes
- Did not touch kiosk/toilet correction files.
- Did not touch SharePoint repository, toilet hook, ToiletDailyBoard, toilet tests, env, docs/roadmaps, dependencies, workflow, migrations, auth, or security code.