### PR TITLE
refactor(billing): compose repository in app route

### DIFF
--- a/src/app/routes/BillingRoute.tsx
+++ b/src/app/routes/BillingRoute.tsx
@@ -1,0 +1,10 @@
+import {
+  BillingPage,
+  useBillingRuntime,
+} from '@/features/billing';
+
+export default function BillingRoute() {
+  const repository = useBillingRuntime();
+
+  return <BillingPage repository={repository} />;
+}

--- a/src/app/routes/__tests__/BillingRoute.spec.tsx
+++ b/src/app/routes/__tests__/BillingRoute.spec.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import BillingRoute from '../BillingRoute';
+
+const state = vi.hoisted(() => ({
+  repository: { kind: 'billing-repository' },
+}));
+
+vi.mock('@/features/billing', () => ({
+  useBillingRuntime: () => state.repository,
+  BillingPage: ({ repository }: { repository: unknown }) => (
+    <div data-testid="billing-route-repository">
+      {repository === state.repository ? 'injected' : 'unexpected'}
+    </div>
+  ),
+}));
+
+describe('BillingRoute', () => {
+  it('injects the public runtime repository into BillingPage', () => {
+    render(<BillingRoute />);
+
+    expect(screen.getByTestId('billing-route-repository')).toHaveTextContent('injected');
+  });
+});

--- a/src/app/routes/lazyPages.tsx
+++ b/src/app/routes/lazyPages.tsx
@@ -36,7 +36,7 @@ const MonthlyRecordPage = React.lazy(() => import('@/pages/MonthlyRecordPage'));
 const ServiceProvisionFormPage = React.lazy(() => import('@/pages/ServiceProvisionFormPage'));
 const BusinessJournalPreviewPage = React.lazy(() => import('@/pages/BusinessJournalPreviewPage'));
 const PersonalJournalPage = React.lazy(() => import('@/pages/PersonalJournalPage'));
-const BillingPage = React.lazy(() => import('@/pages/BillingPage'));
+const BillingPage = React.lazy(() => import('@/app/routes/BillingRoute'));
 
 const AttendanceRecordPage = React.lazy(() => import('@/pages/AttendanceRecordPage'));
 const StaffAttendanceAdminPage = React.lazy(() => import('@/pages/StaffAttendanceAdminPage'));

