### PR TITLE
feat(schedules): simplify schedule form requirements

### DIFF
--- a/src/features/schedules/components/dialogs/ScheduleCreateDialog.tsx
+++ b/src/features/schedules/components/dialogs/ScheduleCreateDialog.tsx
@@ -171,7 +171,7 @@ export const ScheduleCreateDialog: React.FC<ScheduleCreateDialogProps> = (props)
           color="textSecondary"
           sx={{ mb: 2 }}
         >
-          タイトル、開始/終了時刻、カテゴリと対象を入力して{mode === 'edit' ? '内容を更新' : '新しい予定を登録'}します。
+          タイトルと開始日時を入力して{mode === 'edit' ? '内容を更新' : '新しい予定を登録'}します。対象や担当は後から追加できます。
         </Typography>
 
         {vm.showFacilityGuide ? (
@@ -239,7 +239,7 @@ export const ScheduleCreateDialog: React.FC<ScheduleCreateDialogProps> = (props)
             }}
           />
 
-          <FormControl fullWidth required error={Boolean(vm.fieldErrors.category)}>
+          <FormControl fullWidth error={Boolean(vm.fieldErrors.category)}>
             <InputLabel id="schedule-create-category-label">カテゴリ</InputLabel>
             <Select
               labelId="schedule-create-category-label"
@@ -274,9 +274,8 @@ export const ScheduleCreateDialog: React.FC<ScheduleCreateDialogProps> = (props)
                 <TextField
                   {...params}
                   label="利用者"
-                  required
                   error={Boolean(vm.fieldErrors.userId)}
-                  helperText={vm.fieldErrors.userId?.[0]}
+                  helperText={vm.fieldErrors.userId?.[0] ?? '未定でも登録できます。'}
                   inputRef={vm.userInputRef}
                   inputProps={{
                     ...params.inputProps,
@@ -306,13 +305,12 @@ export const ScheduleCreateDialog: React.FC<ScheduleCreateDialogProps> = (props)
             <TextField
               type="datetime-local"
               label="終了日時"
-              required
               fullWidth
               value={vm.form.endLocal}
               onChange={e => vm.handleFieldChange('endLocal', e.target.value)}
               InputLabelProps={{ shrink: true }}
               error={Boolean(vm.dateOrderErrorMessage)}
-              helperText={vm.dateOrderErrorMessage}
+              helperText={vm.dateOrderErrorMessage ?? '未入力の場合は開始から1時間で登録します。'}
               inputProps={{
                 'data-testid': 'schedule-create-end'
               }}
@@ -320,7 +318,7 @@ export const ScheduleCreateDialog: React.FC<ScheduleCreateDialogProps> = (props)
           </Stack>
 
           {(vm.form.category === 'User' || vm.form.category === 'LivingSupport') && (
-            <FormControl fullWidth required error={Boolean(vm.serviceTypeErrorMessage)}>
+            <FormControl fullWidth error={Boolean(vm.serviceTypeErrorMessage)}>
               <InputLabel id="schedule-create-service-type-label">サービス種別</InputLabel>
               <Select
                 labelId="schedule-create-service-type-label"
@@ -342,7 +340,7 @@ export const ScheduleCreateDialog: React.FC<ScheduleCreateDialogProps> = (props)
                 ))}
               </Select>
               <FormHelperText>
-                {vm.serviceTypeErrorMessage ?? 'サービス種別を付けておくと一覧で絞り込みやすくなります。'}
+                {vm.serviceTypeErrorMessage ?? '未選択の場合は標準の予定として登録します。'}
               </FormHelperText>
             </FormControl>
           )}
@@ -423,9 +421,8 @@ export const ScheduleCreateDialog: React.FC<ScheduleCreateDialogProps> = (props)
                   <TextField
                     {...params}
                     placeholder="職員を選択"
-                    required
                     error={Boolean(vm.fieldErrors.assignedStaffId)}
