### PR TITLE
docs(audit): add system inventory and process optimization reports

### DIFF
--- a/docs/audit/investigation-findings-2026-07-14.md
+++ b/docs/audit/investigation-findings-2026-07-14.md
@@ -1,0 +1,149 @@
+# Investigation Findings - 2026-07-14
+
+- 基準コミット: `776335643564b599683fecb3169097e3eb2d7825`
+- 調査worktree: `C:\tmp\audit-management-system-mvp-investigation`
+
+## FINDING-001: 月次CSV文書が旧 `MonthlySummaryExcel` 名を参照している
+
+- 分類: 契約差異 C
+- 基準コミット: `776335643564b599683fecb3169097e3eb2d7825`
+- 対象ファイル: `docs/audit/phase4-monthly-csv-export-contract.md`, `docs/audit/phase4-monthly-billing-flow-boundary.md`, `docs/security/*xlsx*`, `src/features/reports/monthly/MonthlySummaryCsv.ts`
+- 現在の挙動: 実装とテストは `MonthlySummaryCsv` だが、複数文書が `MonthlySummaryExcel.ts` と `MonthlySummaryExcel.spec.ts` を根拠としている。
+- 期待される挙動: 文書は現行ファイル名 `MonthlySummaryCsv` を参照し、旧名は過去経緯としてのみ残す。
+- 証拠: `rg -n "MonthlySummaryExcel|MonthlySummaryCsv" src tests docs`
+- 利用者影響: 直接の画面影響なし。
+- データ影響: なし。
+- CI影響: 調査者が存在しないテストパスを実行する可能性がある。
+- 再現手順: `Test-Path src/features/reports/monthly/MonthlySummaryExcel.ts` はfalse、`Test-Path src/features/reports/monthly/MonthlySummaryCsv.ts` はtrue。
+- 修正候補: 文書内参照を現行名へ更新し、旧名renameの扱いを「完了済み/履歴」として明記する。
+- 修正対象外: CSV出力挙動変更、追加rename。
+- 推奨PR境界: docs-only PR。
+- 依存する作業: なし。
+- 完了判定: `rg "MonthlySummaryExcel" docs src tests` が履歴説明以外で残らない。
+
+## FINDING-002: Route診断リストと実Routeに表現差がある
+
+- 分類: Route/Nav契約差異
+- 基準コミット: `776335643564b599683fecb3169097e3eb2d7825`
+- 対象ファイル: `src/app/routes/appRoutePaths.ts`, `src/app/routes/*Routes.tsx`, `src/app/hubs/hubDefinitions.ts`, `src/features/nurse/routes/NurseRoutes.tsx`
+- 現在の挙動: `appRoutePaths.ts` は `users/new`, `staff/new`, `kiosk-users`, `kiosk-procedures` などを含むが、実Route定義からは同名pathを確認できない。一方で実Routeには `records/quality-review`, `exceptions`, `/nurse/*` など、明示リスト側にない入口がある。
+- 期待される挙動: 診断リストは実Route、nested route、Hub動的routeの差分を区別して表示する。
+- 証拠: NodeによるRoute抽出で実Route100件、明示リスト102件。差分候補あり。
+- 利用者影響: ナビ診断や到達可否調査で誤判定が起きる。
+- データ影響: なし。
+- CI影響: Router/Nav整合テストがfalse positive/false negativeになり得る。
+- 再現手順: `src/app/routes/appRoutePaths.ts` と `path:` 定義を抽出して比較する。
+- 修正候補: `appRoutePaths` を単純なpath配列ではなく、`explicit`, `nested`, `hubGenerated`, `legacyAlias` に分類する。
+- 修正対象外: 画面遷移挙動変更。
+- 推奨PR境界: Route/Nav診断PR。
+- 依存する作業: Hub生成routeの許容ルール決定。
+- 完了判定: 差分が「未実装」「nested」「hub生成」「legacy alias」のいずれかに分類される。
+
+## FINDING-003: `test:ci` がunhandled errorを成功扱いにできる
+
+- 分類: CI false green
+- 基準コミット: `776335643564b599683fecb3169097e3eb2d7825`
+- 対象ファイル: `package.json`
+- 現在の挙動: `test:ci` に `--dangerouslyIgnoreUnhandledErrors` が含まれる。
+- 期待される挙動: required CIはunhandled errorを失敗として扱う。例外的な吸収はnightly診断などに分離する。
+- 証拠: `package.json` script `test:ci`。
+- 利用者影響: 品質保証済みと見えるPRにランタイム異常が残る。
+- データ影響: 間接的。保存系のunhandled rejectionを見逃す可能性がある。
+- CI影響: P1。false greenの直接要因。
+- 再現手順: `rg -n "dangerouslyIgnoreUnhandledErrors" package.json vitest.config.ts`
+- 修正候補: required用scriptを `test:ci:required` へ寄せ、dangerous optionはnightly/diagnostic名に限定する。
+- 修正対象外: 失敗テストの個別修正。
+- 推奨PR境界: CIコマンド整理PR。
+- 依存する作業: required checksの実際のGitHub設定確認。
+- 完了判定: required CIでdangerous optionが使われない。
+
+## FINDING-004: E2E skipが機能未完成・環境差分・データ不足を混在している
+
+- 分類: CI/テスト信頼性
+- 基準コミット: `776335643564b599683fecb3169097e3eb2d7825`
+- 対象ファイル: `tests/e2e/*`, `docs/CATEGORY_C_SKIPS.md`, `docs/E2E_SKIP_INVENTORY.md`
+- 現在の挙動: `test.skip(true, ...)`, 無条件 `test.skip()`, env依存skip、SharePoint実環境skipが混在する。
+- 期待される挙動: skip理由を「未実装」「環境未接続」「データなし」「一時flaky」「意図的対象外」に分類する。
+- 証拠: `rg -n "test\\.skip|describe\\.skip|test\\.fixme" tests docs/CATEGORY_C_SKIPS.md docs/E2E_SKIP_INVENTORY.md`
+- 利用者影響: E2E greenから機能完成度を判断しにくい。
+- データ影響: なし。
+- CI影響: P2。false greenの補助要因。
+- 再現手順: skip検索を実行し、スケジュール・nurse・monthly・usersで分類する。
+- 修正候補: skip台帳を現行specに再同期し、無条件skipはIssue/契約名を必須にする。
+- 修正対象外: skip解除。
+- 推奨PR境界: E2E skip台帳PR。
+- 依存する作業: `test:ci` false green整理。
+- 完了判定: 各skipが分類と再実行条件を持つ。
+
+## FINDING-005: schedules gateは403/timeout後に楽観的に画面到達を許可する
+
+- 分類: 認証・環境診断境界
+- 基準コミット: `776335643564b599683fecb3169097e3eb2d7825`
+- 対象ファイル: `src/app/ProtectedRoute.tsx`, `src/features/schedules/errors.ts`
+- 現在の挙動: schedules list checkで401/403/429/5xx/timeoutをretry後、非404はoptimistic readinessに進む。7秒escape hatchもある。
+- 期待される挙動: 画面到達許可とデータ操作可否を分け、403/timeout/404を運用診断で明確に分類する。
+- 証拠: `ProtectedRoute.tsx` の list check retry、`sp_gate_escape_hatch` health event。
+- 利用者影響: 画面は開くが、保存・読取で後続エラーになる場合がある。
+- データ影響: 操作失敗の扱い次第。
+- CI影響: SharePoint連携E2Eで環境不具合と製品不具合の判別が難しくなる。
+- 再現手順: `ProtectedRoute` の `flag === 'schedules'` list check分岐を確認する。
+- 修正候補: Route guardは到達可否、Repositoryは操作可否、UIは環境診断をそれぞれ別表示にする。
+- 修正対象外: schedules UIの機能改善。
+- 推奨PR境界: 認証/SharePoint診断PR。
+- 依存する作業: SP 403/404分類の受け入れ基準。
+- 完了判定: CIログとUI上で403、404、timeout、auth expiredが区別できる。
+
+## FINDING-006: Billing精算状態はSharePoint列未解決時にLocalStorage fallbackへ落ちる
+
+- 分類: 永続化境界
+- 基準コミット: `776335643564b599683fecb3169097e3eb2d7825`
+- 対象ファイル: `src/features/billing/hooks/useBillingSummary.ts`, `src/features/billing/ui/BillingPage.tsx`, `docs/ops/billing-local-payment-state-runbook.md`
+- 現在の挙動: `PaymentStatus` 未解決時は `app:billing:payment_states` を読み書きし、CSV出力前に警告を出す。
+- 期待される挙動: 正式な請求CSVとして扱える条件が、SharePoint列解決状態と明確に紐づく。
+- 証拠: `useBillingSummary.spec.ts` の fallback/SharePoint正本テスト、代表Vitest 54 passed。
+- 利用者影響: 警告を無視すると端末依存の精算状態をCSVに出せる。
+- データ影響: 請求精算状態の正本誤認。
+- CI影響: mockでは保証できるが、本番列存在は別検証が必要。
+- 再現手順: `getPersistenceDiagnostics` が `missing_payment_status` を返すmockで `useBillingSummary` を実行する。
+- 修正候補: 本番運用チェックに `PaymentStatus/PaidAt/PaidBy` 解決を必須化し、CSV正式出力条件を明文化する。
+- 修正対象外: Billing UI redesign。
+- 推奨PR境界: Billing永続化運用PR。
+- 依存する作業: `/sites/2` List3の列確認。
+- 完了判定: `env_fallback_list3`, `missing_payment_status`, `missing_audit_fields`, `resolved` が運用手順とCI/診断に接続される。
+
+## FINDING-007: 本番依存のaudit残件は破壊的更新を伴う
+
+- 分類: 依存関係・セキュリティ
+- 基準コミット: `776335643564b599683fecb3169097e3eb2d7825`
+- 対象ファイル: `package.json`, `package-lock.json`
+- 現在の挙動: `npm audit --omit=dev --json` は12件を報告する。主経路は `firebase -> undici` と `exceljs -> uuid`。
+- 期待される挙動: 件数ではなく、到達可能性、browser/Node実行、外部入力制御、破壊的変更を評価してからPR化する。
+- 証拠: `npm audit --omit=dev --json`
+- 利用者影響: 未評価。
+- データ影響: 未評価。
+- CI影響: audit gateを入れると現状失敗する。
+- 再現手順: `npm audit --omit=dev --json`
+- 修正候補: Firebase major update評価PR、ExcelJS/uuid到達可能性評価PRを分ける。
+- 修正対象外: `npm audit fix --force` の一括実行。
+- 推奨PR境界: セキュリティ評価PR。
+- 依存する作業: Firebase利用箇所とExcel出力利用箇所の実行環境確認。
+- 完了判定: 各脆弱性に「到達可能/未到達/保留」と更新方針が付く。
+
+## FINDING-008: 月次集計の異月混在データ契約が曖昧
+
+- 分類: 日付境界契約
+- 基準コミット: `776335643564b599683fecb3169097e3eb2d7825`
+- 対象ファイル: `src/features/records/monthly/__tests__/aggregate.holiday.spec.ts`, `src/features/records/monthly/aggregate.ts`
+- 現在の挙動: テスト名に「異なる月の記録が混在 → 現在の実装は全記録をカウント」とある。対象月filter済み入力を前提にするのか、関数側で除外するのかが契約として弱い。
+- 期待される挙動: 月次集計関数の入力契約か、呼び出し側filter契約を明示する。
+- 証拠: 代表Vitestで該当テストを含む月次集計テストはPASS。
+- 利用者影響: 呼び出し側が異月データを渡した場合、誤集計になり得る。
+- データ影響: 月次KPI、請求前確認、CSV/PDFの前提に影響。
+- CI影響: 現状は「全記録をカウント」を固定しているため、仕様変更時にテスト名と期待値を更新する必要がある。
+- 再現手順: `npx vitest run src/features/records/monthly/__tests__/aggregate.holiday.spec.ts --reporter=verbose`
+- 修正候補: `aggregateMonthlyKpi` の入力を「対象月filter済み」にするか、関数に `targetMonth` を渡して除外するかを決める。
+- 修正対象外: CSV/PDF出力の同時変更。
+- 推奨PR境界: 月次日付境界PR。
+- 依存する作業: 月次CSV/PDF契約の入力範囲確定。
+- 完了判定: 異月混在ケースの期待値が仕様文書、実装、unitで一致する。
+

