### PR TITLE
[codex] chore(ci): generate nightly sp telemetry lanes

### DIFF
--- a/.github/workflows/nightly-patrol.yml
+++ b/.github/workflows/nightly-patrol.yml
@@ -115,6 +115,14 @@ jobs:
           echo "open_count=${count}" >> "$GITHUB_OUTPUT"
           echo "open_url=${url}" >> "$GITHUB_OUTPUT"
 
+      - name: Capture SharePoint telemetry lanes
+        env:
+          SP_TOKEN: ${{ secrets.SP_TOKEN }}
+          VITE_SP_RESOURCE: ${{ secrets.VITE_SP_RESOURCE || 'https://contoso.sharepoint.com' }}
+          VITE_SP_SITE_RELATIVE: ${{ secrets.VITE_SP_SITE_RELATIVE || '/sites/Audit' }}
+          SP_TELEMETRY_OUTPUT_PATH: docs/nightly-patrol/sp-telemetry.json
+        run: npm run patrol:telemetry:capture
+
       - name: Run patrol scan
         env:
           ACT_WARNING_SUMMARY_PATH: /tmp/act-warnings-nightly.json

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "release": ".github/scripts/release.sh",
     "patrol": "node scripts/ops/nightly-patrol.mjs",
     "patrol:telemetry": "node scripts/ops/materialize-sp-telemetry.mjs",
+    "patrol:telemetry:capture": "node scripts/ops/capture-sp-telemetry-lanes.mjs",
     "patrol:assert": "node scripts/ops/assert-telemetry-lanes.mjs",
     "patrol:dashboard": "node scripts/ops/os-metrics.mjs",
     "patrol:raw-fetch": "node scripts/ops/fetch-nightly-raw-summaries.mjs",

