### PR TITLE
feat(admin): add duplicate checks to data integrity scan

### DIFF
--- a/src/lib/dataIntegrityScanner.ts
+++ b/src/lib/dataIntegrityScanner.ts
@@ -5,6 +5,18 @@ import { translateZodIssue } from './zodErrorUtils';
 // Types
 // ────────────────────────────────────────────────────────────────────────────
 
+/** Duplicate-check rule definition */
+export interface DuplicateCheckRule {
+  /** Rule key used for export and grouping */
+  id: string;
+  /** Human-readable label for UI/report */
+  label: string;
+  /** Internal field names that compose one business key */
+  fields: readonly string[];
+  /** Skip records missing any key component (recommended for noisy data) */
+  ignoreMissing?: boolean;
+}
+
 /** A single scan target (SharePoint list + Zod schema) */
 export interface ScanTarget {
   /** Technical key (e.g. 'users_master', 'schedules') */
@@ -17,6 +29,8 @@ export interface ScanTarget {
   schema: ZodType;
   /** SP $select fields */
   selectFields: readonly string[];
+  /** Duplicate-check rules for business-key duplicate detection */
+  duplicateChecks?: readonly DuplicateCheckRule[];
 }
 
 /** A single invalid record detected during the scan */
@@ -31,6 +45,25 @@ export interface ScanIssue {
   zodIssues: z.ZodIssue[];
 }
 
+/** Duplicate detection issue (one duplicated key group) */
+export interface DuplicateIssue {
+  target: string;
+  /** Rule identifier */
+  ruleId: string;
+  /** Rule label */
+  ruleLabel: string;
+  /** Canonical key for display/export */
+  key: string;
+  /** Raw key components keyed by field names */
+  keyValues: Record<string, string>;
+  /** Total records in the duplicated group */
+  recordCount: number;
+  /** Duplicate count = recordCount - 1 */
+  duplicateCount: number;
+  /** SharePoint IDs in duplicated group */
+  recordIds: Array<number | string>;
+}
+
 export interface ScanResult {
   target: string;
   displayName?: string;
@@ -39,6 +72,8 @@ export interface ScanResult {
   valid: number;
   invalid: number;
   issues: ScanIssue[];
+  duplicateIssues: DuplicateIssue[];
+  duplicateCount: number;
   durationMs: number;
   /** Phase 1 result */
   fetchStatus: 'success' | 'failed' | 'skipped';
@@ -69,12 +104,129 @@ export interface TargetData {
   skippedFields?: string[];
 }
 
+const DUPLICATE_KEY_SEPARATOR = '||';
+const EMPTY_VALUE_MARK = '<空>';
+
+function getRecordId(item: unknown): number | string {
+  if (typeof item === 'object' && item !== null && 'Id' in item) {
+    const id = (item as Record<string, unknown>).Id;
+    if (typeof id === 'number' || typeof id === 'string') return id;
+  }
+  return 'unknown';
+}
+
+function normalizeDuplicateValue(raw: unknown): string {
+  if (raw === null || raw === undefined) return '';
+
+  if (typeof raw === 'boolean') return raw ? 'true' : 'false';
+
+  if (typeof raw === 'number') return String(raw);
+
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim();
+    if (!trimmed) return '';
+
+    if (/^\d{4}[-/]\d{2}[-/]\d{2}$/.test(trimmed)) {
+      return trimmed.replace(/\//g, '-');
+    }
+
+    if (/^\d{4}-\d{2}-\d{2}T/.test(trimmed)) {
+      return trimmed.substring(0, 10);
+    }
+
+    const parsed = new Date(trimmed);
+    if (!Number.isNaN(parsed.getTime()) && /^\d/.test(trimmed)) {
+      return parsed.toISOString().substring(0, 10);
+    }
+
+    return trimmed.toLowerCase();
+  }
+
+  try {
+    return JSON.stringify(raw) ?? '';
+  } catch {
+    return String(raw);
+  }
+}
+
+function toObject(item: unknown): Record<string, unknown> | undefined {
+  if (item === null || item === undefined) return undefined;
+  if (typeof item === 'object') return item as Record<string, unknown>;
+  return undefined;
+}
+
+function findDuplicateIssues(
+  items: unknown[],
+  target: string,
+  rules: readonly DuplicateCheckRule[] = [],
+): DuplicateIssue[] {
+  if (rules.length === 0 || items.length === 0) return [];
+
+  const outputs: DuplicateIssue[] = [];
+
+  for (const rule of rules) {
+    const groups = new Map<
+      string,
+      { values: Record<string, string>; count: number; ids: Array<number | string> }
+    >();
+
+    for (const item of items) {
+      const row = toObject(item);
+      if (!row) continue;
+
+      const keyValues = rule.fields.reduce<Record<string, string>>((acc, field) => {
+        const normalized = normalizeDuplicateValue(row[field]);
+        acc[field] = normalized === '' ? EMPTY_VALUE_MARK : normalized;
+        return acc;
+      }, {});
+
+      const hasMissing = Object.values(keyValues).some((value) => value === EMPTY_VALUE_MARK);
+      if (hasMissing && rule.ignoreMissing !== false) {
+        continue;
+      }
+
+      const valuesForKey = Object.values(keyValues).map((value) => value.replace(/\|/g, '\\|'));
+      const compositeKey = `${rule.id}${DUPLICATE_KEY_SEPARATOR}${valuesForKey.join(DUPLICATE_KEY_SEPARATOR)}`;
+      const prev = groups.get(compositeKey);
+      const recordId = getRecordId(item);
+
+      if (!prev) {
+        groups.set(compositeKey, {
+          values: keyValues,
+          count: 1,
+          ids: [recordId],
+        });
+      } else {
+        prev.count += 1;
+        prev.ids.push(recordId);
+      }
+    }
+
+    for (const [key, group] of groups) {
+      if (group.count > 1) {
+        outputs.push({
+          target,
+          ruleId: rule.id,
+          ruleLabel: rule.label,
+          key,
+          keyValues: group.values,
+          recordCount: group.count,
+          duplicateCount: Math.max(0, group.count - 1),
+          recordIds: group.ids,
+        });
+      }
+    }
+  }
+
+  return outputs.sort((a, b) => b.recordCount - a.recordCount);
+}
+
 // ────────────────────────────────────────────────────────────────────────────
 // Core: validate an array of raw items against a schema
 // ────────────────────────────────────────────────────────────────────────────
 
 /**
- * Validate an array of raw SharePoint items against a Zod schema.
+ * Validate an array of raw items against a schema.
  * Uses `safeParse` so it collects ALL issues instead of throwing.
  */
 export function validateItems(
@@ -92,10 +244,7 @@ export function validateItems(
       valid++;
     } else {
       invalid++;
-      const recordId =
-        typeof item === 'object' && item !== null && 'Id' in item
-          ? (item as Record<string, unknown>).Id as number
-          : 'unknown';
+      const recordId = getRecordId(item);
 
       issues.push({
         target: targetName,
@@ -150,6 +299,8 @@ export function scanAll(
 
     const start = performance.now();
     const { valid, invalid, issues } = validateItems(items, target.schema, target.name);
+    const duplicateIssues = findDuplicateIssues(items, target.name, target.duplicateChecks);
+    const duplicateCount = duplicateIssues.reduce((sum, issue) => sum + issue.duplicateCount, 0);
     const durationMs = Math.round(performance.now() - start);
 
     results.push({
@@ -160,6 +311,8 @@ export function scanAll(
       valid,
       invalid,
       issues,
+      duplicateIssues,
+      duplicateCount,
       durationMs,
       fetchStatus: entry.fetchStatus,
       fetchError: entry.fetchError,
@@ -189,7 +342,9 @@ export function formatScanSummary(results: ScanResult[]): string {
 
   for (const r of results) {
     const fetchSuffix = r.isTruncated ? ' (上限到達)' : '';
-    lines.push(`【${r.target}】 ${r.total}件中 ${r.valid}件 OK / ${r.invalid}件 エラー${fetchSuffix} (${r.durationMs}ms)`);
+    lines.push(
+      `【${r.target}】 ${r.total}件中 ${r.valid}件 OK / ${r.invalid}件 エラー / ${r.duplicateCount}件 重複${fetchSuffix} (${r.durationMs}ms)`,
+    );
     if (r.fetchStatus === 'failed') {
       lines.push(`  ⚠ 取得エラー: ${r.fetchError}`);
     }
@@ -199,19 +354,28 @@ export function formatScanSummary(results: ScanResult[]): string {
     for (const issue of r.issues) {
       lines.push(`  ▸ ID ${issue.recordId}: ${issue.messages.join('; ')}`);
     }
+    for (const issue of r.duplicateIssues) {
+      const keyText = Object.entries(issue.keyValues)
+        .map(([field, value]) => `${field}=${value}`)
+        .join(', ');
+      lines.push(`  ▸ 重複キー (${issue.ruleLabel}): ${keyText} / ${issue.duplicateCount}件`);
+    }
     lines.push('');
   }
 
   const totalInvalid = results.reduce((sum, r) => sum + r.invalid, 0);
-  const fetchFailures = results.filter(r => r.fetchStatus === 'failed').length;
+  const totalDuplicate = results.reduce((sum, r) => sum + r.duplicateCount, 0);
+  const fetchFailures = results.filter((r) => r.fetchStatus === 'failed').length;
   if (fetchFailures > 0) {
     lines.push(`⚠ ${fetchFailures}件のリストで取得エラーがありました（未検証）。`);
   }
-  lines.push(totalInvalid === 0 && fetchFailures === 0
-    ? '✅ すべてのデータが正常です。'
-    : totalInvalid > 0
-      ? `⚠ ${totalInvalid}件の不整合データが見つかりました。`
-      : '');
+  lines.push(
+    totalInvalid === 0 && fetchFailures === 0
+      ? '✅ すべてのデータが正常です。'
+      : totalInvalid > 0
+        ? `⚠ ${totalInvalid}件の不整合データが見つかりました。`
+        : `⚠ ${totalDuplicate}件の重複の可能性があります。`,
+  );
 
   return lines.join('\n');
 }

--- a/src/pages/admin/DataIntegrityPage.tsx
+++ b/src/pages/admin/DataIntegrityPage.tsx
@@ -1,6 +1,5 @@
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
-import ErrorIcon from '@mui/icons-material/Error';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import StopIcon from '@mui/icons-material/Stop';
 import Alert from '@mui/material/Alert';
@@ -10,6 +9,7 @@ import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
 import Container from '@mui/material/Container';
 import Divider from '@mui/material/Divider';
+import ErrorIcon from '@mui/icons-material/Error';
 import LinearProgress from '@mui/material/LinearProgress';
 import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
@@ -20,7 +20,7 @@ import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Typography from '@mui/material/Typography';
-import type { ZodTypeAny } from 'zod';
+import { z, type ZodTypeAny } from 'zod';
 import React, { useCallback, useMemo, useState } from 'react';
 
 import { SharePointDailyRecordItemSchema } from '@/features/daily/domain/schema';
@@ -36,34 +36,192 @@ import {
 import { useSP } from '@/lib/spClient';
 import { getDriftProbeTargets } from '@/sharepoint/driftProbeRegistry';
 
-// ────────────────────────────────────────────────────────────────────────────
-// Pre-defined scan targets
-// ────────────────────────────────────────────────────────────────────────────
+type DuplicateRule = {
+  id: string;
+  label: string;
+  fields: readonly string[];
+  ignoreMissing?: boolean;
+};
 
 /** 
  * Map technical registry keys to their corresponding validation schemas.
  * This bridge connects the operational registry (SSOT) with UI-level Zod validation.
  */
 const SCHEMA_MAP: Record<string, ZodTypeAny> = {
-  'users_master': SpUserMasterItemSchema,
-  'schedules': SpScheduleRowSchema,
-  'daily_activity_records': SharePointDailyRecordItemSchema,
+  users_master: SpUserMasterItemSchema,
+  schedule_events: SpScheduleRowSchema,
+  daily_activity_records: SharePointDailyRecordItemSchema,
+};
+
+const FALLBACK_SCHEMA = z.unknown();
+
+/** Duplicate-key checks for major operational lists */
+const INTEGRITY_DUPLICATE_RULES: Record<string, readonly DuplicateRule[]> = {
+  users_master: [
+    {
+      id: 'user-id',
+      label: '利用者ID',
+      fields: ['UserID'],
+    },
+  ],
+  schedule_events: [
+    {
+      id: 'user-schedule-slot',
+      label: '対象者の時間軸',
+      fields: ['TargetUserId', 'EventDate', 'EndDate'],
+      ignoreMissing: true,
+    },
+    {
+      id: 'staff-schedule-slot',
+      label: '担当者の時間軸',
+      fields: ['AssignedStaffId', 'EventDate', 'EndDate'],
+      ignoreMissing: true,
+    },
+  ],
+  daily_activity_records: [
+    {
+      id: 'user-activity',
+      label: '利用者別活動時刻',
+      fields: ['UserCode', 'RecordDate', 'TimeSlot', 'PlanSlotKey'],
+      ignoreMissing: true,
+    },
+  ],
+  support_procedure_record_daily: [
+    {
+      id: 'isp-detail-key',
+      label: 'ISP詳細キー',
+      fields: ['UserCode', 'RecordDate', 'PlanningSheetId'],
+      ignoreMissing: true,
+    },
+  ],
+  isp_master: [
+    {
+      id: 'isp-master-user-start',
+      label: 'ISP開始日',
+      fields: ['UserCode', 'PlanStartDate'],
+      ignoreMissing: true,
+    },
+  ],
+  planning_sheet_master: [
+    {
+      id: 'planning-sheet-user',
+      label: '支援計画シート',
+      fields: ['UserCode', 'UserId', 'ISPId'],
+      ignoreMissing: true,
+    },
+  ],
+  planning_sheet_reassessment_master: [
+    {
+      id: 'reassessment-date',
+      label: '再評価日',
+      fields: ['PlanningSheetId', 'ReassessmentDate'],
+      ignoreMissing: true,
+    },
+  ],
+  support_plans: [
+    {
+      id: 'draft-id',
+      label: 'ドラフトID',
+      fields: ['DraftId'],
+      ignoreMissing: true,
+    },
+  ],
+  service_provision_records: [
+    {
+      id: 'service-entry',
+      label: '提供実績エントリ',
+      fields: ['EntryKey'],
+      ignoreMissing: true,
+    },
+  ],
 };
 
 /**
- * Derived scan targets for depth-validation.
- * We only deep-scan a subset of all drift-probed lists which have defined schemas.
+ * Derived scan targets for depth-validation and duplicate checks.
  */
 const SCAN_TARGETS: ScanTarget[] = getDriftProbeTargets()
-  .filter(t => t.key in SCHEMA_MAP)
-  .map(t => ({
-    name: t.key,
-    displayName: t.displayName,
-    listTitle: t.listTitle,
-    schema: SCHEMA_MAP[t.key],
-    selectFields: t.selectFields,
-  }));
+  .filter((target) =>
+    Object.prototype.hasOwnProperty.call(SCHEMA_MAP, target.key) ||
+    Object.prototype.hasOwnProperty.call(INTEGRITY_DUPLICATE_RULES, target.key)
+  )
+  .map((target) => {
+    const duplicateChecks = INTEGRITY_DUPLICATE_RULES[target.key];
+    const duplicateFields = duplicateChecks ? [...new Set(duplicateChecks.flatMap((rule) => rule.fields))] : [];
+    return {
+      name: target.key,
+      displayName: target.displayName,
+      listTitle: target.listTitle,
+      schema: SCHEMA_MAP[target.key] ?? FALLBACK_SCHEMA,
+      selectFields: Array.from(new Set([...target.selectFields, ...duplicateFields])),
+      duplicateChecks,
+    };
+  });
 
+const csvEscape = (value: unknown): string => {
+  const text = String(value ?? '').replace(/\r?\n/g, ' ');
+  const escaped = text.replace(/"/g, '""');
+  return `"${escaped}"`;
+};
+
+const buildDuplicateCsv = (results: ScanResult[]): string => {
+  const header = [
+    'リストキー',
+    '表示名',
+    '一覧名',
+    'ルールID',
+    'ルール名',
+    '重複キー',
+    '重複件数',
+    '該当ID',
+    'キー項目(見出し=値)',
+  ];
+
+  const rows = [header.join(',')];
+
+  for (const result of results) {
+    for (const issue of result.duplicateIssues) {
+      rows.push([
+        result.target,
+        result.displayName ?? '',
+        result.listTitle,
+        issue.ruleId,
+        issue.ruleLabel,
+        issue.key,
+        issue.duplicateCount,
+        issue.recordIds.join(','),
+        Object.entries(issue.keyValues)
+          .map(([name, val]) => `${name}=${val}`)
+          .join(' | '),
+      ].map(csvEscape).join(','));
+    }
+  }
+
+  return rows.join('\n');
+};
+
+const buildDuplicateJson = (results: ScanResult[]) => ({
+  generatedAt: new Date().toISOString(),
+  totals: {
+    lists: results.length,
+    records: results.reduce((sum, result) => sum + result.total, 0),
+    invalid: results.reduce((sum, result) => sum + result.invalid, 0),
+    duplicateGroups: results.reduce((sum, result) => sum + result.duplicateIssues.length, 0),
+    duplicateRows: results.reduce((sum, result) => sum + result.duplicateCount, 0),
+  },
+  results,
+});
+
+const downloadText = (content: string, filename: string, mimeType: string): void => {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+};
 
 // ────────────────────────────────────────────────────────────────────────────
 // Component
@@ -72,19 +230,20 @@ const SCAN_TARGETS: ScanTarget[] = getDriftProbeTargets()
 /**
  * 管理者用データ整合性ダッシュボード。
  *
- * 全 SharePoint リストのデータを Zod スキーマで一括検証し、
- * 不整合レコードの一覧を表示するページ。
+ * 全 SharePoint リストを Zod スキーマで一括検証し、重複キーを検知した結果を表示するページ。
  */
 const DataIntegrityPage: React.FC = () => {
   const { spFetch } = useSP();
   const { status, progress, results, error: scanError, startScan, cancelScan } = useDataIntegrityScan();
   const [copied, setCopied] = useState(false);
+  const [runId, setRunId] = useState<string>('');
   const [fetchingData, setFetchingData] = useState(false);
   const [fetchError, setFetchError] = useState<string | null>(null);
 
   const handleStartScan = useCallback(async () => {
     const requestId = `di-${Date.now().toString(36)}`;
     try {
+      setRunId(requestId);
       setFetchingData(true);
       setFetchError(null);
 
@@ -97,10 +256,20 @@ const DataIntegrityPage: React.FC = () => {
             target.listTitle,
             target.selectFields,
           );
-          data.set(target.name, { items, fetchStatus: 'success', isTruncated, skippedFields });
+          data.set(target.name, {
+            items,
+            fetchStatus: 'success',
+            isTruncated,
+            skippedFields,
+          });
 
           if (skippedFields.length > 0) {
-            emitSkippedFieldTelemetry({ listKey: target.name, skippedFields, count: items.length, requestId });
+            emitSkippedFieldTelemetry({
+              listKey: target.name,
+              skippedFields,
+              count: items.length,
+              requestId,
+            });
           }
         } catch (fetchErr) {
           // eslint-disable-next-line no-console
@@ -123,7 +292,6 @@ const DataIntegrityPage: React.FC = () => {
     }
   }, [spFetch, startScan]);
 
-
   const handleCopy = useCallback(async () => {
     if (results.length === 0) return;
     const summary = formatScanSummary(results);
@@ -136,15 +304,30 @@ const DataIntegrityPage: React.FC = () => {
     }
   }, [results]);
 
+  const handleExportCsv = useCallback(() => {
+    if (results.length === 0) return;
+    const csv = buildDuplicateCsv(results);
+    const filename = `data-integrity-duplicates-${runId || 'latest'}.csv`;
+    downloadText(csv, filename, 'text/csv;charset=utf-8;');
+  }, [results, runId]);
+
+  const handleExportJson = useCallback(() => {
+    if (results.length === 0) return;
+    const json = JSON.stringify(buildDuplicateJson(results), null, 2);
+    const filename = `data-integrity-duplicates-${runId || 'latest'}.json`;
+    downloadText(json, filename, 'application/json;charset=utf-8;');
+  }, [results, runId]);
+
   const totalStats = useMemo(() => {
     if (results.length === 0) return null;
     return {
-      total: results.reduce((s, r) => s + r.total, 0),
-      valid: results.reduce((s, r) => s + r.valid, 0),
-      invalid: results.reduce((s, r) => s + r.invalid, 0),
-      duration: results.reduce((s, r) => s + r.durationMs, 0),
-      // fetchStatus === 'failed' のリスト数。0件成功を「正常」と誤判定しないための必須フラグ
-      fetchFailures: results.filter(r => r.fetchStatus === 'failed').length,
+      total: results.reduce((sum, r) => sum + r.total, 0),
+      valid: results.reduce((sum, r) => sum + r.valid, 0),
+      invalid: results.reduce((sum, r) => sum + r.invalid, 0),
+      duplicates: results.reduce((sum, r) => sum + r.duplicateCount, 0),
+      duplicateGroups: results.reduce((sum, r) => sum + r.duplicateIssues.length, 0),
+      duration: results.reduce((sum, r) => sum + r.durationMs, 0),
+      fetchFailures: results.filter((r) => r.fetchStatus === 'failed').length,
     };
   }, [results]);
 
@@ -154,7 +337,7 @@ const DataIntegrityPage: React.FC = () => {
         🔍 データ整合性チェック
       </Typography>
       <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
-        SharePoint のデータを Zod スキーマで一括検証し、不整合レコードを特定します。
+        SharePoint のデータを Zod スキーマで検証し、主要ビジネスキーの重複を検知します。
       </Typography>
 
       {/* ── Control Bar ──────────────────────── */}
@@ -178,6 +361,18 @@ const DataIntegrityPage: React.FC = () => {
             data-testid="copy-report-btn"
           >
             {copied ? 'コピー済み ✓' : 'レポートをコピー'}
+          </Button>
+        )}
+
+        {results.length > 0 && (
+          <Button variant="outlined" onClick={handleExportCsv} data-testid="export-csv-btn">
+            CSVエクスポート
+          </Button>
+        )}
+
+        {results.length > 0 && (
+          <Button variant="outlined" onClick={handleExportJson} data-testid="export-json-btn">
+            JSONエクスポート
           </Button>
         )}
       </Stack>
@@ -207,20 +402,22 @@ const DataIntegrityPage: React.FC = () => {
       {status === 'done' && totalStats && (
         <>
           <Alert
-            severity={totalStats.invalid === 0 && totalStats.fetchFailures === 0 ? 'success' : 'warning'}
-            icon={totalStats.invalid === 0 && totalStats.fetchFailures === 0 ? <CheckCircleIcon /> : <ErrorIcon />}
+            severity={totalStats.invalid === 0 && totalStats.duplicates === 0 && totalStats.fetchFailures === 0 ? 'success' : 'warning'}
+            icon={totalStats.invalid === 0 && totalStats.duplicates === 0 && totalStats.fetchFailures === 0 ? <CheckCircleIcon /> : <ErrorIcon />}
             sx={{ mb: 2 }}
             data-testid="scan-summary"
           >
             <AlertTitle sx={{ fontWeight: 700 }}>
-              {totalStats.fetchFailures > 0
+            {totalStats.fetchFailures > 0
                 ? `⚠ ${totalStats.fetchFailures}件のリストで取得エラー（検証未完了）`
-                : totalStats.invalid === 0
-                  ? '✅ すべてのデータが正常です'
-                  : `⚠ ${totalStats.invalid}件の不整合が検出されました`}
+                : totalStats.invalid > 0
+                  ? `⚠ ${totalStats.invalid}件の不整合が検出されました`
+                  : totalStats.duplicates > 0
+                    ? `⚠ ${totalStats.duplicates}件の重複の可能性がある記録があります（重複種別 ${totalStats.duplicateGroups}）`
+                    : '✅ すべてのデータが正常です'}
             </AlertTitle>
-            {totalStats.total}件検証 / {totalStats.valid}件 OK / {totalStats.invalid}件 エラー ({totalStats.duration}ms)
-            {results.some(r => r.isTruncated) && (
+            {totalStats.total}件検証 / {totalStats.valid}件 OK / {totalStats.invalid}件 エラー / {totalStats.duplicates}件 重複 ({totalStats.duration}ms)
+            {results.some((r) => r.isTruncated) && (
               <Typography variant="caption" display="block" sx={{ mt: 0.5, fontWeight: 700 }}>
                 ※ 一部のリストで取得上限（10,000件）に到達したため、全件を検証できていない可能性があります。
               </Typography>
@@ -231,8 +428,7 @@ const DataIntegrityPage: React.FC = () => {
           <Alert severity="info" sx={{ mb: 3 }}>
             <AlertTitle sx={{ fontWeight: 700, fontSize: '0.85rem' }}>ℹ️ SharePoint 行サイズ制限 (8KB) に関する注意</AlertTitle>
             <Typography variant="caption">
-              Users_Master 等のフィールド数が多いリストでは、SharePoint の内部制限により一部の列が保存されない、
-              あるいは「列の合計サイズが制限を超えている」エラーが発生する場合があります。
+              Users_Master 等のフィールド数が多いリストでは、SharePoint の内部制限により一部の列が保存されない、あるいは「列の合計サイズが制限を超えている」エラーが発生する場合があります。
               本ツールで「取得エラー」や「必須欠落」が頻発する場合、不要な列の削除や統合を検討してください。
             </Typography>
           </Alert>
@@ -259,6 +455,7 @@ const DataIntegrityPage: React.FC = () => {
                   <TableCell align="right" sx={{ fontWeight: 700 }}>取得数</TableCell>
                   <TableCell align="right" sx={{ fontWeight: 700 }}>検証OK</TableCell>
                   <TableCell align="right" sx={{ fontWeight: 700 }}>検証NG</TableCell>
+                  <TableCell align="right" sx={{ fontWeight: 700 }}>重複件数</TableCell>
                   <TableCell align="right" sx={{ fontWeight: 700 }}>時間</TableCell>
                 </TableRow>
               </TableHead>
@@ -277,9 +474,9 @@ const DataIntegrityPage: React.FC = () => {
                       <Stack spacing={0.5} alignItems="flex-start">
                         {r.fetchStatus === 'success' ? (
                           <Chip
-                            label={r.isTruncated ? "上限到達" : "成功"}
+                            label={r.isTruncated ? '上限到達' : '成功'}
                             size="small"
-                            color={r.isTruncated ? "warning" : "success"}
+                            color={r.isTruncated ? 'warning' : 'success'}
                             variant="filled"
                             sx={{ height: 20, fontSize: '0.7rem' }}
                           />
@@ -325,6 +522,15 @@ const DataIntegrityPage: React.FC = () => {
                         '-'
                       )}
                     </TableCell>
+                    <TableCell align="right">
+                      {r.duplicateCount > 0 ? (
+                        <Typography color="warning.main" variant="body2" fontWeight={700}>
+                          {r.duplicateCount.toLocaleString()} ({r.duplicateIssues.length})
+                        </Typography>
+                      ) : (
+                        '-'
+                      )}
+                    </TableCell>
                     <TableCell align="right" color="text.secondary">{r.durationMs}ms</TableCell>
                   </TableRow>
                 ))}
@@ -344,7 +550,7 @@ const DataIntegrityPage: React.FC = () => {
           {results
             .filter((r) => r.issues.length > 0)
             .map((r) => (
-              <Box key={r.target} sx={{ mb: 3 }}>
+              <Box key={`issue-${r.target}`} sx={{ mb: 3 }}>
                 <Typography variant="subtitle2" component="span" sx={{ mb: 1, color: 'warning.dark' }}>
                   {r.displayName || r.target} — {r.issues.length}件
                 </Typography>
@@ -377,6 +583,49 @@ const DataIntegrityPage: React.FC = () => {
                               </Typography>
                             ))}
                           </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </TableContainer>
+              </Box>
+            ))}
+        </>
+      )}
+
+      {/* ── Duplicate Details ──────────────────────── */}
+      {status === 'done' && results.some((r) => r.duplicateIssues.length > 0) && (
+        <>
+          <Divider sx={{ my: 2 }} />
+          <Typography variant="h6" gutterBottom sx={{ fontWeight: 600 }}>
+            🔁 重複キー詳細
+          </Typography>
+          {results
+            .filter((r) => r.duplicateIssues.length > 0)
+            .map((r) => (
+              <Box key={`dup-${r.target}`} sx={{ mb: 3 }}>
+                <Typography variant="subtitle2" component="span" sx={{ mb: 1, color: 'warning.dark' }}>
+                  {r.displayName || r.target} — {r.duplicateIssues.length}種
+                </Typography>
+                <TableContainer component={Paper} variant="outlined">
+                  <Table size="small" data-testid={`duplicate-${r.target}`}>
+                    <TableHead>
+                      <TableRow sx={{ bgcolor: 'warning.light', opacity: 0.12 }}>
+                        <TableCell sx={{ fontWeight: 700 }}>ルール</TableCell>
+                        <TableCell sx={{ fontWeight: 700 }}>キー</TableCell>
+                        <TableCell align="right" sx={{ fontWeight: 700 }}>重複件数</TableCell>
+                        <TableCell sx={{ fontWeight: 700 }}>対象ID</TableCell>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {r.duplicateIssues.map((issue) => (
+                        <TableRow key={`${issue.ruleId}-${issue.key}`}>
+                          <TableCell>{issue.ruleLabel}</TableCell>
+                          <TableCell>
+                            {Object.entries(issue.keyValues).map(([field, value]) => `${field}=${value}`).join(', ')}
+                          </TableCell>
+                          <TableCell align="right">{issue.duplicateCount}</TableCell>
+                          <TableCell>{issue.recordIds.map((id) => String(id)).join(', ')}</TableCell>
                         </TableRow>
                       ))}
                     </TableBody>

--- a/tests/unit/DataIntegrityPage.spec.tsx
+++ b/tests/unit/DataIntegrityPage.spec.tsx
@@ -23,6 +23,21 @@ import DataIntegrityPage from '@/pages/admin/DataIntegrityPage';
 
 const mockUseDataIntegrityScan = vi.mocked(useDataIntegrityScan);
 
+const duplicateIssueFixture = {
+  target: 'users',
+  ruleId: 'user-date-process',
+  ruleLabel: '利用者・日付・工程',
+  key: 'user-date-process||U001||2026-07-09||A',
+  keyValues: {
+    UserCode: 'U001',
+    RecordDate: '2026-07-09',
+    Process: 'A',
+  },
+  recordCount: 2,
+  duplicateCount: 1,
+  recordIds: [101, 102],
+};
+
 describe('DataIntegrityPage', () => {
   it('renders with scan button in idle state', () => {
     mockUseDataIntegrityScan.mockReturnValue({
@@ -63,7 +78,18 @@ describe('DataIntegrityPage', () => {
       status: 'done',
       progress: null,
       results: [
-        { target: 'users', listTitle: 'Users_Master', total: 100, valid: 100, invalid: 0, issues: [], durationMs: 42, fetchStatus: 'success' },
+        {
+          target: 'users',
+          listTitle: 'Users_Master',
+          total: 100,
+          valid: 100,
+          invalid: 0,
+          duplicateCount: 0,
+          duplicateIssues: [],
+          issues: [],
+          durationMs: 42,
+          fetchStatus: 'success',
+        },
       ],
       error: null,
       startScan: vi.fn(),
@@ -87,6 +113,8 @@ describe('DataIntegrityPage', () => {
           total: 50,
           valid: 48,
           invalid: 2,
+          duplicateCount: 0,
+          duplicateIssues: [],
           issues: [
             { target: 'users', recordId: 101, messages: ['「氏名」は必須項目です'], zodIssues: [] },
             { target: 'users', recordId: 205, messages: ['想定外の値'], zodIssues: [] },
@@ -149,6 +177,8 @@ describe('DataIntegrityPage', () => {
       results: [
         {
           target: 'users', listTitle: 'Users_Master', total: 33, valid: 33, invalid: 0,
+          duplicateCount: 0,
+          duplicateIssues: [],
           issues: [], durationMs: 10, fetchStatus: 'success', skippedFields: ['UserID'],
         },
       ],
@@ -171,6 +201,8 @@ describe('DataIntegrityPage', () => {
       results: [
         {
           target: 'users', listTitle: 'Users_Master', total: 100, valid: 100, invalid: 0,
+          duplicateCount: 0,
+          duplicateIssues: [],
           issues: [], durationMs: 10, fetchStatus: 'success',
         },
       ],
@@ -191,10 +223,14 @@ describe('DataIntegrityPage', () => {
       results: [
         {
           target: 'users', listTitle: 'Users_Master', total: 33, valid: 33, invalid: 0,
+          duplicateCount: 0,
+          duplicateIssues: [],
           issues: [], durationMs: 10, fetchStatus: 'success', skippedFields: ['UserID'],
         },
         {
           target: 'daily', listTitle: 'DailyActivityRecords', total: 10, valid: 10, invalid: 0,
+          duplicateCount: 0,
+          duplicateIssues: [],
           issues: [], durationMs: 5, fetchStatus: 'success',
         },
       ],
@@ -210,5 +246,39 @@ describe('DataIntegrityPage', () => {
     expect(screen.getByText('構成診断を確認する →')).toBeDefined();
     // daily has no skippedFields → no link
     expect(screen.queryByTestId('skipped-fields-link-daily')).toBeNull();
+  });
+
+  it('shows duplicate possibility details and export buttons', () => {
+    mockUseDataIntegrityScan.mockReturnValue({
+      status: 'done',
+      progress: null,
+      results: [
+        {
+          target: 'users',
+          listTitle: 'Users_Master',
+          total: 10,
+          valid: 8,
+          invalid: 0,
+          duplicateCount: 1,
+          duplicateIssues: [duplicateIssueFixture],
+          issues: [],
+          durationMs: 11,
+          fetchStatus: 'success',
+        },
+      ],
+      error: null,
+      startScan: vi.fn(),
+      cancelScan: vi.fn(),
+    });
+
+    render(<DataIntegrityPage />);
+
+    expect(screen.getByText(/重複の可能性がある記録があります/)).toBeDefined();
+    expect(screen.getByTestId('duplicate-users')).toBeDefined();
+    expect(screen.getByText('利用者・日付・工程')).toBeDefined();
+    expect(screen.getByText('101, 102')).toBeDefined();
+    expect(screen.getByTestId('export-csv-btn')).toBeDefined();
+    expect(screen.getByTestId('export-json-btn')).toBeDefined();
+    expect(screen.getByText(/重複種別/)).toBeDefined();
   });
 });

--- a/tests/unit/dataIntegrityScanner.spec.ts
+++ b/tests/unit/dataIntegrityScanner.spec.ts
@@ -29,6 +29,26 @@ const testTarget: ScanTarget = {
   selectFields: ['Id', 'Title', 'Email'],
 };
 
+const duplicateTarget: ScanTarget = {
+  name: 'test-daily-dup',
+  listTitle: 'Daily_Duplicate_Test',
+  schema: z.object({
+    Id: z.number(),
+    UserCode: z.string(),
+    RecordDate: z.string(),
+    Process: z.string(),
+  }),
+  selectFields: ['Id', 'UserCode', 'RecordDate', 'Process'],
+  duplicateChecks: [
+    {
+      id: 'user-date-process',
+      label: '利用者・日付・工程',
+      fields: ['UserCode', 'RecordDate', 'Process'],
+      ignoreMissing: true,
+    },
+  ],
+};
+
 // ────────────────────────────────────────────────────────────────────────────
 // validateItems
 // ────────────────────────────────────────────────────────────────────────────
@@ -143,6 +163,117 @@ describe('scanAll', () => {
     expect(results[0].total).toBe(0);
     expect(results[0].valid).toBe(0);
     expect(results[0].invalid).toBe(0);
+  });
+
+  it('returns duplicateCount 0 when no duplicate keys exist', () => {
+    const data = new Map<string, TargetData>([
+      [
+        'test-daily-dup',
+        {
+          items: [
+            { Id: 1, UserCode: 'U001', RecordDate: '2026-07-09', Process: 'A' },
+            { Id: 2, UserCode: 'U002', RecordDate: '2026-07-10', Process: 'A' },
+            { Id: 3, UserCode: 'U001', RecordDate: '2026-07-09', Process: 'B' },
+          ],
+          fetchStatus: 'success',
+        },
+      ],
+    ]);
+
+    const [result] = scanAll([duplicateTarget], data);
+
+    expect(result.duplicateCount).toBe(0);
+    expect(result.duplicateIssues).toHaveLength(0);
+  });
+
+  it('detects duplicate groups for identical keys and counts excess rows', () => {
+    const data = new Map<string, TargetData>([
+      [
+        'test-daily-dup',
+        {
+          items: [
+            { Id: 101, UserCode: 'U001', RecordDate: '2026-07-09', Process: 'A' },
+            { Id: 102, UserCode: 'U001', RecordDate: '2026-07-09', Process: 'A' },
+            { Id: 103, UserCode: 'U002', RecordDate: '2026-07-09', Process: 'A' },
+          ],
+          fetchStatus: 'success',
+        },
+      ],
+    ]);
+
+    const [result] = scanAll([duplicateTarget], data);
+
+    expect(result.duplicateIssues).toHaveLength(1);
+    expect(result.duplicateCount).toBe(1);
+    expect(result.duplicateIssues[0].recordIds).toEqual([101, 102]);
+    expect(result.duplicateIssues[0].recordCount).toBe(2);
+  });
+
+  it('normalizes date formats so 2026-07-09 and 2026/07/09 match', () => {
+    const data = new Map<string, TargetData>([
+      [
+        'test-daily-dup',
+        {
+          items: [
+            { Id: 201, UserCode: 'U001', RecordDate: '2026-07-09', Process: 'A' },
+            { Id: 202, UserCode: 'U001', RecordDate: '2026/07/09', Process: 'A' },
+            { Id: 203, UserCode: 'U002', RecordDate: '2026-07-10', Process: 'B' },
+          ],
+          fetchStatus: 'success',
+        },
+      ],
+    ]);
+
+    const [result] = scanAll([duplicateTarget], data);
+
+    expect(result.duplicateCount).toBe(1);
+    expect(result.duplicateIssues).toHaveLength(1);
+    expect(result.duplicateIssues[0].keyValues).toEqual({
+      UserCode: 'u001',
+      RecordDate: '2026-07-09',
+      Process: 'a',
+    });
+  });
+
+  it('does not treat similar records with different process as duplicates', () => {
+    const data = new Map<string, TargetData>([
+      [
+        'test-daily-dup',
+        {
+          items: [
+            { Id: 301, UserCode: 'U001', RecordDate: '2026-07-09', Process: 'A' },
+            { Id: 302, UserCode: 'U001', RecordDate: '2026-07-09', Process: 'B' },
+          ],
+          fetchStatus: 'success',
+        },
+      ],
+    ]);
+
+    const [result] = scanAll([duplicateTarget], data);
+
+    expect(result.duplicateCount).toBe(0);
+    expect(result.duplicateIssues).toHaveLength(0);
+  });
+
+  it('does not create duplicate flags only from missing key values when ignoreMissing is true', () => {
+    const data = new Map<string, TargetData>([
+      [
+        'test-daily-dup',
+        {
+          items: [
+            { Id: 401, UserCode: 'U001', RecordDate: '', Process: 'A' },
+            { Id: 402, UserCode: '', RecordDate: '', Process: 'A' },
+            { Id: 403, UserCode: '', RecordDate: '2026-07-09', Process: 'A' },
+          ],
+          fetchStatus: 'success',
+        },
+      ],
+    ]);
+
+    const [result] = scanAll([duplicateTarget], data);
+
+    expect(result.duplicateCount).toBe(0);
+    expect(result.duplicateIssues).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## Summary
- Add duplicate-key detection to the admin data integrity scan
- Normalize date values for duplicate grouping
- Show duplicate candidates in the data integrity page
- Add CSV/JSON exports for duplicate candidates
## Safety
- Uses “重複の可能性” wording to avoid overclaiming
- Ignores missing-key-only duplicate groups
- Keeps existing schema validation behavior unchanged
## Tests
- npm run typecheck
- npm run lint
- npm run test -- dataIntegrityScanner DataIntegrityPage