### PR TITLE
fix(ci): make nightly health shard-aware

### DIFF
--- a/.github/workflows/nightly-health.yml
+++ b/.github/workflows/nightly-health.yml
@@ -43,6 +43,7 @@ jobs:
         env:
           TZ: Asia/Tokyo
           VITEST_MEMORY_LOG: reports/nightly-memory/shard-${{ matrix.shard }}.jsonl
+          VITEST_SHARD: ${{ matrix.shard }}/3
         run: |
           set +e
           set -o pipefail

--- a/scripts/ci/assert-vitest-health.d.mts
+++ b/scripts/ci/assert-vitest-health.d.mts
@@ -2,6 +2,10 @@ export interface VitestHealthSummary {
   expectedFiles: number;
   startedFiles: number;
   endedFiles: number;
+  runEndFiles: number | null;
+  runEndErrors: number | null;
+  shard: string | null;
+  shardConsistent: boolean;
   lastStartedFile: string | null;
   missingEndedFiles: string[];
   unhandledErrors: number;

--- a/scripts/ci/assert-vitest-health.mjs
+++ b/scripts/ci/assert-vitest-health.mjs
@@ -59,9 +59,18 @@ export function summarizeVitestHealth({
 
   const started = events.filter((event) => event?.event === 'module-start');
   const ended = events.filter((event) => event?.event === 'module-end');
-  const expectedFiles = events.find(
+  const runStart = events.find(
     (event) => event?.event === 'run-start' && Number.isInteger(event.expectedModules),
-  )?.expectedModules ?? 0;
+  );
+  const runEnd = events.findLast((event) => event?.event === 'run-end');
+  const expectedFiles = runStart?.expectedModules ?? 0;
+  const runEndFiles = Number.isInteger(runEnd?.completedModules) ? runEnd.completedModules : null;
+  const runEndErrors = Number.isInteger(runEnd?.errorCount) ? runEnd.errorCount : null;
+  const startShard = typeof runStart?.shard === 'string' ? runStart.shard : null;
+  const endShard = typeof runEnd?.shard === 'string' ? runEnd.shard : null;
+  const shard = endShard ?? startShard;
+  const isShard = typeof shard === 'string' && /^\d+\/\d+$/.test(shard);
+  const shardConsistent = startShard === endShard;
   const endedCounts = new Map();
   for (const event of ended) endedCounts.set(event.moduleId, (endedCounts.get(event.moduleId) ?? 0) + 1);
   const missingEndedFiles = [];
@@ -75,6 +84,10 @@ export function summarizeVitestHealth({
     expectedFiles,
     startedFiles: started.length,
     endedFiles: ended.length,
+    runEndFiles,
+    runEndErrors,
+    shard,
+    shardConsistent,
     lastStartedFile: started.at(-1)?.moduleId ?? null,
     missingEndedFiles,
     unhandledErrors: countSignalBlocks(logLines, UNHANDLED_ERROR_PATTERN),
@@ -85,12 +98,24 @@ export function summarizeVitestHealth({
     memoryFilePresent,
   };
 
+  const completedCountHealthy =
+    summary.runEndFiles !== null &&
+    summary.startedFiles === summary.endedFiles &&
+    summary.endedFiles === summary.runEndFiles;
+  const expectedCountHealthy = isShard
+    ? summary.expectedFiles > 0
+    : summary.expectedFiles > 0 &&
+      summary.startedFiles === summary.expectedFiles &&
+      summary.endedFiles === summary.expectedFiles &&
+      summary.runEndFiles === summary.expectedFiles;
+
   return {
     ...summary,
     healthy:
-      summary.expectedFiles > 0 &&
-      summary.startedFiles === summary.expectedFiles &&
-      summary.endedFiles === summary.expectedFiles &&
+      completedCountHealthy &&
+      expectedCountHealthy &&
+      summary.runEndErrors === 0 &&
+      summary.shardConsistent &&
       summary.unhandledErrors === 0 &&
       summary.workerAbnormalExits === 0 &&
       summary.vitestExitCode === 0 &&

--- a/scripts/ci/vitest-memory-reporter.d.mts
+++ b/scripts/ci/vitest-memory-reporter.d.mts
@@ -8,8 +8,13 @@ export interface MemorySnapshot {
 export function memorySnapshot(): MemorySnapshot;
 export default class VitestMemoryReporter {
   outputPath: string;
+  shard: string | null;
   startedAt: Map<string, number>;
-  write(event: string, testModule?: { moduleId?: string; id?: string }): void;
+  write(
+    event: string,
+    testModule?: { moduleId?: string; id?: string },
+    details?: Record<string, unknown>,
+  ): void;
   onTestRunStart(specifications: unknown[]): void;
   onTestModuleStart(testModule: { moduleId: string }): void;
   onTestModuleEnd(testModule: { moduleId: string }): void;

--- a/scripts/ci/vitest-memory-reporter.mjs
+++ b/scripts/ci/vitest-memory-reporter.mjs
@@ -15,6 +15,7 @@ export function memorySnapshot() {
 export default class VitestMemoryReporter {
   constructor() {
     this.outputPath = process.env.VITEST_MEMORY_LOG || 'reports/nightly-memory/vitest-memory.jsonl';
+    this.shard = process.env.VITEST_SHARD || null;
     this.startedAt = new Map();
   }
 
@@ -33,10 +34,18 @@ export default class VitestMemoryReporter {
     this.write(
       'run-start',
       { moduleId: `${specifications.length} specifications` },
-      { expectedModules: specifications.length },
+      { expectedModules: specifications.length, shard: this.shard },
     );
   }
   onTestModuleStart(testModule) { this.startedAt.set(testModule.moduleId, Date.now()); this.write('module-start', testModule); }
   onTestModuleEnd(testModule) { this.write('module-end', testModule); this.startedAt.delete(testModule.moduleId); }
-  onTestRunEnd(testModules, errors) { this.write('run-end', { moduleId: `${testModules.length} modules; ${errors.length} errors` }); }
+  onTestRunEnd(testModules, errors) {
+    const completedModules = Array.isArray(testModules) ? testModules.length : 0;
+    const errorCount = Array.isArray(errors) ? errors.length : 0;
+    this.write(
+      'run-end',
+      { moduleId: `${completedModules} modules; ${errorCount} errors` },
+      { completedModules, errorCount, shard: this.shard },
+    );
+  }
 }

--- a/tests/unit/vitestHealthAssertion.spec.ts
+++ b/tests/unit/vitestHealthAssertion.spec.ts
@@ -2,15 +2,24 @@ import { describe, expect, it } from 'vitest';
 import { summarizeVitestHealth } from '../../scripts/ci/assert-vitest-health.mjs';
 
 const event = (eventName: string, moduleId: string) => JSON.stringify({ event: eventName, moduleId });
-const runStart = (expectedModules: number) => JSON.stringify({
+const runStart = (expectedModules: number, shard: string | null = null) => JSON.stringify({
   event: 'run-start',
   moduleId: `${expectedModules} specifications`,
   expectedModules,
+  shard,
+});
+const runEnd = (completedModules: number, errorCount = 0, shard: string | null = null) => JSON.stringify({
+  event: 'run-end',
+  moduleId: `${completedModules} modules; ${errorCount} errors`,
+  completedModules,
+  errorCount,
+  shard,
 });
 
 const completeMemory = (...moduleIds: string[]) => [
   runStart(moduleIds.length),
   ...moduleIds.flatMap((moduleId) => [event('module-start', moduleId), event('module-end', moduleId)]),
+  runEnd(moduleIds.length),
 ].join('\n');
 
 describe('summarizeVitestHealth', () => {
@@ -23,6 +32,9 @@ describe('summarizeVitestHealth', () => {
       expectedFiles: 1,
       startedFiles: 1,
       endedFiles: 1,
+      runEndFiles: 1,
+      runEndErrors: 0,
+      shard: null,
       lastStartedFile: 'a.spec.ts',
       missingEndedFiles: [],
       unhandledErrors: 0,
@@ -34,7 +46,7 @@ describe('summarizeVitestHealth', () => {
 
   it('fails when a module end is missing and records the last started file', () => {
     const summary = summarizeVitestHealth({
-      memoryText: [runStart(2), event('module-start', 'a.spec.ts'), event('module-end', 'a.spec.ts'), event('module-start', 'b.spec.ts')].join('\n'),
+      memoryText: [runStart(2), event('module-start', 'a.spec.ts'), event('module-end', 'a.spec.ts'), event('module-start', 'b.spec.ts'), runEnd(1)].join('\n'),
       vitestExitCode: 0,
     });
     expect(summary).toMatchObject({ startedFiles: 2, endedFiles: 1, lastStartedFile: 'b.spec.ts', missingEndedFiles: ['b.spec.ts'], healthy: false });
@@ -63,6 +75,43 @@ describe('summarizeVitestHealth', () => {
     expect(summary).toMatchObject({ vitestExitCode: 2, healthy: false });
   });
 
+  it.each([
+    ['1/3', 384],
+    ['2/3', 384],
+    ['3/3', 383],
+  ])('passes completed shard %s without comparing against the unsharded total', (shard, count) => {
+    const moduleIds = Array.from({ length: count }, (_, index) => `${shard}-${index}.spec.ts`);
+    const memoryText = [
+      runStart(1151, shard),
+      ...moduleIds.flatMap((moduleId) => [event('module-start', moduleId), event('module-end', moduleId)]),
+      runEnd(count, 0, shard),
+    ].join('\n');
+    const summary = summarizeVitestHealth({ memoryText, vitestExitCode: 0 });
+    expect(summary).toMatchObject({
+      expectedFiles: 1151,
+      startedFiles: count,
+      endedFiles: count,
+      runEndFiles: count,
+      runEndErrors: 0,
+      shard,
+      shardConsistent: true,
+      healthy: true,
+    });
+  });
+
+  it('fails when run-end is missing or reports errors', () => {
+    const withoutRunEnd = summarizeVitestHealth({
+      memoryText: [runStart(1), event('module-start', 'a.spec.ts'), event('module-end', 'a.spec.ts')].join('\n'),
+      vitestExitCode: 0,
+    });
+    const withErrors = summarizeVitestHealth({
+      memoryText: [runStart(1), event('module-start', 'a.spec.ts'), event('module-end', 'a.spec.ts'), runEnd(1, 1)].join('\n'),
+      vitestExitCode: 0,
+    });
+    expect(withoutRunEnd).toMatchObject({ runEndFiles: null, runEndErrors: null, healthy: false });
+    expect(withErrors).toMatchObject({ runEndFiles: 1, runEndErrors: 1, healthy: false });
+  });
+
   it('reports worker termination separately from unhandled errors', () => {
     const summary = summarizeVitestHealth({
       logText: 'Error: [vitest-pool]: Worker forks emitted error.\nUnhandled Rejection',
@@ -83,7 +132,7 @@ describe('summarizeVitestHealth', () => {
 
   it('keeps a summary and fails when the memory JSONL is truncated', () => {
     const summary = summarizeVitestHealth({
-      memoryText: `${runStart(1)}\n${event('module-start', 'a.spec.ts')}\n{"event":"module-end"`,
+      memoryText: `${runStart(1)}\n${event('module-start', 'a.spec.ts')}\n{"event":"module-end"\n${runEnd(0)}`,
       vitestExitCode: 0,
     });
     expect(summary).toMatchObject({ startedFiles: 1, endedFiles: 0, invalidMemoryLines: 1, healthy: false });
@@ -120,11 +169,11 @@ describe('summarizeVitestHealth', () => {
 
   it('fails when structured expected module count is absent or incomplete', () => {
     const withoutExpected = summarizeVitestHealth({
-      memoryText: [event('module-start', 'a.spec.ts'), event('module-end', 'a.spec.ts')].join('\n'),
+      memoryText: [event('module-start', 'a.spec.ts'), event('module-end', 'a.spec.ts'), runEnd(1)].join('\n'),
       vitestExitCode: 0,
     });
     const incomplete = summarizeVitestHealth({
-      memoryText: [runStart(2), event('module-start', 'a.spec.ts'), event('module-end', 'a.spec.ts')].join('\n'),
+      memoryText: [runStart(2), event('module-start', 'a.spec.ts'), event('module-end', 'a.spec.ts'), runEnd(1)].join('\n'),
       vitestExitCode: 0,
     });
     expect(withoutExpected).toMatchObject({ expectedFiles: 0, healthy: false });

--- a/tests/unit/vitestMemoryReporter.spec.ts
+++ b/tests/unit/vitestMemoryReporter.spec.ts
@@ -4,16 +4,20 @@ import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import VitestMemoryReporter, { memorySnapshot } from '../../scripts/ci/vitest-memory-reporter.mjs';
 
-const directories: string[] = [];
+const createdDirectories: string[] = [];
+
 afterEach(() => {
   delete process.env.VITEST_MEMORY_LOG;
-  directories.splice(0).forEach((directory) => fs.rmSync(directory, { recursive: true, force: true }));
+  delete process.env.VITEST_SHARD;
+  for (const directory of createdDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
 });
 
 describe('VitestMemoryReporter', () => {
   it('records module start and end events as durable JSONL', () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'vitest-memory-'));
-    directories.push(directory);
+    createdDirectories.push(directory);
     const outputPath = path.join(directory, 'memory.jsonl');
     process.env.VITEST_MEMORY_LOG = outputPath;
     const reporter = new VitestMemoryReporter();
@@ -27,5 +31,26 @@ describe('VitestMemoryReporter', () => {
 
   it('reports numeric process memory counters', () => {
     expect(memorySnapshot()).toEqual(expect.objectContaining({ rssBytes: expect.any(Number), heapUsedBytes: expect.any(Number) }));
+  });
+
+  it('records shard metadata and structured run-end counts', () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'vitest-memory-reporter-'));
+    createdDirectories.push(directory);
+    const outputPath = path.join(directory, 'memory.jsonl');
+    process.env.VITEST_MEMORY_LOG = outputPath;
+    process.env.VITEST_SHARD = '2/3';
+
+    const reporter = new VitestMemoryReporter();
+    reporter.onTestRunStart([{}, {}, {}]);
+    reporter.onTestRunEnd([{}, {}], [new Error('worker')]);
+
+    const events = fs.readFileSync(outputPath, 'utf8').trim().split('\n').map((line) => JSON.parse(line));
+    expect(events[0]).toMatchObject({ event: 'run-start', expectedModules: 3, shard: '2/3' });
+    expect(events[1]).toMatchObject({
+      event: 'run-end',
+      completedModules: 2,
+      errorCount: 1,
+      shard: '2/3',
+    });
   });
 });


### PR DESCRIPTION
## Summary

- record structured `completedModules`, `errorCount`, and shard metadata in the Vitest memory reporter
- keep full expected-module equality for non-sharded runs
- validate sharded runs with `startedFiles == endedFiles == runEndFiles` while preserving runtime/error/artifact guards
- add explicit 384 / 384 / 383 shard acceptance coverage and run-end failure cases

## Root cause

Vitest reports the pre-shard total (`expectedModules=1151`) in `onTestRunStart()`. Nightly executes three shards, but the health assertion compared every shard's 384 / 384 / 383 completed files against 1151, making otherwise healthy shards fail.

## Validation

- `npx vitest run tests/unit/vitestHealthAssertion.spec.ts tests/unit/vitestMemoryReporter.spec.ts` (21 tests)
- `npm run test:ci:required` (51 files / 461 tests)
- `npm run typecheck:full -- --pretty false`
- `npm run lint -- --quiet`
- `npx actionlint .github/workflows/nightly-health.yml`
- `git diff --check`
- same-head PR CI: all completed checks succeeded (skips are intentional)
- manual Nightly Health: https://github.com/yasutakesougo/audit-management-system-mvp/actions/runs/29557875379
  - unit shard 1: `started=ended=runEnd=384`, `errorCount=0`, healthy
  - unit shard 2: `started=ended=runEnd=384`, `errorCount=0`, healthy
  - unit shard 3: `started=ended=runEnd=383`, `errorCount=0`, healthy
  - Static Analysis, TypeCheck, and Performance passed
  - workflow result remains red only in the known Exception Center transport E2E lane; unit health no longer produces a false alarm

## Scope note

The manual Nightly E2E failures are not addressed here. They are retained as separate product/test-harness recovery lanes.