### PR TITLE
ci: classify cancelled rerun results in aggregate gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,20 +234,171 @@ jobs:
     runs-on: ubuntu-latest
     needs: [typecheck, unit-test-shard]
     if: ${{ always() }}
+    permissions:
+      actions: read
+      contents: read
     steps:
+      - name: Classify unit shard outcomes
+        id: classify-shards
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const runId = context.runId;
+            const runAttempt = Number(context.runAttempt || 1);
+            const currentAttempt = isNaN(runAttempt) ? 1 : runAttempt;
+
+            const jobs = await github.paginate(
+              github.rest.actions.listJobsForWorkflowRun,
+              {
+                owner,
+                repo,
+                run_id: runId,
+                per_page: 100,
+              }
+            );
+
+            const unitShardJobs = jobs
+              .filter((job) => /^Unit Test \(Shard \d+\/3\)/.test(job.name))
+              .filter((job) => Number(job.run_attempt) === currentAttempt)
+              .map((job) => ({
+                name: job.name,
+                id: job.id,
+                conclusion: job.conclusion,
+                status: job.status,
+                attempt: job.run_attempt,
+                url: job.html_url,
+              }));
+
+            const allowedConclusions = new Set(["success", "failure", "cancelled", "timed_out", "neutral", "skipped", "action_required", "startup_failure", "stopped"]);
+            const canceledConclusions = new Set(["cancelled"]);
+            const failureLikeConclusions = new Set(["failure", "timed_out", "action_required", "startup_failure", "stopped"]);
+
+            const hasFailureLike = unitShardJobs.some((job) => failureLikeConclusions.has(job.conclusion));
+            const hasCancelled = unitShardJobs.some((job) => canceledConclusions.has(job.conclusion));
+            const hasSkipped = unitShardJobs.some((job) => job.conclusion === "skipped");
+            const allSuccessOrCancelled = unitShardJobs.every(
+              (job) => ["success", "cancelled"].includes(job.conclusion)
+            );
+            const hasSuccess = unitShardJobs.some((job) => job.conclusion === "success");
+            const hasUnknownConclusion = unitShardJobs.some((job) => !allowedConclusions.has(job.conclusion));
+            const hasIncomplete = unitShardJobs.some((job) => job.status !== "completed");
+
+            let classification = "unit_shards_pass";
+            let reason = "All shard jobs passed.";
+
+            if (unitShardJobs.length === 0) {
+              classification = "unit_shards_missing";
+              reason = "No unit shard job entries found for current workflow run.";
+            } else if (hasUnknownConclusion || hasIncomplete) {
+              classification = "unit_shards_nonstandard";
+              reason = "Unit shard has unexpected status/conclusion state.";
+            } else if (hasFailureLike) {
+              classification = "unit_shards_failure";
+              reason = "Unit shard job failure detected.";
+            } else if (hasSkipped) {
+              classification = "unit_shards_skipped";
+              reason = "Unit shard job skipped state detected.";
+            } else if (hasCancelled && !(
+              currentAttempt > 1 &&
+              hasSuccess &&
+              allSuccessOrCancelled
+            )) {
+              classification = "unit_shards_cancelled";
+              reason = `Unit shard cancellations detected on initial attempt (${currentAttempt}).`;
+            } else if (hasCancelled && currentAttempt > 1 && hasSuccess && allSuccessOrCancelled) {
+              classification = "unit_shards_cancelled_rerun_side_effect";
+              reason = "Unit shard cancellations are classified as rerun-side-effect and do not block merge by themselves.";
+            }
+
+            const unitShardCurrentJob = jobs.find(
+              (job) => Number(job.run_attempt) === currentAttempt && job.name === context.job && job.status === "completed"
+            );
+
+            const payload = {
+              run_id: runId,
+              workflow: context.workflow,
+              workflow_run_name: context.workflow,
+              attempt: currentAttempt,
+              job_name: context.job,
+              job_id: unitShardCurrentJob ? unitShardCurrentJob.id : "",
+              merge_commit_sha: context.payload.pull_request ? context.payload.pull_request.merge_commit_sha : context.sha,
+              head_sha: context.sha,
+              reason,
+              classification,
+              shards: unitShardJobs,
+            };
+
+            core.setOutput("classification", classification);
+            core.setOutput("reason", reason);
+            core.setOutput("shard_json", JSON.stringify(unitShardJobs));
+            core.setOutput("payload", JSON.stringify(payload));
+
+            await require("fs").promises.writeFile(
+              `${process.env.GITHUB_WORKSPACE}/unit-shard-cancel-audit.json`,
+              JSON.stringify(payload, null, 2)
+            );
+
+            await core.summary
+              .addHeading("CI Unit shard cancellation classification")
+              .addTable([
+                [{ data: "field" }, { data: "value" }],
+                ["workflow", payload.workflow],
+                ["workflow attempt", payload.attempt],
+                ["classification", payload.classification],
+                ["run", payload.run_id],
+                ["head sha", payload.head_sha],
+              ])
+              .addCodeBlock(JSON.stringify(payload, null, 2), "json")
+              .write();
+
+            const shouldFail = [
+              "unit_shards_failure",
+              "unit_shards_skipped",
+              "unit_shards_cancelled",
+              "unit_shards_missing",
+              "unit_shards_nonstandard",
+            ].includes(classification) || unitShardJobs.length === 0;
+
+            if (shouldFail) {
+              core.setFailed(`Unit shard aggregate check blocked: ${reason}`);
+            }
       - name: Verify required CI dependencies