--- a/docs/reports/process-optimization-audit-2026-07-14.md
+++ b/docs/reports/process-optimization-audit-2026-07-14.md
@@ -1,0 +1,54 @@
+# Process Optimization Audit - 2026-07-14
+
+- 基準コミット: `776335643564b599683fecb3169097e3eb2d7825`
+- 調査単位: `origin/main` 固定の読み取り中心調査
+- 詳細台帳: `docs/audit/investigation-findings-2026-07-14.md`
+
+## 結論
+
+次の開発で最初に分離すべきものは、製品挙動修正ではなく契約とCI信頼性の整理である。現時点で代表テストは通るが、Route診断リスト、月次CSV文書、skip/false green、SharePoint認証・列解決fallbackが混在しており、失敗時に製品不具合と環境不具合を切り分けにくい。
+
+## 優先順位
+
+| ID | 優先度 | 分類 | 推奨PR境界 |
+| --- | --- | --- | --- |
+| FINDING-001 | P2 | 文書契約差異 | 月次CSV文書の追従のみ。`MonthlySummaryCsv` への実装変更はしない。 |
+| FINDING-002 | P2 | Route/Nav契約差異 | `appRoutePaths`、nested route、Hub動的routeの診断ロジック整理。 |
+| FINDING-003 | P1 | CI false green | `test:ci` の `--dangerouslyIgnoreUnhandledErrors` をrequired CIから分離。 |
+| FINDING-004 | P2 | E2E信頼性 | skip台帳を現行specへ再同期し、skip理由を契約型に分類。 |
+| FINDING-005 | P2 | 認証/環境診断 | schedules gateのoptimistic bypassと403/404/timeout分類の運用表示を整理。 |
+| FINDING-006 | P2 | 永続化境界 | Billing `PaymentStatus` 未解決時のLocalStorage fallbackを運用チェックとPR境界へ固定。 |
+| FINDING-007 | P2 | セキュリティ/依存 | `firebase/undici` と `exceljs/uuid` を到達可能性評価PRとして分離。 |
+| FINDING-008 | P1 | 日付境界 | 月次集計が異月混在データをどう扱うかの契約を確定。 |
+
+## CI分類
+
+| テスト/コマンド | 保証している契約 | 失敗時に疑う対象 | 外部依存 | 時刻・日付依存 | 認証依存 | 再実行変動 |
+| --- | --- | --- | --- | --- | --- | --- |
+| `npm run typecheck` | TS型契約 | 型不整合、import不整合 | なし | 低 | なし | 低 |
+| `npm run arch:check` | 依存境界 | 新規境界違反 | なし | 低 | なし | 低 |
+| `npm run gen:system-map` | Route/Nav/feature棚卸し | env未設定、route診断差分 | env schema | 低 | なし | 中 |
+| `MonthlySummaryCsv.spec.ts` | 月次CSV形式、filename | CSV契約変更 | browser Blob mock | 低 | なし | 低 |
+| `aggregate.*.spec.ts` | 月次集計計算 | 日付境界、plannedRows契約 | なし | 高 | なし | 低 |
+| `useBillingSummary.spec.ts` | 請求集計、精算永続化fallback | SharePoint列、LocalStorage fallback | mock repo | 中 | auth actor mock | 低 |
+| `useKokuhorenMonthlyPreview.spec.tsx` | 月次提供実績 -> 国保連validation | repository error handling | mock repo | 中 | なし | 低 |
+| Playwright schedule SP系 | SharePoint実データ/書込契約 | 認証期限、403、リスト未存在、通信 | SharePoint, storageState | 高 | 高 | 高 |
+| LHCI | perf予算 | Chromium/LHCI/preview server | Chromium, network | 中 | なし | 中 |
+
+`test:ci` の `--dangerouslyIgnoreUnhandledErrors` は別枠管理が必要。異常終了やunhandled errorを成功扱いにする経路は、required品質保証としては使わない。
+
+## 次の5件
+
+1. `test:ci` false green解消PR: required CI用コマンドから `--dangerouslyIgnoreUnhandledErrors` を外すか、nightly専用に限定する。
+2. 月次CSV文書追従PR: `MonthlySummaryExcel` 参照を `MonthlySummaryCsv` に更新し、過去経緯は「rename済み」として残す。
+3. 月次日付境界PR: 異月混在データを除外するのか、呼び出し側で対象月filter済みを前提にするのかをテスト名と実装契約で固定する。
+4. Route/Nav診断PR: `appRoutePaths` とnested route/hub routeの差分を機械検出し、許容差分を明示する。
+5. Billing永続化運用PR: `PaymentStatus/PaidAt/PaidBy` 未解決時のCSV扱い、LocalStorage fallback、List3 envを運用チェックに接続する。
+
+## 対象外
+
+- `MonthlySummaryCsv` の実装renameや追加renameは行わない。
+- SharePoint列追加、環境変数変更、Firebase/ExcelJS更新は今回の調査PRに含めない。
+- Playwrightの大量skipを一括解除しない。
+- 既存の918件のdependency-cruiser known violationsは今回の修正対象にしない。
+

