### PR TITLE
fix(users): improve dark status chip contrast

### DIFF
--- a/src/features/users/UsersPanel/UsersList.tsx
+++ b/src/features/users/UsersPanel/UsersList.tsx
@@ -181,7 +181,16 @@ const UsersList: FC<UsersListProps> = ({
         color={chip.color}
         variant={chip.variant ?? 'filled'}
         size="small"
-        sx={{ height: 22, fontSize: '0.75rem' }}
+        sx={(theme) => ({
+          height: 22,
+          fontSize: '0.75rem',
+          ...(chip.color === 'error' && theme.palette.mode === 'dark'
+            ? {
+                backgroundColor: theme.palette.error.dark,
+                color: theme.palette.error.contrastText,
+              }
+            : {}),
+        })}
       />
     );
     return chip.tooltip ? (


### PR DESCRIPTION
## Summary

- dark modeのUsers状態チップで、`error.main`背景とラベル色の組み合わせがWCAG color-contrastを満たさない問題を修正
- dark modeのerror chipだけを`error.dark`へ寄せ、light modeと他の状態チップは変更しない

## Fixed batch evidence

- 基準base SHA: `c4d4a447f59bcff0421da7d490db8b621abc8773`
- 固定head SHA: `64dd7611e927df91ce3e987e05b7e84f676de479`
- baseline Deep run: `29398249588` (`334 total / 55 failed / 62 skipped`)
- 対象failure key:
  - `users.color-contrast.spec.ts::f4100e9153c184944f25-fac615b37a1162d92887::chromium`
  - `users.color-contrast.spec.ts::f4100e9153c184944f25-52feab1846508bb0f13a::chromium`
- taxonomy上の分類: `Users / selector_contract`
- 実原因: dark modeのerror status chipのcolor contrast不足

## Changed files

- `src/features/users/UsersPanel/UsersList.tsx`

## Out of scope

- Usersのfixture、CRUD、検索、ふりがな、skip-link failure
- Transport全failure
- Daily / Handoff、Exception Center、Dashboard、Iceberg、ISP
- 認証、実SharePoint、workflow、taxonomy診断
- Nightly Health、本番deploy

## Local verification

- `npm run typecheck:full -- --pretty false`: pass
- `npm run lint -- --max-warnings 0`: pass
- Users直属unit: 2 files / 3 tests pass
- `users.color-contrast.spec.ts`: Chromium / workers=1 / retries=0, 4 passed
- `git diff --check origin/main...HEAD`: pass
- bootstrap: root non-empty (1,575,321 chars), runtime env HTTP 200, console/page/request errors 0
- runtime: memory provider, skip-login on, MSAL mock on, skip-SharePoint on, force-SharePoint off

## GitHub verification

- PR CI: 42 pass / 2 skip / failure・cancelled・timed_out 0（同一head）
- 全Deep E2E（空 `test_pattern`、同一head）: run `29402507441`
  - Integration Scenarios: pass
  - Chromium: workflow failure（固定baseから残る既存failureのため）
  - `334 total / 219 expected / 52 unexpected / 1 flaky / 62 skipped`
- baseline比較: `55 unexpected` → `52 unexpected`、対象2 keyは0
- new failure key: 0
- baselineの `iceberg-flow.spec.ts::c3491c09ddb9271cf351-0e1f8b62dc1248e50684` はunexpectedからflakyへ変動（新規keyではない）
- taxonomy: 固定baseおよび修正headのworkflowにtaxonomy artifact生成がなく、Playwright reportのtestIdで手動比較。公式taxonomy整合は未確認
- bootstrap: GitHubのcapture stepはpass。artifactにはpreview logのみで診断JSONがなく、GitHub artifactだけではconsole/page/request error 0等を再監査不可（同一headのローカルbootstrapは上記の全項目pass）

公式taxonomy整合とGitHub bootstrap診断の証拠が不足するためDraftを維持し、Ready化・mergeは行いません。
