### PR TITLE
Add limited Firestore transport-close contract

### DIFF
--- a/tests/production/helpers/classifyFirestoreTransportClose.ts
+++ b/tests/production/helpers/classifyFirestoreTransportClose.ts
@@ -1,0 +1,169 @@
+export const FIRESTORE_TRANSPORT_CLOSE_HOST = 'firestore.googleapis.com';
+export const FIRESTORE_TRANSPORT_CLOSE_PATHNAME =
+  '/google.firestore.v1.Firestore/Write/channel';
+export const FIRESTORE_TRANSPORT_CLOSE_METHOD = 'POST';
+export const FIRESTORE_TRANSPORT_CLOSE_RESOURCE_TYPE = 'fetch';
+export const FIRESTORE_TRANSPORT_CLOSE_ERROR_TEXT = 'net::ERR_ABORTED';
+export const FIRESTORE_TRANSPORT_CLOSE_MAX_TRANSITION_DELTA_MS = 5_000;
+export const FIRESTORE_TRANSPORT_CLOSE_MIN_RELOAD_OBSERVATION_MS = 10_000;
+
+export type FirestoreTransportCloseFailureWindow =
+  | 'during-goto'
+  | 'after-goto-before-readiness'
+  | 'after-readiness';
+
+export type FirestoreTransportCloseClassification =
+  | 'acceptedTransportClose'
+  | 'unclassifiedRequestFailure';
+
+export type FirestoreTransportCloseRejectionReason =
+  | 'accepted'
+  | 'request-shape-mismatch'
+  | 'invalid-phase'
+  | 'unsupported-failure-window'
+  | 'missing-transition-or-reload-evidence'
+  | 'channel-lifecycle-mismatch'
+  | 'later-connection-not-observed'
+  | 'firebase-auth-unhealthy'
+  | 'functional-health-failed'
+  | 'browser-or-server-errors-present'
+  | 'reload-observation-incomplete'
+  | 'test-ended-immediately';
+
+/**
+ * Safe, production-independent evidence consumed by the transport-close
+ * classifier. Values are intentionally unknown so malformed or missing
+ * evidence cannot pass through truthy coercion.
+ */
+export type FirestoreTransportCloseEvidence = {
+  phase: unknown;
+  failureWindow: unknown;
+  method: unknown;
+  host: unknown;
+  pathname: unknown;
+  resourceType: unknown;
+  safeErrorText: unknown;
+  channelLifecycleMatch: unknown;
+  transitionOrReloadRelated: unknown;
+  transitionOrReloadDeltaMs: unknown;
+  laterConnectionSucceeded: unknown;
+  firebaseAuthHealthy: unknown;
+  functionalHealthPassed: unknown;
+  consoleErrors: unknown;
+  pageErrors: unknown;
+  httpErrors: unknown;
+  serverErrors: unknown;
+  reloadObservationComplete?: unknown;
+  reloadObservationDurationMs?: unknown;
+  testEndedImmediately: unknown;
+};
+
+export type FirestoreTransportCloseResult = {
+  acceptedTransportClose: boolean;
+  classification: FirestoreTransportCloseClassification;
+  reason: FirestoreTransportCloseRejectionReason;
+};
+
+const allowedFailureWindows: readonly FirestoreTransportCloseFailureWindow[] = [
+  'during-goto',
+  'after-goto-before-readiness',
+  'after-readiness',
+];
+
+const rejected = (reason: FirestoreTransportCloseRejectionReason): FirestoreTransportCloseResult => ({
+  acceptedTransportClose: false,
+  classification: 'unclassifiedRequestFailure',
+  reason,
+});
+
+const accepted = (): FirestoreTransportCloseResult => ({
+  acceptedTransportClose: true,
+  classification: 'acceptedTransportClose',
+  reason: 'accepted',
+});
+
+function isKnownPhase(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0 && value !== 'unknown';
+}
+
+function isAllowedFailureWindow(value: unknown): value is FirestoreTransportCloseFailureWindow {
+  return (
+    typeof value === 'string' &&
+    allowedFailureWindows.includes(value as FirestoreTransportCloseFailureWindow)
+  );
+}
+
+function isFiniteNonNegativeNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0;
+}
+
+function isZeroErrorCount(value: unknown): boolean {
+  return typeof value === 'number' && Number.isFinite(value) && value === 0;
+}
+
+export function classifyFirestoreTransportClose(
+  evidence: FirestoreTransportCloseEvidence | null | undefined,
+): FirestoreTransportCloseResult {
+  if (evidence === null || evidence === undefined) {
+    return rejected('request-shape-mismatch');
+  }
+
+  const requestShapeMatches =
+    evidence.method === FIRESTORE_TRANSPORT_CLOSE_METHOD &&
+    evidence.host === FIRESTORE_TRANSPORT_CLOSE_HOST &&
+    evidence.pathname === FIRESTORE_TRANSPORT_CLOSE_PATHNAME &&
+    evidence.resourceType === FIRESTORE_TRANSPORT_CLOSE_RESOURCE_TYPE &&
+    evidence.safeErrorText === FIRESTORE_TRANSPORT_CLOSE_ERROR_TEXT;
+
+  if (!requestShapeMatches) return rejected('request-shape-mismatch');
+  if (!isKnownPhase(evidence.phase)) return rejected('invalid-phase');
+  if (!isAllowedFailureWindow(evidence.failureWindow)) {
+    return rejected('unsupported-failure-window');
+  }
+
+  if (
+    evidence.transitionOrReloadRelated !== true ||
+    !isFiniteNonNegativeNumber(evidence.transitionOrReloadDeltaMs) ||
+    evidence.transitionOrReloadDeltaMs > FIRESTORE_TRANSPORT_CLOSE_MAX_TRANSITION_DELTA_MS
+  ) {
+    return rejected('missing-transition-or-reload-evidence');
+  }
+
+  if (evidence.channelLifecycleMatch !== true) {
+    return rejected('channel-lifecycle-mismatch');
+  }
+  if (evidence.laterConnectionSucceeded !== true) {
+    return rejected('later-connection-not-observed');
+  }
+  if (evidence.firebaseAuthHealthy !== true) {
+    return rejected('firebase-auth-unhealthy');
+  }
+  if (evidence.functionalHealthPassed !== true) {
+    return rejected('functional-health-failed');
+  }
+
+  if (
+    !isZeroErrorCount(evidence.consoleErrors) ||
+    !isZeroErrorCount(evidence.pageErrors) ||
+    !isZeroErrorCount(evidence.httpErrors) ||
+    !isZeroErrorCount(evidence.serverErrors)
+  ) {
+    return rejected('browser-or-server-errors-present');
+  }
+
+  if (evidence.testEndedImmediately !== false) {
+    return rejected('test-ended-immediately');
+  }
+
+  if (evidence.failureWindow === 'after-readiness') {
+    if (
+      evidence.reloadObservationComplete !== true ||
+      !isFiniteNonNegativeNumber(evidence.reloadObservationDurationMs) ||
+      evidence.reloadObservationDurationMs < FIRESTORE_TRANSPORT_CLOSE_MIN_RELOAD_OBSERVATION_MS
+    ) {
+      return rejected('reload-observation-incomplete');
+    }
+  }
+
+  return accepted();
+}

