### PR TITLE
refactor(record-quality): hide concrete adapters

### DIFF
--- a/src/app/routes/RecordQualityHumanReviewRoute.tsx
+++ b/src/app/routes/RecordQualityHumanReviewRoute.tsx
@@ -1,24 +1,10 @@
-import { useMemo } from 'react';
-
 import {
-  DataProviderRecordQualityReviewPersistenceStore,
-  InMemoryRecordQualityHumanReviewQueueRepository,
   RecordQualityHumanReviewPage,
-  RecordQualityReviewPersistenceRepository,
+  useRecordQualityRuntime,
 } from '@/features/record-quality';
-import { useDataProvider } from '@/lib/data/useDataProvider';
 
 export default function RecordQualityHumanReviewRoute() {
-  const { provider } = useDataProvider();
-  const repositories = useMemo(() => {
-    const reviewRepository = new RecordQualityReviewPersistenceRepository(
-      new DataProviderRecordQualityReviewPersistenceStore({ provider }),
-    );
-    const queueRepository = new InMemoryRecordQualityHumanReviewQueueRepository(
-      reviewRepository,
-    );
-    return { reviewRepository, queueRepository };
-  }, [provider]);
+  const repositories = useRecordQualityRuntime();
 
   return <RecordQualityHumanReviewPage {...repositories} />;
 }

--- a/src/features/daily/table/useTableDailyRecordViewModel.ts
+++ b/src/features/daily/table/useTableDailyRecordViewModel.ts
@@ -1,13 +1,11 @@
 import { useCancelToToday } from '@/lib/nav/useCancelToDashboard';
 import { TESTIDS } from '@/testids';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useState } from 'react';
 import toast from 'react-hot-toast';
 import {
-  DataProviderRecordQualityReviewPersistenceStore,
-  RecordQualityReviewPersistenceRepository,
   saveDailyRecordWithQualityReview,
+  useRecordQualityRuntime,
 } from '@/features/record-quality';
-import { useDataProvider } from '@/lib/data/useDataProvider';
 import type { TableDailyRecordData } from '../hooks/useTableDailyRecordForm';
 import { useDailyRecordRepository } from '../repositoryFactory';
 
