### PR TITLE
fix(exceptions): connect corrective child rows

### DIFF
--- a/src/features/exceptions/hooks/useExceptionCenterOrchestrator.ts
+++ b/src/features/exceptions/hooks/useExceptionCenterOrchestrator.ts
@@ -9,6 +9,7 @@ import { useExceptionDataSources } from './useExceptionDataSources';
 import { useBridgeExceptions } from './useBridgeExceptions';
 import { useDailyRecordExceptions } from './useDailyRecordExceptions';
 import { useHandoffExceptions } from './useHandoffExceptions';
+import { useCorrectiveActionExceptions } from './useCorrectiveActionExceptions';
 import {
   detectAttentionUsers, 
   detectDataLayerExceptions,
@@ -20,8 +21,20 @@ import {
 import { buildExceptionCenterSummary } from '../domain/exceptionCenterSummary';
 import { useUsersQuery } from '@/features/users/hooks/useUsersQuery';
 import type { IUserMaster } from '@/features/users/types';
+import type {
+  ActionSuggestion,
+  ActionSuggestionState,
+} from '@/features/action-engine/domain/types';
 
-export function useExceptionCenterOrchestrator() {
+export interface UseExceptionCenterOrchestratorOptions {
+  correctiveSuggestions?: ActionSuggestion[];
+  correctiveStates?: Record<string, ActionSuggestionState>;
+}
+
+export function useExceptionCenterOrchestrator({
+  correctiveSuggestions = [],
+  correctiveStates = {},
+}: UseExceptionCenterOrchestratorOptions = {}) {
   const dataSources = useExceptionDataSources();
   const bridge = useBridgeExceptions();
   const { data: users = [] } = useUsersQuery();
@@ -33,6 +46,10 @@ export function useExceptionCenterOrchestrator() {
   });
   const { items: handoffItems } = useHandoffExceptions({
     handoffs: dataSources.criticalHandoffs,
+  });
+  const { items: correctiveActionItems } = useCorrectiveActionExceptions({
+    suggestions: correctiveSuggestions,
+    states: correctiveStates,
   });
 
   const allExceptions = useMemo(() => {
@@ -51,13 +68,21 @@ export function useExceptionCenterOrchestrator() {
     return aggregateExceptions(
       dailyRecordItems,
       handoffItems,
+      correctiveActionItems,
       attentionUsers,
       dataOSItems,
       bridgeItems,
       setupIncomplete,
       transportSetup
     );
-  }, [dataSources, bridge.exceptions, users, dailyRecordItems, handoffItems]);
+  }, [
+    dataSources,
+    bridge.exceptions,
+    users,
+    dailyRecordItems,
+    handoffItems,
+    correctiveActionItems,
+  ]);
 
   // SSOT サマリの構築
   const summary = useMemo(() => buildExceptionCenterSummary(allExceptions), [allExceptions]);

--- a/src/pages/admin/ExceptionCenterPage.tsx
+++ b/src/pages/admin/ExceptionCenterPage.tsx
@@ -41,9 +41,13 @@ const SEVERITY_COLORS: Record<ExceptionSeverity, 'error' | 'warning' | 'primary'
 };
 
 export const ExceptionCenterPage: React.FC = () => {
-  const { items, summary, isLoading, error } = useExceptionCenterOrchestrator();
-  const { activeEscalations } = useEscalationEvaluation(items, summary);
   const { suggestions } = useAllCorrectiveActions();
+  const suggestionStates = useSuggestionStateStore((s) => s.states);
+  const { items, summary, isLoading, error } = useExceptionCenterOrchestrator({
+    correctiveSuggestions: suggestions,
+    correctiveStates: suggestionStates,
+  });
+  const { activeEscalations } = useEscalationEvaluation(items, summary);
   const dismissSuggestion = useSuggestionStateStore((s) => s.dismiss);
   const snoozeSuggestion = useSuggestionStateStore((s) => s.snooze);
 

--- a/tests/unit/pages/ExceptionCenterPage.suggestionTelemetry.spec.tsx
+++ b/tests/unit/pages/ExceptionCenterPage.suggestionTelemetry.spec.tsx
@@ -3,6 +3,7 @@ import { renderWithProviders } from '../_helpers/renderWithProviders';
 import ExceptionCenterPage from '../../../src/pages/admin/ExceptionCenterPage';
 import { ExceptionTable } from '../../../src/features/exceptions/components/ExceptionTable';
 import type { ActionSuggestion } from '../../../src/features/action-engine/domain/types';
+import { useCorrectiveActionExceptions } from '../../../src/features/exceptions/hooks/useCorrectiveActionExceptions';
 
 const mockNavigate = vi.fn();
 vi.mock('react-router-dom', async (importOriginal) => {
@@ -33,7 +34,19 @@ vi.mock('../../../src/features/exceptions/hooks/useCorrectiveActionExceptions', 
   useCorrectiveActionExceptions: vi.fn(() => ({
     items: [
       {
+        id: 'corrective-user-user-001',
+        category: 'corrective-action',
+        severity: 'high',
+        title: '利用者Aの改善提案',
+        description: '1件の提案があります。',
+        targetUser: '利用者A',
+        targetUserId: 'user-001',
+        targetDate: '2026-03-21',
+        updatedAt: '2026-03-21T09:00:00Z',
+      },
+      {
         id: `ae:${stableId}`,
+        parentId: 'corrective-user-user-001',
         category: 'corrective-action',
         severity: 'high',
         title: '改善提案',
@@ -207,7 +220,18 @@ describe('ExceptionCenterPage suggestion telemetry', () => {
         id: 'handoff-handoff-001',
         parentId: 'handoff-user-user-002',
       }),
+      expect.objectContaining({
+        id: 'corrective-user-user-001',
+      }),
+      expect.objectContaining({
+        id: `ae:${stableId}`,
+        parentId: 'corrective-user-user-001',
+      }),
     ]));
+    expect(vi.mocked(useCorrectiveActionExceptions)).toHaveBeenCalledWith({
+      suggestions: [suggestion],
+      states: {},
+    });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const actions = (props.suggestionActions as any);
 


### PR DESCRIPTION
## Summary

Exception CenterへCorrective Actionのparent／child rowsを接続します。

## Root cause

Pageはcorrective suggestionsとsuggestion stateを保持していましたが、`useExceptionCenterOrchestrator`へ渡しておらず、既存`useCorrectiveActionExceptions`の出力が`aggregateExceptions`へ入っていませんでした。

## Changes

- Pageからsuggestions／statesをorchestratorへ渡す
- Corrective parent／child itemsを既存例外群へ集約する
- Page unitで入力契約とparent／child描画契約を固定する

## Validation

- Corrective hook + Page telemetry unit: 3 passed
- typecheck: PASS
- lint: PASS
- diff-check: PASS
- target Corrective E2E: parent／child locatorを通過し、既知の表示名assertion（line 116）まで前進

A2b-1の進行証拠PRとして、E2E specとfixtureは変更しません。