### PR TITLE
test(diagnostics): align drift observer repository mock typing

### DIFF
--- a/src/features/diagnostics/drift/application/__tests__/DriftObserver.spec.ts
+++ b/src/features/diagnostics/drift/application/__tests__/DriftObserver.spec.ts
@@ -13,6 +13,8 @@ describe('DriftObserver', () => {
       logEvent: vi.fn(async () => {
         throw new Error('write failed');
       }),
+      getEvents: vi.fn(async () => []),
+      markResolved: vi.fn(async () => undefined),
     };
 
     const observer = new DriftObserver(repository);


### PR DESCRIPTION
## Summary
- align diagnostics drift observer repository mock typing by adding required  and  members
- keep change scoped to typed test fixture only

## Verification
- npm run typecheck
- npm run lint
- npx vitest run src/features/diagnostics/drift/application/__tests__/DriftObserver.spec.ts
- git diff --check
- npm run typecheck:full -- --pretty false (fails with unrelated residual lanes)