+        if: always()
         run: |
           echo "typecheck result: ${{ needs.typecheck.result }}"
           echo "unit-test-shard result: ${{ needs.unit-test-shard.result }}"
+          echo "unit shard classification: ${{ steps.classify-shards.outputs.classification }}"
+          echo "unit shard reason: ${{ steps.classify-shards.outputs.reason }}"
 
           if [ "${{ needs.typecheck.result }}" != "success" ]; then
             echo "Error: typecheck failed, cancelled, or skipped."
             exit 1
           fi
 
-          if [ "${{ needs.unit-test-shard.result }}" != "success" ]; then
+          if [ "${{ steps.classify-shards.outputs.classification }}" = "unit_shards_failure" ] || \
+             [ "${{ steps.classify-shards.outputs.classification }}" = "unit_shards_skipped" ] || \
+             [ "${{ steps.classify-shards.outputs.classification }}" = "unit_shards_cancelled" ] || \
+             [ "${{ steps.classify-shards.outputs.classification }}" = "unit_shards_missing" ] || \
+             [ "${{ steps.classify-shards.outputs.classification }}" = "unit_shards_nonstandard" ]; then
             echo "Error: unit-test-shard failed, cancelled, or skipped."
             exit 1
           fi
 
+          if [ "${{ steps.classify-shards.outputs.classification }}" != "unit_shards_pass" ] && \
+             [ "${{ steps.classify-shards.outputs.classification }}" != "unit_shards_cancelled_rerun_side_effect" ]; then
+            echo "Error: Unit shard classification not passable: ${{ steps.classify-shards.outputs.classification }}"
+            exit 1
+          fi
+
           echo "All required CI dependencies passed successfully!"
+
+      - name: Upload unit shard audit artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-shard-cancel-audit-${{ github.run_number }}-${{ github.run_attempt }}
+          path: unit-shard-cancel-audit.json
+          retention-days: 14
+          if-no-files-found: ignore

--- a/.github/workflows/e2e-deep.yml
+++ b/.github/workflows/e2e-deep.yml
@@ -82,16 +82,19 @@ jobs:
             ${{ runner.os }}-playwright-
 
       - name: Install Playwright (Chromium only)
+        id: install_playwright_browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         timeout-minutes: 10
         run: npx playwright install --with-deps chromium
 
       - name: Install Playwright system dependencies
+        id: install_playwright_deps
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         timeout-minutes: 10
         run: npx playwright install-deps chromium
       
       - name: Build application (preview mode)
+        id: build_preview
         run: npm run build
         env:
           VITE_E2E: '1'
