### PR TITLE
ci: compare Deep E2E failures at b0843805

### DIFF
--- a/.github/workflows/e2e-deep.yml
+++ b/.github/workflows/e2e-deep.yml
@@ -36,6 +36,7 @@ env:
   # E2E Environment configuration
   VITE_E2E: '1'
   VITE_E2E_MSAL_MOCK: '1'
+  VITE_E2E_FORCE_SCHEDULES_WRITE: '1'
   VITE_SKIP_LOGIN: '1'
   VITE_SKIP_SHAREPOINT: '1'
   VITE_DEMO_MODE: '1'
@@ -95,20 +96,41 @@ jobs:
       
       - name: Build application (preview mode)
         id: build_preview
-        run: npm run build
+        run: |
+          npm run build
+          node scripts/write-e2e-runtime-env.mjs
         env:
+          NODE_ENV: 'production'
           VITE_E2E: '1'
           VITE_E2E_MSAL_MOCK: '1'
           VITE_SKIP_LOGIN: '1'
+          VITE_SKIP_SHAREPOINT: '1'
+          VITE_FORCE_SHAREPOINT: '0'
+          VITE_DATA_PROVIDER: 'memory'
+          VITE_DEMO_MODE: '1'
           VITE_FEATURE_SCHEDULES: '1'
+          VITE_FEATURE_SCHEDULES_WEEK_V2: '1'
       
       - name: Start preview server
         id: start_preview
-        run: npm run preview -- --host 127.0.0.1 --port 5173 --strictPort &
+        env:
+          NODE_ENV: 'production'
+        run: |
+          nohup npm run preview -- --host 127.0.0.1 --port 5173 --strictPort > /tmp/e2e-preview.log 2>&1 &
+          echo "Preview server starting on port 5173"
       
       - name: Wait for preview server
         id: wait_preview
         run: npx wait-on http://127.0.0.1:5173 --timeout 60000
+
+      - name: Capture bootstrap diagnostics
+        id: bootstrap_diagnostics
+        if: always()
+        run: node scripts/ci/collect-e2e-bootstrap-diagnostics.mjs
+        env:
+          BOOTSTRAP_DIAG_URL: http://127.0.0.1:5173/schedules/week?tab=week
+          BOOTSTRAP_DIAG_DIR: reports/e2e-bootstrap
+        continue-on-error: true
       
       - name: Run deep E2E tests (non-smoke)
         id: deep_tests
@@ -126,7 +148,6 @@ jobs:
             npx playwright test ${{ github.event.inputs.test_pattern }} \
               --config=playwright.config.ts \
               --project=chromium \
-              --reporter=list,junit,html \
               --retries=2
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "PR lane: running schedule/day-focused deep tests only"
@@ -136,7 +157,6 @@ jobs:
               tests/e2e/dashboard-schedule-flow.spec.ts \
               --config=playwright.config.ts \
               --project=chromium \
-              --reporter=list,junit,html \
               --retries=1 \
               --workers=1
           else
@@ -145,7 +165,6 @@ jobs:
               --config=playwright.config.ts \
               --project=chromium \
               --grep-invert smoke \
-              --reporter=list,junit,html \
               --retries=2
           fi
         continue-on-error: true
@@ -168,11 +187,34 @@ jobs:
             echo "**Failures:** ${failures:-0}" >> $GITHUB_STEP_SUMMARY
           fi
 
+      - name: Classify deep E2E failures
+        if: always()
+        env:
+          DEEP_E2E_LANE: deep-non-smoke
+        run: |
+          node scripts/ci/classify-deep-e2e-failures.mjs \
+            --input test-results/results.json \
+            --json reports/deep-e2e-failure-taxonomy.json \
+            --markdown reports/deep-e2e-failure-taxonomy.md
+
       - name: Classify deep test completion
         if: always()
         run: |
           cancellation_step="none"
           direct_cancellation="false"
