### PR TITLE
docs(ops): align msal e2e skip and startup operation docs

### DIFF
--- a/docs/env-reference.md
+++ b/docs/env-reference.md
@@ -13,6 +13,13 @@ present in that schema are included here.
 - **References** – key modules or functions where the variable is used.
 - **Notes** – warnings, caveats, or important usage notes.
 
+## Runtime responsibility map
+
+- `src/lib/env.schema.ts`: schema validation and defaults for all documented variables.
+- `src/env.ts`: runtime parsed/normalized environment object used by app startup and rendering paths.
+- `src/lib/env.ts`: feature gate and skip-logic decisions (e.g. `E2E`/`SKIP_LOGIN`/`SKIP_SHAREPOINT` behavior).
+- `src/auth/msalConfig.ts`: MSAL public client settings generated from normalized env values.
+- `src/lib/envGuards.ts`: guard checks for invalid production-equivalent startup (required keys and URL sanity).
 ## Startup Profiles (Policy)
 
 ### 1) Production-equivalent startup

--- a/docs/env-reference.md
+++ b/docs/env-reference.md
@@ -13,18 +13,50 @@ present in that schema are included here.
 - **References** – key modules or functions where the variable is used.
 - **Notes** – warnings, caveats, or important usage notes.
 
+## Startup Profiles (Policy)
+
+### 1) Production-equivalent startup
+
+For staging/prod-like startup (`VITE_SKIP_LOGIN=0`, `VITE_E2E`/`VITE_E2E_MSAL_MOCK` off), use:
+
+- `VITE_MSAL_CLIENT_ID`, `VITE_MSAL_TENANT_ID` required.
+- Set `VITE_MSAL_REDIRECT_URI` to the Azure AD app redirect URI for the deployed origin (or use origin-consistent fallback only with strict control).
+- `VITE_SP_RESOURCE`, `VITE_SP_SITE_RELATIVE` required for SharePoint repositories.
+- Keep `VITE_SKIP_SHAREPOINT` and `VITE_SKIP_LOGIN` unset/false.
+- If startup fails, the error text identifies the missing key and the remediation target.
+
+### 2) E2E / MSAL mock mode
+
+- Minimum profile: `VITE_E2E=1`, `VITE_E2E_MSAL_MOCK=1`, `VITE_SKIP_LOGIN=1`, `VITE_SKIP_SHAREPOINT=1`, `VITE_DEMO_MODE=1`.
+- `VITE_FORCE_DEMO=1` can be used as equivalent gating in scripts.
+- `VITE_MSAL_CLIENT_ID` and `VITE_MSAL_TENANT_ID` may use test-safe placeholder values.
+- `VITE_MSAL_REDIRECT_URI` may be omitted in mock-only flows.
+
+### 3) Demo / skip-login mode
+
+- `VITE_DEMO_MODE=1` or `VITE_FORCE_DEMO=1` enables non-production fixture startup.
+- `VITE_SKIP_LOGIN=1` disables auth interactions and should be limited to local or automation contexts.
+
+### 4) Skip policy and triage
+
+- There is no dedicated runtime `E2E_SKIP` environment variable in this repository.
+- Existing skip control should be referenced through:
+  - `docs/E2E_SKIP_INVENTORY.md`
+  - `docs/CATEGORY_C_SKIPS.md`
+- If merge checks fail, confirm in order: a11y preflight, E2E smoke env propagation, MSAL required env, then SharePoint scope/site vars.
+
 ## 1. Authentication & MSAL
 
 | Variable | Purpose | Required | Default | References | Notes |
 | --- | --- | --- | --- | --- | --- |
