### PR TITLE
test(editor): align meeting minutes slash menu editor typing

### DIFF
--- a/src/features/meeting-minutes/editor/__tests__/slashMenuItems.spec.ts
+++ b/src/features/meeting-minutes/editor/__tests__/slashMenuItems.spec.ts
@@ -18,11 +18,15 @@ import {
   PRIMARY_MENU_ITEM_TITLES,
   SECONDARY_MENU_ITEM_TITLES,
   MEETING_PREFIX,
+  type MeetingMinutesEditor,
 } from '../slashMenuItems';
 import { BlockNoteEditor } from '@blocknote/core';
+import { meetingMinutesSchema } from '../blockKinds';
 
 describe('slashMenuItems', () => {
-  const editor = BlockNoteEditor.create();
+  const editor: MeetingMinutesEditor = BlockNoteEditor.create({
+    schema: meetingMinutesSchema,
+  });
 
   // ── 全体構造 ──────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Build the slash menu spec editor with the meeting-minutes BlockNote schema.
- Type the test editor as `MeetingMinutesEditor` so slash menu helpers receive the current editor contract.
- Keep the change limited to the slash menu typed-test drift.

## Tests
- `npm run typecheck:full -- --pretty false` (expected fail overall; no remaining meeting-minutes editor / slashMenuItems / MeetingMinutesEditor matches)
- `npm run typecheck`
- `npm run lint`
- `npx vitest run src/features/meeting-minutes/editor/__tests__/slashMenuItems.spec.ts`
- `git diff --check`

## Scope notes
- Limited to `src/features/meeting-minutes/editor/__tests__/slashMenuItems.spec.ts`.
- Does not touch kiosk/toilet, planning-sheet/support-planning sheet, SpFetch/ActivityDiary, home.tiles, app-shell/nav/router/checklist E2E flake, workflow, package, lockfile, migration, auth/security, `.env`, or `docs/roadmaps/`.
