### PR TITLE
[codex] fix(env): register dotenv for env scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "@vitest/ui": "^4.0.16",
         "axe-core": "^4.10.3",
         "danger": "^13.0.7",
+        "dotenv": "^17.4.2",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-import-resolver-typescript": "^4.4.4",
@@ -9766,6 +9767,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -190,6 +190,7 @@
     "@vitest/ui": "^4.0.16",
     "axe-core": "^4.10.3",
     "danger": "^13.0.7",
+    "dotenv": "^17.4.2",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-import-resolver-typescript": "^4.4.4",


### PR DESCRIPTION
## Summary
- Register `dotenv` as a dev dependency for repo-local env helper scripts.
- Keep the fix limited to `package.json` and `package-lock.json`.

## Root cause
`scripts/check-env.ts` and `scripts/smoke-test-sp.ts` import `dotenv`, but the package was not declared in npm dependencies, so the scripts could fail before reaching their intended environment checks.

## Verification
- `npm run check:env` now reaches schema validation; it no longer fails with `Cannot find module 'dotenv'`.
- `npx tsx scripts/smoke-test-sp.ts` now reaches the expected `SMOKE_TEST_BEARER_TOKEN` auth precondition; it no longer fails with `Cannot find module 'dotenv'`.
- `npm run typecheck:full -- --pretty false`
- `npm run lint`
- `git diff --check`

## Out of scope
- `.env`, secrets, SharePoint configuration, workflows, and `docs/roadmaps/` are unchanged.
- Follow-on credential or environment validation failures remain separate from this dependency registration fix.