### PR TITLE
ci(auth): centralize playwright storage state restore

### DIFF
--- a/.github/workflows/integration-dailyops.yml
+++ b/.github/workflows/integration-dailyops.yml
@@ -64,22 +64,7 @@ jobs:
         run: npx playwright install-deps chromium
 
       - name: Restore Playwright storageState
-        shell: bash
-        run: |
-          if [ -z "${PW_STORAGE_STATE_B64:-}" ]; then
-            echo "::error::PW_STORAGE_STATE_B64 is empty. Regenerate the Playwright storage state and update the GitHub secret before running DailyOps integration."
-            exit 1
-          fi
-          mkdir -p tests/.auth
-          if ! echo "${PW_STORAGE_STATE_B64}" | base64 -d > tests/.auth/storageState.json; then
-            echo "::error::PW_STORAGE_STATE_B64 is not valid base64."
-            exit 1
-          fi
-          if [ ! -s tests/.auth/storageState.json ]; then
-            echo "::error::Decoded Playwright storageState is empty. Regenerate PW_STORAGE_STATE_B64."
-            exit 1
-          fi
-          node -e "const fs=require('node:fs'); const p='tests/.auth/storageState.json'; try { const state=JSON.parse(fs.readFileSync(p,'utf8')); if (!Array.isArray(state.cookies) || state.cookies.length===0) { console.error('::error::Decoded storageState has no cookies. Regenerate PW_STORAGE_STATE_B64.'); process.exit(1); } } catch (error) { console.error('::error::Decoded PW_STORAGE_STATE_B64 is not valid Playwright storageState JSON.'); console.error(error.message); process.exit(1); }"
+        run: node scripts/ci/restore-playwright-storage-state.mjs
         env:
           PW_STORAGE_STATE_B64: ${{ secrets.PW_STORAGE_STATE_B64 }}
 

--- a/.github/workflows/integration-staff.yml
+++ b/.github/workflows/integration-staff.yml
@@ -64,22 +64,7 @@ jobs:
         run: npx playwright install-deps chromium
 
       - name: Restore Playwright storageState
-        shell: bash
-        run: |
-          if [ -z "${PW_STORAGE_STATE_B64:-}" ]; then
-            echo "::error::PW_STORAGE_STATE_B64 is empty. Regenerate the Playwright storage state and update the GitHub secret before running Staff integration."
-            exit 1
-          fi
-          mkdir -p tests/.auth
-          if ! echo "${PW_STORAGE_STATE_B64}" | base64 -d > tests/.auth/storageState.json; then
-            echo "::error::PW_STORAGE_STATE_B64 is not valid base64."
-            exit 1
-          fi
-          if [ ! -s tests/.auth/storageState.json ]; then
-            echo "::error::Decoded Playwright storageState is empty. Regenerate PW_STORAGE_STATE_B64."
-            exit 1
-          fi
-          node -e "const fs=require('node:fs'); const p='tests/.auth/storageState.json'; try { const state=JSON.parse(fs.readFileSync(p,'utf8')); if (!Array.isArray(state.cookies) || state.cookies.length===0) { console.error('::error::Decoded storageState has no cookies. Regenerate PW_STORAGE_STATE_B64.'); process.exit(1); } } catch (error) { console.error('::error::Decoded PW_STORAGE_STATE_B64 is not valid Playwright storageState JSON.'); console.error(error.message); process.exit(1); }"
+        run: node scripts/ci/restore-playwright-storage-state.mjs
         env:
           PW_STORAGE_STATE_B64: ${{ secrets.PW_STORAGE_STATE_B64 }}
 

--- a/.github/workflows/integration-users.yml
+++ b/.github/workflows/integration-users.yml
@@ -43,11 +43,7 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Restore Playwright storageState
-        shell: bash
-        run: |
-          mkdir -p tests/.auth
-          echo "${PW_STORAGE_STATE_B64}" | base64 -d > tests/.auth/storageState.json
-          test -s tests/.auth/storageState.json
+        run: node scripts/ci/restore-playwright-storage-state.mjs
         env:
           PW_STORAGE_STATE_B64: ${{ secrets.PW_STORAGE_STATE_B64 }}
 

