### PR TITLE
fix(pdca): stabilize date-dependent orchestrator spec

### DIFF
--- a/src/domain/bridge/__tests__/pdcaCycleOrchestrator.spec.ts
+++ b/src/domain/bridge/__tests__/pdcaCycleOrchestrator.spec.ts
@@ -8,7 +8,7 @@
  * 4. determinePdcaCycleState — 統合テスト（メインエントリ）
  * 5. サイクル循環（Act → 次 Plan）
  */
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import {
   resolveCurrentPhase,
   buildPhaseCompletionMap,
@@ -39,6 +39,10 @@ function makeInput(overrides: Partial<DetermineCycleInput> = {}): DetermineCycle
     ...overrides,
   };
 }
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 // ─────────────────────────────────────────────
 // 1. resolveCurrentPhase
@@ -251,13 +255,14 @@ describe('determinePdcaCycleState', () => {
   });
 
   it('referenceDate 省略時 → computedAt に今日の日付', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-15T09:00:00.000Z'));
+
     const state = determinePdcaCycleState(
       makeInput({ referenceDate: undefined }),
     );
 
-    // 今日の日付（YYYY-MM-DD 形式）
-    const today = new Date().toISOString().slice(0, 10);
-    expect(state.computedAt).toBe(today);
+    expect(state.computedAt).toBe('2026-03-15');
   });
 });
 


### PR DESCRIPTION
## Summary

PDCA cycle orchestrator の date-dependent spec を安定化しました。

`referenceDate` 省略時のテストで現在日付に依存していたため、`vi.useFakeTimers()` と `vi.setSystemTime()` で今日を `2026-03-15` に固定しました。

`afterEach` で `vi.useRealTimers()` を呼び、fake timer の漏れを防いでいます。

## Scope

変更は test-only です。

```text
src/domain/bridge/__tests__/pdcaCycleOrchestrator.spec.ts
```

実装 API、`pdcaHealth.spec.ts`、PR #2355 の差分には触れていません。

## Verification

```text
git diff --check
-> passed (CRLF warning only)

npm run typecheck:full -- --pretty false
-> passed

npm run lint -- --quiet
-> passed

npm run build
-> passed

npm run health
-> passed

npx vitest run src/domain/bridge/__tests__/pdcaCycleOrchestrator.spec.ts --reporter=verbose
-> 1 file / 23 tests passed

npx vitest run src/domain/isp/__tests__/pdcaHealth.spec.ts src/domain/bridge/__tests__/pdcaCycleOrchestrator.spec.ts --reporter=verbose
-> 2 files / 25 tests passed
```

## Notes

This PR is separated from #2355.

`npm run health` completed successfully; no Vitest worker OOM or unexpected exit was observed.