### PR TITLE
fix(test): align dashboard room info selector with current label

### DIFF
--- a/tests/e2e/dashboard-logic-integration.spec.ts
+++ b/tests/e2e/dashboard-logic-integration.spec.ts
@@ -28,8 +28,8 @@ test.describe('Dashboard Page - After Logic Separation', () => {
 
   test('should show meeting guide actions', async ({ page }) => {
     await expect(page.getByRole('button', { name: '朝会・夕会情報' })).toBeVisible();
-    await expect(page.getByRole('button', { name: '🏢 お部屋情報' })).toBeVisible();
-    await expect(page.getByTestId('dashboard-handoff-summary').getByRole('button', { name: 'タイムラインを開く' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'お部屋情報' })).toBeVisible();
+    await expect(page.getByTestId('dashboard-handoff-summary').getByRole('button', { name: 'タイムライン' })).toBeVisible();
   });
 
   test('should display Safety HUD with indicators', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Align the Dashboard E2E room-info button expectation with the current UI label: `お部屋情報`.
- Keep production Dashboard UI unchanged.
- Align the same test's handoff-summary action expectation with the current snapshot label: `タイムライン`, which surfaced after the room-info selector was fixed.

## Root cause
The E2E test still expected older accessible button names while the implementation and Playwright snapshot now render the current labels.

## Scope
- Changed only `tests/e2e/dashboard-logic-integration.spec.ts`.
- Did not touch Dashboard production code, ToiletDailyBoard tests, dependencies, or auth/secret CI settings.

## Validation
- `CI=1 npx playwright test tests/e2e/dashboard-logic-integration.spec.ts --project=chromium --reporter=line`
- `npm run typecheck:full -- --pretty false`
- `npm run lint -- --quiet`
- `git diff --check`