### PR TITLE
fix(e2e): align deep harness contracts

### DIFF
--- a/.github/workflows/e2e-deep.yml
+++ b/.github/workflows/e2e-deep.yml
@@ -164,7 +164,7 @@ jobs:
             npx playwright test tests/e2e \
               --config=playwright.config.ts \
               --project=chromium \
-              --grep-invert smoke \
+              --grep-invert "smoke|@live-sp" \
               --retries=2
           fi
         continue-on-error: true

--- a/tests/e2e/_helpers/setupPlaywrightEnv.ts
+++ b/tests/e2e/_helpers/setupPlaywrightEnv.ts
@@ -63,6 +63,16 @@ export async function setupPlaywrightEnv(page: Page, options: SetupPlaywrightEnv
 
   const envPayload = { ...BASE_ENV, ...envOverrides };
   const storagePayload = { ...BASE_STORAGE, ...storageOverrides };
+  if (
+    Object.prototype.hasOwnProperty.call(envOverrides, 'VITE_SKIP_LOGIN') &&
+    !Object.prototype.hasOwnProperty.call(storageOverrides, 'skipLogin')
+  ) {
+    if (envPayload.VITE_SKIP_LOGIN === '1' || envPayload.VITE_SKIP_LOGIN === 'true') {
+      storagePayload.skipLogin = '1';
+    } else {
+      delete storagePayload.skipLogin;
+    }
+  }
 
   await page.addInitScript((providedEnv) => {
     const scope = window as typeof window & { __ENV__?: Record<string, string> };

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -2,8 +2,7 @@ import { expect, test } from '@playwright/test';
 import { setupPlaywrightEnv } from './_helpers/setupPlaywrightEnv';
 
 test.describe('Authentication Flow (MSAL Mock)', () => {
-  test('interactive login flow', async ({ page }) => {
-    // 1. Start with login required
+  test('exposes an authenticated mock session', async ({ page }) => {
     await setupPlaywrightEnv(page, {
       envOverrides: {
         VITE_SKIP_LOGIN: '0',
@@ -13,52 +12,40 @@ test.describe('Authentication Flow (MSAL Mock)', () => {
 
     await page.goto('/');
 
-    // Check if we are on the home page or redirected to a login state
-    // The app shell should show the Sign In button
-    const signInButton = page.getByRole('button', { name: /サインイン/i });
-    await expect(signInButton).toBeVisible();
-
-    // 2. Click Sign In
-    await signInButton.click();
-
-    // Sign In button clicks handleSignIn which calls signIn().
-    // Our mock signIn sets __E2E_MOCK_AUTH__=1 and reloads.
-
-    // 3. In E2E mock mode, signIn is a safe no-op and Sign In remains visible.
-    await expect(page.getByRole('button', { name: /サインイン/i })).toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole('button', { name: /サインアウト/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /サインイン/i })).toHaveCount(0);
   });
 
-  test('session persistence after reload', async ({ page }) => {
+  test('persists the authenticated mock session after reload', async ({ page }) => {
     await setupPlaywrightEnv(page, {
       envOverrides: {
         VITE_SKIP_LOGIN: '0',
         VITE_E2E_MSAL_MOCK: '1',
-      },
-      storageOverrides: {
-        __E2E_MOCK_AUTH__: '1'
       }
     });
 
     await page.goto('/dashboard');
-    await expect(page.getByRole('button', { name: /サインイン/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /サインアウト/i })).toBeVisible();
 
     await page.reload();
-    await expect(page.getByRole('button', { name: /サインイン/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /サインアウト/i })).toBeVisible();
   });
 
-  test('logout flow', async ({ page }) => {
+  test('keeps the deterministic mock session after no-op logout', async ({ page }) => {
     await setupPlaywrightEnv(page, {
       envOverrides: {
         VITE_SKIP_LOGIN: '0',
         VITE_E2E_MSAL_MOCK: '1',
-      },
-      storageOverrides: {
-        __E2E_MOCK_AUTH__: '1'
       }
     });
 
     await page.goto('/dashboard');
-    // In E2E mock mode, logout control is not rendered because mock auth does not create MSAL accounts.
-    await expect(page.getByRole('button', { name: /サインイン/i })).toBeVisible({ timeout: 10000 });
+    const signOutButton = page.getByRole('button', { name: /サインアウト/i });
+    await expect(signOutButton).toBeVisible();
+
+    await signOutButton.click();
+
+    await expect(page.getByRole('button', { name: /サインアウト/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /サインイン/i })).toHaveCount(0);
   });
 });

--- a/tests/e2e/diagnose.schema_dump.spec.ts
+++ b/tests/e2e/diagnose.schema_dump.spec.ts
@@ -1,7 +1,7 @@
 import { test } from '@playwright/test';
 import { resolveSharePointSiteUrl } from '../integration/_shared/resolveSiteUrl';
 
-test.describe('Targeted Schema Check for 400 Errors', () => {
+test.describe('@live-sp Targeted Schema Check for 400 Errors', () => {
   test.use({
     storageState: 'tests/.auth/storageState.json',
   });

--- a/tests/e2e/schedule.status-service.regression.spec.ts
+++ b/tests/e2e/schedule.status-service.regression.spec.ts
@@ -104,6 +104,8 @@ const orgMasterFixtures = [
 ];
 
 test.describe('Schedule quick-create (regression)', () => {
+  test.skip(IS_PREVIEW, 'Preview UI diverges; quick dialog not exposed.');
+
   test.beforeEach(async ({ page }) => {
     page.on('console', (message) => {
       if (message.type() === 'info' && message.text().startsWith('[schedulesClient] fixtures=')) {
@@ -198,7 +200,6 @@ test.describe('Schedule quick-create (regression)', () => {
   });
 
   test('create new 生活介護休み entry via quick dialog', async ({ page }, testInfo) => {
-    test.skip(IS_PREVIEW, 'Preview UI diverges; quick dialog not exposed.');
     await gotoWeek(page, TEST_DATE);
     await waitForWeekViewReady(page);
 


### PR DESCRIPTION
## Summary

- synchronize the shared localStorage.skipLogin seed with explicit VITE_SKIP_LOGIN overrides
- align the three auth E2E assertions with the existing always-authenticated MSAL mock contract
- tag the live SharePoint schema diagnostic as @live-sp and exclude it from the default Deep E2E lane
- apply the preview schedule skip at describe scope before beforeEach runs

## Root causes addressed

- explicit VITE_SKIP_LOGIN=0 did not remove the helper default localStorage.skipLogin=1
- the auth spec expected an unauthenticated sign-in button even though VITE_E2E_MSAL_MOCK=1 always provides a deterministic authenticated account
- the memory-provider Deep workflow executed a diagnostic spec requiring real SharePoint storage state
- the schedule preview skip ran inside the test body, after beforeEach had already failed

## Validation

- npm run typecheck:full -- --pretty false: passed
- targeted ESLint: passed
- git diff --check: passed
- CI-preview-equivalent targeted auth E2E: 3/3 passed
- final exact-head full Deep run 29572625268 on ab2fc6a3b0f4f314deadab91b801305bcbf74aeb:
  - baseline 49 to final 42
  - removed 7 / remaining 42 / new 0
  - all three auth tests passed
  - diagnose.schema_dump.spec.ts ran zero tests
  - preview schedule test skipped before hooks with duration 0 and no errors
  - Playwright JSON and taxonomy both report 42 unique failures
  - bootstrap error=null, page errors 0, request failures 0
  - setup_failure_step=none, direct_cancellation=false
  - required taxonomy, JUnit, bootstrap, and test-result artifacts uploaded and parsed successfully
- same-head PR checks: pending 0 / failure 0 / CLEAN

## Gate

Gate satisfied on head ab2fc6a3b0f4f314deadab91b801305bcbf74aeb.