### PR TITLE
test(e2e): stabilize handoff page heading locator

### DIFF
--- a/tests/e2e/exception-center.handoff-child-flow.spec.ts
+++ b/tests/e2e/exception-center.handoff-child-flow.spec.ts
@@ -115,7 +115,13 @@ test.describe('ExceptionCenter handoff child flow', () => {
     // 3) child CTA で handoff deep link に遷移する
     await page.getByTestId('corrective-primary-handoff-701').click();
     await expect(page).toHaveURL(/\/handoff-timeline\?range=day&date=\d{4}-\d{2}-\d{2}&handoffId=701/);
-    await expect(page.getByText('申し送りタイムライン')).toBeVisible();
+    await expect(
+      page.getByRole('heading', {
+        name: '申し送りタイムライン',
+        level: 1,
+        exact: true,
+      }),
+    ).toBeVisible();
 
     // URL handoffId により対象カードが先頭表示される（highlight order）
     const firstItem = page.locator('[data-testid="agenda-timeline-item"]').first();


### PR DESCRIPTION
## Summary

- scopes the Handoff timeline landing assertion to the unique level-1 page heading
- removes the strict-mode ambiguity between the side navigation label and the loading status text
- changes only `tests/e2e/exception-center.handoff-child-flow.spec.ts`

## Root cause

`getByText('申し送りタイムライン')` can match both the side navigation item and the page loading status. During a timing window Playwright sees two matches and raises a strict-mode violation, although the product navigation succeeds.

## Impact

This is a test-only locator correction. Product code, fixtures, retries, workflow configuration, and navigation behavior are unchanged.

## Validation

- fixture-memory production-preview runtime, Chromium, workers=1, retries=0, repeat-each=20: 20/20 passed
- target test continues to verify the first highlighted Handoff card and `range` / `date` / `handoffId` query parameters
- `npm run typecheck:full -- --pretty false`: passed
- `npm run lint -- --max-warnings 0`: passed
- `git diff --check`: passed
- PR CI: quality, quality_extended, canary, and all non-Deep checks passed
- PR-event Deep `29676620749`: 34 persistent failures, new 0, true flaky 0, union audit passed
- formal Deep `29677467110`: Integration passed; 34 persistent failures, resolved 0, new 0, common 34, true flaky 0, did-not-run 0
- formal evidence: ownership 189/189, JUnit 331/331, duplicate spec/test 0/0, taxonomy schema v2 with exact head `a1c7a44cddee184fe123d7a33ea3431adde3f7f7`, bootstrap validation passed