### PR TITLE
docs(architecture): standardize modular migration workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -96,6 +96,15 @@
 - [ ] ドキュメント: 必要に応じて README / docs を更新
 - [ ] 既存の a11y/usability gate に影響がないことを確認した
 
+### Module Boundary Changes（`src/features/*` の境界を変更する場合）
+- [ ] [ADR-024](docs/adr/ADR-024-modular-monolith-module-boundaries.md) と [移行プレイブック](docs/architecture/modular-monolith-migration-playbook.md) に準拠した
+- [ ] 外部参照を公開 `index.ts` に限定し、新しい内部パス参照を追加していない
+- [ ] domain から UI / adapter / SharePoint / Firestore / localStorage への依存がない
+- [ ] Repository interface は ports、基盤実装は adapters、全体の組み立ては `src/app` に置いた
+- [ ] `npm run arch:check` が新規違反0、baseline 921以下で通った
+- [ ] shared/commonへ移動した場合、ADR-024の5条件をすべて満たす根拠を記載した
+- [ ] 未変更モジュールの再配置や、別モジュールの移行を混在させていない
+
 ### UI Changes
 - [ ] **a11y/usability checklist**: [docs/checklists/a11y-usability-rollout-checklist.md](docs/checklists/a11y-usability-rollout-checklist.md) を適用済み
 - [ ] **UI語彙チェック**: UI表示語が統一語彙（`個別支援計画` / `支援計画シート` / `支援手順の実施` / `日々の記録` / `見直し・PDCA`）に準拠している

--- a/ARCHITECTURE_GUARDS.md
+++ b/ARCHITECTURE_GUARDS.md
@@ -6,11 +6,16 @@ This document lists ESLint-enforced architectural patterns that prevent common v
 
 ADR-024 のモジュール境界は dependency-cruiser で検査する。
 
+- 運用手順: [Modular Monolith Migration Playbook](docs/architecture/modular-monolith-migration-playbook.md)
+- `record-quality` の実証完了時点の baseline は **921件** とし、以後は増加を認めない。
+
 - `npm run arch:check`: 現在の known violations を許容し、新しい違反だけを失敗させる。
 - `npm run arch:baseline`: 違反を解消した後にベースラインを再生成する。
 - `.dependency-cruiser-known-violations.json` への手編集や、変更と無関係な違反追加は禁止する。
 - ベースライン差分は、違反が減っていること、または ADR で明示承認された例外だけが
   追加されていることをレビューする。
+- `arch:check` の結果はPR本文に記録し、baselineが921件以下かつ変更前以下であることを
+  確認する。
 
 検査対象は feature 間の内部パス参照、domain から外部基盤への依存、
 公開 API を経由しないモジュール参照、runtime 循環依存である。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -120,4 +120,5 @@
 | 設計原則 10 箇条 | [docs/product/principles.md](../product/principles.md) |
 | UI 設計規約 | [docs/product/ui-conventions.md](../product/ui-conventions.md) |
 | OS Architecture | [docs/product/support-operations-os-architecture.md](../product/support-operations-os-architecture.md) |
+| モジュラーモノリス移行手順 | [docs/architecture/modular-monolith-migration-playbook.md](../architecture/modular-monolith-migration-playbook.md) |
 | ロードマップ | [docs/product/roadmap.md](../product/roadmap.md) |

