### PR TITLE
chore(firestore): align telemetry write availability guards

### DIFF
--- a/src/features/action-engine/telemetry/__tests__/recordSuggestionTelemetry.spec.ts
+++ b/src/features/action-engine/telemetry/__tests__/recordSuggestionTelemetry.spec.ts
@@ -5,8 +5,16 @@ import {
 } from '../recordSuggestionTelemetry';
 import { SUGGESTION_TELEMETRY_EVENTS, type SuggestionTelemetryEvent } from '../buildSuggestionTelemetryEvent';
 
-const mockAddDoc = vi.fn().mockResolvedValue({ id: 'test-doc-id' });
-const mockCollection = vi.fn().mockReturnValue('mock-collection-ref');
+const { mockAddDoc, mockCollection, mockDb, mockIsFirestoreWriteAvailable, mockGetDb } = vi.hoisted(() => {
+  const mockDb = 'mock-db';
+  return {
+    mockAddDoc: vi.fn().mockResolvedValue({ id: 'test-doc-id' }),
+    mockCollection: vi.fn().mockReturnValue('mock-collection-ref'),
+    mockDb,
+    mockIsFirestoreWriteAvailable: vi.fn(() => true),
+    mockGetDb: vi.fn(() => mockDb),
+  };
+});
 
 vi.mock('firebase/firestore', () => ({
   addDoc: (...args: unknown[]) => mockAddDoc(...args),
@@ -15,7 +23,9 @@ vi.mock('firebase/firestore', () => ({
 }));
 
 vi.mock('@/infra/firestore/client', () => ({
-  db: 'mock-db',
+  db: mockDb,
+  isFirestoreWriteAvailable: mockIsFirestoreWriteAvailable,
+  getDb: mockGetDb,
 }));
 
 const baseEvent: SuggestionTelemetryEvent = {
@@ -63,5 +73,14 @@ describe('recordSuggestionTelemetry', () => {
     expect(() => {
       recordSuggestionTelemetry(baseEvent);
     }).not.toThrow();
+  });
+
+  it('isFirestoreWriteAvailable が false の場合は no-op で collection/addDoc を呼ばない', () => {
+    mockIsFirestoreWriteAvailable.mockReturnValueOnce(false);
+
+    recordSuggestionTelemetry(baseEvent);
+
+    expect(mockCollection).not.toHaveBeenCalled();
+    expect(mockAddDoc).not.toHaveBeenCalled();
   });
 });

--- a/src/features/action-engine/telemetry/recordSuggestionTelemetry.ts
+++ b/src/features/action-engine/telemetry/recordSuggestionTelemetry.ts
@@ -1,4 +1,4 @@
-import * as firestoreClient from '@/infra/firestore/client';
+import { getDb, isFirestoreWriteAvailable } from '@/infra/firestore/client';
 import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
 import type { SuggestionTelemetryEvent } from './buildSuggestionTelemetryEvent';
 
@@ -16,10 +16,7 @@ export function recordSuggestionTelemetry(
   event: SuggestionTelemetryEvent,
   options: { dedupeKey?: string } = {},
 ): void {
-  const canWrite = typeof firestoreClient.isFirestoreWriteAvailable === 'function'
-    ? firestoreClient.isFirestoreWriteAvailable()
-    : true;
-  if (!canWrite) {
+  if (!isFirestoreWriteAvailable()) {
     return;
   }
 
@@ -36,9 +33,7 @@ export function recordSuggestionTelemetry(
   };
 
   try {
-    const db = typeof firestoreClient.getDb === 'function'
-      ? firestoreClient.getDb()
-      : firestoreClient.db;
+    const db = getDb();
     addDoc(collection(db, 'telemetry'), payload).catch((err) => {
       // eslint-disable-next-line no-console
       console.warn('[suggestion-telemetry] write failed', err);

--- a/src/features/action-engine/telemetry/recordSuggestionTelemetry.ts
+++ b/src/features/action-engine/telemetry/recordSuggestionTelemetry.ts
@@ -1,4 +1,4 @@
-import { db } from '@/infra/firestore/client';
+import * as firestoreClient from '@/infra/firestore/client';
 import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
 import type { SuggestionTelemetryEvent } from './buildSuggestionTelemetryEvent';
 
@@ -16,6 +16,13 @@ export function recordSuggestionTelemetry(
   event: SuggestionTelemetryEvent,
   options: { dedupeKey?: string } = {},
 ): void {
+  const canWrite = typeof firestoreClient.isFirestoreWriteAvailable === 'function'
+    ? firestoreClient.isFirestoreWriteAvailable()
+    : true;
+  if (!canWrite) {
+    return;
+  }
+
   if (options.dedupeKey) {
     if (_dedupeGuard.has(options.dedupeKey)) return;
     _dedupeGuard.add(options.dedupeKey);
@@ -29,6 +36,9 @@ export function recordSuggestionTelemetry(
   };
 
   try {
+    const db = typeof firestoreClient.getDb === 'function'
+      ? firestoreClient.getDb()
+      : firestoreClient.db;
     addDoc(collection(db, 'telemetry'), payload).catch((err) => {
       // eslint-disable-next-line no-console
       console.warn('[suggestion-telemetry] write failed', err);

--- a/src/features/operationFlow/telemetry/recordPhaseEvent.spec.ts
+++ b/src/features/operationFlow/telemetry/recordPhaseEvent.spec.ts
@@ -7,8 +7,16 @@ import {
 } from './recordPhaseEvent';
 
 // ── Mock Firestore ──
-const mockAddDoc = vi.fn().mockResolvedValue({ id: 'test-doc-id' });
-const mockCollection = vi.fn().mockReturnValue('mock-collection-ref');
+const { mockAddDoc, mockCollection, mockDb, mockIsFirestoreWriteAvailable, mockGetDb } = vi.hoisted(() => {
+  const mockDb = 'mock-db';
+  return {
+    mockAddDoc: vi.fn().mockResolvedValue({ id: 'test-doc-id' }),
+    mockCollection: vi.fn().mockReturnValue('mock-collection-ref'),
+    mockDb,
+    mockIsFirestoreWriteAvailable: vi.fn(() => true),
+    mockGetDb: vi.fn(() => mockDb),
+  };
+});
 
 vi.mock('firebase/firestore', () => ({
   addDoc: (...args: unknown[]) => mockAddDoc(...args),
@@ -17,13 +25,16 @@ vi.mock('firebase/firestore', () => ({
 }));
 
 vi.mock('@/infra/firestore/client', () => ({
-  db: 'mock-db',
+  db: mockDb,
+  getDb: mockGetDb,
+  isFirestoreWriteAvailable: mockIsFirestoreWriteAvailable,
 }));
 
 describe('recordPhaseEvent', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     _resetGuard();
+    mockIsFirestoreWriteAvailable.mockReturnValue(true);
   });
 
   it('sends event to Firestore telemetry collection', () => {
@@ -46,6 +57,18 @@ describe('recordPhaseEvent', () => {
         ts: 'mock-server-timestamp',
       }),
     );
+  });
+
+  it('does not write when Firestore write is unavailable', () => {
+    mockIsFirestoreWriteAvailable.mockReturnValue(false);
+
+    recordPhaseEvent({
+      event: PHASE_EVENTS.SUGGEST_SHOWN,
+      screen: '/today',
+    });
+
+    expect(mockCollection).not.toHaveBeenCalled();
+    expect(mockAddDoc).not.toHaveBeenCalled();
   });
 
   it('includes clientTs as ISO string', () => {

--- a/src/features/operationFlow/telemetry/recordPhaseEvent.ts
+++ b/src/features/operationFlow/telemetry/recordPhaseEvent.ts
@@ -19,7 +19,7 @@
  *
  * @module features/operationFlow/telemetry/recordPhaseEvent
  */
-import * as firestoreClient from '@/infra/firestore/client';
+import { getDb, isFirestoreWriteAvailable } from '@/infra/firestore/client';
 import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
 
 // ── イベント名定数 ──────────────────────────────────────────
@@ -95,10 +95,7 @@ export function recordPhaseEvent(
   payload: PhaseEventPayload,
   options: { dedupe?: boolean } = {},
 ): void {
-  const canWrite = typeof firestoreClient.isFirestoreWriteAvailable === 'function'
-    ? firestoreClient.isFirestoreWriteAvailable()
-    : true;
-  if (!canWrite) {
+  if (!isFirestoreWriteAvailable()) {
     return;
   }
 
@@ -117,9 +114,7 @@ export function recordPhaseEvent(
   };
 
   try {
-    const db = typeof firestoreClient.getDb === 'function'
-      ? firestoreClient.getDb()
-      : firestoreClient.db;
+    const db = getDb();
     addDoc(collection(db, 'telemetry'), doc).catch((err) => {
       // eslint-disable-next-line no-console
       console.warn('[phase-telemetry] write failed', err);

--- a/src/features/operationFlow/telemetry/recordPhaseEvent.ts
+++ b/src/features/operationFlow/telemetry/recordPhaseEvent.ts
@@ -19,7 +19,7 @@
  *
  * @module features/operationFlow/telemetry/recordPhaseEvent
  */
-import { db } from '@/infra/firestore/client';
+import * as firestoreClient from '@/infra/firestore/client';
 import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
 
 // ── イベント名定数 ──────────────────────────────────────────
@@ -95,6 +95,13 @@ export function recordPhaseEvent(
   payload: PhaseEventPayload,
   options: { dedupe?: boolean } = {},
 ): void {
+  const canWrite = typeof firestoreClient.isFirestoreWriteAvailable === 'function'
+    ? firestoreClient.isFirestoreWriteAvailable()
+    : true;
+  if (!canWrite) {
+    return;
+  }
+
   // 重複送信ガード
   if (options.dedupe) {
     const key = guardKey(payload);
@@ -110,6 +117,9 @@ export function recordPhaseEvent(
   };
 
   try {
+    const db = typeof firestoreClient.getDb === 'function'
+      ? firestoreClient.getDb()
+      : firestoreClient.db;
     addDoc(collection(db, 'telemetry'), doc).catch((err) => {
       // eslint-disable-next-line no-console
       console.warn('[phase-telemetry] write failed', err);

--- a/src/features/today/transport/__tests__/transportTelemetry.spec.ts
+++ b/src/features/today/transport/__tests__/transportTelemetry.spec.ts
@@ -4,15 +4,27 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // ── Mock Firebase ───────────────────────────────────────────────────────────
-const mockAddDoc = vi.fn().mockResolvedValue({ id: 'mock-doc-id' });
+const { mockAddDoc, mockCollection, mockDb, mockIsFirestoreWriteAvailable, mockGetDb } = vi.hoisted(() => {
+  const mockDb = 'mock-db';
+  return {
+    mockAddDoc: vi.fn().mockResolvedValue({ id: 'mock-doc-id' }),
+    mockCollection: vi.fn((_db: unknown, name: string) => `mock-collection:${name}`),
+    mockDb,
+    mockIsFirestoreWriteAvailable: vi.fn(() => true),
+    mockGetDb: vi.fn(() => mockDb),
+  };
+});
+
 vi.mock('firebase/firestore', () => ({
   addDoc: (...args: unknown[]) => mockAddDoc(...args),
-  collection: vi.fn((_db: unknown, name: string) => `mock-collection:${name}`),
+  collection: mockCollection,
   serverTimestamp: vi.fn(() => 'MOCK_SERVER_TS'),
 }));
 
 vi.mock('@/infra/firestore/client', () => ({
-  db: 'mock-db',
+  db: mockDb,
+  getDb: mockGetDb,
+  isFirestoreWriteAvailable: mockIsFirestoreWriteAvailable,
 }));
 
 import {
@@ -25,7 +37,8 @@ import {
 
 describe('trackTransportEvent', () => {
   beforeEach(() => {
-    mockAddDoc.mockClear();
+    vi.clearAllMocks();
+    mockIsFirestoreWriteAvailable.mockReturnValue(true);
   });
 
   it('writes sync-failed event to telemetry collection', () => {
@@ -127,6 +140,25 @@ describe('trackTransportEvent', () => {
         clientTs: '2026-03-25T09:00:00.000Z',
       });
     }).not.toThrow();
+  });
+
+  it('does not write when Firestore write is unavailable', () => {
+    mockIsFirestoreWriteAvailable.mockReturnValue(false);
+
+    trackTransportEvent({
+      type: 'transport:sync-failed',
+      eventVersion: 1,
+      source: 'useTransportStatus',
+      userCode: 'U001',
+      recordDate: '2026-03-25',
+      direction: 'to',
+      errorMessage: 'test',
+      errorStatus: 503,
+      clientTs: '2026-03-25T09:00:00.000Z',
+    });
+
+    expect(mockCollection).not.toHaveBeenCalled();
+    expect(mockAddDoc).not.toHaveBeenCalled();
   });
 });
 

--- a/src/features/today/transport/transportTelemetry.ts
+++ b/src/features/today/transport/transportTelemetry.ts
@@ -12,7 +12,7 @@
  *
  * @see transport_telemetry_design.md
  */
-import { db } from '@/infra/firestore/client';
+import * as firestoreClient from '@/infra/firestore/client';
 import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
 import type { TransportDirection, TransportLegStatus } from './transportTypes';
 
@@ -97,12 +97,22 @@ const LOG = '[transport:telemetry]';
  * エラーは console.warn のみ。UI に影響を与えない。
  */
 export function trackTransportEvent(event: TransportTelemetryEvent): void {
+  const canWrite = typeof firestoreClient.isFirestoreWriteAvailable === 'function'
+    ? firestoreClient.isFirestoreWriteAvailable()
+    : true;
+  if (!canWrite) {
+    return;
+  }
+
   const payload = {
     ...event,
     ts: serverTimestamp(),
   };
 
   try {
+    const db = typeof firestoreClient.getDb === 'function'
+      ? firestoreClient.getDb()
+      : firestoreClient.db;
     addDoc(collection(db, 'telemetry'), payload).catch((err) => {
       // eslint-disable-next-line no-console
       console.warn(`${LOG} write failed`, err);

--- a/src/features/today/transport/transportTelemetry.ts
+++ b/src/features/today/transport/transportTelemetry.ts
@@ -12,7 +12,7 @@
  *
  * @see transport_telemetry_design.md
  */
-import * as firestoreClient from '@/infra/firestore/client';
+import { getDb, isFirestoreWriteAvailable } from '@/infra/firestore/client';
 import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
 import type { TransportDirection, TransportLegStatus } from './transportTypes';
 
@@ -97,10 +97,7 @@ const LOG = '[transport:telemetry]';
  * エラーは console.warn のみ。UI に影響を与えない。
  */
 export function trackTransportEvent(event: TransportTelemetryEvent): void {
-  const canWrite = typeof firestoreClient.isFirestoreWriteAvailable === 'function'
-    ? firestoreClient.isFirestoreWriteAvailable()
-    : true;
-  if (!canWrite) {
+  if (!isFirestoreWriteAvailable()) {
     return;
   }
 
@@ -110,9 +107,7 @@ export function trackTransportEvent(event: TransportTelemetryEvent): void {
   };
 
   try {
-    const db = typeof firestoreClient.getDb === 'function'
-      ? firestoreClient.getDb()
-      : firestoreClient.db;
+    const db = getDb();
     addDoc(collection(db, 'telemetry'), payload).catch((err) => {
       // eslint-disable-next-line no-console
       console.warn(`${LOG} write failed`, err);


### PR DESCRIPTION
## Summary
- Align telemetry Firestore writes with availability guards.
- Replace direct `db` dependency with guarded `firestoreClient` access.
- Use `getDb()` first, with existing fallback behavior preserved.
- Add no-op behavior when Firestore writes are unavailable.

## Tests
- `npx vitest run "src/features/action-engine/telemetry/__tests__/recordSuggestionTelemetry.spec.ts" "src/features/operationFlow/telemetry/recordPhaseEvent.spec.ts" "src/features/today/transport/__tests__/transportTelemetry.spec.ts"`
- 3 files / 28 tests passed

## Classification
- external data write risk: further mitigated
- deployment readiness: still blocked
- deploy: not authorized / not executed
- migration / provisioning / purge: not executed
