### PR TITLE
docs(ops): add nightly investigation start gate

### DIFF
--- a/docs/ops/nightly-investigation-note-2026-07-10.md
+++ b/docs/ops/nightly-investigation-note-2026-07-10.md
@@ -1,0 +1,141 @@
+# Nightly Investigation Note - 2026-07-10
+
+## Header
+
+- Investigation date: 2026-07-10
+- Repository: `yasutakesougo/audit-management-system-mvp`
+- Target branch: not started
+- Target commit: not started
+- Default branch SHA: not recorded for execution
+- Time window: 3 hours, planned
+- Operator: Codex / user-supervised
+- Overall judgment: `BLOCKED`
+
+## Start Gate Status
+
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| PR #2392 merged | satisfied | PR #2392 is `MERGED`; merge commit `acdc000d3f4569c1e1058f99c1e3463cbd0f6f83` |
+| PR #2392 required CI green | satisfied with note | Rerun checks include successful CI, CI Preflight, Quality Gates, Smoke Tests, E2E Deep Tests; earlier cancelled checks remain in history |
+| Old `SP_TOKEN` revoked | unverified | Secret value and revocation state cannot be checked from CLI without exposing credentials |
+| New `SP_TOKEN` configured | unverified | `SP_TOKEN` name exists, but whether it is the rotated token is not inferable from metadata |
+| `Nightly Patrol` enabled | blocked | `.github/workflows/nightly-patrol.yml` state is `disabled_manually` |
+| Secret-safe diagnostics active | partially satisfied | PR #2392 is merged; post-merge manual safety run is still pending |
+| Previous leaked artifacts absent | unverified | Recent artifact names were listed without content inspection; full historical content scan was not performed |
+| Target branch and SHA recorded | not_applicable | No workflow dispatch was started |
+
+## Workflow State
+
+| Workflow | Path | State |
+| --- | --- | --- |
+| Nightly Health | `.github/workflows/nightly-health.yml` | `active` |
+| Nightly Patrol | `.github/workflows/nightly-patrol.yml` | `disabled_manually` |
+| Nightly Runtime Patrol | `.github/workflows/nightly-runtime-patrol.yml` | `active` |
+
+## Secrets and Variables Snapshot
+
+Values were not read or printed. Only secret or variable names were checked.
+
+| Name | Status | Notes |
+| --- | --- | --- |
+| `SP_TOKEN` | configured | New-vs-old token state unverified |
+| `VITE_SP_RESOURCE` | missing | Not listed as GitHub Secret or Variable |
+| `VITE_SP_SITE_RELATIVE` | missing | Not listed as GitHub Secret or Variable |
+| `VITE_SP_SCOPE_DEFAULT` | configured | Listed as GitHub Secret |
+| `SPO_CERT_BASE64` | configured | Listed as GitHub Secret |
+| `SPO_CERT_PASSWORD` | configured | Listed as GitHub Secret |
+| `AAD_APP_ID` | configured | Listed as GitHub Secret |
+| `AAD_TENANT_ID` | configured | Listed as GitHub Secret |
+| `SHAREPOINT_SITE` | configured | Listed as GitHub Secret |
+| `TEAMS_WEBHOOK_URL` | configured | Listed as GitHub Secret |
+
+Additional observed secret name:
+
+- `NIGHTLY_SP_TOKEN`: configured
+
+## Runs
+
+No three-workflow investigation run was started because the start gate failed.
+
+| Workflow | Run ID | URL | Commit | Started | Finished | Conclusion |
+| --- | --- | --- | --- | --- | --- | --- |
+| Nightly Health | not run | | | | | `BLOCKED` |
+| Nightly Patrol | not run | | | | | `BLOCKED` |
+| Nightly Runtime Patrol | not run | | | | | `BLOCKED` |
+
+## Severity Summary
+
+| Severity | Count |
+| --- | ---: |
+| critical | 0 |
+| action_required | 0 |
+| watch | 0 |
+| silent | 0 |
+
+Counts are zero because the investigation did not start. They are not evidence
+of a green nightly state.
+
+## Findings
+
+- Occurred at: pre-dispatch start gate
+- Workflow/job: `Nightly Patrol`
+- Symptom: workflow is `disabled_manually`
+- Reproducibility: confirmed by `gh workflow list --all` and workflow API state
+- Impact: the required three-workflow sequence cannot safely start
+
+## Cause Analysis
+
+Confirmed facts:
+
+- PR #2392 is merged into `main`.
+- `Nightly Health` is active.
+- `Nightly Runtime Patrol` is active.
+- `Nightly Patrol` is disabled manually.
+- `SP_TOKEN` exists by name in GitHub Actions Secrets.
+- The CLI cannot prove whether the configured `SP_TOKEN` is newly rotated or still the old credential without exposing secret material.
+
+Inferred causes:
+
+- The sequence remains intentionally blocked as part of secret exposure containment.
+- Enabling `Nightly Patrol` before token rotation evidence and a safety run would prematurely end containment.
+
+Unknowns:
+
+- Whether the old `SP_TOKEN` has been revoked.
+- Whether the current `SP_TOKEN` value is the newly rotated token.
+- Whether post-PR #2392 artifact/log diagnostics have been exercised safely with the new token.
+- Whether all previous leaked artifact contents have been fully removed or made inaccessible.
+
+## Actions
+
+Same-night actions:
+
+- Did not run `Nightly Health`, `Nightly Patrol`, or `Nightly Runtime Patrol` as a sequence.
+- Recorded the start-gate state as `BLOCKED`.
+- Added a reusable runbook at `docs/ops/nightly-investigation-runbook.md`.
+
+Next business day actions:
+
+- Confirm old `SP_TOKEN` revocation in the identity provider or SharePoint access path.
+- Set or confirm the newly rotated `SP_TOKEN` in GitHub Actions Secrets without exposing its value.
+- Re-enable `Nightly Patrol` only after credential rotation evidence is available.
+- Run a safety-focused manual `Nightly Patrol` execution and verify artifact/log output does not include secrets.
+
+Next maintenance actions:
+
+- After the safety run passes, execute the full three-workflow investigation sequence.
+- Save one investigation note with Run IDs, artifact locations, severity counts, and final judgment.
+
+## Ownership
+
+- Owner: Operations / repository administrator
+- Due date: before next full nightly investigation
+- Related issues: none recorded in this note
+- Related PRs: PR #2392
+
+## Evidence
+
+- Saved artifacts: none collected for this blocked investigation
+- Key logs: workflow and secret metadata checks only
+- Secret scan result: values were not inspected; no secret values were printed in this note
+

