### PR TITLE
ui(kiosk): show saved procedure record summary

### DIFF
--- a/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureDetailScreen.tsx
@@ -21,6 +21,7 @@ import {
 } from '../domain/kioskProcedureMemo';
 import { resolveProcedureUserQueryCandidates } from '../utils/resolveProcedureUserQuery';
 import { useKioskAttendance } from '../hooks/useKioskAttendance';
+import { KioskProcedureRecordSummary } from './KioskProcedureRecordSummary';
 
 const MOOD_CHIPS = ['落ち着いていた', '不安そう', '拒否あり', '興奮あり', '切り替え困難'];
 const ACTION_CHIPS = ['見守り', '声かけ', '環境調整', '活動変更', '距離を取る', 'クールダウン'];
@@ -421,6 +422,14 @@ export const KioskProcedureDetailScreen: React.FC = () => {
             保存済みかどうかを確認できません。再読み込みするまで記録の保存・取消はできません。
           </Typography>
         </Alert>
+      )}
+
+      {record && !isRecordStatusUnknown && (
+        <KioskProcedureRecordSummary
+          record={record}
+          mode="full"
+          testId="kiosk-saved-record-summary"
+        />
       )}
 
       {/* 観察記録の入力パネル */}

--- a/src/features/kiosk/components/KioskProcedureListScreen.tsx
+++ b/src/features/kiosk/components/KioskProcedureListScreen.tsx
@@ -30,6 +30,7 @@ import { resolveSupportStartDateDetailed } from '@/features/planning-sheet/monit
 import { resolveProcedureUserQueryCandidates } from '../utils/resolveProcedureUserQuery';
 import { isAuthRequiredError } from '@/lib/errors';
 import { useKioskAttendance } from '../hooks/useKioskAttendance';
+import { KioskProcedureRecordSummary } from './KioskProcedureRecordSummary';
 
 const buildProcedureMatchKeys = (
   procedure: { id?: unknown; rowNo?: unknown },
@@ -858,6 +859,14 @@ export const KioskProcedureListScreen: React.FC = () => {
                       <Typography variant="body2" color="text.secondary" noWrap>
                         {step.instruction}
                       </Typography>
+                      {(statusType === 'recorded' || statusType === 'uncertain_local') && recordedRecord && (
+                        <KioskProcedureRecordSummary
+                          record={recordedRecord}
+                          mode="compact"
+                          syncState={statusType === 'uncertain_local' ? 'local-uncertain' : 'confirmed'}
+                          testId={`kiosk-procedure-record-summary-${index}`}
+                        />
+                      )}
                     </Grid>
                     <Grid size={3} sx={{ textAlign: 'right' }}>
                       <Button

--- a/src/features/kiosk/components/KioskProcedureRecordSummary.tsx
+++ b/src/features/kiosk/components/KioskProcedureRecordSummary.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import { Box, Chip, Paper, Stack, Typography } from '@mui/material';
+import type { ExecutionRecord } from '@/features/daily/domain/executionRecordTypes';
+import { parseKioskProcedureMemo } from '../domain/kioskProcedureMemo';
+
+type SummaryMode = 'compact' | 'full';
+type SyncState = 'confirmed' | 'local-uncertain' | 'unknown';
+
+type KioskProcedureRecordSummaryProps = {
+  record?: Pick<ExecutionRecord, 'memo' | 'recordedAt'> | null;
+  mode?: SummaryMode;
+  syncState?: SyncState;
+  testId?: string;
+};
+
+const formatRecordedAt = (value?: string): string => {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  return new Intl.DateTimeFormat('ja-JP', {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+    timeZone: 'Asia/Tokyo',
+  }).format(date);
+};
+
+export const KioskProcedureRecordSummary: React.FC<KioskProcedureRecordSummaryProps> = ({
+  record,
+  mode = 'compact',
+  syncState = 'confirmed',
+  testId = 'kiosk-procedure-record-summary',
+}) => {
+  const parsed = parseKioskProcedureMemo(record?.memo);
+  const items = [
+    { key: 'mood', label: '様子', value: parsed.mood },
+    { key: 'action', label: '対応', value: parsed.action },
+    { key: 'result', label: '変化', value: parsed.result },
+    { key: 'memo', label: 'メモ', value: parsed.memo },
+  ].filter((item) => item.value.trim().length > 0);
+  const recordedAt = formatRecordedAt(record?.recordedAt);
+
+  if (items.length === 0 && !(mode === 'full' && recordedAt)) {
+    return null;
+  }
+
+  if (mode === 'compact') {
+    return (
+      <Box
+        data-testid={testId}
+        sx={{
+          mt: 1.25,
+          p: 1.25,
+          borderRadius: 2,
+          bgcolor: syncState === 'local-uncertain' ? 'warning.lighter' : 'background.paper',
+          border: '1px solid',
+          borderColor: syncState === 'local-uncertain' ? 'warning.light' : 'success.light',
+        }}
+      >
+        <Stack spacing={0.5}>
+          {items.map((item) => (
+            <Typography
+              key={item.key}
+              variant="caption"
+              color="text.secondary"
+              data-testid={`${testId}-${item.key}`}
+              sx={{
+                display: '-webkit-box',
+                WebkitLineClamp: item.key === 'memo' ? 2 : 1,
+                WebkitBoxOrient: 'vertical',
+                overflow: 'hidden',
+                overflowWrap: 'anywhere',
+              }}
+            >
+              <Box component="span" sx={{ fontWeight: 'bold', color: 'text.primary' }}>
+                {item.label}:
+              </Box>{' '}
+              {item.value}
+            </Typography>
+          ))}
+        </Stack>
+      </Box>
+    );
+  }
+
+  return (
+    <Paper
+      elevation={0}
+      data-testid={testId}
+      sx={{
+        p: 3,
+        mb: 3,
+        borderRadius: 4,
+        border: '1px solid',
+        borderColor: 'success.light',
+        bgcolor: 'success.lighter',
+      }}
+    >
+      <Stack spacing={2}>
+        <Stack direction="row" alignItems="center" spacing={1} useFlexGap flexWrap="wrap">
+          <Typography variant="h6" sx={{ fontWeight: 'bold', color: 'success.dark' }}>
+            保存済みの記録内容
+          </Typography>
+          {recordedAt && (
+            <Chip
+              size="small"
+              variant="outlined"
+              color="success"
+              label={`保存日時 ${recordedAt}`}
+              data-testid={`${testId}-recorded-at`}
+            />
+          )}
+        </Stack>
+        <Stack spacing={1.25}>
+          {items.map((item) => (
+            <Box key={item.key} data-testid={`${testId}-${item.key}`}>
+              <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 'bold' }}>
+                {item.label}
+              </Typography>
+              <Typography
+                variant="body1"
+                color="text.primary"
+                sx={{ whiteSpace: 'pre-wrap', overflowWrap: 'anywhere' }}
+              >
+                {item.value}
+              </Typography>
+            </Box>
+          ))}
+        </Stack>
+      </Stack>
+    </Paper>
+  );
+};