@@ -100,9 +103,11 @@ jobs:
           VITE_FEATURE_SCHEDULES: '1'
       
       - name: Start preview server
+        id: start_preview
         run: npm run preview -- --host 127.0.0.1 --port 5173 --strictPort &
       
       - name: Wait for preview server
+        id: wait_preview
         run: npx wait-on http://127.0.0.1:5173 --timeout 60000
       
       - name: Run deep E2E tests (non-smoke)
@@ -162,6 +167,60 @@ jobs:
             echo "**Total Tests:** ${tests:-0}" >> $GITHUB_STEP_SUMMARY
             echo "**Failures:** ${failures:-0}" >> $GITHUB_STEP_SUMMARY
           fi
+
+      - name: Classify deep test completion
+        if: always()
+        run: |
+          cancellation_step="none"
+          direct_cancellation="false"
+          if [ "${{ steps.deep_tests.outcome }}" = "cancelled" ]; then
+            direct_cancellation="true"
+            if [ "${{ steps.wait_preview.outcome }}" = "cancelled" ]; then
+              cancellation_step="Wait for preview server"
+            elif [ "${{ steps.build_preview.outcome }}" = "cancelled" ]; then
+              cancellation_step="Build application (preview mode)"
+            elif [ "${{ steps.install_playwright_deps.outcome }}" = "cancelled" ]; then
+              cancellation_step="Install Playwright system dependencies"
+            elif [ "${{ steps.install_playwright_browsers.outcome }}" = "cancelled" ]; then
+              cancellation_step="Install Playwright (Chromium only)"
+            elif [ "${{ steps.deep_tests.outcome }}" = "cancelled" ]; then
+              cancellation_step="Run deep E2E tests (non-smoke)"
+            fi
+          fi
+
+          classification="deep_tests_pass"
+          reason="Deep tests completed normally."
+          if [ "${{ steps.deep_tests.outcome }}" = "failure" ]; then
+            classification="deep_tests_failed"
+            reason="Deep tests reported failure."
+          elif [ "${{ steps.deep_tests.outcome }}" = "cancelled" ]; then
+            classification="deep_tests_cancelled"
+            reason="Deep test execution was cancelled: ${cancellation_step}"
+          fi
+
+          cat <<EOF > deep-cancel-audit.json
+          {
+            "run_id": "${{ github.run_id }}",
+            "attempt": "${{ github.run_attempt }}",
+            "workflow": "${{ github.workflow }}",
+            "job_name": "${{ github.job }}",
+            "merge_commit_sha": "${{ github.event.pull_request.merge_commit_sha }}",
+            "classification": "${classification}",
+            "direct_cancellation": ${direct_cancellation},
+            "cancellation_step": "${cancellation_step}",
+            "deep_tests_outcome": "${{ steps.deep_tests.outcome }}",
+            "head_sha": "${{ github.sha }}"
+          }
+          EOF
+
+          echo "## Deep E2E Cancellation Classification" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Classification: \`${classification}\`" >> $GITHUB_STEP_SUMMARY
+          echo "Reason: ${reason}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo '```json' >> $GITHUB_STEP_SUMMARY
+          cat deep-cancel-audit.json >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
       
       - name: Upload Playwright HTML report
         if: always()
@@ -180,6 +239,7 @@ jobs:
           path: |
             test-results/
             playwright-report/
+            deep-cancel-audit.json
           retention-days: 14
           if-no-files-found: warn
       

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,12 +103,14 @@ jobs:
         run: npm run test:nurse:mini
         continue-on-error: true
       - name: Test (PR)
+        id: test_pr
         if: ${{ github.event_name == 'pull_request' }}
         run: |
           set -o pipefail
           npm run test:ci:required 2>&1 | tee /tmp/vitest-required.log
           node scripts/ci/check-act-warnings.mjs /tmp/vitest-required.log --json --json-output /tmp/act-warnings-required.json
       - name: Create/Update act warning regression issue (PR)