--- a/tests/unit/production/classifyFirestoreTransportClose.spec.ts
+++ b/tests/unit/production/classifyFirestoreTransportClose.spec.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest';
+import {
+  classifyFirestoreTransportClose,
+  type FirestoreTransportCloseEvidence,
+} from '../../production/helpers/classifyFirestoreTransportClose';
+
+const baseEvidence = (): FirestoreTransportCloseEvidence => ({
+  phase: 'users-goto-in-flight',
+  failureWindow: 'during-goto',
+  method: 'POST',
+  host: 'firestore.googleapis.com',
+  pathname: '/google.firestore.v1.Firestore/Write/channel',
+  resourceType: 'fetch',
+  safeErrorText: 'net::ERR_ABORTED',
+  channelLifecycleMatch: true,
+  transitionOrReloadRelated: true,
+  transitionOrReloadDeltaMs: 100,
+  laterConnectionSucceeded: true,
+  firebaseAuthHealthy: true,
+  functionalHealthPassed: true,
+  consoleErrors: 0,
+  pageErrors: 0,
+  httpErrors: 0,
+  serverErrors: 0,
+  testEndedImmediately: false,
+});
+
+const expectRejected = (
+  overrides: Partial<FirestoreTransportCloseEvidence>,
+): ReturnType<typeof classifyFirestoreTransportClose> => {
+  const result = classifyFirestoreTransportClose({ ...baseEvidence(), ...overrides });
+  expect(result.acceptedTransportClose).toBe(false);
+  expect(result.classification).toBe('unclassifiedRequestFailure');
+  return result;
+};
+
+describe('classifyFirestoreTransportClose', () => {
+  it('accepts a transition-adjacent failure when every condition is satisfied', () => {
+    expect(
+      classifyFirestoreTransportClose({
+        ...baseEvidence(),
+        failureWindow: 'after-goto-before-readiness',
+        transitionOrReloadDeltaMs: 0,
+      }),
+    ).toEqual({
+      acceptedTransportClose: true,
+      classification: 'acceptedTransportClose',
+      reason: 'accepted',
+    });
+  });
+
+  it('accepts a reload-adjacent failure after ten seconds of observation and reconnection', () => {
+    expect(
+      classifyFirestoreTransportClose({
+        ...baseEvidence(),
+        phase: 'reload-after',
+        failureWindow: 'after-readiness',
+        transitionOrReloadDeltaMs: 250,
+        reloadObservationComplete: true,
+        reloadObservationDurationMs: 10_000,
+      }).acceptedTransportClose,
+    ).toBe(true);
+  });
+
+  it.each([
+    ['during-readiness', { failureWindow: 'during-readiness' }],
+    ['before-goto', { failureWindow: 'before-goto' }],
+    ['unknown window', { failureWindow: 'unknown' }],
+    ['missing window', { failureWindow: undefined }],
+    ['null window', { failureWindow: null }],
+  ] as const)('rejects %s', (_label, overrides) => {
+    expectRejected(overrides);
+  });
+
+  it.each([
+    ['host', { host: 'other.example.com' }],
+    ['pathname', { pathname: '/google.firestore.v1.Firestore/Listen/channel' }],
+    ['method', { method: 'GET' }],
+    ['resource type', { resourceType: 'xhr' }],
+    ['error text', { safeErrorText: 'net::ERR_FAILED' }],
+  ] as const)('rejects a %s mismatch', (_label, overrides) => {
+    expectRejected(overrides);
+  });
+
+  it.each([
+    ['missing method', { method: undefined }],
+    ['null host', { host: null }],
+    ['unknown path', { pathname: 'unknown' }],
+    ['unknown phase', { phase: 'unknown' }],
+    ['null lifecycle', { channelLifecycleMatch: null }],
+    ['undefined auth health', { firebaseAuthHealthy: undefined }],
+  ] as const)('rejects %s as missing or unknown evidence', (_label, overrides) => {
+    expectRejected(overrides);
+  });
+
+  it.each([undefined, null])('rejects %s evidence objects without throwing', (evidence) => {
+    expect(classifyFirestoreTransportClose(evidence)).toEqual({
+      acceptedTransportClose: false,
+      classification: 'unclassifiedRequestFailure',
+      reason: 'request-shape-mismatch',
+    });
+  });
+
+  it('rejects a channel lifecycle mismatch', () => {
+    expectRejected({ channelLifecycleMatch: false });
+  });
+
+  it('rejects when the later connection did not succeed', () => {
+    expectRejected({ laterConnectionSucceeded: false });
+  });
+
+  it('rejects when transition or reload evidence is absent or too far away', () => {
+    expect(expectRejected({ transitionOrReloadRelated: false }).reason).toBe(
+      'missing-transition-or-reload-evidence',
+    );
+    expect(expectRejected({ transitionOrReloadDeltaMs: undefined }).reason).toBe(
+      'missing-transition-or-reload-evidence',
+    );
+    expect(expectRejected({ transitionOrReloadDeltaMs: 5_001 }).reason).toBe(
+      'missing-transition-or-reload-evidence',
+    );
+  });
+
+  it('rejects an unhealthy Firebase auth state', () => {
+    expectRejected({ firebaseAuthHealthy: false });
+  });
+
+  it('rejects an unhealthy functional state', () => {
+    expectRejected({ functionalHealthPassed: false });
+  });
+
+  it.each(['consoleErrors', 'pageErrors', 'httpErrors', 'serverErrors'] as const)(
+    'rejects when %s is non-zero',
+    (field) => {
+      expectRejected({ [field]: 1 });
+    },
+  );
+
+  it('rejects a reload failure before the ten-second observation minimum', () => {
+    expect(
+      expectRejected({
+        phase: 'reload-after',
+        failureWindow: 'after-readiness',
+        reloadObservationComplete: true,
+        reloadObservationDurationMs: 9_999,
+      }).reason,
+    ).toBe('reload-observation-incomplete');
+  });
+
+  it('rejects reload evidence that is incomplete even when its duration is long enough', () => {
+    expect(
+      expectRejected({
+        phase: 'reload-after',
+        failureWindow: 'after-readiness',
+        reloadObservationComplete: false,
+        reloadObservationDurationMs: 10_000,
+      }).reason,
+    ).toBe('reload-observation-incomplete');
+  });
+
+  it('rejects a failure observed at test termination', () => {
+    expect(expectRejected({ testEndedImmediately: true }).reason).toBe('test-ended-immediately');
+    expect(expectRejected({ testEndedImmediately: undefined }).reason).toBe(
+      'test-ended-immediately',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Issue #2523の決定に基づき、限定Firestore transport-close契約の純粋classifierとunit testsを追加します。

このDraft PRは`main`起点で、承認対象の2ファイルだけを含みます。

## Scope

- `tests/production/helpers/classifyFirestoreTransportClose.ts`
- `tests/unit/production/classifyFirestoreTransportClose.spec.ts`

固定 `POST`、Firestore channelの厳密なhost/path、`fetch`、`net::ERR_ABORTED`、channel lifecycle、後続接続、Firebase auth、機能健全性、各error件数0を必須条件とします。

`during-readiness`、unknown / missing evidence、観測不足はfail-closedです。reload後の最低観測時間は10秒です。

## Validation

- Vitest: 32 passed
- ESLint: PASS
- TypeScript: PASS

## Explicitly not included

- `production-readonly-smoke.spec.ts`への接続
- PR #2514の変更
- Gate 4A再実行
- productionアクセス、Ready化、merge、deploy、rollback

Production remains NO-GO.