### PR TITLE
fix(schedules): make month page test id unique

### DIFF
--- a/src/features/schedules/routes/WeekPage.tsx
+++ b/src/features/schedules/routes/WeekPage.tsx
@@ -219,13 +219,7 @@ export default function WeekPage() {
       aria-label="週間スケジュール"
       aria-describedby={rangeDescriptionId}
       aria-labelledby={headingId}
-      data-testid={
-        mode === 'month'
-          ? 'schedules-month-page'
-          : mode === 'day'
-            ? 'schedules-day-shell'
-            : 'schedules-week-page'
-      }
+      data-testid="schedules-page-root"
       tabIndex={-1}
       style={{ paddingBottom: 24 }}
     >

--- a/src/features/schedules/routes/WeekPage.tsx
+++ b/src/features/schedules/routes/WeekPage.tsx
@@ -219,7 +219,13 @@ export default function WeekPage() {
       aria-label="週間スケジュール"
       aria-describedby={rangeDescriptionId}
       aria-labelledby={headingId}
-      data-testid="schedules-page-root"
+      data-testid={
+        mode === 'month'
+          ? 'schedules-page-root'
+          : mode === 'day'
+            ? 'schedules-day-shell'
+            : 'schedules-week-page'
+      }
       tabIndex={-1}
       style={{ paddingBottom: 24 }}
     >


### PR DESCRIPTION
## Summary
- keep MonthPage as the sole owner of schedules-month-page
- give the outer month route shell the stable schedules-page-root id
- preserve the existing day and week shell test ids
- remove strict-locator ambiguity in month ARIA coverage

## Verification
- npm run typecheck -- --pretty false
- schedule-month.aria.smoke.spec.ts: 2 passed, 2 intentional skipped, 0 failed
- git diff --check

## Deployment
- No deployment. Keep production HOLD until merged-main CI and Nightly Health pass.