--- a/docs/architecture/modular-monolith-migration-playbook.md
+++ b/docs/architecture/modular-monolith-migration-playbook.md
@@ -1,0 +1,108 @@
+# Modular Monolith Migration Playbook
+
+ADR-024 を、既存機能を止めずに業務モジュールへ適用するための運用手順です。
+`record-quality` を最初の実証例とし、未変更モジュールの再配置は行いません。
+
+## 固定する設計契約
+
+- 全体は単一デプロイのモジュラーモノリスとする。
+- DDD の業務機能をモジュール境界とする。
+- 業務 7 層、ISP L1/L2/L3、ドメイン型 SSOT、ADR 優先順位は維持する。
+- モジュール外からの参照は公開 `index.ts` に限定する。
+- Repository interface は `ports`、基盤実装は `adapters`、全体の組み立ては
+  `src/app` の composition root に置く。
+- CRUD 全体のイベント化、全面再配置、根拠のないマイクロサービス化は行わない。
+
+```text
+src/features/<module>/
+├── index.ts
+├── ui/
+├── application/
+├── domain/
+├── ports/
+└── adapters/
+```
+
+許可する依存方向と共有層の採用条件は
+[ADR-024](../adr/ADR-024-modular-monolith-module-boundaries.md) を正とします。
+
+## 着手条件と優先順位
+
+移行は、そのモジュールに機能変更または不具合修正が発生した場合だけ着手します。
+移行だけを目的に、未変更モジュールを再配置してはいけません。
+
+同時に複数候補へ変更が入る場合の優先順位は次のとおりです。
+
+1. `billing`
+2. `monitoring`
+3. `users`
+
+`today` は統合ハブであるため、複数の低リスクモジュールで運用が定着するまで
+移行対象外とします。
+
+## 変更前の境界調査
+
+対象モジュールを `<module>` として、少なくとも次を確認します。
+
+```bash
+# 外部から内部パスを直接参照している箇所
+rg "@/features/<module>/|features/<module>/" src \
+  --glob '!src/features/<module>/**'
+
+# domain から UI、adapter、外部基盤への依存
+rg "@/features|@/lib|sharepoint|firebase|localStorage" \
+  src/features/<module>/domain
+
+# 現在の依存ガード
+npm run arch:check
+```
+
+調査結果はPR本文に、公開する契約、残す既存違反、今回削減する違反として記録します。
+
+## PRの分割
+
+原則として、次の順序を別PRに分けます。各PRは既存挙動を変えず、単独でCIを通します。
+
+1. **公開API**: `index.ts` を定義し、外部利用を公開APIへ寄せる。
+2. **内部境界**: 純粋な業務ルールを `domain`、Repository契約を `ports` へ置く。
+3. **基盤分離**: SharePoint、Firestore、localStorage等の実装を `adapters` へ置く。
+4. **composition**: UI内のRepository生成や横断オーケストレーションを `src/app` へ移す。
+
+小規模モジュールで複数段階をまとめる場合も、公開API、内部境界、compositionの差分が
+レビュー上識別できる状態にします。別モジュールの移行は同じPRへ混在させません。
+
+## 完了条件
+
+```bash
+npm run arch:check
+npm run typecheck:full -- --pretty false
+npm run lint
+npm run build
+```
+
+- 新規依存違反が0件である。
+- known violations baselineが921件以下で、変更前から増えていない。
+- 対象モジュールのテストが通る。
+- 外部からの内部パス参照、domainから外部基盤への参照、runtime循環依存が増えていない。
+- 業務7層、ISP境界、ドメイン型SSOT、既存の利用者向け挙動を変更していない。
+
+違反を削減した場合だけ `npm run arch:baseline` でbaselineを更新します。手編集や、
+無関係な違反を含む全面再生成は行いません。
+
+## shared / common への移動
+
+次のすべてを満たす場合だけ共有層へ置けます。
+
+1. 2つ以上のモジュールで実際に使われている。
+2. 業務上の所有モジュールを特定できない。
+3. 外部基盤に依存しない。
+4. 変更理由が一つである。
+5. モジュール固有の型を参照しない。
+
+条件を満たさない業務概念は、所有モジュールを決めて公開APIから提供します。
+
+## 実証例
+
+`src/features/record-quality` を標準例とします。新しいモジュール境界を設計するときは、
+公開 `index.ts`、`domain / application / ports / adapters / ui`、および
+`src/app/routes/RecordQualityHumanReviewRoute.tsx` のcompositionを参照してください。

--- a/docs/checklists/module-starter-checklist.md
+++ b/docs/checklists/module-starter-checklist.md
@@ -1,31 +1,42 @@
 # Module Starter Checklist
 
-福祉OSの新しいモジュール（機能）を開発する着手時から完了までに確認すべき、共通レール準拠のチェックリストです。
-開発者（人間）およびAIエージェントの双方が、開発フェーズごとにこのリストをチェックして抜け漏れを防ぎます。
+新規モジュール、および業務変更に伴って境界を整える既存モジュール向けのチェックリストです。
+[ADR-024](../adr/ADR-024-modular-monolith-module-boundaries.md) と
+[移行プレイブック](../architecture/modular-monolith-migration-playbook.md) を正とします。
 
-## 1. Domain / Architecture (設計・型定義)
-- [ ] ドメインモデル（型定義 `domain/{module}.ts`）を作成したか
-- [ ] Repository Port（インターフェース `domain/{module}Repository.ts`）を定義したか
-- [ ] 業務上必要な機能（CRUD・検索条件など）が Port に過不足なく定義されているか
-- [ ] SharePointの仕様（内部システム列など）が Domain 層に漏れ出していないか確認したか
+## 1. Module Boundary
 
