### PR TITLE
ui: toilet当日運用の未記録者ガイダンスを改善

### DIFF
--- a/src/features/kiosk/toilet/ToiletDailyBoard.tsx
+++ b/src/features/kiosk/toilet/ToiletDailyBoard.tsx
@@ -119,6 +119,9 @@ export const ToiletDailyBoard: React.FC = () => {
     [records, targetUsers],
   );
 
+  const unrecordedRows = React.useMemo(() => rows.filter((row) => !row.recorded), [rows]);
+  const nextUnrecordedUser = unrecordedRows[0]?.user;
+
   const recordedCount = rows.filter((row) => row.recorded).length;
   const unrecordedCount = rows.length - recordedCount;
   const summaryLabel = hasRecordsError ? '記録状態を確認できません' : `未記録 ${unrecordedCount}名 / 記録済み ${recordedCount}名`;
@@ -237,11 +240,56 @@ export const ToiletDailyBoard: React.FC = () => {
         </Box>
       ) : (
         <Stack spacing={3}>
-          <Grid container spacing={1.5}>
-            {usersStatus === 'error' && (
-              <Grid size={12}>
-                <Paper
-                  variant="outlined"
+              <Grid container spacing={1.5}>
+                {rows.length > 0 && (
+                  <Grid size={12}>
+                    <Paper
+                      data-testid="toilet-unrecorded-guidance"
+                      variant="outlined"
+                      sx={{
+                        p: { xs: 1.5, md: 2 },
+                        borderRadius: 2,
+                        borderColor: unrecordedRows.length > 0 ? 'warning.light' : 'success.light',
+                        bgcolor: unrecordedRows.length > 0 ? 'rgba(237, 108, 2, 0.06)' : 'rgba(46, 125, 50, 0.06)',
+                      }}
+                    >
+                      {unrecordedRows.length > 0 ? (
+                        <Stack spacing={1}>
+                          <Typography variant="subtitle1" sx={{ fontWeight: 900 }}>
+                            未記録者が {unrecordedRows.length}名います
+                          </Typography>
+                          <Typography variant="body2" color="text.secondary">
+                            次は「{nextUnrecordedUser?.FullName}さん」を先に記録すると、取りこぼしを減らせます。
+                          </Typography>
+                          {nextUnrecordedUser ? (
+                            <Button
+                              variant="contained"
+                              size="small"
+                              onClick={() => openForm(nextUnrecordedUser)}
+                              sx={{ alignSelf: 'flex-start', minHeight: 40, borderRadius: 2, fontWeight: 900 }}
+                            >
+                              次の利用者を記録
+                            </Button>
+                          ) : null}
+                        </Stack>
+                      ) : (
+                        <Stack spacing={0.5}>
+                          <Typography variant="subtitle1" sx={{ fontWeight: 900 }}>
+                            本日の対象者は全員記録済みです
+                          </Typography>
+                          <Typography variant="body2" color="text.secondary">
+                            必要であれば、個別行の「追加記録」を使って追加入力できます。
+                          </Typography>
+                        </Stack>
+                      )}
+                    </Paper>
+                  </Grid>
+                )}
+
+                {usersStatus === 'error' && (
+                  <Grid size={12}>
+                    <Paper
+                      variant="outlined"
                   sx={{
                     p: 3,
                     borderRadius: 2,

--- a/src/features/kiosk/toilet/__tests__/ToiletDailyBoard.spec.tsx
+++ b/src/features/kiosk/toilet/__tests__/ToiletDailyBoard.spec.tsx
@@ -105,6 +105,107 @@ describe('ToiletDailyBoard', () => {
     expect(screen.queryByText('トイレ記録の読み込みに失敗しました')).not.toBeInTheDocument();
   });
 
+  it('shows next-unrecorded guidance with an action button', () => {
+    const anotherUser = {
+      Id: 2,
+      UserID: 'user-2',
+      FullName: '支援 太郎',
+      IsActive: true,
+      RequiresToiletGuidance: true,
+    } as unknown as IUserMaster;
+
+    mockUseUsers.mockReturnValue({
+      data: [toiletTargetUser, anotherUser],
+      isLoading: false,
+      status: 'success',
+    });
+    mockUseToiletRecords.mockReturnValue({
+      records: [
+        {
+          id: 'toilet-record-2',
+          userId: 'user-2',
+          recordDate: '2026-06-12',
+          occurredAt: '2026-06-12T09:00:00.000+09:00',
+          toiletType: 'urination',
+          amount: 'normal',
+          memo: '事前記録',
+          recorderName: 'kiosk',
+          source: 'kiosk',
+          isDeleted: false,
+          createdAt: '2026-06-12T09:00:00.000+09:00',
+          updatedAt: '2026-06-12T09:00:00.000+09:00',
+        },
+      ],
+      create: mockCreateRecord,
+      correct: mockCorrectRecord,
+      refresh: mockRefreshRecords,
+      isLoading: false,
+      error: null,
+    });
+
+    renderBoard();
+
+    const guidance = screen.getByTestId('toilet-unrecorded-guidance');
+    expect(guidance).toHaveTextContent('未記録者が 1名います');
+    expect(guidance).toHaveTextContent('次は「支援 花子さん」を先に記録すると、取りこぼしを減らせます。');
+
+    const nextAction = screen.getByRole('button', { name: '次の利用者を記録' });
+    expect(nextAction).toBeInTheDocument();
+    fireEvent.click(nextAction);
+    expect(screen.getByText('支援 花子さんのトイレ記録')).toBeInTheDocument();
+  });
+
+  it('switches guidance message when all users become recorded', () => {
+    mockUseToiletRecords.mockReturnValueOnce({
+      records: [],
+      create: mockCreateRecord,
+      correct: mockCorrectRecord,
+      refresh: mockRefreshRecords,
+      isLoading: false,
+      error: null,
+    });
+
+    const { rerender } = render(
+      <MemoryRouter initialEntries={['/kiosk/toilet?date=2026-06-12']}>
+        <ToiletDailyBoard />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('toilet-unrecorded-guidance')).toHaveTextContent('未記録者が 1名います');
+
+    mockUseToiletRecords.mockReturnValue({
+      records: [
+        {
+          id: 'toilet-record-1',
+          userId: 'user-1',
+          recordDate: '2026-06-12',
+          occurredAt: '2026-06-12T10:30:00.000+09:00',
+          toiletType: 'urination',
+          amount: 'normal',
+          memo: '記録メモ',
+          recorderName: 'kiosk',
+          source: 'kiosk',
+          isDeleted: false,
+          createdAt: '2026-06-12T10:30:00.000+09:00',
+          updatedAt: '2026-06-12T10:35:00.000+09:00',
+        },
+      ],
+      create: mockCreateRecord,
+      correct: mockCorrectRecord,
+      refresh: mockRefreshRecords,
+      isLoading: false,
+      error: null,
+    });
+
+    rerender(
+      <MemoryRouter initialEntries={['/kiosk/toilet?date=2026-06-12']}>
+        <ToiletDailyBoard />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('toilet-unrecorded-guidance')).toHaveTextContent('本日の対象者は全員記録済みです');
+  });
+
   it("uses today's local date by default (without query parameter)", () => {
     renderBoard();
     const today = toLocalDateISO(new Date());


### PR DESCRIPTION
## Summary\n- 当日運用画面の未記録者導線を追加し、取りこぼしの可能性を低減\n- 未記録者が残る場合は"次の利用者を記録"案内を表示し、迷いなく次アクションへ進める\n- 全記録済み時には"本日の対象者は全員記録済み"を明示\n\n## Scope\n- UI文言・表示の改善（案内カード追加、状態文言の整備）\n- 保存処理、SharePointリポジトリ、権限、スキーマ、today側は変更なし\n\n## Verification\n- npx vitest run src/features/kiosk/toilet/__tests__/ToiletDailyBoard.spec.tsx\n- npx vitest run src/features/kiosk/toilet/__tests__/useToiletRecords.spec.ts\n- npm run typecheck\n- npm run lint\n\n## Notes\n- docs/roadmaps/ remains untracked and untouched