### PR TITLE
Billing P0: 精算状態永続化 diagnostics を追加

### DIFF
--- a/src/features/billing/hooks/__tests__/useBillingSummary.spec.ts
+++ b/src/features/billing/hooks/__tests__/useBillingSummary.spec.ts
@@ -352,8 +352,9 @@ describe('useBillingSummary', () => {
     const { result } = renderHook(() => useBillingSummary('2026-05'));
 
     await waitFor(() => {
-      expect(result.current.isPersistenceMissing).toBe(false);
+      expect(result.current.isPaymentAuditMissing).toBe(true);
     });
+    expect(result.current.isPersistenceMissing).toBe(false);
     expect(result.current.isPaymentAuditMissing).toBe(true);
     expect(result.current.persistenceWarningReason).toContain('PaidAt, PaidBy');
   });

--- a/src/features/billing/hooks/__tests__/useBillingSummary.spec.ts
+++ b/src/features/billing/hooks/__tests__/useBillingSummary.spec.ts
@@ -144,11 +144,13 @@ vi.mock('@tanstack/react-query', async (importOriginal) => {
 
 const mockBulkUpdatePaymentStatus = vi.fn(() => Promise.resolve());
 const mockIsPersistenceColumnsResolved = vi.fn(() => Promise.resolve(true));
+const mockGetPersistenceDiagnostics = vi.fn();
 
 vi.mock('../useBillingOrderRepository', () => ({
   useBillingOrderRepository: () => ({
     list: vi.fn(),
     isPersistenceColumnsResolved: mockIsPersistenceColumnsResolved,
+    getPersistenceDiagnostics: mockGetPersistenceDiagnostics,
     updatePaymentStatus: vi.fn(() => Promise.resolve()),
     bulkUpdatePaymentStatus: mockBulkUpdatePaymentStatus,
   }),
@@ -163,6 +165,19 @@ describe('useBillingSummary', () => {
     mockBulkUpdatePaymentStatus.mockClear();
     mockInvalidateQueries.mockClear();
     mockIsPersistenceColumnsResolved.mockClear();
+    mockGetPersistenceDiagnostics.mockReset();
+    mockGetPersistenceDiagnostics.mockResolvedValue({
+      status: 'resolved',
+      listId: 'c4be5492-9803-4fc6-ac7e-82d10e95ff6d',
+      siteRelative: '/sites/2',
+      missingFields: [],
+      resolvedFields: {
+        paymentStatus: 'PaymentStatus',
+        paidAt: 'PaidAt',
+        paidBy: 'PaidBy',
+      },
+      usesList3Fallback: false,
+    });
   });
 
   afterEach(() => {
@@ -291,11 +306,24 @@ describe('useBillingSummary', () => {
 
   it('SharePoint に精算列が無い場合、isPersistenceMissing が true になり LocalStorage フォールバックが働くこと', async () => {
     mockIsPersistenceColumnsResolved.mockResolvedValue(false);
+    mockGetPersistenceDiagnostics.mockResolvedValue({
+      status: 'missing_payment_status',
+      listId: 'List3',
+      siteRelative: '/sites/2',
+      missingFields: ['PaymentStatus'],
+      resolvedFields: {
+        paidAt: 'PaidAt',
+        paidBy: 'PaidBy',
+      },
+      usesList3Fallback: true,
+    });
     const { result } = renderHook(() => useBillingSummary('2026-05'));
 
     await waitFor(() => {
       expect(result.current.isPersistenceMissing).toBe(true);
     });
+    expect(result.current.persistenceDiagnostics?.status).toBe('missing_payment_status');
+    expect(result.current.persistenceWarningReason).toContain('PaymentStatus');
 
     // この状態でトグルを呼ぶ
     await act(async () => {
@@ -308,6 +336,26 @@ describe('useBillingSummary', () => {
 
     // SharePoint への更新は呼ばれていないこと
     expect(mockBulkUpdatePaymentStatus).not.toHaveBeenCalled();
+  });
+
+  it('PaymentStatus はあるが PaidAt/PaidBy が無い場合、永続化は維持しつつ監査警告を返すこと', async () => {
+    mockGetPersistenceDiagnostics.mockResolvedValue({
+      status: 'missing_audit_fields',
+      listId: 'c4be5492-9803-4fc6-ac7e-82d10e95ff6d',
+      siteRelative: '/sites/2',
+      missingFields: ['PaidAt', 'PaidBy'],
+      resolvedFields: {
+        paymentStatus: 'PaymentStatus',
+      },
+      usesList3Fallback: false,
+    });
+    const { result } = renderHook(() => useBillingSummary('2026-05'));
+
+    await waitFor(() => {
+      expect(result.current.isPersistenceMissing).toBe(false);
+    });
+    expect(result.current.isPaymentAuditMissing).toBe(true);
+    expect(result.current.persistenceWarningReason).toContain('PaidAt, PaidBy');
   });
 
   it('CSV出力が正常に動作し、BOM(\ufeff) が付与されていること', async () => {

--- a/src/features/billing/hooks/useBillingSummary.ts
+++ b/src/features/billing/hooks/useBillingSummary.ts
@@ -5,6 +5,7 @@ import { useBillingOrderRepository } from './useBillingOrderRepository';
 import { useUsersStore } from '@/features/users/store';
 import { useStaffStore } from '@/features/staff/store';
 import { useAuth } from '@/auth/useAuth';
+import type { BillingPersistenceDiagnostics } from '../repository';
 
 export interface AggregatedBillingRecord {
   ordererCode: string;
@@ -27,6 +28,9 @@ export interface BillingSummary {
   isError: boolean;
   isMutating: boolean;
   isPersistenceMissing: boolean;
+  isPaymentAuditMissing: boolean;
+  persistenceDiagnostics: BillingPersistenceDiagnostics | null;
+  persistenceWarningReason?: string;
   togglePaymentStatus: (ordererCode: string) => Promise<void>;
   bulkSettle: (category: '利用者' | '職員' | 'ゲスト' | 'すべて') => Promise<void>;
   exportCsv: (category: '利用者' | '職員' | 'ゲスト' | 'すべて') => void;
@@ -52,6 +56,7 @@ export function useBillingSummary(selectedMonth: string): BillingSummary {
 
   const [isMutating, setIsMutating] = useState(false);
   const [isPersistenceMissing, setIsPersistenceMissing] = useState(false);
+  const [persistenceDiagnostics, setPersistenceDiagnostics] = useState<BillingPersistenceDiagnostics | null>(null);
 
   const isLoading = ordersLoading || usersLoading || staffLoading;
   const paidByActor = useMemo(() => {
@@ -78,13 +83,43 @@ export function useBillingSummary(selectedMonth: string): BillingSummary {
     let active = true;
     async function checkSchema() {
       try {
+        if (repository.getPersistenceDiagnostics) {
+          const diagnostics = await repository.getPersistenceDiagnostics();
+          if (active) {
+            setPersistenceDiagnostics(diagnostics);
+            setIsPersistenceMissing(
+              diagnostics.status === 'missing_payment_status' ||
+              diagnostics.status === 'field_resolution_error'
+            );
+            if (diagnostics.status !== 'resolved') {
+              console.warn('[Billing] Payment persistence diagnostics:', {
+                status: diagnostics.status,
+                listId: diagnostics.listId,
+                siteRelative: diagnostics.siteRelative,
+                missingFields: diagnostics.missingFields,
+                usesList3Fallback: diagnostics.usesList3Fallback,
+                errorMessage: diagnostics.errorMessage,
+              });
+            }
+          }
+          return;
+        }
         const isResolved = await repository.isPersistenceColumnsResolved();
         if (active) {
+          setPersistenceDiagnostics(null);
           setIsPersistenceMissing(!isResolved);
         }
       } catch (e) {
         console.error('Failed to resolve SharePoint billing persistence columns', e);
         if (active) {
+          setPersistenceDiagnostics({
+            status: 'field_resolution_error',
+            listId: 'unknown',
+            missingFields: ['PaymentStatus'],
+            resolvedFields: {},
+            errorMessage: e instanceof Error ? e.message.slice(0, 300) : String(e).slice(0, 300),
+            usesList3Fallback: false,
+          });
           setIsPersistenceMissing(true);
         }
       }
@@ -94,6 +129,23 @@ export function useBillingSummary(selectedMonth: string): BillingSummary {
       active = false;
     };
   }, [repository]);
+
+  const isPaymentAuditMissing = persistenceDiagnostics?.status === 'missing_audit_fields';
+
+  const persistenceWarningReason = useMemo(() => {
+    switch (persistenceDiagnostics?.status) {
+      case 'env_fallback_list3':
+        return '原因: VITE_SP_LIST_BILLING_ORDERS 未設定により List3 fallback が使われています。';
+      case 'field_resolution_error':
+        return '原因: SharePoint field 解決でエラーが発生しました。';
+      case 'missing_payment_status':
+        return '原因: PaymentStatus 列を解決できません。';
+      case 'missing_audit_fields':
+        return `監査情報列が不足しています: ${persistenceDiagnostics.missingFields.join(', ')}`;
+      default:
+        return undefined;
+    }
+  }, [persistenceDiagnostics]);
 
   // 2. LocalStorage フォールバック用の値
   const [fallbackPaymentStates, setFallbackPaymentStates] = useState<Record<string, boolean>>(() => {
@@ -340,6 +392,9 @@ export function useBillingSummary(selectedMonth: string): BillingSummary {
     isError: !!ordersError,
     isMutating,
     isPersistenceMissing,
+    isPaymentAuditMissing,
+    persistenceDiagnostics,
+    persistenceWarningReason,
     togglePaymentStatus,
     bulkSettle,
     exportCsv,

--- a/src/features/billing/infra/DataProviderBillingOrderRepository.ts
+++ b/src/features/billing/infra/DataProviderBillingOrderRepository.ts
@@ -11,11 +11,18 @@ import {
   washRows
 } from '@/lib/sp/helpers';
 import { reportResourceResolution } from '@/lib/data/dataProviderObservabilityStore';
-import type { BillingOrderRepository } from '../repository';
+import { readOptionalEnv } from '@/lib/env';
+import type { BillingOrderRepository, BillingPersistenceDiagnostics } from '../repository';
 import type { BillingOrder } from '../types';
 import { mapToBillingOrder } from '../domain/billingLogic';
 
 export const BILLING_ORDERS_PAGE_SIZE = 5000;
+const BILLING_PAYMENT_FIELDS = ['PaymentStatus', 'PaidAt', 'PaidBy'] as const;
+
+const sanitizeDiagnosticError = (err: unknown): string => {
+  const message = err instanceof Error ? err.message : String(err);
+  return message.replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer [redacted]').slice(0, 300);
+};
 
 /**
  * DataProviderBillingOrderRepository
@@ -26,11 +33,58 @@ export const BILLING_ORDERS_PAGE_SIZE = 5000;
 export class DataProviderBillingOrderRepository implements BillingOrderRepository {
   private readonly provider: IDataProvider;
   private readonly listId: string;
+  private readonly siteRelative?: string;
   private resolvedFields: Record<string, string | undefined> | null = null;
+  private persistenceDiagnostics: BillingPersistenceDiagnostics;
 
-  constructor(provider: IDataProvider, listId: string = BILLING_ORDERS_LIST_ID) {
+  constructor(
+    provider: IDataProvider,
+    listId: string = BILLING_ORDERS_LIST_ID,
+    siteRelative: string | undefined = readOptionalEnv('VITE_SP_LIST_BILLING_ORDERS_SITE_RELATIVE')
+  ) {
     this.provider = provider;
     this.listId = listId;
+    this.siteRelative = siteRelative;
+    this.persistenceDiagnostics = this.createDiagnostics('unknown', {});
+  }
+
+  private createDiagnostics(
+    status: BillingPersistenceDiagnostics['status'],
+    resolvedFields: Record<string, string | undefined>,
+    errorMessage?: string
+  ): BillingPersistenceDiagnostics {
+    const missingFields = BILLING_PAYMENT_FIELDS.filter((field) => {
+      if (field === 'PaymentStatus') return !resolvedFields.paymentStatus;
+      if (field === 'PaidAt') return !resolvedFields.paidAt;
+      return !resolvedFields.paidBy;
+    });
+
+    return {
+      status,
+      listId: this.listId,
+      siteRelative: this.siteRelative,
+      missingFields,
+      resolvedFields,
+      errorMessage,
+      usesList3Fallback: this.listId === 'List3',
+    };
+  }
+
+  private updatePersistenceDiagnostics(
+    resolvedFields: Record<string, string | undefined>,
+    errorMessage?: string
+  ): void {
+    let status: BillingPersistenceDiagnostics['status'] = 'resolved';
+    if (errorMessage) {
+      status = 'field_resolution_error';
+    } else if (!resolvedFields.paymentStatus) {
+      status = 'missing_payment_status';
+    } else if (!resolvedFields.paidAt || !resolvedFields.paidBy) {
+      status = 'missing_audit_fields';
+    } else if (this.listId === 'List3') {
+      status = 'env_fallback_list3';
+    }
+    this.persistenceDiagnostics = this.createDiagnostics(status, resolvedFields, errorMessage);
   }
 
   /**
@@ -61,9 +115,12 @@ export class DataProviderBillingOrderRepository implements BillingOrderRepositor
       }
 
       this.resolvedFields = resolved as Record<string, string | undefined>;
+      this.updatePersistenceDiagnostics(this.resolvedFields);
       return this.resolvedFields;
     } catch (err) {
+      const errorMessage = sanitizeDiagnosticError(err);
       console.error('[BillingOrderRepository] Field resolution failed:', err);
+      this.updatePersistenceDiagnostics({}, errorMessage);
       // フォールバック（空オブジェクトで hardcoded keys へのフォールバックを mapToBillingOrder に委ねる）
       return {};
     }
@@ -94,6 +151,11 @@ export class DataProviderBillingOrderRepository implements BillingOrderRepositor
   async isPersistenceColumnsResolved(): Promise<boolean> {
     const mapping = await this.resolveFields();
     return !!mapping.paymentStatus;
+  }
+
+  async getPersistenceDiagnostics(): Promise<BillingPersistenceDiagnostics> {
+    await this.resolveFields();
+    return this.persistenceDiagnostics;
   }
 
   async updatePaymentStatus(

--- a/src/features/billing/infra/__tests__/DataProviderBillingOrderRepository.spec.ts
+++ b/src/features/billing/infra/__tests__/DataProviderBillingOrderRepository.spec.ts
@@ -97,6 +97,37 @@ describe('DataProviderBillingOrderRepository', () => {
       expect(isResolved).toBe(true);
     });
 
+    it('reports resolved diagnostics when PaymentStatus and audit fields exist', async () => {
+      const provider = createProvider();
+      vi.mocked(provider.getFieldInternalNames).mockResolvedValue(new Set([
+        'ID',
+        'OrderDateTime',
+        'RequesterCode',
+        'PaymentStatus',
+        'PaidAt',
+        'PaidBy',
+      ]));
+      const repository = new DataProviderBillingOrderRepository(
+        provider,
+        'c4be5492-9803-4fc6-ac7e-82d10e95ff6d',
+        '/sites/2'
+      );
+
+      await expect(repository.isPersistenceColumnsResolved()).resolves.toBe(true);
+      await expect(repository.getPersistenceDiagnostics()).resolves.toMatchObject({
+        status: 'resolved',
+        listId: 'c4be5492-9803-4fc6-ac7e-82d10e95ff6d',
+        siteRelative: '/sites/2',
+        missingFields: [],
+        usesList3Fallback: false,
+        resolvedFields: expect.objectContaining({
+          paymentStatus: 'PaymentStatus',
+          paidAt: 'PaidAt',
+          paidBy: 'PaidBy',
+        }),
+      });
+    });
+
     it('returns false when PaymentStatus field is missing in data provider', async () => {
       const provider = createProvider();
       vi.mocked(provider.getFieldInternalNames).mockResolvedValue(new Set([
@@ -108,6 +139,80 @@ describe('DataProviderBillingOrderRepository', () => {
 
       const isResolved = await repository.isPersistenceColumnsResolved();
       expect(isResolved).toBe(false);
+    });
+
+    it('reports missing_payment_status when PaymentStatus is missing', async () => {
+      const provider = createProvider();
+      vi.mocked(provider.getFieldInternalNames).mockResolvedValue(new Set([
+        'ID',
+        'OrderDateTime',
+        'RequesterCode',
+        'PaidAt',
+        'PaidBy',
+      ]));
+      const repository = new DataProviderBillingOrderRepository(provider, 'List3');
+
+      await expect(repository.isPersistenceColumnsResolved()).resolves.toBe(false);
+      await expect(repository.getPersistenceDiagnostics()).resolves.toMatchObject({
+        status: 'missing_payment_status',
+        missingFields: expect.arrayContaining(['PaymentStatus']),
+        usesList3Fallback: true,
+      });
+    });
+
+    it('reports missing_audit_fields when PaymentStatus exists but PaidAt or PaidBy is missing', async () => {
+      const provider = createProvider();
+      vi.mocked(provider.getFieldInternalNames).mockResolvedValue(new Set([
+        'ID',
+        'OrderDateTime',
+        'RequesterCode',
+        'PaymentStatus',
+      ]));
+      const repository = new DataProviderBillingOrderRepository(provider, 'List3');
+
+      await expect(repository.isPersistenceColumnsResolved()).resolves.toBe(true);
+      await expect(repository.getPersistenceDiagnostics()).resolves.toMatchObject({
+        status: 'missing_audit_fields',
+        missingFields: expect.arrayContaining(['PaidAt', 'PaidBy']),
+        usesList3Fallback: true,
+      });
+    });
+
+    it('reports field_resolution_error when field resolution rejects', async () => {
+      const provider = createProvider();
+      vi.mocked(provider.getFieldInternalNames).mockRejectedValue(new Error('HTTP 404 list not found'));
+      const repository = new DataProviderBillingOrderRepository(provider, 'List3');
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await expect(repository.isPersistenceColumnsResolved()).resolves.toBe(false);
+      await expect(repository.getPersistenceDiagnostics()).resolves.toMatchObject({
+        status: 'field_resolution_error',
+        errorMessage: 'HTTP 404 list not found',
+        missingFields: expect.arrayContaining(['PaymentStatus', 'PaidAt', 'PaidBy']),
+        usesList3Fallback: true,
+      });
+
+      consoleError.mockRestore();
+    });
+
+    it('reports env_fallback_list3 when List3 fallback is used even if fields resolve', async () => {
+      const provider = createProvider();
+      vi.mocked(provider.getFieldInternalNames).mockResolvedValue(new Set([
+        'ID',
+        'OrderDateTime',
+        'RequesterCode',
+        'PaymentStatus',
+        'PaidAt',
+        'PaidBy',
+      ]));
+      const repository = new DataProviderBillingOrderRepository(provider, 'List3');
+
+      await expect(repository.isPersistenceColumnsResolved()).resolves.toBe(true);
+      await expect(repository.getPersistenceDiagnostics()).resolves.toMatchObject({
+        status: 'env_fallback_list3',
+        missingFields: [],
+        usesList3Fallback: true,
+      });
     });
   });
 });

--- a/src/features/billing/repository.ts
+++ b/src/features/billing/repository.ts
@@ -1,9 +1,28 @@
 import type { BillingOrder } from './types';
 
+export type BillingPersistenceDiagnosticStatus =
+  | 'resolved'
+  | 'missing_payment_status'
+  | 'missing_audit_fields'
+  | 'field_resolution_error'
+  | 'env_fallback_list3'
+  | 'unknown';
+
+export interface BillingPersistenceDiagnostics {
+  status: BillingPersistenceDiagnosticStatus;
+  listId: string;
+  siteRelative?: string;
+  missingFields: string[];
+  resolvedFields: Record<string, string | undefined>;
+  errorMessage?: string;
+  usesList3Fallback: boolean;
+}
+
 /** Repository インターフェース */
 export interface BillingOrderRepository {
   list(): Promise<BillingOrder[]>;
   isPersistenceColumnsResolved(): Promise<boolean>;
+  getPersistenceDiagnostics?(): Promise<BillingPersistenceDiagnostics>;
   updatePaymentStatus(
     id: number,
     status: '未精算' | '精算済み',

--- a/src/features/billing/repositoryFactory.ts
+++ b/src/features/billing/repositoryFactory.ts
@@ -22,6 +22,10 @@ export function resolveBillingSharePointBaseUrl(): string {
   return baseUrl;
 }
 
+export function resolveBillingSharePointSiteRelative(): string | undefined {
+  return readOptionalEnv('VITE_SP_LIST_BILLING_ORDERS_SITE_RELATIVE');
+}
+
 const factory = createRepositoryFactory<BillingOrderRepository, BillingOrderRepositoryFactoryOptions>({
   name: 'BillingOrder',
   createDemo: () => inMemoryBillingOrderRepository,
@@ -33,7 +37,7 @@ const factory = createRepositoryFactory<BillingOrderRepository, BillingOrderRepo
     const baseUrl = resolveBillingSharePointBaseUrl();
     const provider = new SharePointDataProvider(createSpClient(acquireToken, baseUrl));
     
-    return new DataProviderBillingOrderRepository(provider);
+    return new DataProviderBillingOrderRepository(provider, undefined, resolveBillingSharePointSiteRelative());
   },
 });
 

--- a/src/pages/BillingPage.tsx
+++ b/src/pages/BillingPage.tsx
@@ -80,6 +80,8 @@ export default function BillingPage() {
     isError,
     isMutating,
     isPersistenceMissing,
+    isPaymentAuditMissing,
+    persistenceWarningReason,
     togglePaymentStatus,
     bulkSettle,
     exportCsv,
@@ -444,6 +446,24 @@ export default function BillingPage() {
       {isPersistenceMissing && (
         <Alert severity="warning" sx={{ mb: 3, borderRadius: 2 }}>
           精算状態の永続化列を確認できません。現在の精算状態には、この端末・このブラウザ内の一時情報が含まれる可能性があります。別端末・別ブラウザでは一致しない場合があるため、CSVの精算状況を正式な精算結果として扱わないでください。管理者は SharePoint の PaymentStatus / PaidAt / PaidBy 列を確認してください。
+          {persistenceWarningReason && (
+            <>
+              <br />
+              {persistenceWarningReason}
+            </>
+          )}
+        </Alert>
+      )}
+
+      {!isPersistenceMissing && isPaymentAuditMissing && (
+        <Alert severity="warning" sx={{ mb: 3, borderRadius: 2 }}>
+          精算状態は SharePoint に保存できますが、PaidAt / PaidBy などの監査情報列を一部確認できません。管理者は SharePoint の PaymentStatus / PaidAt / PaidBy 列を確認してください。
+          {persistenceWarningReason && (
+            <>
+              <br />
+              {persistenceWarningReason}
+            </>
+          )}
         </Alert>
       )}
 


### PR DESCRIPTION
## 概要
Billing P0 第3段階として、請求精算状態の永続化判定が `isPersistenceMissing=true` になった理由を切り分ける diagnostics を追加しました。

実環境確認では `/sites/2` の GUID リスト `c4be5492-9803-4fc6-ac7e-82d10e95ff6d` に `PaymentStatus / PaidAt / PaidBy` が存在し、title `List3` 指定ではリストが存在しないことが確認済みです。
そのため本PRでは、SharePoint列追加ではなく、env未設定・List3 fallback・field解決例外・監査列欠落を区別できるようにしています。

## 変更内容
- `BillingPersistenceDiagnostics` 型を追加
- `DataProviderBillingOrderRepository` に `getPersistenceDiagnostics()` を追加
- `PaymentStatus` 欠落を `missing_payment_status` として分類
- `PaidAt` / `PaidBy` 欠落を audit warning として分類
- field解決例外を `field_resolution_error` として分類
- `List3` fallback を検知
- `useBillingSummary` で `persistenceDiagnostics`, `isPaymentAuditMissing`, `persistenceWarningReason` を返却
- `BillingPage` の既存警告に原因を短く追記
- `PaymentStatus` はあるが監査列が不足する場合の警告を追加

## 変更していないこと
- `app:billing:payment_states` の削除なし
- LocalStorage 読み取り停止なし
- LocalStorage 新規保存停止なし
- CSV列構成変更なし
- 精算操作制限なし
- SharePoint schema/provisioning 変更なし
- `vite.config.ts` はPR差分外

## 確認
- `git diff --check`
- `npm run lint`
- `npm run typecheck -- --pretty false`
- `npx vitest run src/features/billing/infra/__tests__/DataProviderBillingOrderRepository.spec.ts src/features/billing/hooks/__tests__/useBillingSummary.spec.ts --run`
- `npx vitest run tests/unit/BillingPage.csv-confirm.spec.tsx --run`

## 次PR候補
diagnostics の結果に応じて、次PRでは以下を判断します。

- `env_fallback_list3` が出る場合: `VITE_SP_LIST_BILLING_ORDERS` 未設定時の明示エラー化
- `field_resolution_error` が出る場合: 権限・proxy allow path・API例外の調査
- 常に `resolved` になる場合: LocalStorage fallback の段階停止検討
- `missing_audit_fields` が出る場合: `PaidAt` / `PaidBy` の監査列必須化または警告強化
