### PR TITLE
fix(today): link users to selected support details

### DIFF
--- a/src/features/today/hooks/useTodayLayoutProps.ts
+++ b/src/features/today/hooks/useTodayLayoutProps.ts
@@ -319,11 +319,12 @@ export function useTodayLayoutProps(input: TodayLayoutPropsInput): TodayLayoutPr
       userListProps: {
         items: isE2EEnv
           ? [
-              { userId: 'I022', name: '中村 裕樹', status: 'present' as const, recordFilled: false },
-              { userId: 'I105', name: '山田 花子', status: 'present' as const, recordFilled: true },
+              { userId: 'I005', name: '石渡 由喜子', status: 'present' as const, recordFilled: false },
+              { userId: 'U-001', name: '桂川 進太朗', status: 'present' as const, recordFilled: true },
             ]
           : userItemsWithStatus,
         onOpenQuickRecord: quickRecord.openUser,
+        onOpenUserDetail: (userId: string) => navigate(`/users?tab=list&selected=${encodeURIComponent(userId)}`),
         onOpenISP: (userId: string) => navigate(`/isp-editor/${userId}`),
         onOpenIceberg: (userId: string) => navigate(buildIcebergPdcaUrl(userId)),
         onAlertClick: (userId: string) => {

--- a/src/features/today/widgets/UserCompactList.tsx
+++ b/src/features/today/widgets/UserCompactList.tsx
@@ -8,6 +8,7 @@ import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import GroupOffIcon from '@mui/icons-material/GroupOff';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+import PersonSearchIcon from '@mui/icons-material/PersonSearch';
 import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked';
 import { Box, Button, Chip, IconButton, Paper, Stack, Tooltip, Typography } from '@mui/material';
 import React, { useMemo, useState } from 'react';
@@ -31,6 +32,7 @@ export type UserRow = {
 export type UserCompactListProps = {
   items: UserRow[];
   onOpenQuickRecord: (id: string) => void;
+  onOpenUserDetail?: (id: string) => void;
   onOpenISP?: (id: string) => void;
   /** Iceberg PDCA 行動分析への導線 */
   onOpenIceberg?: (id: string) => void;
@@ -46,11 +48,12 @@ export type UserCompactListProps = {
 const UserCompactRow = React.memo<{
   user: UserRow;
   onOpenQuickRecord: (id: string) => void;
+  onOpenUserDetail?: (id: string) => void;
   onOpenISP?: (id: string) => void;
   onOpenIceberg?: (id: string) => void;
   onAlertClick?: (userId: string) => void;
   onOpenUserStatus?: (userId: string, userName: string, statusType: UserStatusType) => void;
-}>(function UserCompactRow({ user, onOpenQuickRecord, onOpenISP, onOpenIceberg, onAlertClick, onOpenUserStatus }) {
+}>(function UserCompactRow({ user, onOpenQuickRecord, onOpenUserDetail, onOpenISP, onOpenIceberg, onAlertClick, onOpenUserStatus }) {
   const hasAlerts = user.alerts && user.alerts.length > 0;
   const needsAttention = !user.recordFilled && user.status !== 'absent';
   const isAbsent = user.status === 'absent';
@@ -162,6 +165,21 @@ const UserCompactRow = React.memo<{
         </Box>
       </Box>
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+        {onOpenUserDetail ? (
+          <Tooltip title="利用者詳細">
+            <IconButton
+              size="small"
+              color="info"
+              onClick={(e) => { e.stopPropagation(); onOpenUserDetail(user.userId); }}
+              onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') e.stopPropagation(); }}
+              aria-label={`${user.name}の利用者詳細を確認`}
+              data-testid={`today-user-detail-${user.userId}`}
+              sx={{ minHeight: 44, minWidth: 44, bgcolor: 'info.50', '&:hover': { bgcolor: 'info.100' } }}
+            >
+              <PersonSearchIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        ) : null}
         {onOpenISP ? (
           <Tooltip title="個別支援計画">
             <IconButton
@@ -246,7 +264,7 @@ const UserCompactRow = React.memo<{
   );
 });
 
-export const UserCompactList: React.FC<UserCompactListProps> = ({ items, onOpenQuickRecord, onOpenISP, onOpenIceberg, onAlertClick, onOpenUserStatus, onEmptyAction }) => {
+export const UserCompactList: React.FC<UserCompactListProps> = ({ items, onOpenQuickRecord, onOpenUserDetail, onOpenISP, onOpenIceberg, onAlertClick, onOpenUserStatus, onEmptyAction }) => {
   const [expanded, setExpanded] = useState(false);
 
   // 未記録を先頭に並べる（元の順序を保ちつつ）
@@ -299,6 +317,7 @@ export const UserCompactList: React.FC<UserCompactListProps> = ({ items, onOpenQ
           key={u.userId}
           user={u}
           onOpenQuickRecord={onOpenQuickRecord}
+          onOpenUserDetail={onOpenUserDetail}
           onOpenISP={onOpenISP}
           onOpenIceberg={onOpenIceberg}
           onAlertClick={onAlertClick}

--- a/tests/e2e/today-ops-page.spec.ts
+++ b/tests/e2e/today-ops-page.spec.ts
@@ -2,7 +2,7 @@ import { expect, test, type Page } from '@playwright/test';
 import { bootTodayOpsPage } from './_helpers/bootTodayOpsPage';
 import { TESTIDS } from '@/testids';
 
-const MOCK_USER_ID = 'I022';
+const MOCK_USER_ID = 'I005';
 
 async function waitForTodayMain(page: Page): Promise<void> {
   await page.goto('/today');
@@ -56,5 +56,23 @@ test.describe('Today Ops Screen - Happy Path', () => {
 
     const expectedUserId = new URL(page.url()).searchParams.get('userId');
     expect(expectedUserId).toBeTruthy();
+  });
+
+  test('opens Users detail for the selected operation user and exposes support quick access', async ({ page }) => {
+    await waitForTodayMain(page);
+
+    await page.getByTestId(`today-user-detail-${MOCK_USER_ID}`).click();
+
+    await expect(page).toHaveURL(new RegExp(`/users\\?tab=list&selected=${MOCK_USER_ID}`));
+    await expect(page.getByTestId('user-detail-sections')).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByTestId('user-detail-sections')).toContainText('石渡 由喜子');
+
+    const supportQuickButton = page.getByTestId(`${TESTIDS['users-quick-prefix']}support-procedure`);
+    await expect(supportQuickButton).toBeVisible();
+    await supportQuickButton.click();
+
+    const supportTabPanel = page.getByTestId(`${TESTIDS['user-menu-tabpanel-prefix']}support-procedure`);
+    await expect(supportTabPanel).toBeVisible();
+    await expect(supportTabPanel).toContainText('支援手順テンプレート');
   });
 });

--- a/tests/e2e/today-ops-sort-attendance.spec.ts
+++ b/tests/e2e/today-ops-sort-attendance.spec.ts
@@ -8,7 +8,7 @@ async function waitForTodayMain(page: Page): Promise<void> {
   await expect(page.getByTestId('hero-cta')).toBeVisible({ timeout: 15_000 });
 }
 
-async function openUnfilledStateByUrl(page: Page, userId = 'I022') {
+async function openUnfilledStateByUrl(page: Page, userId = 'I005') {
   await page.goto(`/today?mode=unfilled&userId=${encodeURIComponent(userId)}&autoNext=1`);
   await expect(page).toHaveURL(/[?&]mode=unfilled/);
   await expect(page).toHaveURL(new RegExp(`userId=${userId}`));
@@ -27,7 +27,7 @@ test.describe('Today Ops Screen - Sort Attendance', () => {
     await waitForTodayMain(page);
     await openUnfilledStateByUrl(page);
 
-    const userRow = page.getByRole('button', { name: /中村 裕樹/ }).first();
+    const userRow = page.getByRole('button', { name: /石渡 由喜子/ }).first();
     await expect(userRow).toBeVisible({ timeout: 10_000 });
     await expect(page.locator('text=✏️ 未記録')).toContainText('未記録');
     await expect(page).toHaveURL(/autoNext=1/);


### PR DESCRIPTION
## Summary
- Add a Today user-detail action that routes operation users to `/users?tab=list&selected=<id>`.
- Align Today E2E mock users with the existing Users master seed by using `I005` as the selected ID.
- Update Today E2E coverage for the selected-detail support path.

## Scope
Includes:
- Today user detail navigation
- Today mock and Users master ID alignment
- Targeted Today E2E updates

Out of scope:
- record save behavior
- handoff add behavior
- unrecorded / incomplete state updates
- SharePoint implementation changes
- Users master data changes
- Users selected URL restoration and embedded support access internals, which are covered by #2412

## Verification
- `npm run e2e -- tests/e2e/today-ops-page.spec.ts tests/e2e/today-ops-sort-attendance.spec.ts tests/e2e/users-selection-url-sync.smoke.spec.ts tests/e2e/users-support-flow.spec.ts --project=chromium`
- `npm run typecheck`
- `npm run lint`
- `git diff --check origin/main...HEAD -- src/features/today/widgets/UserCompactList.tsx src/features/today/hooks/useTodayLayoutProps.ts src/features/users/UserDetailSections/index.tsx tests/e2e/today-ops-page.spec.ts tests/e2e/today-ops-sort-attendance.spec.ts`

## Note
`UserDetailSections/index.tsx` was originally considered for this PR, but the required embedded support access was merged separately in #2412. This PR is now limited to the Today-side bridge and tests.
