### PR TITLE
test(diagnostics): align drift event repository spec typing

### DIFF
--- a/src/features/diagnostics/drift/infra/__tests__/SharePointDriftEventRepository.spec.ts
+++ b/src/features/diagnostics/drift/infra/__tests__/SharePointDriftEventRepository.spec.ts
@@ -14,7 +14,10 @@ describe('SharePointDriftEventRepository', () => {
   });
 
   it('omits optional fields missing from schema when logging', async () => {
-    const createItem = vi.fn(async (_listTitle: string, _payload: Record<string, unknown>) => ({}));
+    const createItem = vi.fn(
+      async (_listTitle: string, _payload: Record<string, unknown>, _options?: { spOptions?: { quietStatuses?: number[]; silent?: boolean } }) =>
+        ({}),
+    );
     const repo = new SharePointDriftEventRepository({
       createItem,
       updateItemByTitle: vi.fn(async () => ({})),
@@ -192,7 +195,10 @@ describe('SharePointDriftEventRepository', () => {
   });
 
   it('writes duplicate required encoded/plain fields when both exist in list schema', async () => {
-    const createItem = vi.fn(async (_listTitle: string, _payload: Record<string, unknown>) => ({}));
+    const createItem = vi.fn(
+      async (_listTitle: string, _payload: Record<string, unknown>, _options?: { spOptions?: { quietStatuses?: number[]; silent?: boolean } }) =>
+        ({}),
+    );
     const repo = new SharePointDriftEventRepository({
       createItem,
       updateItemByTitle: vi.fn(async () => ({})),
@@ -631,7 +637,10 @@ describe('SharePointDriftEventRepository', () => {
   });
 
   it('does not include hidden system fields (e.g. _Level) in write payloads', async () => {
-    const createItem = vi.fn(async (_listTitle: string, _payload: Record<string, unknown>) => ({}));
+    const createItem = vi.fn(
+      async (_listTitle: string, _payload: Record<string, unknown>, _options?: { spOptions?: { quietStatuses?: number[]; silent?: boolean } }) =>
+        ({}),
+    );
 
     const repo = new SharePointDriftEventRepository({
       createItem,


### PR DESCRIPTION
## Summary
- align SharePoint drift event repository infra spec typing with the actual `createItem` call signature
- add an optional third `options` argument to local `createItem` mocks that now inspect 400-retry options
- keep scope to test typing/expectation only

## Verification
- npm run typecheck
- npm run lint
- npx vitest run src/features/diagnostics/drift/infra/__tests__/SharePointDriftEventRepository.spec.ts
- git diff --check
- npm run typecheck:full -- --pretty false
  - residual failures remain in unrelated lanes (`#2283` path and others)
