### PR TITLE
test: add vitest serial test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "config:print": "VITE_CONFIG_DEBUG=1 vite --force",
     "gen:system-map": "tsx scripts/generate-system-map.ts",
     "test": "vitest run",
+    "test:serial": "vitest run --pool=forks --maxWorkers=1 --no-file-parallelism",
     "test:csp": "node scripts/run-csp-tests.mjs",
     "test:schedule:mini": "vitest run tests/unit/schedule*.spec.* tests/unit/schedules*.spec.* --reporter=verbose --no-file-parallelism",
     "test:attendance:mini": "vitest run tests/unit/attendance*.spec.* src/features/attendance/__tests__/attendance*.spec.* src/features/dashboard/__tests__/attendanceSummary.spec.ts --reporter=verbose --no-file-parallelism",


### PR DESCRIPTION
Adds a Vitest-native serial test command for baseline checks.
This avoids using Jest-only --runInBand, which Vitest 4 does not recognize.
Scope:
- package.json script only
- no SharePoint runtime changes
- no test repair bundled
- no changes to src/sharepoint/latest-decision.json
Validation:
- npm run test:serial -- --help
- npm run typecheck -- --pretty false
- npm run lint