--- a/src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx
@@ -307,6 +307,65 @@ describe('KioskProcedureDetailScreen (memory provider URL for local UI behavior 
     expect(mockSaveRecord).not.toHaveBeenCalled();
   });
 
+  it('shows a saved-record confirmation panel while keeping the editable form restored', async () => {
+    mockUseExecutionRecord.mockReturnValue(
+      makeExecutionRecordHookResult({
+        record: makeExecutionRecord({
+          memo: '【様子】落ち着いていた\n【対応】見守り\n【変化】改善した\n【メモ】問題なく実施完了',
+        }),
+      }),
+    );
+
+    render(
+      <MemoryRouter>
+        <KioskProcedureDetailScreen />
+      </MemoryRouter>
+    );
+
+    const panel = screen.getByTestId('kiosk-saved-record-summary');
+    expect(panel).toHaveTextContent('保存済みの記録内容');
+    expect(panel).toHaveTextContent('様子');
+    expect(panel).toHaveTextContent('落ち着いていた');
+    expect(panel).toHaveTextContent('対応');
+    expect(panel).toHaveTextContent('見守り');
+    expect(panel).toHaveTextContent('変化');
+    expect(panel).toHaveTextContent('改善した');
+    expect(panel).toHaveTextContent('メモ');
+    expect(panel).toHaveTextContent('問題なく実施完了');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mood-chip-落ち着いていた').className).toContain('MuiChip-filledWarning');
+      expect(screen.getByTestId('action-chip-見守り').className).toContain('MuiChip-filledWarning');
+      expect(screen.getByTestId('result-chip-改善した').className).toContain('MuiChip-filledWarning');
+      expect(screen.getByTestId('kiosk-observation-memo')).toHaveValue('問題なく実施完了');
+    });
+  });
+
+  it('shows raw saved memo as memo fallback in the saved-record confirmation panel', async () => {
+    mockUseExecutionRecord.mockReturnValue(
+      makeExecutionRecordHookResult({
+        record: makeExecutionRecord({
+          memo: '自由入力だけの保存済みメモ',
+        }),
+      }),
+    );
+
+    render(
+      <MemoryRouter>
+        <KioskProcedureDetailScreen />
+      </MemoryRouter>
+    );
+
+    const panel = screen.getByTestId('kiosk-saved-record-summary');
+    expect(panel).toHaveTextContent('保存済みの記録内容');
+    expect(panel).toHaveTextContent('メモ');
+    expect(panel).toHaveTextContent('自由入力だけの保存済みメモ');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('kiosk-observation-memo')).toHaveValue('自由入力だけの保存済みメモ');
+    });
+  });
+
   it('postpones form state initialization and populates form from saved record after user load transitions from loading to success', async () => {
     mockUseUser.mockReturnValue({ data: null, status: 'loading' });
 

--- a/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
+++ b/src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx
@@ -234,6 +234,45 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
     });
   });
 
