### PR TITLE
fix(startup): align MSAL env guard with production startup path

### DIFF
--- a/src/lib/envGuards.spec.ts
+++ b/src/lib/envGuards.spec.ts
@@ -3,6 +3,9 @@ import { guardProdMisconfig } from './envGuards';
 
 const getAppConfigMock = vi.hoisted(() => vi.fn());
 const isE2EMock = vi.hoisted(() => vi.fn());
+const isE2eMsalMockEnabledMock = vi.hoisted(() => vi.fn());
+const isDemoMock = vi.hoisted(() => vi.fn());
+const isDemoModeEnabledMock = vi.hoisted(() => vi.fn());
 const shouldSkipSharePointMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@/lib/env', async (importOriginal) => {
@@ -11,45 +14,123 @@ vi.mock('@/lib/env', async (importOriginal) => {
     ...actual,
     getAppConfig: () => getAppConfigMock(),
     isE2E: () => isE2EMock(),
+    isE2eMsalMockEnabled: () => isE2eMsalMockEnabledMock(),
+    isDemo: () => isDemoMock(),
+    isDemoModeEnabled: () => isDemoModeEnabledMock(),
+    shouldSkipSharePoint: () => shouldSkipSharePointMock(),
   };
 });
 
-vi.mock('@/lib/sharepoint/skipSharePoint', () => ({
-  shouldSkipSharePoint: () => shouldSkipSharePointMock(),
-}));
-
 describe('guardProdMisconfig', () => {
+  const baseConfig = () => ({
+    isDev: false,
+    VITE_MSAL_CLIENT_ID: 'msal-client-id',
+    VITE_MSAL_TENANT_ID: 'msal-tenant-id',
+    VITE_MSAL_REDIRECT_URI: 'https://localhost:5173/auth/callback',
+  });
+
+  const setProdConfig = (overrides: Partial<{
+    isDev: boolean;
+    VITE_MSAL_CLIENT_ID: string | undefined;
+    VITE_MSAL_TENANT_ID: string | undefined;
+    VITE_MSAL_REDIRECT_URI: string | undefined;
+  }> = {}) => {
+    getAppConfigMock.mockReturnValue({
+      ...baseConfig(),
+      ...overrides,
+    });
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
-  });
-
-  it('isDev が false, isE2E が false, SharePoint を skip するときに throw する', () => {
-    getAppConfigMock.mockReturnValue({ isDev: false });
     isE2EMock.mockReturnValue(false);
-    shouldSkipSharePointMock.mockReturnValue(true);
-
-    expect(() => {
-      guardProdMisconfig();
-    }).toThrow('[config] VITE_SKIP_SHAREPOINT=1 is not allowed in PROD. Check environment configuration.');
+    isE2eMsalMockEnabledMock.mockReturnValue(false);
+    isDemoMock.mockReturnValue(false);
+    isDemoModeEnabledMock.mockReturnValue(false);
+    shouldSkipSharePointMock.mockReturnValue(false);
   });
 
-  it('isDev が true の場合は throw しない', () => {
-    getAppConfigMock.mockReturnValue({ isDev: true });
-    isE2EMock.mockReturnValue(false);
-    shouldSkipSharePointMock.mockReturnValue(true);
+  it('throws when client id is missing in production-like mode', () => {
+    setProdConfig({ VITE_MSAL_CLIENT_ID: '' });
+    const run = () => guardProdMisconfig();
 
-    expect(() => {
-      guardProdMisconfig();
-    }).not.toThrow();
+    expect(run).toThrow('[config] MSAL startup configuration is invalid.');
+    expect(run).toThrow(/VITE_MSAL_CLIENT_ID/);
   });
 
-  it('isE2E が true の場合は throw しない', () => {
-    getAppConfigMock.mockReturnValue({ isDev: false });
+  it('throws when tenant id is missing in production-like mode', () => {
+    setProdConfig({ VITE_MSAL_TENANT_ID: '' });
+    const run = () => guardProdMisconfig();
+
+    expect(run).toThrow('[config] MSAL startup configuration is invalid.');
+    expect(run).toThrow(/VITE_MSAL_TENANT_ID/);
+  });
+
+  it('throws when redirect URI is missing in production-like mode', () => {
+    setProdConfig({ VITE_MSAL_REDIRECT_URI: '' });
+    const run = () => guardProdMisconfig();
+
+    expect(run).toThrow('[config] MSAL startup configuration is invalid.');
+    expect(run).toThrow(/VITE_MSAL_REDIRECT_URI/);
+  });
+
+  it('throws when redirect URI is not a valid URL in production-like mode', () => {
+    setProdConfig({ VITE_MSAL_REDIRECT_URI: 'not-a-url' });
+    const run = () => guardProdMisconfig();
+
+    expect(run).toThrow('[config] MSAL startup configuration is invalid.');
+    expect(run).toThrow(/invalid URL/);
+  });
+
+  it('skips all MSAL checks in E2E mode', () => {
     isE2EMock.mockReturnValue(true);
+    setProdConfig({ VITE_MSAL_CLIENT_ID: '', VITE_MSAL_TENANT_ID: '', VITE_MSAL_REDIRECT_URI: '' });
+
+    expect(() => guardProdMisconfig()).not.toThrow();
+  });
+
+  it('skips all MSAL checks in MSAL mock mode', () => {
+    isE2eMsalMockEnabledMock.mockReturnValue(true);
+    setProdConfig({ VITE_MSAL_CLIENT_ID: '', VITE_MSAL_TENANT_ID: '', VITE_MSAL_REDIRECT_URI: '' });
+
+    expect(() => guardProdMisconfig()).not.toThrow();
+  });
+
+  it('skips all MSAL checks in demo mode', () => {
+    isDemoMock.mockReturnValue(true);
+    setProdConfig({ VITE_MSAL_CLIENT_ID: '', VITE_MSAL_TENANT_ID: '', VITE_MSAL_REDIRECT_URI: '' });
+
+    expect(() => guardProdMisconfig()).not.toThrow();
+  });
+
+  it('skips all MSAL checks in demo mode flag', () => {
+    isDemoModeEnabledMock.mockReturnValue(true);
+    setProdConfig({ VITE_MSAL_CLIENT_ID: '', VITE_MSAL_TENANT_ID: '', VITE_MSAL_REDIRECT_URI: '' });
+
+    expect(() => guardProdMisconfig()).not.toThrow();
+  });
+
+  it('throws when PROD is configured with VITE_SKIP_SHAREPOINT=1', () => {
+    setProdConfig();
     shouldSkipSharePointMock.mockReturnValue(true);
 
-    expect(() => {
-      guardProdMisconfig();
-    }).not.toThrow();
+    expect(() => guardProdMisconfig()).toThrow(
+      '[config] VITE_SKIP_SHAREPOINT=1 is not allowed in PROD. Check environment configuration.',
+    );
+  });
+
+  it('does not throw when SHAREPOINT is skipped in E2E', () => {
+    isE2EMock.mockReturnValue(true);
+    setProdConfig();
+    shouldSkipSharePointMock.mockReturnValue(true);
+
+    expect(() => guardProdMisconfig()).not.toThrow();
+  });
+
+  it('does not throw in development mode', () => {
+    setProdConfig({ isDev: true });
+    shouldSkipSharePointMock.mockReturnValue(true);
+
+    expect(() => guardProdMisconfig()).not.toThrow();
   });
 });

--- a/src/lib/envGuards.ts
+++ b/src/lib/envGuards.ts
@@ -1,16 +1,90 @@
-import { getAppConfig, isE2E, shouldSkipSharePoint } from '@/lib/env';
+import {
+  getAppConfig,
+  isDemo,
+  isDemoModeEnabled,
+  isE2E,
+  isE2eMsalMockEnabled,
+  shouldSkipSharePoint,
+} from '@/lib/env';
+
+const isProductionLike = (isDevMode: boolean): boolean => !isDevMode;
+
+const shouldSkipMsalValidation = (): boolean => (
+  isE2E() ||
+  isE2eMsalMockEnabled() ||
+  isDemo() ||
+  isDemoModeEnabled()
+);
+
+const isValidUrl = (value: string): boolean => {
+  try {
+    new URL(value);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const msalValidationFailureMessage = (missing: string[]): string => {
+  const lines = [
+    '[config] MSAL startup configuration is invalid.',
+    '',
+    `Missing or invalid: ${missing.join(', ')}`,
+    '',
+    'Please check and set:',
+    '  - VITE_MSAL_CLIENT_ID (or VITE_AAD_CLIENT_ID)',
+    '  - VITE_MSAL_TENANT_ID (or VITE_AAD_TENANT_ID)',
+    '  - VITE_MSAL_REDIRECT_URI (absolute URL, required in production-like mode)',
+    '',
+    'Reference: .env.example',
+  ];
+  return lines.join('\n');
+};
+
+const validateMsalSettings = (config: ReturnType<typeof getAppConfig>): void => {
+  const missing: string[] = [];
+  const msalRedirectUri = (config as { VITE_MSAL_REDIRECT_URI?: string }).VITE_MSAL_REDIRECT_URI;
+
+  if (!config.VITE_MSAL_CLIENT_ID) {
+    missing.push('VITE_MSAL_CLIENT_ID');
+  }
+  if (!config.VITE_MSAL_TENANT_ID) {
+    missing.push('VITE_MSAL_TENANT_ID');
+  }
+
+  const redirectUri = msalRedirectUri?.trim();
+  if (!redirectUri) {
+    missing.push('VITE_MSAL_REDIRECT_URI');
+  } else if (!isValidUrl(redirectUri)) {
+    throw new Error(msalValidationFailureMessage([
+      `VITE_MSAL_REDIRECT_URI (${redirectUri}) is invalid URL`,
+    ]));
+  }
+
+  if (missing.length > 0) {
+    throw new Error(msalValidationFailureMessage(missing));
+  }
+};
 
 // Guard against misconfigurations that would blank data in production
 export const guardProdMisconfig = (): void => {
+  const appConfig = getAppConfig();
+  const isProduction = isProductionLike(appConfig.isDev);
+
+  if (isProduction && !shouldSkipMsalValidation() && !shouldSkipSharePoint()) {
+    validateMsalSettings(appConfig);
+  }
+
   // PRODでSKIPが立っているのは「空データ運用」の事故なので即停止（E2EはVITE_E2Eで免除）
-  if (!getAppConfig().isDev && !isE2E() && shouldSkipSharePoint()) {
+  if (isProduction && !isE2E() && shouldSkipSharePoint()) {
     throw new Error('[config] VITE_SKIP_SHAREPOINT=1 is not allowed in PROD. Check environment configuration.');
   }
 };
 
 // Optional softer guard for cases where hard-fail is not desired
 export const warnProdMisconfig = (): void => {
-  if (!getAppConfig().isDev && !isE2E() && shouldSkipSharePoint()) {
+  const appConfig = getAppConfig();
+  if (isProductionLike(appConfig.isDev) && !shouldSkipMsalValidation() && shouldSkipSharePoint()) {
     // eslint-disable-next-line no-console
     console.error('[config][FATAL] PROD is running with VITE_SKIP_SHAREPOINT=1. Data will not load.');
   }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -169,6 +169,8 @@ const run = async (): Promise<void> => {
       finalizeHydrationSpan(completeEnv, error);
       throw error;
     });
+  // ✅ Step 1.5: Validate production startup configuration before external auth initialization
+  guardProdMisconfig();
 
   // ✅ Step 2: Initialize MSAL singleton + handle redirect BEFORE Firebase init
   // Skip entirely in demo/skip-login modes to avoid unnecessary AAD initialization.
@@ -369,9 +371,6 @@ const run = async (): Promise<void> => {
   try {
     // 🔧 runtime env を最優先で適用してからモジュールを読み込み
     // (envPromise は既に await ensureRuntimeEnv() で完了済み)
-
-    // ✅ NOW that runtime env is loaded, check for production misconfigurations
-    guardProdMisconfig();
 
     const [modules, appModule] = await Promise.all([modulesPromise, appPromise]);
     const [{ ConfigErrorBoundary }, { auditLog }, featureFlagsModule] = modules;


### PR DESCRIPTION
## Summary
- Integrate MSAL startup validation into the existing production misconfiguration guard.
- Run the guard immediately after runtime environment loading and before MSAL initialization.
- Require MSAL client ID, tenant ID, and redirect URI in production-equivalent startup.
- Validate the redirect URI format.
- Skip MSAL validation for E2E, MSAL mock, and demo modes.
- Preserve the existing production guard for `VITE_SKIP_SHAREPOINT`.

## Scope
Startup guard alignment and unit coverage only.
Changed files:
- `src/lib/envGuards.ts`
- `src/lib/envGuards.spec.ts`
- `src/main.tsx`

## Out of scope
- new environment schema modules
- changes to `src/lib/env.schema.ts`
- changes to `src/env.ts`
- E2E test restructuring
- CI workflow changes
- operations documentation

## Verification
- `npx vitest run src/lib/envGuards.spec.ts`
- `npm run typecheck`
- `npm run lint`
- `git diff --check -- src/lib/envGuards.ts src/lib/envGuards.spec.ts src/main.tsx`

## Supersedes
This PR replaces the implementation approach in #2398 and aligns the MSAL startup guard with the current environment and startup structure on `main`.