### PR TITLE
[codex] ci: wire nightly telemetry path variable

### DIFF
--- a/.github/workflows/nightly-patrol.yml
+++ b/.github/workflows/nightly-patrol.yml
@@ -15,8 +15,8 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  # Keep strict telemetry assertions wired to repository variables, not code constants.
-  SP_TELEMETRY_PATH: ${{ vars.SP_TELEMETRY_PATH }}
+  # Keep telemetry capture and strict assertions wired to the same artifact path.
+  SP_TELEMETRY_PATH: ${{ vars.SP_TELEMETRY_PATH || 'docs/nightly-patrol/sp-telemetry.json' }}
 
 jobs:
   patrol:
@@ -124,7 +124,7 @@ jobs:
           SP_TOKEN: ${{ secrets.SP_TOKEN }}
           VITE_SP_RESOURCE: ${{ secrets.VITE_SP_RESOURCE || 'https://contoso.sharepoint.com' }}
           VITE_SP_SITE_RELATIVE: ${{ secrets.VITE_SP_SITE_RELATIVE || '/sites/Audit' }}
-          SP_TELEMETRY_OUTPUT_PATH: docs/nightly-patrol/sp-telemetry.json
+          SP_TELEMETRY_OUTPUT_PATH: ${{ env.SP_TELEMETRY_PATH }}
         run: npm run patrol:telemetry:capture
 
       - name: Run patrol scan
@@ -132,8 +132,7 @@ jobs:
           ACT_WARNING_SUMMARY_PATH: /tmp/act-warnings-nightly.json
           ACT_WARNING_OPEN_ISSUE_COUNT: ${{ steps.act_issue.outputs.open_count }}
           ACT_WARNING_OPEN_ISSUE_URL: ${{ steps.act_issue.outputs.open_url }}
-          # SP_TELEMETRY_PATH should be provided by the environment if available
-          SP_TELEMETRY_PATH: ${{ env.SP_TELEMETRY_PATH }} 
+          SP_TELEMETRY_PATH: ${{ env.SP_TELEMETRY_PATH }}
           SP_TOKEN: ${{ secrets.SP_TOKEN }}
           VITE_SP_RESOURCE: ${{ secrets.VITE_SP_RESOURCE || 'https://contoso.sharepoint.com' }}
           VITE_SP_SITE_RELATIVE: ${{ secrets.VITE_SP_SITE_RELATIVE || '/sites/Audit' }}

--- a/.github/workflows/nightly-patrol.yml
+++ b/.github/workflows/nightly-patrol.yml
@@ -14,6 +14,10 @@ concurrency:
   group: nightly-patrol
   cancel-in-progress: false
 
+env:
+  # Keep strict telemetry assertions wired to repository variables, not code constants.
+  SP_TELEMETRY_PATH: ${{ vars.SP_TELEMETRY_PATH }}
+
 jobs:
   patrol:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Give Nightly Patrol a workflow-level `SP_TELEMETRY_PATH` default of `docs/nightly-patrol/sp-telemetry.json` when the repository variable is unset.
- Pass that same path into telemetry capture via `SP_TELEMETRY_OUTPUT_PATH`, then reuse it for the patrol scan and strict lane assertion.
- Keep dotenv registration and SharePoint secret/auth follow-ups out of this PR.

## Validation
- `SP_TELEMETRY_PATH=<tmp>/sp-telemetry.json CI_STRICT=true CI_READ_QUEUE_THRESHOLD=1000 npm run patrol:assert`
- `npx vitest run scripts/ops/__tests__/capture-sp-telemetry-lanes.spec.mjs`
- `actionlint -shellcheck= .github/workflows/nightly-patrol.yml`
- `git diff --check`
- commit hook: timezone guard, `npm run lint`, `npm run typecheck`, `npm run lint:cookies`
- pre-push hook: eslint skipped because no JS/TS files changed vs `origin/main`

## Operational follow-up
- `vars.SP_TELEMETRY_PATH` is now optional; when unset, capture and assert both use `docs/nightly-patrol/sp-telemetry.json`.
- Register `dotenv` for env scripts in a separate small PR if we take that lane next.
- Refresh `PW_STORAGE_STATE_B64` and `SPO_CLIENT_SECRET` in GitHub Actions secrets outside this PR.