-| `VITE_MSAL_CLIENT_ID` | The application (client) ID registered in Azure AD for MSAL authentication. | **Yes** | – | `env.schema.ts`, `env.ts` | Without this the app cannot obtain tokens from Azure AD. |
-| `VITE_MSAL_TENANT_ID` | The Azure Active Directory tenant ID used with MSAL. | **Yes** | – | `env.schema.ts`, `env.ts` | Must correspond to the tenant where the app registration resides. |
+| `VITE_MSAL_CLIENT_ID` | The application (client) ID registered in Azure AD for MSAL authentication. | **Yes** | – | `env.schema.ts`, `env.ts` | Production-equivalent startup requires this value; startup errors include missing-key guidance. |
+| `VITE_MSAL_TENANT_ID` | The Azure Active Directory tenant ID used with MSAL. | **Yes** | – | `env.schema.ts`, `env.ts` | Must correspond to the tenant where the app registration resides; startup errors include missing-key guidance. |
 | `VITE_MSAL_AUTHORITY` | Authority URL for MSAL, typically `https://login.microsoftonline.com/<tenantId>`. | No | derived from `VITE_MSAL_TENANT_ID` | `env.ts` | Override only for B2C or national clouds. |
 | `VITE_MSAL_SCOPES` | Additional scopes to request when acquiring access tokens. | No | `""` (empty) | `env.schema.ts` | Provide a space‑separated list of Microsoft Graph or custom scopes. |
 | `VITE_MSAL_LOGIN_SCOPES` | Scopes included during the user login flow. | No | `""` (empty) | `env.schema.ts` | Keep the default unless extra claims are needed. |
 | `VITE_MSAL_TOKEN_REFRESH_MIN` | Minimum number of seconds before proactively refreshing access tokens. | No | `300` | `env.schema.ts` | Note: despite the name, the schema default is **300** (parsed as integer). |
 | `VITE_MSAL_LOGIN_FLOW` | Login interaction type: `redirect` or `popup`. | No | `"popup"` | `env.schema.ts` | Schema default is `popup`. |
-| `VITE_MSAL_REDIRECT_URI` | The redirect URI configured in Azure AD for MSAL. | No | Current origin | `env.ts` | Should match one of the redirect URIs on the app registration. |
+| `VITE_MSAL_REDIRECT_URI` | The redirect URI configured in Azure AD for MSAL. | No | Current origin | `env.ts` | In production-equivalent mode, this should match the app registration and deployed origin/path exactly. |
 | `VITE_LOGIN_SCOPES` | Scopes passed to the login helper. | No | `""` (empty) | `env.schema.ts` | Internal alias. |
 | `VITE_AAD_CLIENT_ID` | Alias for Azure AD client ID used by some services. | No | – | `env.schema.ts` | Legacy; keep in sync with `VITE_MSAL_CLIENT_ID`. |
 | `VITE_AAD_TENANT_ID` | Alias for Azure AD tenant ID. | No | – | `env.schema.ts` | Legacy. |
@@ -64,8 +96,8 @@ present in that schema are included here.
 | `VITE_SP_RETRY_MAX_DELAY_MS` | Maximum delay between SharePoint retry attempts in milliseconds. | No | `5000` | `env.schema.ts` | |
 | `VITE_FORCE_SHAREPOINT` | Force usage of SharePoint instead of demo/mock. | No | `false` | `env.schema.ts` | |
 | `VITE_ALLOW_SHAREPOINT_OUTSIDE_SPFX` | Allow SharePoint calls outside of the SharePoint Framework (SPFx). | No | `false` | `env.schema.ts` | |
-| `VITE_SKIP_SHAREPOINT` | Skip all SharePoint integration. | No | `false` | `env.schema.ts` | Used in local dev or unit tests. |
-| `VITE_SKIP_LOGIN` | Disable login completely (anonymous mode). | No | `false` | `env.schema.ts` | Use only in development or automated tests. |
+| `VITE_SKIP_SHAREPOINT` | Skip all SharePoint integration. | No | `false` | `env.schema.ts` | Used in local dev or unit tests. Production-equivalent startup should keep it disabled. |
+| `VITE_SKIP_LOGIN` | Disable login completely (anonymous mode). | No | `false` | `env.schema.ts` | Use only in development or automated tests; avoid long-term production bypass usage. |
 
 ### SharePoint List Name Resolution (spListRegistry)
 
