### PR TITLE
fix(ci): classify Deep E2E failures

### DIFF
--- a/scripts/ci/generate-deep-e2e-taxonomy.mjs
+++ b/scripts/ci/generate-deep-e2e-taxonomy.mjs
@@ -6,11 +6,74 @@ import path from "node:path";
 export const DEFAULT_INPUT = "test-results/results.json";
 export const DEFAULT_OUTPUT = "reports/deep-e2e-taxonomy.json";
 const UNCLASSIFIED = "unclassified";
+const ERROR_SUMMARY_LIMIT = 500;
 
-function flattenSuites(suites = []) {
+const FEATURE_RULES = [
+  ["exception-center", /(?:^|[/_.-])exception[-_.]?center(?:[/_.-]|$)/i],
+  [
+    "accessibility",
+    /(?:^|[/_.-])(?:accessibility|a11y|touch[-_.]?targets?)(?:[/_.-]|$)/i,
+  ],
+  ["auth", /(?:^|[/_.-])auth(?:[/_.-]|$)/i],
+  ["users", /(?:^|[/_.-])users?(?:[/_.-]|$)/i],
+  ["transport", /(?:^|[/_.-])transport(?:[/_.-]|$)/i],
+  ["isp", /(?:^|[/_.-])isp(?:[/_.-]|$)/i],
+  ["dashboard", /(?:^|[/_.-])dashboard(?:[/_.-]|$)/i],
+  ["staff", /(?:^|[/_.-])staff(?:[/_.-]|$)/i],
+  ["nurse", /(?:^|[/_.-])nurse(?:[/_.-]|$)/i],
+  ["agenda", /(?:^|[/_.-])agenda(?:[/_.-]|$)/i],
+  ["schedules", /(?:^|[/_.-])schedules?(?:[/_.-]|$)/i],
+  ["reliability", /(?:^|[/_.-])reliability(?:[/_.-]|$)/i],
+];
+
+const CAUSE_RULES = [
+  [
+    "missing-storage-state",
+    /(?:storage.?state.*(?:missing|not found|enoent)|(?:missing|not found|enoent).*storage.?state|pw_storage_state)/i,
+  ],
+  [
+    "auth-mode-mismatch",
+    /(?:auth(?:entication)?.?mode.?mismatch|skip.?login|expected.*(?:sign.?in|signed.?out).*(?:not found|hidden)|(?:sign.?in|signed.?out).*expected)/i,
+  ],
+  [
+    "touch-target-size",
+    /(?:touch.?target|minimum (?:height|width)|(?:height|width).*(?:less than|received).*(?:44|48|64)|bounding.?box.*(?:height|width))/i,
+  ],
+  [
+    "unexpected-redirect",
+    /(?:unexpected(?:ly)? redirect|redirected to|expected (?:page )?url|tohaveurl)/i,
+  ],
+  [
+    "request-failure",
+    /(?:request failed|failed to fetch|net::err_|http (?:4|5)\d\d|response status (?:4|5)\d\d)/i,
+  ],
+  ["console-error", /(?:console[.: ]error|unexpected console error)/i],
+  ["page-error", /(?:pageerror|page error|uncaught (?:error|exception))/i],
+  [
+    "fixture-missing",
+    /(?:(?:missing|unavailable) fixture|fixture.*(?:missing|not found)|precondition.*failed)/i,
+  ],
+  [
+    "locator-not-found",
+    /(?:element\(s\) not found|locator.*(?:not found|waiting|visible)|waiting for (?:getby|locator)|getby\w+.*not found)/i,
+  ],
+  ["timeout", /(?:timed out|timeout of \d+ms|test timeout)/i],
+  [
+    "assertion-mismatch",
+    /(?:expect(?:ed)?|received|tobe|toequal|tohave(?:text|count|value|attribute))/i,
+  ],
+];
+
+function flattenSuites(suites = [], ancestors = []) {
   return suites.flatMap((suite) => [
-    ...(suite.specs ?? []).map((spec) => ({ ...spec, suiteTitle: suite.title ?? "" })),
-    ...flattenSuites(suite.suites ?? []),
+    ...(suite.specs ?? []).map((spec) => ({
+      ...spec,
+      suiteTitle: [...ancestors, suite.title].filter(Boolean).join(" > "),
+    })),
+    ...flattenSuites(
+      suite.suites ?? [],
+      [...ancestors, suite.title].filter(Boolean),
+    ),
   ]);
 }
 
@@ -18,9 +81,10 @@ function isFailedTest(test) {
   return test.status === "unexpected" || test.status === "failed";
 }
 
-function failureKey(spec, test) {
+export function failureKey(spec, test) {
   const file = spec.file ?? "unknown-file";
-  const title = [spec.suiteTitle, spec.title].filter(Boolean).join(" > ") || "unknown-test";
+  const title =
+    [spec.suiteTitle, spec.title].filter(Boolean).join(" > ") || "unknown-test";
   const identity = spec.id ?? title;
   const project = test.projectName ?? test.projectId ?? "unknown-project";
   return `${file}::${identity}::${project}`;
@@ -30,15 +94,145 @@ function increment(record, key) {
   record[key] = (record[key] ?? 0) + 1;
 }
 
+function countsFor(failures, field) {
+  const counts = {};
+  for (const failure of failures) increment(counts, failure[field]);
+  return counts;
+}
+
+function sameCounts(left, right) {
+  const leftEntries = Object.entries(left).sort(([a], [b]) =>
+    a.localeCompare(b),
+  );
+  const rightEntries = Object.entries(right).sort(([a], [b]) =>
+    a.localeCompare(b),
+  );
+  return JSON.stringify(leftEntries) === JSON.stringify(rightEntries);
+}
+
+function errorText(value) {
+  if (typeof value === "string") return value;
+  if (!value || typeof value !== "object") return "";
+  return [value.message, value.value, value.stack]
+    .filter((entry) => typeof entry === "string")
+    .join("\n");
+}
+
+function collectErrorText(test) {
+  const results = Array.isArray(test.results) ? test.results : [];
+  return [
+    errorText(test.error),
+    ...(Array.isArray(test.errors) ? test.errors.map(errorText) : []),
+    ...results.flatMap((result) => [
+      errorText(result?.error),
+      ...(Array.isArray(result?.errors) ? result.errors.map(errorText) : []),
+      ...(Array.isArray(result?.stderr) ? result.stderr.map(errorText) : []),
+    ]),
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+function summarizeError(test) {
+  const summary = collectErrorText(test)
+    .replace(/\u001B\[[0-?]*[ -/]*[@-~]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  return (summary || `Playwright status: ${test.status ?? "unknown"}`).slice(
+    0,
+    ERROR_SUMMARY_LIMIT,
+  );
+}
+
+export function classifyFeature(file = "") {
+  return (
+    FEATURE_RULES.find(([, pattern]) => pattern.test(file))?.[0] ?? UNCLASSIFIED
+  );
+}
+
+export function classifyCause({
+  file = "",
+  title = "",
+  errorSummary = "",
+} = {}) {
+  const observable = [file, title, errorSummary].filter(Boolean).join("\n");
+  return (
+    CAUSE_RULES.find(([, pattern]) => pattern.test(observable))?.[0] ??
+    UNCLASSIFIED
+  );
+}
+
+function classifyFailure(spec, test) {
+  const file = spec.file ?? "unknown-file";
+  const title =
+    [spec.suiteTitle, spec.title].filter(Boolean).join(" > ") || "unknown-test";
+  const project = test.projectName ?? test.projectId ?? "unknown-project";
+  const errorSummary = summarizeError(test);
+  return {
+    failureKey: failureKey(spec, test),
+    file,
+    title,
+    project,
+    feature: classifyFeature(file),
+    cause: classifyCause({ file, title, errorSummary }),
+    errorSummary,
+  };
+}
+
 export function validateAvailable(payload) {
+  if (payload.schemaVersion !== 2) {
+    throw new Error("Taxonomy schemaVersion must be 2");
+  }
   if (!Number.isInteger(payload.failed) || payload.failed < 0) {
     throw new Error("Taxonomy failed count must be a non-negative integer");
   }
-  if (!Array.isArray(payload.failureKeys) || payload.failureKeys.length !== payload.failed) {
-    throw new Error("Taxonomy failureKeys must contain one unique key per failed test");
+  if (
+    !Array.isArray(payload.failures) ||
+    payload.failures.length !== payload.failed
+  ) {
+    throw new Error(
+      "Taxonomy failures must contain one classification per failed test",
+    );
+  }
+  const classifiedKeys = payload.failures.map((failure) => failure?.failureKey);
+  if (
+    payload.failures.some(
+      (failure) =>
+        !failure ||
+        [
+          "failureKey",
+          "file",
+          "title",
+          "project",
+          "feature",
+          "cause",
+          "errorSummary",
+        ].some(
+          (field) =>
+            typeof failure[field] !== "string" || failure[field].length === 0,
+        ),
+    )
+  ) {
+    throw new Error(
+      "Taxonomy failures must contain complete string classifications",
+    );
+  }
+  if (new Set(classifiedKeys).size !== classifiedKeys.length) {
+    throw new Error("Taxonomy failure classifications must be unique");
+  }
+  if (
+    !Array.isArray(payload.failureKeys) ||
+    payload.failureKeys.length !== payload.failed
+  ) {
+    throw new Error(
+      "Taxonomy failureKeys must contain one unique key per failed test",
+    );
   }
   if (new Set(payload.failureKeys).size !== payload.failureKeys.length) {
     throw new Error("Taxonomy failureKeys must be unique");
+  }
+  if (payload.failureKeys.some((key, index) => key !== classifiedKeys[index])) {
+    throw new Error("Taxonomy failureKeys must be derived from failures");
   }
   for (const field of ["featureClassifications", "causeClassifications"]) {
     const value = payload[field];
@@ -53,6 +247,12 @@ export function validateAvailable(payload) {
     if (total !== payload.failed) {
       throw new Error(`Taxonomy ${field} total must equal failed`);
     }
+    const sourceField =
+      field === "featureClassifications" ? "feature" : "cause";
+    const derived = countsFor(payload.failures, sourceField);
+    if (!sameCounts(value, derived)) {
+      throw new Error(`Taxonomy ${field} must be derived from failures`);
+    }
   }
   return payload;
 }
@@ -62,35 +262,45 @@ export function classifyReport(report, metadata = {}) {
     throw new Error("Playwright JSON report must contain a suites array");
   }
 
-  const keys = [];
+  const failuresByKey = new Map();
   for (const spec of flattenSuites(report.suites)) {
     for (const test of spec.tests ?? []) {
-      if (isFailedTest(test)) keys.push(failureKey(spec, test));
+      if (!isFailedTest(test)) continue;
+      const failure = classifyFailure(spec, test);
+      const existing = failuresByKey.get(failure.failureKey);
+      if (!existing || existing.errorSummary.startsWith("Playwright status:")) {
+        failuresByKey.set(failure.failureKey, failure);
+      }
     }
   }
 
-  const failureKeys = [...new Set(keys)];
-  const failed = failureKeys.length;
+  const failures = [...failuresByKey.values()];
+  const featureClassifications = countsFor(failures, "feature");
+  const causeClassifications = countsFor(failures, "cause");
+  const failureKeys = failures.map((failure) => failure.failureKey);
+  const failed = failures.length;
   return validateAvailable({
-    schemaVersion: 1,
+    schemaVersion: 2,
     status: "available",
     generatedAt: new Date().toISOString(),
     metadata,
     failed,
-    featureClassifications: failed ? { [UNCLASSIFIED]: failed } : {},
-    causeClassifications: failed ? { [UNCLASSIFIED]: failed } : {},
+    failures,
+    featureClassifications,
+    causeClassifications,
     failureKeys,
   });
 }
 
 export function unavailablePayload(input, error, metadata = {}) {
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     status: "unavailable",
     generatedAt: new Date().toISOString(),
     metadata,
     input,
     failed: null,
+    failures: [],
     featureClassifications: {},
     causeClassifications: {},
     failureKeys: [],

--- a/tests/unit/generateDeepE2eTaxonomy.spec.ts
+++ b/tests/unit/generateDeepE2eTaxonomy.spec.ts
@@ -3,47 +3,122 @@ import { describe, expect, it } from "vitest";
 // @ts-expect-error The production entrypoint is a plain Node ESM diagnostic script.
 import * as taxonomyModule from "../../scripts/ci/generate-deep-e2e-taxonomy.mjs";
 
-const { classifyReport, readAndClassify, validateAvailable } = taxonomyModule;
+const {
+  classifyCause,
+  classifyFeature,
+  classifyReport,
+  readAndClassify,
+  validateAvailable,
+} = taxonomyModule;
 
 function reportWith(specs: unknown[]) {
   return { suites: [{ title: "deep", specs }] };
 }
 
-function failedTest(projectName = "chromium") {
-  return { status: "unexpected", projectName };
+function failedTest(error: string, projectName = "chromium") {
+  return {
+    status: "unexpected",
+    projectName,
+    results: [{ errors: [{ message: error }] }],
+  };
 }
 
 describe("Deep E2E taxonomy generation", () => {
   it("emits a valid zero-failure contract", () => {
     const taxonomy = classifyReport(reportWith([]));
     expect(taxonomy).toMatchObject({
+      schemaVersion: 2,
       status: "available",
       failed: 0,
+      failures: [],
       featureClassifications: {},
       causeClassifications: {},
       failureKeys: [],
     });
   });
 
-  it("records multiple mechanical failure keys and unclassified totals", () => {
+  it("classifies known feature paths and observable failure causes", () => {
     const taxonomy = classifyReport(
       reportWith([
         {
           file: "tests/e2e/users.spec.ts",
           title: "lists users",
-          tests: [failedTest()],
+          tests: [
+            failedTest(
+              "locator('[data-testid=user-row]'): element(s) not found",
+            ),
+          ],
         },
         {
           file: "tests/e2e/transport.spec.ts",
           title: "assigns transport",
-          tests: [failedTest()],
+          tests: [failedTest("Test timeout of 30000ms exceeded")],
         },
       ]),
     );
     expect(taxonomy.failed).toBe(2);
+    expect(taxonomy.failures).toEqual([
+      expect.objectContaining({
+        file: "tests/e2e/users.spec.ts",
+        feature: "users",
+        cause: "locator-not-found",
+      }),
+      expect.objectContaining({
+        file: "tests/e2e/transport.spec.ts",
+        feature: "transport",
+        cause: "timeout",
+      }),
+    ]);
     expect(taxonomy.failureKeys).toHaveLength(2);
-    expect(taxonomy.featureClassifications).toEqual({ unclassified: 2 });
-    expect(taxonomy.causeClassifications).toEqual({ unclassified: 2 });
+    expect(taxonomy.featureClassifications).toEqual({ users: 1, transport: 1 });
+    expect(taxonomy.causeClassifications).toEqual({
+      "locator-not-found": 1,
+      timeout: 1,
+    });
+    expect(
+      taxonomy.failures.filter(
+        (failure: { cause: string }) => failure.cause !== "unclassified",
+      ),
+    ).toHaveLength(2);
+  });
+
+  it.each([
+    ["tests/e2e/auth.spec.ts", "auth"],
+    ["tests/e2e/users.usability.spec.ts", "users"],
+    ["tests/e2e/transport.edit.spec.ts", "transport"],
+    ["tests/e2e/schedule.week.spec.ts", "schedules"],
+    ["tests/e2e/exception-center.spec.ts", "exception-center"],
+    ["tests/e2e/isp.print.spec.ts", "isp"],
+    ["tests/e2e/ui/touch-targets.spec.ts", "accessibility"],
+    ["tests/e2e/dashboard.spec.ts", "dashboard"],
+    ["tests/e2e/staff.spec.ts", "staff"],
+    ["tests/e2e/nurse.spec.ts", "nurse"],
+    ["tests/e2e/agenda.spec.ts", "agenda"],
+    ["tests/e2e/reliability/offline.spec.ts", "reliability"],
+  ])("classifies %s as %s", (file, feature) => {
+    expect(classifyFeature(file)).toBe(feature);
+  });
+
+  it.each([
+    ["ENOENT: storageState file was not found", "missing-storage-state"],
+    [
+      "skipLogin is enabled but expected signed out state",
+      "auth-mode-mismatch",
+    ],
+    ["locator('button'): element(s) not found", "locator-not-found"],
+    ["Test timeout of 30000ms exceeded", "timeout"],
+    ["Expected 2, received 3", "assertion-mismatch"],
+    ["Page unexpectedly redirected to /login", "unexpected-redirect"],
+    ["request failed: net::ERR_CONNECTION_REFUSED", "request-failure"],
+    ["unexpected console error: hydration failed", "console-error"],
+    ["pageerror: uncaught exception", "page-error"],
+    ["required fixture is missing", "fixture-missing"],
+    [
+      "touch target minimum height expected 64, received 51.5",
+      "touch-target-size",
+    ],
+  ])("classifies observable error %s as %s", (errorSummary, cause) => {
+    expect(classifyCause({ errorSummary })).toBe(cause);
   });
 
   it("counts a retried test once", () => {
@@ -53,16 +128,50 @@ describe("Deep E2E taxonomy generation", () => {
           file: "tests/e2e/example.spec.ts",
           title: "retries",
           tests: [
-            { status: "unexpected", projectName: "chromium", results: [{ retry: 0 }, { retry: 1 }] },
+            {
+              status: "unexpected",
+              projectName: "chromium",
+              results: [
+                {
+                  retry: 0,
+                  errors: [{ message: "Test timeout of 30000ms exceeded" }],
+                },
+                {
+                  retry: 1,
+                  errors: [{ message: "Test timeout of 30000ms exceeded" }],
+                },
+              ],
+            },
           ],
         },
       ]),
     );
     expect(taxonomy.failed).toBe(1);
+    expect(taxonomy.failures).toHaveLength(1);
+    expect(new Set(taxonomy.failureKeys).size).toBe(1);
+    expect(taxonomy.causeClassifications).toEqual({ timeout: 1 });
+  });
+
+  it("only leaves unknown input unclassified", () => {
+    const taxonomy = classifyReport(
+      reportWith([
+        {
+          file: "tests/e2e/unknown-area.spec.ts",
+          title: "does something novel",
+          tests: [failedTest("an entirely novel failure form")],
+        },
+      ]),
+    );
+    expect(taxonomy.failures[0]).toMatchObject({
+      feature: "unclassified",
+      cause: "unclassified",
+    });
   });
 
   it("reports missing input explicitly instead of returning an empty success", () => {
-    const taxonomy = readAndClassify("/tmp/does-not-exist-deep-e2e-results.json");
+    const taxonomy = readAndClassify(
+      "/tmp/does-not-exist-deep-e2e-results.json",
+    );
     expect(taxonomy.status).toBe("unavailable");
     expect(taxonomy.error).toMatch(/ENOENT/);
   });
@@ -80,11 +189,69 @@ describe("Deep E2E taxonomy generation", () => {
   it("rejects classification totals that do not equal failed", () => {
     expect(() =>
       validateAvailable({
+        schemaVersion: 2,
         failed: 1,
+        failures: [
+          {
+            failureKey: "one",
+            file: "tests/e2e/users.spec.ts",
+            title: "users",
+            project: "chromium",
+            feature: "users",
+            cause: "locator-not-found",
+            errorSummary: "not found",
+          },
+        ],
         featureClassifications: {},
-        causeClassifications: {},
+        causeClassifications: { "locator-not-found": 1 },
         failureKeys: ["one"],
       }),
     ).toThrow(/featureClassifications total must equal failed/);
+  });
+
+  it("rejects a compatibility failureKeys list that diverges from failures", () => {
+    expect(() =>
+      validateAvailable({
+        schemaVersion: 2,
+        failed: 1,
+        failures: [
+          {
+            failureKey: "one",
+            file: "tests/e2e/users.spec.ts",
+            title: "users",
+            project: "chromium",
+            feature: "users",
+            cause: "locator-not-found",
+            errorSummary: "not found",
+          },
+        ],
+        featureClassifications: { users: 1 },
+        causeClassifications: { "locator-not-found": 1 },
+        failureKeys: ["different"],
+      }),
+    ).toThrow(/derived from failures/);
+  });
+
+  it("rejects aggregates that do not match per-failure classifications", () => {
+    expect(() =>
+      validateAvailable({
+        schemaVersion: 2,
+        failed: 1,
+        failures: [
+          {
+            failureKey: "one",
+            file: "tests/e2e/users.spec.ts",
+            title: "users",
+            project: "chromium",
+            feature: "users",
+            cause: "locator-not-found",
+            errorSummary: "not found",
+          },
+        ],
+        featureClassifications: { transport: 1 },
+        causeClassifications: { "locator-not-found": 1 },
+        failureKeys: ["one"],
+      }),
+    ).toThrow(/featureClassifications must be derived from failures/);
   });
 });


### PR DESCRIPTION
## Summary

- make schema v2 per-failure classifications the source of truth
- classify known feature paths and observable failure forms
- derive feature and cause aggregates plus compatibility failureKeys from failures
- retain unclassified only for unknown paths or error forms
- validate unique keys, retry deduplication, complete records, and aggregate consistency

## Classification contract

Each failure records failureKey, file, title, project, feature, cause, and a normalized errorSummary. Causes describe observed failure forms, not inferred root causes.

Known features include auth, users, transport, schedules, exception-center, isp, accessibility, dashboard, staff, nurse, agenda, and reliability.

Known causes include missing-storage-state, auth-mode-mismatch, locator-not-found, timeout, assertion-mismatch, unexpected-redirect, request-failure, console-error, page-error, fixture-missing, and touch-target-size.

## Validation

- taxonomy unit contract: 33/33 passed
- npm run typecheck:full -- --pretty false: passed
- targeted lint: passed
- Prettier check: passed
- npm run test:ci:required: passed
- npm run build: passed
- git diff --check: passed
- real run 29572625268 results: schemaVersion 2, failed/failures/failureKeys all 42
- real run cause classifications: locator-not-found 38, assertion-mismatch 3, touch-target-size 1
- real run feature classifications: 32 known, 10 unknown left unclassified
- PR Deep artifact run 29574724155: schemaVersion 2, status available
- same-head Ready checks: pending 0 / failure 0 / CLEAN

## Scope

Two files only:

- scripts/ci/generate-deep-e2e-taxonomy.mjs
- tests/unit/generateDeepE2eTaxonomy.spec.ts