### PR TITLE
test(regulatory): align audit check input builder typing

### DIFF
--- a/src/domain/regulatory/__tests__/auditCheckInputBuilder.spec.ts
+++ b/src/domain/regulatory/__tests__/auditCheckInputBuilder.spec.ts
@@ -62,6 +62,8 @@ function makeSheet(overrides: Partial<PlanningSheetListItem> = {}): PlanningShee
     applicableServiceType: 'daily_life_care',
     applicableAddOnTypes: ['severe_disability_support'],
     authoredByQualification: 'practical_training',
+    supportStartDate: null,
+    appliedFrom: null,
     reviewedAt: null,
     ...overrides,
   };


### PR DESCRIPTION
## Summary
- Align regulatory audit check input builder fixture with current PlanningSheetListItem fields
- Add null defaults for supportStartDate and appliedFrom
- Keep the change scoped to the regulatory typed test fixture

## Verification
- npm run typecheck
- npm run lint
- npx vitest run src/domain/regulatory/__tests__/auditCheckInputBuilder.spec.ts
- git diff --check
- npm run typecheck:full -- --pretty false
  - still fails in unrelated remaining lanes
  - auditCheckInputBuilder supportStartDate error is resolved
