### PR TITLE
fix: diagnose Firebase custom token auth failures

### DIFF
--- a/src/__tests__/worker.spec.ts
+++ b/src/__tests__/worker.spec.ts
@@ -13,6 +13,15 @@ describe('Cloudflare Worker - SharePoint Proxy', () => {
     vi.unstubAllGlobals();
   });
 
+  const encodeJwtSegment = (value: unknown): string =>
+    Buffer.from(JSON.stringify(value)).toString('base64url');
+
+  const validGraphToken = (): string =>
+    `${encodeJwtSegment({ alg: 'none', typ: 'JWT' })}.${encodeJwtSegment({ tid: 'tenant-1', oid: 'oid-1' })}.signature`;
+
+  const decodeJwtPayload = (token: string): Record<string, unknown> =>
+    JSON.parse(Buffer.from(token.split('.')[1]!, 'base64url').toString('utf8')) as Record<string, unknown>;
+
   it('returns 204 for OPTIONS request without auth', async () => {
     const request = new Request('https://app.example/api/sp-proxy', {
       method: 'OPTIONS',
@@ -156,5 +165,98 @@ describe('Cloudflare Worker - SharePoint Proxy', () => {
     expect(response.headers.get('Content-Type')).toBe('application/json');
     expect(response.headers.get('ETag')).toBe('W/"1"');
     expect(response.headers.get('Cache-Control')).toBe('no-store');
+  });
+
+  it('returns 401 for Firebase exchange without a bearer token', async () => {
+    const request = new Request('https://app.example/api/firebase/exchange', { method: 'POST' });
+    const response = await worker.fetch(request, defaultEnv);
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: 'missing_bearer_token' });
+  });
+
+  it('returns 401 for Firebase exchange with an invalid JWT format', async () => {
+    const request = new Request('https://app.example/api/firebase/exchange', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer not-a-jwt' },
+    });
+    const response = await worker.fetch(request, defaultEnv);
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: 'invalid_token_format' });
+  });
+
+  it('returns 401 when Graph verification fails', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('{}', { status: 401 })));
+    const request = new Request('https://app.example/api/firebase/exchange', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${validGraphToken()}` },
+    });
+    const response = await worker.fetch(request, {
+      ...defaultEnv,
+      GOOGLE_SERVICE_ACCOUNT_JSON: JSON.stringify({
+        project_id: 'firebase-project',
+        client_email: 'service@example.iam.gserviceaccount.com',
+        private_key: 'AQID',
+      }),
+    });
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: 'token_verification_failed' });
+  });
+
+  it('returns 500 when Firebase service account configuration is missing', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ id: 'graph-id' }), { status: 200 })));
+    const request = new Request('https://app.example/api/firebase/exchange', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${validGraphToken()}` },
+    });
+    const response = await worker.fetch(request, defaultEnv);
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({ error: 'service_account_not_configured' });
+  });
+
+  it('returns a Firebase custom token when Graph and service account configuration succeed', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      id: 'graph-id',
+      displayName: 'Test User',
+      userPrincipalName: 'test@example.com',
+    }), { status: 200 })));
+    const subtle = {
+      importKey: vi.fn().mockResolvedValue({}),
+      sign: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]).buffer),
+    };
+    vi.stubGlobal('crypto', { subtle });
+    const request = new Request('https://app.example/api/firebase/exchange', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${validGraphToken()}` },
+    });
+    const response = await worker.fetch(request, {
+      ...defaultEnv,
+      GOOGLE_SERVICE_ACCOUNT_JSON: JSON.stringify({
+        project_id: 'firebase-project',
+        client_email: 'service@example.iam.gserviceaccount.com',
+        private_key: 'AQID',
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as { firebaseCustomToken?: string; actor?: { id?: string } };
+    expect(body.firebaseCustomToken?.split('.')).toHaveLength(3);
+    expect(body.actor).toEqual({ id: 'aad:oid-1', name: 'Test User' });
+    const tokenPayload = decodeJwtPayload(body.firebaseCustomToken!);
+    expect(tokenPayload.iss).toBe('service@example.iam.gserviceaccount.com');
+    expect(tokenPayload.sub).toBe('service@example.iam.gserviceaccount.com');
+    expect(tokenPayload.aud).toBe('https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit');
+    expect(tokenPayload.uid).toBe('aad:oid-1');
+    expect(tokenPayload.claims).toEqual({
+      orgId: 'tenant-1',
+      actorId: 'aad:oid-1',
+      actorName: 'Test User',
+    });
+    expect(tokenPayload.iat).toEqual(expect.any(Number));
+    expect(tokenPayload.exp).toEqual(expect.any(Number));
+    expect((tokenPayload.exp as number) - (tokenPayload.iat as number)).toBe(3600);
   });
 });

--- a/src/infra/firestore/__tests__/auth.spec.ts
+++ b/src/infra/firestore/__tests__/auth.spec.ts
@@ -9,6 +9,7 @@ const signInWithCustomTokenMock = vi.fn().mockResolvedValue({
 });
 const getAuthMock = vi.fn();
 const getFirebaseAppMock = vi.fn().mockReturnValue({});
+const getPcaSingletonMock = vi.fn();
 
 // ── Module mocks ───────────────────────────────────────────────────
 vi.mock('firebase/auth', () => ({
@@ -20,6 +21,10 @@ vi.mock('firebase/auth', () => ({
 
 vi.mock('../client', () => ({
   getFirebaseApp: () => getFirebaseAppMock(),
+}));
+
+vi.mock('@/auth/azureMsal', () => ({
+  getPcaSingleton: () => getPcaSingletonMock(),
 }));
 
 const mockGet = vi.fn<(name: string, fallback?: string) => string>();
@@ -49,6 +54,9 @@ const setupEnv = (overrides: {
   mockGet.mockImplementation((name: string, fallback = '') => {
     if (name === 'VITE_FIREBASE_API_KEY') return overrides.apiKey ?? 'test-api-key';
     if (name === 'VITE_FIREBASE_AUTH_MODE') return overrides.authMode ?? 'anonymous';
+    if (name === 'VITE_FIREBASE_TOKEN_EXCHANGE_URL') {
+      return `${typeof window === 'undefined' ? 'https://app.example' : window.location.origin}/api/firebase/exchange`;
+    }
     return fallback;
   });
   mockGetFlag.mockImplementation((name: string, fallback = false) => {
@@ -74,6 +82,11 @@ describe('initFirebaseAuth', () => {
 
     // Default: valid API key, anonymous mode, no skip-login
     setupEnv({});
+    getPcaSingletonMock.mockResolvedValue({
+      getActiveAccount: () => ({ homeAccountId: 'home-account' }),
+      getAllAccounts: () => [{ homeAccountId: 'home-account' }],
+      acquireTokenSilent: vi.fn().mockResolvedValue({ accessToken: 'msal-access-token' }),
+    });
 
     // Dynamic import to pick up mocks
     const mod = await import('../auth');
@@ -172,6 +185,55 @@ describe('initFirebaseAuth', () => {
 
     // The self-healing guard should NOT have triggered anonymous sign-in
     // Error is caught by the outer try-catch (non-fatal logging)
+    expect(signInAnonymouslyMock).not.toHaveBeenCalled();
+  });
+
+  it('should complete customToken authentication without anonymous fallback', async () => {
+    setupEnv({ authMode: 'customToken' });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      firebaseCustomToken: 'firebase-custom-token',
+      orgId: 'tenant-1',
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } })));
+
+    await initFirebaseAuth();
+
+    expect(signInWithCustomTokenMock).toHaveBeenCalledWith(
+      expect.anything(),
+      'firebase-custom-token',
+    );
+    expect(signInAnonymouslyMock).not.toHaveBeenCalled();
+  });
+
+  it('records exchange-request stage and does not fall back anonymously on fetch failure', async () => {
+    setupEnv({ authMode: 'customToken' });
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')));
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await initFirebaseAuth();
+
+    expect(consoleError).toHaveBeenCalledWith('[firebase-auth] ❌ initialization failed', expect.objectContaining({
+      stage: 'exchange-request',
+      reason: 'network-failure',
+      host: window.location.host,
+      path: '/api/firebase/exchange',
+    }));
+    expect(signInAnonymouslyMock).not.toHaveBeenCalled();
+  });
+
+  it('records firebase-sign-in stage and does not fall back anonymously on Firebase sign-in failure', async () => {
+    setupEnv({ authMode: 'customToken' });
+    signInWithCustomTokenMock.mockRejectedValueOnce(Object.assign(new Error('invalid custom token'), { name: 'FirebaseError', code: 'auth/invalid-custom-token' }));
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      firebaseCustomToken: 'firebase-custom-token',
+    }), { status: 200 })));
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await initFirebaseAuth();
+
+    expect(consoleError).toHaveBeenCalledWith('[firebase-auth] ❌ initialization failed', expect.objectContaining({
+      stage: 'firebase-sign-in',
+      reason: 'auth/invalid-custom-token',
+    }));
     expect(signInAnonymouslyMock).not.toHaveBeenCalled();
   });
 });

--- a/src/infra/firestore/auth.ts
+++ b/src/infra/firestore/auth.ts
@@ -5,6 +5,33 @@ import { getFirebaseApp } from './client';
 
 type FirebaseAuthMode = 'anonymous' | 'customToken';
 
+type FirebaseAuthInitStage =
+  | 'config'
+  | 'msal-account'
+  | 'msal-token'
+  | 'exchange-request'
+  | 'exchange-response'
+  | 'firebase-sign-in';
+
+type FirebaseAuthDiagnostic = {
+  stage: FirebaseAuthInitStage;
+  reason: string;
+  status?: number;
+  host?: string;
+  path?: string;
+};
+
+class FirebaseAuthStageError extends Error {
+  readonly diagnostic: FirebaseAuthDiagnostic;
+
+  constructor(diagnostic: FirebaseAuthDiagnostic, cause?: unknown) {
+    super(diagnostic.reason);
+    this.name = 'FirebaseAuthStageError';
+    this.diagnostic = diagnostic;
+    void cause;
+  }
+}
+
 type CustomTokenExchangeResponse = {
   firebaseCustomToken: string;
   orgId?: string;
@@ -45,6 +72,39 @@ const normalizeAuthMode = (rawMode: string): FirebaseAuthMode => {
   return normalized === 'customtoken' ? 'customToken' : 'anonymous';
 };
 
+const safeEndpoint = (rawURL: string): Pick<FirebaseAuthDiagnostic, 'host' | 'path'> => {
+  try {
+    const url = new URL(rawURL, typeof window === 'undefined' ? 'https://invalid.local' : window.location.origin);
+    return { host: url.host, path: url.pathname };
+  } catch {
+    return {};
+  }
+};
+
+const safeErrorReason = (error: unknown): string => {
+  if (error instanceof TypeError && /fetch/i.test(error.message)) {
+    return 'network-failure';
+  }
+  if (error instanceof Error && error.name === 'FirebaseError') {
+    const code = (error as Error & { code?: unknown }).code;
+    return typeof code === 'string' && code ? code : 'firebase-error';
+  }
+  if (error instanceof Error) {
+    return error.name || 'error';
+  }
+  return 'unknown-error';
+};
+
+const toFirebaseAuthDiagnostic = (error: unknown): FirebaseAuthDiagnostic => {
+  if (error instanceof FirebaseAuthStageError) {
+    return error.diagnostic;
+  }
+  return {
+    stage: 'firebase-sign-in',
+    reason: safeErrorReason(error),
+  };
+};
+
 const resolveAuthMode = (): FirebaseAuthMode => {
   const raw = get('VITE_FIREBASE_AUTH_MODE', 'anonymous');
   return normalizeAuthMode(raw);
@@ -77,16 +137,30 @@ const acquireMsalAccessToken = async (): Promise<string> => {
     getAllAccounts: () => msal.getAllAccounts(),
   });
   if (!account) {
-    throw new Error('MSAL account is not available for token exchange');
+    throw new FirebaseAuthStageError({
+      stage: 'msal-account',
+      reason: 'account-not-available',
+    });
   }
 
-  const token = await msal.acquireTokenSilent({
-    scopes: ['User.Read'],
-    account,
-  });
+  let token: { accessToken?: string };
+  try {
+    token = await msal.acquireTokenSilent({
+      scopes: ['User.Read'],
+      account,
+    });
+  } catch (error) {
+    throw new FirebaseAuthStageError({
+      stage: 'msal-token',
+      reason: safeErrorReason(error),
+    }, error);
+  }
 
   if (!token.accessToken) {
-    throw new Error('MSAL access token acquisition returned empty token');
+    throw new FirebaseAuthStageError({
+      stage: 'msal-token',
+      reason: 'empty-access-token',
+    });
   }
 
   return token.accessToken;
@@ -95,26 +169,71 @@ const acquireMsalAccessToken = async (): Promise<string> => {
 const exchangeFirebaseCustomToken = async (): Promise<CustomTokenExchangeResponse> => {
   const exchangeUrl = get('VITE_FIREBASE_TOKEN_EXCHANGE_URL', '').trim();
   if (!exchangeUrl) {
-    throw new Error('VITE_FIREBASE_TOKEN_EXCHANGE_URL is not configured');
+    throw new FirebaseAuthStageError({
+      stage: 'config',
+      reason: 'exchange-url-not-configured',
+    });
+  }
+
+  const endpoint = safeEndpoint(exchangeUrl);
+  const expectedOrigin = typeof window === 'undefined' ? undefined : window.location.origin;
+  if (
+    expectedOrigin &&
+    (endpoint.host !== window.location.host || endpoint.path !== '/api/firebase/exchange')
+  ) {
+    throw new FirebaseAuthStageError({
+      stage: 'config',
+      reason: 'exchange-url-must-use-worker-origin',
+      ...endpoint,
+    });
   }
 
   const msalAccessToken = await acquireMsalAccessToken();
-  // eslint-disable-next-line no-restricted-globals -- Worker カスタムトークン交換: Graph ではないため graphFetch 対象外。将来的に専用クライアントを検討
-  const response = await fetch(exchangeUrl, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${msalAccessToken}`,
-      'Content-Type': 'application/json',
-    },
-  });
-
-  if (!response.ok) {
-    throw new Error(`custom token exchange failed: ${response.status} ${response.statusText}`);
+  let response: Response;
+  try {
+    // eslint-disable-next-line no-restricted-globals -- Worker カスタムトークン交換: Graph ではないため graphFetch 対象外。
+    response = await fetch(exchangeUrl, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${msalAccessToken}`,
+        'Content-Type': 'application/json',
+      },
+    });
+  } catch (error) {
+    throw new FirebaseAuthStageError({
+      stage: 'exchange-request',
+      reason: safeErrorReason(error),
+      ...endpoint,
+    }, error);
   }
 
-  const payload = (await response.json()) as Partial<CustomTokenExchangeResponse>;
+  if (!response.ok) {
+    throw new FirebaseAuthStageError({
+      stage: 'exchange-response',
+      reason: 'exchange-http-error',
+      status: response.status,
+      ...endpoint,
+    });
+  }
+
+  let payload: Partial<CustomTokenExchangeResponse>;
+  try {
+    payload = (await response.json()) as Partial<CustomTokenExchangeResponse>;
+  } catch (error) {
+    throw new FirebaseAuthStageError({
+      stage: 'exchange-response',
+      reason: 'exchange-invalid-json',
+      status: response.status,
+      ...endpoint,
+    }, error);
+  }
   if (typeof payload.firebaseCustomToken !== 'string' || payload.firebaseCustomToken.length === 0) {
-    throw new Error('custom token exchange response missing firebaseCustomToken');
+    throw new FirebaseAuthStageError({
+      stage: 'exchange-response',
+      reason: 'exchange-token-missing',
+      status: response.status,
+      ...endpoint,
+    });
   }
 
   return {
@@ -131,7 +250,15 @@ const signInWithConfiguredStrategy = async (
 ): Promise<void> => {
   if (mode === 'customToken') {
     const exchange = await exchangeFirebaseCustomToken();
-    const result = await signInWithCustomToken(auth, exchange.firebaseCustomToken);
+    let result: Awaited<ReturnType<typeof signInWithCustomToken>>;
+    try {
+      result = await signInWithCustomToken(auth, exchange.firebaseCustomToken);
+    } catch (error) {
+      throw new FirebaseAuthStageError({
+        stage: 'firebase-sign-in',
+        reason: safeErrorReason(error),
+      }, error);
+    }
     console.info('[firebase-auth] ✅ custom token sign-in successful', {
       uid: result.user.uid,
       orgId: exchange.orgId ?? null,
@@ -247,6 +374,6 @@ export async function initFirebaseAuth(): Promise<void> {
   } catch (error) {
     // Non-fatal: Log but don't throw
     // App can continue with limited Firestore access or fallback to adapter
-    console.error('[firebase-auth] ❌ initialization failed', error);
+    console.error('[firebase-auth] ❌ initialization failed', toFirebaseAuthDiagnostic(error));
   }
 }


### PR DESCRIPTION
## Summary
- Firebase customToken初期化をconfig、MSAL、Worker交換、Firebase sign-in段階で安全に分類
- token、Authorization、Cookie、request body、利用者情報を診断へ出さない
- Firebase authとWorker交換APIの境界テストを追加
- 匿名fallbackは有効化しない

## Root cause status
本番の初回観測は `[firebase-auth] initialization failed / TypeError: Failed to fetch`。
本PRでは失敗段階を確定できる診断情報を追加し、customToken経路の契約をテストで固定する。
Cloudflare設定値は未変更。

## Validation
- Firebase auth / Worker tests: 28 passed
- `tsc -p tsconfig.build.json --noEmit`: PASS
- `git diff --check`: PASS
- production deploy: 未実施
- 本番read-only smoke: 原因修正PRのデプロイ前のため未実施

## Gate status
- Gate 4A: FAIL維持
- Gate 4B: HOLD
- Gate 3: 未実施
- PR #2512: HOLD
- production deploy: NO-GO

Draftのままレビュー・設定確認・本番再検証を行う。