### PR TITLE
[codex] Harden nightly CI preflight failures

### DIFF
--- a/.github/workflows/integration-dailyops.yml
+++ b/.github/workflows/integration-dailyops.yml
@@ -66,9 +66,20 @@ jobs:
       - name: Restore Playwright storageState
         shell: bash
         run: |
+          if [ -z "${PW_STORAGE_STATE_B64:-}" ]; then
+            echo "::error::PW_STORAGE_STATE_B64 is empty. Regenerate the Playwright storage state and update the GitHub secret before running DailyOps integration."
+            exit 1
+          fi
           mkdir -p tests/.auth
-          echo "${PW_STORAGE_STATE_B64}" | base64 -d > tests/.auth/storageState.json
-          test -s tests/.auth/storageState.json
+          if ! echo "${PW_STORAGE_STATE_B64}" | base64 -d > tests/.auth/storageState.json; then
+            echo "::error::PW_STORAGE_STATE_B64 is not valid base64."
+            exit 1
+          fi
+          if [ ! -s tests/.auth/storageState.json ]; then
+            echo "::error::Decoded Playwright storageState is empty. Regenerate PW_STORAGE_STATE_B64."
+            exit 1
+          fi
+          node -e "const fs=require('node:fs'); const p='tests/.auth/storageState.json'; try { const state=JSON.parse(fs.readFileSync(p,'utf8')); if (!Array.isArray(state.cookies) || state.cookies.length===0) { console.error('::error::Decoded storageState has no cookies. Regenerate PW_STORAGE_STATE_B64.'); process.exit(1); } } catch (error) { console.error('::error::Decoded PW_STORAGE_STATE_B64 is not valid Playwright storageState JSON.'); console.error(error.message); process.exit(1); }"
         env:
           PW_STORAGE_STATE_B64: ${{ secrets.PW_STORAGE_STATE_B64 }}
 

--- a/.github/workflows/integration-staff.yml
+++ b/.github/workflows/integration-staff.yml
@@ -66,9 +66,20 @@ jobs:
       - name: Restore Playwright storageState
         shell: bash
         run: |
+          if [ -z "${PW_STORAGE_STATE_B64:-}" ]; then
+            echo "::error::PW_STORAGE_STATE_B64 is empty. Regenerate the Playwright storage state and update the GitHub secret before running Staff integration."
+            exit 1
+          fi
           mkdir -p tests/.auth
-          echo "${PW_STORAGE_STATE_B64}" | base64 -d > tests/.auth/storageState.json
-          test -s tests/.auth/storageState.json
+          if ! echo "${PW_STORAGE_STATE_B64}" | base64 -d > tests/.auth/storageState.json; then
+            echo "::error::PW_STORAGE_STATE_B64 is not valid base64."
+            exit 1
+          fi
+          if [ ! -s tests/.auth/storageState.json ]; then
+            echo "::error::Decoded Playwright storageState is empty. Regenerate PW_STORAGE_STATE_B64."
+            exit 1
+          fi
+          node -e "const fs=require('node:fs'); const p='tests/.auth/storageState.json'; try { const state=JSON.parse(fs.readFileSync(p,'utf8')); if (!Array.isArray(state.cookies) || state.cookies.length===0) { console.error('::error::Decoded storageState has no cookies. Regenerate PW_STORAGE_STATE_B64.'); process.exit(1); } } catch (error) { console.error('::error::Decoded PW_STORAGE_STATE_B64 is not valid Playwright storageState JSON.'); console.error(error.message); process.exit(1); }"
         env:
           PW_STORAGE_STATE_B64: ${{ secrets.PW_STORAGE_STATE_B64 }}
 

--- a/.github/workflows/nightly-patrol.yml
+++ b/.github/workflows/nightly-patrol.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
   issues: write
 
 concurrency:
@@ -395,20 +395,34 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Commit report if changed
+      - name: Report generated changes
         if: ${{ always() }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
           if [ -z "$(git status --porcelain -- docs/nightly-patrol src/sharepoint/latest-decision.json)" ]; then
             echo "No report changes"
             exit 0
           fi
 
-          git add -A docs/nightly-patrol src/sharepoint/latest-decision.json
-          git commit -m "chore(ops): nightly patrol report"
-          git push
+          {
+            echo "## Nightly report changes"
+            echo "Generated report files changed during this run."
+            echo ""
+            echo '```'
+            git status --short -- docs/nightly-patrol src/sharepoint/latest-decision.json
+            echo '```'
+            echo ""
+            echo "Nightly Patrol is report-only in CI; review the uploaded artifacts instead of pushing directly to main."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload generated patrol reports
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-patrol-reports-${{ github.run_number }}
+          path: |
+            docs/nightly-patrol/**
+            src/sharepoint/latest-decision.json
+          if-no-files-found: ignore
 
       - name: Final Fail Gate
         if: ${{ always() && steps.decision.outputs.exit_code != '0' }}

--- a/.github/workflows/nightly-zombie-purge.yml
+++ b/.github/workflows/nightly-zombie-purge.yml
@@ -48,7 +48,10 @@ jobs:
           AAD_APP_ID: ${{ secrets.AAD_APP_ID }}
           SPO_CLIENT_SECRET: ${{ secrets.SPO_CLIENT_SECRET }}
         run: |
-          npx -y @pnp/cli-microsoft365 login --appId "$AAD_APP_ID" --tenant "$AAD_TENANT_ID" --secret "$SPO_CLIENT_SECRET"
+          test -n "$AAD_TENANT_ID" || (echo "::error::Missing secret: AAD_TENANT_ID" && exit 1)
+          test -n "$AAD_APP_ID" || (echo "::error::Missing secret: AAD_APP_ID" && exit 1)
+          test -n "$SPO_CLIENT_SECRET" || (echo "::error::Missing secret: SPO_CLIENT_SECRET" && exit 1)
+          npx -y --package @pnp/cli-microsoft365 m365 login --appId "$AAD_APP_ID" --tenant "$AAD_TENANT_ID" --secret "$SPO_CLIENT_SECRET"
 
       - name: Build Drift Ledger
         run: npm run patrol:ledger

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "test:schedule:jst": "VITE_SCHEDULES_TZ=Asia/Tokyo vitest run tests/unit/schedule --reporter=verbose --no-file-parallelism",
     "test:schedule:la": "VITE_SCHEDULES_TZ=America/Los_Angeles vitest run tests/unit/schedule --reporter=verbose --no-file-parallelism",
     "test:ui": "vitest",
+    "test:snapshot": "vitest run tests/unit/ui.snapshot.spec.tsx tests/unit/systemMap.spec.ts --reporter=verbose --no-file-parallelism",
     "test:coverage": "vitest run --coverage",
     "test:prefetch": "vitest run tests/unit/prefetch.*.spec.ts* --run",
     "test:e2e": "playwright test",

--- a/scripts/ops/nightly-drift-governance.mjs
+++ b/scripts/ops/nightly-drift-governance.mjs
@@ -40,7 +40,7 @@ function logToAudit(entry) {
     const which = execSync('which m365', { encoding: 'utf8' }).trim();
     if (which) m365 = which;
   } catch {
-    m365 = 'npx -y @pnp/cli-microsoft365';
+    m365 = 'npx -y --package @pnp/cli-microsoft365 m365';
   }
 
   const fields = [

--- a/scripts/ops/nightly-remediation-audit.mjs
+++ b/scripts/ops/nightly-remediation-audit.mjs
@@ -23,7 +23,7 @@ function resolveM365() {
     const which = execSync('which m365', { encoding: 'utf8', stdio: 'pipe' }).trim();
     if (which) return which;
   } catch (_e) { /* ignore */ }
-  return 'npx -y @pnp/cli-microsoft365';
+  return 'npx -y --package @pnp/cli-microsoft365 m365';
 }
 
 function readJsonFile(p) {


### PR DESCRIPTION
## Summary
- fail integration staff/dailyops earlier when `PW_STORAGE_STATE_B64` is empty, invalid base64, empty, or not a Playwright storageState with cookies
- define `npm run test:snapshot` so Nightly Snapshots no longer calls a missing script
- run CLI for Microsoft 365 through the `m365` binary via `npx -y --package @pnp/cli-microsoft365 m365 ...`
- make Nightly Patrol report-only for generated report changes instead of pushing directly to `main`

## Diff-caused vs non-diff-caused
- Diff-caused fixes: missing `test:snapshot`, invalid M365 `npx` invocation, Nightly Patrol direct `main` push behavior, weak storageState restore diagnostics in staff/dailyops integration.
- Non-diff-caused failures left out intentionally: existing `typecheck:full` spec drift and dashboard E2E selector timeouts.

## Validation
- `npm run test:snapshot` passed: 2 files / 3 tests.
- `npx -y --package @pnp/cli-microsoft365 m365 version` returned `v11.8.0`.
- `node --check scripts/ops/nightly-drift-governance.mjs && node --check scripts/ops/nightly-remediation-audit.mjs` passed.
- commit hook ran `lint`, `typecheck`, and `lint:cookies` successfully.

## Notes
- No package lock change was needed because CLI for Microsoft 365 is invoked through `npx --package`, not installed into project dependencies.
- `docs/roadmaps/` remains untracked and is not part of this PR.