@@ -105,7 +137,7 @@ List names used in API calls are resolved by [`spListRegistry.ts`](../src/sharep
 | `VITE_HANDOFF_STORAGE` | Storage backend for handoff data. | No | `"local"` | `env.schema.ts` | Schema default is `local`. |
 | `VITE_STAFF_ATTENDANCE_STORAGE` | Storage backend for staff attendance records. | No | `"local"` | `env.schema.ts` | Schema default is `local`. |
 | `VITE_DEMO_MODE` | Run the application in demonstration mode using fixture data. | No | `false` | `env.schema.ts` | Overrides authentication and data writes. |
-| `VITE_FORCE_DEMO` | Force demonstration mode even when other env vars enable real data. | No | `false` | `env.schema.ts` | |
+| `VITE_FORCE_DEMO` | Force demonstration mode even when other env vars enable real data. | No | `false` | `env.schema.ts` | Use together with `VITE_DEMO_MODE` to align demo/e2e skip behavior. |
 
 ## 4. Schedules & Graph Tuning
 
@@ -123,8 +155,8 @@ List names used in API calls are resolved by [`spListRegistry.ts`](../src/sharep
 
 | Variable | Purpose | Required | Default | References | Notes |
 | --- | --- | --- | --- | --- | --- |
-| `VITE_E2E` | Enable end‑to‑end test mode. | No | `false` | `env.schema.ts` | Enables MSAL mocks and disables real network calls. |
-| `VITE_E2E_MSAL_MOCK` | Mock MSAL responses during E2E tests. | No | `false` | `env.schema.ts` | |
+| `VITE_E2E` | Enable end‑to‑end test mode. | No | `false` | `env.schema.ts` | Enables MSAL mock startup path and relaxes production-equivalent auth strictness. |
+| `VITE_E2E_MSAL_MOCK` | Mock MSAL responses during E2E tests. | No | `false` | `env.schema.ts` | Required for the full mock smoke pattern together with `VITE_E2E=1`. |
 | `VITE_MSAL_MOCK` | Globally mock MSAL (auth) for development. | No | `false` | `env.schema.ts` | |
 | `VITE_AUDIT_DEBUG` | Print verbose logs for audit tracking. | No | `false` | `env.schema.ts` | |
 | `VITE_AUDIT_BATCH_SIZE` | Batch size when processing audit events. | No | `20` | `env.schema.ts` | |

--- a/docs/runbook/auth-troubleshooting.md
+++ b/docs/runbook/auth-troubleshooting.md
@@ -1,12 +1,25 @@
 # Auth Troubleshooting Runbook (MSAL Redirect / COOP-safe)
 
-対象: audit-management-system-mvp  
-更新: 2026-02-01 (Phase 3.6 A/B/C sealed)
+対象: audit-management-system-mvp
+更新: 2026-07-10 (PR4 runbook alignment)
 
-## 0. まず結論（3ステップ）
-1) **強制再ログイン** を押す  
-2) ダメなら **キャッシュクリアして再ログイン** を押す  
-3) それでもダメなら **診断情報をコピー** → Teams/Issue に貼る（診断ID付き）
+## 0. まず結論（4ステップ）
+1) 起動/認証前提の env チェックを実施する
+2) **強制再ログイン** を押す
+3) ダメなら **キャッシュクリアして再ログイン** を押す
+4) それでもダメなら **診断情報をコピー** → Teams/Issue に貼る（診断ID付き）
+
+## 0.1 起動前最優先チェック（MSAL / E2E）
+
+- 本番相当: `VITE_MSAL_CLIENT_ID`, `VITE_MSAL_TENANT_ID`, `VITE_MSAL_REDIRECT_URI`
+- E2E mock: `VITE_E2E=1`, `VITE_E2E_MSAL_MOCK=1`, `VITE_SKIP_LOGIN=1`, `VITE_SKIP_SHAREPOINT=1`, `VITE_DEMO_MODE=1`
+- 併せて `VITE_FORCE_DEMO` / `VITE_SKIP_LOGIN` の残留がないか
+
+必要時は以下コマンドで再現:
+
+```bash
+VITE_E2E='1' VITE_E2E_MSAL_MOCK='1' VITE_SKIP_LOGIN='1' VITE_SKIP_SHAREPOINT='1' VITE_DEMO_MODE='1' npm run build
+```
 
 ---
 
