### PR TITLE
fix(action-engine): keep dismiss snooze menu accessible

### DIFF
--- a/src/features/action-engine/components/DismissSnoozeMenu.tsx
+++ b/src/features/action-engine/components/DismissSnoozeMenu.tsx
@@ -64,7 +64,6 @@ export function DismissSnoozeMenu({
         open={isOpen}
         onClose={closeMenu}
         onClick={(e) => e.stopPropagation()}
-        disablePortal
       >
         <MenuItem
           onClick={() => {

--- a/src/features/exceptions/components/__tests__/ExceptionTable.spec.tsx
+++ b/src/features/exceptions/components/__tests__/ExceptionTable.spec.tsx
@@ -299,8 +299,9 @@ describe('ExceptionTable', () => {
       fireEvent.click(screen.getByTestId('suggestion-menu-button-ae-2'));
     });
     await act(async () => {
-      fireEvent.click(await screen.findByText('明日まで'));
+      fireEvent.click(await screen.findByRole('menuitem', { name: '明日まで' }));
     });
+    expect(onSnooze).toHaveBeenCalledTimes(1);
     expect(onSnooze).toHaveBeenCalledWith('stable-2', 'tomorrow');
   });
 });


### PR DESCRIPTION
## Summary

- remove `disablePortal` from `DismissSnoozeMenu` so the MUI menu remains outside the `aria-hidden` app root
- verify the `明日まで` action through its `menuitem` role
- fix the exactly-once `onSnooze(stableId, 'tomorrow')` contract

## Scope

A2b-2d-6 only. Two allowed files:

- `src/features/action-engine/components/DismissSnoozeMenu.tsx`
- `src/features/exceptions/components/__tests__/ExceptionTable.spec.tsx`

No display-name, E2E spec, fixture, workflow, timeout, retry, or production deployment changes.

## Local verification

- target unit: 8 passed
- target fixture-memory Chromium E2E: 20/20 passed (`workers=1`, `retries=0`, `trace=retain-on-failure`)
- `npm run test:ci`: PASS (Vitest 11511 passed; node:test 5 passed)
- `npm run typecheck:full -- --pretty false`: PASS
- `npm run lint -- --max-warnings 0`: PASS
- `git diff --check`: PASS