--- a/docs/reports/system-inventory-handoff-2026-07-14.md
+++ b/docs/reports/system-inventory-handoff-2026-07-14.md
@@ -21,7 +21,7 @@
 | nurse | `/nurse/*` | nurse | `RequireAudience viewer` |
 | hubs | `/planning`, `/operations`, `/master`, `/platform`, `/severe` など | `HubLanding` | `RequireAudience` は hub定義の `requiredRole` |
 
-`src/features` は48個のトップレベル機能を持つ。調査対象の主要ドメインは `attendance`, `daily`, `records`, `reports`, `billing`, `users`, `schedules`, `kiosk`, `kokuhoren-*`, `service-provision`。
+`src/features` 配下には、多数のトップレベル機能モジュールが配置されている。調査対象の主要ドメインは `attendance`, `daily`, `records`, `reports`, `billing`, `users`, `schedules`, `kiosk`, `kokuhoren-*`, `service-provision`。
 
 ## 主要フロー
 

--- a/docs/reports/system-inventory-handoff-2026-07-14.md
+++ b/docs/reports/system-inventory-handoff-2026-07-14.md
@@ -1,0 +1,59 @@
+# System Inventory Handoff - 2026-07-14
+
+- 基準コミット: `776335643564b599683fecb3169097e3eb2d7825`
+- 基準ブランチ: `origin/main`
+- 調査worktree: `C:\tmp\audit-management-system-mvp-investigation`
+- 調査方針: 製品コードは変更しない。発見事項は証拠、影響、推奨PR境界だけを記録する。
+
+## 構造サマリー
+
+このアプリは `src/app/router.tsx` が薄い合成層になっており、以下のRoute群を `childRoutes` に展開している。
+
+| Route群 | 主な入口 | 主なFeature / Page | 権限境界 |
+| --- | --- | --- | --- |
+| dashboard | `/dashboard`, `/today`, `/ops` | dashboard, today, ops-dashboard | `RequireAudience`, `/today` は `ProtectedRoute flag="todayOps"` |
+| daily | `/daily/*`, `/dailysupport` | daily, attendance, service-provision | `RequireAudience requiredRole="viewer"` |
+| record | `/records/*`, `/billing`, `/meeting-minutes/*` | records, billing, handoff, meeting-minutes | 月次/日誌/実績は `reception`、請求は画面上 `viewer` |
+| schedules | `/schedule*`, `/schedules/*`, `/schedule-ops` | schedules, transport | `ProtectedRoute flag="schedules"` + `RequireAudience viewer` |
+| admin | `/admin/*`, `/users`, `/staff` | admin, users, staff | `RequireAudience admin/reception`、一部 `ProtectedRoute` |
+| analysis / planning | `/analysis/*`, `/assessment`, `/support-plan-guide`, `/isp-editor*` | analysis, planning-sheet, support-plan-guide | viewer/admin混在 |
+| kiosk | `/kiosk/*` | kiosk, kiosk toilet/procedure | `ProtectedRoute` |
+| nurse | `/nurse/*` | nurse | `RequireAudience viewer` |
+| hubs | `/planning`, `/operations`, `/master`, `/platform`, `/severe` など | `HubLanding` | `RequireAudience` は hub定義の `requiredRole` |
+
+`src/features` は48個のトップレベル機能を持つ。調査対象の主要ドメインは `attendance`, `daily`, `records`, `reports`, `billing`, `users`, `schedules`, `kiosk`, `kokuhoren-*`, `service-provision`。
+
+## 主要フロー
+
+| 利用者操作 | Route | Feature / Panel | Hook / UseCase | Repository / Port | Adapter / 永続化 |
+| --- | --- | --- | --- | --- | --- |
+| 出欠確認・欠席登録 | `/daily/attendance` | `attendance/AttendancePanel` | `useAttendanceActions`, 欠席詳細Dialog | `AttendanceRepository` | `DataProviderAttendanceRepository` / in-memory |
+| 出欠からサービス提供実績同期 | 操作入口は支援実績側 | `service-provision` | `useSyncAttendance` | `AttendanceRepository`, `ServiceProvisionRepository` | AttendanceDaily -> ServiceProvision upsert |
+| 日次支援記録 | `/daily/table`, `/daily/support` | `daily` | table/procedure系hook | `DailyRecordRepository`, `ExecutionRecordRepository` | SharePoint / localStorage系storeが混在 |
+| 月次支援実績 | `/records/monthly` | `records/monthly`, `MonthlyRecordPage` | `aggregateMonthlyKpi`, `executeKioskMonthlyAggregation` | kiosk/daily evidence repository | 月次集計ロジック、SharePoint summary mapping |
+| 月次CSV出力 | ユーザーMenu等 | `reports/monthly/MonthlySummaryCsv.ts` | `exportMonthlySummary` | 入力rowsをCSV化 | browser Blob download |
+| 月次PDF系 | `/records/monthly` のPDF操作 | `reports/achievement`, monthly PDF E2E | `useAchievementPDF` | daily/user repositories | react-pdf / browser操作 |
+| 請求 | `/billing` | `billing/ui/BillingPage` | `useBillingSummary` | `BillingOrderRepository` | `/sites/2` List3, LocalStorage fallback |
+| 国保連プレビュー | 機能導線から | `kokuhoren-preview` | `useKokuhorenMonthlyPreview` | `ServiceProvisionRepository` | 月次実績読み取り + validation |
+| スケジュール確認・作成 | `/schedules/week`, `/schedules/create` | `schedules` | `useSchedules`, orchestrators | `ScheduleRepository` | SharePoint / demo / local E2E補助 |
+| キオスク記録 | `/kiosk/users/:userId/procedures/:slotKey`, `/kiosk/toilet` | `kiosk` | `useToiletRecords` 等 | toilet/procedure repositories | SharePoint toilet repo / localStorage fallback |
+
+## 境界観察
+
+- Routeは概ねFeatureまたはPageをlazy importし、永続化Adapterを直接持たない。ただし、`ProtectedRoute` はスケジュールのSharePointリスト存在確認を行うため、画面到達可否と環境診断が同居している。
+- Hubは `src/app/hubs/hubDefinitions.ts` がSSOTに近い。`HUB_DEFINITIONS` は権限、優先度、入口カードを持ち、route本体とは別管理。
+- `src/app/routes/appRoutePaths.ts` は診断・Nav契約用の明示リストだが、nested routeやhub動的routeとの表現差がある。Route棚卸しではこのファイルだけを真実にしない。
+- 請求は月次支援実績とは別系統。`docs/audit/phase4-monthly-billing-flow-boundary.md` も `MonthlyRecord_Summary` から `BillingOrders/List3` への変換契約は現行仕様にないと明記している。
+- 欠席は Attendance と ServiceProvision では明示的に扱われる。一方で Daily新規作成抑止は設計文書上の方針として確認できるが、横断テストはまだ十分に固定されていない。
+
+## 検証ログ
+
+| コマンド | 結果 | 備考 |
+| --- | --- | --- |
+| `npm ci --ignore-scripts` | PASS | prod+dev合計42件のaudit警告。prodは別途12件。 |
+| `npm run typecheck` | PASS | `tsc -p tsconfig.build.json --noEmit` |
+| `npm run gen:system-map` | PASS with warning | `system-map.md` を生成。SP/MSAL env未設定は非致命警告。生成差分は調査後に戻した。 |
+| `npm run arch:check` | PASS | 新規違反なし。既知違反918件はignore。 |
+| 月次/請求/国保連代表Vitest | PASS | 6 files / 54 tests passed |
+| `npm audit --omit=dev --json` | FAIL相当 | prod 12件。主に `firebase -> undici` と `exceljs -> uuid`。 |
+


