### PR TITLE
fix(ci): classify quality canary failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -435,37 +435,20 @@ jobs:
         run: |
           echo "=== /tmp/vite-5173.log (tail -200) ==="
           tail -200 /tmp/vite-5173.log || true
-      - name: Canary checks (E2E + LHCI + Summary)
-        id: canary
+      - name: Canary E2E
+        id: canary_e2e
         run: |
           set +e
-          status=0
+          set -o pipefail
+          mkdir -p reports/quality-gates
 
           export VITE_SP_RESOURCE="${VITE_SP_RESOURCE:-https://contoso.sharepoint.com}"
           export VITE_SP_SITE_RELATIVE="${VITE_SP_SITE_RELATIVE:-/sites/Audit}"
           export VITE_SP_SCOPE_DEFAULT="${VITE_SP_SCOPE_DEFAULT:-${VITE_SP_RESOURCE}/.default}"
 
-          npm run ci:e2e -- --grep-invert @seed --grep-invert @csp
-          exit_code=$?
-          if [ "$exit_code" -ne 0 ]; then
-            status="$exit_code"
-          fi
-
-          npm run ci:lh
-          exit_code=$?
-          if [ "$exit_code" -ne 0 ] && [ "$status" -eq 0 ]; then
-            status="$exit_code"
-          fi
-
-          npm run perf:summary
-          exit_code=$?
-          if [ "$exit_code" -ne 0 ] && [ "$status" -eq 0 ]; then
-            status="$exit_code"
-          fi
-
-          if [ "$status" -ne 0 ]; then
-            exit "$status"
-          fi
+          npm run ci:e2e -- --grep-invert @seed --grep-invert @csp 2>&1 | tee reports/quality-gates/canary-e2e.log
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+          exit 0
         env:
           VITE_E2E: "1"
           VITE_SKIP_LOGIN: "1"
@@ -478,6 +461,82 @@ jobs:
           VITE_SP_RESOURCE: ${{ vars.VITE_SP_RESOURCE }}
           VITE_SP_SITE_RELATIVE: ${{ vars.VITE_SP_SITE_RELATIVE }}
           NOTIFY_WEBHOOK_URL: ${{ secrets.NOTIFY_WEBHOOK_URL }}
+      - name: Canary LHCI
+        id: canary_lhci
+        if: always()
+        run: |
+          set +e
+          set -o pipefail
+          mkdir -p reports/quality-gates
+
+          npm run ci:lh 2>&1 | tee reports/quality-gates/canary-lhci.log
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+          exit 0
+        env:
+          VITE_E2E: "1"
+          VITE_SKIP_LOGIN: "1"
+          VITE_E2E_MSAL_MOCK: "1"
+          VITE_SKIP_SHAREPOINT: "1"
+          VITE_MSAL_CLIENT_ID: "dummy"
+          VITE_MSAL_TENANT_ID: "dummy"
+          VITE_SCHEDULES_TZ: "Asia/Tokyo"
+          VITE_SP_SCOPE_DEFAULT: ${{ secrets.VITE_SP_SCOPE_DEFAULT }}
+          VITE_SP_RESOURCE: ${{ vars.VITE_SP_RESOURCE }}
+          VITE_SP_SITE_RELATIVE: ${{ vars.VITE_SP_SITE_RELATIVE }}
+          NOTIFY_WEBHOOK_URL: ${{ secrets.NOTIFY_WEBHOOK_URL }}
+      - name: Canary perf summary
+        id: canary_summary
+        if: always()
+        run: |
+          set +e
+          set -o pipefail
+          mkdir -p reports/quality-gates
+
+          npm run perf:summary 2>&1 | tee reports/quality-gates/canary-summary.log
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+          exit 0
+        env:
+          VITE_E2E: "1"
+          VITE_SKIP_LOGIN: "1"
+          VITE_E2E_MSAL_MOCK: "1"
+          VITE_SKIP_SHAREPOINT: "1"
+          VITE_MSAL_CLIENT_ID: "dummy"
+          VITE_MSAL_TENANT_ID: "dummy"
+          VITE_SCHEDULES_TZ: "Asia/Tokyo"
+          VITE_SP_SCOPE_DEFAULT: ${{ secrets.VITE_SP_SCOPE_DEFAULT }}
+          VITE_SP_RESOURCE: ${{ vars.VITE_SP_RESOURCE }}
+          VITE_SP_SITE_RELATIVE: ${{ vars.VITE_SP_SITE_RELATIVE }}
+          NOTIFY_WEBHOOK_URL: ${{ secrets.NOTIFY_WEBHOOK_URL }}
+      - name: Classify canary failure
+        id: canary
+        if: always()
+        run: node scripts/ci/classify-canary.mjs
+        env:
+          CANARY_E2E_EXIT_CODE: ${{ steps.canary_e2e.outputs.exit_code || '1' }}
+          CANARY_LHCI_EXIT_CODE: ${{ steps.canary_lhci.outputs.exit_code || '1' }}
+          CANARY_SUMMARY_EXIT_CODE: ${{ steps.canary_summary.outputs.exit_code || '1' }}
+          CANARY_E2E_LOG_PATH: reports/quality-gates/canary-e2e.log
+      - name: Upload canary classification artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: canary-classification-${{ github.run_number }}-${{ github.run_attempt }}
+          path: reports/quality-gates/
+          retention-days: 14
+          if-no-files-found: warn
+      - name: Canary final gate
+        if: always()
+        run: |
+          if [ "${CANARY_SHOULD_FAIL}" != "false" ]; then
+            echo "Canary classified as ${CANARY_CLASSIFICATION:-unknown}"
+            exit "${CANARY_EXIT_CODE:-1}"
+          fi
+        env:
+          CANARY_SHOULD_FAIL: ${{ steps.canary.outputs.should_fail || 'true' }}
+          CANARY_CLASSIFICATION: ${{ steps.canary.outputs.classification || 'unknown' }}
+          CANARY_EXIT_CODE: ${{ steps.canary.outputs.exit_code || '1' }}
       - name: Notify canary failure
         if: failure()
