### PR TITLE
test(e2e): fix conditional skip contract

### DIFF
--- a/tests/e2e/cross-module-issues.spec.ts
+++ b/tests/e2e/cross-module-issues.spec.ts
@@ -198,7 +198,7 @@ test.describe('C-4: Cross-Module Issues E2E', () => {
 
       const hud = getDashboardHud(page);
       if ((await hud.count()) === 0) {
-        test.skip('No dashboard HUD found for integration validation', () => {});
+        test.skip(true, 'No dashboard HUD found for integration validation');
         return;
       }
       await expect(hud).toBeVisible();
@@ -209,7 +209,7 @@ test.describe('C-4: Cross-Module Issues E2E', () => {
       // アラートの存在確認
       const alertCount = await alerts.count();
       if (alertCount === 0) {
-        test.skip('No alerts found for integration validation', () => {});
+        test.skip(true, 'No alerts found for integration validation');
         return;
       }
 
@@ -248,7 +248,7 @@ test.describe('C-4: Cross-Module Issues E2E', () => {
       // 2. Safety HUDアラート確認
       const hud = getDashboardHud(page);
       if ((await hud.count()) === 0) {
-        test.skip('No dashboard HUD found for full circle navigation test', () => {});
+        test.skip(true, 'No dashboard HUD found for full circle navigation test');
         return;
       }
       await expect(hud).toBeVisible();
@@ -300,7 +300,7 @@ test.describe('C-4: Cross-Module Issues E2E', () => {
           }
         }
       } else {
-        test.skip('No alerts found for full circle navigation test', () => {});
+        test.skip(true, 'No alerts found for full circle navigation test');
       }
     });
   });


### PR DESCRIPTION
## Summary
- replace the invalid `test.skip(message, callback)` form with Playwright conditional skip calls
- cover all four equivalent branches in `cross-module-issues.spec.ts`
- keep the change test-only and separate from Exception Center PR #2458

## Root cause
Full Deep run 29323844603 exposed two new failures in S4 and S5 when the dashboard HUD was absent. Playwright interpreted the callback overload as a test declaration and rejected it from inside a running test. The same invalid form existed in two additional alert-empty branches.

## Local verification
- `npx playwright test tests/e2e/cross-module-issues.spec.ts --config=playwright.config.ts --project=chromium --workers=1 --retries=0`: 2 passed, 3 skipped
- targeted ESLint: success
- `npm run typecheck:full -- --pretty false`: success
- `git diff --check`: success

## GitHub verification (head 17d772ca)
- PR checks: 42 success, 0 failure, 0 pending
- targeted run: 29326680051
- Chromium: success
- S4/S5: 2 passed
- conditional fixture cases: 3 skipped
- failures/errors/retries: 0

The targeted workflow also runs the independent Integration Scenarios job, whose existing failure is outside this one-file test-contract change. This PR remains Draft pending the merge-order decision. Nightly Health and production deployment remain HOLD.