### PR TITLE
test(e2e): align corrective child display names

### DIFF
--- a/tests/e2e/exception-center.corrective-child-flow.spec.ts
+++ b/tests/e2e/exception-center.corrective-child-flow.spec.ts
@@ -113,8 +113,8 @@ test.describe('ExceptionCenter corrective child flow', () => {
 
     // 4) grouped/flat で二重集約されない（U-001 は child 2件）
     await page.getByTestId('exception-mode-grouped').click();
-    await expect(page.getByTestId('exception-row-ae:ca-s1').getByText('田中 太郎 の例外 (2件)')).toBeVisible();
-    await expect(page.getByTestId('exception-row-ae:ca-s3').getByText('佐藤 花子 の例外 (1件)')).toBeVisible();
+    await expect(page.getByTestId('exception-row-ae:ca-s1').getByText('桂川 進太朗 の例外 (2件)')).toBeVisible();
+    await expect(page.getByTestId('exception-row-ae:ca-s3').getByText('田中 太郎 の例外 (1件)')).toBeVisible();
     await expect(page.getByText('田中 太郎 の改善提案')).toHaveCount(0);
     await page.getByTestId('exception-mode-flat').click();
 


### PR DESCRIPTION
## Summary
- align Corrective child-flow grouped display-name expectations with the `DEMO_USERS` SSOT
- update U-001 to `桂川 進太朗`
- update U-005 to `田中 太郎`

## Root cause
The E2E spec still expected historical display names while the fixture seed supplies user IDs and the runtime resolves names from `DEMO_USERS`.

## Scope
- test-only
- one E2E spec
- two expectation replacements
- no product, fixture, locator, wait, menu, workflow, or retry changes

## Validation
- grouped display-name assertions: PASS in fixture-memory production-preview runtime
- flat return, CTA navigation, and Exception Center re-entry: PASS
- first stopping point: known separate cluster A2b-2d-6 at the `明日まで` role locator
- `npm run typecheck:full -- --pretty false`: PASS
- `npm run lint -- --max-warnings 0`: PASS
- `git diff --check`: PASS

A2b-2d-6 remains excluded from this PR.