### PR TITLE
test(planning-sheet): align import assessment dialog spec typing

### DIFF
--- a/src/features/planning-sheet/__tests__/ImportAssessmentDialog.integration.spec.tsx
+++ b/src/features/planning-sheet/__tests__/ImportAssessmentDialog.integration.spec.tsx
@@ -107,6 +107,7 @@ const makeEmptyForm = (): PlanningSheetFormValues => ({
   hasMedicalCoordination: false,
   hasEducationCoordination: false,
   monitoringCycleDays: 90,
+  monitoringEvidenceLinks: [],
 });
 
 const makeEmptyIntake = (): PlanningIntake => ({


### PR DESCRIPTION
## Summary
- Align `ImportAssessmentDialog.integration.spec.tsx` fixture typing with current planning sheet contract.
- Add missing `monitoringEvidenceLinks` to the local `PlanningSheetFormValues` test builder.
- Keep the change scoped to a single spec and typing-only updates.

## Verification
- npm run typecheck
- npm run lint
- npx vitest run src/features/planning-sheet/__tests__/ImportAssessmentDialog.integration.spec.tsx
- git diff --check
- npm run typecheck:full -- --pretty false

`typecheck:full` still fails in unrelated lanes.
