### PR TITLE
test(sharepoint): align abc record repository spec typing

### DIFF
--- a/src/infra/sharepoint/repos/__tests__/SharePointAbcRecordRepository.spec.ts
+++ b/src/infra/sharepoint/repos/__tests__/SharePointAbcRecordRepository.spec.ts
@@ -118,7 +118,6 @@ describe('SharePointAbcRecordRepository', () => {
         behavior: '大声で泣く',
         // 不変フィールド (これらは送信されないはず)
         abcRecordId: 'hacker-uuid',
-        createdAt: '2020-01-01T00:00:00Z',
         createdBy: 'hacker-user',
         recorderName: '不審な上書き者',
         // 更新監査


### PR DESCRIPTION
## Summary\n- align SharePoint Abc record repository spec typing with current AbcRecordCreateInput contract\n- remove  from partial update payload fixture that is no longer accepted by type\n- keep changes scoped to test typed fixture only\n\n## Verification\n- npm run typecheck\n- npm run lint\n- npx vitest run src/infra/sharepoint/repos/__tests__/SharePointAbcRecordRepository.spec.ts\n- git diff --check\n- npm run typecheck:full -- --pretty false\n  - residual failures remain in other lanes