### PR TITLE
fix(ci): UserBenefit_Profile_Extの物理InternalName alias解決

### DIFF
--- a/scripts/ci/__tests__/validate-user-benefit-ext-schema.spec.mjs
+++ b/scripts/ci/__tests__/validate-user-benefit-ext-schema.spec.mjs
@@ -1,0 +1,83 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { validateSchema } from '../validate-schema.logic.mjs';
+import {
+  ESSENTIAL_FIELDS,
+  FIELD_ALIASES,
+} from '../schemas/user-benefit-ext.mjs';
+
+describe('UserBenefit_Profile_Ext schema validation', () => {
+  it('accepts the canonical logical InternalName', () => {
+    const result = validateSchema(
+      ['UserID'],
+      ESSENTIAL_FIELDS,
+      [],
+      { aliases: FIELD_ALIASES },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.missing).toEqual([]);
+    expect(result.caseMismatch).toEqual([]);
+    expect(result.resolved.UserID).toBe('UserID');
+  });
+
+  it('resolves the encoded-space physical InternalName alias', () => {
+    const result = validateSchema(
+      ['User_x0020_ID'],
+      ESSENTIAL_FIELDS,
+      [],
+      { aliases: FIELD_ALIASES },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.missing).toEqual([]);
+    expect(result.resolved.UserID).toBe('User_x0020_ID');
+    expect(result.aliasResolutions).toEqual([
+      expect.objectContaining({
+        logical: 'UserID',
+        actual: 'User_x0020_ID',
+        method: 'alias',
+      }),
+    ]);
+  });
+
+  it('keeps canonical resolution when both names are present', () => {
+    const result = validateSchema(
+      ['UserID', 'User_x0020_ID'],
+      ESSENTIAL_FIELDS,
+      [],
+      { aliases: FIELD_ALIASES },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.resolved.UserID).toBe('UserID');
+    expect(result.ambiguousEssential).toEqual([]);
+  });
+
+  it('retains the case-mismatch warning contract', () => {
+    const result = validateSchema(
+      ['userid'],
+      ESSENTIAL_FIELDS,
+      [],
+      { aliases: FIELD_ALIASES },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.resolved.UserID).toBe('userid');
+    expect(result.caseMismatch).toEqual([
+      { expected: 'UserID', actual: 'userid' },
+    ]);
+  });
+
+  it('fails when neither the canonical field nor its alias exists', () => {
+    const result = validateSchema(
+      ['Title'],
+      ESSENTIAL_FIELDS,
+      [],
+      { aliases: FIELD_ALIASES },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.missing).toEqual(['UserID']);
+  });
+});

--- a/scripts/ci/schemas/user-benefit-ext.mjs
+++ b/scripts/ci/schemas/user-benefit-ext.mjs
@@ -9,6 +9,13 @@ export const ESSENTIAL_FIELDS = [
   'UserID',
 ];
 
+// Logical contract -> known SharePoint physical InternalName aliases.
+// Keep the canonical name above unchanged; the CI resolver selects the
+// physical name only when the canonical InternalName is not present.
+export const FIELD_ALIASES = {
+  UserID: ['User_x0020_ID'],
+};
+
 export const OPTIONAL_FIELDS = [
   'RecipientCertNumber',
   'RecipientCertExpiry',


### PR DESCRIPTION
## 概要
UserBenefit_Profile_Extの論理フィールド契約UserIDを維持したまま、実環境のSharePoint InternalName User_x0020_IDを既存の共通resolverで解決できるようにしました。

## 変更内容
- schema定義にUserID -> User_x0020_IDのFIELD_ALIASESを追加
- canonical名、空白エンコード名、大文字・小文字差異、必須列欠落のvalidatorテストを追加
- UserBenefit専用の外部書き込みintegrationは新設せず、既存users workflowのschema検証経路を利用
- SharePoint列、ドメイン契約、Secret、Environment、Cloudflareは変更なし

## 検証
- npm run typecheck:full -- --pretty false ✅
- npx vitest run scripts/ci/__tests__ tests/unit/listSpecFactory.spec.ts --reporter=dot ✅（7 files / 40 tests）
- git diff --check ✅
- commit hooks（lint / typecheck）✅
- eslint対象ファイルはリポジトリignore対象のため警告のみ、エラーなし

## 完了条件
このPRのマージ後、最新mainの同一SHAでusers/staff/dailyopsを再実行し、3レーンすべてがsuccessかつheadSha完全一致になるまで本番Environment、reviewer、Secret、Cloudflare操作は保留します。