### PR TITLE
test(e2e): align handoff fixture with local date

### DIFF
--- a/src/utils/__tests__/toLocalDateISO.spec.ts
+++ b/src/utils/__tests__/toLocalDateISO.spec.ts
@@ -25,6 +25,13 @@ describe('toLocalDateISO', () => {
     // In contrast, toISOString would give 2026-03-03 in JST timezone
   });
 
+  it('keeps the JST date key after midnight before the UTC date changes', () => {
+    const boundary = new Date('2026-07-18T00:30:00+09:00');
+
+    expect(toLocalDateISO(boundary)).toBe('2026-07-18');
+    expect(boundary.toISOString().split('T')[0]).toBe('2026-07-17');
+  });
+
   it('defaults to current date when no argument given', () => {
     const result = toLocalDateISO();
     expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);

--- a/tests/e2e/handoff-daily.phase1.spec.ts
+++ b/tests/e2e/handoff-daily.phase1.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { primeOpsEnv } from './helpers/ops';
+import { toLocalDateISO } from '../../src/utils/getNow';
 
 test.describe('Phase 1: handoff ⇔ daily integration', () => {
   test.beforeEach(async ({ page }) => {
@@ -8,14 +9,14 @@ test.describe('Phase 1: handoff ⇔ daily integration', () => {
 
   test('daily page displays handoff summary card when count > 0', async ({ page }) => {
     // Pre-seed one handoff via localStorage (simulating existing data)
-    await page.addInitScript(() => {
-      const today = new Date().toISOString().split('T')[0];
+    const today = toLocalDateISO();
+    await page.addInitScript((dateKey) => {
       const handoffs = [
         {
           id: 1,
           userCode: '001',
           userDisplayName: '田中太郎',
-          date: today,
+          date: dateKey,
           category: '体調',
           severity: '重要',
           message: 'Phase 1 test handoff',
@@ -25,9 +26,9 @@ test.describe('Phase 1: handoff ⇔ daily integration', () => {
         }
       ];
       localStorage.setItem('handoff.timeline.dev.v1', JSON.stringify({
-        [today]: handoffs
+        [dateKey]: handoffs
       }));
-    });
+    }, today);
 
     await page.goto('/daily/activity');
     await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => undefined);
@@ -42,14 +43,14 @@ test.describe('Phase 1: handoff ⇔ daily integration', () => {
   });
 
   test('daily summary card CTA navigates to timeline with state', async ({ page }) => {
-    await page.addInitScript(() => {
-      const today = new Date().toISOString().split('T')[0];
+    const today = toLocalDateISO();
+    await page.addInitScript((dateKey) => {
       const handoffs = [
         {
           id: 1,
           userCode: 'ALL',
           userDisplayName: '全体',
-          date: today,
+          date: dateKey,
           category: '体調',
           severity: '重要',
           message: 'Navigation test',
@@ -59,9 +60,9 @@ test.describe('Phase 1: handoff ⇔ daily integration', () => {
         }
       ];
       localStorage.setItem('handoff.timeline.dev.v1', JSON.stringify({
-        [today]: handoffs
+        [dateKey]: handoffs
       }));
-    });
+    }, today);
 
     await page.goto('/daily/activity');
     await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => undefined);


### PR DESCRIPTION
## Summary

- Handoff Daily E2E fixtureが`new Date().toISOString().split('T')[0]`でUTC日付を使用していたため、製品コードと同じローカル日付helper（`toLocalDateISO`）を使うよう修正しました。
- `TZ=Asia/Tokyo`でJSTの日付変更後からUTC日付変更前にfixtureが前日キーになる不一致を解消します。
- #2458とは無関係のfixture missing修正です。#2458への変更はありません。

## Scope

- product code変更なし
- storage契約、Daily page、route state、provider設定、workflowのTZ変更なし
- retry、timeout、assertion、expected URL変更なし
- Schedule系変更なし

## Verification

- `TZ=Asia/Tokyo npx vitest run src/utils/__tests__/toLocalDateISO.spec.ts --reporter=verbose`: 6 passed
- `TZ=Asia/Tokyo npx playwright test tests/e2e/handoff-daily.phase1.spec.ts --project=chromium --workers=1 --retries=0 --grep ...`: 対象2件 `2 passed`
- `npm run typecheck:full -- --pretty false`: passed
- `npm run lint -- --max-warnings 0`: passed
- `git diff --check origin/main...HEAD`: passed

境界時刻`2026-07-18T00:30:00+09:00`で、ローカル日付キー`2026-07-18`とUTC日付`2026-07-17`を既存helper unit testで確認しています。