### PR TITLE
test(e2e): accept completed schedules persistence day

### DIFF
--- a/tests/e2e/schedules.persist.spec.ts
+++ b/tests/e2e/schedules.persist.spec.ts
@@ -5,18 +5,8 @@ import { gotoWeek } from './utils/scheduleNav';
 import { waitForWeekViewReady } from './utils/scheduleActions';
 
 const openCreateDialog = async (page: Parameters<typeof test.beforeEach>[0]['page']) => {
-  const headerCreate = page.getByTestId(TESTIDS.SCHEDULES_HEADER_CREATE);
-  if (await headerCreate.isVisible().catch(() => false)) {
-    await headerCreate.click();
-    return;
-  }
-
-  const fab = page.getByTestId(TESTIDS.SCHEDULES_FAB_CREATE);
-  if (await fab.isVisible().catch(() => false)) {
-    await fab.click({ timeout: 5000 });
-    return;
-  }
-
+  // Keep the created item inside the visible week-grid range regardless of
+  // the wall-clock time at which the full Deep suite reaches this spec.
   const url = new URL(page.url());
   const dateParam = url.searchParams.get('date') ?? new Date().toISOString().slice(0, 10);
   url.searchParams.set('dialog', 'create');
@@ -65,19 +55,25 @@ test.describe('Schedules Persistence', () => {
     await saveButton.click();
   };
 
-  const closeFollowUpDialog = async (
+  const settlePostCreateUi = async (
     page: Parameters<typeof test.beforeEach>[0]['page'],
   ) => {
     const dialog = page
       .getByTestId(TESTIDS['schedule-create-dialog'])
       .filter({ has: page.getByTestId(TESTIDS['schedule-create-start']) })
       .last();
-    // A successful create automatically opens the next empty slot. Wait for
-    // its confirmation before closing, rather than racing the submitted one.
-    await expect(page.getByText(/次の未入力枠を開きました/)).toBeVisible({ timeout: 3_000 });
-    await expect(dialog).toBeVisible();
+    const nextGapMessage = page.getByText(/次の未入力枠を開きました/);
+    const dayCompleteMessage = page.getByText(/この日の予定入力が完了しました/);
 
-    await page.keyboard.press('Escape');
+    // Successful creation has two valid outcomes: open the next available
+    // slot, or finish the day when no slot remains.
+    await expect(nextGapMessage.or(dayCompleteMessage)).toBeVisible({ timeout: 3_000 });
+
+    if (await nextGapMessage.isVisible()) {
+      await expect(dialog).toBeVisible();
+      await page.keyboard.press('Escape');
+    }
+
     await expect(dialog).toBeHidden();
   };
 
@@ -162,7 +158,7 @@ test.describe('Schedules Persistence', () => {
         .toBe(true);
     }
 
-    await closeFollowUpDialog(page);
+    await settlePostCreateUi(page);
 
     // Verify the created schedule appears in the week view
     const scheduleItem = page.locator(`text="${testTitle}"`).first();
@@ -204,7 +200,7 @@ test.describe('Schedules Persistence', () => {
         .toBe(true);
     }
 
-    await closeFollowUpDialog(page);
+    await settlePostCreateUi(page);
 
     // Verify it appears before reload
     const scheduleBeforeReload = page.locator(`text="${testTitle}"`).first();


### PR DESCRIPTION
## Summary
- accept both valid post-create outcomes in the Schedules Persistence E2E contract
- close the follow-up dialog only when a next empty slot is actually opened
- preserve exact-title localStorage, week-view, and reload persistence assertions

## Root cause
The failing runs successfully created and stored the schedule. Two wall-clock-dependent assumptions remained:

- when no later business-day gap remained, the app correctly displayed `この日の予定入力が完了しました`, but the test required `次の未入力枠を開きました`
- when the full suite reached the spec late in the day, the header action generated 22:00–23:00; the item was stored successfully but fell outside the visible week-grid range

The test now accepts both valid post-create messages and opens a deterministic 10:00–11:00 slot.

## Scope
This is a test-only, one-file change in `tests/e2e/schedules.persist.spec.ts`. It does not change Schedules application behavior, fixtures, workflows, authentication, SharePoint, Integration bootstrap, Nightly Health, or deployment.

## Local verification
- production preview / memory / MSAL mock / forced-write Schedules Persistence: 2 passed
- `npm run typecheck:full -- --pretty false`: success
- targeted ESLint: success
- `git diff --check`: success

## Acceptance
- the two Schedules Persistence failure keys disappear
- no new Chromium failure keys are introduced
- Integration `jsxDEV` remains a separately tracked lane
- production deploy remains NO-GO / HOLD
