### PR TITLE
test(daily): stabilize daily table startup and submission flow

### DIFF
--- a/tests/e2e/_helpers/bootDailyTablePage.ts
+++ b/tests/e2e/_helpers/bootDailyTablePage.ts
@@ -1,0 +1,120 @@
+import type { Page } from '@playwright/test';
+import { setupPlaywrightEnv } from './setupPlaywrightEnv';
+
+export const DAILY_TABLE_E2E_DATE = '2026-07-13';
+export const DAILY_TABLE_E2E_USER_ID = 'U-001';
+export const DAILY_TABLE_DRAFT_STORAGE_KEY = 'daily-table-record:draft:v1';
+export const DAILY_TABLE_UNSENT_FILTER_STORAGE_KEY = 'daily-table-record:unsent-filter:v1';
+export const PDCA_DAILY_METRICS_STORAGE_KEY = 'pdca:daily-submission-events:v1';
+
+type DailyTableDraftSeed = {
+  reporterName?: string;
+  selectedUserIds?: string[];
+  userRows?: Array<Record<string, unknown>>;
+  savedAt?: string;
+};
+
+type BootDailyTablePageOptions = {
+  path?: string;
+  featureIcebergPdca?: boolean;
+  draft?: DailyTableDraftSeed;
+  unsentFilter?: boolean;
+};
+
+export async function bootDailyTablePage(
+  page: Page,
+  options: BootDailyTablePageOptions = {},
+): Promise<void> {
+  const path = options.path ?? `/daily/table?date=${DAILY_TABLE_E2E_DATE}`;
+
+  await setupPlaywrightEnv(page, {
+    envOverrides: {
+      VITE_E2E: '1',
+      VITE_E2E_MSAL_MOCK: '1',
+      VITE_SKIP_LOGIN: '1',
+      VITE_SKIP_SHAREPOINT: '1',
+      VITE_DEMO_MODE: '1',
+      VITE_FORCE_SHAREPOINT: '0',
+      VITE_WRITE_ENABLED: '1',
+      ...(options.featureIcebergPdca ? { VITE_FEATURE_ICEBERG_PDCA: '1' } : {}),
+    },
+    storageOverrides: {
+      skipLogin: '1',
+      demo: '1',
+      writeEnabled: '1',
+    },
+  });
+
+  await page.route('**/login.microsoftonline.com/**', (route) => route.fulfill({ status: 204, body: '' }));
+  await page.route('https://graph.microsoft.com/**', (route) =>
+    route.fulfill({
+      status: 200,
+      headers: { 'content-type': 'application/json; charset=utf-8' },
+      body: JSON.stringify({ value: [] }),
+    }),
+  );
+  await page.route('/_api/**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ d: { results: [] }, value: [] }),
+    }),
+  );
+
+  if (options.draft || options.unsentFilter) {
+    await page.addInitScript(
+      ({ draft, unsentFilter, storageKey, unsentStorageKey, date, defaultUserId }) => {
+        window.localStorage.removeItem(storageKey);
+        window.localStorage.removeItem(unsentStorageKey);
+        window.localStorage.removeItem('pdca:daily-submission-events:v1');
+
+        if (draft) {
+          const userRows = draft.userRows ?? [
+            {
+              userId: defaultUserId,
+              userName: '桂川 進太朗',
+              amActivity: 'E2E 午前活動',
+              pmActivity: 'E2E 午後活動',
+              lunchAmount: '完食',
+              problemBehavior: {
+                selfHarm: false,
+                otherInjury: false,
+                loudVoice: false,
+                pica: false,
+                other: false,
+              },
+              specialNotes: 'E2E 下書き',
+              behaviorTags: [],
+            },
+          ];
+          window.localStorage.setItem(storageKey, JSON.stringify({
+            formData: {
+              date,
+              reporter: { name: draft.reporterName ?? 'E2E 記録者', role: '生活支援員' },
+              userRows,
+              userCount: userRows.length,
+            },
+            selectedUserIds: draft.selectedUserIds ?? [defaultUserId],
+            searchQuery: '',
+            showTodayOnly: true,
+            savedAt: draft.savedAt ?? new Date().toISOString(),
+          }));
+        }
+
+        if (unsentFilter) {
+          window.localStorage.setItem(unsentStorageKey, '1');
+        }
+      },
+      {
+        draft: options.draft,
+        unsentFilter: options.unsentFilter,
+        storageKey: DAILY_TABLE_DRAFT_STORAGE_KEY,
+        unsentStorageKey: DAILY_TABLE_UNSENT_FILTER_STORAGE_KEY,
+        date: DAILY_TABLE_E2E_DATE,
+        defaultUserId: DAILY_TABLE_E2E_USER_ID,
+      },
+    );
+  }
+
+  await page.goto(path, { waitUntil: 'domcontentloaded' });
+}

