### PR TITLE
test(iceberg): stabilize daily support split stream flow

### DIFF
--- a/tests/e2e/iceberg-flow.spec.ts
+++ b/tests/e2e/iceberg-flow.spec.ts
@@ -1,18 +1,15 @@
 import { expect, test } from '@playwright/test';
+import { primeOpsEnv } from './helpers/ops';
 
 const TARGET_USER = '田中 太郎';
-const ICEBERG_PATH = '/daily/support';
+const ICEBERG_PATH = '/daily/support?planningSheetId=1001';
 
 test.describe('Iceberg-PDCA Split Stream Flow', () => {
   test.beforeEach(async ({ page }) => {
-    await page.addInitScript(() => {
-      window.localStorage.setItem('demo', '1');
-      const win = window as typeof window & { __ENV__?: Record<string, string | undefined> };
-      win.__ENV__ = { ...(win.__ENV__ ?? {}), VITE_DEMO_MODE: '1' };
-    });
+    await primeOpsEnv(page);
 
     await page.goto(ICEBERG_PATH);
-    await expect(page).toHaveURL(/\/(daily\/support|daily\/time-based)/);
+    await expect(page).toHaveURL(/\/daily\/support/);
     const pageRoot = page
       .getByTestId('iceberg-time-based-support-record-page')
       .or(page.getByTestId('time-based-support-record-container'));
@@ -24,35 +21,26 @@ test.describe('Iceberg-PDCA Split Stream Flow', () => {
   });
 
   test('requires Select User -> Confirm Plan -> Record', async ({ page }) => {
+    await page.getByRole('button', { name: new RegExp(TARGET_USER) }).click();
+
+    await expect(page.getByText(`${TARGET_USER} 様`)).toBeVisible();
+    await expect(page.getByTestId('procedure-panel')).toBeVisible();
+    await expect(page.getByText('時間帯を選択してください')).toBeVisible();
+
+    await page.getByTestId('procedure-panel').getByRole('button', { name: /通所・朝の準備/ }).click();
+
     const recordPanel = page.getByTestId('record-panel');
     const saveButton = page.getByTestId('behavior-submit-button');
-    const lockOverlay = page.getByTestId('record-lock-overlay');
-
-    await expect(recordPanel).toContainText('支援対象者を選択してください');
+    await expect(recordPanel).toBeVisible();
     await expect(saveButton).toBeDisabled();
 
-    await page.getByLabel('支援対象者').click();
-    await page.getByRole('option', { name: TARGET_USER }).click();
-
-    await expect(recordPanel).toContainText('左のPlanを確認すると入力できます');
-    await expect(page.getByText(`${TARGET_USER} 様 (Plan)`)).toBeVisible();
-    await expect(page.getByText('朝の受け入れ')).toBeVisible();
-
-    const acknowledgeButton = page.getByTestId('procedure-acknowledge-button');
-    await acknowledgeButton.click();
-
-    await expect(lockOverlay).toBeHidden();
-    await expect(saveButton).toBeDisabled();
-
+    await page.getByLabel(/本人の様子|行動の詳細状況/).fill('朝の受け入れで落ち着いて着席できた。');
     await page.getByRole('button', { name: '他害(叩く/蹴る)' }).first().click();
     await expect(saveButton).toBeEnabled();
 
     await saveButton.click();
 
-    await expect(page.getByText('行動記録を保存しました')).toBeVisible();
-
-    const footer = page.getByText('直近の行動記録');
-    await expect(footer).toBeVisible();
-    await expect(page.getByText('他害(叩く/蹴る) / Lv.1')).toBeVisible();
+    await expect(page.getByText(/保存しました|保存済みを確認しました/)).toBeVisible();
+    await expect(page).toHaveURL(/\/analysis\/iceberg-pdca/, { timeout: 10_000 });
   });
 });


### PR DESCRIPTION
## Summary
- Align `iceberg-flow.spec.ts` with the current `/daily/support` wizard UI.
- Reuse the existing operations E2E boot helper so SharePoint/MSAL stubs and planning-sheet fixtures are initialized consistently.
- Verify the flow from user selection, plan slot selection, record submission, and transition to Iceberg PDCA.

## Scope
Iceberg/Daily support E2E stabilization only.

Changed file:
- `tests/e2e/iceberg-flow.spec.ts`

## Out of scope
- production Daily behavior
- production Iceberg/PDCA behavior
- SharePoint implementation changes
- CI workflow changes
- skip or timeout policy changes
- unrelated Today/Users changes

## Verification
- `npm run e2e -- tests/e2e/iceberg-flow.spec.ts --project=chromium`
- `npm run e2e -- tests/e2e/daily-pdca.integration.spec.ts tests/e2e/iceberg-pdca.nav.smoke.spec.ts tests/e2e/iceberg.analysis.smoke.spec.ts tests/e2e/iceberg-flow.spec.ts --project=chromium`
- `npm run typecheck`
- `npm run lint`
- `git diff --check -- tests/e2e/iceberg-flow.spec.ts`

Notes:
- Phase 3 related E2E result: 6 passed / 2 skipped. The skipped cases are existing skips in `iceberg-pdca.nav.smoke.spec.ts`, not introduced by this change.
- `git diff --check` reported no whitespace errors; Windows emitted the existing LF -> CRLF warning for the touched spec.
