### PR TITLE
fix(nav): keep sidebar aria-current unique

### DIFF
--- a/src/app/config/__tests__/navigationConfig.test.ts
+++ b/src/app/config/__tests__/navigationConfig.test.ts
@@ -89,6 +89,16 @@ describe("Navigation Configuration", () => {
     expect(items.some((item) => item.to === '/survey/tokusei')).toBe(false);
   });
 
+  it.each([
+    ['/schedules/week', '/schedules/week'],
+    ['/users', '/users'],
+  ])('%s では active な通常ナビを1件に保つ', (pathname, expectedPath) => {
+    const items = createNavItems(baseConfig);
+    const activeItems = items.filter((item) => item.isActive(pathname));
+
+    expect(activeItems.map((item) => item.to)).toEqual([expectedPath]);
+  });
+
   it('reception audience では record/勤怠導線を表示し、個別支援計画更新は表示しない', () => {
     const items = createNavItems({
       ...baseConfig,

--- a/src/app/config/navigationConfig.ts
+++ b/src/app/config/navigationConfig.ts
@@ -121,7 +121,12 @@ export function createNavItems(config: CreateNavItemsConfig): NavItem[] {
   const items: NavItem[] = [
     // --- 1. 現場の実行 (today) ---
     ...(todayOpsEnabled
-      ? [createHubNavItem('today', { testId: TESTIDS.nav.todayOps })]
+      ? [createHubNavItem('today', {
+          testId: TESTIDS.nav.todayOps,
+          // Child routes have their own sidebar entries. Keep aria-current
+          // unique by marking the hub entry active only on its root route.
+          isActive: (pathname) => pathname === '/today',
+        })]
       : []),
     TODAY_ROUTES.TRANSPORT(isFieldStaffShell),
     TODAY_ROUTES.DAILY_SUPPORT(isFieldStaffShell),
@@ -158,7 +163,10 @@ export function createNavItems(config: CreateNavItemsConfig): NavItem[] {
     createHubNavItem('operations', { label: '運営・管理', tier: 'admin' }),
     OPS_ROUTES.METRICS(isFieldStaffShell),
     createHubNavItem('billing', { testId: TESTIDS.nav.billing }),
-    createHubNavItem('master'),
+    createHubNavItem('master', {
+      // /users and /staff have dedicated sidebar entries.
+      isActive: (pathname) => pathname === '/master',
+    }),
     createHubNavItem('platform'),
     MASTER_ROUTES.USERS(isFieldStaffShell),
     MASTER_ROUTES.STAFF(isFieldStaffShell),

--- a/tests/e2e/navigation.aria-current.matrix.spec.ts
+++ b/tests/e2e/navigation.aria-current.matrix.spec.ts
@@ -5,7 +5,6 @@ test.describe('Navigation: Aria-Current Matrix', () => {
     '/dashboard',
     '/records',
     '/schedules/week',
-    '/analysis/dashboard',
     '/users'
   ];
 


### PR DESCRIPTION
## Summary
- keep the Today hub active only on `/today` so schedule child routes have one active sidebar link
- keep the Master hub active only on `/master` so `/users` has one active sidebar link
- remove `/analysis/dashboard` from the exactly-one matrix because standard navigation intentionally omits that route
- add factory-level regression coverage for schedule and user routes

## Evidence
- #2453 vs #2455 control: 67/68 current failures reproduce on the pre-#2450 base (98.5% current coverage; Jaccard 84.8%)
- local reproduction before fix: `/schedules/week` and `/users` each exposed two `aria-current=page` links; `/analysis/dashboard` exposed none
- focused E2E after fix: 8 passed
- navigationConfig unit tests: 9 passed
- `npm run typecheck:full -- --pretty false`: pass
- targeted ESLint: pass
- `git diff --check`: pass

## Scope
This is the first isolated upstream cause from the Deep E2E taxonomy. Keep Draft until GitHub Quality Gates and Deep E2E complete on this exact head.