-                    helperText={vm.fieldErrors.assignedStaffId?.[0]}
+                    helperText={vm.fieldErrors.assignedStaffId?.[0] ?? '未定でも登録できます。'}
                     inputRef={vm.staffInputRef}
                     inputProps={{
                       ...params.inputProps,

--- a/src/features/schedules/domain/__tests__/scheduleFormState.spec.ts
+++ b/src/features/schedules/domain/__tests__/scheduleFormState.spec.ts
@@ -48,18 +48,22 @@ describe('validateScheduleForm', () => {
     expect(result.errors).toContain('終了日時は開始日時より後にしてください');
   });
 
-  it('fails if category is User and serviceType is missing', () => {
-    const form = { ...validBaseForm, category: 'User' as const, serviceType: '' };
+  it('passes if endLocal is empty', () => {
+    const form = { ...validBaseForm, endLocal: '' };
     const result = validateScheduleForm(form);
-    expect(result.isValid).toBe(false);
-    expect(result.errors).toContain('サービス種別を選択してください');
+    expect(result.isValid).toBe(true);
   });
 
-  it('fails if category is LivingSupport and serviceType is missing', () => {
+  it('passes if category is User and serviceType is missing', () => {
+    const form = { ...validBaseForm, category: 'User' as const, serviceType: '' };
+    const result = validateScheduleForm(form);
+    expect(result.isValid).toBe(true);
+  });
+
+  it('passes if category is LivingSupport and serviceType is missing', () => {
     const form = { ...validBaseForm, category: 'LivingSupport' as const, serviceType: '' };
     const result = validateScheduleForm(form);
-    expect(result.isValid).toBe(false);
-    expect(result.errors).toContain('サービス種別を選択してください');
+    expect(result.isValid).toBe(true);
   });
 
   it('passes if category is Org and serviceType is missing', () => {

--- a/src/features/schedules/domain/scheduleFormState.ts
+++ b/src/features/schedules/domain/scheduleFormState.ts
@@ -64,7 +64,7 @@ export const ScheduleFormSchema = z.object({
   category: ScheduleCategorySchema,
   userId: z.string(),
   startLocal: z.string().min(1, '開始日時を入力してください'),
-  endLocal: z.string().min(1, '終了日時を入力してください'),
+  endLocal: z.string(),
   serviceType: z.string().nullable().optional(),
   locationName: z.string(),
   notes: z.string(),
@@ -80,14 +80,6 @@ export const ScheduleFormSchema = z.object({
 }, {
   message: '終了日時は開始日時より後にしてください',
   path: ['endLocal'],
-}).refine(data => {
-  if (data.category === 'User' || data.category === 'LivingSupport') {
-    return !!data.serviceType;
-  }
-  return true;
-}, {
-  message: 'サービス種別を選択してください',
-  path: ['serviceType'],
 });
 
 export type ScheduleFormState = z.infer<typeof ScheduleFormSchema>;
@@ -202,11 +194,8 @@ export function toCreateScheduleInput(
   if (!trimmedTitle) {
     throw new Error('title is required');
   }
-  if (!form.startLocal || !form.endLocal) {
-    throw new Error('startLocal and endLocal are required');
-  }
-  if (form.category === 'User' && !form.serviceType) {
-    throw new Error('serviceType is required for user schedules');
+  if (!form.startLocal) {
+    throw new Error('startLocal is required');
   }
 
   const normalizeLookupId = (value?: unknown): string | null => {
@@ -235,32 +224,15 @@ export function toCreateScheduleInput(
     return null;
   };
 
-  if (form.category === 'User' && !form.userId.trim()) {
-    throw new Error('userId is required for user schedules');
-  }
-
-  if (form.category === 'Staff' && !form.assignedStaffId.trim()) {
-    throw new Error('assignedStaffId is required for staff schedules');
-  }
-
-  let resolvedServiceType: ScheduleServiceType;
-  if (form.category === 'User') {
-    if (typeof form.serviceType === 'string') {
-      resolvedServiceType = form.serviceType as ScheduleServiceType;
-    } else if (!form.serviceType) {
-      resolvedServiceType = 'normal';
-    } else {
-      resolvedServiceType = form.serviceType;
-    }
-  } else {
-    if (typeof form.serviceType === 'string') {
-      resolvedServiceType = form.serviceType as ScheduleServiceType;
-    } else if (!form.serviceType) {
-      resolvedServiceType = 'other';
-    } else {
-      resolvedServiceType = form.serviceType;
-    }
-  }
+  const trimmedServiceType = typeof form.serviceType === 'string' ? form.serviceType.trim() : '';
+  const resolvedServiceType = (trimmedServiceType
+    ? trimmedServiceType
+    : form.category === 'User'
+      ? 'normal'
+      : 'other') as ScheduleServiceType;
+  const resolvedEndLocal = form.endLocal?.trim()
+    ? form.endLocal
+    : formatDateTimeLocal(addHours(new Date(form.startLocal), 1));
   const statusReason = form.statusReason.trim();
   const resolvedUserLookupId = normalizeLookupId(selectedUser?.lookupId ?? undefined);
   const resolvedUserName = selectedUser?.name?.trim() || null;
@@ -272,7 +244,7 @@ export function toCreateScheduleInput(
     userLookupId: resolvedUserLookupId,
     userName: resolvedUserName,
     startLocal: form.startLocal,
-    endLocal: form.endLocal,
+    endLocal: resolvedEndLocal,
     serviceType: resolvedServiceType,
     locationName: form.locationName?.trim() || null,
     notes: form.notes?.trim() || null,

--- a/src/features/schedules/hooks/orchestrators/useScheduleCreateForm.ts
+++ b/src/features/schedules/hooks/orchestrators/useScheduleCreateForm.ts
@@ -270,14 +270,7 @@ export function useScheduleCreateForm(input: UseScheduleCreateFormInput): Schedu
       return;
     }
     if (didAutoFocusRef.current) return;
-    const target =
-      mode === 'edit' || isOrgCategory
-        ? titleInputRef.current
-        : form.category === 'User'
-          ? userInputRef.current
-          : form.category === 'Staff'
-            ? staffInputRef.current
-            : titleInputRef.current;
+    const target = titleInputRef.current;
     if (target) {
       if (typeof window === 'undefined') {
         target.focus();
@@ -286,7 +279,7 @@ export function useScheduleCreateForm(input: UseScheduleCreateFormInput): Schedu
       }
       didAutoFocusRef.current = true;
     }
-  }, [form.category, isOrgCategory, mode, open]);
+  }, [open]);
 
   // Facility guide (one-time)
   useEffect(() => {

--- a/tests/unit/ScheduleCreateDialog.spec.tsx
+++ b/tests/unit/ScheduleCreateDialog.spec.tsx
@@ -90,9 +90,7 @@ describe('validateScheduleForm', () => {
     expect(result.isValid).toBe(false);
     expect(result.errors).toEqual([
       '予定タイトルを入力してください',
-      '開始日時を入力してください',
-      '終了日時を入力してください',
-      'サービス種別を選択してください'
+      '開始日時を入力してください'
     ]);
   });
 
@@ -120,23 +118,48 @@ describe('toCreateScheduleInput', () => {
 
     expect(() =>
       toCreateScheduleInput(buildForm({ startLocal: '', serviceType: 'normal' }))
-    ).toThrowError(/startLocal and endLocal are required/);
-
-    expect(() =>
-      toCreateScheduleInput(buildForm({ startLocal: 'a', endLocal: 'b', serviceType: '' }))
-    ).toThrowError(/serviceType is required/);
+    ).toThrowError(/startLocal is required/);
   });
 
-  it('maps optional fields to undefined when empty', () => {
-    const result = toCreateScheduleInput(buildForm({ locationName: '', notes: '' }));
+  it('maps optional fields and default values when empty', () => {
+    const result = toCreateScheduleInput(
+      buildForm({
+        userId: '',
+        endLocal: '',
+        serviceType: '',
+        locationName: '',
+        notes: '',
+      })
+    );
     expect(result).toMatchObject({
       title: 'テスト予定',
-      userId: 'user-1',
+      userId: null,
       startLocal: '2025-11-12T10:00',
       endLocal: '2025-11-12T11:00',
       serviceType: 'normal',
       status: 'Planned',
     });
+  });
+
+  it('defaults non-user schedules to other and preserves explicit values', () => {
+    const result = toCreateScheduleInput(
+      buildForm({
+        category: 'Org',
+        endLocal: '',
+        serviceType: '',
+      })
+    );
+    expect(result.endLocal).toBe('2025-11-12T11:00');
+    expect(result.serviceType).toBe('other');
+
+    const explicit = toCreateScheduleInput(
+      buildForm({
+        endLocal: '2025-11-12T12:30',
+        serviceType: 'absence',
+      })
+    );
+    expect(explicit.endLocal).toBe('2025-11-12T12:30');
+    expect(explicit.serviceType).toBe('absence');
   });
 
   it('includes lookup metadata when the selected user is provided', () => {
@@ -184,6 +207,7 @@ describe('ScheduleCreateDialog component', () => {
     );
 
     const user = userEvent.setup();
+    await user.clear(screen.getByTestId(TESTIDS['schedule-create-title']));
     await user.click(screen.getByTestId(TESTIDS['schedule-create-save']));
 
     const alert = await screen.findByTestId(TESTIDS['schedule-create-error-alert']);
@@ -223,6 +247,9 @@ describe('ScheduleCreateDialog component', () => {
     const endInput = screen.getByTestId(TESTIDS['schedule-create-end']) as HTMLInputElement;
     expect(startInput.value.endsWith('10:00')).toBe(true);
     expect(endInput.value.endsWith('11:00')).toBe(true);
+    expect(startInput).toBeRequired();
+    expect(endInput).not.toBeRequired();
+    expect(userInput).not.toBeRequired();
   });
 
   it('applies initial overrides when provided', async () => {


### PR DESCRIPTION
## Summary
- Schedule作成・編集フォームの必須項目をタイトルと開始日時に限定
- 終了日時未入力時は開始日時から1時間で補完
- serviceType未入力時はUserをnormal、その他をotherへ補完

## Scope
- SharePoint schema、status、URL、navigation、recurring schedule契約は変更なし
- #2485、#2458、#2451の状態は変更なし
- package.jsonのtest glob、retry、timeout、assertionは変更なし

## Validation
- 明示unit/component: 2 files / 24 passed
- test:schedule:unit: 8 files / 92 passed
- typecheck:full: passed
- lint --max-warnings 0: passed
- diff-check: passed
- ScheduleCreateDialog dev harness E2E: skipped（harness unavailable）
