### PR TITLE
fix(sp): respect skip provisioning during bootstrap

### DIFF
--- a/src/sharepoint/spProvisioningCoordinator.ts
+++ b/src/sharepoint/spProvisioningCoordinator.ts
@@ -103,6 +103,9 @@ export function shouldSkipSharePoint(): boolean {
   return false;
 }
 
+const shouldSkipProvisioning = (): boolean =>
+  readBool('VITE_SKIP_PROVISIONING', false);
+
 export class SharePointProvisioningCoordinator {
   /**
    * App 起動時に一括初期化を実行
@@ -173,9 +176,13 @@ export class SharePointProvisioningCoordinator {
     // ── Phase 1: Child Lists (Results/ApprovalLogs/UserFlags) ──
     // 既存のメインリスト provision の後に実行。fail-open (非ブロッキング) 構成。
     try {
-      const provisioner = createProvisioningService(client.spFetch);
-      await provisioner.ensureChildLists('bootstrap');
-      trackSpEvent('sp:child_lists_provision_success');
+      if (shouldSkipProvisioning()) {
+        auditLog.warn('sp:provisioning', 'Child lists provisioning skipped.', { reason: 'VITE_SKIP_PROVISIONING' });
+      } else {
+        const provisioner = createProvisioningService(client.spFetch);
+        await provisioner.ensureChildLists('bootstrap');
+        trackSpEvent('sp:child_lists_provision_success');
+      }
     } catch (err) {
       // 子リストの失敗はメイン機能（L0/L1）を止めないため、警告に留めるが Signal は送る
       const errorMsg = err instanceof Error ? err.message : String(err);
@@ -260,6 +267,18 @@ export class SharePointProvisioningCoordinator {
       if (!metadata) {
         // If absent, check if we should provision
         if (entry.provisioningFields) {
+          if (shouldSkipProvisioning()) {
+            auditLog.warn('sp:provisioning', `List "${listName}" missing. Provisioning skipped.`, { key: entry.key, reason: 'VITE_SKIP_PROVISIONING' });
+            saveStability(entry.key, 'missing');
+            trackSpEvent(isOptional ? 'sp:list_missing_optional' : 'sp:list_missing_required', {
+              key: entry.key,
+              listName,
+              error: 'List not found',
+              details: { reason: 'VITE_SKIP_PROVISIONING' },
+            });
+            return { key: entry.key, displayName: entry.displayName, listName, status: 'missing', details: 'List not found' };
+          }
+
           auditLog.warn('sp:provisioning', `List "${listName}" missing. Provisioning...`, { key: entry.key });
           await provisioner.ensureList(
               listName, 
@@ -306,15 +325,19 @@ export class SharePointProvisioningCoordinator {
 
           // Attempt self-healing if provisioning fields match missing ones
           if (entry.provisioningFields) {
-            auditLog.warn('sp:provisioning', `Healing ${listName}...`, { missingFields });
-            await provisioner.ensureList(listName, entry.provisioningFields as import('@/lib/sp/types').SpFieldDef[], { phase });
-            
-            // Re-verify after healing
-            const reAvailable = await client.getListFieldInternalNames(listName);
-            const { missing: stillMissing } = resolveInternalNamesDetailed(reAvailable, candidates);
-            if (stillMissing.length === 0) {
-              saveStability(entry.key, 'provisioned');
-              return { key: entry.key, displayName: entry.displayName, listName, status: 'provisioned' };
+            if (shouldSkipProvisioning()) {
+              auditLog.warn('sp:provisioning', `Healing ${listName} skipped.`, { missingFields, reason: 'VITE_SKIP_PROVISIONING' });
+            } else {
+              auditLog.warn('sp:provisioning', `Healing ${listName}...`, { missingFields });
+              await provisioner.ensureList(listName, entry.provisioningFields as import('@/lib/sp/types').SpFieldDef[], { phase });
+
+              // Re-verify after healing
+              const reAvailable = await client.getListFieldInternalNames(listName);
+              const { missing: stillMissing } = resolveInternalNamesDetailed(reAvailable, candidates);
+              if (stillMissing.length === 0) {
+                saveStability(entry.key, 'provisioned');
+                return { key: entry.key, displayName: entry.displayName, listName, status: 'provisioned' };
+              }
             }
           }
           

--- a/tests/unit/sharepoint/spProvisioningCoordinator.lifecycle.spec.ts
+++ b/tests/unit/sharepoint/spProvisioningCoordinator.lifecycle.spec.ts
@@ -28,6 +28,16 @@ vi.mock('@/sharepoint/spListRegistry', async (importOriginal) => {
             { key: 'opt', displayName: 'Optional', resolve: () => 'OptionalList', lifecycle: 'optional', operations: ['R'], category: 'master' },
             { key: 'dep', displayName: 'Deprecated', resolve: () => 'DeprecatedList', lifecycle: 'deprecated', operations: ['R'], category: 'master' },
             { key: 'exp', displayName: 'Experimental', resolve: () => 'ExperimentalList', lifecycle: 'experimental', operations: ['R'], category: 'master' },
+            {
+              key: 'exp_heal',
+              displayName: 'Experimental Healing',
+              resolve: () => 'ExperimentalHealingList',
+              lifecycle: 'experimental',
+              operations: ['R'],
+              category: 'master',
+              essentialFields: ['Title'],
+              provisioningFields: [{ internalName: 'Title', type: 'Text', required: true }],
+            },
         ]
     };
 });
@@ -44,7 +54,7 @@ describe('SharePointProvisioningCoordinator - Lifecycle Support', () => {
       tryGetListMetadata: vi.fn().mockResolvedValue({ listId: '', title: 'SomeList' }),
       getListFieldInternalNames: vi.fn().mockResolvedValue(new Set()),
       getExistingListTitlesAndIds: vi.fn().mockResolvedValue(
-        new Set(['RequiredList', 'OptionalList', 'DeprecatedList', 'ExperimentalList'])
+        new Set(['RequiredList', 'OptionalList', 'DeprecatedList', 'ExperimentalList', 'ExperimentalHealingList'])
       ),
     } as unknown as ReturnType<typeof useSP>;
   });
@@ -103,5 +113,55 @@ describe('SharePointProvisioningCoordinator - Lifecycle Support', () => {
     expect(trackSpEvent).toHaveBeenCalledWith('sp:list_missing_optional', expect.objectContaining({
       key: 'opt'
     }));
+  });
+
+  it('VITE_SKIP_PROVISIONING: should not ensure a missing list even when provisioning fields exist', async () => {
+    vi.mocked(readBool).mockImplementation((key) =>
+      key === 'VITE_SKIP_PROVISIONING' || key === 'VITE_FEATURE_EXP'
+    );
+    vi.mocked(mockClient.tryGetListMetadata).mockImplementation((name: string) => {
+      if (name === 'ExperimentalList') return Promise.resolve(null);
+      return Promise.resolve({ listId: '', title: name });
+    });
+
+    const result = await SharePointProvisioningCoordinator.bootstrap(mockClient);
+    const expResult = result.summaries.find(s => s.key === 'exp');
+
+    expect(expResult?.status).toBe('missing');
+    expect(mockClient.tryGetListMetadata).toHaveBeenCalledWith('ExperimentalList', expect.any(Object));
+    expect(mockClient.spFetch).not.toHaveBeenCalled();
+  });
+
+  it('VITE_SKIP_PROVISIONING: should not heal missing essential fields', async () => {
+    vi.mocked(readBool).mockImplementation((key) =>
+      key === 'VITE_SKIP_PROVISIONING' || key === 'VITE_FEATURE_EXP_HEAL'
+    );
+    vi.mocked(mockClient.tryGetListMetadata).mockImplementation((name: string) =>
+      Promise.resolve({ listId: '', title: name })
+    );
+    vi.mocked(mockClient.getListFieldInternalNames).mockImplementation((name: string) => {
+      if (name === 'ExperimentalHealingList') return Promise.resolve(new Set());
+      return Promise.resolve(new Set(['Title']));
+    });
+
+    const result = await SharePointProvisioningCoordinator.bootstrap(mockClient);
+    const healingResult = result.summaries.find(s => s.key === 'exp_heal');
+
+    expect(healingResult?.status).toBe('mismatch');
+    expect(mockClient.getListFieldInternalNames).toHaveBeenCalledWith('ExperimentalHealingList');
+    expect(mockClient.spFetch).not.toHaveBeenCalled();
+  });
+
+  it('VITE_SKIP_PROVISIONING: should not ensure child lists during bootstrap', async () => {
+    vi.mocked(readBool).mockImplementation((key) => key === 'VITE_SKIP_PROVISIONING');
+    vi.mocked(mockClient.tryGetListMetadata).mockImplementation((name: string) =>
+      Promise.resolve({ listId: '', title: name })
+    );
+    vi.mocked(mockClient.getListFieldInternalNames).mockResolvedValue(new Set(['Title']));
+
+    await SharePointProvisioningCoordinator.bootstrap(mockClient);
+
+    expect(mockClient.getExistingListTitlesAndIds).toHaveBeenCalled();
+    expect(mockClient.spFetch).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Respect `VITE_SKIP_PROVISIONING` in `SharePointProvisioningCoordinator.bootstrap()`.
- Keep SharePoint metadata/field checks and health signals read-only.
- Skip physical provisioning writes when the flag is enabled:
  - missing list `ensureList()`
  - essential field healing `ensureList()`
  - child list `ensureChildLists('bootstrap')`

## Rationale
This separates SharePoint connectivity from provisioning writes:
- `VITE_SKIP_SHAREPOINT`: disables SharePoint usage
- `VITE_SKIP_PROVISIONING`: allows SharePoint read/diagnostics but prevents list/field/child-list creation

This reduces deployment risk by preventing startup bootstrap from mutating SharePoint when provisioning is intentionally disabled.

## Deployment readiness
This PR does not make deployment readiness ready.

- deployment readiness: still blocked
- external data write risk: partially mitigated

Remaining deployment blockers include tracked `.env`, `.env.production` / `public/env.runtime.json` / `wrangler.toml` review, billing `/sites/2` cross-site confirmation, migration/purge/scripts/ops operation boundaries, and the large deployment delta smoke plan.

## Validation
- `npx vitest run tests/unit/sharepoint/spProvisioningCoordinator.lifecycle.spec.ts tests/unit/sharepoint/spProvisioningCoordinator.spec.ts --reporter=default`
- `npm run typecheck`
- `git diff --check`
- pre-commit hook: `guard:tz`, `lint`, `typecheck`, `lint:cookies`, `lint-staged`
- pre-push hook: changed-file eslint vs `origin/main`