--- a/scripts/ci/restore-playwright-storage-state.d.mts
+++ b/scripts/ci/restore-playwright-storage-state.d.mts
@@ -1,0 +1,9 @@
+export interface PlaywrightStorageState {
+  readonly cookies: ReadonlyArray<Record<string, unknown>>;
+  readonly origins?: ReadonlyArray<Record<string, unknown>>;
+  readonly [key: string]: unknown;
+}
+
+export function decodeStorageState(encoded: unknown): PlaywrightStorageState;
+
+export function restoreStorageState(encoded: unknown, outputPath?: string): string;

--- a/scripts/ci/restore-playwright-storage-state.mjs
+++ b/scripts/ci/restore-playwright-storage-state.mjs
@@ -1,0 +1,43 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export function decodeStorageState(encoded) {
+  if (!String(encoded ?? '').trim()) {
+    throw new Error('PW_STORAGE_STATE_B64 is empty. Regenerate the Playwright storage state and update the GitHub secret.');
+  }
+
+  const decoded = Buffer.from(encoded, 'base64').toString('utf8');
+  let state;
+  try {
+    state = JSON.parse(decoded);
+  } catch {
+    throw new Error('PW_STORAGE_STATE_B64 is not valid base64-encoded JSON.');
+  }
+
+  if (!Array.isArray(state.cookies) || state.cookies.length === 0) {
+    throw new Error('Decoded Playwright storageState has no cookies. Regenerate PW_STORAGE_STATE_B64.');
+  }
+  return state;
+}
+
+export function restoreStorageState(encoded, outputPath = path.resolve('tests/.auth/storageState.json')) {
+  const state = decodeStorageState(encoded);
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
+  return outputPath;
+}
+
+function main() {
+  try {
+    const outputPath = restoreStorageState(process.env.PW_STORAGE_STATE_B64);
+    console.log(`Playwright storageState restored to ${outputPath}`);
+  } catch (error) {
+    console.error(`::error::${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  main();
+}

--- a/tests/unit/restorePlaywrightStorageState.spec.ts
+++ b/tests/unit/restorePlaywrightStorageState.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { decodeStorageState } from '../../scripts/ci/restore-playwright-storage-state.mjs';
+
+const encode = (value: unknown) => Buffer.from(JSON.stringify(value)).toString('base64');
+
+describe('decodeStorageState', () => {
+  it('rejects an empty secret', () => {
+    expect(() => decodeStorageState('')).toThrow('PW_STORAGE_STATE_B64 is empty');
+  });
+
+  it('rejects invalid base64 or JSON', () => {
+    expect(() => decodeStorageState('not-valid-storage-state')).toThrow('not valid base64-encoded JSON');
+  });
+
+  it('rejects storage state without cookies', () => {
+    expect(() => decodeStorageState(encode({ cookies: [], origins: [] }))).toThrow('has no cookies');
+  });
+
+  it('accepts storage state with cookies', () => {
+    const state = { cookies: [{ name: 'FedAuth', value: 'redacted' }], origins: [] };
+    expect(decodeStorageState(encode(state))).toEqual(state);
+  });
+});


### PR DESCRIPTION
## Summary
- Centralize Playwright storage-state restoration for the DailyOps, Staff, and Users integration workflows.
- Validate the encoded secret consistently before writing the Playwright auth file.

## Changes
- Replace three inline workflow implementations with one shared Node script.
- Reject empty, invalid JSON, and cookie-less storage states.
- Write the restored file with mode 0600.
- Add an adjacent type declaration and focused unit coverage.

## Validation
- `npx vitest run tests/unit/restorePlaywrightStorageState.spec.ts`: 4 passed.
- `actionlint -shellcheck=` for all three workflows: passed.
- Workflow script and secret references: verified.
- `npm run lint -- --quiet`: passed.
- `npm run typecheck:full -- --pretty false`: passed.
- `git diff --check`: passed.

## Scope
- Six files: three workflows, shared script, adjacent declaration, and unit test.
- No package.json, Nightly Health, LHCI, application, or feature changes.

## Origin
- Extracted from the preserved WIP worktree; the original five implementation/test files match byte-for-byte.