--- a/src/features/billing/adapters/in-memory/InMemoryBillingOrderRepository.ts
+++ b/src/features/billing/adapters/in-memory/InMemoryBillingOrderRepository.ts
@@ -1,5 +1,5 @@
-import type { BillingOrderRepository } from '../ports/billingOrderRepository';
-import type { BillingOrder } from '../types';
+import type { BillingOrderRepository } from '../../ports/billingOrderRepository';
+import type { BillingOrder } from '../../types';
 
 export class InMemoryBillingOrderRepository implements BillingOrderRepository {
   private orders: BillingOrder[] = [];

--- a/src/features/billing/adapters/in-memory/__tests__/InMemoryBillingOrderRepository.spec.ts
+++ b/src/features/billing/adapters/in-memory/__tests__/InMemoryBillingOrderRepository.spec.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest';
+
+// Adapter contract tests.
 import { InMemoryBillingOrderRepository } from '../InMemoryBillingOrderRepository';
 
 const baseOrders = [

--- a/src/features/billing/adapters/runtime/useBillingRuntime.ts
+++ b/src/features/billing/adapters/runtime/useBillingRuntime.ts
@@ -1,0 +1,57 @@
+import { createRepositoryFactory, type BaseFactoryOptions } from '@/lib/createRepositoryFactory';
+import { getAppConfig, readOptionalEnv } from '@/lib/env';
+import { createSpClient, ensureConfig } from '@/lib/spClient';
+import { SharePointDataProvider } from '@/lib/sp/spDataProvider';
+
+import { inMemoryBillingOrderRepository } from '../in-memory/InMemoryBillingOrderRepository';
+import { DataProviderBillingOrderRepository } from '../sharepoint/DataProviderBillingOrderRepository';
+import type { BillingOrderRepository } from '../../ports/billingOrderRepository';
+
+export interface BillingOrderRepositoryFactoryOptions extends BaseFactoryOptions {
+  spFetch?: (path: string, init?: RequestInit) => Promise<Response>;
+}
+
+export function resolveBillingSharePointBaseUrl(): string {
+  const billingSiteRelative = readOptionalEnv('VITE_SP_LIST_BILLING_ORDERS_SITE_RELATIVE');
+  const { VITE_SP_RESOURCE } = getAppConfig();
+  const { baseUrl } = billingSiteRelative
+    ? ensureConfig({
+        VITE_SP_RESOURCE,
+        VITE_SP_SITE_RELATIVE: billingSiteRelative,
+      })
+    : ensureConfig();
+  return baseUrl;
+}
+
+export function resolveBillingSharePointSiteRelative(): string | undefined {
+  return readOptionalEnv('VITE_SP_LIST_BILLING_ORDERS_SITE_RELATIVE');
+}
+
+const factory = createRepositoryFactory<BillingOrderRepository, BillingOrderRepositoryFactoryOptions>({
+  name: 'BillingOrder',
+  createDemo: () => inMemoryBillingOrderRepository,
+  createReal: (options) => {
+    const { acquireToken } = options;
+    if (!acquireToken) {
+      throw new Error('[BillingOrderRepositoryFactory] acquireToken is required for real repository.');
+    }
+    const baseUrl = resolveBillingSharePointBaseUrl();
+    const provider = new SharePointDataProvider(createSpClient(acquireToken, baseUrl));
+
+    return new DataProviderBillingOrderRepository(provider, undefined, resolveBillingSharePointSiteRelative());
+  },
+});
+
+/**
+ * Builds the Billing runtime and keeps concrete persistence adapters private.
+ * App routes consume this public hook and inject its port into Billing UI.
+ */
+export function useBillingRuntime(): BillingOrderRepository {
+  return factory.useRepository();
+}
+
+export const getBillingOrderRepository = factory.getRepository;
+export const useBillingOrderRepository = factory.useRepository;
+export const overrideBillingOrderRepository = factory.override;
+export const resetBillingOrderRepository = factory.reset;
+export const getCurrentBillingOrderRepositoryKind = factory.getCurrentKind;

--- a/src/features/billing/adapters/sharepoint/DataProviderBillingOrderRepository.ts
+++ b/src/features/billing/adapters/sharepoint/DataProviderBillingOrderRepository.ts
@@ -12,9 +12,9 @@ import {
 } from '@/lib/sp/helpers';
 import { reportResourceResolution } from '@/lib/data/dataProviderObservabilityStore';
 import { readOptionalEnv } from '@/lib/env';
-import type { BillingOrderRepository, BillingPersistenceDiagnostics } from '../ports/billingOrderRepository';
-import type { BillingOrder } from '../types';
-import { mapToBillingOrder } from '../domain/billingLogic';
+import type { BillingOrderRepository, BillingPersistenceDiagnostics } from '../../ports/billingOrderRepository';
+import type { BillingOrder } from '../../types';
+import { mapToBillingOrder } from '../../domain/billingLogic';
 
 export const BILLING_ORDERS_PAGE_SIZE = 5000;
 const BILLING_PAYMENT_FIELDS = ['PaymentStatus', 'PaidAt', 'PaidBy'] as const;

--- a/src/features/billing/adapters/sharepoint/__tests__/DataProviderBillingOrderRepository.spec.ts
+++ b/src/features/billing/adapters/sharepoint/__tests__/DataProviderBillingOrderRepository.spec.ts
@@ -4,7 +4,7 @@ import {
   BILLING_ORDERS_PAGE_SIZE,
   DataProviderBillingOrderRepository,
 } from '../DataProviderBillingOrderRepository';
-import { BILLING_DEFAULT_DRINK_PRICE } from '../../domain/billingLogic';
+import { BILLING_DEFAULT_DRINK_PRICE } from '../../../domain/billingLogic';
 
 const createProvider = (): IDataProvider => ({
   listItems: vi.fn().mockResolvedValue([]),

--- a/src/features/billing/hooks/__tests__/useBillingSummary.spec.ts
+++ b/src/features/billing/hooks/__tests__/useBillingSummary.spec.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useBillingSummary } from '../useBillingSummary';
+import type { BillingOrderRepository } from '../../ports/billingOrderRepository';
+
+const { mockUseBillingOrders } = vi.hoisted(() => ({
+  mockUseBillingOrders: vi.fn(),
+}));
 
 // ─── モック定義 ───────────────────────────────────────────
 
@@ -123,13 +128,15 @@ const mockOrders = [
 ];
 
 vi.mock('../../useBillingOrders', () => ({
-  useBillingOrders: () => ({
+  useBillingOrders: mockUseBillingOrders,
+  billingOrdersQueryKey: ['billingOrders', 'list'],
+}));
+
+const billingOrdersResult = {
     data: mockOrders,
     isLoading: false,
     isError: false,
-  }),
-  billingOrdersQueryKey: ['billingOrders', 'list'],
-}));
+};
 
 const mockInvalidateQueries = vi.fn();
 vi.mock('@tanstack/react-query', async (importOriginal) => {
@@ -146,15 +153,13 @@ const mockBulkUpdatePaymentStatus = vi.fn(() => Promise.resolve());
 const mockIsPersistenceColumnsResolved = vi.fn(() => Promise.resolve(true));
 const mockGetPersistenceDiagnostics = vi.fn();
 
-vi.mock('../useBillingOrderRepository', () => ({
-  useBillingOrderRepository: () => ({
-    list: vi.fn(),
-    isPersistenceColumnsResolved: mockIsPersistenceColumnsResolved,
-    getPersistenceDiagnostics: mockGetPersistenceDiagnostics,
-    updatePaymentStatus: vi.fn(() => Promise.resolve()),
-    bulkUpdatePaymentStatus: mockBulkUpdatePaymentStatus,
-  }),
-}));
+const mockRepository: BillingOrderRepository = {
+  list: vi.fn(),
+  isPersistenceColumnsResolved: mockIsPersistenceColumnsResolved,
+  getPersistenceDiagnostics: mockGetPersistenceDiagnostics,
+  updatePaymentStatus: vi.fn(() => Promise.resolve()),
+  bulkUpdatePaymentStatus: mockBulkUpdatePaymentStatus,
+};
 
 describe('useBillingSummary', () => {
   beforeEach(() => {
@@ -164,6 +169,7 @@ describe('useBillingSummary', () => {
     vi.spyOn(window, 'alert').mockImplementation(() => {});
     mockBulkUpdatePaymentStatus.mockClear();
     mockInvalidateQueries.mockClear();
+    mockUseBillingOrders.mockReturnValue(billingOrdersResult);
     mockIsPersistenceColumnsResolved.mockClear();
     mockGetPersistenceDiagnostics.mockReset();
     mockGetPersistenceDiagnostics.mockResolvedValue({
@@ -186,7 +192,7 @@ describe('useBillingSummary', () => {
 
   it('対象月と served===true でフィルタリングし、人ごとに正しく集計すること', async () => {
     mockIsPersistenceColumnsResolved.mockResolvedValue(true);
-    const { result } = renderHook(() => useBillingSummary('2026-05'));
+    const { result } = renderHook(() => useBillingSummary('2026-05', mockRepository));
 
     // スキーマ判定の解決を待つ
     await waitFor(() => {
@@ -213,11 +219,12 @@ describe('useBillingSummary', () => {
     expect(result.current.availableMonths).toEqual(['2026-05', '2026-04']);
     expect(result.current.hasLocalPaymentState).toBe(false);
     expect(result.current.localPaymentStateCount).toBe(0);
+    expect(mockUseBillingOrders).toHaveBeenCalledWith(mockRepository);
   });
 
   it('個別の精算トグル状態が SharePoint の repository に送られ、query invalidation が走ること', async () => {
     mockIsPersistenceColumnsResolved.mockResolvedValue(true);
-    const { result } = renderHook(() => useBillingSummary('2026-05'));
+    const { result } = renderHook(() => useBillingSummary('2026-05', mockRepository));
 
     await waitFor(() => {
       expect(result.current.persistenceDiagnostics?.status).toBe('resolved');
@@ -244,7 +251,7 @@ describe('useBillingSummary', () => {
   it('PaymentStatus 解決済みの場合、既存 LocalStorage 値があっても SharePoint の精算状態を正本にし、新規保存しないこと', async () => {
     localStorage.setItem('app:billing:payment_states', JSON.stringify({ '2026-05:U-001': true }));
     const setItemSpy = vi.spyOn(Storage.prototype, 'setItem');
-    const { result } = renderHook(() => useBillingSummary('2026-05'));
+    const { result } = renderHook(() => useBillingSummary('2026-05', mockRepository));
 
     await waitFor(() => {
       expect(result.current.persistenceDiagnostics?.status).toBe('resolved');
@@ -271,7 +278,7 @@ describe('useBillingSummary', () => {
 
   it('一括精算を実行すると、選択されたカテゴリがすべて精算済みになるよう SharePoint を一括更新すること', async () => {
     mockIsPersistenceColumnsResolved.mockResolvedValue(true);
-    const { result } = renderHook(() => useBillingSummary('2026-05'));
+    const { result } = renderHook(() => useBillingSummary('2026-05', mockRepository));
 
     await waitFor(() => {
       expect(result.current.persistenceDiagnostics?.status).toBe('resolved');
@@ -294,7 +301,7 @@ describe('useBillingSummary', () => {
 
   it('PaymentStatus 解決済みの場合、一括精算でも LocalStorage へ新規保存しないこと', async () => {
     const setItemSpy = vi.spyOn(Storage.prototype, 'setItem');
-    const { result } = renderHook(() => useBillingSummary('2026-05'));
+    const { result } = renderHook(() => useBillingSummary('2026-05', mockRepository));
 
     await waitFor(() => {
       expect(result.current.persistenceDiagnostics?.status).toBe('resolved');
@@ -318,7 +325,7 @@ describe('useBillingSummary', () => {
     mockAuthAccount.name = '';
     mockAuthAccount.username = 'billing.operator@example.com';
     mockIsPersistenceColumnsResolved.mockResolvedValue(true);
-    const { result } = renderHook(() => useBillingSummary('2026-05'));
+    const { result } = renderHook(() => useBillingSummary('2026-05', mockRepository));
 
     await waitFor(() => {
       expect(result.current.isPersistenceMissing).toBe(false);
@@ -340,7 +347,7 @@ describe('useBillingSummary', () => {
     mockAuthAccount.name = '';
     mockAuthAccount.username = '';
     mockIsPersistenceColumnsResolved.mockResolvedValue(true);
-    const { result } = renderHook(() => useBillingSummary('2026-05'));
+    const { result } = renderHook(() => useBillingSummary('2026-05', mockRepository));
 
     await waitFor(() => {
       expect(result.current.isPersistenceMissing).toBe(false);
@@ -371,7 +378,7 @@ describe('useBillingSummary', () => {
       },
       usesList3Fallback: true,
     });
-    const { result } = renderHook(() => useBillingSummary('2026-05'));
+    const { result } = renderHook(() => useBillingSummary('2026-05', mockRepository));
 
     await waitFor(() => {
       expect(result.current.isPersistenceMissing).toBe(true);
@@ -406,7 +413,7 @@ describe('useBillingSummary', () => {
       usesList3Fallback: true,
     });
 
-    const { result } = renderHook(() => useBillingSummary('2026-05'));
+    const { result } = renderHook(() => useBillingSummary('2026-05', mockRepository));
 
     await waitFor(() => {
       expect(result.current.isPersistenceMissing).toBe(true);
@@ -430,7 +437,7 @@ describe('useBillingSummary', () => {
       },
       usesList3Fallback: false,
     });
-    const { result } = renderHook(() => useBillingSummary('2026-05'));
+    const { result } = renderHook(() => useBillingSummary('2026-05', mockRepository));
 
     await waitFor(() => {
       expect(result.current.isPaymentAuditMissing).toBe(true);
@@ -442,7 +449,7 @@ describe('useBillingSummary', () => {
 
   it('CSV出力が正常に動作し、BOM(\ufeff) が付与されていること', async () => {
     mockIsPersistenceColumnsResolved.mockResolvedValue(true);
-    const { result } = renderHook(() => useBillingSummary('2026-05'));
+    const { result } = renderHook(() => useBillingSummary('2026-05', mockRepository));
 
     await waitFor(() => {
       expect(result.current.isPersistenceMissing).toBe(false);

--- a/src/features/billing/hooks/useBillingOrderRepository.spec.ts
+++ b/src/features/billing/hooks/useBillingOrderRepository.spec.ts
@@ -34,7 +34,8 @@ vi.mock('@/lib/runtime', () => ({
   hasSpfxContext: () => true,
 }));
 
-import { inMemoryBillingOrderRepository } from '../infra/InMemoryBillingOrderRepository';
+import { inMemoryBillingOrderRepository } from '../adapters/in-memory/InMemoryBillingOrderRepository';
+import { useBillingRuntime } from '../adapters/runtime/useBillingRuntime';
 import {
   getCurrentBillingOrderRepositoryKind,
   overrideBillingOrderRepository,
@@ -51,10 +52,16 @@ describe('useBillingOrderRepository', () => {
   });
 
   it('returns in-memory repository in test mode by default', () => {
-    const { result } = renderHook(() => useBillingOrderRepository());
+    const { result } = renderHook(() => useBillingRuntime());
 
     expect(result.current).toBe(inMemoryBillingOrderRepository);
     expect(getCurrentBillingOrderRepositoryKind()).toBe('demo');
+  });
+
+  it('keeps the legacy repository hook compatible with the runtime selection', () => {
+    const { result } = renderHook(() => useBillingOrderRepository());
+
+    expect(result.current).toBe(inMemoryBillingOrderRepository);
   });
 
   it('returns override repository before reset', () => {
@@ -66,13 +73,13 @@ describe('useBillingOrderRepository', () => {
     };
 
     overrideBillingOrderRepository(overrideRepo, 'real');
-    const { result } = renderHook(() => useBillingOrderRepository());
+    const { result } = renderHook(() => useBillingRuntime());
 
     expect(result.current).toBe(overrideRepo);
     expect(getCurrentBillingOrderRepositoryKind()).toBe('real');
 
     resetBillingOrderRepository();
-    const { result: resetResult } = renderHook(() => useBillingOrderRepository());
+    const { result: resetResult } = renderHook(() => useBillingRuntime());
     expect(resetResult.current).toBe(inMemoryBillingOrderRepository);
     expect(getCurrentBillingOrderRepositoryKind()).toBe('demo');
   });
@@ -81,7 +88,7 @@ describe('useBillingOrderRepository', () => {
     envState.isTestMode = false;
     envState.shouldSkipSharePoint = true;
 
-    const { result } = renderHook(() => useBillingOrderRepository());
+    const { result } = renderHook(() => useBillingRuntime());
 
     expect(result.current).toBe(inMemoryBillingOrderRepository);
     expect(getCurrentBillingOrderRepositoryKind()).toBe('demo');
@@ -91,7 +98,7 @@ describe('useBillingOrderRepository', () => {
     envState.isTestMode = false;
     envState.shouldSkipSharePoint = false;
 
-    const { result } = renderHook(() => useBillingOrderRepository());
+    const { result } = renderHook(() => useBillingRuntime());
 
     expect(getCurrentBillingOrderRepositoryKind()).toBe('real');
     expect(result.current).not.toBe(inMemoryBillingOrderRepository);

--- a/src/features/billing/hooks/useBillingSummary.ts
+++ b/src/features/billing/hooks/useBillingSummary.ts
@@ -1,11 +1,10 @@
 import { useState, useMemo, useCallback, useEffect } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useBillingOrders, billingOrdersQueryKey } from '../useBillingOrders';
-import { useBillingOrderRepository } from './useBillingOrderRepository';
 import { useUsersStore } from '@/features/users/store';
 import { useStaffStore } from '@/features/staff/store';
 import { useAuth } from '@/auth/useAuth';
-import type { BillingPersistenceDiagnostics } from '../ports/billingOrderRepository';
+import type { BillingOrderRepository, BillingPersistenceDiagnostics } from '../ports/billingOrderRepository';
 
 export interface AggregatedBillingRecord {
   ordererCode: string;
@@ -47,8 +46,10 @@ export const isServedOrder = (served: unknown): boolean => {
   return normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'served' || normalized === '提供済み';
 };
 
-export function useBillingSummary(selectedMonth: string): BillingSummary {
-  const repository = useBillingOrderRepository();
+export function useBillingSummary(
+  selectedMonth: string,
+  repository: BillingOrderRepository,
+): BillingSummary {
   const queryClient = useQueryClient();
   const { account } = useAuth();
   

--- a/src/features/billing/index.ts
+++ b/src/features/billing/index.ts
@@ -1,6 +1,6 @@
-export { useBillingSummary } from './hooks/useBillingSummary';
-export { useBillingOrderRepository } from './hooks/useBillingOrderRepository';
-export { useBillingOrders, billingOrdersQueryKey } from './useBillingOrders';
+export { default as BillingPage } from './ui/BillingPage';
+export type { BillingPageProps } from './ui/BillingPage';
+export { useBillingRuntime } from './adapters/runtime/useBillingRuntime';
 export type {
   BillingOrderRepository,
   BillingPersistenceDiagnostics,

--- a/src/features/billing/repositoryFactory.ts
+++ b/src/features/billing/repositoryFactory.ts
@@ -1,48 +1,11 @@
-import { createRepositoryFactory, type BaseFactoryOptions } from '@/lib/createRepositoryFactory';
-import type { BillingOrderRepository } from './ports/billingOrderRepository';
-import { DataProviderBillingOrderRepository } from './infra/DataProviderBillingOrderRepository';
-import { inMemoryBillingOrderRepository } from './infra/InMemoryBillingOrderRepository';
-import { createSpClient, ensureConfig } from '@/lib/spClient';
-import { SharePointDataProvider } from '@/lib/sp/spDataProvider';
-import { getAppConfig, readOptionalEnv } from '@/lib/env';
-
-export interface BillingOrderRepositoryFactoryOptions extends BaseFactoryOptions {
-  spFetch?: (path: string, init?: RequestInit) => Promise<Response>;
-}
-
-export function resolveBillingSharePointBaseUrl(): string {
-  const billingSiteRelative = readOptionalEnv('VITE_SP_LIST_BILLING_ORDERS_SITE_RELATIVE');
-  const { VITE_SP_RESOURCE } = getAppConfig();
-  const { baseUrl } = billingSiteRelative
-    ? ensureConfig({
-        VITE_SP_RESOURCE,
-        VITE_SP_SITE_RELATIVE: billingSiteRelative,
-      })
-    : ensureConfig();
-  return baseUrl;
-}
-
-export function resolveBillingSharePointSiteRelative(): string | undefined {
-  return readOptionalEnv('VITE_SP_LIST_BILLING_ORDERS_SITE_RELATIVE');
-}
-
-const factory = createRepositoryFactory<BillingOrderRepository, BillingOrderRepositoryFactoryOptions>({
-  name: 'BillingOrder',
-  createDemo: () => inMemoryBillingOrderRepository,
-  createReal: (options) => {
-    const { acquireToken } = options;
-    if (!acquireToken) {
-      throw new Error('[BillingOrderRepositoryFactory] acquireToken is required for real repository.');
-    }
-    const baseUrl = resolveBillingSharePointBaseUrl();
-    const provider = new SharePointDataProvider(createSpClient(acquireToken, baseUrl));
-    
-    return new DataProviderBillingOrderRepository(provider, undefined, resolveBillingSharePointSiteRelative());
-  },
-});
-
-export const getBillingOrderRepository = factory.getRepository;
-export const useBillingOrderRepository = factory.useRepository;
-export const overrideBillingOrderRepository = factory.override;
-export const resetBillingOrderRepository = factory.reset;
-export const getCurrentBillingOrderRepositoryKind = factory.getCurrentKind;
+/** @deprecated Use the Billing public runtime API instead. Removed in PR 3. */
+export {
+  getBillingOrderRepository,
+  useBillingOrderRepository,
+  overrideBillingOrderRepository,
+  resetBillingOrderRepository,
+  getCurrentBillingOrderRepositoryKind,
+  resolveBillingSharePointBaseUrl,
+  resolveBillingSharePointSiteRelative,
+} from './adapters/runtime/useBillingRuntime';
+export type { BillingOrderRepositoryFactoryOptions } from './adapters/runtime/useBillingRuntime';

--- a/src/features/billing/ui/BillingPage.tsx
+++ b/src/features/billing/ui/BillingPage.tsx
@@ -35,7 +35,8 @@ import {
   AccountCircle as AccountCircleIcon,
   Check as CheckIcon,
 } from '@mui/icons-material';
-import { useBillingSummary } from '@/features/billing';
+import { useBillingSummary } from '../hooks/useBillingSummary';
+import type { BillingOrderRepository } from '../ports/billingOrderRepository';
 
 type ActiveTab = '利用者' | '職員' | 'ゲスト' | 'すべて';
 
@@ -63,7 +64,11 @@ const buildMonthOptions = (availableMonths: string[], selectedMonth: string): st
     .sort((a, b) => b.localeCompare(a));
 };
 
-export default function BillingPage() {
+export type BillingPageProps = {
+  readonly repository: BillingOrderRepository;
+};
+
+export default function BillingPage({ repository }: BillingPageProps) {
   const [selectedMonth, setSelectedMonth] = useState(() => toMonthKey(new Date()));
   const [hasUserSelectedMonth, setHasUserSelectedMonth] = useState(false);
   const [activeTab, setActiveTab] = useState<ActiveTab>('利用者');
@@ -87,7 +92,7 @@ export default function BillingPage() {
     togglePaymentStatus,
     bulkSettle,
     exportCsv,
-  } = useBillingSummary(selectedMonth);
+  } = useBillingSummary(selectedMonth, repository);
 
   useEffect(() => {
     if (!hasUserSelectedMonth && availableMonths.length > 0 && !availableMonths.includes(selectedMonth)) {

--- a/tests/unit/BillingPage.csv-confirm.spec.tsx
+++ b/tests/unit/BillingPage.csv-confirm.spec.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import BillingPage from '@/pages/BillingPage';
+import { BillingPage, type BillingOrderRepository } from '@/features/billing';
 
 const billingSummaryState = vi.hoisted(() => ({
   isPersistenceMissing: false,
@@ -12,7 +12,7 @@ const exportCsvMock = vi.hoisted(() => vi.fn());
 const togglePaymentStatusMock = vi.hoisted(() => vi.fn());
 const bulkSettleMock = vi.hoisted(() => vi.fn());
 
-vi.mock('@/features/billing', () => ({
+vi.mock('@/features/billing/hooks/useBillingSummary', () => ({
   useBillingSummary: () => ({
     records: [],
     availableMonths: ['2026-05'],
@@ -34,6 +34,8 @@ vi.mock('@/features/billing', () => ({
   }),
 }));
 
+const repository = {} as BillingOrderRepository;
+
 describe('BillingPage CSV export confirmation', () => {
   beforeEach(() => {
     billingSummaryState.isPersistenceMissing = false;
@@ -48,7 +50,7 @@ describe('BillingPage CSV export confirmation', () => {
   it('exports CSV without confirmation when payment persistence is available', () => {
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
 
-    render(<BillingPage />);
+    render(<BillingPage repository={repository} />);
     fireEvent.click(screen.getByRole('button', { name: /CSV出力/ }));
 
     expect(confirmSpy).not.toHaveBeenCalled();
@@ -59,7 +61,7 @@ describe('BillingPage CSV export confirmation', () => {
     billingSummaryState.isPersistenceMissing = true;
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
 
-    render(<BillingPage />);
+    render(<BillingPage repository={repository} />);
     fireEvent.click(screen.getByRole('button', { name: /CSV出力/ }));
 
     expect(confirmSpy).toHaveBeenCalledWith(
@@ -72,7 +74,7 @@ describe('BillingPage CSV export confirmation', () => {
     billingSummaryState.isPersistenceMissing = true;
     vi.spyOn(window, 'confirm').mockReturnValue(true);
 
-    render(<BillingPage />);
+    render(<BillingPage repository={repository} />);
     fireEvent.click(screen.getByRole('button', { name: /CSV出力/ }));
 
     expect(exportCsvMock).toHaveBeenCalledWith('利用者');
@@ -81,7 +83,7 @@ describe('BillingPage CSV export confirmation', () => {
   it('shows a stronger warning when payment persistence is missing', () => {
     billingSummaryState.isPersistenceMissing = true;
 
-    render(<BillingPage />);
+    render(<BillingPage repository={repository} />);
 
     expect(screen.getByText(/PaymentStatus \/ PaidAt \/ PaidBy/)).toBeInTheDocument();
     expect(screen.getByText(/CSVの精算状況を正式な精算結果として扱わないでください/)).toBeInTheDocument();
@@ -92,7 +94,7 @@ describe('BillingPage CSV export confirmation', () => {
     billingSummaryState.hasLocalPaymentState = true;
     billingSummaryState.localPaymentStateCount = 2;
 
-    render(<BillingPage />);
+    render(<BillingPage repository={repository} />);
 
     expect(screen.getByText(/端末内の過去一時状態が残っています/)).toBeInTheDocument();
     expect(screen.getByText(/SharePoint の精算状態を正本として表示しています/)).toBeInTheDocument();
@@ -100,7 +102,7 @@ describe('BillingPage CSV export confirmation', () => {
   });
 
   it('does not show a local temporary state notice when no LocalStorage payment state remains', () => {
-    render(<BillingPage />);
+    render(<BillingPage repository={repository} />);
 
     expect(
       screen.queryByText(/端末内の過去一時状態が残っています/)
@@ -112,7 +114,7 @@ describe('BillingPage CSV export confirmation', () => {
     billingSummaryState.hasLocalPaymentState = true;
     billingSummaryState.localPaymentStateCount = 1;
 
-    render(<BillingPage />);
+    render(<BillingPage repository={repository} />);
 
     expect(screen.getByText(/端末内の一時状態が表示やCSVへ影響する可能性があります/)).toBeInTheDocument();
     expect(screen.getByText(/端末内一時状態:\s*1件/)).toBeInTheDocument();


### PR DESCRIPTION
## Summary
Reconstructs Billing PR 2 from latest main after stacked PR #2421 diverged following the squash merge of #2419.

## Changes
- adds the app-level BillingRoute composition root
- injects BillingOrderRepository into BillingPage and useBillingSummary
- centralizes runtime repository selection
- moves concrete SharePoint and in-memory adapters under Billing-internal paths
- switches the lazy Billing route to BillingRoute
- updates focused unit tests

## Runtime selection
The Billing runtime hook selects the SharePoint or in-memory implementation and returns the public BillingOrderRepository port.

## Adapter visibility
Concrete adapters remain internal and are not exported from the Billing public API.

## Validation
- npm run arch:check
- targeted Vitest: 6 files / 41 tests
- npm run typecheck:full -- --pretty false
- npm run lint -- --quiet
- npm run build
- git diff --check

## Architecture result
- new violations: 0
- known violations: 919
- app to Billing internal paths: 0
- concrete adapter exports: 0

## Stack relationship
- follows merged #2419
- replaces the composition-root scope of #2421 without rebasing or resolving its retarget conflicts

## Out of scope
- legacy factory/hook removal
- viewer authorization E2E contract
- Billing business rules or UI behavior
- changes outside Billing and its app route