### PR TITLE
fix(ci): Users_Masterの物理InternalName alias解決を追加

### DIFF
--- a/scripts/ci/__tests__/resolve-schema-fields.spec.mjs
+++ b/scripts/ci/__tests__/resolve-schema-fields.spec.mjs
@@ -51,12 +51,23 @@ describe('resolveSchemaFields', () => {
     const result = resolveSchemaFields(
       ['User_x0020_ID', 'User-ID'],
       ['UserID'],
+      { UserID: ['LegacyUserId'] },
     );
 
     expect(result.missing).toEqual(['UserID']);
     expect(result.ambiguous).toEqual([
       { logical: 'UserID', actual: ['User_x0020_ID', 'User-ID'] },
     ]);
+  });
+
+  it('does not normalize drift when no alias is declared', () => {
+    const result = resolveSchemaFields(
+      ['target_x0020_Type'],
+      ['targetType'],
+    );
+
+    expect(result.missing).toEqual(['targetType']);
+    expect(result.resolved).toEqual({});
   });
 
   it('maps payload keys with the same logical-to-physical result', () => {

--- a/scripts/ci/__tests__/resolve-schema-fields.spec.mjs
+++ b/scripts/ci/__tests__/resolve-schema-fields.spec.mjs
@@ -1,0 +1,73 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import {
+  mapSchemaPayload,
+  resolveSchemaFields,
+} from '../resolve-schema-fields.mjs';
+import { FIELD_ALIASES } from '../schemas/users.mjs';
+
+describe('resolveSchemaFields', () => {
+  it('keeps canonical InternalNames when they are available', () => {
+    const result = resolveSchemaFields(
+      ['UserID', 'FullName', 'IsActive'],
+      ['UserID', 'FullName', 'IsActive'],
+      FIELD_ALIASES,
+    );
+
+    expect(result.missing).toEqual([]);
+    expect(result.ambiguous).toEqual([]);
+    expect(result.resolved).toEqual({
+      UserID: 'UserID',
+      FullName: 'FullName',
+      IsActive: 'IsActive',
+    });
+    expect(result.resolutions.every(({ method }) => method === 'exact')).toBe(true);
+  });
+
+  it('resolves Users_Master logical fields to encoded physical InternalNames', () => {
+    const result = resolveSchemaFields(
+      ['Title', 'User_x0020_ID', 'Full_x0020_Name', 'IsActive'],
+      ['UserID', 'FullName', 'Title', 'IsActive'],
+      FIELD_ALIASES,
+    );
+
+    expect(result.missing).toEqual([]);
+    expect(result.resolved.UserID).toBe('User_x0020_ID');
+    expect(result.resolved.FullName).toBe('Full_x0020_Name');
+  });
+
+  it('fails unresolved logical fields instead of guessing', () => {
+    const result = resolveSchemaFields(
+      ['Title', 'User_x0020_ID'],
+      ['UserID', 'FullName'],
+      FIELD_ALIASES,
+    );
+
+    expect(result.missing).toEqual(['FullName']);
+    expect(result.resolved.UserID).toBe('User_x0020_ID');
+  });
+
+  it('reports ambiguous normalized matches', () => {
+    const result = resolveSchemaFields(
+      ['User_x0020_ID', 'User-ID'],
+      ['UserID'],
+    );
+
+    expect(result.missing).toEqual(['UserID']);
+    expect(result.ambiguous).toEqual([
+      { logical: 'UserID', actual: ['User_x0020_ID', 'User-ID'] },
+    ]);
+  });
+
+  it('maps payload keys with the same logical-to-physical result', () => {
+    expect(mapSchemaPayload(
+      { UserID: 'E2E', FullName: 'Name', IsActive: true, Title: 'Title' },
+      { UserID: 'User_x0020_ID', FullName: 'Full_x0020_Name', IsActive: 'IsActive', Title: 'Title' },
+    )).toEqual({
+      User_x0020_ID: 'E2E',
+      Full_x0020_Name: 'Name',
+      IsActive: true,
+      Title: 'Title',
+    });
+  });
+});

--- a/scripts/ci/__tests__/validate-users-schema.spec.mjs
+++ b/scripts/ci/__tests__/validate-users-schema.spec.mjs
@@ -50,4 +50,22 @@ describe('Users_Master schema validation', () => {
     expect(result.ok).toBe(false);
     expect(result.missing).toEqual(['FullName']);
   });
+
+  it('keeps optional ambiguity as a warning rather than a schema failure', () => {
+    const result = validateSchema(
+      ['UserID', 'FullName', 'Full_x0020_Name_x0020_Kana', 'Full-Name-Kana'],
+      ESSENTIAL_FIELDS,
+      ['FullNameKana'],
+      { aliases: { ...FIELD_ALIASES, FullNameKana: ['LegacyFullNameKana'] } },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.ambiguousEssential).toEqual([]);
+    expect(result.ambiguousOptional).toEqual([
+      {
+        logical: 'FullNameKana',
+        actual: ['Full_x0020_Name_x0020_Kana', 'Full-Name-Kana'],
+      },
+    ]);
+  });
 });

