### PR TITLE
fix(schedules): keep created items in page state

### DIFF
--- a/src/features/schedules/hooks/legacy/useSchedules.ts
+++ b/src/features/schedules/hooks/legacy/useSchedules.ts
@@ -21,7 +21,7 @@ export type { InlineScheduleDraft } from '../../domain/builders/inlineScheduleDr
 export type UseSchedulesResult = {
   items: SchedItem[];
   loading: boolean;
-  create: (draft: InlineScheduleDraft) => Promise<void>;
+  create: (draft: InlineScheduleDraft) => Promise<SchedItem>;
   update: (input: UpdateScheduleEventInput) => Promise<void>;
   remove: (eventId: string) => Promise<void>;
   lastError: ResultError | null;
@@ -171,7 +171,7 @@ export function useSchedules(range: DateRange): UseSchedulesResult {
     };
   }, [normalizedRange.from, normalizedRange.to, repository, reloadToken]);
 
-  const create = async (draft: InlineScheduleDraft) => {
+  const create = async (draft: InlineScheduleDraft): Promise<SchedItem> => {
     if (!draft.sourceInput) {
       throw new Error('Schedule draft is missing sourceInput');
     }
@@ -217,6 +217,8 @@ export function useSchedules(range: DateRange): UseSchedulesResult {
           console.warn('[schedules] E2E localStorage write failed', error);
         }
       }
+
+      return created;
     } catch (error) {
       const safeError = toSafeError(error);
       const isConflict = isSchedulesConflictError(error);

--- a/src/features/schedules/hooks/legacy/useSchedulesCrud.ts
+++ b/src/features/schedules/hooks/legacy/useSchedulesCrud.ts
@@ -35,7 +35,7 @@ import {
 
 export interface CrudDeps {
   // CRUD operations from pageState
-  create: (draft: InlineScheduleDraft) => Promise<void>;
+  create: (draft: InlineScheduleDraft) => Promise<SchedItem>;
   update: (input: import('@/features/schedules/domain').UpdateScheduleEventInput) => Promise<void>;
   remove: (id: string) => Promise<void>;
   refetch: () => void;
@@ -238,6 +238,21 @@ export function useSchedulesCrud(deps: CrudDeps): CrudReturn {
   // ── Orchestrator Integration ─────────────────────────────────────────────
   const orchestrator = useScheduleOrchestrator({
     repository: repository,
+    createSchedule: (input) => {
+      const [dateIso = '', startTime = '00:00'] = input.startLocal.split('T');
+      const [, endTime = '00:00'] = input.endLocal.split('T');
+      return create({
+        title: input.title,
+        start: input.startLocal,
+        end: input.endLocal,
+        notes: input.notes,
+        serviceType: input.serviceType,
+        dateIso,
+        startTime: startTime.slice(0, 5),
+        endTime: endTime.slice(0, 5),
+        sourceInput: input,
+      });
+    },
     showSnack,
     onSuccess: () => refetch()
   });

--- a/src/features/schedules/hooks/orchestrators/__tests__/useScheduleOrchestrator.spec.ts
+++ b/src/features/schedules/hooks/orchestrators/__tests__/useScheduleOrchestrator.spec.ts
@@ -1,0 +1,55 @@
+import { renderHook, act } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { CreateScheduleInput, ScheduleRepository } from '../../../domain/ScheduleRepository';
+import { useScheduleOrchestrator } from '../useScheduleOrchestrator';
+
+const saveAudit = vi.fn();
+
+vi.mock('@/features/telemetry/repositories/FirestoreAuditRepository', () => ({
+  auditRepository: {
+    save: (...args: unknown[]) => saveAudit(...args),
+    resolve: vi.fn(),
+  },
+}));
+
+const input: CreateScheduleInput = {
+  title: '永続化確認',
+  category: 'Staff',
+  startLocal: '2026-07-13T10:00:00',
+  endLocal: '2026-07-13T11:00:00',
+  assignedStaffId: '1',
+};
+
+describe('useScheduleOrchestrator', () => {
+  beforeEach(() => {
+    saveAudit.mockReset();
+    saveAudit.mockResolvedValue(undefined);
+  });
+
+  it('delegates creation to the injected mutation callback', async () => {
+    const repository = {
+      create: vi.fn(),
+      update: vi.fn(),
+      remove: vi.fn(),
+      list: vi.fn(),
+    } as unknown as ScheduleRepository;
+    const createSchedule = vi.fn().mockResolvedValue({ id: 'created-1' });
+    const showSnack = vi.fn();
+    const onSuccess = vi.fn();
+
+    const { result } = renderHook(() =>
+      useScheduleOrchestrator({ repository, createSchedule, showSnack, onSuccess }),
+    );
+
+    await act(async () => {
+      await result.current.handleCreateSchedule(input);
+    });
+
+    expect(createSchedule).toHaveBeenCalledWith(input);
+    expect(repository.create).not.toHaveBeenCalled();
+    expect(saveAudit).toHaveBeenCalledTimes(1);
+    expect(showSnack).toHaveBeenCalledWith('success', 'スケジュールを作成しました');
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/schedules/hooks/orchestrators/useScheduleOrchestrator.ts
+++ b/src/features/schedules/hooks/orchestrators/useScheduleOrchestrator.ts
@@ -5,6 +5,7 @@ import { auditRepository } from '@/features/telemetry/repositories/FirestoreAudi
 
 export interface ScheduleOrchestratorDeps {
   repository: ScheduleRepository;
+  createSchedule: (input: CreateScheduleInput) => Promise<{ id: string | number }>;
   onSuccess?: () => void;
   showSnack: (severity: 'success' | 'error' | 'info', message: string) => void;
 }
@@ -15,7 +16,7 @@ export interface ScheduleOrchestratorDeps {
  * スケジュールの作成・移動・削除などの業務アクションを調整する Orchestrator。
  */
 export function useScheduleOrchestrator(deps: ScheduleOrchestratorDeps) {
-  const { repository, onSuccess, showSnack } = deps;
+  const { repository, createSchedule, onSuccess, showSnack } = deps;
 
   /**
    * スケジュールの新規作成
@@ -23,7 +24,7 @@ export function useScheduleOrchestrator(deps: ScheduleOrchestratorDeps) {
   const handleCreateSchedule = useCallback(async (input: CreateScheduleInput) => {
     const startTime = performance.now();
     try {
-      const created = await repository.create(input);
+      const created = await createSchedule(input);
       
       const auditEntry = recordAudit({
         action: 'CREATE_SCHEDULE',
@@ -56,7 +57,7 @@ export function useScheduleOrchestrator(deps: ScheduleOrchestratorDeps) {
       showSnack('error', `作成に失敗しました: ${message}`);
       throw e;
     }
-  }, [repository, onSuccess, showSnack]);
+  }, [createSchedule, onSuccess, showSnack]);
 
   /**
    * スケジュールの移動 (ドラッグ&ドロップ等)


### PR DESCRIPTION
## Summary
- delegate schedule creation through the useSchedules mutation port
- preserve React state and E2E localStorage persistence while keeping orchestrator audit handling
- add a unit guard proving the repository is not called directly by the create orchestrator

## Verification
- npm run typecheck -- --pretty false
- useScheduleOrchestrator.spec.ts: 1 passed
- schedules.persist.spec.ts: 2 passed (create and reload)
- git diff --check

## Deployment
- No deployment. Keep production HOLD until merged-main CI and Nightly Health pass.