### PR TITLE
fix(ci): serve existing build for LHCI

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -3,7 +3,7 @@
     "collect": {
       "numberOfRuns": 1,
       "url": ["http://127.0.0.1:4173/analysis/dashboard"],
-      "startServerCommand": "npm run perf:preview",
+      "startServerCommand": "vite preview --host 127.0.0.1 --port 4173 --strictPort",
       "startServerReadyPattern": "localhost:4173|127.0.0.1:4173",
       "startServerReadyTimeout": 120000
     },

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -4,7 +4,7 @@
       "numberOfRuns": 1,
       "url": ["http://127.0.0.1:4173/analysis/dashboard"],
       "startServerCommand": "if [ ! -f dist/index.html ]; then npm run perf:build || exit 1; fi; vite preview --host 127.0.0.1 --port 4173 --strictPort",
-      "startServerReadyPattern": "Local",
+      "startServerReadyPattern": "Local:",
       "startServerReadyTimeout": 120000
     },
     "assert": {

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -4,7 +4,7 @@
       "numberOfRuns": 1,
       "url": ["http://127.0.0.1:4173/analysis/dashboard"],
       "startServerCommand": "vite preview --host 127.0.0.1 --port 4173 --strictPort",
-      "startServerReadyPattern": "localhost:4173|127.0.0.1:4173",
+      "startServerReadyPattern": "Local",
       "startServerReadyTimeout": 120000
     },
     "assert": {

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -3,7 +3,7 @@
     "collect": {
       "numberOfRuns": 1,
       "url": ["http://127.0.0.1:4173/analysis/dashboard"],
-      "startServerCommand": "vite preview --host 127.0.0.1 --port 4173 --strictPort",
+      "startServerCommand": "if [ ! -f dist/index.html ]; then npm run perf:build || exit 1; fi; vite preview --host 127.0.0.1 --port 4173 --strictPort",
       "startServerReadyPattern": "Local",
       "startServerReadyTimeout": 120000
     },


### PR DESCRIPTION
## 原因

Quality Gates の LHCI は `perf:check` で production build を作成した後、`startServerCommand` の `npm run perf:preview` で同じ build を再実行していました。2回目の build が `startServerReadyTimeout=120000` を超え、preview server 未起動のまま `chrome-error://chromewebdata/` へ遷移していました。

## 変更範囲

- `lighthouserc.json` のみ
- LHCI は既に生成済みの `dist` を `vite preview` で直接配信

## 対象 failure key

- `Perf report (LHCI + Web Vitals) / server-ready timeout`
- `CHROME_INTERSTITIAL_ERROR`

## 対象外

- Deep E2E
- Canary 分類器
- Auth / SharePoint
- 性能閾値の変更
- Nightly Health / deploy workflow

## ローカル検証

- lighthouserc JSON parse: pass
- `npm run typecheck:full -- --pretty false`: pass
- `npm run lint`: pass
- `git diff --check`: pass
- `npm run perf:check`: pass
  - build: 1回
  - preview server: 起動成功
  - Lighthouse collect/assert/upload: 完走

## GitHub検証

Draft PR CI および同一headの Quality Gates を確認するまでReady化しません。

## デプロイ判定

NO-GO / HOLD。mainの全ゲートとNightly Health成功前にデプロイしません。
