### PR TITLE
ci(nightly): isolate heap diagnostics by shard

### DIFF
--- a/.github/workflows/nightly-health.yml
+++ b/.github/workflows/nightly-health.yml
@@ -4,19 +4,70 @@ on:
   schedule:
     - cron: '0 18 * * *' # JST 03:00
   workflow_dispatch:
+    inputs:
+      serial:
+        description: Run each shard without file parallelism for comparison
+        required: false
+        type: boolean
+        default: false
 
 jobs:
-  health:
+  static-health:
+    name: Static health
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 24
+          cache: npm
       - run: npm ci
-      - run: npm run health
+      - run: npm run typecheck
+      - run: npm run lint:dev
+
+  unit-health:
+    name: Unit health (${{ matrix.shard }}/3)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - name: Run unit tests with memory diagnostics
         env:
           TZ: Asia/Tokyo
+          VITEST_MEMORY_LOG: reports/nightly-memory/shard-${{ matrix.shard }}.jsonl
+        run: |
+          extra_args=""
+          if [ "${{ inputs.serial }}" = "true" ]; then
+            extra_args="--no-file-parallelism"
+          fi
+          npm run test:ci -- --shard=${{ matrix.shard }}/3 $extra_args --reporter=./scripts/ci/vitest-memory-reporter.mjs
+      - name: Upload unit memory diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-memory-shard-${{ matrix.shard }}
+          path: reports/nightly-memory/
+          if-no-files-found: warn
+
+  e2e-health:
+    name: E2E health
+    needs: [static-health, unit-health]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
       - run: npx playwright install --with-deps chromium
       - name: E2E (nightly transport critical)
         run: npm run test:e2e:transport:critical
@@ -54,6 +105,18 @@ jobs:
 
           VITE_SP_SCOPE_DEFAULT: ${{ secrets.VITE_SP_SCOPE_DEFAULT }}
           NOTIFY_WEBHOOK_URL: ${{ secrets.NOTIFY_WEBHOOK_URL }}
+
+  perf-health:
+    name: Perf health
+    needs: [static-health, unit-health]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
       - name: Perf report (LHCI + Web Vitals)
         run: npm run -s ci:perf-report
         env:
@@ -72,8 +135,14 @@ jobs:
             reports/perf-summary.md
             reports/perf-summary.json
             lhci-results.json
+
+  notify-failure:
+    name: Notify failure
+    needs: [static-health, unit-health, e2e-health, perf-health]
+    if: ${{ always() && (needs.static-health.result == 'failure' || needs.unit-health.result == 'failure' || needs.e2e-health.result == 'failure' || needs.perf-health.result == 'failure') }}
+    runs-on: ubuntu-latest
+    steps:
       - name: Notify failure
-        if: failure()
         env:
           WEBHOOK_URL: ${{ secrets.NOTIFY_WEBHOOK_URL }}
         run: |

--- a/scripts/ci/vitest-memory-reporter.d.mts
+++ b/scripts/ci/vitest-memory-reporter.d.mts
@@ -1,0 +1,17 @@
+export interface MemorySnapshot {
+  rssBytes: number;
+  heapTotalBytes: number;
+  heapUsedBytes: number;
+  externalBytes: number;
+  arrayBuffersBytes: number;
+}
+export function memorySnapshot(): MemorySnapshot;
+export default class VitestMemoryReporter {
+  outputPath: string;
+  startedAt: Map<string, number>;
+  write(event: string, testModule?: { moduleId?: string; id?: string }): void;
+  onTestRunStart(specifications: unknown[]): void;
+  onTestModuleStart(testModule: { moduleId: string }): void;
+  onTestModuleEnd(testModule: { moduleId: string }): void;
+  onTestRunEnd(testModules: unknown[], errors: unknown[]): void;
+}