+        id: act_warning_required
         if: ${{ failure() && github.event_name == 'pull_request' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -146,6 +148,7 @@ jobs:
           echo "=== /tmp/vite-5173.log (tail -200) ==="
           tail -200 /tmp/vite-5173.log || true
       - name: Playwright E2E
+        id: playwright_e2e
         if: github.event_name == 'workflow_dispatch' || (github.ref == 'refs/heads/main' && steps.changes.outputs.playwright == 'true')
         env:
           VITE_E2E: "1"
@@ -175,6 +178,7 @@ jobs:
           # Run only the lightest Playwright smoke to keep Quality Gates aligned with this PR scope.
           npx playwright test tests/e2e/basic-smoke.spec.ts --config=playwright.smoke.config.ts --project=smoke
       - name: a11y CI integration tests (complex pages)
+        id: a11y_ci_integration
         if: github.event_name == 'workflow_dispatch' || (github.ref == 'refs/heads/main' && steps.changes.outputs.playwright == 'true')
         env:
           VITE_E2E: "1"
@@ -220,6 +224,73 @@ jobs:
             reports/perf-summary.json
             lhci-results.json
 
+      - name: Classify quality job completion
+        if: always()
+        run: |
+          cancellation_step="none"
+          direct_cancellation="false"
+
+          if [ "${{ steps.test_pr.outcome }}" = "cancelled" ]; then
+            direct_cancellation="true"
+            cancellation_step="Test (PR)"
+          elif [ "${{ steps.playwright_e2e.outcome }}" = "cancelled" ]; then
+            direct_cancellation="true"
+            cancellation_step="Playwright E2E"
+          elif [ "${{ steps.a11y_ci_integration.outcome }}" = "cancelled" ]; then
+            direct_cancellation="true"
+            cancellation_step="a11y CI integration tests"
+          fi
+
+          case "${{ steps.test_pr.outcome }}|${{ steps.playwright_e2e.outcome }}|${{ steps.a11y_ci_integration.outcome }}" in
+            *failure*)
+              classification="quality_failed"
+              reason="One or more required quality steps failed."
+              ;;
+            *cancelled*)
+              classification="quality_cancelled"
+              reason="Cancellation detected: ${cancellation_step}"
+              ;;
+            *)
+              classification="quality_pass"
+              reason="Quality workflow completed without failure/cancellation."
+              ;;
+          esac
+
+          cat <<EOF > quality-cancel-audit.json
+          {
+            "run_id": "${{ github.run_id }}",
+            "attempt": "${{ github.run_attempt }}",
+            "workflow": "${{ github.workflow }}",
+            "job_name": "${{ github.job }}",
+            "merge_commit_sha": "${{ github.event.pull_request.merge_commit_sha }}",
+            "classification": "${classification}",
+            "direct_cancellation": ${direct_cancellation},
+            "cancellation_step": "${cancellation_step}",
+            "test_pr_outcome": "${{ steps.test_pr.outcome }}",
+            "playwright_e2e_outcome": "${{ steps.playwright_e2e.outcome }}",
+            "a11y_ci_integration_outcome": "${{ steps.a11y_ci_integration.outcome }}",
+            "head_sha": "${{ github.sha }}"
+          }
+          EOF
+
+          echo "## Quality completion classification" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Classification: \`${classification}\`" >> $GITHUB_STEP_SUMMARY
+          echo "Reason: ${reason}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo '```json' >> $GITHUB_STEP_SUMMARY
+          cat quality-cancel-audit.json >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload quality completion artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: quality-cancel-audit-${{ github.run_number }}-${{ github.run_attempt }}
+          path: quality-cancel-audit.json
+          retention-days: 14
+          if-no-files-found: ignore
+
 
   quality_extended:
     name: quality_extended
@@ -245,11 +316,13 @@ jobs:
       - name: Install deps
         run: npm ci
       - name: Test (ci full)
+        id: test_ci_full
         run: |
           set -o pipefail
           npm run test:ci 2>&1 | tee /tmp/vitest-full.log
           node scripts/ci/check-act-warnings.mjs /tmp/vitest-full.log --json --json-output /tmp/act-warnings-full.json
       - name: Create/Update act warning regression issue (ci full)