-## 2. Infrastructure (データアクセス実装)
-- [ ] SharePoint との Field Map（マッピングロジック `infra/sharepoint/fields/{module}Fields.ts`）を定義したか
-- [ ] SharePoint Repository の必要性を判断し、必要なら実装（`infra/sharepoint/repos/sp{Module}Repository.ts`）したか
-- [ ] Local (Mock / localStorage) Repository を作成したか
-- [ ] どちらの Repository 実装も、Port の定義を完全に満たしているか
+- [ ] 業務上の所有者と責務を一つのfeature moduleとして説明できる
+- [ ] 外部公開する型・UseCase・UIを `src/features/<module>/index.ts` に限定した
+- [ ] 他featureの内部パスを直接importしていない
+- [ ] 業務7層やISP L1/L2/L3をディレクトリへ一対一に写像していない
 
-## 3. Features Integration (統合・フック)
-- [ ] 環境によるモード選択用の Factory (`features/{module}/repositories/create{Module}Repository.ts`) を作成したか
-- [ ] Factory は `VITE_SP_ENABLED` 定数を用いて厳密なモード切替が行われるよう接続したか
-- [ ] UI からデータを取得・操作するための Custom Hook (`features/{module}/hooks/use{Module}.ts`) を作成したか
-- [ ] UI が要求する形にするための Adapter の要否を判断し、必要なら実装 (`adapters/adapt{Module}.ts`) したか
+## 2. Internal Layers
 
-## 4. Runbook & Verification (検証準備)
-- [ ] 実装・テスト要件を整理した Verification Checklist（検証観点）を作成したか
-- [ ] 本番での実機確認用手順書（Runbook `docs/runbooks/{module}-verification.md`）を作成したか
-- [ ] Level 1〜5 のテスト（自動テスト、スキーマテスト、エッジケース）を完了したか
-- [ ] Level 6 のテスト（Runbookに沿った手動のブラウザ確認）を完了したか
+- [ ] 純粋な業務型・状態遷移・ルールを `domain` に置いた
+- [ ] Repository interfaceを `ports` に置いた
+- [ ] UseCase・ViewModel・ReadModelを `application` に置いた
+- [ ] React UI・hooksを `ui` に置いた
+- [ ] SharePoint、Firestore、localStorage、InMemory実装を `adapters` に置いた
+- [ ] domainがUI、adapter、外部基盤へ依存していない
 
-## 5. Definition of Done (完了確認)
-- [ ] `docs/architecture/welfare-os-development-framework.md` に定める「モジュール実装完了の Definition of Done」をすべて満たしたか
+## 3. Composition
+
+- [ ] UI内でRepositoryを生成していない
+- [ ] 環境選択と依存注入をadapterまたは `src/app` のcomposition rootに置いた
+- [ ] モジュール横断処理を公開APIまたはapplication service経由で組み立てた
+- [ ] 即時結果が不要な監査・テレメトリ以外を安易にイベント化していない
+
+## 4. Shared Decision
+
+- [ ] shared/commonへ移動する場合、ADR-024の5条件をすべて満たした
+- [ ] 業務概念を共有化せず、所有モジュールを決めた
+- [ ] ドメイン型SSOTを複製していない
+
+## 5. Verification
+
+- [ ] 対象モジュールのテストが通る
+- [ ] `npm run arch:check` が新規違反0、baseline 921以下で通る
+- [ ] `npm run typecheck:full -- --pretty false`、`npm run lint`、`npm run build` が通る
+- [ ] 既存挙動、業務7層、ISP境界、ADR優先順位を変更していない
+- [ ] 必要なVerification Checklistと本番Runbookを更新した


### PR DESCRIPTION
## Summary

ADR-024とrecord-qualityの実証結果を、今後のモジュラーモノリス漸進移行で再利用できる運用標準として固定します。

## Changes

- モジュラーモノリス移行プレイブックを追加
- Module Starter ChecklistをADR-024の `ui / application / domain / ports / adapters` に同期
- PRテンプレートへモジュール境界レビュー項目を追加
- architecture guardへbaseline 921と非増加ルールを明記
- ADR indexから移行プレイブックへ導線を追加

## Scope

- ドキュメントとPRレビュー運用のみ
- featureコードの移動・変更なし
- billing / monitoring / usersの先行再配置なし
- today作業ツリーへの変更なし

## Validation

- `npm run arch:check`: PASS（新規違反0、baseline 921）
- `npm run typecheck:full -- --pretty false`: PASS
- `npm run lint`: PASS
- `npm run build`: PASS（16,777 modules transformed）
- `npm run lint:docs`: 実行済み（現状はstub）
- `git diff --check`: PASS