### PR TITLE
fix(settings): stabilize kiosk layout toggle

### DIFF
--- a/src/app/AppShell.kiosk-route.spec.tsx
+++ b/src/app/AppShell.kiosk-route.spec.tsx
@@ -79,6 +79,24 @@ describe('AppShell kiosk query routing', () => {
     expect(stored.layoutMode).toBe('kiosk');
   });
 
+  it('keeps manually enabled kiosk mode on /today without kiosk query', async () => {
+    renderAppShell('/today');
+
+    const settingsButton = screen.getByRole('button', { name: '表示設定' });
+    fireEvent.click(settingsButton);
+
+    fireEvent.click(screen.getByRole('switch', { name: 'キオスクモード（タブレット端末用）' }));
+
+    const appShell = screen.getByTestId('app-shell');
+    await waitFor(() => {
+      expect(appShell).toHaveAttribute('data-kiosk', 'true');
+      expect(screen.getByRole('switch', { name: 'キオスクモード（タブレット端末用）' })).toBeChecked();
+    });
+
+    const stored = JSON.parse(localStorage.getItem(SETTINGS_STORAGE_KEY) ?? '{}');
+    expect(stored.layoutMode).toBe('kiosk');
+  });
+
   it('disables kiosk mode when /today?kiosk=0 is opened', async () => {
     localStorage.setItem(
       SETTINGS_STORAGE_KEY,

--- a/src/app/useAppShellState.ts
+++ b/src/app/useAppShellState.ts
@@ -121,9 +121,8 @@ export function useAppShellState() {
       return;
     }
 
-    if (settings.layoutMode === 'kiosk') {
-      updateSettings({ layoutMode: 'normal' });
-    }
+    // NOTE: keep explicitly persisted settings as-is.
+    // Manual kiosk selection should remain effective on non-kiosk routes.
   }, [location.pathname, location.search, settings.layoutMode, updateSettings]);
 
   useEffect(() => {

--- a/src/features/settings/SettingsDialog.tsx
+++ b/src/features/settings/SettingsDialog.tsx
@@ -18,7 +18,7 @@ import Stack from '@mui/material/Stack';
 import Switch from '@mui/material/Switch';
 import Typography from '@mui/material/Typography';
 import React, { useCallback, useContext } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useSettingsContext } from './SettingsContext';
 import { ColorPresetControl, DensityControl, FontSizeControl, NavGroupVisibilityControl } from './components';
 
@@ -34,6 +34,9 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({ open, onClose, n
   const { mode, toggle } = useContext(ColorModeContext);
   const { settings, updateSettings } = useSettingsContext();
   const location = useLocation();
+  const navigate = useNavigate();
+  const isKioskPath = location.pathname.startsWith('/kiosk');
+  const isKioskQuery = new URLSearchParams(location.search).has('kiosk');
 
   const handleDensityChange = useCallback((newDensity: 'compact' | 'comfortable' | 'spacious') => {
     updateSettings({ density: newDensity });
@@ -182,9 +185,27 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({ open, onClose, n
               control={
                 <Switch
                   checked={settings.layoutMode === 'kiosk'}
-                  onChange={(_, checked) =>
-                    updateSettings({ layoutMode: checked ? 'kiosk' : 'normal' })
-                  }
+                  onChange={(_, checked) => {
+                    const nextParams = new URLSearchParams(location.search);
+                    nextParams.delete('kiosk');
+                    const nextSearch = nextParams.toString();
+                    const nextPath = `${location.pathname}${nextSearch ? `?${nextSearch}` : ''}`;
+
+                    if (checked) {
+                      if (isKioskQuery) {
+                        navigate(nextPath, { replace: true });
+                      }
+                      updateSettings({ layoutMode: 'kiosk' });
+                      return;
+                    }
+
+                    if (isKioskPath) {
+                      navigate('/dashboard', { replace: true });
+                    } else if (isKioskQuery) {
+                      navigate(nextPath, { replace: true });
+                    }
+                    updateSettings({ layoutMode: 'normal' });
+                  }}
                   inputProps={{ 'aria-label': 'キオスクモード（タブレット端末用）' }}
                 />
               }

--- a/src/features/settings/__tests__/SettingsDialog.spec.tsx
+++ b/src/features/settings/__tests__/SettingsDialog.spec.tsx
@@ -4,9 +4,9 @@ import {
   PLANNING_NAV_TELEMETRY_EVENTS,
   type PlanningNavTelemetryEvent,
 } from '@/app/navigation/planningNavTelemetry';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { SettingsDialog } from '../SettingsDialog';
 import type { UserSettings } from '../settingsModel';
@@ -49,11 +49,28 @@ const navItems: NavItem[] = [
   },
 ];
 
-const renderDialog = () =>
+const locationProbeKey = 'location-probe';
+
+const LocationProbe = () => {
+  const location = useLocation();
+  return <span data-testid={locationProbeKey} data-path={location.pathname} data-search={location.search} />;
+};
+
+const renderDialog = (initialPath = '/settings') =>
   render(
     <ColorModeContext.Provider value={{ mode: 'light', toggle: vi.fn() }}>
-      <MemoryRouter initialEntries={['/settings']}>
-        <SettingsDialog open onClose={vi.fn()} navItems={navItems} />
+      <MemoryRouter initialEntries={[initialPath]}>
+        <Routes>
+          <Route
+            path="*"
+            element={
+              <>
+                <LocationProbe />
+                <SettingsDialog open onClose={vi.fn()} navItems={navItems} />
+              </>
+            }
+          />
+        </Routes>
       </MemoryRouter>
     </ColorModeContext.Provider>,
   );
@@ -123,5 +140,39 @@ describe('SettingsDialog planning visibility behavior', () => {
         trigger: 'user_toggle',
       }),
     );
+  });
+
+  it('can disable kiosk mode even when forced by ?kiosk=1', async () => {
+    mockSettings = {
+      ...mockSettings,
+      layoutMode: 'kiosk',
+    };
+    renderDialog('/today?kiosk=1');
+
+    fireEvent.click(screen.getByRole('switch', { name: 'キオスクモード（タブレット端末用）' }));
+    expect(mockUpdateSettings).toHaveBeenCalledWith({ layoutMode: 'normal' });
+
+    await waitFor(() => {
+      const probe = screen.getByTestId(locationProbeKey);
+      expect(probe.getAttribute('data-path')).toBe('/today');
+      expect(probe.getAttribute('data-search')).toBe('');
+    });
+  });
+
+  it('exits to dashboard when disabling kiosk mode from /kiosk route', async () => {
+    mockSettings = {
+      ...mockSettings,
+      layoutMode: 'kiosk',
+    };
+    renderDialog('/kiosk/users');
+
+    fireEvent.click(screen.getByRole('switch', { name: 'キオスクモード（タブレット端末用）' }));
+    expect(mockUpdateSettings).toHaveBeenCalledWith({ layoutMode: 'normal' });
+
+    await waitFor(() => {
+      const probe = screen.getByTestId(locationProbeKey);
+      expect(probe.getAttribute('data-path')).toBe('/dashboard');
+      expect(probe.getAttribute('data-search')).toBe('');
+    });
   });
 });

--- a/src/features/settings/hooks/useKioskDetection.ts
+++ b/src/features/settings/hooks/useKioskDetection.ts
@@ -3,14 +3,16 @@ import { useSettingsContext } from '../SettingsContext';
 import { useMemo } from 'react';
 
 /**
- * useKioskDetection — キオスクモード判定の SSOT
- * 
+ * useKioskDetection — キオスク表示判定の SSOT
+ *
  * 優先順位:
- * 1. URLパラメータ (?kiosk=1) -> 最優先 (即時反映)
- * 2. Settings (layoutMode === 'kiosk') -> 永続状態
- * 
- * このフックにより、状態伝播の遅延（Race Condition）に関わらず、
- * URLにkiosk=1があれば初回フレームからキオスク表示を強制できる。
+ * 1. /kiosk 配下のルート -> キオスク表示を強制
+ * 2. URLパラメータ (?kiosk=1 / ?kiosk=true) -> 通常ルートでもキオスク表示を強制
+ * 3. URLパラメータ (?kiosk=0 / ?kiosk=false) -> 明示的な非キオスク表示
+ * 4. Settings (layoutMode === 'kiosk') -> 手動選択された永続状態
+ *
+ * SettingsDialog 側では、OFF 操作時に強制条件を解除するため、
+ * ?kiosk クエリ削除や /kiosk ルートからの退避を行う。
  */
 export function useKioskDetection() {
   const { settings } = useSettingsContext();


### PR DESCRIPTION
## Summary
- Preserve manually selected kiosk layout mode on normal routes such as `/today`
- Clear forced kiosk query state when disabling kiosk mode from settings
- Navigate out of `/kiosk` routes when disabling kiosk mode
- Clarify kiosk detection priority comments without changing hook behavior
- Add regression coverage for kiosk ON/OFF toggle behavior

## Verification
- npm run typecheck
- npm run lint
- npx vitest run src/app/AppShell.kiosk-route.spec.tsx
- npx vitest run src/features/settings/__tests__/SettingsDialog.spec.tsx
- npx vitest run src/app/__tests__/AppShell.kiosk-nav.spec.tsx
- git diff --check

## Notes
- dev-server.err and dev-server.log are local untracked files and are intentionally excluded.
- git diff --check passed; LF/CRLF messages are line-ending warnings only.