--- a/scripts/ci/__tests__/validate-users-schema.spec.mjs
+++ b/scripts/ci/__tests__/validate-users-schema.spec.mjs
@@ -1,0 +1,53 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { validateSchema } from '../validate-schema.logic.mjs';
+import {
+  ESSENTIAL_FIELDS,
+  FIELD_ALIASES,
+  OPTIONAL_FIELDS,
+} from '../schemas/users.mjs';
+
+describe('Users_Master schema validation', () => {
+  it('accepts canonical logical InternalNames', () => {
+    const result = validateSchema(
+      [...ESSENTIAL_FIELDS, 'IsActive'],
+      ESSENTIAL_FIELDS,
+      OPTIONAL_FIELDS,
+      { aliases: FIELD_ALIASES },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.missing).toEqual([]);
+    expect(result.caseMismatch).toEqual([]);
+    expect(result.resolved.UserID).toBe('UserID');
+    expect(result.resolved.FullName).toBe('FullName');
+  });
+
+  it('accepts the known physical SharePoint InternalNames', () => {
+    const result = validateSchema(
+      ['User_x0020_ID', 'Full_x0020_Name', 'IsActive'],
+      ESSENTIAL_FIELDS,
+      OPTIONAL_FIELDS,
+      { aliases: FIELD_ALIASES },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.missing).toEqual([]);
+    expect(result.aliasResolutions).toEqual(expect.arrayContaining([
+      expect.objectContaining({ logical: 'UserID', actual: 'User_x0020_ID' }),
+      expect.objectContaining({ logical: 'FullName', actual: 'Full_x0020_Name' }),
+    ]));
+  });
+
+  it('still fails when an essential logical field has no physical match', () => {
+    const result = validateSchema(
+      ['User_x0020_ID'],
+      ESSENTIAL_FIELDS,
+      [],
+      { aliases: FIELD_ALIASES },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.missing).toEqual(['FullName']);
+  });
+});

--- a/scripts/ci/resolve-schema-fields.d.mts
+++ b/scripts/ci/resolve-schema-fields.d.mts
@@ -1,0 +1,24 @@
+export type SchemaFieldAliases = Record<string, readonly string[]>;
+
+export type SchemaFieldResolution = {
+  resolved: Record<string, string>;
+  missing: string[];
+  ambiguous: { logical: string; actual: string[] }[];
+  resolutions: {
+    logical: string;
+    actual: string;
+    method: string;
+    candidate: string;
+  }[];
+};
+
+export function resolveSchemaFields(
+  actualNames?: string[],
+  logicalNames?: string[],
+  aliases?: SchemaFieldAliases,
+): SchemaFieldResolution;
+
+export function mapSchemaPayload(
+  payload: Record<string, unknown>,
+  resolved?: Record<string, string>,
+): Record<string, unknown>;

