### PR TITLE
test(daily): align user selection step spec typing

### DIFF
--- a/src/features/daily/components/__tests__/UserSelectionStep.spec.tsx
+++ b/src/features/daily/components/__tests__/UserSelectionStep.spec.tsx
@@ -16,22 +16,24 @@ import { UserSelectionStep } from '../wizard/UserSelectionStep';
 describe('UserSelectionStep', () => {
   const dummyUsers: IUserMaster[] = [
     {
+      Id: 1,
       UserID: 'U001',
       FullName: '利用者 一郎',
       DisabilitySupportLevel: '区分3',
       IsHighIntensitySupportTarget: false,
       BehaviorScore: 5,
       ServiceStartDate: '2026-01-01',
-      Status: 'active',
+      UsageStatus: 'active',
     },
     {
+      Id: 2,
       UserID: 'U002',
       FullName: '利用者 二郎',
       DisabilitySupportLevel: '区分6',
       IsHighIntensitySupportTarget: true,
       BehaviorScore: 12,
       ServiceStartDate: '2026-01-01',
-      Status: 'active',
+      UsageStatus: 'active',
     },
   ];
 


### PR DESCRIPTION
## Summary
- Align `UserSelectionStep` typed spec fixture with current `IUserMaster` contract.
- Replace obsolete `Status` with `UsageStatus` and add required `Id` in typed user fixtures.
- Keep scope limited to `src/features/daily/components/__tests__/UserSelectionStep.spec.tsx`.

## Verification
- npm run typecheck:full -- --pretty false
  - domain/today and many other lanes still fail (pre-existing/other lanes)
  - `src/features/daily/components/__tests__/UserSelectionStep.spec.tsx` failure is resolved
- npm run lint
- npx vitest run src/features/daily/components/__tests__/UserSelectionStep.spec.tsx
- git diff --check

## Scope
- test-only / typing-only change
- no production behavior changes
- no unrelated files modified
