### PR TITLE
test(planning-sheet): align version workflow spec typing

### DIFF
--- a/src/features/planning-sheet/domain/__tests__/planningSheetVersionWorkflow.spec.ts
+++ b/src/features/planning-sheet/domain/__tests__/planningSheetVersionWorkflow.spec.ts
@@ -52,6 +52,8 @@ function toListItem(sheet: SupportPlanningSheet): PlanningSheetListItem {
     applicableAddOnTypes: sheet.applicableAddOnTypes,
     authoredByQualification: sheet.authoredByQualification,
     reviewedAt: sheet.reviewedAt,
+    supportStartDate: sheet.supportStartDate,
+    appliedFrom: sheet.appliedFrom,
   };
 }
 


### PR DESCRIPTION
## Summary
- Align `planningSheetVersionWorkflow.spec.ts` test typing with current `PlanningSheetListItem` contract.
- Add missing `supportStartDate` and `appliedFrom` fields in the test list-item conversion helper.
- Keep changes test-only and scoped to one spec.

## Verification
- npm run typecheck
- npm run lint
- npx vitest run src/features/planning-sheet/domain/__tests__/planningSheetVersionWorkflow.spec.ts
- git diff --check
- npm run typecheck:full -- --pretty false

`typecheck:full` still fails on unrelated lanes not covered by this PR.
