### PR TITLE
test(today): align plan patch mapper spec typing

### DIFF
--- a/src/domain/today/__tests__/planPatchToTodayActionMapper.spec.ts
+++ b/src/domain/today/__tests__/planPatchToTodayActionMapper.spec.ts
@@ -56,6 +56,6 @@ describe('mapPlanPatchToTodayActionSource', () => {
     });
 
     expect(result.isCompleted).toBe(true);
-    expect(result.payload.userName).toBe('U001');
+    expect((result.payload as { userName: string }).userName).toBe('U001');
   });
 });


### PR DESCRIPTION
## Summary
- Align plan patch mapper spec typing to current `RawActionSource` payload contract by narrowing `result.payload` before accessing `userName`.
- Keep change scoped to `src/domain/today/__tests__/planPatchToTodayActionMapper.spec.ts`.

## Verification
- npm run typecheck:full -- --pretty false
  - this file is no longer the failure source
  - remaining failures are in other lanes
- npm run lint
- npx vitest run src/domain/today/__tests__/planPatchToTodayActionMapper.spec.ts

## Scope
- test-only / typing-only change
- no behavior/runtime changes
- no changes outside the target spec
