### PR TITLE
fix(ci): retry transient Danger GitHub API failures

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -28,6 +28,6 @@ jobs:
 
       # Today 領域が変更された場合に自動実行（RejectではなくWarnで啓蒙する）
       - name: Run Danger
-        run: npx danger ci
+        run: node scripts/ci/run-danger-with-retry.mjs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - 'src/features/today/**'
       - 'dangerfile.ts'
+      - '.github/workflows/danger.yml'
+      - 'scripts/ci/run-danger-with-retry.mjs'
+      - 'scripts/ci/__tests__/run-danger-with-retry.spec.mjs'
 
 jobs:
   danger:

--- a/scripts/ci/__tests__/run-danger-with-retry.spec.mjs
+++ b/scripts/ci/__tests__/run-danger-with-retry.spec.mjs
@@ -1,0 +1,27 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+
+import { isTransientDangerFailure } from "../run-danger-with-retry.mjs";
+
+describe("isTransientDangerFailure", () => {
+  it.each([
+    "ERR_STREAM_PREMATURE_CLOSE",
+    "Error: Premature close",
+    "Danger: Failed to fetch GitHub pull request files",
+    "Danger: Failed to fetch pull request diff",
+    "GET /repos/example/repo/pulls/2345/commits failed: fetch failed",
+    "fetch failure while requesting /repos/example/repo/pulls/2345/commits",
+  ])("classifies transient Danger API output: %s", (output) => {
+    expect(isTransientDangerFailure(output)).toBe(true);
+  });
+
+  it.each([
+    "Danger found 2 fails. Please update Today guardrails.",
+    "SyntaxError: Unexpected token in dangerfile.ts",
+    "npm ERR! missing script: danger",
+    "Error: Request failed with status code 422",
+    "GET /repos/example/repo/pulls/2345/files failed",
+  ])("does not classify non-transient output: %s", (output) => {
+    expect(isTransientDangerFailure(output)).toBe(false);
+  });
+});

--- a/scripts/ci/run-danger-with-retry.mjs
+++ b/scripts/ci/run-danger-with-retry.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+const MAX_ATTEMPTS = 3;
+const RETRY_DELAY_MS = 5_000;
+
+const TRANSIENT_PATTERNS = [
+  /ERR_STREAM_PREMATURE_CLOSE/,
+  /Premature close/i,
+  /Failed to fetch GitHub pull request files/i,
+  /Failed to fetch pull request diff/i,
+  /\/pulls\/[^/\s]+\/commits[\s\S]*(?:Failed to fetch|fetch failed|failure|error)/i,
+  /(?:Failed to fetch|fetch failed|failure|error)[\s\S]*\/pulls\/[^/\s]+\/commits/i,
+];
+
+export function isTransientDangerFailure(output) {
+  return TRANSIENT_PATTERNS.some((pattern) => pattern.test(output));
+}
+
+function wait(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function runDangerOnce() {
+  return new Promise((resolve) => {
+    const child = spawn("npx", ["danger", "ci"], {
+      env: process.env,
+      shell: process.platform === "win32",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let output = "";
+
+    child.stdout.on("data", (chunk) => {
+      process.stdout.write(chunk);
+      output += chunk.toString("utf8");
+    });
+
+    child.stderr.on("data", (chunk) => {
+      process.stderr.write(chunk);
+      output += chunk.toString("utf8");
+    });
+
+    child.on("error", (error) => {
+      const message = error instanceof Error ? error.stack ?? error.message : String(error);
+      process.stderr.write(`${message}\n`);
+      output += `\n${message}\n`;
+      resolve({ code: 1, output });
+    });
+
+    child.on("close", (code, signal) => {
+      resolve({
+        code: code ?? 1,
+        output,
+        signal,
+      });
+    });
+  });
+}
+
+async function main() {
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+    console.log(`[danger-retry] running Danger.js attempt ${attempt}/${MAX_ATTEMPTS}`);
+    const result = await runDangerOnce();
+
+    if (result.code === 0) {
+      console.log(`[danger-retry] Danger.js passed on attempt ${attempt}/${MAX_ATTEMPTS}`);
+      process.exit(0);
+    }
+
+    const transient = isTransientDangerFailure(result.output);
+    const exitDetail = result.signal ? `signal ${result.signal}` : `exit code ${result.code}`;
+
+    if (!transient) {
+      console.error(
+        `[danger-retry] non-transient failure detected (${exitDetail}); failing without retry.`,
+      );
+      process.exit(result.code || 1);
+    }
+
+    if (attempt === MAX_ATTEMPTS) {
+      console.error(
+        `[danger-retry] transient API failure detected (${exitDetail}); retry exhausted after ${MAX_ATTEMPTS} attempts.`,
+      );
+      process.exit(result.code || 1);
+    }
+
+    console.warn(
+      `[danger-retry] transient API failure detected (${exitDetail}); retrying in ${RETRY_DELAY_MS / 1000}s.`,
+    );
+    await wait(RETRY_DELAY_MS);
+  }
+}
+
+const isDirectRun =
+  typeof process.argv[1] === "string" &&
+  import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isDirectRun) {
+  main();
+}


### PR DESCRIPTION
## Summary
- add a small wrapper around `npx danger ci`
- retry only transient GitHub API / stream premature close failures
- keep non-transient Danger failures strict
- update Danger workflow to use the wrapper
## Scope
This PR is for Issue #2345.
It does not change:
- `dangerfile.ts`
- telemetry implementation
- `src/`
- branch protection
- required checks
## Validation
- `npx vitest run scripts/ci/__tests__/run-danger-with-retry.spec.mjs`
- `npm run build`
- commit hook checks: `guard:tz`, `lint`, `typecheck`, `lint:cookies`
## Notes
This is intentionally separated from PR #2342.  
PR #2342 remains on HOLD because its Danger status check is still failed.