### PR TITLE
ci: prevent false-green nightly health runs

### DIFF
--- a/.github/workflows/nightly-health.yml
+++ b/.github/workflows/nightly-health.yml
@@ -44,11 +44,25 @@ jobs:
           TZ: Asia/Tokyo
           VITEST_MEMORY_LOG: reports/nightly-memory/shard-${{ matrix.shard }}.jsonl
         run: |
+          set +e
+          set -o pipefail
           extra_args=""
           if [ "${{ inputs.serial }}" = "true" ]; then
             extra_args="--no-file-parallelism"
           fi
-          npm run test:ci -- --shard=${{ matrix.shard }}/3 $extra_args --reporter=./scripts/ci/vitest-memory-reporter.mjs
+          log_path="reports/nightly-memory/shard-${{ matrix.shard }}.log"
+          summary_path="reports/nightly-memory/shard-${{ matrix.shard }}-summary.json"
+          npm run test:ci:nightly -- --shard=${{ matrix.shard }}/3 $extra_args --reporter=./scripts/ci/vitest-memory-reporter.mjs 2>&1 | tee "$log_path"
+          vitest_exit_code=${PIPESTATUS[0]}
+          node scripts/ci/assert-vitest-health.mjs \
+            --log "$log_path" \
+            --memory "$VITEST_MEMORY_LOG" \
+            --vitest-exit-code "$vitest_exit_code" \
+            --summary "$summary_path"
+          assertion_exit_code=$?
+          if [ "$vitest_exit_code" -ne 0 ] || [ "$assertion_exit_code" -ne 0 ]; then
+            exit 1
+          fi
       - name: Upload unit memory diagnostics
         if: always()
         uses: actions/upload-artifact@v4

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "test:schedule": "npm run test:schedule:unit && npm run test:schedule:e2e",
     "test:ci:required": "vitest run --reporter=default --pool=forks --maxWorkers=1 tests/contracts/*.contract.spec.ts tests/unit/schedule*.spec.* tests/unit/schedules*.spec.* tests/unit/*schedules*.spec.* tests/unit/attendance*.spec.* src/features/attendance/__tests__/attendance*.spec.* src/features/dashboard/__tests__/attendanceSummary.spec.ts tests/unit/records.*.spec.ts tests/unit/exportCsv.spec.ts src/features/daily/__tests__/*.spec.ts src/features/daily/domain/__tests__/*.spec.ts tests/unit/users.store.spec.* tests/unit/users.api.spec.* tests/unit/users.form.spec.* tests/unit/auth*.spec.* tests/smoke/*.spec.ts*",
     "test:ci": "vitest run --run --reporter=verbose --pool=forks --maxWorkers=1 --hookTimeout=${HOOK_TIMEOUT:-10000} --dangerouslyIgnoreUnhandledErrors",
+    "test:ci:nightly": "vitest run --run --reporter=verbose --pool=forks --maxWorkers=1 --hookTimeout=${HOOK_TIMEOUT:-10000}",
     "test:hydration": "vitest run tests/unit/hydration --reporter=verbose --no-file-parallelism",
     "test:store": "vitest run tests/unit/users.store.spec.ts tests/unit/operation-hub.useOperationHubData.spec.ts tests/unit/operation-hub.useOperationHubData.branches.spec.ts tests/unit/operation-hub.useOperationHubData.full.spec.tsx --reporter=verbose --no-file-parallelism",
     "test:schedule:jst": "VITE_SCHEDULES_TZ=Asia/Tokyo vitest run tests/unit/schedule --reporter=verbose --no-file-parallelism",

--- a/scripts/ci/assert-vitest-health.d.mts
+++ b/scripts/ci/assert-vitest-health.d.mts
@@ -1,0 +1,23 @@
+export interface VitestHealthSummary {
+  startedFiles: number;
+  endedFiles: number;
+  lastStartedFile: string | null;
+  unhandledErrors: number;
+  workerAbnormalExits: number;
+  vitestExitCode: number;
+  invalidMemoryLines: number;
+  healthy: boolean;
+}
+
+export function summarizeVitestHealth(input?: {
+  logText?: string;
+  memoryText?: string;
+  vitestExitCode?: number | string;
+}): VitestHealthSummary;
+
+export function runVitestHealthAssertion(input: {
+  logPath: string;
+  memoryPath: string;
+  summaryPath: string;
+  vitestExitCode: number | string;
+}): VitestHealthSummary;

