### PR TITLE
fix(e2e): align daily handoff contracts

### DIFF
--- a/src/pages/daily-record/hooks/__tests__/useDailyRecordUiState.spec.tsx
+++ b/src/pages/daily-record/hooks/__tests__/useDailyRecordUiState.spec.tsx
@@ -1,0 +1,86 @@
+import { act, renderHook } from '@testing-library/react';
+import { useEffect } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { mockRecords } from '../../../dailyRecordMockData';
+import { useDailyRecordUiState } from '../useDailyRecordUiState';
+
+describe('useDailyRecordUiState', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('keeps actions stable across state-driven rerenders', () => {
+    const { result, rerender } = renderHook(() => useDailyRecordUiState(mockRecords));
+    const firstActions = result.current.actions;
+
+    rerender();
+    expect(result.current.actions).toBe(firstActions);
+
+    act(() => result.current.actions.setSearchQuery('田中'));
+    expect(result.current.actions).toBe(firstActions);
+  });
+
+  it('does not recreate an action-dependent timer for the same highlight', () => {
+    const onHighlight = vi.fn();
+    const { rerender } = renderHook(
+      ({ highlight }) => {
+        const { actions } = useDailyRecordUiState(mockRecords);
+        useEffect(() => {
+          const timer = window.setTimeout(() => onHighlight(highlight), 100);
+          return () => window.clearTimeout(timer);
+        }, [actions, highlight]);
+      },
+      { initialProps: { highlight: '001' } },
+    );
+
+    act(() => vi.advanceTimersByTime(50));
+    rerender({ highlight: '001' });
+    act(() => vi.advanceTimersByTime(50));
+
+    expect(onHighlight).toHaveBeenCalledOnce();
+    expect(onHighlight).toHaveBeenCalledWith('001');
+  });
+
+  it('restarts the timer only when the highlight changes', () => {
+    const onHighlight = vi.fn();
+    const { rerender } = renderHook(
+      ({ highlight }) => {
+        const { actions } = useDailyRecordUiState(mockRecords);
+        useEffect(() => {
+          const timer = window.setTimeout(() => onHighlight(highlight), 100);
+          return () => window.clearTimeout(timer);
+        }, [actions, highlight]);
+      },
+      { initialProps: { highlight: '001' } },
+    );
+
+    act(() => vi.advanceTimersByTime(50));
+    rerender({ highlight: '002' });
+    act(() => vi.advanceTimersByTime(99));
+    expect(onHighlight).not.toHaveBeenCalled();
+
+    act(() => vi.advanceTimersByTime(1));
+    expect(onHighlight).toHaveBeenCalledOnce();
+    expect(onHighlight).toHaveBeenCalledWith('002');
+  });
+
+  it('clears the timer on unmount', () => {
+    const onHighlight = vi.fn();
+    const { unmount } = renderHook(() => {
+      const { actions } = useDailyRecordUiState(mockRecords);
+      useEffect(() => {
+        const timer = window.setTimeout(onHighlight, 100);
+        return () => window.clearTimeout(timer);
+      }, [actions]);
+    });
+
+    unmount();
+    act(() => vi.runAllTimers());
+    expect(onHighlight).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/daily-record/hooks/useDailyRecordOrchestrator.ts
+++ b/src/pages/daily-record/hooks/useDailyRecordOrchestrator.ts
@@ -55,20 +55,25 @@ export function useDailyRecordOrchestrator(): {
     highlightDate?: string | null;
   };
   const highlightUserId = navState.highlightUserId ?? searchParams.get('userId');
+  const setActiveHighlightUserId = uiActions.setActiveHighlightUserId;
 
   // ハイライト実行 (副作用)
   useEffect(() => {
     if (!highlightUserId) return;
-    const timer = setTimeout(() => {
-      const element = document.querySelector(`[data-person-id="${highlightUserId}"]`);
-      if (element) {
-        element.scrollIntoView({ behavior: 'smooth', block: 'center' });
-        uiActions.setActiveHighlightUserId(highlightUserId);
-        setTimeout(() => uiActions.setActiveHighlightUserId(null), 1500);
-      }
-    }, 100);
-    return () => clearTimeout(timer);
-  }, [highlightUserId, uiState.records, uiActions]);
+    if (!uiState.records.some((record) => record.userId === highlightUserId)) return;
+
+    setActiveHighlightUserId(highlightUserId);
+    const scrollFrame = requestAnimationFrame(() => {
+      document
+        .querySelector(`[data-person-id="${highlightUserId}"]`)
+        ?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    });
+    const clearHighlightTimer = setTimeout(() => setActiveHighlightUserId(null), 5000);
+    return () => {
+      cancelAnimationFrame(scrollFrame);
+      clearTimeout(clearHighlightTimer);
+    };
+  }, [highlightUserId, setActiveHighlightUserId, uiState.records]);
 
   // 2. 外部データ統合
   const { total: handoffTotal, criticalCount: handoffCritical } = useHandoffSummary({ dayScope: 'today' });

--- a/src/pages/daily-record/hooks/useDailyRecordUiState.ts
+++ b/src/pages/daily-record/hooks/useDailyRecordUiState.ts
@@ -73,7 +73,7 @@ export function useDailyRecordUiState(initialRecords: PersonDaily[]) {
     searchQuery, statusFilter, dateFilter, activeHighlightUserId
   ]);
 
