### PR TITLE
chore(deps): override ExcelJS uuid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10856,6 +10856,19 @@
         "node": ">=14.14"
       }
     },
+    "node_modules/exceljs/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/execa": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
@@ -20411,6 +20424,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"

--- a/package.json
+++ b/package.json
@@ -215,6 +215,9 @@
   },
   "overrides": {
     "date-fns-tz": "^3.2.0",
+    "exceljs": {
+      "uuid": "^11.1.1"
+    },
     "react-is": "18.3.1"
   },
   "lint-staged": {


### PR DESCRIPTION
## Summary

- override only ExcelJS's transitive `uuid` dependency from 8.3.2 to 11.1.1
- leave Firebase and all application/report APIs unchanged
- keep development-only consumers of uuid 8 isolated from the production tree

## Why

ExcelJS 4.4.0 is the current release and still declares `uuid ^8.3.0`. That range is affected by the buffer bounds advisory, while npm's suggested ExcelJS downgrade would be a larger compatibility risk. UUID 11 retains the CommonJS `v4` API used by ExcelJS.

## Security impact

On this branch, `npm audit --omit=dev` no longer reports `exceljs` or `uuid`. The remaining findings are the separate Firebase lane handled by #2395.

## Validation

- Excel/official-form suites: 5 files, 24 tests passed
- generated workbook round-trip tests cover Japanese text, dates, formulas, multiple sheets, and empty input
- `npm run typecheck:full -- --pretty false`
- `npm run lint -- --quiet`
- `npm run build`
- `git diff --check`
