### PR TITLE
fix(ci): build integration preview in production mode

### DIFF
--- a/.github/workflows/e2e-deep.yml
+++ b/.github/workflows/e2e-deep.yml
@@ -416,6 +416,7 @@ jobs:
             --reporter=list,junit,html \
             --retries=1
         env:
+          NODE_ENV: production
           PLAYWRIGHT_JUNIT_OUTPUT: 'test-results/junit-e2e-integration.xml'
         continue-on-error: true
       


### PR DESCRIPTION
## 原因

Deep E2E の Integration job が workflow 全体の `NODE_ENV=test` を継承したまま production preview build を起動し、開発用 `jsxDEV` 変換と production React runtime が混在していました。

## 変更範囲

- `.github/workflows/e2e-deep.yml` のみ
- Integration test stepだけ `NODE_ENV=production` を明示

## 対象 failure key

- `Deep Tests (Integration Scenarios) / TypeError: a.jsxDEV is not a function`
- Dashboard 6件のbootstrap後続timeout

## 対象外

- Chromium全Deepの既存機能failure
- Canary分類器
- Auth / SharePoint実接続
- LHCI

## 検証

- final head: `65ea65ddafafba697bf4c790a836f43a8c4df3e9`
- base: `7c0abd8d9640245d7b10f97344ef11143974f6bb`
- changed files: 1
- workflow YAML / typecheck / lint / diff check: pass
- local Integration: 7 passed / 7 skipped / 0 failed
- fixed-head full Deep run `29351409615`: Integration actual success
- Chromium comparison against base main: 62 common / 0 resolved / 0 new
- Ready後のrequired checks: all completed / success
- Quality Gates: quality / Canary E2E / Canary LHCI / summary / final gate success

## マージ後

- merge commit: `5001f233a6900aa6458f50b734f17a2daf957f26`
- main Deep run `29354628199`: failure
- remaining Chromium failure keys: 62
- previous main comparison: 62 common / 0 resolved / 0 new
- Nightly Health: not run because the Deep gate failed
- production deploy: not run

IntegrationのjsxDEV起動不整合は解消しましたが、mainの既存Deep失敗が残るため本番判定はNO-GO / HOLDです。
