### PR TITLE
Billing P0: 既存LocalStorage精算状態の可視化と運用メモを追加

### DIFF
--- a/docs/ops/billing-local-payment-state-runbook.md
+++ b/docs/ops/billing-local-payment-state-runbook.md
@@ -1,0 +1,81 @@
+# Billing Local Payment State Runbook
+
+## 目的
+
+請求画面の端末内一時状態 `app:billing:payment_states` の扱いを、削除前に確認できるようにするための運用メモです。
+
+このキーは、SharePoint の精算状態列 `PaymentStatus` が解決できない場合に使われていた LocalStorage fallback です。現在の方針では、`PaymentStatus` が解決できる環境では SharePoint 側を正本として扱い、端末内一時状態を正式な精算状態として扱いません。
+
+## 対象キー
+
+- `app:billing:payment_states`
+
+## 現在の扱い
+
+- `PaymentStatus` が解決できる環境では、SharePoint の `PaymentStatus` を正本として表示します。
+- `PaymentStatus` が解決できる環境では、新規の LocalStorage 保存は行いません。
+- 既存端末に残っている `app:billing:payment_states` は、互換確認のため読み取り自体は残しています。
+- `PaymentStatus` が解決できない環境では、既存 LocalStorage 値が表示や CSV の精算状態に影響する可能性があります。
+- 自動削除、削除ボタン、読み取り停止はまだ行いません。
+
+## 画面での見え方
+
+請求画面は、`app:billing:payment_states` に既存値が残っている場合だけ注意を表示します。
+
+- `PaymentStatus` 解決済み: 端末内の過去一時状態が残っていても、現在は SharePoint の精算状態を正本として表示していることを表示します。
+- `PaymentStatus` 未解決: 端末内の一時状態が表示や CSV に影響する可能性があることを表示します。
+
+## 手動確認方法
+
+ブラウザの開発者ツール Console で確認します。
+
+```js
+localStorage.getItem('app:billing:payment_states')
+```
+
+件数の目安を確認する場合:
+
+```js
+Object.keys(JSON.parse(localStorage.getItem('app:billing:payment_states') || '{}')).length
+```
+
+内容を確認する場合:
+
+```js
+JSON.parse(localStorage.getItem('app:billing:payment_states') || '{}')
+```
+
+## 削除判断の前提
+
+削除は、少なくとも以下を確認してから行います。
+
+- 本番または検証の請求画面で `PaymentStatus` が解決済みである。
+- `PaymentStatus`, `PaidAt`, `PaidBy` が対象 SharePoint リストに存在する。
+- 請求担当が端末内一時状態を現行の精算確認に使っていない。
+- CSV の精算状況を LocalStorage fallback 由来で運用していない。
+- 複数端末で SharePoint 側の精算状態が一致している。
+
+## 削除してはいけないタイミング
+
+- `isPersistenceMissing=true` の警告が出ている。
+- diagnostics で `env_fallback_list3`, `field_resolution_error`, `missing_payment_status` が出ている。
+- 現場が端末内一時状態を使って精算確認している可能性が残っている。
+- SharePoint の接続先、list id、siteRelative が確認できていない。
+- 削除後の問い合わせ先と復旧手順が決まっていない。
+
+## 手動削除コマンド
+
+削除判断が完了した端末でのみ実行します。
+
+```js
+localStorage.removeItem('app:billing:payment_states')
+```
+
+削除後は請求画面を再読み込みし、端末内一時状態の注意表示が消えること、SharePoint の `PaymentStatus` に基づく精算状態が表示されることを確認します。
+
+## 後続PR候補
+
+1. `isPersistenceMissing=true` 時の新規 LocalStorage 保存停止
+2. 既存 LocalStorage 値の削除手順の現場展開
+3. LocalStorage 読み取り停止
+4. `app:billing:payment_states` 関連コード削除