-        run: node scripts/notify.mjs --only-on-fail --title "canary(schedule)" --files reports/perf-summary.md
+        run: node scripts/notify.mjs --only-on-fail --title "canary(schedule)" --files reports/quality-gates/canary-classification.md,reports/perf-summary.md
+        env:
+          NOTIFY_LAST_EXIT_CODE: ${{ steps.canary.outputs.exit_code }}

--- a/scripts/ci/classify-canary.mjs
+++ b/scripts/ci/classify-canary.mjs
@@ -1,0 +1,145 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const AUTH_SIGNAL_PATTERNS = [
+  /\bAUTH_REQUIRED\b/i,
+  /SharePoint Authentication Failed/i,
+  /\b(?:401|403)\b/,
+  /\bPW_STORAGE_STATE_B64\b/i,
+  /\bstorageState\b/i,
+  /\bstorage state\b/i,
+];
+
+const toExitCode = (value) => {
+  const parsed = Number.parseInt(String(value ?? '0'), 10);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+const hasAuthSignal = (logText) => AUTH_SIGNAL_PATTERNS.some((pattern) => pattern.test(logText ?? ''));
+
+export function classifyCanaryResult({ e2eExitCode = 0, lhciExitCode = 0, summaryExitCode = 0, e2eLog = '' } = {}) {
+  const e2e = toExitCode(e2eExitCode);
+  const lhci = toExitCode(lhciExitCode);
+  const summary = toExitCode(summaryExitCode);
+
+  if (e2e !== 0) {
+    if (hasAuthSignal(e2eLog)) {
+      return {
+        classification: 'canary_auth_required',
+        failedStage: 'e2e',
+        reason: 'E2E failed with an authentication-related signal.',
+        exitCode: e2e,
+      };
+    }
+    return {
+      classification: 'canary_ui_failure',
+      failedStage: 'e2e',
+      reason: 'E2E failed without an authentication-related signal.',
+      exitCode: e2e,
+    };
+  }
+
+  if (lhci !== 0) {
+    return {
+      classification: 'canary_lhci_failure',
+      failedStage: 'lhci',
+      reason: 'LHCI failed after E2E completed.',
+      exitCode: lhci,
+    };
+  }
+
+  if (summary !== 0) {
+    return {
+      classification: 'canary_summary_failure',
+      failedStage: 'summary',
+      reason: 'Performance summary generation failed after E2E and LHCI completed.',
+      exitCode: summary,
+    };
+  }
+
+  return {
+    classification: 'canary_pass',
+    failedStage: 'none',
+    reason: 'Canary completed without failure.',
+    exitCode: 0,
+  };
+}
+
+const readTextSafe = (filePath) => {
+  if (!filePath) return '';
+  try {
+    return fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return '';
+  }
+};
+
+const appendGithubOutput = (entries) => {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) return;
+  const lines = Object.entries(entries).map(([key, value]) => `${key}=${value}`);
+  fs.appendFileSync(outputPath, `${lines.join('\n')}\n`);
+};
+
+const appendStepSummary = (markdown) => {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryPath) return;
+  fs.appendFileSync(summaryPath, `${markdown}\n`);
+};
+
+const renderMarkdown = (result, inputs) => `# Quality Gates Canary Classification
+
+- classification: **${result.classification}**
+- failedStage: **${result.failedStage}**
+- reason: ${result.reason}
+- exitCode: **${result.exitCode}**
+- e2eExitCode: ${inputs.e2eExitCode}
+- lhciExitCode: ${inputs.lhciExitCode}
+- summaryExitCode: ${inputs.summaryExitCode}
+`;
+
+async function main() {
+  const outDir = process.env.CANARY_CLASSIFICATION_DIR || 'reports/quality-gates';
+  const e2eLogPath = process.env.CANARY_E2E_LOG_PATH || path.join(outDir, 'canary-e2e.log');
+  const inputs = {
+    e2eExitCode: toExitCode(process.env.CANARY_E2E_EXIT_CODE),
+    lhciExitCode: toExitCode(process.env.CANARY_LHCI_EXIT_CODE),
+    summaryExitCode: toExitCode(process.env.CANARY_SUMMARY_EXIT_CODE),
+  };
+  const result = classifyCanaryResult({
+    ...inputs,
+    e2eLog: readTextSafe(e2eLogPath),
+  });
+
+  fs.mkdirSync(outDir, { recursive: true });
+  const jsonPath = path.join(outDir, 'canary-classification.json');
+  const mdPath = path.join(outDir, 'canary-classification.md');
+  const payload = {
+    ...result,
+    ...inputs,
+    e2eLogPath,
+    generatedAt: new Date().toISOString(),
+  };
+  const markdown = renderMarkdown(result, inputs);
+
+  fs.writeFileSync(jsonPath, `${JSON.stringify(payload, null, 2)}\n`);
+  fs.writeFileSync(mdPath, markdown);
+  appendGithubOutput({
+    classification: result.classification,
+    failed_stage: result.failedStage,
+    exit_code: result.exitCode,
+    should_fail: result.classification === 'canary_pass' ? 'false' : 'true',
+  });
+  appendStepSummary(markdown);
+
+  console.log(markdown);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  main().catch((error) => {
+    console.error('[classify-canary] failed unexpectedly');
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/tests/unit/canaryClassification.spec.ts
+++ b/tests/unit/canaryClassification.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { classifyCanaryResult } from '../../scripts/ci/classify-canary.mjs';
+
+describe('classifyCanaryResult', () => {
+  it('classifies AUTH_REQUIRED E2E failures as auth required', () => {
+    expect(classifyCanaryResult({ e2eExitCode: 1, e2eLog: 'Error: AUTH_REQUIRED' }).classification).toBe(
+      'canary_auth_required'
+    );
+  });
+
+  it('classifies non-auth E2E failures as UI failures', () => {
+    expect(classifyCanaryResult({ e2eExitCode: 1, e2eLog: 'locator timed out' }).classification).toBe(
+      'canary_ui_failure'
+    );
+  });
+
+  it('classifies LHCI failures after E2E passes', () => {
+    expect(classifyCanaryResult({ e2eExitCode: 0, lhciExitCode: 1 }).classification).toBe('canary_lhci_failure');
+  });
+
+  it('classifies summary failures after E2E and LHCI pass', () => {
+    expect(classifyCanaryResult({ e2eExitCode: 0, lhciExitCode: 0, summaryExitCode: 1 }).classification).toBe(
+      'canary_summary_failure'
+    );
+  });
+
+  it('classifies all-zero exits as pass', () => {
+    expect(classifyCanaryResult({ e2eExitCode: 0, lhciExitCode: 0, summaryExitCode: 0 }).classification).toBe(
+      'canary_pass'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- split Quality Gates canary into E2E, LHCI, and perf summary stages
- add canary classification output for auth-required vs UI/LHCI/summary failures
- keep the final canary gate failing when any stage fails

## Classification
- AUTH_REQUIRED / SharePoint auth / 401 / 403 / PW_STORAGE_STATE_B64 / storageState signals -> canary_auth_required
- E2E failure without auth signal -> canary_ui_failure
- LHCI failure -> canary_lhci_failure
- perf summary failure -> canary_summary_failure
- all stages pass -> canary_pass

## Tests
- npx vitest run tests/unit/canaryClassification.spec.ts --reporter=verbose
- node scripts/ci/classify-canary.mjs with AUTH_REQUIRED fixture
- npm run typecheck
- git diff --check
- npm run lint -- --quiet

## Notes
- Secret refresh / SharePoint 403 remains a separate secret lane.
- UI failures, npm audit, and build warning cleanup remain separate lanes.