### PR TITLE
test(pdca): stabilize iceberg pdca route readiness in e2e

### DIFF
--- a/tests/e2e/daily-pdca.integration.spec.ts
+++ b/tests/e2e/daily-pdca.integration.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, type Page, test } from '@playwright/test';
 
 import { expectTestIdVisibleBestEffort } from './_helpers/smoke';
 import {
@@ -7,6 +7,15 @@ import {
   DAILY_TABLE_E2E_USER_ID,
   PDCA_DAILY_METRICS_STORAGE_KEY,
 } from './_helpers/bootDailyTablePage';
+
+async function waitForIcebergPdcaReady(page: Page): Promise<void> {
+  await page.goto('/analysis/iceberg-pdca', { waitUntil: 'domcontentloaded' });
+  await expect(page).toHaveURL(/\/analysis\/iceberg-pdca/);
+
+  const root = page.getByTestId('iceberg-pdca-root');
+  await expect(root).toBeAttached({ timeout: 30_000 });
+  await expect(root).toBeVisible({ timeout: 30_000 });
+}
 
 test.describe('daily -> PDCA integration', () => {
   test('daily submit is reflected in PDCA metrics cards', async ({ page }) => {
@@ -69,8 +78,7 @@ test.describe('daily -> PDCA integration', () => {
       description: `pdca metrics snapshot: ${JSON.stringify(storedMetrics)}`,
     });
 
-    await page.goto('/analysis/iceberg-pdca');
-    await expect(page.getByTestId('iceberg-pdca-root')).toBeVisible();
+    await waitForIcebergPdcaReady(page);
 
     await expectTestIdVisibleBestEffort(page, 'pdca-daily-completion-card');
     await expectTestIdVisibleBestEffort(page, 'pdca-daily-leadtime-card');


### PR DESCRIPTION
Summary

* Stabilize the Daily-to-PDCA integration E2E route transition.
* Wait explicitly for the Iceberg PDCA URL, root attachment, and root visibility.
* Avoid fixed sleeps and keep the change limited to E2E readiness handling.

Scope

PDCA route readiness in the Daily integration E2E only.

Changed file:

* tests/e2e/daily-pdca.integration.spec.ts

Out of scope

* production PDCA behavior
* Daily production code
* route implementation changes
* fixed timeout increases
* CI workflow changes

Verification

* npm run e2e -- tests/e2e/daily-pdca.integration.spec.ts --project=chromium
* P0 vertical E2E set: 13 passed
* P0 vertical E2E set rerun: 13 passed
* npm run typecheck
* npm run lint
* git diff --check -- tests/e2e/daily-pdca.integration.spec.ts
