### PR TITLE
test(planning-sheet): align assessment bridge spec typing

### DIFF
--- a/src/features/planning-sheet/__tests__/assessmentBridge.spec.ts
+++ b/src/features/planning-sheet/__tests__/assessmentBridge.spec.ts
@@ -68,6 +68,7 @@ const makeEmptyForm = (overrides: Partial<PlanningSheetFormValues> = {}): Planni
   hasEducationCoordination: false,
   monitoringCycleDays: 90,
   ...overrides,
+  monitoringEvidenceLinks: overrides.monitoringEvidenceLinks ?? [],
 });
 
 const makeEmptyIntake = (overrides: Partial<PlanningIntake> = {}): PlanningIntake => ({
@@ -369,4 +370,3 @@ describe('provenance tracking', () => {
     expect(result.provenance).toEqual([]);
   });
 });
-


### PR DESCRIPTION
## Summary
- Align assessment bridge test fixture type with current PlanningSheetFormValues.
- Ensure makeEmptyForm always provides required monitoringEvidenceLinks.

## Verification
- npm run typecheck
- npm run lint
- npx vitest run src/features/planning-sheet/__tests__/assessmentBridge.spec.ts
- npm run typecheck:full -- --pretty false

## Notes
- Scope: planning-sheet spec typing only.
- docs/roadmaps/ and other files unchanged.
- Source behavior unchanged.
