### PR TITLE
test(mappers): align sp user item fixture typing

### DIFF
--- a/tests/unit/mappers.spec.ts
+++ b/tests/unit/mappers.spec.ts
@@ -32,7 +32,7 @@ describe('lib/mappers', () => {
       ContractDate: '2024-12-31T15:00:00Z',
       ServiceStartDate: '2025-01-01T09:00:00Z',
       ServiceEndDate: null,
-      SevereFlag: true,
+      severeFlag: true,
       IsActive: undefined,
       Modified: '2025-01-02T00:00:00Z',
       Created: '2025-01-01T00:00:00Z',


### PR DESCRIPTION
## Summary
- Align SpUserItem fixture typing in mappers unit test to current contract.
- Replace legacy 
`SevereFlag` with `severeFlag` in `tests/unit/mappers.spec.ts`.

## Scope / Verification
- Target file: `tests/unit/mappers.spec.ts`
- `npm run typecheck`
- `npm run lint`
- `npx vitest run tests/unit/mappers.spec.ts`
- `git diff --check`
- `npm run typecheck:full -- --pretty false` (other failures remain in unrelated lanes)
