### PR TITLE
test(date): make local boundary timezone-independent

### DIFF
--- a/src/utils/__tests__/toLocalDateISO.spec.ts
+++ b/src/utils/__tests__/toLocalDateISO.spec.ts
@@ -25,11 +25,10 @@ describe('toLocalDateISO', () => {
     // In contrast, toISOString would give 2026-03-03 in JST timezone
   });
 
-  it('keeps the JST date key after midnight before the UTC date changes', () => {
-    const boundary = new Date('2026-07-18T00:30:00+09:00');
+  it('returns the local calendar date at a post-midnight boundary', () => {
+    const boundary = new Date(2026, 6, 18, 0, 30);
 
     expect(toLocalDateISO(boundary)).toBe('2026-07-18');
-    expect(boundary.toISOString().split('T')[0]).toBe('2026-07-17');
   });
 
   it('defaults to current date when no argument given', () => {


### PR DESCRIPTION
## Summary
- construct the local-date boundary with the runtime timezone instead of a fixed JST offset
- remove the UTC-date comparison from the generic local-date unit
- keep product code unchanged

## Root cause
The fixed instant `2026-07-18T00:30:00+09:00` is July 17 when the test process runs in UTC, while `toLocalDateISO` intentionally reads the process-local calendar fields. The test mixed a JST-specific instant with a runtime-local contract.

## Scope
- allowed file only: `src/utils/__tests__/toLocalDateISO.spec.ts`
- no product code or fixture changes

## Validation
- `TZ=UTC npx vitest run src/utils/__tests__/toLocalDateISO.spec.ts --reporter=verbose`: PASS (6)
- `TZ=Asia/Tokyo npx vitest run src/utils/__tests__/toLocalDateISO.spec.ts --reporter=verbose`: PASS (6)
- `npm run test:ci`: PASS (1151 files / 11509 tests)
- `npm run typecheck:full -- --pretty false`: PASS
- `npm run lint -- --max-warnings 0`: PASS
- `git diff --check`: PASS