### PR DESCRIPTION
## Summary
This docs-only PR records the system inventory and process optimization investigation based on `origin/main` at `776335643564b599683fecb3169097e3eb2d7825`.

## This PR does
- Records the system structure as of 2026-07-14
- Records observed issues, constraints, and warnings
- Defines follow-up PR boundaries and priority order

## This PR does not
- Change product code
- Change CI settings
- Update dependencies
- Implement lint:docs
- Resolve SP/MSAL environment warnings
- Rename product modules
- Fix the findings listed in the reports

## Validation
- `npm ci --ignore-scripts` passed
- `npm run typecheck` passed
- `npm run gen:system-map` passed with non-fatal SP/MSAL env warnings
- `npm run arch:check` passed with no new violations; 918 known violations ignored
- Representative Vitest suite passed: 6 files / 54 tests
- `npm run lint:docs` passed, but the command is currently a stub
- `npm audit --omit=dev --json` reported 12 production dependency findings, recorded for follow-up

## Follow-up candidates
1. MonthlySummaryExcel / MonthlySummaryCsv naming cleanup or documentation reconciliation
2. Monthly PDF contract documentation
3. lint:docs stub follow-up
4. Architecture ignore classification
5. exceljs remaining usage and removal feasibility
6. Vitest worker / false green investigation