--- a/scripts/ci/resolve-schema-fields.mjs
+++ b/scripts/ci/resolve-schema-fields.mjs
@@ -41,6 +41,7 @@ function findUnique(actualNames, predicate, used) {
  *   1. exact candidate match
  *   2. case-insensitive candidate match
  *   3. normalized match (removes SharePoint _x####_ tokens and punctuation)
+ *      only when the logical field declares explicit aliases
  *
  * A physical name can be used only once.  Ambiguous normalized matches are
  * reported instead of selecting an arbitrary field.
@@ -87,6 +88,9 @@ export function resolveSchemaFields(actualNames = [], logicalNames = [], aliases
       }
     }
 
+    const hasExplicitAliases =
+      Array.isArray(aliases?.[logicalName]) && aliases[logicalName].length > 0;
+
     if (!actual && !ambiguous.some((entry) => entry.logical === logicalName)) {
       for (const currentCandidate of candidates) {
         const result = findUnique(
@@ -107,7 +111,7 @@ export function resolveSchemaFields(actualNames = [], logicalNames = [], aliases
       }
     }
 
-    if (!actual && !ambiguous.some((entry) => entry.logical === logicalName)) {
+    if (hasExplicitAliases && !actual && !ambiguous.some((entry) => entry.logical === logicalName)) {
       const normalizedCandidates = unique(candidates.map(normalizeName));
       const result = findUnique(
         available,

--- a/scripts/ci/resolve-schema-fields.mjs
+++ b/scripts/ci/resolve-schema-fields.mjs
@@ -1,0 +1,146 @@
+/**
+ * Pure SharePoint InternalName resolver shared by CI schema validation and
+ * Playwright integration tests.
+ *
+ * The logical field name remains the contract.  Aliases are only a mapping
+ * for known physical InternalName drift (for example, SharePoint's encoded
+ * space form).
+ */
+
+const ENCODED_TOKEN = /_x[0-9a-f]{4}_/gi;
+
+function normalizeName(value) {
+  return String(value ?? '')
+    .toLowerCase()
+    .replace(ENCODED_TOKEN, '')
+    .replace(/[^a-z0-9]/g, '');
+}
+
+function unique(values) {
+  return [...new Set(values.filter((value) => typeof value === 'string' && value.length > 0))];
+}
+
+function candidateNames(logicalName, aliases) {
+  const explicitAliases = Array.isArray(aliases?.[logicalName])
+    ? aliases[logicalName]
+    : [];
+  const encodedLogicalName = logicalName.replace(/ /g, '_x0020_');
+  return unique([logicalName, ...explicitAliases, encodedLogicalName]);
+}
+
+function findUnique(actualNames, predicate, used) {
+  const matches = actualNames.filter((actual) => !used.has(actual) && predicate(actual));
+  if (matches.length > 1) return { ambiguous: matches };
+  return { actual: matches[0] };
+}
+
+/**
+ * Resolve logical field names to the available SharePoint InternalNames.
+ *
+ * Resolution precedence is deterministic:
+ *   1. exact candidate match
+ *   2. case-insensitive candidate match
+ *   3. normalized match (removes SharePoint _x####_ tokens and punctuation)
+ *
+ * A physical name can be used only once.  Ambiguous normalized matches are
+ * reported instead of selecting an arbitrary field.
+ *
+ * @param {string[]} actualNames
+ * @param {string[]} logicalNames
+ * @param {Record<string, string[]>} aliases
+ * @returns {{
+ *   resolved: Record<string, string>,
+ *   missing: string[],
+ *   ambiguous: { logical: string, actual: string[] }[],
+ *   resolutions: { logical: string, actual: string, method: string, candidate: string }[],
+ * }}
+ */
+export function resolveSchemaFields(actualNames = [], logicalNames = [], aliases = {}) {
+  const available = unique(actualNames);
+  const resolved = {};
+  const missing = [];
+  const ambiguous = [];
+  const resolutions = [];
+  const used = new Set();
+
+  for (const logicalName of unique(logicalNames)) {
+    const candidates = candidateNames(logicalName, aliases);
+    let actual;
+    let method;
+    let candidate;
+
+    for (const currentCandidate of candidates) {
+      const result = findUnique(
+        available,
+        (name) => name === currentCandidate,
+        used,
+      );
+      if (result.ambiguous) {
+        ambiguous.push({ logical: logicalName, actual: result.ambiguous });
+        break;
+      }
+      if (result.actual) {
+        actual = result.actual;
+        method = currentCandidate === logicalName ? 'exact' : 'alias';
+        candidate = currentCandidate;
+        break;
+      }
+    }
+
+    if (!actual && !ambiguous.some((entry) => entry.logical === logicalName)) {
+      for (const currentCandidate of candidates) {
+        const result = findUnique(
+          available,
+          (name) => name.toLowerCase() === currentCandidate.toLowerCase(),
+          used,
+        );
+        if (result.ambiguous) {
+          ambiguous.push({ logical: logicalName, actual: result.ambiguous });
+          break;
+        }
+        if (result.actual) {
+          actual = result.actual;
+          method = currentCandidate === logicalName ? 'case-insensitive' : 'alias';
+          candidate = currentCandidate;
+          break;
+        }
+      }
+    }
+
+    if (!actual && !ambiguous.some((entry) => entry.logical === logicalName)) {
+      const normalizedCandidates = unique(candidates.map(normalizeName));
+      const result = findUnique(
+        available,
+        (name) => normalizedCandidates.includes(normalizeName(name)),
+        used,
+      );
+      if (result.ambiguous) {
+        ambiguous.push({ logical: logicalName, actual: result.ambiguous });
+      } else if (result.actual) {
+        actual = result.actual;
+        method = 'normalized';
+        candidate = candidates.find((value) => normalizeName(value) === normalizeName(actual)) || logicalName;
+      }
+    }
+
+    if (actual) {
+      used.add(actual);
+      resolved[logicalName] = actual;
+      resolutions.push({ logical: logicalName, actual, method, candidate });
+    } else {
+      missing.push(logicalName);
+    }
+  }
+
+  return { resolved, missing, ambiguous, resolutions };
+}
+
+/**
+ * Convert logical payload keys to their resolved physical InternalNames.
+ * Unknown keys are retained so existing system fields continue to work.
+ */
+export function mapSchemaPayload(payload, resolved = {}) {
+  return Object.fromEntries(
+    Object.entries(payload ?? {}).map(([key, value]) => [resolved[key] || key, value]),
+  );
+}

--- a/scripts/ci/schemas/users.d.mts
+++ b/scripts/ci/schemas/users.d.mts
@@ -1,0 +1,4 @@
+export const LIST_TITLE: 'Users_Master';
+export const ESSENTIAL_FIELDS: readonly ['UserID', 'FullName'];
+export const OPTIONAL_FIELDS: readonly string[];
+export const FIELD_ALIASES: Record<string, readonly string[]>;

--- a/scripts/ci/schemas/users.mjs
+++ b/scripts/ci/schemas/users.mjs
@@ -10,6 +10,14 @@ export const ESSENTIAL_FIELDS = [
   'FullName',
 ];
 
+// Logical contract -> known SharePoint physical InternalName aliases.
+// Keep the canonical names above unchanged; the resolver chooses the
+// physical name only when the canonical InternalName is not present.
+export const FIELD_ALIASES = {
+  UserID: ['User_x0020_ID'],
+  FullName: ['Full_x0020_Name'],
+};
+
 export const OPTIONAL_FIELDS = [
   'IsActive',
   'Title',

--- a/scripts/ci/validate-list-schema.mjs
+++ b/scripts/ci/validate-list-schema.mjs
@@ -28,7 +28,12 @@ const schemaPath = path.isAbsolute(schemaRelativePath)
   ? schemaRelativePath
   : path.resolve(process.cwd(), schemaRelativePath);
 
-const { LIST_TITLE, ESSENTIAL_FIELDS, OPTIONAL_FIELDS } = await import(`file://${schemaPath}`);
+const {
+  LIST_TITLE,
+  ESSENTIAL_FIELDS,
+  OPTIONAL_FIELDS,
+  FIELD_ALIASES = {},
+} = await import(`file://${schemaPath}`);
 
 // ── Main ────────────────────────────────────────────────────────
 const site = process.env.SHAREPOINT_SITE;
@@ -70,7 +75,9 @@ try {
 
   // ── Validation ──
   const actualNames = fields.map((f) => f.InternalName);
-  const result = validateSchema(actualNames, ESSENTIAL_FIELDS, OPTIONAL_FIELDS);
+  const result = validateSchema(actualNames, ESSENTIAL_FIELDS, OPTIONAL_FIELDS, {
+    aliases: FIELD_ALIASES,
+  });
 
   // ── Report ──
   console.log('');
@@ -80,6 +87,20 @@ try {
     console.warn(`⚠️  Case mismatch (drifting):`);
     for (const { expected, actual } of result.caseMismatch) {
       console.warn(`   expected "${expected}" → found "${actual}"`);
+    }
+  }
+
+  if (result.aliasResolutions.length) {
+    console.warn('⚠️  Logical fields resolved through aliases:');
+    for (const { logical, actual, method } of result.aliasResolutions) {
+      console.warn(`   ${logical} → ${actual} (${method})`);
+    }
+  }
+
+  if (result.ambiguous.length) {
+    console.error('❌ Ambiguous InternalName resolution:');
+    for (const { logical, actual } of result.ambiguous) {
+      console.error(`   ${logical} → ${actual.join(', ')}`);
     }
   }
 

--- a/scripts/ci/validate-list-schema.mjs
+++ b/scripts/ci/validate-list-schema.mjs
@@ -97,10 +97,17 @@ try {
     }
   }
 
-  if (result.ambiguous.length) {
+  if (result.ambiguousEssential.length) {
     console.error('❌ Ambiguous InternalName resolution:');
-    for (const { logical, actual } of result.ambiguous) {
+    for (const { logical, actual } of result.ambiguousEssential) {
       console.error(`   ${logical} → ${actual.join(', ')}`);
+    }
+  }
+
+  if (result.ambiguousOptional.length) {
+    console.warn('⚠️  Ambiguous optional InternalName resolution:');
+    for (const { logical, actual } of result.ambiguousOptional) {
+      console.warn(`   ${logical} → ${actual.join(', ')}`);
     }
   }
 

--- a/scripts/ci/validate-schema.logic.mjs
+++ b/scripts/ci/validate-schema.logic.mjs
@@ -3,51 +3,50 @@
  * No I/O — testable without SharePoint or Playwright.
  */
 
+import { resolveSchemaFields } from './resolve-schema-fields.mjs';
+
 /**
  * Validate actual SharePoint field names against expected fields.
  *
  * @param {string[]} actualNames - InternalName values from SharePoint
  * @param {string[]} essentialFields - Fields that MUST exist (case-insensitive check, case-match preferred)
  * @param {string[]} optionalFields - Fields that SHOULD exist (warn if missing)
+ * @param {{ aliases?: Record<string, string[]> }} options - Logical field aliases
  * @returns {{
  *   ok: boolean,
  *   missing: string[],
  *   caseMismatch: { expected: string, actual: string }[],
- *   optionalMissing: string[]
+ *   optionalMissing: string[],
+ *   resolved: Record<string, string>,
+ *   aliasResolutions: { logical: string, actual: string, method: string, candidate: string }[],
+ *   ambiguous: { logical: string, actual: string[] }[],
  * }}
  */
-export function validateSchema(actualNames, essentialFields = [], optionalFields = []) {
-  const nameSet = new Set(actualNames);
-  const lowerMap = new Map(
-    actualNames.map((n) => [n.toLowerCase(), n]),
-  );
-
-  const missing = [];
-  const caseMismatch = [];
-
-  for (const name of essentialFields) {
-    if (nameSet.has(name)) continue;
-
-    const lower = name.toLowerCase();
-    if (lowerMap.has(lower)) {
-      caseMismatch.push({ expected: name, actual: lowerMap.get(lower) });
-    } else {
-      missing.push(name);
-    }
-  }
-
-  const optionalMissing = [];
-  for (const name of optionalFields) {
-    if (!nameSet.has(name) && !lowerMap.has(name.toLowerCase())) {
-      optionalMissing.push(name);
-    }
-  }
+export function validateSchema(
+  actualNames,
+  essentialFields = [],
+  optionalFields = [],
+  options = {},
+) {
+  const logicalFields = [...new Set([...essentialFields, ...optionalFields])];
+  const resolution = resolveSchemaFields(actualNames, logicalFields, options.aliases || {});
+  const missing = essentialFields.filter((name) => !resolution.resolved[name]);
+  const caseMismatch = essentialFields
+    .filter((name) => {
+      const actual = resolution.resolved[name];
+      return actual && actual !== name && actual.toLowerCase() === name.toLowerCase();
+    })
+    .map((name) => ({ expected: name, actual: resolution.resolved[name] }));
+  const optionalMissing = optionalFields.filter((name) => !resolution.resolved[name]);
+  const aliasResolutions = resolution.resolutions.filter(({ method }) => method !== 'exact');
 
   return {
-    ok: missing.length === 0,
+    ok: missing.length === 0 && resolution.ambiguous.length === 0,
     missing,
     caseMismatch,
     optionalMissing,
+    resolved: resolution.resolved,
+    aliasResolutions,
+    ambiguous: resolution.ambiguous,
   };
 }
-

--- a/scripts/ci/validate-schema.logic.mjs
+++ b/scripts/ci/validate-schema.logic.mjs
@@ -20,6 +20,8 @@ import { resolveSchemaFields } from './resolve-schema-fields.mjs';
  *   resolved: Record<string, string>,
  *   aliasResolutions: { logical: string, actual: string, method: string, candidate: string }[],
  *   ambiguous: { logical: string, actual: string[] }[],
+ *   ambiguousEssential: { logical: string, actual: string[] }[],
+ *   ambiguousOptional: { logical: string, actual: string[] }[],
  * }}
  */
 export function validateSchema(
@@ -39,14 +41,19 @@ export function validateSchema(
     .map((name) => ({ expected: name, actual: resolution.resolved[name] }));
   const optionalMissing = optionalFields.filter((name) => !resolution.resolved[name]);
   const aliasResolutions = resolution.resolutions.filter(({ method }) => method !== 'exact');
+  const essentialSet = new Set(essentialFields);
+  const ambiguousEssential = resolution.ambiguous.filter(({ logical }) => essentialSet.has(logical));
+  const ambiguousOptional = resolution.ambiguous.filter(({ logical }) => !essentialSet.has(logical));
 
   return {
-    ok: missing.length === 0 && resolution.ambiguous.length === 0,
+    ok: missing.length === 0 && ambiguousEssential.length === 0,
     missing,
     caseMismatch,
     optionalMissing,
     resolved: resolution.resolved,
     aliasResolutions,
     ambiguous: resolution.ambiguous,
+    ambiguousEssential,
+    ambiguousOptional,
   };
 }

--- a/tests/integration/_shared/listSpecFactory.spec.ts
+++ b/tests/integration/_shared/listSpecFactory.spec.ts
@@ -1,0 +1,63 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { FIELD_ALIASES } from '../../../scripts/ci/schemas/users.mjs';
+import { mapSchemaPayload } from '../../../scripts/ci/resolve-schema-fields.mjs';
+import { resolveListSpecFields } from './listSpecFactory';
+
+const usersSpec = {
+  name: 'Users_Master',
+  siteUrl: 'https://example.sharepoint.com/sites/welfare',
+  listTitle: 'Users_Master',
+  keyField: 'UserID',
+  selectFields: ['Title', 'FullName', 'IsActive', 'Modified'],
+  fieldAliases: FIELD_ALIASES,
+  fixedKeyValue: 'E2E_INTEGRATION_USER_0001',
+  makeUpsertPayload: (key: string) => ({
+    UserID: key,
+    Title: `E2E User ${key}`,
+    FullName: 'E2E User FullName',
+    IsActive: true,
+  }),
+  deactivate: { field: 'IsActive', value: false },
+};
+
+describe('Users_Master list field resolution', () => {
+  it('uses one logical-to-physical mapping for list operations', () => {
+    const fields = resolveListSpecFields(usersSpec, [
+      'Id',
+      'Title',
+      'User_x0020_ID',
+      'Full_x0020_Name',
+      'IsActive',
+      'Modified',
+    ]);
+
+    expect(fields.keyField).toBe('User_x0020_ID');
+    expect(fields.selectFields).toEqual([
+      'Title',
+      'Full_x0020_Name',
+      'IsActive',
+      'Modified',
+    ]);
+    expect(fields.deactivateField).toBe('IsActive');
+    expect(mapSchemaPayload(usersSpec.makeUpsertPayload('E2E'), fields.logicalToPhysical)).toEqual({
+      User_x0020_ID: 'E2E',
+      Title: 'E2E User E2E',
+      Full_x0020_Name: 'E2E User FullName',
+      IsActive: true,
+    });
+  });
+
+  it('keeps the canonical mapping when standard InternalNames are present', () => {
+    const fields = resolveListSpecFields(usersSpec, [
+      'Title',
+      'UserID',
+      'FullName',
+      'IsActive',
+      'Modified',
+    ]);
+
+    expect(fields.keyField).toBe('UserID');
+    expect(fields.selectFields).toEqual(['Title', 'FullName', 'IsActive', 'Modified']);
+  });
+});

--- a/tests/integration/_shared/listSpecFactory.ts
+++ b/tests/integration/_shared/listSpecFactory.ts
@@ -1,5 +1,6 @@
 import { expect, type APIRequestContext } from '@playwright/test';
 import { assertHasFields, makeListApi, toSelectQuery, type SpClient } from './spHttp';
+import { mapSchemaPayload, resolveSchemaFields } from '../../../scripts/ci/resolve-schema-fields.mjs';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -9,10 +10,11 @@ export type ListSpec<TCreate extends Record<string, unknown>> = {
   listTitle: string;    // e.g. Staff_Master
   keyField: string;     // e.g. StaffID / UserID
   selectFields: string[]; // fields you require (schema)
+  fieldAliases?: Record<string, readonly string[]>; // logical -> physical InternalName aliases
   fixedKeyValue: string; // stable key to avoid record growth
   makeUpsertPayload: (key: string) => TCreate; // create/update payload
   // optional: "deactivate" or "resolve" semantics
-  afterUpsertAssert?: (item: any) => void;
+  afterUpsertAssert?: (item: any, logicalToPhysical?: Record<string, string>) => void;
   deactivate?: {
     field: string;       // e.g. IsActive / Status
     value: unknown;      // e.g. false / 'Resolved'
@@ -26,6 +28,13 @@ export type ListRunner = {
   deactivateIfNeeded: () => Promise<void>;
 };
 
+export type ResolvedListFields = {
+  logicalToPhysical: Record<string, string>;
+  keyField: string;
+  selectFields: string[];
+  deactivateField?: string;
+};
+
 type ODataItem = { d?: any; value?: any };
 
 function buildListItemUrl(siteUrl: string, listTitle: string): string {
@@ -35,6 +44,51 @@ function buildListItemUrl(siteUrl: string, listTitle: string): string {
 
 function buildItemByIdUrl(siteUrl: string, listTitle: string, id: number): string {
   return `${buildListItemUrl(siteUrl, listTitle)}(${id})`;
+}
+
+export function resolveListSpecFields<TCreate extends Record<string, unknown>>(
+  spec: ListSpec<TCreate>,
+  actualNames: string[],
+): ResolvedListFields {
+  const logicalNames = [
+    spec.keyField,
+    ...spec.selectFields,
+    ...(spec.deactivate ? [spec.deactivate.field] : []),
+  ];
+
+  if (!spec.fieldAliases) {
+    const logicalToPhysical = Object.fromEntries(
+      [...new Set(logicalNames)].map((name) => [name, name]),
+    );
+    return {
+      logicalToPhysical,
+      keyField: spec.keyField,
+      selectFields: spec.selectFields,
+      deactivateField: spec.deactivate?.field,
+    };
+  }
+
+  const result = resolveSchemaFields(actualNames, logicalNames, spec.fieldAliases);
+  if (result.missing.length || result.ambiguous.length) {
+    const missing = result.missing.join(', ') || '(none)';
+    const ambiguous = result.ambiguous
+      .map(({ logical, actual }) => `${logical} -> ${actual.join(', ')}`)
+      .join('; ') || '(none)';
+    throw new Error(
+      `[integration] ${spec.name}: unresolved SharePoint fields\n` +
+      `missing=${missing}\n` +
+      `ambiguous=${ambiguous}`,
+    );
+  }
+
+  return {
+    logicalToPhysical: result.resolved,
+    keyField: result.resolved[spec.keyField],
+    selectFields: spec.selectFields.map((field) => result.resolved[field]),
+    deactivateField: spec.deactivate
+      ? result.resolved[spec.deactivate.field]
+      : undefined,
+  };
 }
 
 export function createListRunner<TCreate extends Record<string, unknown>>(
@@ -72,10 +126,34 @@ export function createListRunner<TCreate extends Record<string, unknown>>(
 
   const itemsUrl = buildListItemUrl(spec.siteUrl, spec.listTitle);
 
-  const select = toSelectQuery(['Id', spec.keyField, ...spec.selectFields]);
-  const filter = `${spec.keyField} eq '${spec.fixedKeyValue.replace(/'/g, "''")}'`; // OData escape
+  let resolvedFieldsPromise: Promise<ResolvedListFields> | undefined;
+
+  async function resolveFields(): Promise<ResolvedListFields> {
+    if (!spec.fieldAliases) {
+      return resolveListSpecFields(spec, []);
+    }
+
+    const fieldsUrl =
+      `${spec.siteUrl}/_api/web/lists/GetByTitle('${encodeURIComponent(spec.listTitle)}')/fields?` +
+      '$filter=Hidden eq false&$select=InternalName';
+    const response = await api.get(fieldsUrl, `${spec.name}:discoverFields`);
+    const json = await response.json().catch(() => ({}));
+    const fields = json?.d?.results ?? json?.value ?? [];
+    const actualNames = fields
+      .map((field: { InternalName?: unknown }) => field.InternalName)
+      .filter((name: unknown): name is string => typeof name === 'string');
+    return resolveListSpecFields(spec, actualNames);
+  }
+
+  function getResolvedFields(): Promise<ResolvedListFields> {
+    resolvedFieldsPromise ??= resolveFields();
+    return resolvedFieldsPromise;
+  }
 
   async function fetchByKey(): Promise<any[]> {
+    const fields = await getResolvedFields();
+    const select = toSelectQuery(['Id', fields.keyField, ...fields.selectFields]);
+    const filter = `${fields.keyField} eq '${spec.fixedKeyValue.replace(/'/g, "''")}'`; // OData escape
     const url = `${itemsUrl}?$select=${select}&$filter=${encodeURIComponent(filter)}&$top=5`;
     const res = await api.get(url, `${spec.name}:listByKey`);
     const json: ODataItem = await res.json().catch(() => ({}));
@@ -84,18 +162,23 @@ export function createListRunner<TCreate extends Record<string, unknown>>(
   }
 
   async function upsertOnce(): Promise<{ id: number; count: number; item: any }> {
+    const fields = await getResolvedFields();
+    const makePayload = () => mapSchemaPayload(
+      spec.makeUpsertPayload(spec.fixedKeyValue),
+      fields.logicalToPhysical,
+    );
     const before = await fetchByKey();
     if (before.length > 0) {
       const id = Number(before[0].Id);
       const url = buildItemByIdUrl(spec.siteUrl, spec.listTitle, id);
-      await api.merge(url, spec.makeUpsertPayload(spec.fixedKeyValue), `${spec.name}:merge`);
+      await api.merge(url, makePayload(), `${spec.name}:merge`);
       const after = await fetchByKey();
       return { id, count: after.length, item: after[0] };
     }
 
     // Create (POST)
     const url = itemsUrl;
-    await api.post(url, spec.makeUpsertPayload(spec.fixedKeyValue), `${spec.name}:create`);
+    await api.post(url, makePayload(), `${spec.name}:create`);
     const after = await fetchByKey();
     expect(after.length).toBeGreaterThan(0);
     return { id: Number(after[0].Id), count: after.length, item: after[0] };
@@ -103,16 +186,18 @@ export function createListRunner<TCreate extends Record<string, unknown>>(
 
   return {
     async reachability() {
+      await getResolvedFields();
       const url = `${itemsUrl}?$select=Id&$top=1`;
       const res = await api.get(url, `${spec.name}:reachability`);
       await res.json().catch(() => ({}));
     },
 
     async schema() {
+      const fields = await getResolvedFields();
       const rows = await fetchByKey();
       // If not found yet, create once so schema can be asserted on a real item
       const item = rows[0] ?? (await upsertOnce()).item;
-      assertHasFields(item, ['Id', spec.keyField, ...spec.selectFields]);
+      assertHasFields(item, ['Id', fields.keyField, ...fields.selectFields]);
     },
 
     async idempotentUpsert() {
@@ -123,23 +208,29 @@ export function createListRunner<TCreate extends Record<string, unknown>>(
       expect(second.count).toBe(first.count);
 
       if (spec.afterUpsertAssert) {
-        spec.afterUpsertAssert(second.item);
+        const fields = await getResolvedFields();
+        spec.afterUpsertAssert(second.item, fields.logicalToPhysical);
       }
     },
 
     async deactivateIfNeeded() {
       if (!spec.deactivate) return;
 
+      const fields = await getResolvedFields();
       const rows = await fetchByKey();
       const item = rows[0] ?? (await upsertOnce()).item;
       const id = Number(item.Id);
 
       const url = buildItemByIdUrl(spec.siteUrl, spec.listTitle, id);
-      await api.merge(url, { [spec.deactivate.field]: spec.deactivate.value }, `${spec.name}:deactivate`);
+      const payload = mapSchemaPayload(
+        { [spec.deactivate.field]: spec.deactivate.value },
+        fields.logicalToPhysical,
+      );
+      await api.merge(url, payload, `${spec.name}:deactivate`);
 
       const after = await fetchByKey();
       expect(after.length).toBeGreaterThan(0);
-      expect(after[0][spec.deactivate.field]).toEqual(spec.deactivate.value);
+      expect(after[0][fields.deactivateField || spec.deactivate.field]).toEqual(spec.deactivate.value);
     },
   };
 }

--- a/tests/integration/usersMaster.sp.integration.spec.ts
+++ b/tests/integration/usersMaster.sp.integration.spec.ts
@@ -1,5 +1,6 @@
 import { runListIntegration } from './_shared/runListIntegration';
 import { resolveSharePointSiteUrl } from './_shared/resolveSiteUrl';
+import { FIELD_ALIASES } from '../../scripts/ci/schemas/users.mjs';
 
 const siteUrl = resolveSharePointSiteUrl();
 
@@ -9,6 +10,7 @@ runListIntegration({
   listTitle: 'Users_Master',
   keyField: 'UserID',
   selectFields: ['Title', 'FullName', 'IsActive', 'Modified'],
+  fieldAliases: FIELD_ALIASES,
   fixedKeyValue: 'E2E_INTEGRATION_USER_0001',
   makeUpsertPayload: (key) => ({
     UserID: key,

--- a/tests/unit/listSpecFactory.spec.ts
+++ b/tests/unit/listSpecFactory.spec.ts
@@ -1,8 +1,8 @@
 // @vitest-environment node
 import { describe, expect, it } from 'vitest';
-import { FIELD_ALIASES } from '../../../scripts/ci/schemas/users.mjs';
-import { mapSchemaPayload } from '../../../scripts/ci/resolve-schema-fields.mjs';
-import { resolveListSpecFields } from './listSpecFactory';
+import { FIELD_ALIASES } from '../../scripts/ci/schemas/users.mjs';
+import { mapSchemaPayload } from '../../scripts/ci/resolve-schema-fields.mjs';
+import { resolveListSpecFields } from '../integration/_shared/listSpecFactory';
 
 const usersSpec = {
   name: 'Users_Master',


### PR DESCRIPTION
## 変更内容

Users_Masterの論理フィールド契約（`UserID` / `FullName`）を維持したまま、SharePointの既知の物理InternalName（`User_x0020_ID` / `Full_x0020_Name`）をCI validatorとusers integrationで解決する共通resolverを追加しました。

- 純粋なCI/integration共通resolverとpayload mappingを追加
- `scripts/ci/schemas/users.mjs`に`FIELD_ALIASES`を追加
- validatorのcanonical名、alias、大小文字差異、欠落、曖昧解決を検証
- users integrationの`$select`、`$filter`、payload、deactivate、schema assertionへ同一mappingを適用
- staff/dailyopsはalias未指定で既存挙動を維持

## 原因と影響

実環境のUsers_Masterは`User_x0020_ID` / `Full_x0020_Name`を持つ一方、CI validatorとintegrationが論理名を直接参照していたためusersレーンだけがschema failureになっていました。SharePoint列やアプリ本体は変更していません。

## 検証結果

- `npm run typecheck:full -- --pretty false` ✅
- `npx vitest run scripts/ci/__tests__ tests/integration/_shared --reporter=dot` ✅ 5 files / 31 tests
- 対象integration TSのESLint ✅
- `git diff --check` ✅
- `tests/.auth/storageState.json`は存在せず、live users integrationは未実行

## スコープと外部操作

- base: `bcb61571202705949b27a68bf12fe5e495a2dea5`
- commit: `3d874a4a0`
- 変更はresolver、users schema/validator、integration共通部、users関連テストの11ファイルのみ
- GitHub Secret、SharePoint列、GitHub Environment、required reviewer、workflow実行、Cloudflare API Token、Cloudflareデプロイは実施していません
- 本PRはDraftのまま保持し、Ready化・マージは別判断です