### PR TITLE
refactor(daily): compose quality review saves in app

### DIFF
--- a/src/app/routes/TableDailyRecordRoute.tsx
+++ b/src/app/routes/TableDailyRecordRoute.tsx
@@ -1,0 +1,24 @@
+import { useMemo } from 'react';
+
+import {
+  TableDailyRecordPage,
+  useDailyRecordRepository,
+} from '@/features/daily';
+import { useRecordQualityRuntime } from '@/features/record-quality';
+
+import { createDailyRecordQualityReviewRepository } from '../services/createDailyRecordQualityReviewRepository';
+
+export default function TableDailyRecordRoute() {
+  const dailyRepository = useDailyRecordRepository();
+  const { reviewRepository } = useRecordQualityRuntime();
+  const repository = useMemo(
+    () =>
+      createDailyRecordQualityReviewRepository({
+        dailyRepository,
+        reviewRepository,
+      }),
+    [dailyRepository, reviewRepository],
+  );
+
+  return <TableDailyRecordPage repository={repository} />;
+}

--- a/src/app/routes/__tests__/TableDailyRecordRoute.spec.tsx
+++ b/src/app/routes/__tests__/TableDailyRecordRoute.spec.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import TableDailyRecordRoute from '../TableDailyRecordRoute';
+
+const state = vi.hoisted(() => ({
+  dailyRepository: { kind: 'daily' },
+  reviewRepository: { kind: 'review' },
+  composedRepository: { kind: 'composed' },
+  createRepository: vi.fn(),
+}));
+
+vi.mock('@/features/daily', () => ({
+  useDailyRecordRepository: () => state.dailyRepository,
+  TableDailyRecordPage: ({ repository }: { repository: unknown }) => (
+    <div data-testid="daily-repository">{repository === state.composedRepository ? 'composed' : 'unexpected'}</div>
+  ),
+}));
+
+vi.mock('@/features/record-quality', () => ({
+  useRecordQualityRuntime: () => ({
+    reviewRepository: state.reviewRepository,
+    queueRepository: {},
+  }),
+}));
+
+vi.mock('../../services/createDailyRecordQualityReviewRepository', () => ({
+  createDailyRecordQualityReviewRepository: (options: unknown) => {
+    state.createRepository(options);
+    return state.composedRepository;
+  },
+}));
+
+describe('TableDailyRecordRoute', () => {
+  it('composes the public daily and record-quality ports in the app route', () => {
+    render(<TableDailyRecordRoute />);
+
+    expect(screen.getByTestId('daily-repository')).toHaveTextContent('composed');
+    expect(state.createRepository).toHaveBeenCalledWith({
+      dailyRepository: state.dailyRepository,
+      reviewRepository: state.reviewRepository,
+    });
+  });
+});

