### PR TITLE
test(audit): align audit engine history typed expectations

### DIFF
--- a/src/domain/audit/__tests__/auditEngine.spec.ts
+++ b/src/domain/audit/__tests__/auditEngine.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { auditISP, auditProcess, runAudit, buildEvidenceLinks, generateRecommendations } from "../auditEngine";
-import { ISP, IcebergAnalysis } from "../types";
+import { AuditHistoryEntry, ISP, IcebergAnalysis } from "../types";
 
 describe("AuditEngine", () => {
   const validISP: ISP = {
@@ -265,7 +265,7 @@ describe("AuditEngine", () => {
 
   describe("Adaptive Loop (History & Learning)", () => {
     it("should mark results as isRecurring and add urgency prefix if streak > 0", () => {
-      const history: Record<string, unknown>[] = [
+      const history: AuditHistoryEntry[] = [
         { code: "ICEBERG_MISSING", streak: 2, lastSeen: "2024-04-10", riskTrend: "stable" }
       ];
 
@@ -294,7 +294,7 @@ describe("AuditEngine", () => {
     });
 
     it("should flag predictive risk for long streaks of process warnings", () => {
-      const history: Record<string, unknown>[] = [
+      const history: AuditHistoryEntry[] = [
         { code: "ICEBERG_MISSING", streak: 4, lastSeen: "2024-04-10", riskTrend: "rising" }
       ];
 


### PR DESCRIPTION
## Summary
- Fix auditEngine spec typed test drift for history entries by aligning history fixtures to AuditHistoryEntry.

## Scope
- Scope is limited to src/domain/audit/__tests__/auditEngine.spec.ts.

## Verification
- npm run typecheck
- npm run lint
- npx vitest run src/domain/audit/__tests__/auditEngine.spec.ts (21 passed)
- git diff --check

## Notes
- main remains with other unrelated typecheck:full failures in other lanes.
