### PR TITLE
test(e2e): stabilize Iceberg navigation contract

### DIFF
--- a/tests/e2e/iceberg-flow.spec.ts
+++ b/tests/e2e/iceberg-flow.spec.ts
@@ -7,6 +7,14 @@ const ICEBERG_PATH = '/daily/support?planningSheetId=1001';
 test.describe('Iceberg-PDCA Split Stream Flow', () => {
   test.beforeEach(async ({ page }) => {
     await primeOpsEnv(page);
+    await page.addInitScript(() => {
+      const win = window as typeof window & { __ENV__?: Record<string, string> };
+      win.__ENV__ = {
+        ...(win.__ENV__ ?? {}),
+        VITE_FEATURE_ICEBERG_PDCA: '1',
+      };
+      window.localStorage.setItem('feature:icebergPdca', '1');
+    });
 
     await page.goto(ICEBERG_PATH);
     await expect(page).toHaveURL(/\/daily\/support/);


### PR DESCRIPTION
## 原因

`iceberg-flow.spec.ts` は保存後に `/analysis/iceberg-pdca` へ遷移する契約を検証しますが、Iceberg PDCA feature flagを初期化していませんでした。保存処理は目的URLへ遷移した後、`IcebergPdcaGate` により `/analysis/dashboard` へredirectされ、run間の状態によりpass/failが変動していました。

## 変更範囲

- `tests/e2e/iceberg-flow.spec.ts` のみ
- spec起動前に `VITE_FEATURE_ICEBERG_PDCA=1` と `feature:icebergPdca=1` を明示

## 対象failure key

- `iceberg-flow.spec.ts::c3491c09ddb9271cf351-0e1f8b62dc1248e50684::chromium`

## 対象外

- Daily-Handoff / Exception Center
- Auth / SharePoint実接続 / Canary
- 他のDeep E2E既存失敗

## ローカル検証

- Iceberg target: 1 passed
- targeted ESLint: success
- `typecheck:full`: success
- `git diff --check`: success
- changed files: 1

## GitHub検証

- PR CI: pending
- 全Deep E2E比較: pending

## デプロイ判定

Deep E2E全体、Nightly Health、SharePoint認証、本番Environmentが未収束のため `NO-GO / HOLD`。