### PR TITLE
test(monthly): honor e2e monthly fixtures in demo mode

### DIFF
--- a/src/features/records/monthly/hooks/useMonthlySummaries.ts
+++ b/src/features/records/monthly/hooks/useMonthlySummaries.ts
@@ -6,7 +6,7 @@ import { useSP } from '@/lib/spClient';
 import { DAILY_ATTENDANCE_LIST_TITLE } from '@/sharepoint/fields/dailyAttendanceFields';
 import { HOLIDAY_MASTER_LIST_TITLE } from '@/sharepoint/fields/holidayFields';
 import { HOLIDAYS } from '@/sharepoint/holidays';
-import { mockMonthlySummaries } from '../monthlyRecordSeedData';
+import { getDemoSummaries } from '../monthlyRecordSeedData';
 import { executeKioskMonthlyAggregation } from '../kioskMonthlyAggregationUseCase';
 import { convertJapaneseWeekdaysToNumbers } from '../utils/weekdayConverter';
 import { getTotalDaysInMonth } from '../aggregate';
@@ -35,9 +35,7 @@ export function useMonthlySummaries(yearMonth: YearMonth) {
   const refresh = useCallback(async () => {
     // 1. Handle Demo Mode
     if (isDemoModeEnabled()) {
-      // Filter mocks by yearMonth if needed, but for now we just return them
-      // as they are primarily for UI demonstration.
-      setSummaries(mockMonthlySummaries);
+      setSummaries(getDemoSummaries());
       setLoading(false);
       return;
     }

--- a/src/features/records/monthly/monthlyRecordSeedData.ts
+++ b/src/features/records/monthly/monthlyRecordSeedData.ts
@@ -86,7 +86,7 @@ export const DEFAULT_MONTH: YearMonth = mockMonthlySummaries[0]?.yearMonth ?? ge
 /**
  * E2E用 Demo Seed から月次サマリーを取得（E2E限定）
  */
-export function useDemoSummaries(): MonthlySummary[] {
+export function getDemoSummaries(): MonthlySummary[] {
   const e2e = isE2E();
   const w = (typeof window !== 'undefined' ? window : {}) as E2ESeedWindow;
 
@@ -127,5 +127,7 @@ export function useDemoSummaries(): MonthlySummary[] {
 
   return mockMonthlySummaries;
 }
+
+export const useDemoSummaries = getDemoSummaries;
 
 export type { E2ESeedWindow };


### PR DESCRIPTION
Summary

* Make monthly demo mode use the fixture-aware monthly summary reader.
* Allow E2E monthly seed data to drive the monthly summaries shown in tests.
* Preserve useDemoSummaries as an alias for compatibility.
* Fix the monthly empty-fixture path without changing production monthly aggregation logic.

Scope

Monthly E2E fixture selection and demo-mode seed loading only.

Changed files:

* src/features/records/monthly/monthlyRecordSeedData.ts
* src/features/records/monthly/hooks/useMonthlySummaries.ts

Out of scope

* monthly aggregation formulas
* billing calculations
* CSV / Excel / PDF output behavior
* SharePoint production data access
* authorization rules
* unrelated Daily or PDCA tests

Verification

* Monthly user-detail isolated: 9 passed
* Focused Phase 4 E2E bundle: 37 passed
* Focused CSV/export unit bundle: 38 passed
* npm run typecheck
* npm run lint
* git diff --check -- src/features/records/monthly/monthlyRecordSeedData.ts src/features/records/monthly/hooks/useMonthlySummaries.ts

Next work

After this PR is fixed, continue Phase 4 with read-only re-verification of:

出欠
↓
日次支援実績
↓
月次集計
↓
利用者別詳細
↓
請求確認
↓
CSV / Excel / PDF

Next focus:

* 月次合計と利用者別合計の一致
* 請求画面への到達と権限制御
* CSV / Excel / PDFの出力内容整合
