### PR TITLE
test: pin transport deep lane timezone

### DIFF
--- a/tests/e2e/transport-assignments-save-reflects-in-today.spec.ts
+++ b/tests/e2e/transport-assignments-save-reflects-in-today.spec.ts
@@ -6,6 +6,8 @@ import { selectMuiOptionByLabel } from './utils/muiSelect';
 const TARGET_USER_ID = 'U002';
 const TARGET_USER_NAME = '鈴木 美子';
 
+test.use({ timezoneId: 'Asia/Tokyo' });
+
 test.describe('Transport assignments save reflects in today', () => {
   test('assign/save and unassign/save are reflected in today transport vehicle board', async ({ page }) => {
     const today = new Intl.DateTimeFormat('sv-SE', {

--- a/tests/e2e/transport-assignments-week-bulk-apply-reflects-in-today.spec.ts
+++ b/tests/e2e/transport-assignments-week-bulk-apply-reflects-in-today.spec.ts
@@ -11,6 +11,8 @@ const USER_APPLY_NAME = '鈴木 美子';
 const USER_KEEP_ID = 'U001';
 const USER_KEEP_NAME = '田中 太郎';
 
+test.use({ timezoneId: 'Asia/Tokyo' });
+
 test.describe('Transport assignments week bulk apply reflects in today', () => {
   test('bulk apply + save reflects in today board and does not overwrite existing assignment', async ({ page }) => {
     await setupSharePointStubs(page, {

--- a/tests/e2e/transport-course-users-update-reflects-in-transport-assignments.spec.ts
+++ b/tests/e2e/transport-course-users-update-reflects-in-transport-assignments.spec.ts
@@ -8,6 +8,8 @@ const TARGET_DATE = '2026-03-25';
 const TARGET_USER_ID = 'U002';
 const TARGET_USER_NAME = '鈴木 美子';
 
+test.use({ timezoneId: 'Asia/Tokyo' });
+
 test.describe('Users TransportCourse update reflects in transport assignments', () => {
   test('updating TransportCourse on /users is reflected as fixed-course default on /transport/assignments', async ({ page }) => {
     await setupSharePointStubs(page, {


### PR DESCRIPTION
Pin the three transport date-sensitive Deep specs to Asia/Tokyo so browser timezone matches the application date contract. PR #2516 is not modified; no deploy or data writes.