@@ -22,6 +35,11 @@
 - 画面URL:
 - 理由コード:
 - 診断ID:
+- 確認した env:
+  - VITE_MSAL_CLIENT_ID / VITE_MSAL_TENANT_ID / VITE_MSAL_REDIRECT_URI
+  - VITE_E2E / VITE_E2E_MSAL_MOCK / VITE_SKIP_LOGIN / VITE_SKIP_SHAREPOINT
+- 実行モード:
+  - 本番相当 / E2E / デモ
 - 実施した操作: (強制再ログイン / キャッシュクリア / どちらも)
 - コピーボタンの内容:
 

--- a/docs/runbooks/env-mode-policy.md
+++ b/docs/runbooks/env-mode-policy.md
@@ -46,8 +46,13 @@
 
 ## 4. 旧仕様との整合
 
-本書はデータモードの運用方針を固定し、`VITE_SKIP_LOGIN`/`VITE_FORCE_DEMO` の挙動を「データモードではなく運用制御」として扱います。
-実装詳細は `src/lib/env.ts` / `src/lib/env.schema.ts` です。
+本書はデータモードの運用方針を固定し、`VITE_SKIP_LOGIN`/`VITE_FORCE_DEMO` の挙動を「データモードではなく運用制御」として扱います。実装は1つのSSOTに集約せず、責務分離で確認します。
+
+- `src/lib/env.schema.ts`: 定義・必須・既定値
+- `src/env.ts`: 起動時の実行時env整形
+- `src/lib/env.ts`: スキップ判定（E2E/skip-login/sharepoint）
+- `src/auth/msalConfig.ts`: MSAL client 設定生成
+- `src/lib/envGuards.ts`: 本番相当起動時の起動ガード（必須キーとURL妥当性）
 
 > [!NOTE]
 > `VITE_MSAL` 系の必須前提は環境監査や起動ガードの結果に基づき、運用手順で優先確認してください。

--- a/docs/runbooks/env-mode-policy.md
+++ b/docs/runbooks/env-mode-policy.md
@@ -1,36 +1,53 @@
 # Environment Mode Policy
 
-This document defines the single source of truth for switching the application's data source mode (SharePoint vs Local Mock).
+この文書はデータ取得モードと認証ガードの運用ルールを固定し、起動時の想定外動作を防ぐための運用ガイドです。
 
-## Mode Policy
+## 1. データモードの基本方針
 
-* `VITE_SP_ENABLED=true` の場合のみ、Monitoring / Planning 系の repository は `sharepoint` モードを使用する
-* `VITE_SP_ENABLED` が未設定、`false`、その他の値である場合は、`local` モードを使用する
-* `local` モードは localStorage / mock ベースの開発・検証用であり、MSAL 認証を必要としない
-* `sharepoint` モードは SharePoint への実接続を行い、MSAL 認証を必要とする
-* 認証スキップやデモ表示に関する他フラグ（`IS_DEMO`, `IS_SKIP_LOGIN`, etc.）は、repository モード判定には使用しない
+- `VITE_SP_ENABLED=true` の場合、SharePoint 接続モードを前提にします。
+- `VITE_SP_ENABLED` が未設定・`false`・曖昧な値の場合はローカルモード扱いです。
+- `VITE_FORCE_DEMO` や `VITE_DEMO_MODE`、`VITE_SKIP_LOGIN` はデータモードを直接切り替えず、認証・表示の運用前提を変えるだけのフラグです。
 
----
+## 2. 運用パターン
 
-## 運用パターンと動作の対応表
+### A. 本番相当（MSAL + SharePoint）
 
