### PR TITLE
ci: allow LHCI preview build to finish

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -5,7 +5,7 @@
       "url": ["http://127.0.0.1:4173/analysis/dashboard"],
       "startServerCommand": "if [ ! -f dist/index.html ]; then npm run perf:build || exit 1; fi; vite preview --host 127.0.0.1 --port 4173 --strictPort",
       "startServerReadyPattern": "Local:",
-      "startServerReadyTimeout": 120000
+      "startServerReadyTimeout": 300000
     },
     "assert": {
       "assertions": {


### PR DESCRIPTION
## Summary

- increase the LHCI start-server readiness timeout from 120 seconds to 300 seconds
- keep the existing conditional production build and port 4173 preview contract unchanged

## Root cause

Quality Gates canary run `29566094512` spent more than 120 seconds in `npm run perf:build`. LHCI timed out before `vite preview` started, then attempted `http://127.0.0.1:4173/analysis/dashboard` with no server listening and failed with `CHROME_INTERSTITIAL_ERROR`. Canary E2E against the separate port 5173 dev server succeeded.

## Validation

- `lighthouserc.json` parses as JSON
- `git diff --check`: passed
- clean-worktree `npm run ci:lh`: production build completed, port 4173 preview started, Lighthouse collection/assertion/upload completed with exit 0
- existing performance thresholds remained warnings and were not relaxed

## Scope

One configuration file only. No application, #2490, Secret, or performance-budget changes.