### PR TITLE
fix(exceptions): isolate corrective display parents from escalation

### DIFF
--- a/src/features/exceptions/hooks/useExceptionCenterOrchestrator.ts
+++ b/src/features/exceptions/hooks/useExceptionCenterOrchestrator.ts
@@ -84,11 +84,22 @@ export function useExceptionCenterOrchestrator({
     correctiveActionItems,
   ]);
 
+  const evaluationItems = useMemo(
+    () => allExceptions.filter(
+      (item) => item.category !== 'corrective-action' || Boolean(item.stableId),
+    ),
+    [allExceptions],
+  );
+
   // SSOT サマリの構築
-  const summary = useMemo(() => buildExceptionCenterSummary(allExceptions), [allExceptions]);
+  const summary = useMemo(
+    () => buildExceptionCenterSummary(evaluationItems),
+    [evaluationItems],
+  );
 
   return {
     items: allExceptions,
+    evaluationItems,
     summary,
     isLoading: dataSources.status === 'loading' || bridge.isLoading,
     error: dataSources.error,

--- a/src/pages/admin/ExceptionCenterPage.tsx
+++ b/src/pages/admin/ExceptionCenterPage.tsx
@@ -43,11 +43,11 @@ const SEVERITY_COLORS: Record<ExceptionSeverity, 'error' | 'warning' | 'primary'
 export const ExceptionCenterPage: React.FC = () => {
   const { suggestions } = useAllCorrectiveActions();
   const suggestionStates = useSuggestionStateStore((s) => s.states);
-  const { items, summary, isLoading, error } = useExceptionCenterOrchestrator({
+  const { items, evaluationItems, summary, isLoading, error } = useExceptionCenterOrchestrator({
     correctiveSuggestions: suggestions,
     correctiveStates: suggestionStates,
   });
-  const { activeEscalations } = useEscalationEvaluation(items, summary);
+  const { activeEscalations } = useEscalationEvaluation(evaluationItems, summary);
   const dismissSuggestion = useSuggestionStateStore((s) => s.dismiss);
   const snoozeSuggestion = useSuggestionStateStore((s) => s.snooze);
 

--- a/tests/unit/pages/ExceptionCenterPage.suggestionTelemetry.spec.tsx
+++ b/tests/unit/pages/ExceptionCenterPage.suggestionTelemetry.spec.tsx
@@ -1,9 +1,11 @@
-import { act } from '@testing-library/react';
+import { act, screen, within } from '@testing-library/react';
 import { renderWithProviders } from '../_helpers/renderWithProviders';
 import ExceptionCenterPage from '../../../src/pages/admin/ExceptionCenterPage';
 import { ExceptionTable } from '../../../src/features/exceptions/components/ExceptionTable';
 import type { ActionSuggestion } from '../../../src/features/action-engine/domain/types';
+import type { ExceptionItem } from '../../../src/features/exceptions/domain/exceptionLogic';
 import { useCorrectiveActionExceptions } from '../../../src/features/exceptions/hooks/useCorrectiveActionExceptions';
+import type { EscalatedException } from '../../../src/features/exceptions/hooks/useEscalationEvaluation';
 
 const mockNavigate = vi.fn();
 vi.mock('react-router-dom', async (importOriginal) => {
@@ -30,96 +32,105 @@ vi.mock('../../../src/features/exceptions/hooks/useExceptionDataSources', () => 
 
 const stableId = 'behavior-trend-increase:user-001:2026-W12';
 
+const defaultCorrectiveItems: ExceptionItem[] = [
+  {
+    id: 'corrective-user-user-001',
+    category: 'corrective-action',
+    severity: 'high',
+    title: '利用者Aの改善提案',
+    description: '1件の提案があります。',
+    targetUser: '利用者A',
+    targetUserId: 'user-001',
+    targetDate: '2026-03-21',
+    updatedAt: '2026-03-21T09:00:00Z',
+  },
+  {
+    id: `ae:${stableId}`,
+    parentId: 'corrective-user-user-001',
+    category: 'corrective-action',
+    severity: 'high',
+    title: '改善提案',
+    description: '根拠',
+    targetUserId: 'user-001',
+    targetDate: '2026-03-21',
+    updatedAt: '2026-03-21T09:00:00Z',
+    actionPath: '/assessment',
+    actionLabel: '確認',
+    stableId,
+  },
+];
+let mockCorrectiveItems = defaultCorrectiveItems;
+
 vi.mock('../../../src/features/exceptions/hooks/useCorrectiveActionExceptions', () => ({
   useCorrectiveActionExceptions: vi.fn(() => ({
-    items: [
-      {
-        id: 'corrective-user-user-001',
-        category: 'corrective-action',
-        severity: 'high',
-        title: '利用者Aの改善提案',
-        description: '1件の提案があります。',
-        targetUser: '利用者A',
-        targetUserId: 'user-001',
-        targetDate: '2026-03-21',
-        updatedAt: '2026-03-21T09:00:00Z',
-      },
-      {
-        id: `ae:${stableId}`,
-        parentId: 'corrective-user-user-001',
-        category: 'corrective-action',
-        severity: 'high',
-        title: '改善提案',
-        description: '根拠',
-        targetUserId: 'user-001',
-        targetDate: '2026-03-21',
-        updatedAt: '2026-03-21T09:00:00Z',
-        actionPath: '/assessment',
-        actionLabel: '確認',
-        stableId,
-      },
-    ],
-    count: 1,
+    items: mockCorrectiveItems,
+    count: mockCorrectiveItems.filter((item) => Boolean(item.stableId)).length,
   })),
 }));
+
+const defaultHandoffItems: ExceptionItem[] = [
+  {
+    id: 'handoff-user-user-002',
+    category: 'critical-handoff',
+    severity: 'critical',
+    title: '利用者Bの重要申し送り',
+    description: '1件の未完了申し送りがあります。',
+    targetUser: '利用者B',
+    targetUserId: 'user-002',
+    targetDate: '2026-03-21',
+    updatedAt: '2026-03-21T09:00:00Z',
+  },
+  {
+    id: 'handoff-handoff-001',
+    parentId: 'handoff-user-user-002',
+    category: 'critical-handoff',
+    severity: 'critical',
+    title: '利用者Bの重要申し送り（未対応）',
+    description: '要確認',
+    targetUser: '利用者B',
+    targetUserId: 'user-002',
+    targetDate: '2026-03-21',
+    updatedAt: '2026-03-21T09:00:00Z',
+  },
+];
+let mockHandoffItems = defaultHandoffItems;
 
 vi.mock('../../../src/features/exceptions/hooks/useHandoffExceptions', () => ({
   useHandoffExceptions: vi.fn(() => ({
-    items: [
-      {
-        id: 'handoff-user-user-002',
-        category: 'critical-handoff',
-        severity: 'critical',
-        title: '利用者Bの重要申し送り',
-        description: '1件の未完了申し送りがあります。',
-        targetUser: '利用者B',
-        targetUserId: 'user-002',
-        targetDate: '2026-03-21',
-        updatedAt: '2026-03-21T09:00:00Z',
-      },
-      {
-        id: 'handoff-handoff-001',
-        parentId: 'handoff-user-user-002',
-        category: 'critical-handoff',
-        severity: 'critical',
-        title: '利用者Bの重要申し送り（未対応）',
-        description: '要確認',
-        targetUser: '利用者B',
-        targetUserId: 'user-002',
-        targetDate: '2026-03-21',
-        updatedAt: '2026-03-21T09:00:00Z',
-      },
-    ],
-    count: 1,
+    items: mockHandoffItems,
+    count: mockHandoffItems.filter((item) => Boolean(item.parentId)).length,
   })),
 }));
 
+const defaultDailyRecordItems: ExceptionItem[] = [
+  {
+    id: 'daily-missing-record-2026-03-21',
+    category: 'missing-record',
+    severity: 'high',
+    title: '2026-03-21 の日々の記録未作成',
+    description: '1名の日々の記録が未作成です。',
+    targetDate: '2026-03-21',
+    updatedAt: '2026-03-21',
+  },
+  {
+    id: 'missing-record-user-001-2026-03-21',
+    parentId: 'daily-missing-record-2026-03-21',
+    category: 'missing-record',
+    severity: 'high',
+    title: '利用者Aの日々の記録が未作成',
+    description: '日々の記録を作成してください。',
+    targetUser: '利用者A',
+    targetUserId: 'user-001',
+    targetDate: '2026-03-21',
+    updatedAt: '2026-03-21',
+  },
+];
+let mockDailyRecordItems = defaultDailyRecordItems;
+
 vi.mock('../../../src/features/exceptions/hooks/useDailyRecordExceptions', () => ({
   useDailyRecordExceptions: vi.fn(() => ({
-    items: [
-      {
-        id: 'daily-missing-record-2026-03-21',
-        category: 'missing-record',
-        severity: 'high',
-        title: '2026-03-21 の日々の記録未作成',
-        description: '1名の日々の記録が未作成です。',
-        targetDate: '2026-03-21',
-        updatedAt: '2026-03-21',
-      },
-      {
-        id: 'missing-record-user-001-2026-03-21',
-        parentId: 'daily-missing-record-2026-03-21',
-        category: 'missing-record',
-        severity: 'high',
-        title: '利用者Aの日々の記録が未作成',
-        description: '日々の記録を作成してください。',
-        targetUser: '利用者A',
-        targetUserId: 'user-001',
-        targetDate: '2026-03-21',
-        updatedAt: '2026-03-21',
-      },
-    ],
-    count: 1,
+    items: mockDailyRecordItems,
+    count: mockDailyRecordItems.filter((item) => Boolean(item.parentId)).length,
   })),
 }));
 
@@ -132,6 +143,15 @@ vi.mock('../../../src/features/exceptions/hooks/useTransportExceptions', () => (
 
 vi.mock('../../../src/features/exceptions/components/ExceptionTable', () => ({
   ExceptionTable: vi.fn(() => <div data-testid="exception-table" />),
+}));
+
+const mockUseNotificationDispatcher = vi.fn((_activeEscalations: EscalatedException[]) => ({
+  dispatchNotifications: vi.fn(),
+  historyCount: 0,
+}));
+vi.mock('../../../src/features/exceptions/hooks/useNotificationDispatcher', () => ({
+  useNotificationDispatcher: (activeEscalations: EscalatedException[]) =>
+    mockUseNotificationDispatcher(activeEscalations),
 }));
 
 const mockDismissSuggestion = vi.fn();
@@ -172,6 +192,9 @@ describe('ExceptionCenterPage suggestion telemetry', () => {
     vi.setSystemTime(new Date('2026-03-21T10:00:00Z'));
     vi.clearAllMocks();
     mockAllSuggestions = [];
+    mockCorrectiveItems = defaultCorrectiveItems;
+    mockHandoffItems = defaultHandoffItems;
+    mockDailyRecordItems = defaultDailyRecordItems;
   });
 
   afterEach(() => {
@@ -232,6 +255,9 @@ describe('ExceptionCenterPage suggestion telemetry', () => {
       suggestions: [suggestion],
       states: {},
     });
+    expect(
+      within(screen.getByText('未解消例外 合計').parentElement as HTMLElement).getByText('5'),
+    ).toBeInTheDocument();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const actions = (props.suggestionActions as any);
 
@@ -272,5 +298,110 @@ describe('ExceptionCenterPage suggestion telemetry', () => {
       expect.any(String),
       { by: 'exception-center' },
     );
+  });
+
+  it('Corrective P2 child 2件はparentを表示しつつsummary・escalation・notificationから除外する', async () => {
+    mockDailyRecordItems = [];
+    mockHandoffItems = [];
+    mockCorrectiveItems = [
+      {
+        id: 'corrective-user-user-003',
+        category: 'corrective-action',
+        severity: 'medium',
+        title: '利用者Cの改善提案',
+        description: '2件の提案があります。',
+        targetUser: '利用者C',
+        targetUserId: 'user-003',
+        targetDate: '2026-03-21',
+        updatedAt: '2026-03-21T10:00:00Z',
+      },
+      {
+        id: 'ae:p2-1',
+        parentId: 'corrective-user-user-003',
+        category: 'corrective-action',
+        severity: 'medium',
+        title: '改善提案1',
+        description: '根拠1',
+        targetUser: '利用者C',
+        targetUserId: 'user-003',
+        targetDate: '2026-03-21',
+        updatedAt: '2026-03-21T10:00:00Z',
+        stableId: 'p2-1',
+      },
+      {
+        id: 'ae:p2-2',
+        parentId: 'corrective-user-user-003',
+        category: 'corrective-action',
+        severity: 'medium',
+        title: '改善提案2',
+        description: '根拠2',
+        targetUser: '利用者C',
+        targetUserId: 'user-003',
+        targetDate: '2026-03-21',
+        updatedAt: '2026-03-21T10:00:00Z',
+        stableId: 'p2-2',
+      },
+    ];
+
+    await act(async () => {
+      renderWithProviders(<ExceptionCenterPage />);
+    });
+
+    const tableProps = vi.mocked(ExceptionTable).mock.lastCall?.[0];
+    expect(tableProps?.items).toHaveLength(3);
+    expect(
+      within(screen.getByText('未解消例外 合計').parentElement as HTMLElement).getByText('2'),
+    ).toBeInTheDocument();
+    expect(mockUseNotificationDispatcher).toHaveBeenLastCalledWith([]);
+    expect(screen.queryByText('⚠️ リーダー警告')).not.toBeInTheDocument();
+  });
+
+  it('Corrective P0 child 1件だけをnotification対象にし、parentを重複配送しない', async () => {
+    mockDailyRecordItems = [];
+    mockHandoffItems = [];
+    mockCorrectiveItems = [
+      {
+        id: 'corrective-user-user-004',
+        category: 'corrective-action',
+        severity: 'critical',
+        title: '利用者Dの改善提案',
+        description: '1件の提案があります。',
+        targetUser: '利用者D',
+        targetUserId: 'user-004',
+        targetDate: '2026-03-21',
+        updatedAt: '2026-03-21T10:00:00Z',
+      },
+      {
+        id: 'ae:p0-1',
+        parentId: 'corrective-user-user-004',
+        category: 'corrective-action',
+        severity: 'critical',
+        title: '即時対応提案',
+        description: '重大な根拠',
+        targetUser: '利用者D',
+        targetUserId: 'user-004',
+        targetDate: '2026-03-21',
+        updatedAt: '2026-03-21T10:00:00Z',
+        stableId: 'p0-1',
+      },
+    ];
+
+    await act(async () => {
+      renderWithProviders(<ExceptionCenterPage />);
+    });
+
+    const tableProps = vi.mocked(ExceptionTable).mock.lastCall?.[0];
+    expect(tableProps?.items).toHaveLength(2);
+    expect(
+      within(screen.getByText('未解消例外 合計').parentElement as HTMLElement).getByText('1'),
+    ).toBeInTheDocument();
+
+    const activeEscalations = mockUseNotificationDispatcher.mock.lastCall?.[0] ?? [];
+    expect(activeEscalations).toHaveLength(1);
+    expect(activeEscalations[0]?.item).toMatchObject({
+      id: 'ae:p0-1',
+      stableId: 'p0-1',
+    });
+    expect(activeEscalations.some(({ item }) => item.id === 'corrective-user-user-004')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- keep Corrective display parents in `items` for `ExceptionTable`
- add `evaluationItems` containing only Corrective children with `stableId`
- build summary, escalation, and notification inputs from `evaluationItems`
- preserve the existing parent/child contracts for Daily, Handoff, and other categories

## Root cause

Corrective display-only parents were included in summary and escalation inputs. Two P2 children plus their parent could be counted as a cluster of three, and a P0 parent could be notified alongside its actionable child.

## Current base / scope

- base: `f3427620d9138b166b5bce672336c06bc00465b2`
- head: `1973036f6f60ae9a84a23a649b6dd41cb94a9418`
- changed files: 3 allowed files only
- no workflow, E2E spec, `DEMO_USERS`, or fixture changes

## Product and local verification

- targeted unit: 3 passed
  - P2: display items 3, summary 2, warning escalation 0, notification parent 0
  - P0: display items 2, summary 1, notification child only
- `npm run test:ci`: PASS
- Deep lane node tests: 2 suites / 5 tests PASS via `node --test`
- `npm run typecheck:full -- --pretty false`: PASS
- `npm run lint -- --max-warnings 0`: PASS
- `git diff --check origin/main...HEAD`: PASS

## CI

- `quality_extended`: SUCCESS
- regular PR CI: failure/cancelled/timed_out 0
- Handoff read-only reproduction on fixture-memory runtime: 10/10 PASS, retries 0; no speculative fix created
- PR-event Deep run: `29670381812`

## Formal Deep gate

Run: `29671138176`

- baseline: 34
- PR: 34
- resolved: 0
- new: 0
- common: 34
- true flaky: 0
- did not run: 0
- Integration: PASS
- ownership: 189 / 189
- JUnit identities: 331 / 331
- duplicate spec/test: 0 / 0
- taxonomy: schema v2 / available / exact head
- bootstrap: normal; only the expected 3 sp-stub request failures

This PR is Ready for review. It is not configured for auto-merge and must not be merged automatically.