### PR TITLE
fix(ops): normalize index audit token

### DIFF
--- a/scripts/ops/index-audit.ts
+++ b/scripts/ops/index-audit.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { normalizeSharePointBearerToken } from './indexAuditToken';
 
 // --- 1. Load Env FIRST ---
 function loadEnv() {
@@ -108,7 +109,7 @@ async function main() {
     results: [],
   };
 
-  const token = process.env.SP_TOKEN || process.env.VITE_SP_TOKEN;
+  const token = normalizeSharePointBearerToken(process.env.SP_TOKEN || process.env.VITE_SP_TOKEN);
   if (!token) {
     if (isJson) {
       console.log(JSON.stringify({ error: "SP_TOKEN is not set" }));

--- a/scripts/ops/indexAuditToken.ts
+++ b/scripts/ops/indexAuditToken.ts
@@ -1,0 +1,8 @@
+export function normalizeSharePointBearerToken(rawToken: string | undefined): string | null {
+  const normalized = rawToken
+    ?.trim()
+    .replace(/^Bearer\s+/i, '')
+    .replace(/\s+/g, '');
+
+  return normalized ? normalized : null;
+}

--- a/tests/unit/indexAuditToken.spec.ts
+++ b/tests/unit/indexAuditToken.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeSharePointBearerToken } from '../../scripts/ops/indexAuditToken';
+
+describe('normalizeSharePointBearerToken', () => {
+  it('removes surrounding line breaks and whitespace', () => {
+    expect(normalizeSharePointBearerToken('abc.def.ghi\n')).toBe('abc.def.ghi');
+    expect(normalizeSharePointBearerToken('\r\nabc.def.ghi\r\n')).toBe('abc.def.ghi');
+  });
+
+  it('removes folded whitespace inside the token', () => {
+    expect(normalizeSharePointBearerToken('abc.\ndef.\nghi')).toBe('abc.def.ghi');
+  });
+
+  it('removes a bearer prefix before the script adds Authorization', () => {
+    expect(normalizeSharePointBearerToken('Bearer abc.def.ghi')).toBe('abc.def.ghi');
+  });
+
+  it('returns null for blank tokens', () => {
+    expect(normalizeSharePointBearerToken(' \r\n\t ')).toBeNull();
+    expect(normalizeSharePointBearerToken(undefined)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- normalize SP_TOKEN / VITE_SP_TOKEN before building the Index Audit Authorization header
- strip surrounding/folded whitespace and an existing Bearer prefix to avoid invalid header values
- keep Nightly Patrol workflow behavior unchanged and leave generated reports untouched

## Tests
- PASS: `git diff --check`
- PASS: `npm run lint -- --quiet`
- PASS: `npm run build`
  - Existing Vite warnings only: plugin-legacy target override and large chunk warnings.
- PASS: `npx vitest run tests/unit/indexAuditToken.spec.ts --reporter=verbose`
- PASS: newline-token execution check
  - PowerShell env: `SP_TOKEN="Bearer dummy-token`n"`, `VITE_SP_RESOURCE=https://contoso.sharepoint.com`, `VITE_SP_SITE_RELATIVE=/sites/Audit`
  - Command: `npx tsx scripts/ops/index-audit.ts --json`
  - Result: completed without `Headers.append: invalid header value`; token value was not logged.

## Notes
- SharePoint authorization/tenant issues such as 401/403, `SPO_CLIENT_SECRET missing`, and secret configuration remain separate secret-lane work.
- Generated `docs/nightly-patrol/**` output is not included in this PR.
