### PR TITLE
test(ui): align planning sheet handler typed tests

### DIFF
--- a/src/pages/planning-sheet-list/__tests__/PlanningSheetListPage.regression.spec.tsx
+++ b/src/pages/planning-sheet-list/__tests__/PlanningSheetListPage.regression.spec.tsx
@@ -13,6 +13,7 @@ const mockHandlers: PlanningSheetListActionHandlers = {
   onOpenIceberg: vi.fn(),
   onCreateFromIceberg: vi.fn(),
   onReviseFromIceberg: vi.fn(),
+  onDeleteSheet: vi.fn(),
   onBackToIsp: vi.fn(),
 };
 

--- a/src/pages/support-planning-sheet/__tests__/SupportPlanningSheetReflection.spec.tsx
+++ b/src/pages/support-planning-sheet/__tests__/SupportPlanningSheetReflection.spec.tsx
@@ -22,6 +22,10 @@ vi.mock('@/features/ibd/analysis/pdca/components/AbcEvidencePanel', () => ({
 import { SupportPlanningSheetView } from '../SupportPlanningSheetView';
 import { MemoryRouter } from 'react-router-dom';
 import { SupportPlanningSheetViewModel, SupportPlanningSheetActionHandlers } from '../types';
+import type { SupportPlanningSheet } from '@/domain/isp/schema';
+import { createEmptyEvidenceLinkMap } from '@/domain/isp/evidenceLink';
+import type { ContextPanelData } from '@/features/context/domain/contextPanelLogic';
+import type { UsePlanningSheetFormReturn } from '@/features/planning-sheet/hooks/usePlanningSheetForm';
 
 vi.mock('@/features/planning-sheet/hooks/orchestrators/usePlanningSheetOrchestrator', () => ({
   usePlanningSheetOrchestrator: () => ({
@@ -109,7 +113,7 @@ const mockViewModel: SupportPlanningSheetViewModel = {
   auditRecords: [],
   filteredAuditRecords: [],
   latestMonitoringRecord: null,
-  evidenceLinks: {},
+  evidenceLinks: createEmptyEvidenceLinkMap(),
   abcRecords: [],
   pdcaItems: [],
   strategyUsage: null,

--- a/src/pages/support-planning-sheet/__tests__/SupportPlanningSheetView.regression.spec.tsx
+++ b/src/pages/support-planning-sheet/__tests__/SupportPlanningSheetView.regression.spec.tsx
@@ -67,6 +67,9 @@ const mockHandlers: SupportPlanningSheetActionHandlers = {
   onReflectCandidate: vi.fn(),
   onNavigateToExecution: vi.fn(),
   onNavigateToPdca: vi.fn(),
+  onOpenReflectPreview: vi.fn(),
+  onCloseReflectPreview: vi.fn(),
+  onConfirmReflect: vi.fn(),
   onRefresh: vi.fn(),
 };
 

--- a/src/pages/support-planning-sheet/hooks/__tests__/supportPlanningSheetViewModelMapper.spec.ts
+++ b/src/pages/support-planning-sheet/hooks/__tests__/supportPlanningSheetViewModelMapper.spec.ts
@@ -69,6 +69,7 @@ describe('supportPlanningSheetViewModelMapper', () => {
     source: null,
     diffSummary: null,
     latestIcebergSnapshot: null,
+    reflectPreviewOpen: false,
   };
 
   it('ViewModel が正しくマッピングされること', () => {


### PR DESCRIPTION
## Summary
- Align planning sheet list regression handlers with the current `PlanningSheetListActionHandlers` contract.
- Align support planning sheet regression handlers and mapper input fixtures with the current view-model props.
- Replace stale reflection test placeholders with current imports and the canonical empty `EvidenceLinkMap` helper.

## Tests
- `npm run typecheck:full -- --pretty false` (expected fail overall; no remaining UI handler lane matches for PlanningSheetListActionHandlers / SupportPlanningSheetActionHandlers / SupportPlanningSheetReflection / supportPlanningSheetViewModelMapper)
- `npm run typecheck`
- `npm run lint`
- `npx vitest run src/pages/planning-sheet-list/__tests__/PlanningSheetListPage.regression.spec.tsx src/pages/support-planning-sheet/__tests__/SupportPlanningSheetView.regression.spec.tsx src/pages/support-planning-sheet/hooks/__tests__/supportPlanningSheetViewModelMapper.spec.ts src/pages/support-planning-sheet/__tests__/SupportPlanningSheetReflection.spec.tsx`
- `git diff --check`

## Scope notes
- Limited to planning / support-planning sheet UI handler typed tests in four spec files.
- Does not touch kiosk/toilet, home.tiles, app-shell/nav/router/checklist E2E flake, SpFetch / ActivityDiary, workflow, package, lockfile, migration, auth/security, `.env`, or `docs/roadmaps/`.
