### PR TITLE
refactor(billing): expose public repository boundary

### DIFF
--- a/.dependency-cruiser-known-violations.json
+++ b/.dependency-cruiser-known-violations.json
@@ -8197,23 +8197,6 @@
   {
     "type": "dependency",
     "from": "src/app/routes/lazyPages.tsx",
-    "to": "src/features/daily/components/table/TableDailyRecordPage.tsx",
-    "unresolvedTo": "@/features/daily/components/table/TableDailyRecordPage",
-    "dependencyTypes": [
-      "aliased",
-      "aliased-tsconfig",
-      "aliased-tsconfig-paths",
-      "local",
-      "dynamic-import"
-    ],
-    "rule": {
-      "severity": "error",
-      "name": "no-external-feature-internals"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/app/routes/lazyPages.tsx",
     "to": "src/features/records/RecordList.tsx",
     "unresolvedTo": "@/features/records/RecordList",
     "dependencyTypes": [
@@ -9448,23 +9431,6 @@
     "from": "src/pages/AttendanceRecordPage.tsx",
     "to": "src/features/daily/components/pages/FullScreenDailyDialogPage.tsx",
     "unresolvedTo": "@/features/daily/components/pages/FullScreenDailyDialogPage",
-    "dependencyTypes": [
-      "aliased",
-      "aliased-tsconfig",
-      "aliased-tsconfig-paths",
-      "local",
-      "import"
-    ],
-    "rule": {
-      "severity": "error",
-      "name": "no-external-feature-internals"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/pages/BillingPage.tsx",
-    "to": "src/features/billing/hooks/useBillingSummary.ts",
-    "unresolvedTo": "@/features/billing/hooks/useBillingSummary",
     "dependencyTypes": [
       "aliased",
       "aliased-tsconfig",

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -101,7 +101,7 @@
 - [ ] 外部参照を公開 `index.ts` に限定し、新しい内部パス参照を追加していない
 - [ ] domain から UI / adapter / SharePoint / Firestore / localStorage への依存がない
 - [ ] Repository interface は ports、基盤実装は adapters、全体の組み立ては `src/app` に置いた
-- [ ] `npm run arch:check` が新規違反0、baseline 921以下で通った
+- [ ] `npm run arch:check` が新規違反0、baseline 919以下で通った
 - [ ] shared/commonへ移動した場合、ADR-024の5条件をすべて満たす根拠を記載した
 - [ ] 未変更モジュールの再配置や、別モジュールの移行を混在させていない
 

--- a/ARCHITECTURE_GUARDS.md
+++ b/ARCHITECTURE_GUARDS.md
@@ -7,14 +7,14 @@ This document lists ESLint-enforced architectural patterns that prevent common v
 ADR-024 のモジュール境界は dependency-cruiser で検査する。
 
 - 運用手順: [Modular Monolith Migration Playbook](docs/architecture/modular-monolith-migration-playbook.md)
-- `record-quality` の実証完了時点の baseline は **921件** とし、以後は増加を認めない。
+- 現在の baseline は **919件** とし、以後は増加を認めない。
 
 - `npm run arch:check`: 現在の known violations を許容し、新しい違反だけを失敗させる。
 - `npm run arch:baseline`: 違反を解消した後にベースラインを再生成する。
 - `.dependency-cruiser-known-violations.json` への手編集や、変更と無関係な違反追加は禁止する。
 - ベースライン差分は、違反が減っていること、または ADR で明示承認された例外だけが
   追加されていることをレビューする。
-- `arch:check` の結果はPR本文に記録し、baselineが921件以下かつ変更前以下であることを
+- `arch:check` の結果はPR本文に記録し、baselineが919件以下かつ変更前以下であることを
   確認する。
 
 検査対象は feature 間の内部パス参照、domain から外部基盤への依存、

--- a/src/features/billing/hooks/useBillingOrderRepository.spec.ts
+++ b/src/features/billing/hooks/useBillingOrderRepository.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
-import type { BillingOrderRepository } from '../repository';
+import type { BillingOrderRepository } from '../ports/billingOrderRepository';
 
 const envState = {
   isTestMode: true,

--- a/src/features/billing/hooks/useBillingSummary.ts
+++ b/src/features/billing/hooks/useBillingSummary.ts
@@ -5,7 +5,7 @@ import { useBillingOrderRepository } from './useBillingOrderRepository';
 import { useUsersStore } from '@/features/users/store';
 import { useStaffStore } from '@/features/staff/store';
 import { useAuth } from '@/auth/useAuth';
-import type { BillingPersistenceDiagnostics } from '../repository';
+import type { BillingPersistenceDiagnostics } from '../ports/billingOrderRepository';
 
 export interface AggregatedBillingRecord {
   ordererCode: string;

--- a/src/features/billing/index.ts
+++ b/src/features/billing/index.ts
@@ -1,0 +1,9 @@
+export { useBillingSummary } from './hooks/useBillingSummary';
+export { useBillingOrderRepository } from './hooks/useBillingOrderRepository';
+export { useBillingOrders, billingOrdersQueryKey } from './useBillingOrders';
+export type {
+  BillingOrderRepository,
+  BillingPersistenceDiagnostics,
+  BillingPersistenceDiagnosticStatus,
+} from './ports/billingOrderRepository';
+export type { BillingOrder } from './types';

--- a/src/features/billing/infra/DataProviderBillingOrderRepository.ts
+++ b/src/features/billing/infra/DataProviderBillingOrderRepository.ts
@@ -12,7 +12,7 @@ import {
 } from '@/lib/sp/helpers';
 import { reportResourceResolution } from '@/lib/data/dataProviderObservabilityStore';
 import { readOptionalEnv } from '@/lib/env';
-import type { BillingOrderRepository, BillingPersistenceDiagnostics } from '../repository';
+import type { BillingOrderRepository, BillingPersistenceDiagnostics } from '../ports/billingOrderRepository';
 import type { BillingOrder } from '../types';
 import { mapToBillingOrder } from '../domain/billingLogic';
 

--- a/src/features/billing/infra/InMemoryBillingOrderRepository.ts
+++ b/src/features/billing/infra/InMemoryBillingOrderRepository.ts
@@ -1,4 +1,4 @@
-import type { BillingOrderRepository } from '../repository';
+import type { BillingOrderRepository } from '../ports/billingOrderRepository';
 import type { BillingOrder } from '../types';
 
 export class InMemoryBillingOrderRepository implements BillingOrderRepository {

--- a/src/features/billing/ports/billingOrderRepository.ts
+++ b/src/features/billing/ports/billingOrderRepository.ts
@@ -1,0 +1,38 @@
+import type { BillingOrder } from '../types';
+
+export type BillingPersistenceDiagnosticStatus =
+  | 'resolved'
+  | 'missing_payment_status'
+  | 'missing_audit_fields'
+  | 'field_resolution_error'
+  | 'env_fallback_list3'
+  | 'unknown';
+
+export interface BillingPersistenceDiagnostics {
+  status: BillingPersistenceDiagnosticStatus;
+  listId: string;
+  siteRelative?: string;
+  missingFields: string[];
+  resolvedFields: Record<string, string | undefined>;
+  errorMessage?: string;
+  usesList3Fallback: boolean;
+}
+
+/** Billing order persistence contract. */
+export interface BillingOrderRepository {
+  list(): Promise<BillingOrder[]>;
+  isPersistenceColumnsResolved(): Promise<boolean>;
+  getPersistenceDiagnostics?(): Promise<BillingPersistenceDiagnostics>;
+  updatePaymentStatus(
+    id: number,
+    status: '未精算' | '精算済み',
+    paidAt?: string,
+    paidBy?: string,
+  ): Promise<void>;
+  bulkUpdatePaymentStatus(
+    ids: number[],
+    status: '未精算' | '精算済み',
+    paidAt?: string,
+    paidBy?: string,
+  ): Promise<void>;
+}

--- a/src/features/billing/repository.ts
+++ b/src/features/billing/repository.ts
@@ -1,38 +1,6 @@
-import type { BillingOrder } from './types';
-
-export type BillingPersistenceDiagnosticStatus =
-  | 'resolved'
-  | 'missing_payment_status'
-  | 'missing_audit_fields'
-  | 'field_resolution_error'
-  | 'env_fallback_list3'
-  | 'unknown';
-
-export interface BillingPersistenceDiagnostics {
-  status: BillingPersistenceDiagnosticStatus;
-  listId: string;
-  siteRelative?: string;
-  missingFields: string[];
-  resolvedFields: Record<string, string | undefined>;
-  errorMessage?: string;
-  usesList3Fallback: boolean;
-}
-
-/** Repository インターフェース */
-export interface BillingOrderRepository {
-  list(): Promise<BillingOrder[]>;
-  isPersistenceColumnsResolved(): Promise<boolean>;
-  getPersistenceDiagnostics?(): Promise<BillingPersistenceDiagnostics>;
-  updatePaymentStatus(
-    id: number,
-    status: '未精算' | '精算済み',
-    paidAt?: string,
-    paidBy?: string
-  ): Promise<void>;
-  bulkUpdatePaymentStatus(
-    ids: number[],
-    status: '未精算' | '精算済み',
-    paidAt?: string,
-    paidBy?: string
-  ): Promise<void>;
-}
+/** @deprecated Import Billing persistence contracts from './ports/billingOrderRepository'. */
+export type {
+  BillingOrderRepository,
+  BillingPersistenceDiagnostics,
+  BillingPersistenceDiagnosticStatus,
+} from './ports/billingOrderRepository';

--- a/src/features/billing/repositoryFactory.ts
+++ b/src/features/billing/repositoryFactory.ts
@@ -1,5 +1,5 @@
 import { createRepositoryFactory, type BaseFactoryOptions } from '@/lib/createRepositoryFactory';
-import type { BillingOrderRepository } from './repository';
+import type { BillingOrderRepository } from './ports/billingOrderRepository';
 import { DataProviderBillingOrderRepository } from './infra/DataProviderBillingOrderRepository';
 import { inMemoryBillingOrderRepository } from './infra/InMemoryBillingOrderRepository';
 import { createSpClient, ensureConfig } from '@/lib/spClient';

--- a/src/features/billing/useBillingOrders.ts
+++ b/src/features/billing/useBillingOrders.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import type { BillingOrderRepository } from './repository';
+import type { BillingOrderRepository } from './ports/billingOrderRepository';
 
 export const billingOrdersQueryKey = ['billingOrders', 'list'] as const;
 

--- a/src/pages/BillingPage.tsx
+++ b/src/pages/BillingPage.tsx
@@ -35,7 +35,7 @@ import {
   AccountCircle as AccountCircleIcon,
   Check as CheckIcon,
 } from '@mui/icons-material';
-import { useBillingSummary } from '@/features/billing/hooks/useBillingSummary';
+import { useBillingSummary } from '@/features/billing';
 
 type ActiveTab = '利用者' | '職員' | 'ゲスト' | 'すべて';
 

--- a/tests/unit/BillingPage.csv-confirm.spec.tsx
+++ b/tests/unit/BillingPage.csv-confirm.spec.tsx
@@ -12,7 +12,7 @@ const exportCsvMock = vi.hoisted(() => vi.fn());
 const togglePaymentStatusMock = vi.hoisted(() => vi.fn());
 const bulkSettleMock = vi.hoisted(() => vi.fn());
 
-vi.mock('@/features/billing/hooks/useBillingSummary', () => ({
+vi.mock('@/features/billing', () => ({
   useBillingSummary: () => ({
     records: [],
     availableMonths: ['2026-05'],


### PR DESCRIPTION
## Summary
- Add the Billing public API and make the Billing order repository contract canonical under `ports/`.
- Update BillingPage and its focused test to consume the public API instead of an internal hook path.
- Regenerate the architecture baseline from 921 to 919 after removing the BillingPage internal-import violation and an already-resolved stale daily route entry.

## Validation
- `npm run arch:check` — new violations: 0; known baseline: 919
- `npx vitest run src/features/billing/hooks/useBillingOrderRepository.spec.ts src/features/billing/hooks/useBillingOrders.spec.ts tests/unit/BillingPage.csv-confirm.spec.tsx --pool=forks --maxWorkers=1 --no-file-parallelism` — 3 files / 14 tests passed
- `npm run typecheck:full -- --pretty false`
- `npm run lint -- --quiet`
- `git diff --check`

## Scope
- Changed files: 14
- No UI behavior, localStorage fallback, or Billing business-rule changes.
- Follow-up composition/adapters work will be a separate stacked PR.