### PR TITLE
test(e2e): stabilize router smoke checklist fallback readiness on main

### DIFF
--- a/tests/e2e/router.smoke.spec.ts
+++ b/tests/e2e/router.smoke.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import fs from 'node:fs';
 import path from 'node:path';
-import { expectSmokePageReady, prepareSmokePage } from './_helpers/smoke';
+import { expectLocatorVisibleBestEffort, expectSmokePageReady, prepareSmokePage } from './_helpers/smoke';
 
 const BASE_URL = process.env.E2E_BASE_URL ?? 'http://127.0.0.1:5173';
 
@@ -91,6 +91,11 @@ test.describe('router smoke (URL direct, testid based)', () => {
     } else {
       // Fallback: checklist-root may not exist; use minimal UI
       await expectSmokePageReady(page);
+      await expectLocatorVisibleBestEffort(
+        page.getByRole('heading').first(),
+        'heading not found: heading (allowed for smoke)',
+        15_000
+      );
     }
   });
 });

--- a/tests/e2e/router.smoke.spec.ts
+++ b/tests/e2e/router.smoke.spec.ts
@@ -93,8 +93,7 @@ test.describe('router smoke (URL direct, testid based)', () => {
       await expectSmokePageReady(page);
       await expectLocatorVisibleBestEffort(
         page.getByRole('heading').first(),
-        'heading not found: heading (allowed for smoke)',
-        15_000
+        'heading not found: heading (allowed for smoke)'
       );
     }
   });


### PR DESCRIPTION
## Summary - `tests/e2e/router.smoke.spec.ts` の `/checklist` ルート fallback 検証を、現行 `main` の shared smoke フローを維持したまま最小変更で調整する - 変更対象を router fallback のみとし、app-shell への影響は避ける  ## Why - #2327 は現行 `main` との差分差異と merge 衝突で再実装が必要だったため、`main` の `prepareSmokePage` / `expectSmokePageReady` を維持した再実装が必要 - fallback の観測性を上げるため、`checklist-root` が見えない場合は既存の shared flow で到達性を確認し、best-effort の診断を追加する  ## What changed - **scope:** `tests/e2e/router.smoke.spec.ts`（変更 1 ファイル） - `/checklist` の `checklist-root` が見つからない場合、従来どおりの shared flow を維持して `expectSmokePageReady(page)` を実行した後、heading の best-effort diagnostic を追加   - import: `expectLocatorVisibleBestEffort` を追加   - fallback 分岐: `expectSmokePageReady(page)` の後に `expectLocatorVisibleBestEffort(page.getByRole('heading').first(), ...)` を追加   - 重複待機を避けるため、best-effort helper への明示 `15_000` timeout は指定しない  ## Non-goals - app-shell の smoke spec の変更は行わない - 共通ヘルパーや infra 周りの変更は行わない  ## Compatibility - `prepareSmokePage` / `expectSmokePageReady` の既存 `main` 共有フローを維持 - 差分は 1 ファイルに限定、最小変更（追加 5 / 削除 1）  ## Notes - 元の PR #2327 は旧フローベースで close 済みのため再利用せず、`main` 起点で router fallback 単独の最小再実装として実施 - `expectLocatorVisibleBestEffort` は strict assertion ではなく、診断用途の観測として扱う - final head SHA: `d8395149d2c9a75e23aa76d6c35b8f6f928340fd`  ## Verification ### Targeted local verification - `npx playwright test tests/e2e/router.smoke.spec.ts -g "GET /checklist renders checklist-root" --config=playwright.smoke.config.ts --project=smoke --reporter=line` => pass (`VITE_SKIP_LOGIN=1`) - `npx playwright test tests/e2e/router.smoke.spec.ts --config=playwright.smoke.config.ts --project=smoke --reporter=line` => pass - `npx eslint tests/e2e/router.smoke.spec.ts` => pass  ### Local full-lane observations - `npm run -s test:e2e:smoke` => fail（`router.smoke.spec.ts` 以外の 3 spec。baseline 未比較のため原因未確定） - `npx tsc -p tsconfig.playwright.json --noEmit` => fail（ローカルの実行条件差を含む。正規 CI typecheck は success） - `npm run -s test:ci` => ローカル timeout。正規 CI / `quality_extended` は success  ### Final-SHA CI - `E2E Smoke (Chromium)` => success（run `27953880563`, job `82718209496`）   - `E2E router + nav smoke (chromium + smoke)` => success - `quality_extended` => success（run `27953880444`, job `82718311052`） - `CI` => success（run `27953880445`） - typecheck / lint / PR Guardrails => success - final SHA に紐づく workflow runs に未解決の failure なし  ## Checklist - [x] `tests/e2e/router.smoke.spec.ts` のみ変更 - [x] `prepareSmokePage` / `expectSmokePageReady` の利用が維持されている - [x] `E2E Smoke (Chromium)` を通過 - [x] `quality_extended` を通過 - [x] 追加の regression 失敗（smoke 以外の lane）がないこと   ## Final post-merge note - final PR head: `d8395149d2c9a75e23aa76d6c35b8f6f928340fd` - squash merge: `66dce1e16853a7b428e43d6e04c02938c530b6e2` - `Unit Test (Shard 3/3)` initially failed on `src/features/kiosk/toilet/__tests__/ToiletDailyBoard.spec.tsx` - the isolated target passed once on both the pre-merge base (`7abc1766`) and current `main` - the retried `Unit Test (Shard 3/3)` job (`82847939136`) passed - final aggregate failure was caused by `Unit Test (Shard 2/3)` being cancelled - `TypeCheck` remained successful - no evidence links the failure to the router fallback change - no revert is required; CI cancellation behavior is tracked separately 
