### PR TITLE
test(authz): align billing viewer access contract

### DIFF
--- a/tests/e2e/authz.reception-billing-guard.spec.ts
+++ b/tests/e2e/authz.reception-billing-guard.spec.ts
@@ -30,11 +30,11 @@ test.describe('reception billing guard e2e', () => {
     baseURL: process.env.E2E_BASE_URL ?? 'http://127.0.0.1:5173',
   });
 
-  test('viewer is blocked on billing route', async ({ page }) => {
+  test('viewer can access billing route', async ({ page }) => {
     await bootstrapRole(page, 'viewer', '/billing');
 
-    await expect(page.getByRole('heading', { name: accessDeniedHeading })).toBeVisible();
-    await expect(page.getByTestId('billing-root')).toHaveCount(0);
+    await expect(page.getByTestId('billing-root')).toBeVisible();
+    await expect(page.getByRole('heading', { name: accessDeniedHeading })).toHaveCount(0);
   });
 
   test('reception can access billing route', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Align the Billing authorization E2E expectation with the current hub contract, which allows viewer access.

## Changes
- Update the viewer scenario to require the Billing root and no access-denied heading.
- Keep reception and admin access expectations unchanged.

## Validation
- Target Playwright Chromium spec run twice: viewer, reception, and admin passed both times.
- npm run lint -- --quiet: passed.
- git diff --check: passed.

## Boundaries
- One E2E test file only.
- No route guard, role mapping, Billing implementation, or other feature changes.

## Stack relationship
- Follows merged Billing PRs #2419, #2424, and #2430.
- Final post-merge validation and stack cleanup follow this PR.