### PR TITLE
test(types): reconcile stale exports and enum mappings

### DIFF
--- a/scripts/generate-system-map.ts
+++ b/scripts/generate-system-map.ts
@@ -559,7 +559,7 @@ function formatDiagnosticsSection(routes: RouteRow[]): string {
   // 2. Navigation Targets exposure (cross-reference based on APP_ROUTE_PATHS)
   const routerPathSet = new Set(APP_ROUTE_PATHS.map(normalizeRouterPath));
 
-  const roles: ('admin' | 'reception' | 'viewer')[] = ['admin', 'reception', 'viewer'];
+  const roles: ('admin' | 'reception' | 'staff')[] = ['admin', 'reception', 'staff'];
   const activeNavHrefs = new Set<string>();
 
   roles.forEach((role) => {

--- a/src/data/isp/__tests__/mapper.spec.ts
+++ b/src/data/isp/__tests__/mapper.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { mapPlanningSheetRowToDomain, mapPlanningSheetRowToListItem, extractSpId } from '../mapper';
-import type { SpPlanningSheetRow } from '@/lib/sp/types';
+import type { SpPlanningSheetRow } from '@/sharepoint/fields/ispThreeLayerFields';
 
 describe('isp mapper parseDateOnly', () => {
   it('correctly maps various appliedFrom date formats to YYYY-MM-DD JST strings', () => {
@@ -60,4 +60,3 @@ describe('isp mapper ID normalization', () => {
     expect(extractSpId('invalid')).toBeNull();
   });
 });
-

--- a/src/features/daily/infra/__tests__/DataProviderDailyRecordRepository.spec.ts
+++ b/src/features/daily/infra/__tests__/DataProviderDailyRecordRepository.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { DataProviderDailyRecordRepository } from '../DataProviderDailyRecordRepository';
 import type { IDataProvider } from '@/lib/data/dataProvider.interface';
-import type { SaveDailyRecordInput } from '../domain/DailyRecordRepository';
+import type { SaveDailyRecordInput } from '../../domain/DailyRecordRepository';
 
 describe('DataProviderDailyRecordRepository (Contract Tests)', () => {
   const mockProvider = {

--- a/src/features/daily/repositories/sharepoint/__tests__/DailyRecordSchemaDrift.spec.ts
+++ b/src/features/daily/repositories/sharepoint/__tests__/DailyRecordSchemaDrift.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { DailyRecordSchemaResolver } from '../modules/SchemaResolver';
 import { SharePointDailyRecordRepository } from '../SharePointDailyRecordRepository';
-import type { TableDailyRecord } from '../../../domain/types';
+import type { SaveDailyRecordInput } from '../../../domain/legacy/DailyRecordRepository';
 
 const jsonResponse = (value: unknown): Response =>
   new Response(JSON.stringify(value), {
@@ -34,7 +34,7 @@ describe('DailyRecord Schema Drift & Dynamic Resolution', () => {
       return jsonResponse({ value: [] });
     });
 
-    const resolver = new DailyRecordSchemaResolver(spFetch);
+    const resolver = new DailyRecordSchemaResolver(spFetch, 'SupportRecord_Daily');
     const resolved = await resolver.resolveParentFields("lists/getbytitle('SupportRecord_Daily')");
 
     expect(resolved.recordDate).toBe('Date');
@@ -80,13 +80,11 @@ describe('DailyRecord Schema Drift & Dynamic Resolution', () => {
       listTitle: 'SupportRecord_Daily',
     });
 
-    const record: TableDailyRecord = {
-      id: '2026-05-14',
+    const record: SaveDailyRecordInput = {
       date: '2026-05-14',
       reporter: { name: 'Test Reporter', role: 'Staff' },
       userRows: [],
       userCount: 0,
-      status: 'draft',
     };
 
     await repo.save(record);
@@ -160,7 +158,6 @@ describe('DailyRecord Schema Drift & Dynamic Resolution', () => {
     });
 
     await repo.save({
-      id: '2026-05-15',
       date: '2026-05-15',
       reporter: { name: 'Reporter', role: 'Staff' },
       userRows: [
@@ -182,7 +179,6 @@ describe('DailyRecord Schema Drift & Dynamic Resolution', () => {
         },
       ],
       userCount: 1,
-      status: 'draft',
     });
 
     expect(childBodies.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- Align navigation diagnostics generation with current `NavAudience` values by using `staff` instead of stale `viewer`.
- Move stale `SpPlanningSheetRow` and daily record repository imports to their current module paths.
- Update the daily schema drift test payloads to the current save input shape after following the moved type.

## Verification
- `npm run typecheck:full` (still fails, but the targeted stale export/path/enum errors are removed; remaining failures are separate lanes such as SpFetch/ActivityDiary, UI handler types, kiosk/toilet, residual planning-sheet fixtures, and schema mock drift)
- `npm run typecheck`
- `npm run lint`
- `npx vitest run src/data/isp/__tests__/mapper.spec.ts src/features/daily/infra/__tests__/DataProviderDailyRecordRepository.spec.ts src/features/daily/repositories/sharepoint/__tests__/DailyRecordSchemaDrift.spec.ts`
- `git diff --check`

## Scope notes
- Did not touch SpFetch / ActivityDiary fixes, UI handler types, home.tiles, kiosk/toilet, E2E smoke flakes, workflow, package, lockfile, migrations, auth/security, `.env`, or `docs/roadmaps/`.