--- a/src/app/routes/lazyPages.tsx
+++ b/src/app/routes/lazyPages.tsx
@@ -20,7 +20,7 @@ const NewSchedulesWeekPage = lazyWithPreload(() => import('@/features/schedules/
 const OpsSchedulePage = React.lazy(() => import('@/features/schedules/components/ops/OpsSchedulePage').then(m => ({ default: m.OpsSchedulePage })));
 const DailyRecordPage = React.lazy(() => import('@/pages/DailyRecordPage'));
 const DailyRecordMenuPage = React.lazy(() => import('@/pages/DailyRecordMenuPage'));
-const TableDailyRecordPage = React.lazy(() => import('@/features/daily/components/table/TableDailyRecordPage'));
+const TableDailyRecordPage = React.lazy(() => import('./TableDailyRecordRoute'));
 const TimeFlowSupportRecordPage = React.lazy(() => import('@/pages/TimeFlowSupportRecordPage'));
 const TimeBasedSupportRecordPage = React.lazy(() => import('@/pages/TimeBasedSupportRecordPage'));
 

--- a/src/app/services/createDailyRecordQualityReviewRepository.spec.ts
+++ b/src/app/services/createDailyRecordQualityReviewRepository.spec.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type {
+  DailyRecordDomain,
+  DailyRecordRepository,
+  DailyRecordRepositoryMutationParams,
+} from '@/features/daily';
+import type { RecordQualityReviewRepository } from '@/features/record-quality';
+
+import { createDailyRecordQualityReviewRepository } from './createDailyRecordQualityReviewRepository';
+
+describe('createDailyRecordQualityReviewRepository', () => {
+  it('normalizes userCount, preserves mutation params, and creates review metadata', async () => {
+    const dailyRepository = createDailyRepository();
+    const reviewRepository = createReviewRepository();
+    const repository = createDailyRecordQualityReviewRepository({
+      dailyRepository,
+      reviewRepository,
+      now: () => '2026-07-10T10:00:00.000Z',
+    });
+    const params: DailyRecordRepositoryMutationParams = {
+      signal: new AbortController().signal,
+    };
+
+    await repository.save(createDailyRecord(), params);
+
+    expect(dailyRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({ userCount: 2 }),
+      params,
+    );
+    expect(reviewRepository.saveReview).toHaveBeenCalledTimes(1);
+    expect(reviewRepository.saveReview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recordId: 'daily:2026-07-10:user-1',
+        originalRecord: { recordId: 'daily:2026-07-10:user-1' },
+        createdAt: '2026-07-10T10:00:00.000Z',
+      }),
+    );
+  });
+
+  it('delegates non-save repository operations without changing their arguments', async () => {
+    const dailyRepository = createDailyRepository();
+    const repository = createDailyRecordQualityReviewRepository({
+      dailyRepository,
+      reviewRepository: createReviewRepository(),
+    });
+    const signal = new AbortController().signal;
+    const range = { startDate: '2026-07-01', endDate: '2026-07-10' };
+    const approval = {
+      date: '2026-07-10',
+      approverName: 'Reviewer',
+      approverRole: 'Manager',
+    };
+
+    await repository.load('2026-07-10');
+    await repository.list({ range, signal });
+    await repository.approve(approval, { signal });
+    await repository.scanIntegrity(['2026-07-10'], signal);
+
+    expect(dailyRepository.load).toHaveBeenCalledWith('2026-07-10');
+    expect(dailyRepository.list).toHaveBeenCalledWith({ range, signal });
+    expect(dailyRepository.approve).toHaveBeenCalledWith(approval, { signal });
+    expect(dailyRepository.scanIntegrity).toHaveBeenCalledWith(['2026-07-10'], signal);
+  });
+
+  it('propagates a review creation failure after the daily record is saved', async () => {
+    const dailyRepository = createDailyRepository();
+    const reviewRepository = createReviewRepository();
+    vi.mocked(reviewRepository.saveReview).mockRejectedValueOnce(new Error('review failed'));
+    const repository = createDailyRecordQualityReviewRepository({
+      dailyRepository,
+      reviewRepository,
+    });
+
+    await expect(repository.save(createDailyRecord())).rejects.toThrow('review failed');
+    expect(dailyRepository.save).toHaveBeenCalledOnce();
+  });
+});
+
+function createDailyRepository(): DailyRecordRepository {
+  return {
+    save: vi.fn(async () => undefined),
+    load: vi.fn(async () => null),
+    list: vi.fn(async () => []),
+    approve: vi.fn(async () => createDailyRecord()),
+    scanIntegrity: vi.fn(async () => []),
+  };
+}
+
+function createReviewRepository(): RecordQualityReviewRepository {
+  return {
+    saveReview: vi.fn(async review => review),
+    getReview: vi.fn(async () => null),
+    updateReview: vi.fn(async review => review),
+    listReviews: vi.fn(async () => []),
+  };
+}
+
+function createDailyRecord(): DailyRecordDomain {
+  return {
+    date: '2026-07-10',
+    reporter: { name: 'Reporter', role: 'Staff' },
+    userCount: 0,
+    userRows: [
+      {
+        userId: 'user-1',
+        userName: 'User One',
+        amActivity: '散歩',
+        pmActivity: '',
+        lunchAmount: '',
+        problemBehavior: {
+          selfHarm: false,
+          otherInjury: false,
+          loudVoice: false,
+          pica: false,
+          other: false,
+        },
+        specialNotes: '',
+        behaviorTags: [],
+      },
+      {
+        userId: 'user-2',
+        userName: 'User Two',
+        amActivity: '',
+        pmActivity: '',
+        lunchAmount: '',
+        problemBehavior: {
+          selfHarm: false,
+          otherInjury: false,
+          loudVoice: false,
+          pica: false,
+          other: false,
+        },
+        specialNotes: '',
+        behaviorTags: [],
+      },
+    ],
+  };
+}

--- a/src/app/services/createDailyRecordQualityReviewRepository.ts
+++ b/src/app/services/createDailyRecordQualityReviewRepository.ts
@@ -1,0 +1,40 @@
+import type { DailyRecordRepository } from '@/features/daily';
+import {
+  saveDailyRecordWithQualityReview,
+  type RecordQualityReviewRepository,
+} from '@/features/record-quality';
+
+export type CreateDailyRecordQualityReviewRepositoryOptions = {
+  readonly dailyRepository: DailyRecordRepository;
+  readonly reviewRepository: RecordQualityReviewRepository;
+  readonly now?: () => string;
+};
+
+/**
+ * Adds record-quality metadata creation to daily saves while preserving the
+ * complete DailyRecordRepository contract for the UI.
+ */
+export function createDailyRecordQualityReviewRepository({
+  dailyRepository,
+  reviewRepository,
+  now = () => new Date().toISOString(),
+}: CreateDailyRecordQualityReviewRepositoryOptions): DailyRecordRepository {
+  return {
+    async save(input, params) {
+      await saveDailyRecordWithQualityReview({
+        dailyRepository,
+        reviewRepository,
+        input: {
+          ...input,
+          userCount: input.userRows.length,
+        },
+        mutationParams: params,
+        createdAt: now(),
+      });
+    },
+    load: date => dailyRepository.load(date),
+    list: params => dailyRepository.list(params),
+    approve: (input, params) => dailyRepository.approve(input, params),
+    scanIntegrity: (dates, signal) => dailyRepository.scanIntegrity(dates, signal),
+  };
+}

