### PR TITLE
fix(admin): align duplicate candidate wording

### DIFF
--- a/src/lib/dataIntegrityScanner.ts
+++ b/src/lib/dataIntegrityScanner.ts
@@ -343,7 +343,7 @@ export function formatScanSummary(results: ScanResult[]): string {
   for (const r of results) {
     const fetchSuffix = r.isTruncated ? ' (上限到達)' : '';
     lines.push(
-      `【${r.target}】 ${r.total}件中 ${r.valid}件 OK / ${r.invalid}件 エラー / ${r.duplicateCount}件 重複${fetchSuffix} (${r.durationMs}ms)`,
+      `【${r.target}】 ${r.total}件中 ${r.valid}件 OK / ${r.invalid}件 エラー / ${r.duplicateCount}件 重複の可能性${fetchSuffix} (${r.durationMs}ms)`,
     );
     if (r.fetchStatus === 'failed') {
       lines.push(`  ⚠ 取得エラー: ${r.fetchError}`);

--- a/src/pages/admin/DataIntegrityPage.tsx
+++ b/src/pages/admin/DataIntegrityPage.tsx
@@ -337,7 +337,7 @@ const DataIntegrityPage: React.FC = () => {
         🔍 データ整合性チェック
       </Typography>
       <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
-        SharePoint のデータを Zod スキーマで検証し、主要ビジネスキーの重複を検知します。
+        SharePoint のデータを Zod スキーマで検証し、主要ビジネスキーの重複の可能性を検知します。
       </Typography>
 
       {/* ── Control Bar ──────────────────────── */}
@@ -416,7 +416,7 @@ const DataIntegrityPage: React.FC = () => {
                     ? `⚠ ${totalStats.duplicates}件の重複の可能性がある記録があります（重複種別 ${totalStats.duplicateGroups}）`
                     : '✅ すべてのデータが正常です'}
             </AlertTitle>
-            {totalStats.total}件検証 / {totalStats.valid}件 OK / {totalStats.invalid}件 エラー / {totalStats.duplicates}件 重複 ({totalStats.duration}ms)
+            {totalStats.total}件検証 / {totalStats.valid}件 OK / {totalStats.invalid}件 エラー / {totalStats.duplicates}件 重複の可能性 ({totalStats.duration}ms)
             {results.some((r) => r.isTruncated) && (
               <Typography variant="caption" display="block" sx={{ mt: 0.5, fontWeight: 700 }}>
                 ※ 一部のリストで取得上限（10,000件）に到達したため、全件を検証できていない可能性があります。

--- a/tests/unit/DataIntegrityPage.spec.tsx
+++ b/tests/unit/DataIntegrityPage.spec.tsx
@@ -274,6 +274,7 @@ describe('DataIntegrityPage', () => {
     render(<DataIntegrityPage />);
 
     expect(screen.getByText(/重複の可能性がある記録があります/)).toBeDefined();
+    expect(screen.getByText(/\d+件 重複の可能性 \(/)).toBeDefined();
     expect(screen.getByTestId('duplicate-users')).toBeDefined();
     expect(screen.getByText('利用者・日付・工程')).toBeDefined();
     expect(screen.getByText('101, 102')).toBeDefined();

--- a/tests/unit/dataIntegrityScanner.spec.ts
+++ b/tests/unit/dataIntegrityScanner.spec.ts
@@ -339,6 +339,7 @@ describe('formatScanSummary', () => {
     expect(summary).toContain('2件中 1件 OK / 1件 エラー');
     expect(summary).toContain('ID 2');
     expect(summary).toContain('不整合データが見つかりました');
+    expect(summary).toContain('重複の可能性');
   });
 
   it('includes ⚠ 列スキップ line when skippedFields are present', () => {


### PR DESCRIPTION
## Summary
- Align duplicate-related wording in data integrity scan summary and UI to indicate possible duplicates.
- Keep duplicate detection behavior unchanged while making messaging consistent.

## Safety
- Aligns duplicate-related UI and summary wording to “重複の可能性”.

## Tests
- npm run typecheck
- npm run lint
- npm run test -- dataIntegrityScanner DataIntegrityPage
- npx vitest run tests/unit/dataIntegrityScanner.spec.ts tests/unit/DataIntegrityPage.spec.tsx