-  const actions: DailyRecordUiActions = {
+  const actions: DailyRecordUiActions = useMemo(() => ({
     setRecords,
     updateRecord,
     removeRecord,
@@ -84,7 +84,7 @@ export function useDailyRecordUiState(initialRecords: PersonDaily[]) {
     setStatusFilter,
     setDateFilter,
     setActiveHighlightUserId,
-  };
+  }), [removeRecord, updateRecord]);
 
   return { state, actions };
 }

--- a/tests/e2e/daily.records-flow.spec.ts
+++ b/tests/e2e/daily.records-flow.spec.ts
@@ -7,25 +7,23 @@ test.describe('Daily – Records flow', () => {
 
     await page.goto('/daily/activity', { waitUntil: 'domcontentloaded' });
     await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => undefined);
-    await expect(page.getByRole('heading', { name: /支援記録（ケース記録）/, level: 1 })).toBeVisible({ timeout: 15_000 });
-
     const root = page.getByTestId('records-daily-root');
-    await expect(root).toBeVisible();
+    await expect(root).toBeVisible({ timeout: 15_000 });
 
-    await expect(page.getByRole('heading', { name: '支援記録（ケース記録）', level: 1 })).toBeVisible();
-    await expect(page.getByRole('button', { name: '本日分全員作成（32名）' })).toBeVisible();
+    await expect(root.getByRole('heading', { name: '日々の記録', level: 1 })).toBeVisible();
+    await expect(page.getByTestId('bulk-generate-today-records-button')).toBeVisible();
 
     // Wait for record cards to be visible
-    await expect(page.getByText('田中太郎', { exact: false })).toBeVisible();
-    await expect(page.getByText('佐藤花子', { exact: false })).toBeVisible();
-    await expect(page.getByText('鈴木次郎', { exact: false })).toBeVisible();
+    await expect(root.getByTestId('person-name-1')).toHaveText('田中太郎');
+    await expect(root.getByTestId('person-name-2')).toHaveText('佐藤花子');
+    await expect(root.getByTestId('person-name-3')).toHaveText('鈴木次郎');
 
     // Verify FAB button exists (don't click it if it's not working reliably)
     const fabButton = page.getByTestId('add-record-fab');
     await expect(fabButton).toBeVisible();
 
     // Test the bulk create button instead which should be more reliable
-    await page.getByRole('button', { name: '本日分全員作成（32名）' }).click();
+    await page.getByTestId('bulk-generate-today-records-button').click();
 
     // Check if more record cards appear
     await page.waitForTimeout(1000); // Give time for any UI updates

--- a/tests/e2e/handoff-daily.phase2-1.spec.ts
+++ b/tests/e2e/handoff-daily.phase2-1.spec.ts
@@ -70,9 +70,10 @@ test.describe('Phase 2-1: handoff → daily highlight navigation', () => {
     // 最初のレコード（userCode 001）の id は 1
     const targetCard = page.getByTestId('daily-record-card-1');
     await expect(targetCard).toBeVisible({ timeout: 10_000 });
+    await expect(targetCard).toHaveAttribute('data-person-id', '001');
 
     // ✅ ハイライトバナーが一時表示される
-    const banner = page.getByTestId('daily-highlight-banner');
+    const banner = targetCard.getByTestId('daily-highlight-banner');
     await expect(banner).toBeVisible({ timeout: 5_000 });
     await expect(banner).toHaveText(/申し送りから移動しました/);
   });

--- a/tests/e2e/handoff.timeline.spec.ts
+++ b/tests/e2e/handoff.timeline.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from '@playwright/test';
 /**
  * Validates that the handoff quick-note Dialog is accessible from both:
  * 1. The page-level "今すぐ申し送り" button on /handoff-timeline
- * 2. The global footer "申し送り" button
+ * 2. The retired global footer action is not exposed in the standard app shell
  */
 test.describe('Handoff Timeline quick note Dialog', () => {
   test.beforeEach(async ({ page }) => {
@@ -28,13 +28,8 @@ test.describe('Handoff Timeline quick note Dialog', () => {
     await expect(pageDialog).toBeHidden();
   });
 
-  test('footer button opens same dialog on /handoff-timeline', async ({ page }) => {
-    // Click the footer quick action
-    await page.getByTestId('handoff-footer-quicknote').click();
-
-    // Same dialog should appear
-    const dialog = page.getByTestId('handoff-quicknote-dialog');
-    await expect(dialog).toBeVisible();
-    await expect(dialog.getByTestId('handoff-quicknote-card')).toBeVisible();
+  test('standard app shell exposes only the page quick-note entry', async ({ page }) => {
+    await expect(page.getByTestId('handoff-page-quicknote-open')).toBeVisible();
+    await expect(page.getByTestId('handoff-footer-quicknote')).toHaveCount(0);
   });
 });

--- a/tests/e2e/procedure-17row-bridge.spec.ts
+++ b/tests/e2e/procedure-17row-bridge.spec.ts
@@ -1,13 +1,128 @@
-import { expect, test } from '@playwright/test';
-import { primeOpsEnv } from './helpers/ops';
+import { expect, test, type Page } from '@playwright/test';
+import { setupSharePointStubs } from './_helpers/setupSharePointStubs';
+
+const jsonHeaders = {
+  'content-type': 'application/json; charset=utf-8',
+  'cache-control': 'no-store',
+};
+
+type SharePointStubEvidence = {
+  apiRequests: string[];
+  authRequests: string[];
+  failures: string[];
+};
+
+async function primeProcedureEnv(page: Page): Promise<SharePointStubEvidence> {
+  const evidence: SharePointStubEvidence = { apiRequests: [], authRequests: [], failures: [] };
+  page.on('request', (request) => {
+    const url = request.url();
+    if (url.includes('/_api/')) evidence.apiRequests.push(url);
+    if (url.includes('login.microsoftonline.com')) evidence.authRequests.push(url);
+  });
+  page.on('requestfailed', (request) => {
+    const url = request.url();
+    if (url.includes('/_api/') || url.includes('sharepoint.com')) evidence.failures.push(url);
+  });
+  page.on('response', (response) => {
+    const url = response.url();
+    if (url.includes('/_api/') && response.status() >= 400) {
+      evidence.failures.push(`${response.status()} ${url}`);
+    }
+  });
+
+  await page.addInitScript(() => {
+    const win = window as typeof window & { __ENV__?: Record<string, string> };
+    win.__ENV__ = {
+      ...(win.__ENV__ ?? {}),
+      VITE_E2E: '1',
+      VITE_E2E_MSAL_MOCK: '1',
+      VITE_SKIP_LOGIN: '0',
+      VITE_SKIP_SHAREPOINT: '0',
+      VITE_FORCE_SHAREPOINT: '1',
+      VITE_DEMO_MODE: '0',
+      VITE_USE_DEMO: '0',
+      VITE_WRITE_ENABLED: '1',
+      VITE_SP_RESOURCE: 'https://contoso.sharepoint.com',
+      VITE_SP_SITE_RELATIVE: '/sites/Audit',
+      VITE_SP_SCOPE_DEFAULT: 'https://contoso.sharepoint.com/AllSites.Read',
+    };
+    window.localStorage.removeItem('skipLogin');
+    window.localStorage.setItem('demo', '0');
+    window.localStorage.setItem('writeEnabled', '1');
+    window.localStorage.removeItem('dataProvider');
+    window.localStorage.removeItem('VITE_DATA_PROVIDER');
+  });
+
+  await page.route('**/login.microsoftonline.com/**', (route) => route.fulfill({ status: 204, body: '' }));
+  await page.route('https://graph.microsoft.com/**', (route) =>
+    route.fulfill({ status: 200, headers: jsonHeaders, body: JSON.stringify({ value: [] }) }),
+  );
+
+  await setupSharePointStubs(page, {
+    currentUser: { status: 200, body: { Id: 12345, Title: 'Mock User' } },
+    fallback: { status: 200, body: { value: [] } },
+    lists: [
+      {
+        name: 'Users_Master',
+        items: [
+          {
+            Id: 7,
+            UserID: 'U-007',
+            FullName: '伊藤 雄介',
+            IsHighIntensitySupportTarget: true,
+            IsSupportProcedureTarget: true,
+            IsActive: true,
+            UsageStatus: 'active',
+          },
+        ],
+      },
+      {
+        name: 'SupportPlanningSheet_Master',
+        items: [
+          {
+            Id: 1007,
+            Title: '支援計画 U-007',
+            UserCode: 'U-007',
+            ISPId: '7',
+            Status: 'active',
+            VersionNo: 1,
+            IsCurrent: true,
+            SupportPolicy: '伊藤さんの対応方針',
+            ConcreteApproaches: '伊藤さんの具体策',
+            EnvironmentalAdjustments: '伊藤さんの環境調整',
+            FormDataJson: JSON.stringify({
+              title: '支援計画 U-007',
+              observationFacts: '伊藤さんの行動観察',
+              interpretationHypothesis: '伊藤さんの分析',
+              supportIssues: '伊藤さんの課題',
+            }),
+            PlanningJson: JSON.stringify({ procedureSteps: [] }),
+          },
+        ],
+      },
+      {
+        name: 'SupportProcedureRecord_Daily',
+        items: [],
+      },
+    ],
+  });
+
+  return evidence;
+}
+
+function expectSharePointStubEvidence(evidence: SharePointStubEvidence): void {
+  expect(evidence.apiRequests.length).toBeGreaterThan(0);
+  expect(evidence.authRequests).toEqual([]);
+  expect(evidence.failures).toEqual([]);
+}
 
 test.describe('Procedure 17-row Bridge Verification', () => {
   test.describe.configure({ mode: 'serial' });
 
   const TEST_PLAN_ID = '1007';
 
-  const openPlanningSheetEditor = async (page: Parameters<typeof primeOpsEnv>[0]) => {
-    await page.goto(`/support-planning-sheet/${TEST_PLAN_ID}`, { waitUntil: 'domcontentloaded' });
+  const openPlanningSheetEditor = async (page: Page) => {
+    await page.goto(`/support-planning-sheet/${TEST_PLAN_ID}?provider=sharepoint`, { waitUntil: 'domcontentloaded' });
     await expect(page).toHaveURL(new RegExp(`/support-planning-sheet/${TEST_PLAN_ID}`));
 
     const editButton = page.getByTestId('planning-sheet-btn-edit');
@@ -15,21 +130,29 @@ test.describe('Procedure 17-row Bridge Verification', () => {
     await editButton.click();
   };
 
-  const startDailyWizard = async (page: Parameters<typeof primeOpsEnv>[0]) => {
+  const startDailyWizard = async (page: Page) => {
     const params = new URLSearchParams({
       planningSheetId: TEST_PLAN_ID,
+      provider: 'sharepoint',
     });
     await page.goto(`/daily/support?${params.toString()}`, { waitUntil: 'domcontentloaded' });
     await expect(page).toHaveURL(/\/daily\/support/);
 
-    const availableHighIntensityUser = page.getByRole('button', { name: /石渡|桂川|田中|塩田/ }).first();
+    // This bridge test verifies the planning-sheet data path, not the default
+    // user-filter contract. Make the stubbed user selectable regardless of
+    // tenant-specific lifecycle/high-intensity field mappings.
+    await page.getByRole('button', { name: '強度行動障害支援対象者のみ表示' }).click();
+    await page.getByRole('combobox', { name: 'ステータス' }).click();
+    await page.getByRole('option', { name: '（全て）' }).click();
+
+    const availableHighIntensityUser = page.getByRole('button', { name: /伊藤 雄介/ }).first();
     await expect(availableHighIntensityUser).toBeVisible({ timeout: 30000 });
     await availableHighIntensityUser.click();
 
     await expect(page.getByText('時間帯を選択してください')).toBeVisible({ timeout: 30000 });
   };
   test('reflects structured planning steps to 17-row daily record', async ({ page }) => {
-    await primeOpsEnv(page);
+    const stubEvidence = await primeProcedureEnv(page);
 
     // 1. 支援計画シートエディタで手順を設定
     await openPlanningSheetEditor(page);
@@ -97,10 +220,11 @@ test.describe('Procedure 17-row Bridge Verification', () => {
     await expect(step2.getByText('本人AMテスト')).toBeVisible();
     await expect(step2.getByText('支援', { exact: true })).toBeVisible();
     await expect(step2.getByText('支援者AMテスト')).toBeVisible();
+    expectSharePointStubEvidence(stubEvidence);
   });
 
   test('backward compatibility: legacy text aggregation', async ({ page }) => {
-    await primeOpsEnv(page);
+    const stubEvidence = await primeProcedureEnv(page);
 
     // 1. 支援計画シートエディタで構造化手順を削除し、古いテキストフィールドのみ埋める
     await openPlanningSheetEditor(page);
@@ -134,5 +258,6 @@ test.describe('Procedure 17-row Bridge Verification', () => {
     await expect(step5.getByText(/テストの具体策/)).toBeVisible();
     await expect(step5.getByText('本人', { exact: true })).toBeVisible();
     await expect(step5.getByText(/テストの支援方針/)).toBeVisible();
+    expectSharePointStubEvidence(stubEvidence);
   });
 });

--- a/tests/e2e/procedure-17row-bridge.spec.ts
+++ b/tests/e2e/procedure-17row-bridge.spec.ts
@@ -36,6 +36,8 @@ async function primeProcedureEnv(page: Page): Promise<SharePointStubEvidence> {
       ...(win.__ENV__ ?? {}),
       VITE_E2E: '1',
       VITE_E2E_MSAL_MOCK: '1',
+      MODE: 'production',
+      NODE_ENV: 'production',
       VITE_SKIP_LOGIN: '0',
       VITE_SKIP_SHAREPOINT: '0',
       VITE_FORCE_SHAREPOINT: '1',
@@ -46,6 +48,7 @@ async function primeProcedureEnv(page: Page): Promise<SharePointStubEvidence> {
       VITE_SP_SITE_RELATIVE: '/sites/Audit',
       VITE_SP_SCOPE_DEFAULT: 'https://contoso.sharepoint.com/AllSites.Read',
     };
+    delete win.__ENV__.VITE_DATA_PROVIDER;
     window.localStorage.removeItem('skipLogin');
     window.localStorage.setItem('demo', '0');
     window.localStorage.setItem('writeEnabled', '1');
@@ -66,9 +69,9 @@ async function primeProcedureEnv(page: Page): Promise<SharePointStubEvidence> {
         name: 'Users_Master',
         items: [
           {
-            Id: 7,
-            UserID: 'U-007',
-            FullName: '伊藤 雄介',
+            Id: 1,
+            UserID: 'U-001',
+            FullName: '田中 太郎',
             IsHighIntensitySupportTarget: true,
             IsSupportProcedureTarget: true,
             IsActive: true,
@@ -80,21 +83,21 @@ async function primeProcedureEnv(page: Page): Promise<SharePointStubEvidence> {
         name: 'SupportPlanningSheet_Master',
         items: [
           {
-            Id: 1007,
-            Title: '支援計画 U-007',
-            UserCode: 'U-007',
-            ISPId: '7',
+            Id: 1001,
+            Title: '支援計画 U-001',
+            UserCode: 'U-001',
+            ISPId: '1',
             Status: 'active',
             VersionNo: 1,
             IsCurrent: true,
-            SupportPolicy: '伊藤さんの対応方針',
-            ConcreteApproaches: '伊藤さんの具体策',
-            EnvironmentalAdjustments: '伊藤さんの環境調整',
+            SupportPolicy: '田中さんの対応方針',
+            ConcreteApproaches: '田中さんの具体策',
+            EnvironmentalAdjustments: '田中さんの環境調整',
             FormDataJson: JSON.stringify({
-              title: '支援計画 U-007',
-              observationFacts: '伊藤さんの行動観察',
-              interpretationHypothesis: '伊藤さんの分析',
-              supportIssues: '伊藤さんの課題',
+              title: '支援計画 U-001',
+              observationFacts: '田中さんの行動観察',
+              interpretationHypothesis: '田中さんの分析',
+              supportIssues: '田中さんの課題',
             }),
             PlanningJson: JSON.stringify({ procedureSteps: [] }),
           },
@@ -111,7 +114,12 @@ async function primeProcedureEnv(page: Page): Promise<SharePointStubEvidence> {
 }
 
 function expectSharePointStubEvidence(evidence: SharePointStubEvidence): void {
-  expect(evidence.apiRequests.length).toBeGreaterThan(0);
+  expect(
+    evidence.apiRequests.some((url) => url.includes("getbytitle('SupportPlanningSheet_Master')")),
+  ).toBe(true);
+  expect(
+    evidence.apiRequests.some((url) => url.includes("getbytitle('SupportProcedureRecord_Daily')")),
+  ).toBe(true);
   expect(evidence.authRequests).toEqual([]);
   expect(evidence.failures).toEqual([]);
 }
@@ -119,7 +127,7 @@ function expectSharePointStubEvidence(evidence: SharePointStubEvidence): void {
 test.describe('Procedure 17-row Bridge Verification', () => {
   test.describe.configure({ mode: 'serial' });
 
-  const TEST_PLAN_ID = '1007';
+  const TEST_PLAN_ID = '1001';
 
   const openPlanningSheetEditor = async (page: Page) => {
     await page.goto(`/support-planning-sheet/${TEST_PLAN_ID}?provider=sharepoint`, { waitUntil: 'domcontentloaded' });
@@ -145,7 +153,7 @@ test.describe('Procedure 17-row Bridge Verification', () => {
     await page.getByRole('combobox', { name: 'ステータス' }).click();
     await page.getByRole('option', { name: '（全て）' }).click();
 
-    const availableHighIntensityUser = page.getByRole('button', { name: /伊藤 雄介/ }).first();
+    const availableHighIntensityUser = page.getByRole('button', { name: /田中 太郎/ }).first();
     await expect(availableHighIntensityUser).toBeVisible({ timeout: 30000 });
     await availableHighIntensityUser.click();
 

--- a/tests/e2e/records-daily.spec.ts
+++ b/tests/e2e/records-daily.spec.ts
@@ -168,9 +168,6 @@ test.describe('Daily records end-to-end', () => {
     await expect(reloadedRow.locator('td').nth(1)).toHaveText('2025-10-01');
     await expect(reloadedRow.locator('td').nth(2)).toHaveText('午後に通院予定');
     expect(
-      sharePointApiRequests.some((url) => url.includes("getbytitle('Users_Master')")),
-    ).toBe(true);
-    expect(
       sharePointApiRequests.some((url) => url.includes("getbytitle('SupportRecord_Daily')")),
     ).toBe(true);
     expect(authRequests).toEqual([]);

--- a/tests/e2e/records-daily.spec.ts
+++ b/tests/e2e/records-daily.spec.ts
@@ -23,6 +23,25 @@ const sortById = <T extends { Id: number }>(items: T[]) => [...items].sort((a, b
 
 test.describe('Daily records end-to-end', () => {
   test('creates a record and persists extended activity fields', async ({ page }) => {
+    const sharePointApiRequests: string[] = [];
+    const authRequests: string[] = [];
+    const sharePointFailures: string[] = [];
+    page.on('request', (request) => {
+      const url = request.url();
+      if (url.includes('/_api/')) sharePointApiRequests.push(url);
+      if (url.includes('login.microsoftonline.com')) authRequests.push(url);
+    });
+    page.on('requestfailed', (request) => {
+      const url = request.url();
+      if (url.includes('/_api/') || url.includes('sharepoint.com')) sharePointFailures.push(url);
+    });
+    page.on('response', (response) => {
+      const url = response.url();
+      if (url.includes('/_api/') && response.status() >= 400) {
+        sharePointFailures.push(`${response.status()} ${url}`);
+      }
+    });
+
     const users = [
       { Id: 1, UserID: 'U-001', FullName: '山田 太郎' },
       { Id: 2, UserID: 'U-002', FullName: '鈴木 花子' },
@@ -37,7 +56,10 @@ test.describe('Daily records end-to-end', () => {
         VITE_E2E: '1',
         VITE_E2E_MSAL_MOCK: '1',
         VITE_SKIP_LOGIN: '1',
+        VITE_SKIP_SHAREPOINT: '0',
         VITE_FORCE_SHAREPOINT: '1',
+        VITE_DEMO_MODE: '0',
+        VITE_USE_DEMO: '0',
         VITE_E2E_ENFORCE_AUDIENCE: '1',
         VITE_TEST_ROLE: 'viewer',
         VITE_AAD_ADMIN_GROUP_ID: 'e2e-admin-group-id',
@@ -50,11 +72,14 @@ test.describe('Daily records end-to-end', () => {
         VITE_SP_SITE_RELATIVE: '/sites/Audit',
         VITE_SP_SCOPE_DEFAULT: 'https://contoso.sharepoint.com/AllSites.Read',
       };
+      delete globalWithEnv.__ENV__.VITE_DATA_PROVIDER;
 
       try {
         window.localStorage.setItem('skipLogin', '1');
         window.localStorage.setItem('demo', '0');
         window.localStorage.setItem('writeEnabled', '1');
+        window.localStorage.removeItem('dataProvider');
+        window.localStorage.removeItem('VITE_DATA_PROVIDER');
       } catch {
         // ignore storage failures (e.g. safari private mode)
       }
@@ -111,7 +136,7 @@ test.describe('Daily records end-to-end', () => {
     });
 
     await page.goto('/records', { waitUntil: 'load' });
-    await expect(page.getByRole('heading', { name: '日次記録' })).toBeVisible({ timeout: 15000 });
+    await expect(page.getByRole('heading', { name: '日々の記録', level: 2 })).toBeVisible({ timeout: 15000 });
 
     const titleInput = page.getByPlaceholder('タイトル');
     await titleInput.fill('山田 太郎');
@@ -138,5 +163,8 @@ test.describe('Daily records end-to-end', () => {
     await expect(reloadedRow.locator('td').nth(0)).toHaveText('山田 太郎');
     await expect(reloadedRow.locator('td').nth(1)).toHaveText('2025-10-01');
     await expect(reloadedRow.locator('td').nth(2)).toHaveText('午後に通院予定');
+    expect(sharePointApiRequests.length).toBeGreaterThan(0);
+    expect(authRequests).toEqual([]);
+    expect(sharePointFailures).toEqual([]);
   });
 });

--- a/tests/e2e/records-daily.spec.ts
+++ b/tests/e2e/records-daily.spec.ts
@@ -26,6 +26,10 @@ test.describe('Daily records end-to-end', () => {
     const sharePointApiRequests: string[] = [];
     const authRequests: string[] = [];
     const sharePointFailures: string[] = [];
+    const isDailyRecordContractRequest = (url: string) =>
+      url.includes("getbytitle('Users_Master')") || url.includes("getbytitle('SupportRecord_Daily')");
+    const isDailyRecordDataRequest = (url: string) =>
+      isDailyRecordContractRequest(url) && url.includes('/items');
     page.on('request', (request) => {
       const url = request.url();
       if (url.includes('/_api/')) sharePointApiRequests.push(url);
@@ -33,11 +37,11 @@ test.describe('Daily records end-to-end', () => {
     });
     page.on('requestfailed', (request) => {
       const url = request.url();
-      if (url.includes('/_api/') || url.includes('sharepoint.com')) sharePointFailures.push(url);
+      if (isDailyRecordDataRequest(url)) sharePointFailures.push(url);
     });
     page.on('response', (response) => {
       const url = response.url();
-      if (url.includes('/_api/') && response.status() >= 400) {
+      if (isDailyRecordDataRequest(url) && response.status() >= 400) {
         sharePointFailures.push(`${response.status()} ${url}`);
       }
     });
@@ -163,7 +167,12 @@ test.describe('Daily records end-to-end', () => {
     await expect(reloadedRow.locator('td').nth(0)).toHaveText('山田 太郎');
     await expect(reloadedRow.locator('td').nth(1)).toHaveText('2025-10-01');
     await expect(reloadedRow.locator('td').nth(2)).toHaveText('午後に通院予定');
-    expect(sharePointApiRequests.length).toBeGreaterThan(0);
+    expect(
+      sharePointApiRequests.some((url) => url.includes("getbytitle('Users_Master')")),
+    ).toBe(true);
+    expect(
+      sharePointApiRequests.some((url) => url.includes("getbytitle('SupportRecord_Daily')")),
+    ).toBe(true);
     expect(authRequests).toEqual([]);
     expect(sharePointFailures).toEqual([]);
   });


### PR DESCRIPTION
## 原因

Daily / Handoff のE2E期待値が現在の画面契約とずれていました。また、daily highlight effectが不安定なactions参照と遅延DOM照合に依存し、Procedure 17-row specがmemory laneと実SharePoint前提を混在させていました。

## 変更範囲

- Daily Record UI actionsをmemo化
- 申し送り遷移時のhighlightを即時反映し、timerを確実にcleanup
- Daily / Handoffのheading、testid、標準shell契約を現行UIへ同期
- Procedure / Recordsを認証不要のSharePoint stubレーンへ固定
- 対象SharePoint APIのstub捕捉、認証要求0、対象data request failure 0をspec内で検証
- actions参照とtimer lifecycleのunit testを追加

変更は8ファイルのみです。

## 対象failure keys

- daily.records-flow.spec.ts::ad8375492823f9a8595f-89784dbbb614e98c32bd::chromium
- handoff-daily.phase2-1.spec.ts::63d6fdf3641a6837e36a-76876880404504ed17d1::chromium
- handoff.timeline.spec.ts::8177d855e04005a674b8-b1ae4e89d9d459259690::chromium
- procedure-17row-bridge.spec.ts::d28b08341ae149862425-c1f8ff70f60e0e6df42b::chromium
- records-daily.spec.ts::8fd73362668228649568-453eb61949636a126b0e::chromium

## 対象外

- Exception Center fixture不足
- 実SharePoint認証とPW_STORAGE_STATE_B64
- Canary分類器
- 他機能のfailure key
- 単発flaky / Iceberg-PDCA遷移契約

## ローカル検証

- 対象5 spec: 9 passed
- actions/timer unit: 4 passed
- typecheck:full: success
- targeted ESLint: success
- git diff --check: success
- SharePoint planning/record API stub捕捉: success
- Microsoft認証request: 0
- 対象SharePoint data request failure: 0

E2Eのglobal build contractでは利用者fixtureはdeterministic memory/demoですが、Procedureの計画・日次記録APIとRecordsの日次記録APIは明示的なSharePoint stubで捕捉しています。

開始時の最新main `8ae11865d07b4c9f9a26e6b7dad35053eb65b66d` を一度だけmergeし、以後の検証基準を固定しました。

## GitHub検証

固定head: `3dad489e3435ca16ba6d29c34d28a68924b547de`

- PR checks: all completed / success、failure / cancelled / timed_out 0
- PR限定Deep: success (run 29393949146)
- Quality Gates / quality_extended / Canary: success (run 29393949137)
- 全Deep: 217 passed / 54 failed / 62 skipped (run 29395071982)
- Integration Scenarios: success
- 対象5 failure key: 0
- exact-base 60件との比較: common 54 / resolved 6 / new 0 / Jaccard 0.9
- resolved: 対象5キー + iceberg-flow
- taxonomy: status available、failed 54 = featureClassifications 54 = causeClassifications 54、didNotRun 0
- bootstrap: root 1,590,054 chars、env.runtime.json HTTP 200、console error 0、page error 0、request failure 0
- runtime lane: production build / memory provider / skip-login=1 / MSAL mock=1 / skip-SharePoint=1

全Deep全体には既存54件が残るため、本PRの修正成功と本番デプロイ可否は分けて扱います。

## デプロイ判定

NO-GO / HOLD。全Deep、Quality Gates、Canary、Nightly Healthなどの前段ゲートが同一main SHAで成功するまでデプロイしません。
