### PR TITLE
fix(security): block credentials in patrol artifacts

### DIFF
--- a/.github/workflows/nightly-patrol.yml
+++ b/.github/workflows/nightly-patrol.yml
@@ -425,8 +425,15 @@ jobs:
             echo "Nightly Patrol is report-only in CI; review the uploaded artifacts instead of pushing directly to main."
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Upload generated patrol reports
+      - name: Scan generated patrol reports for credential material
+        id: report_secret_scan
         if: ${{ always() }}
+        env:
+          SP_TOKEN: ${{ secrets.SP_TOKEN }}
+        run: npm run patrol:artifact-scan -- docs/nightly-patrol
+
+      - name: Upload generated patrol reports
+        if: ${{ always() && steps.report_secret_scan.outcome == 'success' }}
         uses: actions/upload-artifact@v4
         with:
           name: nightly-patrol-reports-${{ github.run_number }}

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "patrol:telemetry": "node scripts/ops/materialize-sp-telemetry.mjs",
     "patrol:telemetry:capture": "node scripts/ops/capture-sp-telemetry-lanes.mjs",
     "patrol:assert": "node scripts/ops/assert-telemetry-lanes.mjs",
+    "patrol:artifact-scan": "node scripts/ops/assert-patrol-artifacts-safe.mjs",
     "patrol:dashboard": "node scripts/ops/os-metrics.mjs",
     "patrol:raw-fetch": "node scripts/ops/fetch-nightly-raw-summaries.mjs",
     "patrol:admin-status": "node scripts/ops/export-admin-status-summary.mjs",

--- a/scripts/ops/__tests__/assert-patrol-artifacts-safe.spec.mjs
+++ b/scripts/ops/__tests__/assert-patrol-artifacts-safe.spec.mjs
@@ -1,0 +1,58 @@
+// @vitest-environment node
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { assertPatrolArtifactsSafe, findUnsafePatrolArtifacts } from '../assert-patrol-artifacts-safe.mjs';
+
+const SCRIPT = path.join(process.cwd(), 'scripts', 'ops', 'assert-patrol-artifacts-safe.mjs');
+const tmpDirs = [];
+
+function makeReport(content) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'patrol-artifact-scan-'));
+  tmpDirs.push(dir);
+  const filePath = path.join(dir, 'report.json');
+  fs.writeFileSync(filePath, content, 'utf8');
+  return { dir, filePath };
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('assert-patrol-artifacts-safe', () => {
+  it('accepts reports without credential-like material', () => {
+    const { dir } = makeReport(JSON.stringify({ diagnostics: [{ code: 'sp_probe_fetch_error' }] }));
+    expect(assertPatrolArtifactsSafe([dir], { token: 'not-present' })).toEqual({ scannedFiles: 1 });
+  });
+
+  it.each([
+    'Authorization: Bearer secret-value',
+    'Bearer secret-value',
+    'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.signature',
+  ])('detects credential patterns without returning matched values', (content) => {
+    const { dir } = makeReport(content);
+    expect(findUnsafePatrolArtifacts([dir])).toHaveLength(1);
+  });
+
+  it('detects the current token even when it is not JWT-shaped', () => {
+    const token = 'opaque-current-token';
+    const { dir } = makeReport(`diagnostic=${token}`);
+    expect(findUnsafePatrolArtifacts([dir], { token })).toHaveLength(1);
+  });
+
+  it('fails closed without printing detected secret material', () => {
+    const secret = 'opaque-current-token';
+    const { dir } = makeReport(`diagnostic=${secret}`);
+    const result = spawnSync(process.execPath, [SCRIPT, dir], {
+      env: { ...process.env, SP_TOKEN: secret },
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(1);
+    expect(`${result.stdout}${result.stderr}`).toContain('Credential-like material detected');
+    expect(`${result.stdout}${result.stderr}`).not.toContain(secret);
+  });
+});

--- a/scripts/ops/__tests__/capture-sp-telemetry-lanes.spec.mjs
+++ b/scripts/ops/__tests__/capture-sp-telemetry-lanes.spec.mjs
@@ -117,4 +117,46 @@ describe('capture-sp-telemetry-lanes', () => {
     expect(assertResult.stderr).not.toContain('SP_TELEMETRY_PATH is required in strict mode');
     expect(assertResult.stderr).not.toContain('Telemetry file missing in strict mode');
   });
+
+  it.each([
+    {
+      name: 'Error with an authorization header',
+      thrown: new Error('Headers.append: Authorization: Bearer test-token\n is an invalid header value'),
+    },
+    {
+      name: 'Error with a JWT-like value',
+      thrown: new Error('eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.signature'),
+    },
+    {
+      name: 'unknown thrown value',
+      thrown: { message: 'Bearer test-token' },
+    },
+  ])('does not persist external exception details for $name', async ({ thrown }) => {
+    const cwd = makeTempDir();
+    const outputPath = path.join(cwd, 'docs/nightly-patrol/sp-telemetry.json');
+    const fetchImpl = vi.fn(async () => {
+      throw thrown;
+    });
+
+    await captureAndWriteSpTelemetryLanes({
+      env: BASE_ENV,
+      fetchImpl,
+      outputPath,
+      now: () => new Date('2026-07-03T00:00:00.000Z'),
+    });
+
+    const writtenText = fs.readFileSync(outputPath, 'utf8');
+    const written = JSON.parse(writtenText);
+    expect(written.diagnostics).toEqual([
+      {
+        code: 'sp_probe_fetch_error',
+        message: 'The SharePoint read probe failed before receiving a response.',
+      },
+    ]);
+    expect(written.metrics.lanes.read).toMatchObject({ requests: 1, failed: 1 });
+    expect(written.topEndpoints[0]).toMatchObject({ endpoint: '/_api/web/currentuser', failures: 1 });
+    expect(writtenText).not.toContain('Bearer');
+    expect(writtenText).not.toContain('eyJ');
+    expect(writtenText).not.toContain(BASE_ENV.SP_TOKEN);
+  });
 });