--- a/scripts/ops/__tests__/capture-sp-telemetry-lanes.spec.mjs
+++ b/scripts/ops/__tests__/capture-sp-telemetry-lanes.spec.mjs
@@ -1,0 +1,120 @@
+// @vitest-environment node
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { captureAndWriteSpTelemetryLanes } from '../capture-sp-telemetry-lanes.mjs';
+
+const ROOT = process.cwd();
+const ASSERT_SCRIPT = path.join(ROOT, 'scripts', 'ops', 'assert-telemetry-lanes.mjs');
+
+const BASE_ENV = {
+  SP_TOKEN: 'test-token',
+  VITE_SP_RESOURCE: 'https://tenant.sharepoint.com',
+  VITE_SP_SITE_RELATIVE: '/sites/Audit',
+};
+
+const tmpDirs = [];
+
+function makeTempDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sp-telemetry-lanes-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function runAssert(cwd, telemetryPath) {
+  return spawnSync(process.execPath, [ASSERT_SCRIPT], {
+    cwd,
+    env: {
+      ...process.env,
+      SP_TELEMETRY_PATH: telemetryPath,
+      CI_STRICT: 'true',
+      CI_READ_QUEUE_THRESHOLD: '1000',
+    },
+    encoding: 'utf8',
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const dir of tmpDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('capture-sp-telemetry-lanes', () => {
+  it('writes assert-compatible lane JSON for a successful read probe', async () => {
+    const cwd = makeTempDir();
+    const outputPath = path.join(cwd, 'docs/nightly-patrol/sp-telemetry.json');
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({ Id: 1, Title: 'CI User' }), { status: 200 }));
+
+    const { snapshot } = await captureAndWriteSpTelemetryLanes({
+      env: BASE_ENV,
+      fetchImpl,
+      outputPath,
+      now: () => new Date('2026-07-03T00:00:00.000Z'),
+    });
+
+    const written = readJson(outputPath);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(snapshot.source.kind).toBe('nightly-patrol-sp-token-read-probe');
+    expect(written.metrics.lanes.read.requests).toBe(1);
+    expect(written.metrics.lanes.read.failed).toBe(0);
+    expect(written.metrics.lanes.write.requests).toBe(0);
+    expect(written.metrics.lanes.provisioning.requests).toBe(0);
+    expect(written.summary.lanes.read.requests).toBe(1);
+
+    const assertResult = runAssert(cwd, outputPath);
+    expect(assertResult.status).toBe(0);
+    expect(assertResult.stdout).toContain('Lane assertion passed');
+  });
+
+  it.each([
+    {
+      name: 'missing SP_TOKEN',
+      env: { VITE_SP_RESOURCE: BASE_ENV.VITE_SP_RESOURCE, VITE_SP_SITE_RELATIVE: BASE_ENV.VITE_SP_SITE_RELATIVE },
+      fetchImpl: vi.fn(),
+      code: 'sp_token_missing',
+    },
+    {
+      name: 'HTTP non-OK',
+      env: BASE_ENV,
+      fetchImpl: vi.fn(async () => new Response('forbidden', { status: 500 })),
+      code: 'sp_probe_http_non_ok',
+    },
+    {
+      name: 'fetch error',
+      env: BASE_ENV,
+      fetchImpl: vi.fn(async () => {
+        throw new Error('network unavailable');
+      }),
+      code: 'sp_probe_fetch_error',
+    },
+  ])('writes failed read lane JSON for $name', async ({ env, fetchImpl, code }) => {
+    const cwd = makeTempDir();
+    const outputPath = path.join(cwd, 'docs/nightly-patrol/sp-telemetry.json');
+
+    await captureAndWriteSpTelemetryLanes({
+      env,
+      fetchImpl,
+      outputPath,
+      now: () => new Date('2026-07-03T00:00:00.000Z'),
+    });
+
+    const written = readJson(outputPath);
+    expect(written.metrics.lanes.read.failed).toBeGreaterThan(0);
+    expect(written.diagnostics.map((entry) => entry.code)).toContain(code);
+
+    const assertResult = runAssert(cwd, outputPath);
+    expect(assertResult.status).toBe(1);
+    expect(assertResult.stderr).toContain('[READ LANE] Failures detected');
+    expect(assertResult.stderr).not.toContain('SP_TELEMETRY_PATH is required in strict mode');
+    expect(assertResult.stderr).not.toContain('Telemetry file missing in strict mode');
+  });
+});

--- a/scripts/ops/capture-sp-telemetry-lanes.mjs
+++ b/scripts/ops/capture-sp-telemetry-lanes.mjs
@@ -1,0 +1,261 @@
+/* eslint-disable no-console -- CI ops script */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const SOURCE_KIND = 'nightly-patrol-sp-token-read-probe';
+export const DEFAULT_OUTPUT_PATH = path.join('docs', 'nightly-patrol', 'sp-telemetry.json');
+
+const EMPTY_LANE = Object.freeze({
+  requests: 0,
+  failed: 0,
+  retries: 0,
+  maxQueuedMs: 0,
+  avgQueuedMs: 0,
+  avgDurationMs: 0,
+});
+
+function cloneLane(lane = {}) {
+  return {
+    requests: Number(lane.requests ?? 0),
+    failed: Number(lane.failed ?? 0),
+    retries: Number(lane.retries ?? 0),
+    maxQueuedMs: Number(lane.maxQueuedMs ?? 0),
+    avgQueuedMs: Number(lane.avgQueuedMs ?? 0),
+    avgDurationMs: Number(lane.avgDurationMs ?? 0),
+  };
+}
+
+function createMetrics({ readLane, durationMs = 0 }) {
+  const read = cloneLane(readLane);
+  const write = cloneLane(EMPTY_LANE);
+  const provisioning = cloneLane(EMPTY_LANE);
+  const failedCount = read.failed + write.failed + provisioning.failed;
+  const retryCount = read.retries + write.retries + provisioning.retries;
+
+  return {
+    throttledCount: 0,
+    retryCount,
+    failedCount,
+    avgDurationMs: read.requests > 0 ? Math.round(durationMs / read.requests) : 0,
+    p95DurationMs: read.requests > 0 ? durationMs : 0,
+    avgQueuedMs: 0,
+    maxQueuedMs: read.maxQueuedMs,
+    lanes: {
+      read,
+      write,
+      provisioning,
+    },
+    assignmentConcurrencyConflicts: 0,
+    assignmentConflictVehicles: [],
+    assignmentConflictResolved: 0,
+    assignmentConflictUnresolved: 0,
+    assignmentRetryTotal: 0,
+  };
+}
+
+function normalizeSiteRelative(value) {
+  const trimmed = String(value ?? '').trim();
+  if (!trimmed) return '';
+  return (trimmed.startsWith('/') ? trimmed : `/${trimmed}`).replace(/\/+$/, '');
+}
+
+export function resolveSharePointProbeConfig(env = process.env) {
+  const resourceRaw = String(env.VITE_SP_RESOURCE ?? '').trim();
+  const siteRelative = normalizeSiteRelative(env.VITE_SP_SITE_RELATIVE);
+
+  if (!resourceRaw) {
+    throw Object.assign(new Error('VITE_SP_RESOURCE is required.'), { code: 'sp_config_missing_resource' });
+  }
+  if (!siteRelative) {
+    throw Object.assign(new Error('VITE_SP_SITE_RELATIVE is required.'), { code: 'sp_config_missing_site_relative' });
+  }
+
+  let resourceUrl;
+  try {
+    resourceUrl = new URL(resourceRaw);
+  } catch {
+    throw Object.assign(new Error('VITE_SP_RESOURCE must be a valid URL.'), { code: 'sp_config_invalid_resource' });
+  }
+
+  if (resourceUrl.protocol !== 'https:' || !/\.sharepoint\.com$/i.test(resourceUrl.hostname)) {
+    throw Object.assign(new Error('VITE_SP_RESOURCE must be an https://*.sharepoint.com origin.'), {
+      code: 'sp_config_invalid_resource',
+    });
+  }
+
+  if (!siteRelative.startsWith('/sites/') && !siteRelative.startsWith('/teams/')) {
+    throw Object.assign(new Error('VITE_SP_SITE_RELATIVE must start with /sites/ or /teams/.'), {
+      code: 'sp_config_invalid_site_relative',
+    });
+  }
+
+  const resource = resourceUrl.origin.replace(/\/+$/, '');
+  const baseUrl = `${resource}${siteRelative}/_api/web`;
+
+  return {
+    resource,
+    siteRelative,
+    endpointPath: '/_api/web/currentuser',
+    probeUrl: `${baseUrl}/currentuser?$select=Id,Title`,
+  };
+}
+
+function createSnapshot({ generatedAt, readLane, durationMs, diagnostics, topEndpoints }) {
+  const metrics = createMetrics({ readLane, durationMs });
+  return {
+    generatedAt,
+    source: {
+      kind: SOURCE_KIND,
+    },
+    metrics,
+    summary: metrics,
+    topEndpoints,
+    diagnostics,
+  };
+}
+
+function failureSnapshot({ generatedAt, code, message, requestStarted = false, endpointPath = '/_api/web/currentuser', status, durationMs = 0 }) {
+  const readLane = {
+    requests: requestStarted ? 1 : 0,
+    failed: 1,
+    retries: 0,
+    maxQueuedMs: 0,
+    avgQueuedMs: 0,
+    avgDurationMs: requestStarted ? durationMs : 0,
+  };
+
+  return createSnapshot({
+    generatedAt,
+    readLane,
+    durationMs: requestStarted ? durationMs : 0,
+    topEndpoints: requestStarted
+      ? [{ endpoint: endpointPath, failures: 1, retries: 0, status: status ?? null, durationMs }]
+      : [],
+    diagnostics: [{ code, message }],
+  });
+}
+
+export async function captureSpTelemetryLanes(options = {}) {
+  const env = options.env ?? process.env;
+  const now = options.now ?? (() => new Date());
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+  const generatedAt = now().toISOString();
+  const token = String(env.SP_TOKEN ?? '').trim();
+
+  if (!token) {
+    return failureSnapshot({
+      generatedAt,
+      code: 'sp_token_missing',
+      message: 'SP_TOKEN is required for the Nightly Patrol SharePoint read probe.',
+    });
+  }
+
+  let config;
+  try {
+    config = resolveSharePointProbeConfig(env);
+  } catch (error) {
+    return failureSnapshot({
+      generatedAt,
+      code: error?.code || 'sp_config_invalid',
+      message: error instanceof Error ? error.message : 'SharePoint probe config is invalid.',
+    });
+  }
+
+  if (typeof fetchImpl !== 'function') {
+    return failureSnapshot({
+      generatedAt,
+      code: 'fetch_unavailable',
+      message: 'global fetch is not available in this Node runtime.',
+    });
+  }
+
+  const startedAt = Date.now();
+  try {
+    const response = await fetchImpl(config.probeUrl, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/json;odata=nometadata',
+      },
+    });
+    const durationMs = Math.max(0, Date.now() - startedAt);
+
+    if (!response.ok) {
+      return failureSnapshot({
+        generatedAt,
+        code: 'sp_probe_http_non_ok',
+        message: `SharePoint read probe returned HTTP ${response.status}.`,
+        requestStarted: true,
+        endpointPath: config.endpointPath,
+        status: response.status,
+        durationMs,
+      });
+    }
+
+    const readLane = {
+      requests: 1,
+      failed: 0,
+      retries: 0,
+      maxQueuedMs: 0,
+      avgQueuedMs: 0,
+      avgDurationMs: durationMs,
+    };
+
+    return createSnapshot({
+      generatedAt,
+      readLane,
+      durationMs,
+      topEndpoints: [{ endpoint: config.endpointPath, failures: 0, retries: 0, status: response.status, durationMs }],
+      diagnostics: [{ code: 'sp_probe_ok', message: 'SharePoint read probe completed.' }],
+    });
+  } catch (error) {
+    return failureSnapshot({
+      generatedAt,
+      code: 'sp_probe_fetch_error',
+      message: error instanceof Error ? error.message : 'SharePoint read probe failed.',
+      requestStarted: true,
+      endpointPath: config.endpointPath,
+      durationMs: Math.max(0, Date.now() - startedAt),
+    });
+  }
+}
+
+export function writeSpTelemetrySnapshot(snapshot, outputPath = DEFAULT_OUTPUT_PATH, options = {}) {
+  const root = options.root ?? process.cwd();
+  const resolvedPath = path.isAbsolute(outputPath) ? outputPath : path.join(root, outputPath);
+  fs.mkdirSync(path.dirname(resolvedPath), { recursive: true });
+  fs.writeFileSync(resolvedPath, `${JSON.stringify(snapshot, null, 2)}\n`, 'utf8');
+  return resolvedPath;
+}
+
+export async function captureAndWriteSpTelemetryLanes(options = {}) {
+  const snapshot = await captureSpTelemetryLanes(options);
+  const outputPath = writeSpTelemetrySnapshot(
+    snapshot,
+    options.outputPath ?? options.env?.SP_TELEMETRY_OUTPUT_PATH ?? process.env.SP_TELEMETRY_OUTPUT_PATH ?? DEFAULT_OUTPUT_PATH,
+    { root: options.root },
+  );
+  return { snapshot, outputPath };
+}
+
+async function main() {
+  const { snapshot, outputPath } = await captureAndWriteSpTelemetryLanes();
+  const relativeOutput = path.relative(process.cwd(), outputPath) || outputPath;
+  const codes = snapshot.diagnostics.map((entry) => entry.code).join(', ');
+  console.log(`[sp-telemetry] wrote ${relativeOutput}`);
+  console.log(`[sp-telemetry] diagnostics: ${codes}`);
+  if (snapshot.metrics.failedCount > 0) {
+    console.warn('[sp-telemetry] read probe captured a failure; lane assertion will evaluate it.');
+  }
+}
+
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+
+if (isMain) {
+  main().catch((error) => {
+    console.error('[sp-telemetry] failed to write telemetry artifact.');
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- Add a read-only Nightly Patrol SharePoint telemetry capture script backed by the existing `SP_TOKEN` lane.
- Generate `docs/nightly-patrol/sp-telemetry.json` with assert-compatible `metrics.lanes` and `summary.lanes`.
- Run the capture step before `Run patrol scan` and `Assert Telemetry Lanes` without changing the #2350 `SP_TELEMETRY_PATH` plumbing scope.

## Scope boundaries
- No `PW_STORAGE_STATE_B64` update.
- No `SPO_CLIENT_SECRET` update.
- No repository variable update.
- No fail-open change.
- No change to existing `patrol:telemetry` / `materialize-sp-telemetry` external dump behavior.

## Notes
Controlled probe failures such as missing `SP_TOKEN`, SharePoint HTTP non-OK, or fetch errors still write the telemetry JSON. That keeps strict mode away from missing path / missing file failures and lets `assert-telemetry-lanes.mjs` report the issue as a read lane failure.

#2350 plus `SP_TELEMETRY_PATH=docs/nightly-patrol/sp-telemetry.json` is still required before the combined Nightly Patrol strict gate can pass end to end.

## Validation
- `npx vitest run scripts/ops/__tests__/capture-sp-telemetry-lanes.spec.mjs --pool=forks --maxWorkers=1`
- `SP_TELEMETRY_OUTPUT_PATH=<tmp>/sp-telemetry.json npm run patrol:telemetry:capture`
- `node --check scripts/ops/capture-sp-telemetry-lanes.mjs`
- `git diff --check`
- pre-commit hook: `lint`, `typecheck`, `lint:cookies`