--- a/src/features/daily/components/table/TableDailyRecordPage.tsx
+++ b/src/features/daily/components/table/TableDailyRecordPage.tsx
@@ -15,6 +15,7 @@ import {
     Tooltip
 } from '@mui/material';
 import React from 'react';
+import type { DailyRecordRepository } from '../../domain/legacy/DailyRecordRepository';
 
 import { FullScreenDailyDialogPage } from '../pages/FullScreenDailyDialogPage';
 import { TableDailyRecordForm } from '../forms/TableDailyRecordForm';
@@ -23,8 +24,12 @@ import { useTableDailyRecordViewModel } from './useTableDailyRecordViewModel';
 
 
 
-export const TableDailyRecordPage: React.FC = () => {
-  const vm = useTableDailyRecordViewModel();
+export type TableDailyRecordPageProps = {
+  readonly repository: DailyRecordRepository;
+};
+
+export const TableDailyRecordPage: React.FC<TableDailyRecordPageProps> = ({ repository }) => {
+  const vm = useTableDailyRecordViewModel(repository);
 
   const formState = useTableDailyRecordForm({
     open: vm.open,

--- a/src/features/daily/components/table/useTableDailyRecordViewModel.ts
+++ b/src/features/daily/components/table/useTableDailyRecordViewModel.ts
@@ -1,7 +1,6 @@
 import { useCancelToToday } from '@/lib/nav/useCancelToDashboard';
 import { TESTIDS } from '@/testids';
 import { useCallback, useState } from 'react';
-import { useDailyRecordRepository } from '../../repositories/repositoryFactory';
 import type { DailyRecordRepository } from '../../domain/legacy/DailyRecordRepository';
 
 type TableDailyRecordViewModel = {
@@ -14,9 +13,10 @@ type TableDailyRecordViewModel = {
   repository: DailyRecordRepository;
 };
 
-export const useTableDailyRecordViewModel = (): TableDailyRecordViewModel => {
+export const useTableDailyRecordViewModel = (
+  repository: DailyRecordRepository,
+): TableDailyRecordViewModel => {
   const cancelToToday = useCancelToToday();
-  const repository = useDailyRecordRepository();
   const [open, setOpen] = useState(true);
 
   const navigateBackToMenu = useCallback(() => {

--- a/src/features/daily/index.ts
+++ b/src/features/daily/index.ts
@@ -36,6 +36,8 @@ export { DailyRecordList } from './lists/DailyRecordList';
 export { useDailyUserOptions } from './forms/useDailyUserOptions';
 export type { DailyUserOption } from './forms/useDailyUserOptions';
 export { useDaily } from './hooks/useDaily';
+export { TableDailyRecordPage } from './components/table/TableDailyRecordPage';
+export type { TableDailyRecordPageProps } from './components/table/TableDailyRecordPage';
 
 // Domain Utilities
 export { getScheduleKey } from './domain/getScheduleKey';


### PR DESCRIPTION
## Summary

本番の一覧形式daily保存をapp composition rootでrecord-qualityレビュー生成と接続します。

## Changes

- app-localの品質レビュー連携付き`DailyRecordRepository`を追加
- `save`時に`userCount`を正規化し、既存`saveDailyRecordWithQualityReview`を利用
- load / list / approve / scanIntegrityは元Repositoryへ委譲
- `TableDailyRecordRoute`でdailyとrecord-qualityの公開Portを合成
- 本番ページへRepositoryを注入し、UI内のRepository生成を除去
- lazy routeをapp routeへ切り替え

## Behavior

- daily保存後に非空行のレビューmetadataを生成
- 空行・既存レビューは既存UseCaseどおりskip
- URL、画面、未入力フィルタ、Suspense、lazy chunkを維持

## Validation

- focused tests: 4 files / 12 tests PASS
- `npm run arch:check`: PASS（新規違反0、known violations 920）
- `npm run typecheck:full -- --pretty false`: PASS
- `npm run lint`: PASS
- `npm run build`: PASS（16,649 modules transformed、TableDailyRecordRoute chunk確認）

## Stack

- base: `codex/record-quality-public-runtime` (#2408)
- 旧daily実装の削除は後続PR