--- a/scripts/ops/assert-patrol-artifacts-safe.mjs
+++ b/scripts/ops/assert-patrol-artifacts-safe.mjs
@@ -1,0 +1,62 @@
+/* eslint-disable no-console -- CI security guard */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const CREDENTIAL_PATTERNS = [
+  /\bBearer\s+[^\s"'<>]+/i,
+  /\bAuthorization\s*[:=]/i,
+  /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/,
+];
+
+function collectFiles(targetPath) {
+  const stat = fs.statSync(targetPath);
+  if (stat.isFile()) return [targetPath];
+  if (!stat.isDirectory()) return [];
+
+  return fs.readdirSync(targetPath, { withFileTypes: true }).flatMap((entry) => {
+    const childPath = path.join(targetPath, entry.name);
+    return entry.isDirectory() ? collectFiles(childPath) : entry.isFile() ? [childPath] : [];
+  });
+}
+
+export function findUnsafePatrolArtifacts(targetPaths, options = {}) {
+  const token = String(options.token ?? '').trim();
+  const files = targetPaths.flatMap(collectFiles);
+
+  return files.filter((filePath) => {
+    const content = fs.readFileSync(filePath, 'utf8');
+    if (token && content.includes(token)) return true;
+    return CREDENTIAL_PATTERNS.some((pattern) => pattern.test(content));
+  });
+}
+
+export function assertPatrolArtifactsSafe(targetPaths, options = {}) {
+  const unsafeFiles = findUnsafePatrolArtifacts(targetPaths, options);
+  if (unsafeFiles.length > 0) {
+    throw new Error(`Credential-like material detected in ${unsafeFiles.length} patrol artifact file(s).`);
+  }
+  return { scannedFiles: targetPaths.flatMap(collectFiles).length };
+}
+
+async function main() {
+  const targetPaths = process.argv.slice(2);
+  if (targetPaths.length === 0) {
+    console.error('[patrol-artifact-scan] No artifact path was provided.');
+    process.exitCode = 1;
+    return;
+  }
+
+  try {
+    const result = assertPatrolArtifactsSafe(targetPaths, { token: process.env.SP_TOKEN });
+    console.log(`[patrol-artifact-scan] Passed: ${result.scannedFiles} file(s) scanned.`);
+  } catch (error) {
+    console.error(`[patrol-artifact-scan] Blocked: ${error instanceof Error ? error.message : 'Artifact scan failed.'}`);
+    process.exitCode = 1;
+  }
+}
+
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+if (isMain) {
+  await main();
+}

--- a/scripts/ops/capture-sp-telemetry-lanes.mjs
+++ b/scripts/ops/capture-sp-telemetry-lanes.mjs
@@ -6,6 +6,21 @@ import { fileURLToPath } from 'node:url';
 export const SOURCE_KIND = 'nightly-patrol-sp-token-read-probe';
 export const DEFAULT_OUTPUT_PATH = path.join('docs', 'nightly-patrol', 'sp-telemetry.json');
 
+const SAFE_FAILURE_MESSAGES = Object.freeze({
+  sp_token_missing: 'SP_TOKEN is required for the Nightly Patrol SharePoint read probe.',
+  sp_config_missing_resource: 'SharePoint probe resource configuration is missing.',
+  sp_config_missing_site_relative: 'SharePoint probe site configuration is missing.',
+  sp_config_invalid_resource: 'SharePoint probe resource configuration is invalid.',
+  sp_config_invalid_site_relative: 'SharePoint probe site configuration is invalid.',
+  sp_config_invalid: 'SharePoint probe configuration is invalid.',
+  fetch_unavailable: 'The SharePoint read probe cannot run in this Node runtime.',
+  sp_probe_fetch_error: 'The SharePoint read probe failed before receiving a response.',
+});
+
+function safeFailureMessage(code) {
+  return SAFE_FAILURE_MESSAGES[code] ?? 'The SharePoint read probe failed.';
+}
+
 const EMPTY_LANE = Object.freeze({
   requests: 0,
   failed: 0,
@@ -147,7 +162,7 @@ export async function captureSpTelemetryLanes(options = {}) {
     return failureSnapshot({
       generatedAt,
       code: 'sp_token_missing',
-      message: 'SP_TOKEN is required for the Nightly Patrol SharePoint read probe.',
+      message: safeFailureMessage('sp_token_missing'),
     });
   }
 
@@ -155,10 +170,11 @@ export async function captureSpTelemetryLanes(options = {}) {
   try {
     config = resolveSharePointProbeConfig(env);
   } catch (error) {
+    const code = typeof error?.code === 'string' ? error.code : 'sp_config_invalid';
     return failureSnapshot({
       generatedAt,
-      code: error?.code || 'sp_config_invalid',
-      message: error instanceof Error ? error.message : 'SharePoint probe config is invalid.',
+      code,
+      message: safeFailureMessage(code),
     });
   }
 
@@ -166,7 +182,7 @@ export async function captureSpTelemetryLanes(options = {}) {
     return failureSnapshot({
       generatedAt,
       code: 'fetch_unavailable',
-      message: 'global fetch is not available in this Node runtime.',
+      message: safeFailureMessage('fetch_unavailable'),
     });
   }
 
@@ -213,7 +229,7 @@ export async function captureSpTelemetryLanes(options = {}) {
     return failureSnapshot({
       generatedAt,
       code: 'sp_probe_fetch_error',
-      message: error instanceof Error ? error.message : 'SharePoint read probe failed.',
+      message: safeFailureMessage('sp_probe_fetch_error'),
       requestStarted: true,
       endpointPath: config.endpointPath,
       durationMs: Math.max(0, Date.now() - startedAt),


### PR DESCRIPTION
## Summary
- replace raw SharePoint probe exception messages with allowlisted diagnostics
- scan generated Nightly Patrol reports for Bearer, JWT, Authorization, and current-token material
- suppress the generated reports upload when the scan fails
- add regression coverage that proves detected secrets are never printed

## Root cause
The capture path persisted `Error.message` into `sp-telemetry.json`. Node header validation errors can include the complete Authorization value, and the workflow uploaded the report directory without a credential-content gate.

## Validation
- targeted Vitest: 13 passed
- `actionlint -shellcheck= .github/workflows/nightly-patrol.yml`
- strict telemetry lane assertion: passed
- artifact scan against checked-in patrol reports: passed
- `npm run lint -- --quiet`: passed
- `npm run build`: passed
- `npm run typecheck:full -- --pretty false`: blocked by pre-existing `TodayBentoLayout.spec.tsx` type errors on `origin/main`

## Operations
Nightly Patrol is temporarily disabled and vulnerable `nightly-patrol-reports-122` through `-127` artifacts were deleted. Re-enable only after this fix is merged and `SP_TOKEN` has been revoked/reissued.