+          setup_failure_step="none"
+          if [ "${{ steps.install_playwright_browsers.outcome }}" = "failure" ]; then
+            setup_failure_step="Install Playwright (Chromium only)"
+          elif [ "${{ steps.install_playwright_deps.outcome }}" = "failure" ]; then
+            setup_failure_step="Install Playwright system dependencies"
+          elif [ "${{ steps.build_preview.outcome }}" = "failure" ]; then
+            setup_failure_step="Build application (preview mode)"
+          elif [ "${{ steps.start_preview.outcome }}" = "failure" ]; then
+            setup_failure_step="Start preview server"
+          elif [ "${{ steps.wait_preview.outcome }}" = "failure" ]; then
+            setup_failure_step="Wait for preview server"
+          fi
+
           if [ "${{ steps.deep_tests.outcome }}" = "cancelled" ]; then
             direct_cancellation="true"
             if [ "${{ steps.wait_preview.outcome }}" = "cancelled" ]; then
@@ -193,9 +235,15 @@ jobs:
           if [ "${{ steps.deep_tests.outcome }}" = "failure" ]; then
             classification="deep_tests_failed"
             reason="Deep tests reported failure."
+          elif [ "${setup_failure_step}" != "none" ]; then
+            classification="deep_setup_failed"
+            reason="Deep test setup failed: ${setup_failure_step}"
           elif [ "${{ steps.deep_tests.outcome }}" = "cancelled" ]; then
             classification="deep_tests_cancelled"
             reason="Deep test execution was cancelled: ${cancellation_step}"
+          elif [ "${{ steps.deep_tests.outcome }}" = "skipped" ]; then
+            classification="deep_tests_skipped"
+            reason="Deep test step did not execute."
           fi
 
           cat <<EOF > deep-cancel-audit.json
@@ -208,6 +256,7 @@ jobs:
             "classification": "${classification}",
             "direct_cancellation": ${direct_cancellation},
             "cancellation_step": "${cancellation_step}",
+            "setup_failure_step": "${setup_failure_step}",
             "deep_tests_outcome": "${{ steps.deep_tests.outcome }}",
             "head_sha": "${{ github.sha }}"
           }
@@ -242,6 +291,17 @@ jobs:
             deep-cancel-audit.json
           retention-days: 14
           if-no-files-found: warn
+
+      - name: Upload bootstrap diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-bootstrap-diagnostics-${{ github.run_number }}-${{ github.run_attempt }}
+          path: |
+            reports/e2e-bootstrap/
+            /tmp/e2e-preview.log
+          retention-days: 14
+          if-no-files-found: warn
       
       - name: Upload JUnit report
         if: always()
@@ -252,6 +312,17 @@ jobs:
           retention-days: 14
           if-no-files-found: warn
       
+      - name: Upload deep E2E failure taxonomy
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: deep-e2e-failure-taxonomy-${{ github.run_number }}-${{ github.run_attempt }}
+          path: |
+            reports/deep-e2e-failure-taxonomy.json
+            reports/deep-e2e-failure-taxonomy.md
+          retention-days: 14
+          if-no-files-found: error
+
       - name: Upload artifacts on partial failure
         if: failure() || steps.deep_tests.outcome == 'failure'
         uses: actions/upload-artifact@v4
@@ -300,7 +371,7 @@ jobs:
           if-no-files-found: ignore
       
       - name: Fail job if tests failed
-        if: steps.deep_tests.outcome == 'failure' && github.event_name != 'pull_request'
+        if: steps.deep_tests.outcome == 'failure'
         run: exit 1
 
   deep-tests-integration:

--- a/scripts/ci/classify-deep-e2e-failures.mjs
+++ b/scripts/ci/classify-deep-e2e-failures.mjs
@@ -1,0 +1,363 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_INPUT = "test-results/results.json";
+const DEFAULT_JSON_OUTPUT = "reports/deep-e2e-failure-taxonomy.json";
+const DEFAULT_MARKDOWN_OUTPUT = "reports/deep-e2e-failure-taxonomy.md";
+
+const SAFE_RUNTIME_FLAGS = [
+  "VITE_SKIP_LOGIN",
+  "VITE_E2E_MSAL_MOCK",
+  "VITE_SKIP_SHAREPOINT",
+  "VITE_FORCE_SHAREPOINT",
+  "VITE_DATA_PROVIDER",
+  "VITE_SCHEDULES_ENABLED",
+];
+
+const CAUSE_RULES = [
+  {
+    category: "auth_required",
+    pattern:
+      /auth(?:entication|orization)? required|login required|sign[ -]?in|unauthorized|forbidden|aadsts|msal/i,
+  },
+  {
+    category: "sharepoint_provider",
+    pattern:
+      /sharepoint|graph\.microsoft|sp(?:o)? client|data provider.*sharepoint/i,
+  },
+  {
+    category: "date_timezone",
+    pattern:
+      /time\s?zone|timezone|utc|local date|date mismatch|day boundary|midnight/i,
+  },
+  {
+    category: "persistence",
+    pattern:
+      /persist|localstorage|indexeddb|save(?:d| failure)?|reload.*(?:lost|missing)/i,
+  },
+  {
+    category: "fixture_missing",
+    pattern:
+      /fixture|seed|expected data|no data|empty state|not found in (?:mock|memory)/i,
+  },
+  {
+    category: "page_not_rendered",
+    pattern:
+      /#root.*(?:empty|0)|rootlength\D*0|page.*(?:blank|not rendered)|bootstrap/i,
+  },
+  {
+    category: "selector_contract",
+    pattern:
+      /locator|selector|testid|data-testid|strict mode violation|resolved to \d+ elements|element\(s\) not found/i,
+  },
+  {
+    category: "accessibility",
+    pattern: /accessib|aria|axe|wcag|focus(?:ed| order| trap)?/i,
+  },
+  {
+    category: "timeout",
+    pattern: /timed out|timeout|exceeded.*(?:ms|minutes)|test timeout/i,
+  },
+];
+
+const FEATURE_RULES = [
+  { feature: "Auth", pattern: /(?:^|[/._-])auth(?:[/._-]|$)|login|msal/i },
+  { feature: "Users", pattern: /(?:^|[/._-])users?(?:[/._-]|$)/i },
+  { feature: "Transport", pattern: /transport|vehicle|route-planning/i },
+  { feature: "Dashboard", pattern: /dashboard/i },
+  { feature: "Schedules", pattern: /schedules?|calendar|shift/i },
+  { feature: "Daily-Handoff", pattern: /daily|handoff|today/i },
+  { feature: "Kiosk", pattern: /kiosk|toilet.*board/i },
+  { feature: "SharePoint", pattern: /sharepoint|sp-lane/i },
+];
+
+function parseArgs(argv) {
+  const options = {
+    input: DEFAULT_INPUT,
+    json: DEFAULT_JSON_OUTPUT,
+    markdown: DEFAULT_MARKDOWN_OUTPUT,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (
+      argument === "--input" ||
+      argument === "--json" ||
+      argument === "--markdown"
+    ) {
+      const value = argv[index + 1];
+      if (!value) throw new Error(`Missing value for ${argument}`);
+      options[argument.slice(2)] = value;
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${argument}`);
+  }
+
+  return options;
+}
+
+function flattenSuites(suites = []) {
+  const specs = [];
+  for (const suite of suites) {
+    for (const spec of suite.specs ?? []) {
+      specs.push({ ...spec, suiteTitle: suite.title ?? "" });
+    }
+    specs.push(...flattenSuites(suite.suites ?? []));
+  }
+  return specs;
+}
+
+function errorTextForTest(test) {
+  return (test.results ?? [])
+    .filter((result) => result.status !== "passed")
+    .flatMap((result) => [
+      result.error?.message,
+      ...(result.errors ?? []).map((error) => error.message),
+      ...(result.stderr ?? []).map((line) =>
+        typeof line === "string" ? line : line.text,
+      ),
+    ])
+    .filter(Boolean)
+    .join("\n");
+}
+
+function classifyCause(text) {
+  const matches = CAUSE_RULES.filter((rule) => rule.pattern.test(text)).map(
+    (rule) => rule.category,
+  );
+  return {
+    primaryCategory: matches[0] ?? "unknown",
+    signals: matches,
+  };
+}
+
+function classifyFeature(file, title) {
+  const haystack = `${file} ${title}`;
+  return (
+    FEATURE_RULES.find((rule) => rule.pattern.test(haystack))?.feature ??
+    "Other"
+  );
+}
+
+function increment(record, key, amount = 1) {
+  record[key] = (record[key] ?? 0) + amount;
+}
+
+function runtimeFlags(env) {
+  return Object.fromEntries(
+    SAFE_RUNTIME_FLAGS.filter((name) => env[name] !== undefined).map((name) => [
+      name,
+      env[name],
+    ]),
+  );
+}
+
+function firstLine(value) {
+  return String(value ?? "")
+    .split("\n")[0]
+    .slice(0, 500);
+}
+
+export function classifyReport(report, env = process.env) {
+  if (!report || !Array.isArray(report.suites)) {
+    throw new Error("Playwright JSON report must contain a suites array");
+  }
+
+  const specs = flattenSuites(report.suites);
+  const failures = [];
+  const testStatuses = {};
+  let totalTests = 0;
+  let didNotRun = 0;
+
+  for (const spec of specs) {
+    for (const test of spec.tests ?? []) {
+      totalTests += 1;
+      const isDidNotRun =
+        test.status === "skipped" && test.expectedStatus !== "skipped";
+      increment(
+        testStatuses,
+        isDidNotRun ? "didNotRun" : (test.status ?? "unknown"),
+      );
+      if (isDidNotRun) didNotRun += 1;
+      if (test.status !== "unexpected") continue;
+
+      const errorText = errorTextForTest(test);
+      const title = [spec.suiteTitle, spec.title].filter(Boolean).join(" > ");
+      const file = spec.file ?? "";
+      const cause = classifyCause(errorText);
+      const attempts = test.results?.length ?? 0;
+
+      failures.push({
+        key: `${file}::${spec.id ?? title}::${test.projectName ?? test.projectId ?? "unknown"}`,
+        feature: classifyFeature(file, title),
+        primaryCategory: cause.primaryCategory,
+        signals: cause.signals,
+        file,
+        title,
+        project: test.projectName ?? test.projectId ?? "unknown",
+        attempts,
+        retryCount: Math.max(
+          0,
+          ...(test.results ?? []).map((result) => result.retry ?? 0),
+        ),
+        firstError: firstLine(errorText),
+      });
+    }
+  }
+
+  const byFeature = {};
+  const byCause = {};
+  for (const failure of failures) {
+    increment(byFeature, failure.feature);
+    increment(byCause, failure.primaryCategory);
+  }
+
+  return {
+    schemaVersion: 1,
+    status: "available",
+    generatedAt: new Date().toISOString(),
+    metadata: {
+      headSha: env.GITHUB_SHA ?? null,
+      eventName: env.GITHUB_EVENT_NAME ?? null,
+      runId: env.GITHUB_RUN_ID ?? null,
+      runAttempt: env.GITHUB_RUN_ATTEMPT ?? null,
+      lane: env.DEEP_E2E_LANE ?? null,
+      runtimeFlags: runtimeFlags(env),
+    },
+    totals: {
+      specs: specs.length,
+      tests: totalTests,
+      failed: failures.length,
+      didNotRun,
+      byStatus: testStatuses,
+      featureClassifications: Object.values(byFeature).reduce(
+        (sum, value) => sum + value,
+        0,
+      ),
+      causeClassifications: Object.values(byCause).reduce(
+        (sum, value) => sum + value,
+        0,
+      ),
+    },
+    playwrightStats: report.stats ?? null,
+    byFeature,
+    byCause,
+    dominantCategories: Object.entries(byCause)
+      .filter(([, count]) => count >= 20)
+      .map(([category, count]) => ({ category, count })),
+    failures,
+  };
+}
+
+function unavailablePayload(error, input, env) {
+  return {
+    schemaVersion: 1,
+    status: "unavailable",
+    generatedAt: new Date().toISOString(),
+    metadata: {
+      headSha: env.GITHUB_SHA ?? null,
+      eventName: env.GITHUB_EVENT_NAME ?? null,
+      runId: env.GITHUB_RUN_ID ?? null,
+      runAttempt: env.GITHUB_RUN_ATTEMPT ?? null,
+      lane: env.DEEP_E2E_LANE ?? null,
+      runtimeFlags: runtimeFlags(env),
+    },
+    input,
+    error: firstLine(error instanceof Error ? error.message : error),
+  };
+}
+
+function markdownTable(entries) {
+  if (!entries.length) return "_None_";
+  return [
+    "| Classification | Count |",
+    "| --- | ---: |",
+    ...entries.map(([name, count]) => `| ${name} | ${count} |`),
+  ].join("\n");
+}
+
+export function renderMarkdown(payload) {
+  if (payload.status !== "available") {
+    return [
+      "# Deep E2E Failure Taxonomy",
+      "",
+      `Status: **unavailable**`,
+      "",
+      `Input: \`${payload.input}\``,
+      "",
+      `Error: ${payload.error}`,
+      "",
+      "This diagnostic failure does not change the Deep E2E test outcome.",
+      "",
+    ].join("\n");
+  }
+
+  return [
+    "# Deep E2E Failure Taxonomy",
+    "",
+    `Head SHA: \`${payload.metadata.headSha ?? "unknown"}\``,
+    `Lane: \`${payload.metadata.lane ?? "unknown"}\``,
+    `Unique failed tests: **${payload.totals.failed}**`,
+    `Did not run: **${payload.totals.didNotRun}**`,
+    `Feature classifications: **${payload.totals.featureClassifications}**`,
+    `Cause classifications: **${payload.totals.causeClassifications}**`,
+    "",
+    "## By feature",
+    "",
+    markdownTable(
+      Object.entries(payload.byFeature).sort((a, b) => b[1] - a[1]),
+    ),
+    "",
+    "## By primary cause",
+    "",
+    markdownTable(Object.entries(payload.byCause).sort((a, b) => b[1] - a[1])),
+    "",
+    "## Failures",
+    "",
+    "| Feature | Cause | Spec | Project | Attempts | First error |",
+    "| --- | --- | --- | --- | ---: | --- |",
+    ...payload.failures.map(
+      (failure) =>
+        `| ${failure.feature} | ${failure.primaryCategory} | ${failure.file}: ${failure.title} | ${failure.project} | ${failure.attempts} | ${failure.firstError.replaceAll("|", "\\|")} |`,
+    ),
+    "",
+  ].join("\n");
+}
+
+function writeOutput(filePath, contents) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, contents);
+}
+
+function runCli() {
+  const options = parseArgs(process.argv.slice(2));
+  let payload;
+  try {
+    payload = classifyReport(
+      JSON.parse(fs.readFileSync(options.input, "utf8")),
+    );
+  } catch (error) {
+    payload = unavailablePayload(error, options.input, process.env);
+  }
+
+  const markdown = renderMarkdown(payload);
+  writeOutput(options.json, `${JSON.stringify(payload, null, 2)}\n`);
+  writeOutput(options.markdown, markdown);
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n${markdown}`);
+  }
+  process.stdout.write(
+    `${JSON.stringify({ status: payload.status, totals: payload.totals ?? null })}\n`,
+  );
+}
+
+if (
+  process.argv[1] &&
+  fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+) {
+  runCli();
+}

--- a/scripts/ci/collect-e2e-bootstrap-diagnostics.mjs
+++ b/scripts/ci/collect-e2e-bootstrap-diagnostics.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { chromium } from 'playwright';
+
+const outputDir = process.env.BOOTSTRAP_DIAG_DIR || 'reports/e2e-bootstrap';
+const targetUrl = process.env.BOOTSTRAP_DIAG_URL || 'http://127.0.0.1:5173/schedules/week?tab=week';
+const safeEnvKeys = [
+  'MODE',
+  'NODE_ENV',
+  'VITE_APP_ENV',
+  'VITE_E2E',
+  'VITE_E2E_MSAL_MOCK',
+  'VITE_SKIP_LOGIN',
+  'VITE_SKIP_SHAREPOINT',
+  'VITE_FORCE_SHAREPOINT',
+  'VITE_DATA_PROVIDER',
+  'VITE_DEMO_MODE',
+  'VITE_FEATURE_SCHEDULES',
+  'VITE_FEATURE_SCHEDULES_WEEK_V2',
+];
+
+fs.mkdirSync(outputDir, { recursive: true });
+
+const diagnostics = {
+  targetUrl,
+  finalUrl: null,
+  capturedAt: new Date().toISOString(),
+  console: [],
+  pageErrors: [],
+  requestFailures: [],
+  responses: [],
+  runtimeFlags: {},
+  bodyHtml: '',
+  rootHtml: '',
+  documentHtml: '',
+  error: null,
+};
+
+const writeDiagnostics = () => {
+  fs.writeFileSync(path.join(outputDir, 'bootstrap-diagnostics.json'), `${JSON.stringify(diagnostics, null, 2)}\n`);
+  fs.writeFileSync(path.join(outputDir, 'document.html'), diagnostics.documentHtml, 'utf8');
+  fs.writeFileSync(path.join(outputDir, 'body.html'), diagnostics.bodyHtml, 'utf8');
+  fs.writeFileSync(path.join(outputDir, 'root.html'), diagnostics.rootHtml, 'utf8');
+};
+
+const responseBody = async (response) => {
+  if (!/\/env\.runtime\.json$|\/manifest\.webmanifest$/.test(response.url())) return undefined;
+  try {
+    const body = await response.text();
+    return body.slice(0, 50_000);
+  } catch {
+    return undefined;
+  }
+};
+
+let browser;
+try {
+  browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+
+  page.on('console', (message) => {
+    diagnostics.console.push({ type: message.type(), text: message.text() });
+  });
+  page.on('pageerror', (error) => {
+    diagnostics.pageErrors.push({ name: error.name, message: error.message, stack: error.stack ?? '' });
+  });
+  page.on('requestfailed', (request) => {
+    diagnostics.requestFailures.push({
+      method: request.method(),
+      url: request.url(),
+      resourceType: request.resourceType(),
+      errorText: request.failure()?.errorText ?? 'unknown',
+    });
+  });
+  page.on('response', async (response) => {
+    if (!/\/env\.runtime\.json$|\/manifest\.webmanifest$/.test(response.url())) return;
+    diagnostics.responses.push({
+      url: response.url(),
+      status: response.status(),
+      body: await responseBody(response),
+    });
+  });
+
+  await page.goto(targetUrl, { waitUntil: 'domcontentloaded', timeout: 60_000 });
+  await page.waitForTimeout(5_000);
+  diagnostics.finalUrl = page.url();
+  const snapshot = await page.evaluate((keys) => {
+    const env = (window.__ENV__ ?? {});
+    return {
+      runtimeFlags: Object.fromEntries(keys.map((key) => [key, env[key] ?? null])),
+      bodyHtml: document.body?.innerHTML ?? '',
+      rootHtml: document.querySelector('#root')?.innerHTML ?? '',
+      documentHtml: document.documentElement?.outerHTML ?? '',
+    };
+  }, safeEnvKeys);
+  Object.assign(diagnostics, snapshot);
+  await page.screenshot({ path: path.join(outputDir, 'bootstrap.png'), fullPage: true });
+} catch (error) {
+  diagnostics.error = { name: error?.name ?? 'Error', message: error?.message ?? String(error), stack: error?.stack ?? '' };
+} finally {
+  if (browser) await browser.close();
+  writeDiagnostics();
+}
+
+console.log(JSON.stringify({
+  targetUrl: diagnostics.targetUrl,
+  finalUrl: diagnostics.finalUrl,
+  rootLength: diagnostics.rootHtml.length,
+  consoleCount: diagnostics.console.length,
+  pageErrorCount: diagnostics.pageErrors.length,
+  requestFailureCount: diagnostics.requestFailures.length,
+  error: diagnostics.error,
+}, null, 2));

--- a/scripts/write-e2e-runtime-env.mjs
+++ b/scripts/write-e2e-runtime-env.mjs
@@ -29,7 +29,12 @@ const e2eRuntimeEnv = {
   VITE_E2E: "1",
   VITE_SKIP_LOGIN: "1",
   VITE_E2E_MSAL_MOCK: "1",
+  VITE_E2E_FORCE_SCHEDULES_WRITE: "1",
   VITE_SKIP_SHAREPOINT: "1",
+  VITE_FORCE_SHAREPOINT: "0",
+  VITE_DATA_PROVIDER: "memory",
+  VITE_FEATURE_SCHEDULES: "1",
+  VITE_FEATURE_SCHEDULES_WEEK_V2: "1",
   // Dummy SharePoint settings to pass zod validation
   VITE_SP_RESOURCE: "https://contoso.sharepoint.com",
   VITE_SP_SITE_RELATIVE: "/sites/Audit",

--- a/tests/unit/deepE2eFailureClassification.spec.ts
+++ b/tests/unit/deepE2eFailureClassification.spec.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "vitest";
+
+// @ts-expect-error The production entrypoint is a plain Node ESM diagnostic script.
+import * as taxonomyModule from "../../scripts/ci/classify-deep-e2e-failures.mjs";
+
+const { classifyReport, renderMarkdown } = taxonomyModule;
+
+function result(message: string, retry = 0) {
+  return {
+    workerIndex: 0,
+    parallelIndex: 0,
+    status: "failed",
+    duration: 10,
+    errors: [{ message }],
+    stdout: [],
+    stderr: [],
+    retry,
+    startTime: "2026-07-14T00:00:00.000Z",
+    attachments: [],
+  };
+}
+
+function testEntry(message: string, results = [result(message)]) {
+  return {
+    timeout: 30_000,
+    annotations: [],
+    expectedStatus: "passed",
+    projectId: "chromium",
+    projectName: "chromium",
+    results,
+    status: "unexpected",
+  };
+}
+
+function reportWith(specs: unknown[]) {
+  return {
+    config: {},
+    suites: [{ title: "deep", file: "tests/e2e/example.spec.ts", specs }],
+    errors: [],
+    stats: { startTime: "2026-07-14T00:00:00.000Z", duration: 100 },
+  };
+}
+
+describe("deep E2E failure taxonomy", () => {
+  it("counts a retried test once and records its attempts", () => {
+    const report = reportWith([
+      {
+        title: "loads the users page",
+        ok: false,
+        id: "users-retry",
+        file: "tests/e2e/users.spec.ts",
+        tests: [
+          testEntry('locator("[data-testid=users-table]") timed out', [
+            result("locator timed out", 0),
+            result("locator timed out", 1),
+            result("locator timed out", 2),
+          ]),
+        ],
+      },
+    ]);
+
+    const taxonomy = classifyReport(report);
+
+    expect(taxonomy.totals.failed).toBe(1);
+    expect(taxonomy.totals.featureClassifications).toBe(1);
+    expect(taxonomy.totals.causeClassifications).toBe(1);
+    expect(taxonomy.failures[0]).toMatchObject({
+      feature: "Users",
+      primaryCategory: "selector_contract",
+      attempts: 3,
+      retryCount: 2,
+    });
+  });
+
+  it("uses deterministic cause precedence and records secondary signals", () => {
+    const report = reportWith([
+      {
+        title: "opens protected dashboard",
+        ok: false,
+        id: "auth-dashboard",
+        file: "tests/e2e/dashboard.spec.ts",
+        tests: [
+          testEntry(
+            "locator timed out because authentication required; sign in",
+          ),
+        ],
+      },
+    ]);
+
+    const taxonomy = classifyReport(report);
+
+    expect(taxonomy.failures[0].primaryCategory).toBe("auth_required");
+    expect(taxonomy.failures[0].signals).toEqual([
+      "auth_required",
+      "selector_contract",
+      "timeout",
+    ]);
+  });
+
+  it("keeps all classification totals equal to the unique failed-test count", () => {
+    const taxonomy = classifyReport(
+      reportWith(
+        Array.from({ length: 70 }, (_, index) => ({
+          title: `dashboard failure ${index}`,
+          ok: false,
+          id: `dashboard-${index}`,
+          file: "tests/e2e/dashboard.spec.ts",
+          tests: [
+            testEntry(`locator for dashboard row ${index} timed out`, [
+              result("locator timed out", 0),
+              result("locator timed out", 1),
+            ]),
+          ],
+        })),
+      ),
+    );
+
+    expect(taxonomy.totals.failed).toBe(70);
+    expect(taxonomy.totals.featureClassifications).toBe(70);
+    expect(taxonomy.totals.causeClassifications).toBe(70);
+    expect(taxonomy.byFeature).toEqual({ Dashboard: 70 });
+    expect(taxonomy.dominantCategories).toEqual([
+      { category: "selector_contract", count: 70 },
+    ]);
+  });
+
+  it("separates intentionally skipped tests from tests that did not run", () => {
+    const skipped = {
+      ...testEntry(""),
+      expectedStatus: "skipped",
+      status: "skipped",
+      annotations: [
+        { type: "skip", description: "not available in this lane" },
+      ],
+      results: [{ ...result(""), status: "skipped" }],
+    };
+    const didNotRun = {
+      ...testEntry(""),
+      expectedStatus: "passed",
+      status: "skipped",
+      results: [0, 1, 2].map((retry) => ({
+        ...result("", retry),
+        status: "skipped",
+        duration: 0,
+        errors: [],
+      })),
+    };
+    const taxonomy = classifyReport(
+      reportWith([
+        {
+          title: "skip accounting",
+          ok: true,
+          id: "skip-accounting",
+          file: "tests/e2e/example.spec.ts",
+          tests: [skipped, didNotRun],
+        },
+      ]),
+    );
+
+    expect(taxonomy.totals.didNotRun).toBe(1);
+    expect(taxonomy.totals.byStatus).toEqual({ skipped: 1, didNotRun: 1 });
+  });
+
+  it.each([
+    ["tests/e2e/transport.routes.spec.ts", "Transport"],
+    ["tests/e2e/dashboard.spec.ts", "Dashboard"],
+    ["tests/e2e/schedules.persist.spec.ts", "Schedules"],
+    ["tests/e2e/daily-handoff.spec.ts", "Daily-Handoff"],
+    ["tests/e2e/kiosk.spec.ts", "Kiosk"],
+    ["tests/e2e/sharepoint.contract.spec.ts", "SharePoint"],
+    ["tests/e2e/misc.spec.ts", "Other"],
+  ])("maps %s to %s", (file, feature) => {
+    const taxonomy = classifyReport(
+      reportWith([
+        {
+          title: "fails",
+          ok: false,
+          id: file,
+          file,
+          tests: [testEntry("unexpected application result")],
+        },
+      ]),
+    );
+
+    expect(taxonomy.failures[0].feature).toBe(feature);
+  });
+
+  it("throws for malformed Playwright data instead of producing false counts", () => {
+    expect(() => classifyReport({ config: {} })).toThrow(/suites array/);
+  });
+
+  it("renders classification totals in Markdown", () => {
+    const taxonomy = classifyReport(
+      reportWith([
+        {
+          title: "does not persist",
+          ok: false,
+          id: "persist",
+          file: "tests/e2e/schedules.persist.spec.ts",
+          tests: [testEntry("localStorage persistence failed")],
+        },
+      ]),
+      { GITHUB_SHA: "abc123", DEEP_E2E_LANE: "deep-non-smoke" },
+    );
+
+    expect(renderMarkdown(taxonomy)).toContain("Unique failed tests: **1**");
+    expect(renderMarkdown(taxonomy)).toContain("| persistence | 1 |");
+  });
+});


### PR DESCRIPTION
## Purpose

Evidence-only control lane for deciding whether the current Deep E2E failures are regressions after b0843805 or pre-existing lane-contract failures.

This PR is not intended for merge into main. Its base branch is pinned exactly to b0843805 and contains no application or E2E spec changes.

## Diagnostic harness

- run the production preview with deterministic memory/mock runtime flags
- capture bootstrap diagnostics and preview logs
- restore the configured Playwright JSON reporter
- classify unique failed tests by feature and primary cause
- distinguish skipped tests from tests that did not run
- preserve the Deep E2E failure conclusion

## Scope

Five diagnostic files only. No package, application, fixture, selector, or spec changes.

## Local verification

- taxonomy unit tests: 13 passed
- typecheck:full: passed
- ESLint: passed
- workflow YAML parse: passed
- git diff --check: passed

## Comparison rule

Run the full workflow_dispatch lane on this head and compare failure keys, bootstrap health, runtime flags, skipped count, and didNotRun count with #2453 head bad43f13. Do not use this PR for deploy or merge readiness.