### PR TITLE
fix(vite): dedupe react router dependencies

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -137,7 +137,7 @@ export default defineConfig(({ mode }) => {
       },
     },
     resolve: {
-      dedupe: ['react-is'],
+      dedupe: ['react', 'react-dom', 'react-router', 'react-router-dom', 'react-is'],
       alias: {
         '@': srcDir,
         '@/adapters': resolve(srcDir, 'adapters'),


### PR DESCRIPTION
## Summary

Prevent duplicate React and React Router instances in Vite development builds by extending `resolve.dedupe` to include `react`, `react-dom`, `react-router`, and `react-router-dom` alongside `react-is`.

## Root cause

The local AppShell previously failed in `useNavigate` / `useContext` when Vite loaded duplicate React or React Router instances. This keeps those packages on a single resolved instance.

## Validation

- `npm run build`: PASS
- `npm run typecheck:full -- --pretty false`: PASS
- `npm run lint`: PASS
- AppShell rendered after two full Vite stop, cache-clear, and `--force` restart cycles
- No `useNavigate`, `useContext`, invalid-hook-call, duplicate React, duplicate React Router, white-screen, or unhandled runtime errors
- SharePoint authentication and SharePoint-backed DataProvider errors were observed in the local smoke environment and classified as unrelated environment noise
- All console errors were checked against a narrow SharePoint-only allowlist; non-allowlisted errors: 0 in both runs

## Scope

- One changed file: `vite.config.ts`
- No runtime feature, route, schema, dependency, or public API changes
