### PR TITLE
test(users): align furigana expectation with demo fixture

### DIFF
--- a/tests/e2e/users-basic-edit-flow.spec.ts
+++ b/tests/e2e/users-basic-edit-flow.spec.ts
@@ -47,7 +47,7 @@ test.describe('users basic info edit flow', () => {
       .locator('dt', { hasText: 'ふりがな' })
       .first()
       .locator('xpath=following-sibling::*[1]');
-    await expect(furiganaValue).toHaveText('未登録');
+    await expect(furiganaValue).toHaveText('たなか たろう');
 
     const editButton = targetRow.locator('[aria-label="編集"]');
     await scrollAndClick(editButton, page, { testInfo, label: 'users-edit-btn' });


### PR DESCRIPTION
## Summary

- Align the initial furigana expectation for `田中 太郎` with the `DEMO_USERS` SSOT.
- Keep the edited value assertion (`たなか たろう（編集済み）`) unchanged.
- Limit the change to one assertion in `tests/e2e/users-basic-edit-flow.spec.ts`.

## Root cause

The E2E expected the selected demo user’s furigana to be unregistered, but `田中 太郎` is `U-005` and has `たなか たろう` in the demo fixture.

## Local validation

- Initial furigana assertion: PASS in fixture-memory production preview
- The scenario then reaches the independently tracked A3b failure: the edit form remains mounted after the successful save notification
- `npm run typecheck:full -- --pretty false`: PASS
- `npm run lint -- --max-warnings 0`: PASS
- `git diff --check`: PASS

## Formal Deep

Exact head: `59d22f50a8495c8b58611dc92550cb2c982e25d9`
Run: `29707907093`

- baseline / PR: `33 / 33`
- resolved / new / common: `0 / 0 / 33`
- true flaky: `0`
- did not run: `0`
- Integration Scenarios: PASS
- ownership: `189 / 189`
- JUnit identities: `331 / 331`
- duplicate spec/test: `0 / 0`
- taxonomy: schema v2, available, exact head
- bootstrap/setup failures: none

The `users-basic-edit-flow` failure key remains as expected because A3b is intentionally separate.

## Scope separation

This PR intentionally does not include the A3b product fix for update-success callback propagation. No product code, fixture, retry, timeout, or wait behavior is changed.