-| 環境 | `VITE_SP_ENABLED` の値 | 適用モード | MSAL 認証 | 用途 |
-|---|---|---|---|---|
-| **Local 開発** | **未設定 （または false）** | `local` | **不要** (Mock / localStorage) | 日々の UI・機能実装、高速なローカル開発 |
-| **SP 接続検証** | `true` | `sharepoint` | **必須** | SPとのつなぎ込み確認、データ整合性テスト |
-| **本番 (Prod)** | `true` | `sharepoint` | **必須** | サポート計画シート等の本番運用 |
+1. 起動前提:
+   - `VITE_E2E=0`
+   - `VITE_E2E_MSAL_MOCK=0`
+   - `VITE_SKIP_LOGIN=0`
+   - `VITE_SKIP_SHAREPOINT=0`
+2. 認証必須項目:
+   - `VITE_MSAL_CLIENT_ID`（必須）
+   - `VITE_MSAL_TENANT_ID`（必須）
+   - `VITE_MSAL_REDIRECT_URI`（本番登録との一致が推奨）
+3. SharePoint:
+   - `VITE_SP_RESOURCE`、`VITE_SP_SITE_RELATIVE` を設定
 
----
+### B. E2E / MSAL mock
 
-## 実装上の注意点
+1. 最低構成:
+   - `VITE_E2E=1`
+   - `VITE_E2E_MSAL_MOCK=1`
+   - `VITE_SKIP_LOGIN=1`
+   - `VITE_SKIP_SHAREPOINT=1`
+   - `VITE_DEMO_MODE=1`（または `VITE_FORCE_DEMO=1`）
+2. 用途:
+   - CI/E2E の安定実行、共有環境の短時間再現
+3. MSAL識別子:
+   - `VITE_MSAL_CLIENT_ID`、`VITE_MSAL_TENANT_ID` はテスト用値で可
 
-`src/lib/env.ts` では、Vite の環境変数 (`VITE_SP_ENABLED`) を文字列の厳密な比較で評価し、モードを決定しています。
+## 3. 本番相当起動での確認対象
 
-```ts
-// src/lib/env.ts — 実装は env.ts を参照
-export const SP_ENABLED = /* VITE_SP_ENABLED === 'true' */;
-export const SP_DISABLED = !SP_ENABLED;
-```
+- MSAL の識別子が欠損していないこと
+- Redirect URI が本番登録と origin / path で齟齬がないこと
+- SharePoint 接続変数が揃っていること
+- skip フラグの残留がないこと
 
-* `'1'`, `'yes'`, `'TRUE'` などの曖昧な値はすべて `false` としてフォールバックし、意図せず SharePoint の本番環境に繋がってしまう事故を防ぎます。
-* アプリケーションが提供するRepository Factory (`createXYZRepository` など) やUI層では、必ずこの `SP_ENABLED` 定数を参照し、3項演算子等でシンプルに分岐を行ってください。
+## 4. 旧仕様との整合
+
+本書はデータモードの運用方針を固定し、`VITE_SKIP_LOGIN`/`VITE_FORCE_DEMO` の挙動を「データモードではなく運用制御」として扱います。
+実装詳細は `src/lib/env.ts` / `src/lib/env.schema.ts` です。
+
+> [!NOTE]
+> `VITE_MSAL` 系の必須前提は環境監査や起動ガードの結果に基づき、運用手順で優先確認してください。

--- a/docs/runbooks/post-merge-checklist.md
+++ b/docs/runbooks/post-merge-checklist.md
@@ -35,7 +35,30 @@ gh run list --branch main -L 5 --json databaseId,name,status,conclusion,createdA
 
 ---
 
