### PR TITLE
test(sp): align list schema field fixture typing

### DIFF
--- a/src/lib/sp/__tests__/spListSchema.spec.ts
+++ b/src/lib/sp/__tests__/spListSchema.spec.ts
@@ -24,7 +24,7 @@ describe('ensureListExists boundaries', () => {
     const result = await ensureListExists(
       spFetch,
       'SupportOrders',
-      [{ internalName: 'NewColumn', typeAsString: 'Text', required: true }],
+      [{ internalName: 'NewColumn', type: 'Text', required: true }],
       { preventPhysicalCreation: true },
     );
 
@@ -84,7 +84,7 @@ describe('ensureListExists boundaries', () => {
     const result = await ensureListExists(
       spFetch,
       'QAList',
-      [{ internalName: 'NewColumn', typeAsString: 'Text', required: true }],
+      [{ internalName: 'NewColumn', type: 'Text', required: true }],
       { preventPhysicalCreation: true },
     );
 
@@ -120,7 +120,7 @@ describe('ensureListExists boundaries', () => {
     const result = await ensureListExists(
       spFetch,
       'OptionalColumnList',
-      [{ internalName: 'OptionalColumn', typeAsString: 'Text', required: false }],
+      [{ internalName: 'OptionalColumn', type: 'Text', required: false }],
     );
 
     expect(spFetch).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
## Summary\n- align SharePoint list schema test fixtures with current SpFieldDef contract\n- replace obsolete  field with current \n- keep scope to spListSchema spec typing only\n\n## Verification\n- npm run typecheck\n- npm run lint\n- npx vitest run src/lib/sp/__tests__/spListSchema.spec.ts\n- git diff --check\n- npm run typecheck:full -- --pretty false\n  - residual failures remain in other lanes