### PR TITLE
test(sp): align SharePoint ABC repository spec typing

### DIFF
--- a/src/infra/sharepoint/repos/__tests__/SharePointAbcRecordRepository.spec.ts
+++ b/src/infra/sharepoint/repos/__tests__/SharePointAbcRecordRepository.spec.ts
@@ -3,6 +3,10 @@ import type { IDataProvider } from '@/lib/data/dataProvider.interface';
 import { SharePointAbcRecordRepository } from '../SharePointAbcRecordRepository';
 import type { AbcRecordCreateInput } from '@/domain/abc/abcRecord';
 
+type UnsafeAbcRecordUpdateInput = Partial<AbcRecordCreateInput> & {
+  createdAt?: string;
+};
+
 describe('SharePointAbcRecordRepository', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let mockDataProvider: Record<string, any>;
@@ -113,7 +117,7 @@ describe('SharePointAbcRecordRepository', () => {
 
   describe('update', () => {
     it('不変フィールドの上書きを禁止し、更新日時と安全な項目のみをPATCH送信すること', async () => {
-      const inputUpdate: Partial<AbcRecordCreateInput> = {
+      const inputUpdate: UnsafeAbcRecordUpdateInput = {
         setting: '食堂',
         behavior: '大声で泣く',
         // 不変フィールド (これらは送信されないはず)


### PR DESCRIPTION
Align SharePoint ABC repository typed test fixtures with the current repository contract. This is a test-only split from Nightly Health typecheck-full drift.

## Summary
- Keep the SharePoint ABC repository implementation and domain types unchanged.
- Add a local unsafe update input type in the spec so the immutable `createdAt` guard remains covered without widening `AbcRecordCreateInput`.
- Remove the `SharePointAbcRecordRepository.spec.ts` typed-test drift from `typecheck:full`.

## Verification
- `npx vitest run src/infra/sharepoint/repos/__tests__/SharePointAbcRecordRepository.spec.ts`
- `npm run typecheck`
- `npm run lint`
- `git diff --check`
- `npx tsc --noEmit --pretty false` confirms the SharePoint ABC error is gone; remaining errors are kiosk, planning-sheet, and spListSchema lanes.
- `npm run typecheck:full -- --pretty false` confirms the SharePoint ABC error is gone; remaining errors are kiosk, planning-sheet, and spListSchema lanes.