### PR TITLE
test(today): align workflow phases hook spec typing

### DIFF
--- a/src/features/today/hooks/__tests__/useWorkflowPhases.spec.ts
+++ b/src/features/today/hooks/__tests__/useWorkflowPhases.spec.ts
@@ -185,6 +185,8 @@ describe('toPlanningSheetSnapshot', () => {
       applicableAddOnTypes: ['severe_disability_support'],
       authoredByQualification: 'practical_training',
       reviewedAt: null,
+      supportStartDate: null,
+      appliedFrom: null,
     };
 
     const snapshot = toPlanningSheetSnapshot(item, 3);
@@ -210,6 +212,8 @@ describe('toPlanningSheetSnapshot', () => {
       applicableAddOnTypes: ['none'],
       authoredByQualification: 'unknown',
       reviewedAt: null,
+      supportStartDate: null,
+      appliedFrom: null,
     };
 
     const snapshot = toPlanningSheetSnapshot(item);


### PR DESCRIPTION
## Summary
- Align workflow phases hook fixture typings with current PlanningSheetListItem contract.
- Add missing  and  fields to planning sheet fixtures in .
- Keep changes test-only and scoped to type drift.

## Verification
- npm run typecheck:full -- --pretty false
- npm run typecheck
- npm run lint
- npx vitest run src/features/today/hooks/__tests__/useWorkflowPhases.spec.ts
- git diff --check

## Scope Notes
- production code unchanged
- touched file: src/features/today/hooks/__tests__/useWorkflowPhases.spec.ts only
- docs/roadmaps kept untouched