+        id: act_warning_full
         if: ${{ failure() }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -261,6 +334,65 @@ jobs:
             --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             --branch "${{ github.ref_name }}" \
             --sha "${{ github.sha }}"
+
+      - name: Classify quality_extended completion
+        if: always()
+        run: |
+          cancellation_step="none"
+          direct_cancellation="false"
+
+          if [ "${{ steps.test_ci_full.outcome }}" = "cancelled" ]; then
+            direct_cancellation="true"
+            cancellation_step="Test (ci full)"
+          elif [ "${{ steps.act_warning_full.outcome }}" = "cancelled" ]; then
+            direct_cancellation="true"
+            cancellation_step="Create/Update act warning regression issue (ci full)"
+          fi
+
+          if [ "${{ steps.test_ci_full.outcome }}" = "failure" ]; then
+            classification="quality_extended_failure"
+            reason="Unit/lint/test suite failed in quality_extended."
+          elif [ "${{ steps.test_ci_full.outcome }}" = "cancelled" ]; then
+            classification="quality_extended_cancelled"
+            reason="quality_extended cancelled while running test suite: ${cancellation_step}"
+          else
+            classification="quality_extended_pass"
+            reason="quality_extended completed."
+          fi
+
+          cat <<EOF > quality-extended-cancel-audit.json
+          {
+            "run_id": "${{ github.run_id }}",
+            "attempt": "${{ github.run_attempt }}",
+            "workflow": "${{ github.workflow }}",
+            "job_name": "${{ github.job }}",
+            "merge_commit_sha": "${{ github.event.pull_request.merge_commit_sha }}",
+            "classification": "${classification}",
+            "direct_cancellation": ${direct_cancellation},
+            "cancellation_step": "${cancellation_step}",
+            "test_ci_full_outcome": "${{ steps.test_ci_full.outcome }}",
+            "act_warning_full_outcome": "${{ steps.act_warning_full.outcome }}",
+            "head_sha": "${{ github.sha }}"
+          }
+          EOF
+
+          echo "## Quality extended completion classification" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Classification: \`${classification}\`" >> $GITHUB_STEP_SUMMARY
+          echo "Reason: ${reason}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo '```json' >> $GITHUB_STEP_SUMMARY
+          cat quality-extended-cancel-audit.json >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload quality_extended completion artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: quality-extended-cancel-audit-${{ github.run_number }}-${{ github.run_attempt }}
+          path: quality-extended-cancel-audit.json
+          retention-days: 14
+          if-no-files-found: ignore
 
   canary:
     runs-on: ubuntu-latest

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -27,6 +27,7 @@
 - [Transport Assignment Page Spec (Phase 1)](./transport-assignment-page-spec.md)
 - [Transport Nightly Critical E2E](./transport-nightly-critical-e2e.md)
 - [TransportCourse Migration](./transport-course-migration.md)
+- [CI Cancellation Triage](./ci-cancellation-triage.md)
 - Weekly Review Issue Template: `.github/ISSUE_TEMPLATE/corrective-action-weekly-review.yml`
 - Transport Week1 Review Issue Template: `.github/ISSUE_TEMPLATE/transport-week1-review.yml`
 - TransportCourse Fallback Removal Issue Template: `.github/ISSUE_TEMPLATE/transport-course-fallback-removal.yml`

--- a/docs/runbooks/ci-cancellation-triage.md
+++ b/docs/runbooks/ci-cancellation-triage.md
@@ -1,0 +1,89 @@
+# CI Cancellation Triage Runbook
+
+更新日: 2026-06-23
+
+## 目的
+
+`#2334` の追跡対象である CI のキャンセル/集約挙動を、次の観点で分類し、PR差分起因とCI基盤側の影響を分離する。
+
+- PR差分起因の実障害
+- flaky / infra 由来の失敗
+- 部分再試行時の aggregate false negative
+- Playwright / Deep / Quality の直接 cancel
+- unit shard 再試行時の別 shard canceled
+
+## 分類カテゴリ
+
+### 1) PR-diff-caused failure
+
+- 単体失敗 / テスト失敗が `failure` で、再試行しても同一シグネチャで継続
+- `head SHA`/`merge commit SHA`を添えて、対象PR変更範囲と照合
+- 再現対象: 同一テスト、同一 assertion failure、同一 fixture path
+
+### 2) flaky or infra cancellation
+
+- `failure` / `timed_out` / `startup_failure` / `action_required` / `stopped`
+- 再実行で成功/失敗が揺れる、またはインフラ側手順の影響が明示的
+
+### 3) partial rerun side-effect cancellation (A)
+
+- `unit-test-shard` の aggregate 判定で、`run_attempt > 1` かつ
+  - 失敗はなし
+  - `success`/`cancelled` のみ
+  - `cancelled` に、当該再試行対象外 shard が混在
+- `TypeCheck & Test` が canceled を失敗に扱っていた状態を回避する対象
+
+### 4) direct workflow cancellation
+
+- `deep-tests` / `quality` / `quality_extended` の主要テストステップで `cancelled`
+- 失敗そのものではなく、直接キャンセルとして分類
+- ただし、対象ステップで `failure` が確認されれば最優先で fix 対象
+
+## CI上の監査フィールド
+
+監査ログには必ず次を残す。
+
+- `run_id`
+- `job_id`
+- `workflow name`
+- `job name`
+- `attempt`
+- `shard`
+- `conclusion`
+- `head SHA`
+- `merge commit SHA`
+- `classification`
+
+### aggregate での記録
+
+- `typecheck-and-test`（`ci.yml`）は `unit-shard-cancel-audit.json` を生成
+  - artifact: `unit-shard-cancel-audit-<run_number>-<attempt>`
+  - 結果: `unit_shards_pass` / `unit_shards_cancelled_rerun_side_effect` / `unit_shards_cancelled` / `unit_shards_failure` / `unit_shards_skipped` / `unit_shards_missing` / `unit_shards_nonstandard`
+- `deep`（`e2e-deep.yml`）は `deep-cancel-audit.json` を生成
+  - artifact: `playwright-report-deep-*` / `test-results-deep-*` に同梱
+- `quality` は `quality-cancel-audit.json` を生成
+- `quality_extended` は `quality-extended-cancel-audit.json` を生成
+
+## 判定手順（最小）
+
+1. 対象 PR の失敗シグネチャを列挙
+2. `#2334` 事象と照合し、A/B/C 判定に振り分け
+3. PR差分起因なら修正を対象 PR へ反映
+4. A/B は aggregate の扱いを変更せず、分類情報を残して再試行・追跡
+
+## ケース分離（今回の対象）
+
+- A: `#2333` / `#2299` の aggregate rerun 側 cancelled
+  - `TypeCheck & Test` で `unit-test-shard result: cancelled` が再試行結果に混入
+  - `unit-test-shard` 再試行側効果として識別
+- B: `#2329` の `Quality Gates` / `Deep Tests` の実行中に直接 cancel
+  - `TypeCheck` 成功ではなく、playwright実行・インストール系 step が `cancelled`
+- C: 同一 `main` / unit shard での再現比較による非PR起因評価
+  - issue 追跡と切り分け結果は `#2334` に追加追記
+
+## 例外
+
+- cancellation を無条件 success 扱いしない
+- 実際のテスト failure は必ず fail-closed
+- PR 実装との関係が不明な場合は保留して追加観測を行う
+


### PR DESCRIPTION
## Summary
- Classify CI cancellation paths for aggregate/rerun workflows.
- Keep real shard/test failures fail-closed.
- Separate partial rerun side-effect `cancelled` from PR-diff-caused failures and direct runtime cancellations.
- Record run/job/shard evidence in workflow summary and artifacts for audit.

## Scope
- CI/workflow/scripts/docs only.
- No production code changes.
- No unrelated PR cleanup.

## Validation
- Pre-push hooks executed on commit:
  - `npm run lint`
  - `npm run typecheck`
  - `npm run lint:cookies`
- Static checks not re-run in this change after this commit.

## Risk
- Aggregate behavior changes in `TypeCheck & Test` can affect required check outcomes.
- This change intentionally still treats real test failures and non-retryable cancellations as failures.

## Related
- #2334