--- a/docs/ops/nightly-investigation-runbook.md
+++ b/docs/ops/nightly-investigation-runbook.md
@@ -1,0 +1,264 @@
+# Nightly Investigation Runbook
+
+Last updated: 2026-07-10
+
+## Purpose
+
+This runbook defines the safe procedure for a same-night investigation using the
+three GitHub Actions workflows:
+
+- `Nightly Health`
+- `Nightly Patrol`
+- `Nightly Runtime Patrol`
+
+The investigation is read-only from the product code perspective. Its purpose is
+to detect operational anomalies, collect evidence, make a first-pass severity
+classification, and decide follow-up priority.
+
+## Start Gate
+
+Do not run the three-workflow sequence unless every gate below is satisfied.
+If any gate is not satisfied, record the investigation result as `BLOCKED`.
+
+| Gate | Required state |
+| --- | --- |
+| Secret guard PR | PR #2392 is merged into the target branch |
+| Required CI | Required checks for PR #2392 are green after rerun if needed |
+| Old credential | The leaked or potentially leaked old `SP_TOKEN` is revoked |
+| New credential | A new `SP_TOKEN` is set in GitHub Actions Secrets |
+| Workflow state | `Nightly Patrol` is no longer `disabled_manually` |
+| Secret-safe diagnostics | Artifact/log diagnostics avoid printing secret values |
+| Historical artifacts | Previously leaked artifacts are deleted or confirmed absent |
+| Target identity | Repository, branch, and commit SHA are recorded |
+
+Secrets and variables must be checked by name only. Never copy secret values into
+logs, notes, screenshots, PR comments, or artifacts.
+
+## Preflight Record
+
+Before dispatching workflows, record:
+
+- Repository
+- Target branch
+- Target commit SHA
+- Default branch SHA
+- Investigation start time
+- Investigation time window, default `3 hours`
+- Operator
+- Reason if the target is not latest `main`
+
+Record these settings as `configured`, `missing`, or `not_required`:
+
+- `SP_TOKEN`
+- `VITE_SP_RESOURCE`
+- `VITE_SP_SITE_RELATIVE`
+- `VITE_SP_SCOPE_DEFAULT`
+- `SPO_CERT_BASE64`
+- `SPO_CERT_PASSWORD`
+- `AAD_APP_ID`
+- `AAD_TENANT_ID`
+- `SHAREPOINT_SITE`
+- `TEAMS_WEBHOOK_URL`
+
+## Dispatch Order
+
+Run workflows in this exact order after each previous workflow completes and its
+evidence is saved:
+
+1. `Nightly Health`
+2. `Nightly Patrol`
+3. `Nightly Runtime Patrol`
+
+Record for every run:
+
+- Run ID and URL
+- Commit SHA
+- Start and end time
+- Conclusion
+- Failed job and step, if any
+- Artifact names
+
+Stop immediately if a log or artifact may contain a secret value. Revoke the
+credential, isolate or delete the artifact, and classify the investigation as
+`CRITICAL`.
+
+## Workflow Checks
+
+### Nightly Health
+
+Primary checks:
+
+- `e2e`
+- `ci:e2e`
+- `ci:perf-report`
+
+If this workflow fails but there is no evidence of secret exposure, collect the
+logs and artifacts, then continue only if later workflows are still safe and
+useful for diagnosis.
+
+### Nightly Patrol
+
+Primary checks:
+
+- Contract patrol
+- `act(...)` warning monitor
+- Coverage scan
+- Telemetry lane assertion
+- Decision summary
+- Artifact scan
+
+Record counts for:
+
+- `critical`
+- `action_required`
+- `watch`
+- `silent`
+
+If `critical` is detected, normal sequential execution may be stopped. If
+`Nightly Runtime Patrol` is skipped, record the reason.
+
+### Nightly Runtime Patrol
+
+Required artifacts:
+
+- `.nightly/runtime-summary.md`
+- `.nightly/runtime-summary.json`
+
+If these files are missing, classify the investigation as `INCOMPLETE` even if
+the workflow conclusion is `success`.
+
+## Analysis Rules
+
+Analyze in this order:
+
+1. Runtime severity from `runtime-summary`.
+2. Nightly decision classification.
+3. `act(...)` warning and coverage trend.
+
+Severity handling:
+
+| Classification | Required action |
+| --- | --- |
+| `critical` | Immediate containment or operational stop |
+| `action_required` | Investigation or remediation by next business day |
+| `watch` | Continue monitoring until the next nightly investigation |
+| `silent` | Evidence only, no action |
+
+Coverage and `act(...)` warnings are not regressions on a single-night change
+alone. Treat them as regression candidates only if they deviate from the 7-day
+baseline and reproduce on the same commit with the relevant job rerun.
+
+## Rerun Rules
+
+Do not rerun all three workflows by default. Rerun only the job or workflow
+needed to fix the cause classification.
+
+Rerun is allowed when:
+
+- GitHub Actions infrastructure failure is suspected.
+- External service transient failure is suspected.
+- Coverage or `act(...)` warning drift deviates from the 7-day baseline.
+- Reproducibility must be confirmed on the same commit.
+
+Always link the original Run ID and rerun Run ID. Keep the first failure in the
+record even if the rerun succeeds.
+
+## Final Judgment
+
+| Judgment | Condition |
+| --- | --- |
+| `GREEN` | All required workflows complete, `critical=0`, `action_required=0`, required artifacts present |
+| `ACTION_REQUIRED` | One or more `action_required` items exist |
+| `CRITICAL` | Immediate containment, secret exposure, data corruption, or operational stop is needed |
+| `WATCH` | Only `watch` items exist and no immediate action is required |
+| `BLOCKED` | Start gate, credentials, permissions, or workflow state prevents execution |
+| `INCOMPLETE` | Workflow or required artifacts are missing |
+
+Successful workflow conclusions alone are not sufficient for `GREEN`; required
+artifacts must also be present.
+
+## Investigation Note Template
+
+Use one investigation note per investigation.
+
+```markdown
+# Nightly Investigation Note - YYYY-MM-DD
+
+## Header
+
+- Investigation date:
+- Repository:
+- Target branch:
+- Target commit:
+- Default branch SHA:
+- Time window:
+- Operator:
+- Overall judgment:
+
+## Runs
+
+| Workflow | Run ID | URL | Commit | Started | Finished | Conclusion |
+| --- | --- | --- | --- | --- | --- | --- |
+| Nightly Health | | | | | | |
+| Nightly Patrol | | | | | | |
+| Nightly Runtime Patrol | | | | | | |
+
+## Severity Summary
+
+| Severity | Count |
+| --- | ---: |
+| critical | |
+| action_required | |
+| watch | |
+| silent | |
+
+## Findings
+
+- Occurred at:
+- Workflow/job:
+- Symptom:
+- Reproducibility:
+- Impact:
+
+## Cause Analysis
+
+Confirmed facts:
+
+- 
+
+Inferred causes:
+
+- 
+
+Unknowns:
+
+- 
+
+## Actions
+
+Same-night actions:
+
+- 
+
+Next business day actions:
+
+- 
+
+Next maintenance actions:
+
+- 
+
+## Ownership
+
+- Owner:
+- Due date:
+- Related issues:
+- Related PRs:
+
+## Evidence
+
+- Saved artifacts:
+- Key logs:
+- Secret scan result:
+```
+


### PR DESCRIPTION
## Summary
- Add a reusable runbook for the three-workflow nightly investigation sequence with an explicit restart gate.
- Record the current 2026-07-10 investigation as `BLOCKED` instead of dispatching workflows.
- Preserve the key operational facts: PR #2392 is merged, `Nightly Patrol` is still `disabled_manually`, and token rotation cannot be proven from secret metadata alone.

## Validation
- No workflow dispatch was performed.
- Checked workflow states by name only:
  - `Nightly Health`: active
  - `Nightly Patrol`: disabled_manually
  - `Nightly Runtime Patrol`: active
- Checked GitHub Secret/Variable names only; no secret values were read or printed.

## Notes
- `docs/nightly-patrol/*.md` is ignored as generated output, so the investigation note is stored under `docs/ops/` for repository tracking.