--- a/tests/e2e/daily-pdca.integration.spec.ts
+++ b/tests/e2e/daily-pdca.integration.spec.ts
@@ -1,44 +1,38 @@
 import { expect, test } from '@playwright/test';
 
 import { expectTestIdVisibleBestEffort } from './_helpers/smoke';
-import { bootstrapDashboard } from './utils/bootstrapApp';
-
-const TABLE_DAILY_DRAFT_STORAGE_KEY = 'daily-table-record:draft:v1';
-const PDCA_DAILY_METRICS_STORAGE_KEY = 'pdca:daily-submission-events:v1';
+import {
+  bootDailyTablePage,
+  DAILY_TABLE_E2E_DATE,
+  DAILY_TABLE_E2E_USER_ID,
+  PDCA_DAILY_METRICS_STORAGE_KEY,
+} from './_helpers/bootDailyTablePage';
 
 test.describe('daily -> PDCA integration', () => {
   test('daily submit is reflected in PDCA metrics cards', async ({ page }) => {
-    await bootstrapDashboard(page, {
-      skipLogin: true,
-      featureSchedules: true,
+    await bootDailyTablePage(page, {
       featureIcebergPdca: true,
-      initialPath: '/daily/table',
+      path: `/daily/table?date=${DAILY_TABLE_E2E_DATE}`,
+      draft: {
+        reporterName: 'PDCA連携E2E',
+        selectedUserIds: [DAILY_TABLE_E2E_USER_ID],
+        savedAt: new Date(Date.now() - 120000).toISOString(),
+      },
     });
 
-    await page.evaluate(([draftStorageKey, metricsStorageKey]) => {
-      localStorage.removeItem(draftStorageKey);
-      localStorage.removeItem(metricsStorageKey);
+    await expect(page.getByTestId('daily-table-record-form')).toBeVisible({ timeout: 15_000 });
 
-      localStorage.setItem(draftStorageKey, JSON.stringify({
-        formData: {
-          date: new Date().toISOString().slice(0, 10),
-          reporter: { name: 'PDCA連携E2E', role: '生活支援員' },
-          userRows: [],
-        },
-        selectedUserIds: ['e2e-pdca-user'],
-        searchQuery: '',
-        showTodayOnly: true,
-        savedAt: new Date(Date.now() - 120000).toISOString(),
-      }));
-    }, [TABLE_DAILY_DRAFT_STORAGE_KEY, PDCA_DAILY_METRICS_STORAGE_KEY]);
-
-    await page.reload();
-    await expect(page.getByTestId('daily-table-record-form')).toBeVisible();
-
-    const reporterNameInput = page.getByRole('textbox', { name: '記録者名' });
+    const reporterNameInput = page.getByPlaceholder('記録者');
+    await expect(reporterNameInput).toBeVisible();
     if ((await reporterNameInput.inputValue()).trim().length === 0) {
       await reporterNameInput.fill('PDCA連携E2E');
     }
+
+    const table = page.getByTestId('daily-table-record-form-table');
+    await expect(table).toBeVisible();
+    await table.getByPlaceholder('午前').first().fill('PDCA 午前活動');
+    await table.getByPlaceholder('午後').first().fill('PDCA 午後活動');
+    await table.getByPlaceholder('特記').first().fill('PDCA metrics E2E');
 
     const saveButton = page.getByRole('button', { name: /^\d+人分保存$/ });
     if (await saveButton.isDisabled()) {
@@ -46,12 +40,8 @@ test.describe('daily -> PDCA integration', () => {
     }
     await expect(saveButton).toBeEnabled();
 
-    page.once('dialog', async (dialog) => {
-      await dialog.accept();
-    });
-
     await saveButton.click({ force: true });
-    await expect.poll(() => new URL(page.url()).pathname).toMatch(/^(\/dashboard|\/daily\/support|\/dailysupport)$/);
+    await expect.poll(() => new URL(page.url()).pathname).toMatch(/^\/today$/);
 
     const storedMetrics = await page.evaluate((metricsStorageKey) => {
       const raw = localStorage.getItem(metricsStorageKey);
@@ -64,8 +54,16 @@ test.describe('daily -> PDCA integration', () => {
       return {
         count: events.length,
         firstUserId: events[0]?.userId,
+        firstRecordDate: events[0]?.recordDate,
       };
     }, PDCA_DAILY_METRICS_STORAGE_KEY);
+
+    expect(storedMetrics).toMatchObject({
+      count: 1,
+      firstUserId: DAILY_TABLE_E2E_USER_ID,
+      firstRecordDate: DAILY_TABLE_E2E_DATE,
+    });
+
     test.info().annotations.push({
       type: 'note',
       description: `pdca metrics snapshot: ${JSON.stringify(storedMetrics)}`,

--- a/tests/e2e/daily.table.spec.ts
+++ b/tests/e2e/daily.table.spec.ts
@@ -1,162 +1,116 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
+import {
+  bootDailyTablePage,
+  DAILY_TABLE_DRAFT_STORAGE_KEY,
+  DAILY_TABLE_E2E_DATE,
+  DAILY_TABLE_E2E_USER_ID,
+} from './_helpers/bootDailyTablePage';
 
-const TABLE_DAILY_DRAFT_STORAGE_KEY = 'daily-table-record:draft:v1';
+const tablePath = `/daily/table?date=${DAILY_TABLE_E2E_DATE}`;
 
-const submitFromTableForm = async (page: import('@playwright/test').Page) => {
+async function expectTableFormReady(page: Page): Promise<void> {
+  await expect(page.getByTestId('daily-table-record-page')).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByRole('heading', { name: '一覧形式の日々の記録' })).toBeVisible();
   await expect(page.getByTestId('daily-table-record-form')).toBeVisible();
+}
 
-  const reporterNameInput = page.getByRole('textbox', { name: '記録者名' });
-  if ((await reporterNameInput.inputValue()).trim().length === 0) {
-    await reporterNameInput.fill('E2E 記録者');
-  }
+async function fillReporter(page: Page, name = 'E2E 記録者'): Promise<void> {
+  const reporterInput = page.getByPlaceholder('記録者');
+  await expect(reporterInput).toBeVisible();
+  await reporterInput.fill(name);
+}
 
+async function selectVisibleUsers(page: Page): Promise<void> {
   const saveButton = page.getByRole('button', { name: /^\d+人分保存$/ });
   if (await saveButton.isDisabled()) {
     await page.getByRole('button', { name: '表示中の利用者を全選択' }).click();
   }
   await expect(saveButton).toBeEnabled();
+}
 
-  page.once('dialog', async (dialog) => {
-    await dialog.accept();
-  });
+async function fillFirstRecordRow(page: Page): Promise<void> {
+  const table = page.getByTestId('daily-table-record-form-table');
+  await expect(table).toBeVisible();
+  await table.getByPlaceholder('午前').first().fill('E2E 午前活動');
+  await table.getByPlaceholder('午後').first().fill('E2E 午後活動');
+  await table.getByPlaceholder('特記').first().fill('E2E 保存確認');
+}
 
+async function submitFromTableForm(page: Page): Promise<void> {
+  await expectTableFormReady(page);
+  await fillReporter(page);
+  await selectVisibleUsers(page);
+  await fillFirstRecordRow(page);
+
+  const saveButton = page.getByRole('button', { name: /^\d+人分保存$/ });
   await saveButton.click({ force: true });
-};
+}
 
 test.describe('日次記録: /daily/table entry points', () => {
   test('direct route loads the table form', async ({ page }) => {
-    await page.goto('/daily/table');
-    await expect(page.getByRole('heading', { name: '一覧形式ケース記録入力' })).toBeVisible();
+    await bootDailyTablePage(page, { path: tablePath });
+
+    await expectTableFormReady(page);
   });
 
-  test('footer quick action navigates to /daily/table', async ({ page }) => {
-    await page.goto('/');
-    await expect(page.getByTestId('daily-footer-activity')).toBeVisible();
+  test('daily hub opens /daily/table from the table activity card', async ({ page }) => {
+    await bootDailyTablePage(page, { path: '/dailysupport' });
+    await expect(page.getByTestId('daily-record-menu')).toBeVisible({ timeout: 15_000 });
 
-    await page.getByTestId('daily-footer-activity').click();
-
-    await expect(page).toHaveURL(/\/daily\/table/);
-    await expect(page.getByRole('heading', { name: '一覧形式ケース記録入力' })).toBeVisible();
-  });
-
-  test('header nav "日次記録" navigates to /daily/table', async ({ page }) => {
-    await page.goto('/');
-    const dailyNavLink = page.getByRole('link', { name: /日次記録|Daily/ }).first();
-    await expect(dailyNavLink).toBeVisible();
-
-    await dailyNavLink.click();
-    await expect(page).toHaveURL(/\/(daily|dailysupport)/);
-
-    await page.getByRole('link', { name: 'ケース記録' }).last().click();
+    await page.getByTestId('btn-open-table-activity').click();
 
     await expect(page).toHaveURL(/\/daily\/table/);
-    await expect(page.getByRole('heading', { name: '一覧形式ケース記録入力' })).toBeVisible();
+    await expectTableFormReady(page);
   });
 });
 
 test.describe('日次記録: /daily/table draft lifecycle', () => {
   test('save draft, restore after reload, and clear draft after submit', async ({ page }) => {
-    await page.goto('/daily/table');
-    await page.evaluate((storageKey) => localStorage.removeItem(storageKey), TABLE_DAILY_DRAFT_STORAGE_KEY);
-    await page.evaluate((storageKey) => {
-      localStorage.setItem(storageKey, JSON.stringify({
-        formData: {
-          date: new Date().toISOString().split('T')[0],
-          reporter: { name: 'E2E 記録者', role: '生活支援員' },
-          userRows: [],
-        },
-        selectedUserIds: [],
-        searchQuery: '',
-        showTodayOnly: true,
-        savedAt: new Date().toISOString(),
-      }));
-    }, TABLE_DAILY_DRAFT_STORAGE_KEY);
+    await bootDailyTablePage(page, {
+      path: tablePath,
+      draft: {
+        reporterName: 'E2E 記録者',
+        selectedUserIds: [DAILY_TABLE_E2E_USER_ID],
+      },
+    });
 
-    await page.reload();
-    await expect(page.getByLabel('記録者名')).toHaveValue('E2E 記録者');
+    await expectTableFormReady(page);
+    await expect(page.getByPlaceholder('記録者')).toHaveValue('E2E 記録者');
     await expect(page.getByTestId('daily-table-draft-status')).toBeVisible();
 
-    await page.evaluate((storageKey) => {
-      const raw = localStorage.getItem(storageKey);
-      if (!raw) {
-        return;
-      }
-      const parsed = JSON.parse(raw) as {
-        formData: { date: string; reporter: { name: string; role: string }; userRows: unknown[] };
-        selectedUserIds: string[];
-        searchQuery: string;
-        showTodayOnly: boolean;
-        savedAt: string;
-      };
-      parsed.selectedUserIds = ['e2e-unsent-user'];
-      localStorage.setItem(storageKey, JSON.stringify(parsed));
-    }, TABLE_DAILY_DRAFT_STORAGE_KEY);
-    await page.reload();
-
     await submitFromTableForm(page);
-    await expect.poll(() => new URL(page.url()).pathname).toMatch(/^(\/dashboard|\/daily\/support|\/dailysupport)$/);
+    await expect.poll(() => new URL(page.url()).pathname).toMatch(/^\/today$/);
 
-    await page.goto('/daily/table');
-    await expect(page.getByLabel('記録者名')).toBeVisible();
+    const remainingDraft = await page.evaluate((storageKey) => localStorage.getItem(storageKey), DAILY_TABLE_DRAFT_STORAGE_KEY);
+    expect(remainingDraft).toBeNull();
+
+    await page.goto(tablePath);
+    await expectTableFormReady(page);
+    await expect(page.getByPlaceholder('記録者')).toBeVisible();
   });
 });
 
 test.describe('日次記録: /daily/table unsent recovery flow', () => {
   test('unsent-only ON then submit turns filter OFF when unsent reaches zero', async ({ page }) => {
-    await page.goto('/daily/table');
-    await page.evaluate((draftStorageKey) => {
-      localStorage.removeItem(draftStorageKey);
-      localStorage.removeItem('daily-table-record:unsent-filter:v1');
-      const next = new URL(window.location.href);
-      next.searchParams.delete('unsent');
-      window.history.replaceState({}, '', next.toString());
-    }, TABLE_DAILY_DRAFT_STORAGE_KEY);
-
-    await page.evaluate((draftStorageKey) => {
-      localStorage.setItem(draftStorageKey, JSON.stringify({
-        formData: {
-          date: new Date().toISOString().split('T')[0],
-          reporter: { name: '未送信回収E2E', role: '生活支援員' },
-          userRows: [
-            {
-              userId: 'e2e-unsent-user',
-              userName: 'E2E 利用者',
-              amActivity: '未送信対象データ',
-              pmActivity: '',
-              lunchAmount: '',
-              problemBehavior: {
-                selfHarm: false,
-                violence: false,
-                loudVoice: false,
-                pica: false,
-                other: false,
-              },
-              specialNotes: '',
-            },
-          ],
-        },
-        selectedUserIds: ['e2e-unsent-user'],
-        searchQuery: '',
-        showTodayOnly: true,
-        savedAt: new Date().toISOString(),
-      }));
-    }, TABLE_DAILY_DRAFT_STORAGE_KEY);
-
-    await page.evaluate(() => {
-      localStorage.setItem('daily-table-record:unsent-filter:v1', '1');
-      const next = new URL(window.location.href);
-      next.searchParams.set('unsent', '1');
-      window.history.replaceState({}, '', next.toString());
+    await bootDailyTablePage(page, {
+      path: `${tablePath}&unsent=1`,
+      unsentFilter: true,
+      draft: {
+        reporterName: '未送信回収E2E',
+        selectedUserIds: [DAILY_TABLE_E2E_USER_ID],
+      },
     });
 
-    await page.reload();
-    await expect(page).toHaveURL(/\?unsent=1/);
+    await expectTableFormReady(page);
+    await expect(page.getByTestId('daily-table-unsent-count-chip')).toBeVisible();
 
     await submitFromTableForm(page);
-    await expect.poll(() => new URL(page.url()).pathname).toMatch(/^(\/dashboard|\/daily\/support|\/dailysupport)$/);
+    await expect.poll(() => new URL(page.url()).pathname).toMatch(/^\/today$/);
+    const unsentFilter = await page.evaluate(() => localStorage.getItem('daily-table-record:unsent-filter:v1'));
+    expect(unsentFilter).toBeNull();
 
-    await page.goto('/daily/table');
-    await expect(page).not.toHaveURL(/\?unsent=1/);
-    await expect(page.getByTestId('daily-table-unsent-count-chip')).toHaveCount(0);
+    await page.goto(tablePath);
+    await expectTableFormReady(page);
+    await expect(page).not.toHaveURL(/unsent=1/);
   });
 });


### PR DESCRIPTION
## Summary
- Add a shared E2E boot helper for the Daily table flow.
- Start `/daily/table` with the memory provider, SharePoint disabled, and MSAL mock enabled.
- Fix the E2E date to `2026-07-13` so the attendance fixture contains eligible users.
- Align `daily.table.spec.ts` with the current Daily UI and official navigation.
- Move `daily-pdca.integration.spec.ts` away from `VITE_FORCE_SHAREPOINT` and onto the Daily-specific E2E startup.
- Verify draft removal, unsent-filter clearing, and PDCA metric generation after submission.

## Scope
Daily table E2E startup, submission flow, and PDCA integration coverage only.

Changed files:
- `tests/e2e/_helpers/bootDailyTablePage.ts`
- `tests/e2e/daily.table.spec.ts`
- `tests/e2e/daily-pdca.integration.spec.ts`

Out of scope:
- production Daily behavior changes
- AppShell layout changes
- restoration of `daily-footer-activity`
- Today or Users flow changes
- SharePoint implementation changes
- CI workflow changes

## Verification
- `npm run e2e -- tests/e2e/daily.table.spec.ts tests/e2e/daily-pdca.integration.spec.ts --project=chromium`
- `npm run typecheck`
- `npm run lint`
- `git diff --check -- tests/e2e/_helpers/bootDailyTablePage.ts tests/e2e/daily.table.spec.ts tests/e2e/daily-pdca.integration.spec.ts`