--- a/scripts/ci/vitest-memory-reporter.mjs
+++ b/scripts/ci/vitest-memory-reporter.mjs
@@ -1,0 +1,36 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export function memorySnapshot() {
+  const usage = process.memoryUsage();
+  return {
+    rssBytes: usage.rss,
+    heapTotalBytes: usage.heapTotal,
+    heapUsedBytes: usage.heapUsed,
+    externalBytes: usage.external,
+    arrayBuffersBytes: usage.arrayBuffers,
+  };
+}
+
+export default class VitestMemoryReporter {
+  constructor() {
+    this.outputPath = process.env.VITEST_MEMORY_LOG || 'reports/nightly-memory/vitest-memory.jsonl';
+    this.startedAt = new Map();
+  }
+
+  write(event, testModule) {
+    fs.mkdirSync(path.dirname(this.outputPath), { recursive: true });
+    const moduleId = testModule?.moduleId || testModule?.id || 'unknown';
+    const startedAt = this.startedAt.get(moduleId);
+    fs.appendFileSync(this.outputPath, `${JSON.stringify({
+      timestamp: new Date().toISOString(), event, moduleId,
+      elapsedMs: startedAt === undefined ? undefined : Date.now() - startedAt,
+      pid: process.pid, ...memorySnapshot(),
+    })}\n`);
+  }
+
+  onTestRunStart(specifications) { this.write('run-start', { moduleId: `${specifications.length} specifications` }); }
+  onTestModuleStart(testModule) { this.startedAt.set(testModule.moduleId, Date.now()); this.write('module-start', testModule); }
+  onTestModuleEnd(testModule) { this.write('module-end', testModule); this.startedAt.delete(testModule.moduleId); }
+  onTestRunEnd(testModules, errors) { this.write('run-end', { moduleId: `${testModules.length} modules; ${errors.length} errors` }); }
+}

--- a/tests/unit/vitestMemoryReporter.spec.ts
+++ b/tests/unit/vitestMemoryReporter.spec.ts
@@ -1,0 +1,31 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import VitestMemoryReporter, { memorySnapshot } from '../../scripts/ci/vitest-memory-reporter.mjs';
+
+const directories: string[] = [];
+afterEach(() => {
+  delete process.env.VITEST_MEMORY_LOG;
+  directories.splice(0).forEach((directory) => fs.rmSync(directory, { recursive: true, force: true }));
+});
+
+describe('VitestMemoryReporter', () => {
+  it('records module start and end events as durable JSONL', () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'vitest-memory-'));
+    directories.push(directory);
+    const outputPath = path.join(directory, 'memory.jsonl');
+    process.env.VITEST_MEMORY_LOG = outputPath;
+    const reporter = new VitestMemoryReporter();
+    reporter.onTestModuleStart({ moduleId: 'tests/unit/example.spec.ts' });
+    reporter.onTestModuleEnd({ moduleId: 'tests/unit/example.spec.ts' });
+    const events = fs.readFileSync(outputPath, 'utf8').trim().split('\n').map((line) => JSON.parse(line));
+    expect(events.map((event) => event.event)).toEqual(['module-start', 'module-end']);
+    expect(events[1]).toMatchObject({ moduleId: 'tests/unit/example.spec.ts', pid: process.pid });
+    expect(events[1].elapsedMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('reports numeric process memory counters', () => {
+    expect(memorySnapshot()).toEqual(expect.objectContaining({ rssBytes: expect.any(Number), heapUsedBytes: expect.any(Number) }));
+  });
+});


### PR DESCRIPTION
## Summary

- split Nightly Health static, unit, E2E, and performance work into separate jobs
- shard the full Vitest run three ways without increasing the Node heap limit
- record file start/end, elapsed time, process RSS, and heap counters as durable JSONL per shard
- add a manual serial-mode comparison while preserving scheduled defaults and failure notification

## Why

The current single `npm run health` process passes more than eleven thousand tests before exhausting the heap, then only reports a worker exit. Persistent per-file events and isolated shards identify the last active files and whether file parallelism changes the memory curve.

## Impact

Test behavior and assertions are unchanged. The scheduled run uses the existing Vitest worker configuration, divided into three shards. Heap limits are not raised.

## Validation

- custom reporter integration smoke produced run/module start/end JSONL
- `npx vitest run tests/unit/vitestMemoryReporter.spec.ts --pool=forks --maxWorkers=1 --no-file-parallelism` (2 passed)
- `npm run typecheck:full -- --pretty false`
- `npm run lint -- --quiet`
- `git diff --check`