-## 3️⃣ Local Smoke Tests (Optional but Recommended)
+## 3️⃣ Runtime Startup / Env Gate Check (Required)
+
+### 3.1 本番相当起動の必須確認
+
+- `VITE_MSAL_CLIENT_ID` / `VITE_MSAL_TENANT_ID` が実環境値で設定されること
+- `VITE_MSAL_REDIRECT_URI` が Azure AD の登録 URI と一致すること
+- `VITE_SKIP_LOGIN=1` / `VITE_SKIP_SHAREPOINT=1` が誤って有効化されていないこと
+
+### 3.2 E2E / MSAL mock 起動の再現
+
+- E2E smoke 実行は最低以下を想定する:
+  - `VITE_E2E=1`
+  - `VITE_E2E_MSAL_MOCK=1`
+  - `VITE_SKIP_LOGIN=1`
+  - `VITE_SKIP_SHAREPOINT=1`
+  - `VITE_DEMO_MODE=1`
+- 起動時に MSAL missing-key / URL mismatch 由来の停止ログが出た場合、まず以下順で確認:
+  1. `VITE_E2E`, `VITE_E2E_MSAL_MOCK`, `VITE_SKIP_LOGIN`, `VITE_SKIP_SHAREPOINT`
+  2. `VITE_MSAL_CLIENT_ID`, `VITE_MSAL_TENANT_ID`, `VITE_MSAL_REDIRECT_URI`
+  3. `VITE_SP_RESOURCE`, `VITE_SP_SITE_RELATIVE`
+
+---
+
+## 4️⃣ Local Smoke Tests (Optional but Recommended)
 
 For E2E or config changes, run smoke suite locally:
 
@@ -56,7 +79,7 @@ npx playwright test tests/e2e \
 
 ---
 
-## 4️⃣ Manual Smoke (Optional but Thorough)
+## 5️⃣ Manual Smoke (Optional but Thorough)
 
 Start a local preview and spot-check UI:
 
@@ -82,7 +105,7 @@ open http://localhost:5173
 
 ---
 
-## 5️⃣ Cleanup Local Branches (Optional)
+## 6️⃣ Cleanup Local Branches (Optional)
 
 Remove merged branches:
 
@@ -96,7 +119,7 @@ git branch --merged main | egrep -v '^\*| main$' | xargs -n 1 git branch -d
 
 ---
 
-## 6️⃣ Plan Next Steps
+## 7️⃣ Plan Next Steps
 
 ### ✅ If Main is Green
 
@@ -150,6 +173,11 @@ grep -A 10 "smokeTestMatch" playwright.smoke.config.ts
 **Fix**:
 - Add test file to `playwright.smoke.config.ts` `smokeTestMatch` array
 - Or ensure `VITE_E2E: '1'` is set in `webServerEnvVars`
+
+### `test.skip()` の運用
+
+- 運用で長期的に残る skip は、`docs/E2E_SKIP_INVENTORY.md` あるいは `docs/CATEGORY_C_SKIPS.md` で理由・対象・期限付きで管理する。
+- 現行実装に `E2E_SKIP` という実行一括トグルは未確認のため、追加を前提としない。
 
 ### "Main Actions showed FAILURE"
 


### PR DESCRIPTION
## Summary
- Consolidate MSAL startup requirements and environment mode guidance.
- Document production-equivalent redirect URI requirements.
- Clarify E2E mock and demo skip conditions.
- Add startup and environment gate checks to the post-merge checklist.
- Document the current handling of `test.skip()` and the absence of a dedicated `E2E_SKIP` implementation.
- Add environment and execution-mode details to the authentication troubleshooting template.

## Scope
Docs-only operations guidance.
Changed files:
- `docs/env-reference.md`
- `docs/runbooks/env-mode-policy.md`
- `docs/runbooks/post-merge-checklist.md`
- `docs/runbook/auth-troubleshooting.md`

## Out of scope
- runtime code
- CI workflow changes
- package scripts
- E2E test changes
- existing skip removal
- implementation of a new `E2E_SKIP` mechanism

## Verification
- `git status --short`
- `git diff --check -- docs/env-reference.md docs/runbooks/env-mode-policy.md docs/runbooks/post-merge-checklist.md docs/runbook/auth-troubleshooting.md`