### PR TITLE
fix(reports): export monthly summary as csv

### DIFF
--- a/src/features/reports/__tests__/MonthlySummaryExcel.spec.ts
+++ b/src/features/reports/__tests__/MonthlySummaryExcel.spec.ts
@@ -1,14 +1,10 @@
 import type { DailyRecordItem } from '@/features/daily';
 import { describe, expect, it, vi } from 'vitest';
-import { exportMonthlySummary } from '../monthly/MonthlySummaryExcel';
-
-const { exportToExcelMock } = vi.hoisted(() => ({
-  exportToExcelMock: vi.fn(),
-}));
-
-vi.mock('@/lib/reports/xlsxUtils', () => ({
-  exportToExcel: (...args: unknown[]) => exportToExcelMock(...args),
-}));
+import {
+  buildMonthlySummaryCsvContent,
+  buildMonthlySummaryRows,
+  exportMonthlySummary,
+} from '../monthly/MonthlySummaryExcel';
 
 const makeRecord = (overrides: Partial<DailyRecordItem> = {}): DailyRecordItem => ({
   date: '2026-03-01',
@@ -38,9 +34,11 @@ const makeRecord = (overrides: Partial<DailyRecordItem> = {}): DailyRecordItem =
 } as unknown as DailyRecordItem);
 
 describe('exportMonthlySummary', () => {
-  it('maps labels, sorts rows, and delegates to exportToExcel', () => {
-    exportToExcelMock.mockClear();
-
+  it('maps labels, sorts rows, and builds CSV content', () => {
+    const users = [
+      { id: 1, userId: 'U1', name: '利用者A', severe: false },
+      { id: 2, userId: 'U2', name: '利用者B', severe: true },
+    ];
     const records: DailyRecordItem[] = [
       makeRecord({
         date: '2026-03-03',
@@ -59,7 +57,7 @@ describe('exportMonthlySummary', () => {
               pica: false,
               other: false,
             },
-            specialNotes: '注意事項あり',
+            specialNotes: '注意,重要',
           },
         ],
       } as unknown as DailyRecordItem),
@@ -86,36 +84,41 @@ describe('exportMonthlySummary', () => {
       } as unknown as DailyRecordItem),
     ];
 
+    const rows = buildMonthlySummaryRows({ users, records });
+    const csv = buildMonthlySummaryCsvContent(rows);
+    const lines = csv.split('\n');
+
+    expect(lines[0]).toBe(
+      '\ufeff日付,利用者ID,利用者名,午前活動,午後活動,昼食摂取,重度フラグ,問題行動,特記事項,記録者'
+    );
+    expect(lines[1]).toBe('2026-03-01,U1,利用者A,散歩,休憩,半分,-,,,Reporter A');
+    expect(lines[2]).toBe(
+      '2026-03-03,U2,利用者B,制作,運動,8割,○,"自傷, 大声","注意,重要",Reporter B'
+    );
+  });
+
+  it('downloads a CSV file with the expected filename', () => {
+    const originalCreateElement = document.createElement.bind(document);
+    const anchor = originalCreateElement('a') as HTMLAnchorElement;
+    const clickSpy = vi.spyOn(anchor, 'click').mockImplementation(() => {});
+    vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+      if (tagName === 'a') {
+        return anchor;
+      }
+      return originalCreateElement(tagName);
+    });
+    vi.spyOn(URL, 'createObjectURL').mockImplementation(() => 'blob:monthly-summary');
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+
     exportMonthlySummary({
       month: '2026-03',
-      users: [
-        { id: 1, userId: 'U1', name: '利用者A', severe: false },
-        { id: 2, userId: 'U2', name: '利用者B', severe: true },
-      ],
-      records,
+      users: [],
+      records: [],
     });
 
-    expect(exportToExcelMock).toHaveBeenCalledTimes(1);
-    const [data, options] = exportToExcelMock.mock.calls[0] as [
-      Array<Record<string, string>>,
-      { fileName: string; sheetName: string },
-    ];
+    expect(anchor.download).toBe('利用実績月次サマリ_2026-03.csv');
+    expect(clickSpy).toHaveBeenCalledTimes(1);
 
-    expect(options).toEqual({
-      fileName: '利用実績月次サマリ_2026-03',
-      sheetName: '月次状況',
-    });
-
-    expect(data).toHaveLength(2);
-    expect(data[0]['日付']).toBe('2026-03-01');
-    expect(data[0]['利用者ID']).toBe('U1');
-    expect(data[0]['昼食摂取']).toBe('半分');
-    expect(data[0]['重度フラグ']).toBe('-');
-
-    expect(data[1]['日付']).toBe('2026-03-03');
-    expect(data[1]['利用者ID']).toBe('U2');
-    expect(data[1]['昼食摂取']).toBe('8割');
-    expect(data[1]['重度フラグ']).toBe('○');
-    expect(data[1]['問題行動']).toBe('自傷, 大声');
+    vi.restoreAllMocks();
   });
 });

