### PR TITLE
test(toilet): remove timezone-sensitive date expectation

### DIFF
--- a/src/features/kiosk/toilet/__tests__/ToiletDailyBoard.spec.tsx
+++ b/src/features/kiosk/toilet/__tests__/ToiletDailyBoard.spec.tsx
@@ -268,13 +268,10 @@ describe('ToiletDailyBoard', () => {
     fireEvent.click(screen.getByTestId('toilet-record-save'));
 
     await waitFor(() => {
-      expect(mockCreateRecord).toHaveBeenCalledWith(
-        expect.objectContaining({
-          userId: 'user-1',
-          occurredAt: expect.stringContaining('2026-06-12'),
-        }),
-      );
+      expect(mockCreateRecord).toHaveBeenCalledWith(expect.objectContaining({ userId: 'user-1' }));
     });
+    const createInput = mockCreateRecord.mock.calls[0]?.[0];
+    expect(toLocalDateISO(new Date(createInput.occurredAt))).toBe('2026-06-12');
     await waitFor(() => {
       expect(screen.queryByText('支援 花子さんのトイレ記録')).not.toBeInTheDocument();
     });


### PR DESCRIPTION
## Summary
- Remove the timezone-sensitive `occurredAt` substring expectation from `ToiletDailyBoard` spec.
- Keep the production `ToiletDailyBoard` implementation unchanged.
- Verify the saved input still preserves the selected date through local-date semantics.

## Root cause
The test expected the UTC ISO string for `occurredAt` to contain `2026-06-12`. CI execution time and timezone can legitimately serialize an early local-time value as a previous UTC date, so the substring assertion was brittle.

## Scope
- Changed only `src/features/kiosk/toilet/__tests__/ToiletDailyBoard.spec.tsx`.
- Did not touch production code, repositories, types, dependencies, auth/secret CI, or #2347.

## Validation
- `TZ=Asia/Tokyo npx vitest run src/features/kiosk/toilet/__tests__/ToiletDailyBoard.spec.tsx --reporter=default`
- `TZ=UTC npx vitest run src/features/kiosk/toilet/__tests__/ToiletDailyBoard.spec.tsx --reporter=default`
- `npm run typecheck:full -- --pretty false`
- `npm run lint -- --quiet`
- `git diff --check`