--- a/src/features/billing/hooks/__tests__/useBillingSummary.spec.ts
+++ b/src/features/billing/hooks/__tests__/useBillingSummary.spec.ts
@@ -211,6 +211,8 @@ describe('useBillingSummary', () => {
     expect(result.current.totalServedCount).toBe(5);
     expect(result.current.totalServedAmount).toBe(800);
     expect(result.current.availableMonths).toEqual(['2026-05', '2026-04']);
+    expect(result.current.hasLocalPaymentState).toBe(false);
+    expect(result.current.localPaymentStateCount).toBe(0);
   });
 
   it('個別の精算トグル状態が SharePoint の repository に送られ、query invalidation が走ること', async () => {
@@ -248,6 +250,8 @@ describe('useBillingSummary', () => {
       expect(result.current.persistenceDiagnostics?.status).toBe('resolved');
     });
     expect(result.current.isPersistenceMissing).toBe(false);
+    expect(result.current.hasLocalPaymentState).toBe(true);
+    expect(result.current.localPaymentStateCount).toBe(1);
 
     const userRecord = result.current.records.find((r) => r.ordererCode === 'U-001');
     expect(userRecord?.isPaid).toBe(false);
@@ -410,6 +414,8 @@ describe('useBillingSummary', () => {
 
     const userRecord = result.current.records.find((r) => r.ordererCode === 'U-001');
     expect(userRecord?.isPaid).toBe(true);
+    expect(result.current.hasLocalPaymentState).toBe(true);
+    expect(result.current.localPaymentStateCount).toBe(1);
     expect(mockBulkUpdatePaymentStatus).not.toHaveBeenCalled();
   });
 

--- a/src/features/billing/hooks/useBillingSummary.ts
+++ b/src/features/billing/hooks/useBillingSummary.ts
@@ -29,6 +29,8 @@ export interface BillingSummary {
   isMutating: boolean;
   isPersistenceMissing: boolean;
   isPaymentAuditMissing: boolean;
+  hasLocalPaymentState: boolean;
+  localPaymentStateCount: number;
   persistenceDiagnostics: BillingPersistenceDiagnostics | null;
   persistenceWarningReason?: string;
   togglePaymentStatus: (ordererCode: string) => Promise<void>;
@@ -158,6 +160,12 @@ export function useBillingSummary(selectedMonth: string): BillingSummary {
       return {};
     }
   });
+
+  const localPaymentStateCount = useMemo(
+    () => Object.keys(fallbackPaymentStates).length,
+    [fallbackPaymentStates]
+  );
+  const hasLocalPaymentState = localPaymentStateCount > 0;
 
   const saveFallbackState = (key: string, val: boolean) => {
     const next = { ...fallbackPaymentStates, [key]: val };
@@ -395,6 +403,8 @@ export function useBillingSummary(selectedMonth: string): BillingSummary {
     isMutating,
     isPersistenceMissing,
     isPaymentAuditMissing,
+    hasLocalPaymentState,
+    localPaymentStateCount,
     persistenceDiagnostics,
     persistenceWarningReason,
     togglePaymentStatus,

--- a/src/pages/BillingPage.tsx
+++ b/src/pages/BillingPage.tsx
@@ -81,6 +81,8 @@ export default function BillingPage() {
     isMutating,
     isPersistenceMissing,
     isPaymentAuditMissing,
+    hasLocalPaymentState,
+    localPaymentStateCount,
     persistenceWarningReason,
     togglePaymentStatus,
     bulkSettle,
@@ -462,6 +464,24 @@ export default function BillingPage() {
             <>
               <br />
               {persistenceWarningReason}
+            </>
+          )}
+        </Alert>
+      )}
+
+      {hasLocalPaymentState && (
+        <Alert severity={isPersistenceMissing ? 'warning' : 'info'} sx={{ mb: 3, borderRadius: 2 }}>
+          {isPersistenceMissing ? (
+            <>
+              端末内の一時状態が表示やCSVへ影響する可能性があります。
+              <br />
+              端末内一時状態: {localPaymentStateCount}件
+            </>
+          ) : (
+            <>
+              端末内の過去一時状態が残っていますが、現在は SharePoint の精算状態を正本として表示しています。
+              <br />
+              端末内一時状態: {localPaymentStateCount}件
             </>
           )}
         </Alert>

--- a/tests/unit/BillingPage.csv-confirm.spec.tsx
+++ b/tests/unit/BillingPage.csv-confirm.spec.tsx
@@ -4,6 +4,8 @@ import BillingPage from '@/pages/BillingPage';
 
 const billingSummaryState = vi.hoisted(() => ({
   isPersistenceMissing: false,
+  hasLocalPaymentState: false,
+  localPaymentStateCount: 0,
 }));
 
 const exportCsvMock = vi.hoisted(() => vi.fn());
@@ -22,6 +24,10 @@ vi.mock('@/features/billing/hooks/useBillingSummary', () => ({
     isError: false,
     isMutating: false,
     isPersistenceMissing: billingSummaryState.isPersistenceMissing,
+    isPaymentAuditMissing: false,
+    hasLocalPaymentState: billingSummaryState.hasLocalPaymentState,
+    localPaymentStateCount: billingSummaryState.localPaymentStateCount,
+    persistenceWarningReason: undefined,
     togglePaymentStatus: togglePaymentStatusMock,
     bulkSettle: bulkSettleMock,
     exportCsv: exportCsvMock,
@@ -31,6 +37,8 @@ vi.mock('@/features/billing/hooks/useBillingSummary', () => ({
 describe('BillingPage CSV export confirmation', () => {
   beforeEach(() => {
     billingSummaryState.isPersistenceMissing = false;
+    billingSummaryState.hasLocalPaymentState = false;
+    billingSummaryState.localPaymentStateCount = 0;
     exportCsvMock.mockReset();
     togglePaymentStatusMock.mockReset();
     bulkSettleMock.mockReset();
@@ -78,5 +86,36 @@ describe('BillingPage CSV export confirmation', () => {
     expect(screen.getByText(/PaymentStatus \/ PaidAt \/ PaidBy/)).toBeInTheDocument();
     expect(screen.getByText(/CSVの精算状況を正式な精算結果として扱わないでください/)).toBeInTheDocument();
     expect(screen.getByText('精算状態未検証のため、CSV出力時に確認が必要です')).toBeInTheDocument();
+  });
+
+  it('shows a local temporary state notice when existing LocalStorage payment state remains in resolved mode', () => {
+    billingSummaryState.hasLocalPaymentState = true;
+    billingSummaryState.localPaymentStateCount = 2;
+
+    render(<BillingPage />);
+
+    expect(screen.getByText(/端末内の過去一時状態が残っています/)).toBeInTheDocument();
+    expect(screen.getByText(/SharePoint の精算状態を正本として表示しています/)).toBeInTheDocument();
+    expect(screen.getByText(/端末内一時状態:\s*2件/)).toBeInTheDocument();
+  });
+
+  it('does not show a local temporary state notice when no LocalStorage payment state remains', () => {
+    render(<BillingPage />);
+
+    expect(
+      screen.queryByText(/端末内の過去一時状態が残っています/)
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows a stronger local temporary state warning when payment persistence is missing', () => {
+    billingSummaryState.isPersistenceMissing = true;
+    billingSummaryState.hasLocalPaymentState = true;
+    billingSummaryState.localPaymentStateCount = 1;
+
+    render(<BillingPage />);
+
+    expect(screen.getByText(/端末内の一時状態が表示やCSVへ影響する可能性があります/)).toBeInTheDocument();
+    expect(screen.getByText(/端末内一時状態:\s*1件/)).toBeInTheDocument();
+    expect(screen.getByText(/CSVの精算状況を正式な精算結果として扱わないでください/)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## 概要
Billing P0 第5段階の入口として、既存 `app:billing:payment_states` の可視化と運用メモを追加しました。

本PRでは、既存 LocalStorage 値を削除せず、読み取り互換も維持します。

目的は、過去 fallback で端末内に残った精算状態をいきなり消すのではなく、まず存在を把握できるようにすることです。

## 変更内容
- `useBillingSummary` で既存 LocalStorage 精算状態の有無と件数を返却
  - `hasLocalPaymentState`
  - `localPaymentStateCount`
- `BillingPage` に既存 LocalStorage 値がある場合のみ注意表示を追加
- resolved 環境では SharePoint `PaymentStatus` が正本であることを表示
- `isPersistenceMissing=true` 環境では、端末内一時状態が表示やCSVへ影響し得ることを表示
- `docs/ops/billing-local-payment-state-runbook.md` を追加
- hook / BillingPage のテストを追加

## 変更していないこと
- `app:billing:payment_states` の削除なし
- LocalStorage 読み取り停止なし
- `isPersistenceMissing=true` 時の新規保存停止なし
- CSV列構成変更なし
- 精算操作制限なし
- SharePoint schema/provisioning 変更なし
- `vite.config.ts` はPR差分外

## 確認
- `npm run lint`
- `npm run typecheck -- --pretty false`
- `npx vitest run src/features/billing/hooks/__tests__/useBillingSummary.spec.ts --run`
- `npx vitest run tests/unit/BillingPage.csv-confirm.spec.tsx --run`
- `git diff --check`

## 次PR候補
- `isPersistenceMissing=true` 時の新規 LocalStorage 保存停止
- 既存 `app:billing:payment_states` の削除手順の確定
- 管理者向け削除導線の要否
- LocalStorage 読み取り停止の時期