--- a/scripts/ci/assert-vitest-health.mjs
+++ b/scripts/ci/assert-vitest-health.mjs
@@ -1,0 +1,105 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const UNHANDLED_ERROR_PATTERN = /vitest-pool|unhandled error/i;
+const WORKER_ABNORMAL_EXIT_PATTERN = /worker exited unexpectedly/i;
+
+const parseExitCode = (value) => {
+  const parsed = Number.parseInt(String(value ?? ''), 10);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : 1;
+};
+
+export function summarizeVitestHealth({ logText = '', memoryText = '', vitestExitCode = 1 } = {}) {
+  const events = [];
+  let invalidMemoryLines = 0;
+
+  for (const line of memoryText.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    try {
+      events.push(JSON.parse(line));
+    } catch {
+      invalidMemoryLines += 1;
+    }
+  }
+
+  const started = events.filter((event) => event?.event === 'module-start');
+  const ended = events.filter((event) => event?.event === 'module-end');
+  const logLines = logText.split(/\r?\n/);
+  const summary = {
+    startedFiles: started.length,
+    endedFiles: ended.length,
+    lastStartedFile: started.at(-1)?.moduleId ?? null,
+    unhandledErrors: logLines.filter((line) => UNHANDLED_ERROR_PATTERN.test(line)).length,
+    workerAbnormalExits: logLines.filter((line) => WORKER_ABNORMAL_EXIT_PATTERN.test(line)).length,
+    vitestExitCode: parseExitCode(vitestExitCode),
+    invalidMemoryLines,
+  };
+
+  return {
+    ...summary,
+    healthy:
+      summary.startedFiles === summary.endedFiles &&
+      summary.unhandledErrors === 0 &&
+      summary.workerAbnormalExits === 0 &&
+      summary.vitestExitCode === 0 &&
+      summary.invalidMemoryLines === 0,
+  };
+}
+
+const parseArgs = (args) => {
+  const options = {};
+  for (let index = 0; index < args.length; index += 2) {
+    const key = args[index];
+    const value = args[index + 1];
+    if (!key?.startsWith('--') || value === undefined) {
+      throw new Error(`Invalid argument near: ${key ?? '<missing>'}`);
+    }
+    options[key.slice(2)] = value;
+  }
+  for (const required of ['log', 'memory', 'vitest-exit-code', 'summary']) {
+    if (!options[required]) throw new Error(`Missing required argument: --${required}`);
+  }
+  return options;
+};
+
+const readTextSafe = (filePath) => {
+  try {
+    return fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return '';
+  }
+};
+
+export function runVitestHealthAssertion({ logPath, memoryPath, summaryPath, vitestExitCode }) {
+  const summary = summarizeVitestHealth({
+    logText: readTextSafe(logPath),
+    memoryText: readTextSafe(memoryPath),
+    vitestExitCode,
+  });
+  fs.mkdirSync(path.dirname(summaryPath), { recursive: true });
+  fs.writeFileSync(summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
+  return summary;
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const summary = runVitestHealthAssertion({
+    logPath: options.log,
+    memoryPath: options.memory,
+    summaryPath: options.summary,
+    vitestExitCode: options['vitest-exit-code'],
+  });
+  console.log(JSON.stringify(summary, null, 2));
+  if (!summary.healthy) process.exitCode = 1;
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  try {
+    main();
+  } catch (error) {
+    console.error('[assert-vitest-health] failed unexpectedly');
+    console.error(error);
+    process.exitCode = 1;
+  }
+}

--- a/tests/unit/vitestHealthAssertion.spec.ts
+++ b/tests/unit/vitestHealthAssertion.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { summarizeVitestHealth } from '../../scripts/ci/assert-vitest-health.mjs';
+
+const event = (eventName: string, moduleId: string) => JSON.stringify({ event: eventName, moduleId });
+
+describe('summarizeVitestHealth', () => {
+  it('passes when every module ends without runtime errors', () => {
+    const summary = summarizeVitestHealth({
+      memoryText: [event('module-start', 'a.spec.ts'), event('module-end', 'a.spec.ts')].join('\n'),
+      vitestExitCode: 0,
+    });
+    expect(summary).toMatchObject({
+      startedFiles: 1,
+      endedFiles: 1,
+      lastStartedFile: 'a.spec.ts',
+      unhandledErrors: 0,
+      workerAbnormalExits: 0,
+      vitestExitCode: 0,
+      healthy: true,
+    });
+  });
+
+  it('fails when a module end is missing and records the last started file', () => {
+    const summary = summarizeVitestHealth({
+      memoryText: [event('module-start', 'a.spec.ts'), event('module-end', 'a.spec.ts'), event('module-start', 'b.spec.ts')].join('\n'),
+      vitestExitCode: 0,
+    });
+    expect(summary).toMatchObject({ startedFiles: 2, endedFiles: 1, lastStartedFile: 'b.spec.ts', healthy: false });
+  });
+
+  it.each([
+    'Worker exited unexpectedly',
+    'Error: [vitest-pool]: Worker forks emitted error.',
+    'Unhandled Error',
+    'unhandled error',
+  ])('fails for runtime signal: %s', (signal) => {
+    const summary = summarizeVitestHealth({
+      logText: signal,
+      memoryText: [event('module-start', 'a.spec.ts'), event('module-end', 'a.spec.ts')].join('\n'),
+      vitestExitCode: 0,
+    });
+    expect(summary.healthy).toBe(false);
+    expect(summary.unhandledErrors + summary.workerAbnormalExits).toBeGreaterThan(0);
+  });
+
+  it('fails when Vitest exits non-zero without a runtime signal', () => {
+    const summary = summarizeVitestHealth({
+      memoryText: [event('module-start', 'a.spec.ts'), event('module-end', 'a.spec.ts')].join('\n'),
+      vitestExitCode: 2,
+    });
+    expect(summary).toMatchObject({ vitestExitCode: 2, healthy: false });
+  });
+
+  it('keeps a summary and fails when the memory JSONL is truncated', () => {
+    const summary = summarizeVitestHealth({
+      memoryText: `${event('module-start', 'a.spec.ts')}\n{"event":"module-end"`,
+      vitestExitCode: 0,
+    });
+    expect(summary).toMatchObject({ startedFiles: 1, endedFiles: 0, invalidMemoryLines: 1, healthy: false });
+  });
+});


### PR DESCRIPTION
## 目的

Nightly HealthでVitest workerが異常終了しても成功扱いになるfalse greenを防止する。

## 変更

- Nightly専用の`test:ci:nightly`を追加し、共有`test:ci`は変更しない
- Vitestログとmemory JSONL診断情報をshard別artifactへ保存
- pipe越しでもVitest終了コードを保持
- started/ended数、最後の開始ファイル、unhandled error、worker異常終了、終了コードをsummary JSONへ記録
- 壊れたJSONLでもsummaryを生成し、診断生成後にジョブを失敗させる

## 対象外

- `TodayOpsPage.spec.tsx`の原因修正
- shard構成・heap上限の変更
- LHCI / #2425
- Firebase / #2395
- ExcelJS/uuid / #2428
- Transport日付
- 認証情報・Secret更新

## ローカル検証

- `npx vitest run tests/unit/vitestHealthAssertion.spec.ts --pool=forks --maxWorkers=1 --no-file-parallelism`: 8 passed
- `npm run typecheck:full -- --pretty false`: PASS
- `npm run lint -- --quiet`: PASS
- `npx actionlint .github/workflows/nightly-health.yml`: PASS
- `git diff --check`: PASS

## Nightly実検証

- workflow_dispatch run: https://github.com/yasutakesougo/audit-management-system-mvp/actions/runs/29214859604
- shard 1/3・3/3: strict条件で成功し、summary artifactを生成
- shard 2/3: `startedFiles=381` / `endedFiles=380` / `vitestExitCode=1` / `healthy=false`として失敗
- JSONL差分で未終了モジュールを`tests/unit/pages/TodayOpsPage.spec.tsx`と特定
- 従来false greenになり得たworker異常終了をNightly failureへ変換できることを確認

診断情報の完全性（異常件数とshard log artifact）は別PRで改善し、`TodayOpsPage.spec.tsx`の原因修正も別レーンで扱う。