@@ -26,14 +24,7 @@ type TableDailyRecordViewModel = {
 export const useTableDailyRecordViewModel = (): TableDailyRecordViewModel => {
   const cancelToToday = useCancelToToday();
   const repository = useDailyRecordRepository();
-  const { provider } = useDataProvider();
-  const reviewRepository = useMemo(
-    () =>
-      new RecordQualityReviewPersistenceRepository(
-        new DataProviderRecordQualityReviewPersistenceStore({ provider }),
-      ),
-    [provider],
-  );
+  const { reviewRepository } = useRecordQualityRuntime();
   const [open, setOpen] = useState(true);
 
   const navigateBackToMenu = useCallback(() => {

--- a/src/features/record-quality/adapters/runtime/useRecordQualityRuntime.spec.ts
+++ b/src/features/record-quality/adapters/runtime/useRecordQualityRuntime.spec.ts
@@ -1,0 +1,58 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { IDataProvider } from '@/lib/data/dataProvider.interface';
+
+import { useRecordQualityRuntime } from './useRecordQualityRuntime';
+
+const providerState = vi.hoisted(() => ({
+  current: null as IDataProvider | null,
+}));
+
+vi.mock('@/lib/data/useDataProvider', () => ({
+  useDataProvider: () => ({ provider: providerState.current, type: 'sharepoint' }),
+}));
+
+describe('useRecordQualityRuntime', () => {
+  beforeEach(() => {
+    providerState.current = createProvider();
+  });
+
+  it('keeps the same port instances while the data provider is unchanged', () => {
+    const { result, rerender } = renderHook(() => useRecordQualityRuntime());
+    const first = result.current;
+
+    rerender();
+
+    expect(result.current).toBe(first);
+    expect(result.current.reviewRepository).toBe(first.reviewRepository);
+    expect(result.current.queueRepository).toBe(first.queueRepository);
+  });
+
+  it('rebuilds the port instances when the data provider changes', () => {
+    const { result, rerender } = renderHook(() => useRecordQualityRuntime());
+    const first = result.current;
+
+    providerState.current = createProvider();
+    rerender();
+
+    expect(result.current).not.toBe(first);
+    expect(result.current.reviewRepository).not.toBe(first.reviewRepository);
+    expect(result.current.queueRepository).not.toBe(first.queueRepository);
+  });
+});
+
+function createProvider(): IDataProvider {
+  type Provider = IDataProvider;
+  return {
+    listItems: vi.fn(async <T,>() => [] as T[]) as Provider['listItems'],
+    getItemById: vi.fn(async <T,>() => ({} as T)) as Provider['getItemById'],
+    createItem: vi.fn(async <T,>() => ({} as T)) as Provider['createItem'],
+    updateItem: vi.fn(async <T,>() => ({} as T)) as Provider['updateItem'],
+    deleteItem: vi.fn(async () => undefined),
+    getMetadata: vi.fn(async () => ({})),
+    getResourceNames: vi.fn(async () => []),
+    getFieldInternalNames: vi.fn(async () => new Set<string>()),
+    ensureListExists: vi.fn(async () => undefined),
+  };
+}

--- a/src/features/record-quality/adapters/runtime/useRecordQualityRuntime.ts
+++ b/src/features/record-quality/adapters/runtime/useRecordQualityRuntime.ts
@@ -1,0 +1,33 @@
+import { useMemo } from 'react';
+
+import { useDataProvider } from '@/lib/data/useDataProvider';
+
+import { InMemoryRecordQualityHumanReviewQueueRepository } from '../in-memory/inMemoryRecordQualityHumanReviewQueueRepository';
+import { DataProviderRecordQualityReviewPersistenceStore } from '../sharepoint/dataProviderRecordQualityReviewPersistenceStore';
+import { RecordQualityReviewPersistenceRepository } from '../sharepoint/recordQualityReviewPersistenceRepository';
+import type { RecordQualityHumanReviewQueueRepository } from '../../ports/recordQualityHumanReviewQueueRepository';
+import type { RecordQualityReviewRepository } from '../../ports/recordQualityReviewRepository';
+
+export type RecordQualityRuntime = {
+  readonly reviewRepository: RecordQualityReviewRepository;
+  readonly queueRepository: RecordQualityHumanReviewQueueRepository;
+};
+
+/**
+ * Builds the module runtime while keeping concrete persistence adapters private.
+ * The app composition root consumes only the public repository ports.
+ */
+export function useRecordQualityRuntime(): RecordQualityRuntime {
+  const { provider } = useDataProvider();
+
+  return useMemo(() => {
+    const reviewRepository = new RecordQualityReviewPersistenceRepository(
+      new DataProviderRecordQualityReviewPersistenceStore({ provider }),
+    );
+    const queueRepository = new InMemoryRecordQualityHumanReviewQueueRepository(
+      reviewRepository,
+    );
+
+    return { reviewRepository, queueRepository };
+  }, [provider]);
+}

--- a/src/features/record-quality/index.ts
+++ b/src/features/record-quality/index.ts
@@ -13,10 +13,8 @@ export type {
   SaveDailyRecordWithQualityReviewResult,
 } from './application/saveDailyRecordWithQualityReview';
 
-export { DataProviderRecordQualityReviewPersistenceStore } from './adapters/sharepoint/dataProviderRecordQualityReviewPersistenceStore';
-export { RecordQualityReviewPersistenceRepository } from './adapters/sharepoint/recordQualityReviewPersistenceRepository';
-export { InMemoryRecordQualityHumanReviewQueueRepository } from './adapters/in-memory/inMemoryRecordQualityHumanReviewQueueRepository';
-export { InMemoryRecordQualityReviewRepository } from './adapters/in-memory/inMemoryRecordQualityReviewRepository';
+export { useRecordQualityRuntime } from './adapters/runtime/useRecordQualityRuntime';
+export type { RecordQualityRuntime } from './adapters/runtime/useRecordQualityRuntime';
 
 export type { RecordQualityHumanReviewQueueRepository } from './ports/recordQualityHumanReviewQueueRepository';
 export type { RecordQualityReviewRepository } from './ports/recordQualityReviewRepository';


### PR DESCRIPTION
## Summary

record-quality の具体 adapter を公開 API から隠し、Port だけを返す module runtime hook を導入します。

## Changes

- `useRecordQualityRuntime` を公開 API に追加
- DataProvider / SharePoint / InMemory adapter の組み立てをモジュール内部へ移動
- 人間レビュー route と旧 daily view model を公開 runtime 経由へ変更
- concrete adapter の `index.ts` export を削除

## Validation

- focused tests: 3 files / 6 tests PASS
- `npm run arch:check`: PASS（新規違反0、baseline 921）
- `npm run typecheck:full -- --pretty false`: PASS
- `npm run lint`: PASS
- `npm run build`: PASS（16,647 modules transformed）

## Scope

- daily 本番 route のcomposition変更は後続PR
- 旧 daily 実装の削除は後続PR
- today、billing、monitoring、usersは変更しない