--- a/src/features/reports/monthly/MonthlySummaryExcel.ts
+++ b/src/features/reports/monthly/MonthlySummaryExcel.ts
@@ -1,5 +1,4 @@
 import type { DailyRecordItem } from '@/features/daily';
-import { exportToExcel } from '@/lib/reports/xlsxUtils';
 
 export interface User {
   id: number;
@@ -36,47 +35,103 @@ export interface MonthlySummaryOptions {
   records: DailyRecordItem[];
 }
 
+export interface MonthSummaryCsvRow {
+  date: string;
+  userId: string;
+  userName: string;
+  amActivity: string;
+  pmActivity: string;
+  lunchAmount: string;
+  severeFlag: string;
+  problemBehavior: string;
+  specialNotes: string;
+  reporter: string;
+}
+
+const HEADER_COLUMNS: Array<[keyof MonthSummaryCsvRow, string]> = [
+  ['date', '日付'],
+  ['userId', '利用者ID'],
+  ['userName', '利用者名'],
+  ['amActivity', '午前活動'],
+  ['pmActivity', '午後活動'],
+  ['lunchAmount', '昼食摂取'],
+  ['severeFlag', '重度フラグ'],
+  ['problemBehavior', '問題行動'],
+  ['specialNotes', '特記事項'],
+  ['reporter', '記録者'],
+];
+
+const csvEscape = (value: unknown): string => {
+  const text = value == null ? '' : String(value);
+  if (/[",\n]/.test(text)) {
+    return `"${text.replace(/"/g, '""')}"`;
+  }
+  return text;
+};
+
+export const buildMonthlySummaryCsvContent = (rows: Array<MonthSummaryCsvRow>): string => {
+  const header = HEADER_COLUMNS.map(([, label]) => csvEscape(label)).join(',');
+  const body = rows.map(row =>
+    HEADER_COLUMNS.map(([key]) => csvEscape(row[key])).join(',')
+  );
+  return `\ufeff${header}\n${body.join('\n')}\n`;
+};
+
+export const buildMonthlySummaryRows = ({
+  users,
+  records,
+}: Pick<MonthlySummaryOptions, 'users' | 'records'>): Array<MonthSummaryCsvRow> =>
+  records
+    .flatMap(record => {
+      return record.userRows.map(row => {
+        const user = users.find(u => u.userId === row.userId);
+        const behaviors = Object.entries(row.problemBehavior)
+          .filter(([, checked]) => checked)
+          .map(([type]) => BEHAVIOR_LABELS[type] || type)
+          .join(', ');
+
+        return {
+          date: record.date,
+          userId: row.userId,
+          userName: row.userName,
+          amActivity: row.amActivity,
+          pmActivity: row.pmActivity,
+          lunchAmount: LUNCH_LABELS[row.lunchAmount] || row.lunchAmount,
+          severeFlag: user?.severe ? '○' : '-',
+          problemBehavior: behaviors,
+          specialNotes: row.specialNotes,
+          reporter: record.reporter.name,
+        };
+      });
+    })
+    .sort((a, b) => {
+      const dateCmp = a.date.localeCompare(b.date);
+      if (dateCmp !== 0) return dateCmp;
+      return a.userId.localeCompare(b.userId);
+    });
+
+const downloadCsv = (filename: string, content: string): void => {
+  const blob = new Blob([content], { type: 'text/csv;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(url);
+};
+
 /**
- * Generate and download a monthly summary Excel file
+ * Generate and download a monthly summary CSV file
  */
 export function exportMonthlySummary({
   month,
   users,
   records,
 }: MonthlySummaryOptions): void {
-  // Flatten data for Excel
-  const data = records.flatMap(record => {
-    return record.userRows.map(row => {
-      const user = users.find(u => u.userId === row.userId);
-      const behaviors = Object.entries(row.problemBehavior)
-        .filter(([, checked]) => checked)
-        .map(([type]) => BEHAVIOR_LABELS[type] || type)
-        .join(', ');
+  const rows = buildMonthlySummaryRows({ users, records });
 
-      return {
-        '日付': record.date,
-        '利用者ID': row.userId,
-        '利用者名': row.userName,
-        '午前活動': row.amActivity,
-        '午後活動': row.pmActivity,
-        '昼食摂取': LUNCH_LABELS[row.lunchAmount] || row.lunchAmount,
-        '重度フラグ': user?.severe ? '○' : '-',
-        '問題行動': behaviors,
-        '特記事項': row.specialNotes,
-        '記録者': record.reporter.name,
-      };
-    });
-  });
-
-  // Sort by date then user ID
-  data.sort((a, b) => {
-    const dateCmp = a['日付'].localeCompare(b['日付']);
-    if (dateCmp !== 0) return dateCmp;
-    return a['利用者ID'].localeCompare(b['利用者ID']);
-  });
-
-  exportToExcel(data, {
-    fileName: `利用実績月次サマリ_${month}`,
-    sheetName: '月次状況',
-  });
+  downloadCsv(
+    `利用実績月次サマリ_${month}.csv`,
+    buildMonthlySummaryCsvContent(rows),
+  );
 }

--- a/src/features/users/UsersPanel/UsersMenu.tsx
+++ b/src/features/users/UsersPanel/UsersMenu.tsx
@@ -57,7 +57,7 @@ const UsersMenu: FC<UsersMenuProps> = ({
         onClick={onExportMonthlySummary}
         sx={{ alignSelf: 'flex-start' }}
       >
-        利用実績月次サマリ (Excel) 出力
+        利用実績月次サマリ (CSV) 出力
       </Button>
     </Stack>
 

--- a/src/features/users/UsersPanel/hooks/useUsersPanelExport.ts
+++ b/src/features/users/UsersPanel/hooks/useUsersPanelExport.ts
@@ -1,9 +1,9 @@
 /**
  * useUsersPanelExport
  *
- * PDF・Excel 出力ハンドラ
+ * PDF・CSV 出力ハンドラ
  *
- * Heavy report libraries (@react-pdf/renderer, xlsx) are loaded lazily
+ * Heavy report libraries (@react-pdf/renderer) are loaded lazily
  * via dynamic import() so they stay out of the initial bundle.
  */
 import { useDailyRecordRepository } from '@/features/daily/repositories/repositoryFactory';
@@ -67,7 +67,7 @@ export function useUsersPanelExport(
         },
       });
 
-      // Lazy-load xlsx only when user clicks export
+      // Lazy-load export module only when user clicks export
       const { exportMonthlySummary } = await import(
         '@/features/reports/monthly/MonthlySummaryExcel'
       );
@@ -92,8 +92,8 @@ export function useUsersPanelExport(
         records,
       });
     } catch (err) {
-      console.error('Excel export failed:', err);
-      alert('Excel出力に失敗しました。');
+      console.error('Monthly summary export failed:', err);
+      alert('CSV出力に失敗しました。');
     } finally {
       setBusyId(null);
     }


### PR DESCRIPTION
## Summary
- xlsx 依存そのものの削除は行わず、月次サマリ出力を CSV へ縮小する変更に限定しました。
- `MonthlySummaryExcel` のエクスポート処理を CSV 出力へ変更し、UI 側の文言/エラー文言を CSV 前提へ更新します。

## Scope
- MonthlySummary export CSV 化
- MonthlySummary のユニットテストを CSV 検証に更新
- UsersPanel の表示文言とログ文言更新
- package / lockfile は変更なし、`xlsx` 依存除去は別PR

## Validation
- `npm run typecheck:full -- --pretty false` **失敗**: `tests/unit/canaryClassification.spec.ts` の既存型宣言不足（`../../scripts/ci/classify-canary.mjs`）。本PR関連差分ではありません。
- `npm run health` (実行済み)
- `npm run lint:dev` (実行済み)
- `npx vitest run src/features/reports/__tests__/MonthlySummaryExcel.spec.ts --reporter=verbose` (実行済み)
- `npx vitest run` は時間制約でタイムアウト（既存の全体実行時間が長いため）

## Changed files
- src/features/reports/monthly/MonthlySummaryExcel.ts
- src/features/reports/__tests__/MonthlySummaryExcel.spec.ts
- src/features/users/UsersPanel/UsersMenu.tsx
- src/features/users/UsersPanel/hooks/useUsersPanelExport.ts

## Notes
- `changedFiles` は 4 files。
- `xlsxUtils` 全体の削除や package 依存更新は含めていません。
