### PR TITLE
fix(ci): avoid Nightly Health result-line false positives

### DIFF
--- a/scripts/ci/assert-vitest-health.d.mts
+++ b/scripts/ci/assert-vitest-health.d.mts
@@ -1,4 +1,5 @@
 export interface VitestHealthSummary {
+  expectedFiles: number;
   startedFiles: number;
   endedFiles: number;
   lastStartedFile: string | null;
@@ -8,6 +9,7 @@ export interface VitestHealthSummary {
   vitestExitCode: number;
   invalidMemoryLines: number;
   logFilePresent: boolean;
+  memoryFilePresent: boolean;
   healthy: boolean;
 }
 
@@ -16,6 +18,7 @@ export function summarizeVitestHealth(input?: {
   memoryText?: string;
   vitestExitCode?: number | string;
   logFilePresent?: boolean;
+  memoryFilePresent?: boolean;
 }): VitestHealthSummary;
 
 export function runVitestHealthAssertion(input: {

--- a/scripts/ci/assert-vitest-health.mjs
+++ b/scripts/ci/assert-vitest-health.mjs
@@ -2,7 +2,15 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const UNHANDLED_ERROR_PATTERN = /unhandled (?:error|rejection)/i;
+const ESCAPE = String.fromCharCode(27);
+const BELL = String.fromCharCode(7);
+const ANSI_PATTERN = new RegExp(
+  `${ESCAPE}(?:\\[[0-?]*[ -/]*[@-~]|\\][^${BELL}]*(?:${BELL}|${ESCAPE}\\\\))`,
+  'g',
+);
+const VITEST_RESULT_LINE_PATTERN = /^\s*(?:✓|×)\s+\S+\.(?:spec|test)\.[cm]?[jt]sx?\s+>\s+/;
+const JEST_RESULT_LINE_PATTERN = /^\s*(?:PASS|FAIL)\s+\S+\.(?:spec|test)\.[cm]?[jt]sx?(?:\s|$)/;
+const UNHANDLED_ERROR_PATTERN = /^\s*(?:[-━⎯]+\s*)?unhandled (?:error|rejection)s?(?:\s*[-━⎯]+)?\s*$/i;
 const WORKER_ABNORMAL_EXIT_PATTERN = /worker exited unexpectedly|worker forks emitted error|timeout terminating forks worker/i;
 
 const parseExitCode = (value) => {
@@ -10,7 +18,33 @@ const parseExitCode = (value) => {
   return Number.isInteger(parsed) && parsed >= 0 ? parsed : 1;
 };
 
-export function summarizeVitestHealth({ logText = '', memoryText = '', vitestExitCode = 1, logFilePresent = true } = {}) {
+const stripAnsi = (line) => line.replace(ANSI_PATTERN, '');
+
+const isTestResultLine = (line) =>
+  VITEST_RESULT_LINE_PATTERN.test(line) || JEST_RESULT_LINE_PATTERN.test(line);
+
+const countSignalBlocks = (lines, pattern) => {
+  let count = 0;
+  let signalSeenInBlock = false;
+  for (const line of lines) {
+    if (!line.trim()) {
+      signalSeenInBlock = false;
+      continue;
+    }
+    if (isTestResultLine(line) || !pattern.test(line)) continue;
+    if (!signalSeenInBlock) count += 1;
+    signalSeenInBlock = true;
+  }
+  return count;
+};
+
+export function summarizeVitestHealth({
+  logText = '',
+  memoryText = '',
+  vitestExitCode = 1,
+  logFilePresent = true,
+  memoryFilePresent = true,
+} = {}) {
   const events = [];
   let invalidMemoryLines = 0;
 
@@ -25,6 +59,9 @@ export function summarizeVitestHealth({ logText = '', memoryText = '', vitestExi
 
   const started = events.filter((event) => event?.event === 'module-start');
   const ended = events.filter((event) => event?.event === 'module-end');
+  const expectedFiles = events.find(
+    (event) => event?.event === 'run-start' && Number.isInteger(event.expectedModules),
+  )?.expectedModules ?? 0;
   const endedCounts = new Map();
   for (const event of ended) endedCounts.set(event.moduleId, (endedCounts.get(event.moduleId) ?? 0) + 1);
   const missingEndedFiles = [];
@@ -33,28 +70,33 @@ export function summarizeVitestHealth({ logText = '', memoryText = '', vitestExi
     if (remaining > 0) endedCounts.set(event.moduleId, remaining - 1);
     else if (event.moduleId && !missingEndedFiles.includes(event.moduleId)) missingEndedFiles.push(event.moduleId);
   }
-  const logLines = logText.split(/\r?\n/);
+  const logLines = logText.split(/\r?\n/).map(stripAnsi);
   const summary = {
+    expectedFiles,
     startedFiles: started.length,
     endedFiles: ended.length,
     lastStartedFile: started.at(-1)?.moduleId ?? null,
     missingEndedFiles,
-    unhandledErrors: logLines.filter((line) => UNHANDLED_ERROR_PATTERN.test(line)).length,
-    workerAbnormalExits: logLines.filter((line) => WORKER_ABNORMAL_EXIT_PATTERN.test(line)).length,
+    unhandledErrors: countSignalBlocks(logLines, UNHANDLED_ERROR_PATTERN),
+    workerAbnormalExits: countSignalBlocks(logLines, WORKER_ABNORMAL_EXIT_PATTERN),
     vitestExitCode: parseExitCode(vitestExitCode),
     invalidMemoryLines,
     logFilePresent,
+    memoryFilePresent,
   };
 
   return {
     ...summary,
     healthy:
-      summary.startedFiles === summary.endedFiles &&
+      summary.expectedFiles > 0 &&
+      summary.startedFiles === summary.expectedFiles &&
+      summary.endedFiles === summary.expectedFiles &&
       summary.unhandledErrors === 0 &&
       summary.workerAbnormalExits === 0 &&
       summary.vitestExitCode === 0 &&
       summary.invalidMemoryLines === 0 &&
-      summary.logFilePresent,
+      summary.logFilePresent &&
+      summary.memoryFilePresent,
   };
 }
 
@@ -88,6 +130,7 @@ export function runVitestHealthAssertion({ logPath, memoryPath, summaryPath, vit
     memoryText: readTextSafe(memoryPath),
     vitestExitCode,
     logFilePresent: fs.existsSync(logPath),
+    memoryFilePresent: fs.existsSync(memoryPath),
   });
   fs.mkdirSync(path.dirname(summaryPath), { recursive: true });
   fs.writeFileSync(summaryPath, `${JSON.stringify(summary, null, 2)}\n`);

--- a/scripts/ci/vitest-memory-reporter.mjs
+++ b/scripts/ci/vitest-memory-reporter.mjs
@@ -18,18 +18,24 @@ export default class VitestMemoryReporter {
     this.startedAt = new Map();
   }
 
-  write(event, testModule) {
+  write(event, testModule, details = {}) {
     fs.mkdirSync(path.dirname(this.outputPath), { recursive: true });
     const moduleId = testModule?.moduleId || testModule?.id || 'unknown';
     const startedAt = this.startedAt.get(moduleId);
     fs.appendFileSync(this.outputPath, `${JSON.stringify({
       timestamp: new Date().toISOString(), event, moduleId,
       elapsedMs: startedAt === undefined ? undefined : Date.now() - startedAt,
-      pid: process.pid, ...memorySnapshot(),
+      pid: process.pid, ...details, ...memorySnapshot(),
     })}\n`);
   }
 
-  onTestRunStart(specifications) { this.write('run-start', { moduleId: `${specifications.length} specifications` }); }
+  onTestRunStart(specifications) {
+    this.write(
+      'run-start',
+      { moduleId: `${specifications.length} specifications` },
+      { expectedModules: specifications.length },
+    );
+  }
   onTestModuleStart(testModule) { this.startedAt.set(testModule.moduleId, Date.now()); this.write('module-start', testModule); }
   onTestModuleEnd(testModule) { this.write('module-end', testModule); this.startedAt.delete(testModule.moduleId); }
   onTestRunEnd(testModules, errors) { this.write('run-end', { moduleId: `${testModules.length} modules; ${errors.length} errors` }); }

--- a/tests/unit/vitestHealthAssertion.spec.ts
+++ b/tests/unit/vitestHealthAssertion.spec.ts
@@ -2,14 +2,25 @@ import { describe, expect, it } from 'vitest';
 import { summarizeVitestHealth } from '../../scripts/ci/assert-vitest-health.mjs';
 
 const event = (eventName: string, moduleId: string) => JSON.stringify({ event: eventName, moduleId });
+const runStart = (expectedModules: number) => JSON.stringify({
+  event: 'run-start',
+  moduleId: `${expectedModules} specifications`,
+  expectedModules,
+});
+
+const completeMemory = (...moduleIds: string[]) => [
+  runStart(moduleIds.length),
+  ...moduleIds.flatMap((moduleId) => [event('module-start', moduleId), event('module-end', moduleId)]),
+].join('\n');
 
 describe('summarizeVitestHealth', () => {
   it('passes when every module ends without runtime errors', () => {
     const summary = summarizeVitestHealth({
-      memoryText: [event('module-start', 'a.spec.ts'), event('module-end', 'a.spec.ts')].join('\n'),
+      memoryText: completeMemory('a.spec.ts'),
       vitestExitCode: 0,
     });
     expect(summary).toMatchObject({
+      expectedFiles: 1,
       startedFiles: 1,
       endedFiles: 1,
       lastStartedFile: 'a.spec.ts',
@@ -23,7 +34,7 @@ describe('summarizeVitestHealth', () => {
 
   it('fails when a module end is missing and records the last started file', () => {
     const summary = summarizeVitestHealth({
-      memoryText: [event('module-start', 'a.spec.ts'), event('module-end', 'a.spec.ts'), event('module-start', 'b.spec.ts')].join('\n'),
+      memoryText: [runStart(2), event('module-start', 'a.spec.ts'), event('module-end', 'a.spec.ts'), event('module-start', 'b.spec.ts')].join('\n'),
       vitestExitCode: 0,
     });
     expect(summary).toMatchObject({ startedFiles: 2, endedFiles: 1, lastStartedFile: 'b.spec.ts', missingEndedFiles: ['b.spec.ts'], healthy: false });
@@ -37,7 +48,7 @@ describe('summarizeVitestHealth', () => {
   ])('fails for runtime signal: %s', (signal) => {
     const summary = summarizeVitestHealth({
       logText: signal,
-      memoryText: [event('module-start', 'a.spec.ts'), event('module-end', 'a.spec.ts')].join('\n'),
+      memoryText: completeMemory('a.spec.ts'),
       vitestExitCode: 0,
     });
     expect(summary.healthy).toBe(false);
@@ -46,7 +57,7 @@ describe('summarizeVitestHealth', () => {
 
   it('fails when Vitest exits non-zero without a runtime signal', () => {
     const summary = summarizeVitestHealth({
-      memoryText: [event('module-start', 'a.spec.ts'), event('module-end', 'a.spec.ts')].join('\n'),
+      memoryText: completeMemory('a.spec.ts'),
       vitestExitCode: 2,
     });
     expect(summary).toMatchObject({ vitestExitCode: 2, healthy: false });
@@ -55,7 +66,7 @@ describe('summarizeVitestHealth', () => {
   it('reports worker termination separately from unhandled errors', () => {
     const summary = summarizeVitestHealth({
       logText: 'Error: [vitest-pool]: Worker forks emitted error.\nUnhandled Rejection',
-      memoryText: [event('module-start', 'a.spec.ts'), event('module-end', 'a.spec.ts')].join('\n'),
+      memoryText: completeMemory('a.spec.ts'),
       vitestExitCode: 1,
     });
     expect(summary).toMatchObject({ workerAbnormalExits: 1, unhandledErrors: 1, healthy: false });
@@ -63,7 +74,7 @@ describe('summarizeVitestHealth', () => {
 
   it('fails when the shard log is missing', () => {
     const summary = summarizeVitestHealth({
-      memoryText: [event('module-start', 'a.spec.ts'), event('module-end', 'a.spec.ts')].join('\n'),
+      memoryText: completeMemory('a.spec.ts'),
       vitestExitCode: 0,
       logFilePresent: false,
     });
@@ -72,9 +83,60 @@ describe('summarizeVitestHealth', () => {
 
   it('keeps a summary and fails when the memory JSONL is truncated', () => {
     const summary = summarizeVitestHealth({
-      memoryText: `${event('module-start', 'a.spec.ts')}\n{"event":"module-end"`,
+      memoryText: `${runStart(1)}\n${event('module-start', 'a.spec.ts')}\n{"event":"module-end"`,
       vitestExitCode: 0,
     });
     expect(summary).toMatchObject({ startedFiles: 1, endedFiles: 0, invalidMemoryLines: 1, healthy: false });
+  });
+
+  it('ignores runtime words only in strict Vitest and Jest result lines', () => {
+    const summary = summarizeVitestHealth({
+      logText: [
+        '\u001b[32m✓\u001b[39m tests/unit/vitestHealthAssertion.spec.ts\u001b[2m > \u001b[22msummarizeVitestHealth\u001b[2m > \u001b[22mfails for runtime signal: Worker exited unexpectedly',
+        '× tests/unit/vitestHealthAssertion.spec.ts > detects Unhandled Error',
+        'PASS tests/unit/vitestHealthAssertion.spec.ts Unhandled Rejection',
+        'FAIL tests/unit/vitestHealthAssertion.test.ts Worker forks emitted error',
+      ].join('\n'),
+      memoryText: completeMemory('a.spec.ts'),
+      vitestExitCode: 0,
+    });
+    expect(summary).toMatchObject({ unhandledErrors: 0, workerAbnormalExits: 0, healthy: true });
+  });
+
+  it('still detects runtime signals outside strict result lines', () => {
+    const summary = summarizeVitestHealth({
+      logText: [
+        'diagnostic: Worker exited unexpectedly',
+        'stack: Worker forks emitted error',
+        '',
+        '⎯⎯⎯⎯⎯⎯ Unhandled Error ⎯⎯⎯⎯⎯⎯',
+        'stack mentions Unhandled Error again',
+      ].join('\n'),
+      memoryText: completeMemory('a.spec.ts'),
+      vitestExitCode: 0,
+    });
+    expect(summary).toMatchObject({ unhandledErrors: 1, workerAbnormalExits: 1, healthy: false });
+  });
+
+  it('fails when structured expected module count is absent or incomplete', () => {
+    const withoutExpected = summarizeVitestHealth({
+      memoryText: [event('module-start', 'a.spec.ts'), event('module-end', 'a.spec.ts')].join('\n'),
+      vitestExitCode: 0,
+    });
+    const incomplete = summarizeVitestHealth({
+      memoryText: [runStart(2), event('module-start', 'a.spec.ts'), event('module-end', 'a.spec.ts')].join('\n'),
+      vitestExitCode: 0,
+    });
+    expect(withoutExpected).toMatchObject({ expectedFiles: 0, healthy: false });
+    expect(incomplete).toMatchObject({ expectedFiles: 2, startedFiles: 1, endedFiles: 1, healthy: false });
+  });
+
+  it('fails when the memory artifact is missing', () => {
+    const summary = summarizeVitestHealth({
+      memoryText: completeMemory('a.spec.ts'),
+      vitestExitCode: 0,
+      memoryFilePresent: false,
+    });
+    expect(summary).toMatchObject({ memoryFilePresent: false, healthy: false });
   });
 });


### PR DESCRIPTION
## Summary

- record the reporter expected module count as structured JSONL data
- ignore runtime-signal words only on strict Vitest/Jest result lines after ANSI removal
- count worker and unhandled runtime events by log block
- fail closed when expected module or diagnostic artifacts are missing

## Root cause

Nightly Health shard 3 completed all 381 modules with Vitest exit code 0, but successful test names contained Worker exited unexpectedly and Unhandled Error. The health assertion used unanchored substring matching and counted those result lines as runtime failures.

## Scope

Only the Vitest memory reporter, health assertion/type declaration, and its unit test are changed. Deep E2E, Canary, SharePoint authentication, and deployment configuration are out of scope.

## Validation

- npx vitest run tests/unit/vitestHealthAssertion.spec.ts: 14 passed
- npm run typecheck:full -- --pretty false: success
- targeted ESLint with --no-ignore: success
- git diff --check: success
- replay of Nightly run 29357541214 shard 3: expected=started=ended=381, unhandled=0, worker=0, healthy=true

## Deployment judgment

NO-GO / HOLD. This PR only repairs Nightly diagnostic accuracy; Deep E2E, SharePoint authentication, Cloudflare production environment, and a fresh post-merge Nightly run remain required.