### PR TITLE
ui(handoff): improve quick note guidance copy

### DIFF
--- a/src/features/handoff/HandoffQuickNoteCard.tsx
+++ b/src/features/handoff/HandoffQuickNoteCard.tsx
@@ -152,7 +152,7 @@ export const HandoffQuickNoteCard: React.FC = () => {
     <Card elevation={2} data-testid="handoff-quicknote-card">
       <CardHeader
         title="📝 今すぐ申し送り"
-        subheader="気になったこと・良かったこと・明日につなげたいことを、短くメモしてください"
+        subheader="誰に向けて・何が起きたか・どの程度急ぎかを、短く共有するための入力です"
         titleTypographyProps={{ variant: 'h6', fontWeight: 'bold' }}
       />
       <CardContent>
@@ -187,8 +187,9 @@ export const HandoffQuickNoteCard: React.FC = () => {
           <Stack direction="row" spacing={1} alignItems="center">
             <TextField
               select
-              label="対象"
+              label="対象（誰へ共有するか）"
               size="small"
+              helperText="「全体向け」は全スタッフ共有、個別は対象者名を選択します"
               value={target === 'ALL' ? 'ALL' : target.UserID.toString()}
               onChange={e => {
                 const value = e.target.value;
@@ -228,7 +229,7 @@ export const HandoffQuickNoteCard: React.FC = () => {
           {/* カテゴリ選択 */}
           <Box>
             <Typography variant="body2" sx={{ mb: 1, fontWeight: 500 }}>
-              カテゴリ
+              カテゴリ（何の内容か）
             </Typography>
             <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
               {CATEGORY_OPTIONS.map(opt => (
@@ -248,7 +249,7 @@ export const HandoffQuickNoteCard: React.FC = () => {
           {/* 重要度選択 */}
           <Box>
             <Typography variant="body2" sx={{ mb: 1, fontWeight: 500 }}>
-              重要度
+              緊急度（どれくらい優先して共有すべきか）
             </Typography>
             <Stack direction="row" spacing={1} alignItems="center">
               {SEVERITY_OPTIONS.map(opt => (
@@ -273,7 +274,7 @@ export const HandoffQuickNoteCard: React.FC = () => {
 
           {/* 本文入力 */}
           <TextField
-            label="申し送り内容"
+            label="申し送りメモ（事実と共有事項）"
             multiline
             minRows={3}
             maxRows={6}
@@ -282,7 +283,11 @@ export const HandoffQuickNoteCard: React.FC = () => {
             placeholder={placeholder}
             fullWidth
             variant="outlined"
-            helperText="改行・箇条書きもOKです。簡潔にポイントを記載してください。"
+            helperText={
+              message.trim()
+                ? '1〜2文で「誰が・何が・対応が必要か」を簡潔に記載すると受け手がすぐ理解できます。'
+                : '本文を入力してください。未入力では投稿できません。'
+            }
           />
 
           <Divider />
@@ -296,7 +301,7 @@ export const HandoffQuickNoteCard: React.FC = () => {
               sx={{ mb: 1 }}
             >
               <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>
-                最近の申し送り
+                最近の申し送り（直近5件）
               </Typography>
               <Button
                 href="/handoff-timeline"
@@ -332,7 +337,7 @@ export const HandoffQuickNoteCard: React.FC = () => {
                 }}
               >
                 <Typography variant="body2" color="text.secondary">
-                  まだ入力された申し送りはありません。
+                  まだ申し送りはありません。
                 </Typography>
               </Box>
             )}

--- a/src/pages/HandoffTimelinePage.tsx
+++ b/src/pages/HandoffTimelinePage.tsx
@@ -13,7 +13,24 @@ import {
   Today as TodayIcon,
   ViewDay as DayIcon,
 } from '@mui/icons-material';
-import { Alert, Box, Button, Chip, Container, Dialog, DialogContent, DialogTitle, IconButton, Popover, Snackbar, TextField, ToggleButton, ToggleButtonGroup, Tooltip } from '@mui/material';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  Container,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Popover,
+  Snackbar,
+  TextField,
+  ToggleButton,
+  ToggleButtonGroup,
+  Tooltip,
+  Typography,
+} from '@mui/material';
 import { useCallback, useRef, useState } from 'react';
 import { HandoffQuickNoteCard } from '../features/handoff/HandoffQuickNoteCard';
 import { useNavigate } from 'react-router-dom';
@@ -155,6 +172,24 @@ export default function HandoffTimelinePage() {
           subtitle="申し送りの記録・確認・会議進行ができます"
           icon={<AccessTimeIcon />}
         />
+
+        <Alert severity="info" variant="outlined" sx={{ mt: 2 }}>
+          <Typography variant="body2" sx={{ fontWeight: 500 }}>
+            この画面では当日の申し送りを確認し、必要時に新規メモを追加できます。
+          </Typography>
+          <Box component="ul" sx={{ mt: 1.25, mb: 0, pl: 2.5, m: 0 }}>
+            <Box component="li" sx={{ mb: 0.5 }}>
+              日: 今日の流れを確認します
+            </Box>
+            <Box component="li" sx={{ mb: 0.5 }}>
+              週: 週内の流れを確認します
+            </Box>
+            <Box component="li" sx={{ mb: 0.5 }}>
+              月: 月全体の傾向を確認します
+            </Box>
+            <Box component="li">「今すぐ申し送り」は HandoffQuickNoteCard を開いて新規メモを作成する入力です</Box>
+          </Box>
+        </Alert>
 
         {/* ── 日付ナビゲーション + 申し送りボタン ── */}
         <Box


### PR DESCRIPTION
## Summary\n- Improve UI copy in HandoffQuickNoteCard to clarify: who to send to, what happened, and urgency\n- Update guidance text on target/label/placeholder/button context for field staff\n- Keep quick note submission behavior unchanged\n\n## Scope\n- UI text copy only: title subheader, labels, helper texts, empty-state guidance\n- No changes to useHandoffTimeline, useUsersQuery, useCurrentTimeBand\n- No SharePoint/Graph/DataProvider/API changes\n- No refactoring of component structure or save flow\n\n## Verification\n- npm run typecheck\n- npm run lint\n- git diff --check\n- target unit spec for HandoffQuickNoteCard not present, so not executed\n\n## Notes\n- docs/roadmaps/ is intentionally untracked and untouched\n- Draft PR for low-risk copy-only change\n