### PR TITLE
fix(firestore): guard daily PDCA persistence writes

### DIFF
--- a/src/features/ibd/analysis/pdca/__tests__/persistDailyPdca.spec.ts
+++ b/src/features/ibd/analysis/pdca/__tests__/persistDailyPdca.spec.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  createDailyEventCreateOnly,
+  upsertDailySnapshot,
+  persistDailySubmission,
+  makeIdempotencyKey,
+  type PersistDailyPdcaInput,
+} from '../persistDailyPdca';
+
+const mockSetDoc = vi.fn().mockResolvedValue(undefined);
+const mockDoc = vi.fn().mockReturnValue('mock-doc-ref');
+const mockTimestampFromDate = vi.fn((value: Date) => ({ value }));
+
+let firestoreWriteAvailable = true;
+
+vi.mock('firebase/firestore', () => ({
+  setDoc: (...args: unknown[]) => mockSetDoc(...args),
+  doc: (...args: unknown[]) => mockDoc(...args),
+  serverTimestamp: () => 'mock-server-timestamp',
+  Timestamp: {
+    fromDate: (value: Date) => mockTimestampFromDate(value),
+  },
+}));
+
+vi.mock('@/infra/firestore/client', () => ({
+  db: 'mock-db',
+  isFirestoreWriteAvailable: () => firestoreWriteAvailable,
+}));
+
+const baseInput: PersistDailyPdcaInput = {
+  orgId: 'org-1',
+  templateId: 'template-1',
+  targetDate: '2026-06-26',
+  targetUserId: 'user-1',
+  actorUserId: 'actor-1',
+  actorName: 'Alice',
+  type: 'DAILY_SUPPORT_SUBMITTED',
+  clientVersion: '1.0.0',
+  sourceRoute: '/daily',
+  ref: 'ref-1',
+  metrics: { completionRate: 100, leadTimeMinutes: 12, unfilledCount: 0 },
+  submittedAt: new Date('2026-06-26T01:02:03.000Z'),
+};
+
+describe('persistDailyPdca', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    firestoreWriteAvailable = true;
+  });
+
+  it('returns idempotencyKey and does not call setDoc when Firestore writes are unavailable', async () => {
+    firestoreWriteAvailable = false;
+
+    const result = await createDailyEventCreateOnly(baseInput);
+
+    expect(result).toEqual({ idempotencyKey: makeIdempotencyKey(baseInput) });
+    expect(mockSetDoc).not.toHaveBeenCalled();
+  });
+
+  it('does not call setDoc in upsertDailySnapshot when Firestore writes are unavailable', async () => {
+    firestoreWriteAvailable = false;
+
+    await upsertDailySnapshot(baseInput);
+
+    expect(mockSetDoc).not.toHaveBeenCalled();
+  });
+
+  it('calls setDoc when Firestore writes are available', async () => {
+    await createDailyEventCreateOnly(baseInput);
+    await upsertDailySnapshot(baseInput);
+
+    expect(mockSetDoc).toHaveBeenCalledTimes(2);
+    expect(mockSetDoc).toHaveBeenNthCalledWith(
+      1,
+      'mock-doc-ref',
+      expect.objectContaining({
+        type: 'DAILY_SUPPORT_SUBMITTED',
+        idempotencyKey: makeIdempotencyKey(baseInput),
+      }),
+      { merge: false },
+    );
+    expect(mockSetDoc).toHaveBeenNthCalledWith(
+      2,
+      'mock-doc-ref',
+      expect.objectContaining({
+        orgId: 'org-1',
+        templateId: 'template-1',
+      }),
+      { merge: true },
+    );
+  });
+
+  it('skips both writes in persistDailySubmission when Firestore writes are unavailable', async () => {
+    firestoreWriteAvailable = false;
+
+    const result = await persistDailySubmission(baseInput);
+
+    expect(result).toBeUndefined();
+    expect(mockSetDoc).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/ibd/analysis/pdca/persistDailyPdca.ts
+++ b/src/features/ibd/analysis/pdca/persistDailyPdca.ts
@@ -23,7 +23,7 @@
  */
 import { doc, serverTimestamp, setDoc, Timestamp } from 'firebase/firestore';
 
-import { db } from '@/infra/firestore/client';
+import { db, isFirestoreWriteAvailable } from '@/infra/firestore/client';
 
 export type DailyPdcaEventType = 'DAILY_SUPPORT_SUBMITTED' | 'PDCA_CHECK_VIEWED';
 
@@ -66,6 +66,10 @@ export async function createDailyEventCreateOnly(input: PersistDailyPdcaInput) {
   const idempotencyKey = makeIdempotencyKey(input);
   const ref = doc(db, 'orgs', input.orgId, 'events', idempotencyKey);
 
+  if (!isFirestoreWriteAvailable()) {
+    return { idempotencyKey };
+  }
+
   const payload = {
     orgId: input.orgId,
     templateId: input.templateId,
@@ -91,6 +95,10 @@ export async function createDailyEventCreateOnly(input: PersistDailyPdcaInput) {
 export async function upsertDailySnapshot(input: PersistDailyPdcaInput) {
   const snapId = makeDailySnapshotId(input);
   const ref = doc(db, 'orgs', input.orgId, 'dailySnapshots', snapId);
+
+  if (!isFirestoreWriteAvailable()) {
+    return;
+  }
 
   const submittedAtTs = input.submittedAt ? Timestamp.fromDate(input.submittedAt) : null;
 


### PR DESCRIPTION
## Summary
- Add explicit Firestore write availability guards to daily PDCA persistence.
- Skip create/upsert setDoc calls when Firestore writes are unavailable.
- Add direct unit coverage for unavailable and available write paths.

## Validation
- npm run test -- src/features/ibd/analysis/pdca/__tests__/persistDailyPdca.spec.ts

## Notes
- Scope is limited to persistDailyPdca.ts and its direct unit test.
- Telemetry guard alignment is intentionally left for a separate PR.
- No SharePoint, workflow, deploy, migration, provisioning, or purge changes.

## Behavior change
- In read-only / Firebase-unconfigured / E2E environments, daily PDCA persistence now becomes a no-op success instead of triggering retry UX.
- When Firestore writes are available, existing setDoc behavior is preserved.

## Deployment Readiness
- not fully ready / still blocked