### PR TITLE
ci(perf): wait for lhci preview server readiness

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -5,7 +5,7 @@
       "url": ["http://127.0.0.1:4173/analysis/dashboard"],
       "startServerCommand": "npm run perf:preview",
       "startServerReadyPattern": "localhost:4173|127.0.0.1:4173",
-      "startServerTimeout": 120000
+      "startServerReadyTimeout": 120000
     },
     "assert": {
       "assertions": {


### PR DESCRIPTION
## Summary
- Fix the LHCI server readiness timeout option in `lighthouserc.json`.
- Allow the perf preview server enough time to finish its build before Lighthouse navigates to `/analysis/dashboard`.
- Keep the change limited to CI perf configuration.

## Verification
- `npm run test -- src/features/today/hooks/__tests__/useTodayExceptions.spec.ts`
- `npm run perf:check` reached Lighthouse collection; local Windows exited during Chrome temp cleanup, not server readiness
- `npm run typecheck`
- `npm run lint`
- `git diff --check -- lighthouserc.json`

## Notes
- Latest `origin/main` no longer reproduces the Today exception spec failure locally.
- Latest main Quality Gates failure is the LHCI preview readiness issue, not `useTodayExceptions`.
