### PR TITLE
ci(lhci): capture runtime diagnostics

### DIFF
--- a/.github/workflows/nightly-health.yml
+++ b/.github/workflows/nightly-health.yml
@@ -55,7 +55,7 @@ jobs:
           VITE_SP_SCOPE_DEFAULT: ${{ secrets.VITE_SP_SCOPE_DEFAULT }}
           NOTIFY_WEBHOOK_URL: ${{ secrets.NOTIFY_WEBHOOK_URL }}
       - name: Perf report (LHCI + Web Vitals)
-        run: npm run -s ci:perf-report
+        run: node scripts/ci/run-perf-with-diagnostics.mjs
         env:
           VITE_E2E: "1"
           VITE_SKIP_LOGIN: "1"
@@ -72,6 +72,9 @@ jobs:
             reports/perf-summary.md
             reports/perf-summary.json
             lhci-results.json
+            reports/lhci-diagnostics/
+            .lighthouseci/
+            lhci-artifacts/
       - name: Notify failure
         if: failure()
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -206,7 +206,7 @@ jobs:
           if-no-files-found: ignore
       - name: Perf report (LHCI + Web Vitals)
         if: github.event_name == 'workflow_dispatch' || (github.ref == 'refs/heads/main' && steps.changes.outputs.perf == 'true')
-        run: npm run -s ci:perf-report
+        run: node scripts/ci/run-perf-with-diagnostics.mjs
         env:
           VITE_E2E: "1"
           VITE_SKIP_LOGIN: "1"
@@ -223,6 +223,9 @@ jobs:
             reports/perf-summary.md
             reports/perf-summary.json
             lhci-results.json
+            reports/lhci-diagnostics/
+            .lighthouseci/
+            lhci-artifacts/
 
       - name: Classify quality job completion
         if: always()

