### PR TITLE
test(today): declare transport target mock state

### DIFF
--- a/src/features/today/hooks/__tests__/useTodayExceptions.spec.ts
+++ b/src/features/today/hooks/__tests__/useTodayExceptions.spec.ts
@@ -27,7 +27,7 @@ describe('useTodayExceptions - Signal Governance RBV', () => {
   it('admin ロールでは setup-incomplete シグナルが表示される', () => {
     vi.mocked(useExceptionDataSources).mockReturnValue({
       status: 'ready',
-      userSummaries: [{ userId: 'user-1', userName: 'User 1', isSupportProcedureTarget: false }],
+      userSummaries: [{ userId: 'user-1', userName: 'User 1', isSupportProcedureTarget: false, isTransportTarget: false }],
       expectedUsers: [],
       todayRecords: [],
       criticalHandoffs: [],
@@ -44,7 +44,7 @@ describe('useTodayExceptions - Signal Governance RBV', () => {
   it('staff ロールでは setup-incomplete シグナルが抑制される', () => {
     vi.mocked(useExceptionDataSources).mockReturnValue({
       status: 'ready',
-      userSummaries: [{ userId: 'user-1', userName: 'User 1', isSupportProcedureTarget: false }],
+      userSummaries: [{ userId: 'user-1', userName: 'User 1', isSupportProcedureTarget: false, isTransportTarget: false }],
       expectedUsers: [],
       todayRecords: [],
       criticalHandoffs: [],
@@ -61,7 +61,7 @@ describe('useTodayExceptions - Signal Governance RBV', () => {
   it('staff ロールでも missing-record (ownerRole: staff) は表示される', () => {
     vi.mocked(useExceptionDataSources).mockReturnValue({
       status: 'ready',
-      userSummaries: [{ userId: 'user-1', userName: 'User 1', isSupportProcedureTarget: true }],
+      userSummaries: [{ userId: 'user-1', userName: 'User 1', isSupportProcedureTarget: true, isTransportTarget: false }],
       expectedUsers: [{ userId: 'user-1', userName: 'User 1' }],
       todayRecords: [], // Case record missing
       criticalHandoffs: [],
@@ -82,7 +82,8 @@ describe('useTodayExceptions - Signal Governance RBV', () => {
         userId: 'user-1', 
         userName: 'User 1', 
         isHighIntensity: true, 
-        isSupportProcedureTarget: false 
+        isSupportProcedureTarget: false,
+        isTransportTarget: false,
       }],
       expectedUsers: [],
       todayRecords: [],


### PR DESCRIPTION
## Summary

- Declare `isTransportTarget: false` in Today exception hook test fixtures.
- Keep analysis setup signal tests isolated from the transport setup signal.

## Root cause

`UserSummary.isTransportTarget` is a required boolean in the exception-domain contract. The test fixtures omitted it, so the transport detector interpreted the mock user as a non-transport target and emitted a second `setup-incomplete` signal. Full-suite ordering then made the test select the transport signal instead of the analysis signal.

## Validation

- `npx vitest run src/features/today/hooks/__tests__/useTodayExceptions.spec.ts --pool=forks --maxWorkers=1 --reporter=verbose` — 4 passed
- `npm run test:ci` — 1151 files passed, 11508 tests passed, 1 skipped, 33 skipped tests, 1 todo
- `npm run typecheck:full -- --pretty false` — passed
- `npx eslint --max-warnings=0 src/features/today/hooks/__tests__/useTodayExceptions.spec.ts` — passed
- `git diff --check origin/main...HEAD` — passed

## Scope

- Test-only change in one file.
- No application code, schedule PR #2495, Transport commit `a0aa508ce`, #2494, Secret, or GitHub Environment changes.
