### PR TITLE
test(types): align spfetch and activity diary typed tests

### DIFF
--- a/src/features/daily/repositories/sharepoint/activityDiary/SharePointActivityDiaryRepository.spec.ts
+++ b/src/features/daily/repositories/sharepoint/activityDiary/SharePointActivityDiaryRepository.spec.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from 'vitest';
 import type { ADMapping } from './constants';
 import { getADListTitle } from './constants';
 import { SharePointActivityDiaryRepository } from './SharePointActivityDiaryRepository';
+import type { SpFetchFn } from '@/lib/sp/spLists';
+import type { ActivityDiaryUpsert } from '@/features/daily/domain/activityDiaryTypes';
 
 const mockResolve = vi.fn();
 const mockLoadByDate = vi.fn();
@@ -33,21 +35,21 @@ vi.mock('./modules/Saver', () => ({
 
 describe('SharePointActivityDiaryRepository', () => {
   it('schema が解決できない場合は保存で例外を投げる', async () => {
-    const resolver = new SharePointActivityDiaryRepository({ spFetch: vi.fn() as never });
+    const resolver = new SharePointActivityDiaryRepository({ spFetch: vi.fn<SpFetchFn>() });
 
     mockResolve.mockResolvedValueOnce(null);
 
-    const input = {
-      userId: 'U-001',
+    const input: ActivityDiaryUpsert = {
+      userId: 1,
       dateISO: '2026-06-10',
       period: 'AM',
-      category: '日常',
-      mealMain: null,
-      mealSide: null,
+      category: '請負',
+      mealMain: undefined,
+      mealSide: undefined,
       behavior: { has: false, kinds: [] },
-      seizure: { has: false, at: null },
+      seizure: { has: false, at: undefined },
       goalIds: [],
-      notes: null,
+      notes: undefined,
     };
 
     await expect(
@@ -71,29 +73,29 @@ describe('SharePointActivityDiaryRepository', () => {
       {
         Id: '999',
         Shift: 'AM',
-        Category: '日常',
+        Category: '請負',
       },
     ]);
     mockSave.mockResolvedValueOnce({ id: 999 });
 
-    const repo = new SharePointActivityDiaryRepository({ spFetch: vi.fn() as never });
+    const repo = new SharePointActivityDiaryRepository({ spFetch: vi.fn<SpFetchFn>() });
 
-    const input = {
-      userId: 'U-001',
+    const input: ActivityDiaryUpsert = {
+      userId: 1,
       dateISO: '2026-06-10',
       period: 'AM',
-      category: '日常',
-      mealMain: null,
-      mealSide: null,
+      category: '請負',
+      mealMain: undefined,
+      mealSide: undefined,
       behavior: { has: true, kinds: ['離席'] },
-      seizure: { has: false, at: null },
-      goalIds: ['G-1'],
+      seizure: { has: false, at: undefined },
+      goalIds: [1],
       notes: 'ノート',
     };
 
     await repo.save(input);
 
-    expect(mockLoadByDate).toHaveBeenCalledWith('2026-06-10', 'U-001', '/lists/ActivityDiary', resolverValue.mapping, undefined);
+    expect(mockLoadByDate).toHaveBeenCalledWith('2026-06-10', 1, '/lists/ActivityDiary', resolverValue.mapping, undefined);
     expect(mockSave).toHaveBeenCalledWith(input, '/lists/ActivityDiary', getADListTitle(), resolverValue.mapping, 999);
   });
 });

--- a/src/features/daily/repositories/sharepoint/activityDiary/modules/DataAccess.spec.ts
+++ b/src/features/daily/repositories/sharepoint/activityDiary/modules/DataAccess.spec.ts
@@ -3,6 +3,12 @@ import { ActivityDiaryDataAccess } from './DataAccess';
 import type { ADMapping } from '../constants';
 import type { SpFetchFn } from '@/lib/sp/spLists';
 
+const jsonResponse = (value: unknown): Response =>
+  new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
 describe('ActivityDiaryDataAccess', () => {
   const defaultMapping: ADMapping = {
     userId: 'UserID',
@@ -28,7 +34,7 @@ describe('ActivityDiaryDataAccess', () => {
         { Id: 102, Title: 'entry-102' },
       ],
     };
-    const spFetch = vi.fn(async () => ({ ok: true, json: async () => response })) as SpFetchFn;
+    const spFetch = vi.fn<SpFetchFn>().mockResolvedValue(jsonResponse(response));
     const access = new ActivityDiaryDataAccess(spFetch);
 
     const result = await access.loadByDate(
@@ -52,7 +58,7 @@ describe('ActivityDiaryDataAccess', () => {
   });
 
   it('lists with date range and default top', async () => {
-    const spFetch = vi.fn(async () => ({ ok: true, json: async () => ({ value: [{ Id: 1 }, { Id: 2 }] }) })) as SpFetchFn;
+    const spFetch = vi.fn<SpFetchFn>().mockResolvedValue(jsonResponse({ value: [{ Id: 1 }, { Id: 2 }] }));
     const access = new ActivityDiaryDataAccess(spFetch);
 
     await access.list('2026-06-01', '2026-06-30', 'lists/ActivityDiary', defaultMapping);

--- a/src/features/daily/repositories/sharepoint/activityDiary/modules/Saver.spec.ts
+++ b/src/features/daily/repositories/sharepoint/activityDiary/modules/Saver.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { ActivityDiarySaver } from './Saver';
 import { AD_FIELDS, type ADMapping } from '../constants';
 import { spWriteResilient } from '@/lib/spWrite';
+import type { SpFetchFn } from '@/lib/sp/spLists';
 
 vi.mock('@/lib/spWrite', () => ({
   spWriteResilient: vi.fn(),
@@ -37,19 +38,19 @@ describe('ActivityDiarySaver mapper boundaries', () => {
   it('maps mealMain "多め" to SharePoint lunch amount "8割"', async () => {
     vi.mocked(spWriteResilient).mockResolvedValue(createResponse());
 
-    const saver = new ActivityDiarySaver(vi.fn());
+    const saver = new ActivityDiarySaver(vi.fn<SpFetchFn>());
     await saver.save(
       {
-        userId: 'U001',
+        userId: 1,
         dateISO: '2026-06-10',
-        period: 'am',
-        category: '日常',
+        period: 'AM',
+        category: '請負',
         mealMain: '多め',
-        mealSide: null,
+        mealSide: undefined,
         behavior: { has: false, kinds: [] },
-        seizure: { has: false, at: null },
+        seizure: { has: false, at: undefined },
         goalIds: [],
-        notes: null,
+        notes: undefined,
       },
       'lists/ActivityDiary',
       'ActivityDiary',
@@ -65,19 +66,19 @@ describe('ActivityDiarySaver mapper boundaries', () => {
   it('maps behavior.has=false to false/null fields for problem behavior payload', async () => {
     vi.mocked(spWriteResilient).mockResolvedValue(createResponse());
 
-    const saver = new ActivityDiarySaver(vi.fn());
+    const saver = new ActivityDiarySaver(vi.fn<SpFetchFn>());
     await saver.save(
       {
-        userId: 'U001',
+        userId: 1,
         dateISO: '2026-06-10',
-        period: 'pm',
-        category: '日常',
-        mealMain: null,
-        mealSide: null,
+        period: 'PM',
+        category: '請負',
+        mealMain: undefined,
+        mealSide: undefined,
         behavior: { has: false, kinds: ['離席'] },
-        seizure: { has: false, at: null },
+        seizure: { has: false, at: undefined },
         goalIds: [],
-        notes: null,
+        notes: undefined,
       },
       'lists/ActivityDiary',
       'ActivityDiary',

--- a/src/features/daily/repositories/sharepoint/modules/IntegrityScanner.spec.ts
+++ b/src/features/daily/repositories/sharepoint/modules/IntegrityScanner.spec.ts
@@ -2,6 +2,12 @@ import { describe, expect, it, vi } from 'vitest';
 import type { SpFetchFn } from '@/lib/sp/spLists';
 import { DailyRecordIntegrityScanner } from './IntegrityScanner';
 
+const jsonResponse = (value: unknown): Response =>
+  new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
 describe('DailyRecordIntegrityScanner', () => {
   const resolvedRowsFields = {
     parentId: 'Parent_x0020_ID',
@@ -14,7 +20,7 @@ describe('DailyRecordIntegrityScanner', () => {
   };
 
   it('returns empty result when dates are empty without querying', async () => {
-    const spFetch = vi.fn(async () => ({ ok: true, json: async () => ({ value: [] }) })) as SpFetchFn;
+    const spFetch = vi.fn<SpFetchFn>().mockResolvedValue(jsonResponse({ value: [] }));
     const scanner = new DailyRecordIntegrityScanner(spFetch);
 
     const result = await scanner.scan([], 'SupportRecord_Daily', 'DailyRecordRows', resolvedRowsFields);
@@ -24,45 +30,33 @@ describe('DailyRecordIntegrityScanner', () => {
   });
 
   it('classifies mismatch between parent latest version and child versions', async () => {
-    const spFetch = vi.fn(async (url: string) => {
+    const spFetch = vi.fn<SpFetchFn>(async (url) => {
       if (url.startsWith('SupportRecord_Daily/items?')) {
-        return {
-          ok: true,
-          json: async () => ({
-            value: [{ Id: 11, RecordDate: '2026-06-10T00:00:00Z', LatestVersion: 3 }],
-          }),
-        };
+        return jsonResponse({
+          value: [{ Id: 11, RecordDate: '2026-06-10T00:00:00Z', LatestVersion: 3 }],
+        });
       }
 
       if (url.includes('DailyRecordRows/items?$filter=')) {
-        return {
-          ok: true,
-          json: async () => ({
-            value: [
-              {
-                Parent_x0020_ID: 11,
-                User_x0020_ID: 'U001',
-                Version: 1,
-                Status: 'committed',
-                Recorded_x0020_At: '2026-06-10T00:00:00Z',
-              },
-            ],
-          }),
-        };
+        return jsonResponse({
+          value: [
+            {
+              Parent_x0020_ID: 11,
+              User_x0020_ID: 'U001',
+              Version: 1,
+              Status: 'committed',
+              Recorded_x0020_At: '2026-06-10T00:00:00Z',
+            },
+          ],
+        });
       }
 
       if (url.includes("lists/getbytitle('UserTransport_Settings')/items?$filter=")) {
-        return {
-          ok: true,
-          json: async () => ({ value: [] }),
-        };
+        return jsonResponse({ value: [] });
       }
 
-      return {
-        ok: true,
-        json: async () => ({ value: [] }),
-      };
-    }) as SpFetchFn;
+      return jsonResponse({ value: [] });
+    });
 
     const scanner = new DailyRecordIntegrityScanner(spFetch);
     const result = await scanner.scan(
@@ -78,39 +72,33 @@ describe('DailyRecordIntegrityScanner', () => {
   });
 
   it('continues when accessory probe fails and still reports orphan_parent', async () => {
-    const spFetch = vi.fn(async (url: string) => {
+    const spFetch = vi.fn<SpFetchFn>(async (url) => {
       if (url.startsWith('SupportRecord_Daily/items?')) {
-        return {
-          ok: true,
-          json: async () => ({
-            value: [{ Id: 11, RecordDate: '2026-06-10T00:00:00Z', LatestVersion: 2 }],
-          }),
-        };
+        return jsonResponse({
+          value: [{ Id: 11, RecordDate: '2026-06-10T00:00:00Z', LatestVersion: 2 }],
+        });
       }
 
       if (url.includes('DailyRecordRows/items?$filter=')) {
-        return {
-          ok: true,
-          json: async () => ({
-            value: [
-              {
-                Parent_x0020_ID: 11,
-                User_x0020_ID: 'U001',
-                Version: 1,
-                Status: 'committed',
-                Recorded_x0020_At: '2026-06-10T00:00:00Z',
-              },
-            ],
-          }),
-        };
+        return jsonResponse({
+          value: [
+            {
+              Parent_x0020_ID: 11,
+              User_x0020_ID: 'U001',
+              Version: 1,
+              Status: 'committed',
+              Recorded_x0020_At: '2026-06-10T00:00:00Z',
+            },
+          ],
+        });
       }
 
       if (url.includes("lists/getbytitle('UserTransport_Settings')/items?$filter=")) {
         throw new Error('transport fetch failed');
       }
 
-      return { ok: true, json: async () => ({ value: [] }) };
-    }) as SpFetchFn;
+      return jsonResponse({ value: [] });
+    });
 
     const scanner = new DailyRecordIntegrityScanner(spFetch);
     const result = await scanner.scan(

--- a/src/features/daily/repositories/sharepoint/modules/RowAggregateAccess.spec.ts
+++ b/src/features/daily/repositories/sharepoint/modules/RowAggregateAccess.spec.ts
@@ -3,6 +3,12 @@ import { RowAggregateAccess } from './RowAggregateAccess';
 import type { RowAggregateSource } from '../constants';
 import type { SpFetchFn } from '@/lib/sp/spLists';
 
+const jsonResponse = (value: unknown): Response =>
+  new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
 describe('RowAggregateAccess', () => {
   it('aggregates rows by date and merges duplicate users', async () => {
     const source: RowAggregateSource = {
@@ -12,62 +18,59 @@ describe('RowAggregateAccess', () => {
       selectFields: ['Id', 'cr013_personId', 'Title', 'cr013_date', 'cr013_payload', 'cr013_kind'],
     };
 
-    const spFetch = vi.fn(async (url: string) => {
+    const spFetch = vi.fn<SpFetchFn>(async (url) => {
       if (url.startsWith('lists/DailyRows/items?')) {
-        return {
-          ok: true,
-          json: async () => ({
-            value: [
-              {
-                Id: 1,
-                cr013_personId: 'U-001',
-                Title: 'Alice',
-                cr013_date: '2026-06-10',
-                cr013_kind: 'A',
-                cr013_payload: JSON.stringify({
-                  amActivities: ['walk'],
-                  pmActivities: ['study'],
-                  specialNotes: 'first',
-                }),
-              },
-              {
-                Id: 2,
-                cr013_personId: 'U-001',
-                Title: 'Alice',
-                cr013_date: '2026-06-10',
-                cr013_kind: 'A',
-                cr013_payload: JSON.stringify({
-                  pmActivities: ['rest'],
-                  specialNotes: 'second',
-                }),
-              },
-              {
-                Id: 3,
-                cr013_personId: 'U-002',
-                Title: 'Bob',
-                cr013_date: '2026-06-11',
-                cr013_kind: 'A',
-                cr013_payload: JSON.stringify({
-                  amActivities: ['meal'],
-                  specialNotes: 'single',
-                }),
-              },
-              {
-                Id: 4,
-                cr013_personId: 'U-003',
-                Title: 'Carol',
-                cr013_date: '2026-05-31',
-                cr013_kind: 'A',
-                cr013_payload: JSON.stringify({
-                  amActivities: ['skip'],
-                }),
-              },
-            ],
-          }),
-        };
+        return jsonResponse({
+          value: [
+            {
+              Id: 1,
+              cr013_personId: 'U-001',
+              Title: 'Alice',
+              cr013_date: '2026-06-10',
+              cr013_kind: 'A',
+              cr013_payload: JSON.stringify({
+                amActivities: ['walk'],
+                pmActivities: ['study'],
+                specialNotes: 'first',
+              }),
+            },
+            {
+              Id: 2,
+              cr013_personId: 'U-001',
+              Title: 'Alice',
+              cr013_date: '2026-06-10',
+              cr013_kind: 'A',
+              cr013_payload: JSON.stringify({
+                pmActivities: ['rest'],
+                specialNotes: 'second',
+              }),
+            },
+            {
+              Id: 3,
+              cr013_personId: 'U-002',
+              Title: 'Bob',
+              cr013_date: '2026-06-11',
+              cr013_kind: 'A',
+              cr013_payload: JSON.stringify({
+                amActivities: ['meal'],
+                specialNotes: 'single',
+              }),
+            },
+            {
+              Id: 4,
+              cr013_personId: 'U-003',
+              Title: 'Carol',
+              cr013_date: '2026-05-31',
+              cr013_kind: 'A',
+              cr013_payload: JSON.stringify({
+                amActivities: ['skip'],
+              }),
+            },
+          ],
+        });
       }
-      return { ok: true, json: async () => ({ value: [] }) };
-    }) as SpFetchFn;
+      return jsonResponse({ value: [] });
+    });
 
     const access = new RowAggregateAccess(spFetch);
     const result = await access.list(source, { range: { startDate: '2026-06-10', endDate: '2026-06-11' } });
@@ -91,10 +94,7 @@ describe('RowAggregateAccess', () => {
       selectFields: ['Id', 'cr013_personId', 'Title', 'cr013_date', 'cr013_payload', 'cr013_kind'],
     };
 
-    const spFetch = vi.fn(async () => ({
-      ok: true,
-      json: async () => ({ value: [] }),
-    })) as SpFetchFn;
+    const spFetch = vi.fn<SpFetchFn>().mockResolvedValue(jsonResponse({ value: [] }));
 
     const access = new RowAggregateAccess(spFetch);
     await access.list(source, { range: { startDate: '2026-01-01', endDate: '2026-01-31' }, limit: 2 });


### PR DESCRIPTION
## Summary
- Align daily SharePoint SpFetch test doubles with the current `SpFetchFn` contract by returning `Response` objects from typed mocks.
- Keep Vitest mock handles typed as mocks while passing them directly to repository/data-access constructors.
- Update ActivityDiary typed test inputs to the current `ActivityDiaryUpsert` contract for numeric user/goal IDs, uppercase periods, current categories, and optional fields.

## Tests
- `npm run typecheck:full -- --pretty false` (expected fail overall; no remaining SpFetch / ActivityDiary / IntegrityScanner / RowAggregateAccess / SharePointActivityDiary matches)
- `npm run typecheck`
- `npm run lint`
- `npx vitest run src/features/daily/repositories/sharepoint/activityDiary/modules/DataAccess.spec.ts src/features/daily/repositories/sharepoint/activityDiary/modules/Saver.spec.ts src/features/daily/repositories/sharepoint/activityDiary/SharePointActivityDiaryRepository.spec.ts src/features/daily/repositories/sharepoint/modules/IntegrityScanner.spec.ts src/features/daily/repositories/sharepoint/modules/RowAggregateAccess.spec.ts`
- `git diff --check`

## Scope notes
- Limited to SpFetch / ActivityDiary typed tests in five spec files.
- Does not touch UI handler types, kiosk/toilet, home.tiles, app-shell/nav/router/checklist E2E flake, workflow, package, lockfile, migration, auth/security, `.env`, or `docs/roadmaps/`.