--- a/scripts/ci/classify-canary.d.mts
+++ b/scripts/ci/classify-canary.d.mts
@@ -3,6 +3,7 @@ export interface CanaryClassificationInput {
   lhciExitCode?: number | string | null;
   summaryExitCode?: number | string | null;
   e2eLog?: string | null;
+  lhciLog?: string | null;
 }
 
 export interface CanaryClassificationResult {
@@ -10,6 +11,9 @@ export interface CanaryClassificationResult {
     | 'canary_auth_required'
     | 'canary_ui_failure'
     | 'canary_lhci_failure'
+    | 'canary_lhci_server_failure'
+    | 'canary_lhci_chrome_failure'
+    | 'canary_lhci_budget_failure'
     | 'canary_summary_failure'
     | 'canary_pass';
   failedStage: 'e2e' | 'lhci' | 'summary' | 'none';

--- a/scripts/ci/classify-canary.mjs
+++ b/scripts/ci/classify-canary.mjs
@@ -18,7 +18,11 @@ const toExitCode = (value) => {
 
 const hasAuthSignal = (logText) => AUTH_SIGNAL_PATTERNS.some((pattern) => pattern.test(logText ?? ''));
 
-export function classifyCanaryResult({ e2eExitCode = 0, lhciExitCode = 0, summaryExitCode = 0, e2eLog = '' } = {}) {
+const LHCI_SERVER_PATTERNS = [/startServer/i, /ECONNREFUSED/i, /timed out waiting for.*server/i];
+const LHCI_CHROME_PATTERNS = [/CHROME_INTERSTITIAL_ERROR/i, /Chrome.*(?:failed|error|crash)/i, /Unable to connect to Chrome/i, /PROTOCOL_TIMEOUT/i];
+const LHCI_BUDGET_PATTERNS = [/assertion failed/i, /categories:performance/i, /largest-contentful-paint/i, /cumulative-layout-shift/i];
+
+export function classifyCanaryResult({ e2eExitCode = 0, lhciExitCode = 0, summaryExitCode = 0, e2eLog = '', lhciLog = '' } = {}) {
   const e2e = toExitCode(e2eExitCode);
   const lhci = toExitCode(lhciExitCode);
   const summary = toExitCode(summaryExitCode);
@@ -41,6 +45,15 @@ export function classifyCanaryResult({ e2eExitCode = 0, lhciExitCode = 0, summar
   }
 
   if (lhci !== 0) {
+    if (LHCI_SERVER_PATTERNS.some((pattern) => pattern.test(lhciLog))) {
+      return { classification: 'canary_lhci_server_failure', failedStage: 'lhci', reason: 'LHCI could not reach a healthy preview server.', exitCode: lhci };
+    }
+    if (LHCI_CHROME_PATTERNS.some((pattern) => pattern.test(lhciLog))) {
+      return { classification: 'canary_lhci_chrome_failure', failedStage: 'lhci', reason: 'LHCI failed while starting or controlling Chrome.', exitCode: lhci };
+    }
+    if (LHCI_BUDGET_PATTERNS.some((pattern) => pattern.test(lhciLog))) {
+      return { classification: 'canary_lhci_budget_failure', failedStage: 'lhci', reason: 'LHCI completed collection but failed a performance assertion.', exitCode: lhci };
+    }
     return {
       classification: 'canary_lhci_failure',
       failedStage: 'lhci',
@@ -110,6 +123,7 @@ async function main() {
   const result = classifyCanaryResult({
     ...inputs,
     e2eLog: readTextSafe(e2eLogPath),
+    lhciLog: readTextSafe(lhciLogPath),
   });
 
   fs.mkdirSync(outDir, { recursive: true });

--- a/scripts/ci/run-perf-with-diagnostics.d.mts
+++ b/scripts/ci/run-perf-with-diagnostics.d.mts
@@ -1,0 +1,15 @@
+export function commandVersion(command: string, args?: string[]): string;
+
+export interface LhciUrlProbe {
+  timestamp: string;
+  url: string;
+  status?: number;
+  location?: string | null;
+  error?: string;
+  elapsedMs: number;
+}
+
+export function probeUrl(
+  url: string,
+  fetchImpl?: typeof fetch,
+): Promise<LhciUrlProbe>;

--- a/scripts/ci/run-perf-with-diagnostics.mjs
+++ b/scripts/ci/run-perf-with-diagnostics.mjs
@@ -1,0 +1,100 @@
+import { execFileSync, spawn } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const outputDir = process.env.LHCI_DIAGNOSTICS_DIR || 'reports/lhci-diagnostics';
+const targetUrl = process.env.LHCI_TARGET_URL || 'http://127.0.0.1:4173/analysis/dashboard';
+const probeIntervalMs = Number.parseInt(process.env.LHCI_PROBE_INTERVAL_MS || '1000', 10);
+
+export function commandVersion(command, args = ['--version']) {
+  try {
+    return execFileSync(command, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+  } catch (error) {
+    return `unavailable: ${error instanceof Error ? error.message : String(error)}`;
+  }
+}
+
+export async function probeUrl(url, fetchImpl = fetch) {
+  const startedAt = Date.now();
+  try {
+    const response = await fetchImpl(url, { redirect: 'manual', signal: AbortSignal.timeout(3000) });
+    return {
+      timestamp: new Date().toISOString(),
+      url,
+      status: response.status,
+      location: response.headers.get('location'),
+      elapsedMs: Date.now() - startedAt,
+    };
+  } catch (error) {
+    return {
+      timestamp: new Date().toISOString(),
+      url,
+      error: error instanceof Error ? error.message : String(error),
+      elapsedMs: Date.now() - startedAt,
+    };
+  }
+}
+
+function processSnapshot() {
+  try {
+    return execFileSync('ps', ['-eo', 'pid,ppid,rss,etime,args'], { encoding: 'utf8' })
+      .split('\n')
+      .filter((line) => /chrome|chromium|lighthouse|vite/i.test(line))
+      .join('\n');
+  } catch (error) {
+    return `unable to capture process list: ${error instanceof Error ? error.message : String(error)}`;
+  }
+}
+
+async function main() {
+  fs.mkdirSync(outputDir, { recursive: true });
+  const perfLogPath = path.join(outputDir, 'perf-report.log');
+  const probePath = path.join(outputDir, 'http-probes.jsonl');
+  const processPath = path.join(outputDir, 'processes.log');
+  const metadataPath = path.join(outputDir, 'runtime.json');
+  const chromeCandidates = ['google-chrome', 'google-chrome-stable', 'chromium', 'chromium-browser'];
+  const metadata = {
+    generatedAt: new Date().toISOString(),
+    targetUrl,
+    targetPort: new URL(targetUrl).port || '80',
+    platform: process.platform,
+    architecture: process.arch,
+    node: process.version,
+    npm: commandVersion('npm'),
+    lhci: commandVersion(path.resolve('node_modules/.bin/lhci')),
+    chrome: Object.fromEntries(chromeCandidates.map((command) => [command, commandVersion(command)])),
+    chromePath: process.env.CHROME_PATH || null,
+  };
+  fs.writeFileSync(metadataPath, `${JSON.stringify(metadata, null, 2)}\n`);
+  fs.writeFileSync(processPath, `# before\n${processSnapshot()}\n`);
+
+  const logStream = fs.createWriteStream(perfLogPath, { flags: 'w' });
+  const child = spawn('npm', ['run', '-s', 'ci:perf-report'], { env: process.env, stdio: ['inherit', 'pipe', 'pipe'] });
+  child.stdout.on('data', (chunk) => { process.stdout.write(chunk); logStream.write(chunk); });
+  child.stderr.on('data', (chunk) => { process.stderr.write(chunk); logStream.write(chunk); });
+
+  let probing = false;
+  const probe = async () => {
+    if (probing) return;
+    probing = true;
+    fs.appendFileSync(probePath, `${JSON.stringify(await probeUrl(targetUrl))}\n`);
+    probing = false;
+  };
+  await probe();
+  const timer = setInterval(probe, Number.isFinite(probeIntervalMs) ? probeIntervalMs : 1000);
+  const exitCode = await new Promise((resolve) => child.on('close', (code) => resolve(code ?? 1)));
+  clearInterval(timer);
+  await probe();
+  logStream.end();
+  fs.appendFileSync(processPath, `# after\n${processSnapshot()}\n`);
+  process.exitCode = exitCode;
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  main().catch((error) => {
+    console.error('[lhci-diagnostics] failed unexpectedly');
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/tests/unit/canaryClassification.spec.ts
+++ b/tests/unit/canaryClassification.spec.ts
@@ -18,6 +18,24 @@ describe('classifyCanaryResult', () => {
     expect(classifyCanaryResult({ e2eExitCode: 0, lhciExitCode: 1 }).classification).toBe('canary_lhci_failure');
   });
 
+  it('classifies LHCI preview server failures', () => {
+    expect(classifyCanaryResult({ lhciExitCode: 1, lhciLog: 'ECONNREFUSED while waiting for startServer' }).classification).toBe(
+      'canary_lhci_server_failure'
+    );
+  });
+
+  it('classifies Chrome interstitials as Chrome failures', () => {
+    expect(classifyCanaryResult({ lhciExitCode: 1, lhciLog: 'CHROME_INTERSTITIAL_ERROR' }).classification).toBe(
+      'canary_lhci_chrome_failure'
+    );
+  });
+
+  it('classifies LHCI budget failures', () => {
+    expect(classifyCanaryResult({ lhciExitCode: 1, lhciLog: 'categories:performance assertion failed' }).classification).toBe(
+      'canary_lhci_budget_failure'
+    );
+  });
+
   it('classifies summary failures after E2E and LHCI pass', () => {
     expect(classifyCanaryResult({ e2eExitCode: 0, lhciExitCode: 0, summaryExitCode: 1 }).classification).toBe(
       'canary_summary_failure'

--- a/tests/unit/lhciDiagnostics.spec.ts
+++ b/tests/unit/lhciDiagnostics.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from 'vitest';
+import { commandVersion, probeUrl } from '../../scripts/ci/run-perf-with-diagnostics.mjs';
+
+describe('LHCI runtime diagnostics', () => {
+  it('records HTTP status and redirect location', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response(null, { status: 302, headers: { location: '/login' } }));
+    const result = await probeUrl('http://127.0.0.1:4173/analysis/dashboard', fetchImpl);
+    expect(result).toMatchObject({ status: 302, location: '/login' });
+    expect(result.elapsedMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('records connection errors without throwing', async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    await expect(probeUrl('http://127.0.0.1:4173', fetchImpl)).resolves.toMatchObject({ error: 'ECONNREFUSED' });
+  });
+
+  it('reports unavailable commands as diagnostics', () => {
+    expect(commandVersion('definitely-not-a-real-command')).toMatch(/^unavailable:/);
+  });
+});


### PR DESCRIPTION
## Summary

- run the existing LHCI performance command through a diagnostics wrapper without changing thresholds or preview behavior
- capture Node, npm, LHCI, Chrome candidates, target URL/port, HTTP probes, process snapshots, and combined output
- always upload the diagnostic directory and native Lighthouse artifacts
- classify `CHROME_INTERSTITIAL_ERROR` as a Chrome-control failure instead of an undifferentiated LHCI failure

## Why

Main Quality Gates repeatedly fail with `CHROME_INTERSTITIAL_ERROR` while local production builds pass. The current artifacts do not show whether Chrome launched, whether port 4173 became reachable, or which HTTP response Lighthouse received.

## Impact

The performance command and its exit code remain unchanged. This PR only adds evidence collection and more specific failure classification.

## Validation

- `npx vitest run tests/unit/canaryClassification.spec.ts tests/unit/lhciDiagnostics.spec.ts --pool=forks --maxWorkers=1 --no-file-parallelism` (11 passed)
- `npm run typecheck:full -- --pretty false`
- `npm run lint -- --quiet`
- `git diff --check`