+  it('shows saved record summary on recorded procedure cards', async () => {
+    mockGetRecords.mockResolvedValue([
+      {
+        scheduleItemId: '1',
+        status: 'completed',
+        memo: '【様子】落ち着いていた\n【対応】見守り\n【変化】改善した\n【メモ】問題なく実施完了',
+      }
+    ]);
+
+    render(
+      <MemoryRouter>
+        <KioskProcedureListScreen />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      const firstCard = screen.getByTestId('kiosk-procedure-card-0');
+      const summary = within(firstCard).getByTestId('kiosk-procedure-record-summary-0');
+      expect(summary).toHaveTextContent('様子: 落ち着いていた');
+      expect(summary).toHaveTextContent('対応: 見守り');
+      expect(summary).toHaveTextContent('変化: 改善した');
+      expect(summary).toHaveTextContent('メモ: 問題なく実施完了');
+    });
+  });
+
+  it('does not show saved record summary on unrecorded procedure cards', async () => {
+    render(
+      <MemoryRouter>
+        <KioskProcedureListScreen />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      const firstCard = screen.getByTestId('kiosk-procedure-card-0');
+      expect(within(firstCard).getByText('未実施')).toBeInTheDocument();
+      expect(within(firstCard).queryByTestId('kiosk-procedure-record-summary-0')).toBeNull();
+    });
+  });
+
   it('shows an auth-required alert instead of user-not-found when user lookup requires Microsoft 365 auth', async () => {
     mockRouteUserId = '23';
     mockUseUser.mockReturnValue({
@@ -1343,7 +1382,12 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
     it('shows "同期状態未確認" Chip for slots with local cache and "状態未確認" for others when SharePoint load fails', async () => {
       mockGetRecords.mockRejectedValue(new Error('SharePoint fetch failed'));
       mockGetStoreRecords.mockReturnValue([
-        { scheduleItemId: '1', status: 'completed', recordedAt: '2026-05-08T10:00:00Z' }
+        {
+          scheduleItemId: '1',
+          status: 'completed',
+          memo: '【様子】落ち着いていた\n【対応】見守り',
+          recordedAt: '2026-05-08T10:00:00Z',
+        }
       ]);
 
       render(
@@ -1353,7 +1397,10 @@ describe('KioskProcedureListScreen (includes local/memory-style recorded-state c
       );
 
       await waitFor(() => {
-        expect(screen.getByTestId('kiosk-uncertain-local-chip-0')).toBeInTheDocument();
+        const firstCard = screen.getByTestId('kiosk-procedure-card-0');
+        expect(within(firstCard).getByTestId('kiosk-uncertain-local-chip-0')).toBeInTheDocument();
+        expect(within(firstCard).getByTestId('kiosk-procedure-record-summary-0')).toHaveTextContent('様子: 落ち着いていた');
+        expect(within(firstCard).getByTestId('kiosk-procedure-record-summary-0')).toHaveTextContent('対応: 見守り');
         expect(screen.getByTestId('kiosk-uncertain-chip-1')).toBeInTheDocument();
         expect(screen.queryByText('未実施')).toBeNull();
         expect(screen.queryByText('記録済み')).toBeNull();


### PR DESCRIPTION
## Summary

- Added a reusable `KioskProcedureRecordSummary` display component for saved `/kiosk/users` procedure record memos.
- Show saved memo summaries on recorded procedure list cards.
- Show a saved-record confirmation panel above the editable detail form.
- Added component coverage for parsed memo display, raw memo fallback, unrecorded cards, uncertain local records, and preserved detail form restoration.

## Scope

UI-only kiosk procedure record visibility improvement.

## Acceptance criteria

- Saved memo summary visible on recorded cards.
- No summary on unrecorded cards.
- Warning state retained for uncertain local records.
- Saved confirmation panel visible on detail.
- Existing form restoration maintained.
- Raw memo fallback supported.
- No backend, SharePoint, repository, route, `facilityId`, save/cancel, ABC, or history changes.

## Checks

- `npm run test -- src/features/kiosk/components/__tests__/KioskProcedureListScreen.spec.tsx src/features/kiosk/components/__tests__/KioskProcedureDetailScreen.spec.tsx --reporter=verbose --no-file-parallelism`
- `npm run typecheck`
- `npm run lint`
- `git diff --cached --check`

## Not included

- No backend changes.
- No SharePoint schema changes.
- No repository API changes.
- No route/query behavior changes.
- No `ExecutionRecord` type changes.
- No `facilityId` work.
- No save/cancel, ABC, or history behavior changes.