### PR TITLE
Connect Firestore transport-close contract to readonly smoke

### DIFF
--- a/playwright.production-readonly.config.ts
+++ b/playwright.production-readonly.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const productionBaseURL =
+  process.env.PRODUCTION_BASE_URL ??
+  'https://audit-management-system-mvp.momosantanuki.workers.dev';
+
+export default defineConfig({
+  testDir: 'tests/production',
+  testMatch: /production-readonly-smoke\.spec\.ts$/,
+  timeout: 240_000,
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  reporter: 'line',
+  use: {
+    baseURL: productionBaseURL,
+    headless: true,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'production-readonly',
+      use: devices['Desktop Chrome'],
+    },
+  ],
+});

--- a/tests/production/helpers/buildFirestoreTransportCloseEvidence.ts
+++ b/tests/production/helpers/buildFirestoreTransportCloseEvidence.ts
@@ -1,0 +1,80 @@
+import {
+  FIRESTORE_TRANSPORT_CLOSE_RECONNECT_OBSERVATION_WINDOW_MS,
+  type FirestoreTransportCloseEvidence,
+} from './classifyFirestoreTransportClose';
+
+export type FirestoreTransportCloseFailureSnapshot = {
+  observedAtMs: number;
+  method: unknown;
+  host: unknown;
+  pathname: unknown;
+  resourceType: unknown;
+  safeErrorText: unknown;
+  phase: unknown;
+  failureWindow: unknown;
+  transitionOrReloadRelated: unknown;
+  transitionOrReloadDeltaMs: unknown;
+  reloadObservationComplete: unknown;
+  reloadObservationDurationMs: unknown;
+  testEndedImmediately: unknown;
+  channelLifecycleObserved: boolean;
+};
+
+export type FirestoreTransportCloseChannelSnapshot = {
+  startedAtMs: number;
+  finishedAtMs?: number;
+};
+
+export type FirestoreTransportCloseAuthResponseSnapshot = {
+  observedAtMs: number;
+  status: number;
+};
+
+export type FirestoreTransportCloseErrorCounts = {
+  consoleErrors: number;
+  pageErrors: number;
+  httpErrors: number;
+  serverErrors: number;
+};
+
+export function buildFirestoreTransportCloseEvidence(
+  failure: FirestoreTransportCloseFailureSnapshot,
+  channelEvents: readonly FirestoreTransportCloseChannelSnapshot[],
+  authResponses: readonly FirestoreTransportCloseAuthResponseSnapshot[],
+  functionalHealthPassed: boolean,
+  errorCounts: FirestoreTransportCloseErrorCounts,
+): FirestoreTransportCloseEvidence {
+  const laterConnectionSucceeded = channelEvents.some(
+    (event) =>
+      event.startedAtMs > failure.observedAtMs &&
+      event.finishedAtMs !== undefined &&
+      event.finishedAtMs <=
+        failure.observedAtMs + FIRESTORE_TRANSPORT_CLOSE_RECONNECT_OBSERVATION_WINDOW_MS,
+  );
+  const authEvidence = authResponses.filter(
+    (response) => response.observedAtMs <= failure.observedAtMs,
+  );
+  const firebaseAuthHealthy = authEvidence.length === 0
+    ? undefined
+    : authEvidence.every((response) => response.status >= 200 && response.status < 400);
+
+  return {
+    phase: failure.phase,
+    failureWindow: failure.failureWindow,
+    method: failure.method,
+    host: failure.host,
+    pathname: failure.pathname,
+    resourceType: failure.resourceType,
+    safeErrorText: failure.safeErrorText,
+    channelLifecycleMatch: failure.channelLifecycleObserved,
+    transitionOrReloadRelated: failure.transitionOrReloadRelated,
+    transitionOrReloadDeltaMs: failure.transitionOrReloadDeltaMs,
+    laterConnectionSucceeded,
+    firebaseAuthHealthy,
+    functionalHealthPassed,
+    ...errorCounts,
+    reloadObservationComplete: failure.reloadObservationComplete,
+    reloadObservationDurationMs: failure.reloadObservationDurationMs,
+    testEndedImmediately: failure.testEndedImmediately,
+  };
+}

--- a/tests/production/helpers/classifyFirestoreTransportClose.ts
+++ b/tests/production/helpers/classifyFirestoreTransportClose.ts
@@ -1,0 +1,169 @@
+export const FIRESTORE_TRANSPORT_CLOSE_HOST = 'firestore.googleapis.com';
+export const FIRESTORE_TRANSPORT_CLOSE_PATHNAME =
+  '/google.firestore.v1.Firestore/Write/channel';
+export const FIRESTORE_TRANSPORT_CLOSE_METHOD = 'POST';
+export const FIRESTORE_TRANSPORT_CLOSE_RESOURCE_TYPE = 'fetch';
+export const FIRESTORE_TRANSPORT_CLOSE_ERROR_TEXT = 'net::ERR_ABORTED';
+export const FIRESTORE_TRANSPORT_CLOSE_MAX_TRANSITION_DELTA_MS = 5_000;
+export const FIRESTORE_TRANSPORT_CLOSE_MIN_RELOAD_OBSERVATION_MS = 10_000;
+
+export type FirestoreTransportCloseFailureWindow =
+  | 'during-goto'
+  | 'after-goto-before-readiness'
+  | 'after-readiness';
+
+export type FirestoreTransportCloseClassification =
+  | 'acceptedTransportClose'
+  | 'unclassifiedRequestFailure';
+
+export type FirestoreTransportCloseRejectionReason =
+  | 'accepted'
+  | 'request-shape-mismatch'
+  | 'invalid-phase'
+  | 'unsupported-failure-window'
+  | 'missing-transition-or-reload-evidence'
+  | 'channel-lifecycle-mismatch'
+  | 'later-connection-not-observed'
+  | 'firebase-auth-unhealthy'
+  | 'functional-health-failed'
+  | 'browser-or-server-errors-present'
+  | 'reload-observation-incomplete'
+  | 'test-ended-immediately';
+
+/**
+ * Safe, production-independent evidence consumed by the transport-close
+ * classifier. Values are intentionally unknown so malformed or missing
+ * evidence cannot pass through truthy coercion.
+ */
+export type FirestoreTransportCloseEvidence = {
+  phase: unknown;
+  failureWindow: unknown;
+  method: unknown;
+  host: unknown;
+  pathname: unknown;
+  resourceType: unknown;
+  safeErrorText: unknown;
+  channelLifecycleMatch: unknown;
+  transitionOrReloadRelated: unknown;
+  transitionOrReloadDeltaMs: unknown;
+  laterConnectionSucceeded: unknown;
+  firebaseAuthHealthy: unknown;
+  functionalHealthPassed: unknown;
+  consoleErrors: unknown;
+  pageErrors: unknown;
+  httpErrors: unknown;
+  serverErrors: unknown;
+  reloadObservationComplete?: unknown;
+  reloadObservationDurationMs?: unknown;
+  testEndedImmediately: unknown;
+};
+
+export type FirestoreTransportCloseResult = {
+  acceptedTransportClose: boolean;
+  classification: FirestoreTransportCloseClassification;
+  reason: FirestoreTransportCloseRejectionReason;
+};
+
+const allowedFailureWindows: readonly FirestoreTransportCloseFailureWindow[] = [
+  'during-goto',
+  'after-goto-before-readiness',
+  'after-readiness',
+];
+
+const rejected = (reason: FirestoreTransportCloseRejectionReason): FirestoreTransportCloseResult => ({
+  acceptedTransportClose: false,
+  classification: 'unclassifiedRequestFailure',
+  reason,
+});
+
+const accepted = (): FirestoreTransportCloseResult => ({
+  acceptedTransportClose: true,
+  classification: 'acceptedTransportClose',
+  reason: 'accepted',
+});
+
+function isKnownPhase(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0 && value !== 'unknown';
+}
+
+function isAllowedFailureWindow(value: unknown): value is FirestoreTransportCloseFailureWindow {
+  return (
+    typeof value === 'string' &&
+    allowedFailureWindows.includes(value as FirestoreTransportCloseFailureWindow)
+  );
+}
+
+function isFiniteNonNegativeNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0;
+}
+
+function isZeroErrorCount(value: unknown): boolean {
+  return typeof value === 'number' && Number.isFinite(value) && value === 0;
+}
+
+export function classifyFirestoreTransportClose(
+  evidence: FirestoreTransportCloseEvidence | null | undefined,
+): FirestoreTransportCloseResult {
+  if (evidence === null || evidence === undefined) {
+    return rejected('request-shape-mismatch');
+  }
+
+  const requestShapeMatches =
+    evidence.method === FIRESTORE_TRANSPORT_CLOSE_METHOD &&
+    evidence.host === FIRESTORE_TRANSPORT_CLOSE_HOST &&
+    evidence.pathname === FIRESTORE_TRANSPORT_CLOSE_PATHNAME &&
+    evidence.resourceType === FIRESTORE_TRANSPORT_CLOSE_RESOURCE_TYPE &&
+    evidence.safeErrorText === FIRESTORE_TRANSPORT_CLOSE_ERROR_TEXT;
+
+  if (!requestShapeMatches) return rejected('request-shape-mismatch');
+  if (!isKnownPhase(evidence.phase)) return rejected('invalid-phase');
+  if (!isAllowedFailureWindow(evidence.failureWindow)) {
+    return rejected('unsupported-failure-window');
+  }
+
+  if (
+    evidence.transitionOrReloadRelated !== true ||
+    !isFiniteNonNegativeNumber(evidence.transitionOrReloadDeltaMs) ||
+    evidence.transitionOrReloadDeltaMs > FIRESTORE_TRANSPORT_CLOSE_MAX_TRANSITION_DELTA_MS
+  ) {
+    return rejected('missing-transition-or-reload-evidence');
+  }
+
+  if (evidence.channelLifecycleMatch !== true) {
+    return rejected('channel-lifecycle-mismatch');
+  }
+  if (evidence.laterConnectionSucceeded !== true) {
+    return rejected('later-connection-not-observed');
+  }
+  if (evidence.firebaseAuthHealthy !== true) {
+    return rejected('firebase-auth-unhealthy');
+  }
+  if (evidence.functionalHealthPassed !== true) {
+    return rejected('functional-health-failed');
+  }
+
+  if (
+    !isZeroErrorCount(evidence.consoleErrors) ||
+    !isZeroErrorCount(evidence.pageErrors) ||
+    !isZeroErrorCount(evidence.httpErrors) ||
+    !isZeroErrorCount(evidence.serverErrors)
+  ) {
+    return rejected('browser-or-server-errors-present');
+  }
+
+  if (evidence.testEndedImmediately !== false) {
+    return rejected('test-ended-immediately');
+  }
+
+  if (evidence.failureWindow === 'after-readiness') {
+    if (
+      evidence.reloadObservationComplete !== true ||
+      !isFiniteNonNegativeNumber(evidence.reloadObservationDurationMs) ||
+      evidence.reloadObservationDurationMs < FIRESTORE_TRANSPORT_CLOSE_MIN_RELOAD_OBSERVATION_MS
+    ) {
+      return rejected('reload-observation-incomplete');
+    }
+  }
+
+  return accepted();
+}

--- a/tests/production/helpers/classifyFirestoreTransportClose.ts
+++ b/tests/production/helpers/classifyFirestoreTransportClose.ts
@@ -6,6 +6,7 @@ export const FIRESTORE_TRANSPORT_CLOSE_RESOURCE_TYPE = 'fetch';
 export const FIRESTORE_TRANSPORT_CLOSE_ERROR_TEXT = 'net::ERR_ABORTED';
 export const FIRESTORE_TRANSPORT_CLOSE_MAX_TRANSITION_DELTA_MS = 5_000;
 export const FIRESTORE_TRANSPORT_CLOSE_MIN_RELOAD_OBSERVATION_MS = 10_000;
+export const FIRESTORE_TRANSPORT_CLOSE_RECONNECT_OBSERVATION_WINDOW_MS = 10_000;
 
 export type FirestoreTransportCloseFailureWindow =
   | 'during-goto'
@@ -62,6 +63,13 @@ export type FirestoreTransportCloseResult = {
   acceptedTransportClose: boolean;
   classification: FirestoreTransportCloseClassification;
   reason: FirestoreTransportCloseRejectionReason;
+};
+
+export type FirestoreTransportCloseSummary = {
+  rawRequestFailureCount: number;
+  acceptedTransportCloseCount: number;
+  unclassifiedRequestFailureCount: number;
+  results: FirestoreTransportCloseResult[];
 };
 
 const allowedFailureWindows: readonly FirestoreTransportCloseFailureWindow[] = [
@@ -166,4 +174,20 @@ export function classifyFirestoreTransportClose(
   }
 
   return accepted();
+}
+
+export function summarizeFirestoreTransportClose(
+  evidence: readonly (FirestoreTransportCloseEvidence | null | undefined)[],
+): FirestoreTransportCloseSummary {
+  const results = evidence.map((item) => classifyFirestoreTransportClose(item));
+  const acceptedTransportCloseCount = results.filter(
+    (result) => result.acceptedTransportClose,
+  ).length;
+
+  return {
+    rawRequestFailureCount: evidence.length,
+    acceptedTransportCloseCount,
+    unclassifiedRequestFailureCount: evidence.length - acceptedTransportCloseCount,
+    results,
+  };
 }

--- a/tests/production/production-readonly-smoke.spec.ts
+++ b/tests/production/production-readonly-smoke.spec.ts
@@ -1,0 +1,450 @@
+import { expect, test, type Page, type Request, type TestInfo } from '@playwright/test';
+import {
+  FIRESTORE_TRANSPORT_CLOSE_HOST,
+  FIRESTORE_TRANSPORT_CLOSE_METHOD,
+  FIRESTORE_TRANSPORT_CLOSE_PATHNAME,
+  FIRESTORE_TRANSPORT_CLOSE_RECONNECT_OBSERVATION_WINDOW_MS,
+  FIRESTORE_TRANSPORT_CLOSE_RESOURCE_TYPE,
+  FIRESTORE_TRANSPORT_CLOSE_MIN_RELOAD_OBSERVATION_MS,
+  summarizeFirestoreTransportClose,
+} from './helpers/classifyFirestoreTransportClose';
+import { buildFirestoreTransportCloseEvidence } from './helpers/buildFirestoreTransportCloseEvidence';
+
+const productionBaseURL =
+  process.env.PRODUCTION_BASE_URL ??
+  'https://audit-management-system-mvp.momosantanuki.workers.dev';
+const authWaitTimeout = Number(process.env.PRODUCTION_AUTH_TIMEOUT_MS ?? 120_000);
+
+type SafeRequestTarget = {
+  host: string;
+  pathname: string;
+};
+
+type FailureContext = {
+  phase: unknown;
+  failureWindow: unknown;
+  transitionOrReloadRelated: unknown;
+  transitionOrReloadDeltaMs: unknown;
+  reloadObservationComplete: unknown;
+  reloadObservationDurationMs: unknown;
+  testEndedImmediately: unknown;
+};
+
+type FirestoreRequestFailureObservation = {
+  sequence: number;
+  observedAt: string;
+  observedAtMs: number;
+  method: unknown;
+  host: unknown;
+  pathname: unknown;
+  resourceType: unknown;
+  safeErrorText: unknown;
+  context: FailureContext;
+  channelLifecycleObserved: boolean;
+};
+
+type ChannelLifecycleEvent = {
+  request: Request;
+  startedAtMs: number;
+  finishedAtMs?: number;
+};
+
+type AuthResponseObservation = {
+  observedAtMs: number;
+  status: number;
+};
+
+type SmokeDiagnostics = {
+  capturedAt: string;
+  consoleErrors: string[];
+  pageErrors: string[];
+  requestFailures: FirestoreRequestFailureObservation[];
+  httpErrors: string[];
+  serverErrors: string[];
+};
+
+type SmokeContext = {
+  phase: unknown;
+  failureWindow: unknown;
+  transitionOrReloadRelated: unknown;
+  referenceAtMs?: number;
+  reloadObservationComplete: boolean;
+  reloadObservationDurationMs?: number;
+};
+
+function safeRequestTarget(rawURL: string): SafeRequestTarget | undefined {
+  try {
+    const url = new URL(rawURL);
+    return { host: url.host, pathname: url.pathname };
+  } catch {
+    return undefined;
+  }
+}
+
+function safeRequestLabel(method: unknown, target: SafeRequestTarget | undefined): string {
+  return `${typeof method === 'string' ? method : 'unknown'} ${
+    target ? `${target.host}${target.pathname}` : '<unparsed-url>'
+  }`;
+}
+
+function redactDiagnosticText(value: string): string {
+  return value
+    .replace(/Bearer\s+[^\s]+/gi, 'Bearer <redacted>')
+    .replace(/\b[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g, '<redacted-token>');
+}
+
+function isExactFirestoreChannelRequest(request: Request): boolean {
+  const target = safeRequestTarget(request.url());
+  return (
+    request.method() === FIRESTORE_TRANSPORT_CLOSE_METHOD &&
+    target?.host === FIRESTORE_TRANSPORT_CLOSE_HOST &&
+    target.pathname === FIRESTORE_TRANSPORT_CLOSE_PATHNAME &&
+    request.resourceType() === FIRESTORE_TRANSPORT_CLOSE_RESOURCE_TYPE
+  );
+}
+
+function isFirebaseAuthResponse(responseURL: string): boolean {
+  const target = safeRequestTarget(responseURL);
+  return (
+    target?.pathname === '/api/firebase/exchange' ||
+    target?.host === 'identitytoolkit.googleapis.com' ||
+    target?.host === 'securetoken.googleapis.com'
+  );
+}
+
+function installProductionDiagnostics(page: Page): {
+  diagnostics: SmokeDiagnostics;
+  channelEvents: ChannelLifecycleEvent[];
+  authResponses: AuthResponseObservation[];
+  setContext: (context: SmokeContext) => void;
+  setTestEnding: (ending: boolean) => void;
+} {
+  const diagnostics: SmokeDiagnostics = {
+    capturedAt: new Date().toISOString(),
+    consoleErrors: [],
+    pageErrors: [],
+    requestFailures: [],
+    httpErrors: [],
+    serverErrors: [],
+  };
+  const channelEvents: ChannelLifecycleEvent[] = [];
+  const channelEventByRequest = new WeakMap<Request, ChannelLifecycleEvent>();
+  const authResponses: AuthResponseObservation[] = [];
+  let context: SmokeContext = {
+    phase: undefined,
+    failureWindow: undefined,
+    transitionOrReloadRelated: undefined,
+    reloadObservationComplete: false,
+  };
+  let testEnding = false;
+
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      diagnostics.consoleErrors.push(redactDiagnosticText(message.text()));
+    }
+  });
+
+  page.on('pageerror', (error) => {
+    diagnostics.pageErrors.push(redactDiagnosticText(String(error)));
+  });
+
+  page.on('request', (request) => {
+    if (!isExactFirestoreChannelRequest(request)) return;
+    const event: ChannelLifecycleEvent = { request, startedAtMs: Date.now() };
+    channelEvents.push(event);
+    channelEventByRequest.set(request, event);
+  });
+
+  page.on('requestfinished', (request) => {
+    const event = channelEventByRequest.get(request);
+    if (event) event.finishedAtMs = Date.now();
+  });
+
+  page.on('requestfailed', (request) => {
+    const observedAtMs = Date.now();
+    const target = safeRequestTarget(request.url());
+    const channelEvent = channelEventByRequest.get(request);
+    const transitionOrReloadDeltaMs = context.referenceAtMs === undefined
+      ? undefined
+      : Math.abs(observedAtMs - context.referenceAtMs);
+
+    diagnostics.requestFailures.push({
+      sequence: diagnostics.requestFailures.length + 1,
+      observedAt: new Date(observedAtMs).toISOString(),
+      observedAtMs,
+      method: request.method(),
+      host: target?.host,
+      pathname: target?.pathname,
+      resourceType: request.resourceType(),
+      safeErrorText: request.failure()?.errorText ?? 'unknown',
+      context: {
+        phase: context.phase,
+        failureWindow: context.failureWindow,
+        transitionOrReloadRelated: context.transitionOrReloadRelated,
+        transitionOrReloadDeltaMs,
+        reloadObservationComplete: context.reloadObservationComplete,
+        reloadObservationDurationMs: context.reloadObservationDurationMs,
+        testEndedImmediately: testEnding,
+      },
+      channelLifecycleObserved: channelEvent !== undefined,
+    });
+  });
+
+  page.on('response', (response) => {
+    const status = response.status();
+    const label = `${status} ${safeRequestLabel(response.request().method(), safeRequestTarget(response.url()))}`;
+
+    if (status >= 400 && status < 500) diagnostics.httpErrors.push(label);
+    if (status >= 500) diagnostics.serverErrors.push(label);
+    if (isFirebaseAuthResponse(response.url())) {
+      authResponses.push({ observedAtMs: Date.now(), status });
+    }
+  });
+
+  return {
+    diagnostics,
+    channelEvents,
+    authResponses,
+    setContext: (nextContext) => {
+      context = nextContext;
+    },
+    setTestEnding: (ending) => {
+      testEnding = ending;
+    },
+  };
+}
+
+function buildEvidence(
+  failure: FirestoreRequestFailureObservation,
+  channelEvents: readonly ChannelLifecycleEvent[],
+  authResponses: readonly AuthResponseObservation[],
+  functionalHealthPassed: boolean,
+  errorCounts: {
+    consoleErrors: number;
+    pageErrors: number;
+    httpErrors: number;
+    serverErrors: number;
+  },
+) {
+  return buildFirestoreTransportCloseEvidence(
+    {
+      observedAtMs: failure.observedAtMs,
+      method: failure.method,
+      host: failure.host,
+      pathname: failure.pathname,
+      resourceType: failure.resourceType,
+      safeErrorText: failure.safeErrorText,
+      phase: failure.context.phase,
+      failureWindow: failure.context.failureWindow,
+      transitionOrReloadRelated: failure.context.transitionOrReloadRelated,
+      transitionOrReloadDeltaMs: failure.context.transitionOrReloadDeltaMs,
+      reloadObservationComplete: failure.context.reloadObservationComplete,
+      reloadObservationDurationMs: failure.context.reloadObservationDurationMs,
+      testEndedImmediately: failure.context.testEndedImmediately,
+      channelLifecycleObserved: failure.channelLifecycleObserved,
+    },
+    channelEvents,
+    authResponses,
+    functionalHealthPassed,
+    errorCounts,
+  );
+}
+
+async function attachDiagnostics(
+  page: Page,
+  diagnostics: SmokeDiagnostics,
+  channelEvents: readonly ChannelLifecycleEvent[],
+  authResponses: readonly AuthResponseObservation[],
+  functionalHealthPassed: boolean,
+  testInfo: TestInfo,
+): Promise<void> {
+  const evidence = diagnostics.requestFailures.map((failure) =>
+    buildEvidence(failure, channelEvents, authResponses, functionalHealthPassed, {
+      consoleErrors: diagnostics.consoleErrors.length,
+      pageErrors: diagnostics.pageErrors.length,
+      httpErrors: diagnostics.httpErrors.length,
+      serverErrors: diagnostics.serverErrors.length,
+    }),
+  );
+  const summary = summarizeFirestoreTransportClose(evidence);
+  const payload = {
+    capturedAt: diagnostics.capturedAt,
+    finalUrl: safeRequestTarget(page.url()),
+    requestFailures: diagnostics.requestFailures,
+    classifiedRequestFailures: evidence.map((item, index) => ({
+      sequence: diagnostics.requestFailures[index]?.sequence,
+      evidence: item,
+      result: summary.results[index],
+    })),
+    counts: {
+      consoleErrors: diagnostics.consoleErrors.length,
+      pageErrors: diagnostics.pageErrors.length,
+      httpErrors: diagnostics.httpErrors.length,
+      serverErrors: diagnostics.serverErrors.length,
+      requestFailures: diagnostics.requestFailures.length,
+      rawRequestFailureCount: summary.rawRequestFailureCount,
+      acceptedTransportCloseCount: summary.acceptedTransportCloseCount,
+      unclassifiedRequestFailureCount: summary.unclassifiedRequestFailureCount,
+    },
+    errors: {
+      console: diagnostics.consoleErrors,
+      page: diagnostics.pageErrors,
+      http: diagnostics.httpErrors,
+      server: diagnostics.serverErrors,
+    },
+    contract: {
+      method: FIRESTORE_TRANSPORT_CLOSE_METHOD,
+      reloadMinimumObservationMs: FIRESTORE_TRANSPORT_CLOSE_MIN_RELOAD_OBSERVATION_MS,
+      reconnectObservationWindowMs: FIRESTORE_TRANSPORT_CLOSE_RECONNECT_OBSERVATION_WINDOW_MS,
+      duringReadiness: 'always-reject',
+      unknownOrMissingEvidence: 'fail-closed',
+    },
+    policy: {
+      save操作: 'なし',
+      queryString: '記録しない',
+      fragment: '記録しない',
+      credentials: '記録しない',
+    },
+  };
+
+  await testInfo.attach('production-readonly-smoke.json', {
+    body: JSON.stringify(payload, null, 2),
+    contentType: 'application/json',
+  });
+}
+
+test('production read-only kiosk smoke classifies Firestore transport closes', async ({ page }, testInfo) => {
+  const installed = installProductionDiagnostics(page);
+  let functionalHealthPassed = false;
+
+  try {
+    installed.setContext({
+      phase: 'root-goto',
+      failureWindow: 'during-goto',
+      transitionOrReloadRelated: true,
+      referenceAtMs: Date.now(),
+      reloadObservationComplete: false,
+    });
+    await page.goto(`${productionBaseURL}/`, {
+      waitUntil: 'domcontentloaded',
+      timeout: 60_000,
+    });
+
+    installed.setContext({
+      phase: 'kiosk-goto',
+      failureWindow: 'during-goto',
+      transitionOrReloadRelated: true,
+      referenceAtMs: Date.now(),
+      reloadObservationComplete: false,
+    });
+    await page.goto(`${productionBaseURL}/kiosk`, {
+      waitUntil: 'domcontentloaded',
+      timeout: 60_000,
+    });
+    installed.setContext({
+      phase: 'kiosk-readiness',
+      failureWindow: 'after-goto-before-readiness',
+      transitionOrReloadRelated: true,
+      referenceAtMs: Date.now(),
+      reloadObservationComplete: false,
+    });
+    await expect(page.getByRole('heading', { name: 'キオスクモード' })).toBeVisible({
+      timeout: authWaitTimeout,
+    });
+    functionalHealthPassed = true;
+
+    installed.setContext({
+      phase: 'toilet-goto',
+      failureWindow: 'during-goto',
+      transitionOrReloadRelated: true,
+      referenceAtMs: Date.now(),
+      reloadObservationComplete: false,
+    });
+    await page.goto(`${productionBaseURL}/kiosk/toilet`, {
+      waitUntil: 'domcontentloaded',
+      timeout: 60_000,
+    });
+    installed.setContext({
+      phase: 'toilet-readiness',
+      failureWindow: 'after-goto-before-readiness',
+      transitionOrReloadRelated: true,
+      referenceAtMs: Date.now(),
+      reloadObservationComplete: false,
+    });
+    await expect(page.getByRole('heading', { name: '本日のトイレ確認' })).toBeVisible({
+      timeout: 30_000,
+    });
+    functionalHealthPassed = true;
+
+    installed.setContext({
+      phase: 'toilet-ready-before-reload',
+      failureWindow: 'after-readiness',
+      transitionOrReloadRelated: false,
+      reloadObservationComplete: false,
+    });
+    await page.waitForTimeout(30_000);
+
+    const reloadCompletedAtMs = Date.now();
+    installed.setContext({
+      phase: 'reload-in-flight',
+      failureWindow: 'after-readiness',
+      transitionOrReloadRelated: true,
+      referenceAtMs: reloadCompletedAtMs,
+      reloadObservationComplete: false,
+    });
+    await page.reload({ waitUntil: 'domcontentloaded', timeout: 60_000 });
+    await expect(page.getByRole('heading', { name: '本日のトイレ確認' })).toBeVisible({
+      timeout: 30_000,
+    });
+    functionalHealthPassed = true;
+
+    const observationStartedAtMs = Date.now();
+    installed.setContext({
+      phase: 'reload-after',
+      failureWindow: 'after-readiness',
+      transitionOrReloadRelated: true,
+      referenceAtMs: observationStartedAtMs,
+      reloadObservationComplete: false,
+    });
+    await page.waitForTimeout(FIRESTORE_TRANSPORT_CLOSE_MIN_RELOAD_OBSERVATION_MS);
+    installed.setContext({
+      phase: 'reload-after-observed',
+      failureWindow: 'after-readiness',
+      transitionOrReloadRelated: true,
+      referenceAtMs: observationStartedAtMs,
+      reloadObservationComplete: true,
+      reloadObservationDurationMs: Date.now() - observationStartedAtMs,
+    });
+
+    installed.setTestEnding(true);
+    const evidence = installed.diagnostics.requestFailures.map((failure) =>
+      buildEvidence(failure, installed.channelEvents, installed.authResponses, functionalHealthPassed, {
+        consoleErrors: installed.diagnostics.consoleErrors.length,
+        pageErrors: installed.diagnostics.pageErrors.length,
+        httpErrors: installed.diagnostics.httpErrors.length,
+        serverErrors: installed.diagnostics.serverErrors.length,
+      }),
+    );
+    const summary = summarizeFirestoreTransportClose(evidence);
+
+    expect(summary.rawRequestFailureCount).toBe(installed.diagnostics.requestFailures.length);
+    expect(
+      summary.acceptedTransportCloseCount + summary.unclassifiedRequestFailureCount,
+    ).toBe(summary.rawRequestFailureCount);
+    expect(summary.unclassifiedRequestFailureCount).toBe(0);
+    expect(installed.diagnostics.consoleErrors).toHaveLength(0);
+    expect(installed.diagnostics.pageErrors).toHaveLength(0);
+    expect(installed.diagnostics.httpErrors).toHaveLength(0);
+    expect(installed.diagnostics.serverErrors).toHaveLength(0);
+  } finally {
+    installed.setTestEnding(true);
+    await attachDiagnostics(
+      page,
+      installed.diagnostics,
+      installed.channelEvents,
+      installed.authResponses,
+      functionalHealthPassed,
+      testInfo,
+    );
+  }
+});

--- a/tests/unit/production/buildFirestoreTransportCloseEvidence.spec.ts
+++ b/tests/unit/production/buildFirestoreTransportCloseEvidence.spec.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildFirestoreTransportCloseEvidence,
+  type FirestoreTransportCloseAuthResponseSnapshot,
+  type FirestoreTransportCloseChannelSnapshot,
+  type FirestoreTransportCloseFailureSnapshot,
+} from '../../production/helpers/buildFirestoreTransportCloseEvidence';
+import {
+  FIRESTORE_TRANSPORT_CLOSE_ERROR_TEXT,
+  FIRESTORE_TRANSPORT_CLOSE_HOST,
+  FIRESTORE_TRANSPORT_CLOSE_METHOD,
+  FIRESTORE_TRANSPORT_CLOSE_PATHNAME,
+  FIRESTORE_TRANSPORT_CLOSE_RESOURCE_TYPE,
+} from '../../production/helpers/classifyFirestoreTransportClose';
+
+const baseFailure = (): FirestoreTransportCloseFailureSnapshot => ({
+  observedAtMs: 1_000,
+  method: FIRESTORE_TRANSPORT_CLOSE_METHOD,
+  host: FIRESTORE_TRANSPORT_CLOSE_HOST,
+  pathname: FIRESTORE_TRANSPORT_CLOSE_PATHNAME,
+  resourceType: FIRESTORE_TRANSPORT_CLOSE_RESOURCE_TYPE,
+  safeErrorText: FIRESTORE_TRANSPORT_CLOSE_ERROR_TEXT,
+  phase: 'reload-after',
+  failureWindow: 'after-readiness',
+  transitionOrReloadRelated: true,
+  transitionOrReloadDeltaMs: 250,
+  reloadObservationComplete: true,
+  reloadObservationDurationMs: 10_000,
+  testEndedImmediately: false,
+  channelLifecycleObserved: true,
+});
+
+const healthyAuth = (): FirestoreTransportCloseAuthResponseSnapshot[] => [
+  { observedAtMs: 900, status: 200 },
+];
+
+const laterConnection = (): FirestoreTransportCloseChannelSnapshot[] => [
+  { startedAtMs: 1_500, finishedAtMs: 1_600 },
+];
+
+const zeroErrors = {
+  consoleErrors: 0,
+  pageErrors: 0,
+  httpErrors: 0,
+  serverErrors: 0,
+};
+
+describe('buildFirestoreTransportCloseEvidence', () => {
+  it('builds complete evidence for a successful later connection', () => {
+    expect(
+      buildFirestoreTransportCloseEvidence(
+        baseFailure(),
+        laterConnection(),
+        healthyAuth(),
+        true,
+        zeroErrors,
+      ),
+    ).toMatchObject({
+      laterConnectionSucceeded: true,
+      firebaseAuthHealthy: true,
+      functionalHealthPassed: true,
+      consoleErrors: 0,
+      pageErrors: 0,
+      httpErrors: 0,
+      serverErrors: 0,
+    });
+  });
+
+  it('fails closed when auth evidence is absent', () => {
+    const evidence = buildFirestoreTransportCloseEvidence(
+      baseFailure(),
+      laterConnection(),
+      [],
+      true,
+      zeroErrors,
+    );
+
+    expect(evidence.firebaseAuthHealthy).toBeUndefined();
+  });
+
+  it('does not count a connection outside the fixed observation window', () => {
+    const evidence = buildFirestoreTransportCloseEvidence(
+      baseFailure(),
+      [{ startedAtMs: 11_001, finishedAtMs: 11_002 }],
+      healthyAuth(),
+      true,
+      zeroErrors,
+    );
+
+    expect(evidence.laterConnectionSucceeded).toBe(false);
+  });
+
+  it('carries non-zero error counts into the classifier evidence', () => {
+    const evidence = buildFirestoreTransportCloseEvidence(
+      baseFailure(),
+      laterConnection(),
+      healthyAuth(),
+      true,
+      { ...zeroErrors, httpErrors: 1 },
+    );
+
+    expect(evidence.httpErrors).toBe(1);
+  });
+});

--- a/tests/unit/production/classifyFirestoreTransportClose.spec.ts
+++ b/tests/unit/production/classifyFirestoreTransportClose.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   classifyFirestoreTransportClose,
+  summarizeFirestoreTransportClose,
   type FirestoreTransportCloseEvidence,
 } from '../../production/helpers/classifyFirestoreTransportClose';
 
@@ -163,5 +164,37 @@ describe('classifyFirestoreTransportClose', () => {
     expect(expectRejected({ testEndedImmediately: undefined }).reason).toBe(
       'test-ended-immediately',
     );
+  });
+
+  it('preserves raw failures while separating accepted and unclassified counts', () => {
+    const summary = summarizeFirestoreTransportClose([
+      {
+        ...baseEvidence(),
+        failureWindow: 'after-goto-before-readiness',
+      },
+      {
+        ...baseEvidence(),
+        method: 'GET',
+      },
+    ]);
+
+    expect(summary.rawRequestFailureCount).toBe(2);
+    expect(summary.acceptedTransportCloseCount).toBe(1);
+    expect(summary.unclassifiedRequestFailureCount).toBe(1);
+    expect(summary.results.map((result) => result.classification)).toEqual([
+      'acceptedTransportClose',
+      'unclassifiedRequestFailure',
+    ]);
+  });
+
+  it('fails closed when the summary contains missing evidence', () => {
+    const summary = summarizeFirestoreTransportClose([undefined, null]);
+
+    expect(summary).toMatchObject({
+      rawRequestFailureCount: 2,
+      acceptedTransportCloseCount: 0,
+      unclassifiedRequestFailureCount: 2,
+    });
+    expect(summary.results.every((result) => !result.acceptedTransportClose)).toBe(true);
   });
 });

--- a/tests/unit/production/classifyFirestoreTransportClose.spec.ts
+++ b/tests/unit/production/classifyFirestoreTransportClose.spec.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest';
+import {
+  classifyFirestoreTransportClose,
+  type FirestoreTransportCloseEvidence,
+} from '../../production/helpers/classifyFirestoreTransportClose';
+
+const baseEvidence = (): FirestoreTransportCloseEvidence => ({
+  phase: 'users-goto-in-flight',
+  failureWindow: 'during-goto',
+  method: 'POST',
+  host: 'firestore.googleapis.com',
+  pathname: '/google.firestore.v1.Firestore/Write/channel',
+  resourceType: 'fetch',
+  safeErrorText: 'net::ERR_ABORTED',
+  channelLifecycleMatch: true,
+  transitionOrReloadRelated: true,
+  transitionOrReloadDeltaMs: 100,
+  laterConnectionSucceeded: true,
+  firebaseAuthHealthy: true,
+  functionalHealthPassed: true,
+  consoleErrors: 0,
+  pageErrors: 0,
+  httpErrors: 0,
+  serverErrors: 0,
+  testEndedImmediately: false,
+});
+
+const expectRejected = (
+  overrides: Partial<FirestoreTransportCloseEvidence>,
+): ReturnType<typeof classifyFirestoreTransportClose> => {
+  const result = classifyFirestoreTransportClose({ ...baseEvidence(), ...overrides });
+  expect(result.acceptedTransportClose).toBe(false);
+  expect(result.classification).toBe('unclassifiedRequestFailure');
+  return result;
+};
+
+describe('classifyFirestoreTransportClose', () => {
+  it('accepts a transition-adjacent failure when every condition is satisfied', () => {
+    expect(
+      classifyFirestoreTransportClose({
+        ...baseEvidence(),
+        failureWindow: 'after-goto-before-readiness',
+        transitionOrReloadDeltaMs: 0,
+      }),
+    ).toEqual({
+      acceptedTransportClose: true,
+      classification: 'acceptedTransportClose',
+      reason: 'accepted',
+    });
+  });
+
+  it('accepts a reload-adjacent failure after ten seconds of observation and reconnection', () => {
+    expect(
+      classifyFirestoreTransportClose({
+        ...baseEvidence(),
+        phase: 'reload-after',
+        failureWindow: 'after-readiness',
+        transitionOrReloadDeltaMs: 250,
+        reloadObservationComplete: true,
+        reloadObservationDurationMs: 10_000,
+      }).acceptedTransportClose,
+    ).toBe(true);
+  });
+
+  it.each([
+    ['during-readiness', { failureWindow: 'during-readiness' }],
+    ['before-goto', { failureWindow: 'before-goto' }],
+    ['unknown window', { failureWindow: 'unknown' }],
+    ['missing window', { failureWindow: undefined }],
+    ['null window', { failureWindow: null }],
+  ] as const)('rejects %s', (_label, overrides) => {
+    expectRejected(overrides);
+  });
+
+  it.each([
+    ['host', { host: 'other.example.com' }],
+    ['pathname', { pathname: '/google.firestore.v1.Firestore/Listen/channel' }],
+    ['method', { method: 'GET' }],
+    ['resource type', { resourceType: 'xhr' }],
+    ['error text', { safeErrorText: 'net::ERR_FAILED' }],
+  ] as const)('rejects a %s mismatch', (_label, overrides) => {
+    expectRejected(overrides);
+  });
+
+  it.each([
+    ['missing method', { method: undefined }],
+    ['null host', { host: null }],
+    ['unknown path', { pathname: 'unknown' }],
+    ['unknown phase', { phase: 'unknown' }],
+    ['null lifecycle', { channelLifecycleMatch: null }],
+    ['undefined auth health', { firebaseAuthHealthy: undefined }],
+  ] as const)('rejects %s as missing or unknown evidence', (_label, overrides) => {
+    expectRejected(overrides);
+  });
+
+  it.each([undefined, null])('rejects %s evidence objects without throwing', (evidence) => {
+    expect(classifyFirestoreTransportClose(evidence)).toEqual({
+      acceptedTransportClose: false,
+      classification: 'unclassifiedRequestFailure',
+      reason: 'request-shape-mismatch',
+    });
+  });
+
+  it('rejects a channel lifecycle mismatch', () => {
+    expectRejected({ channelLifecycleMatch: false });
+  });
+
+  it('rejects when the later connection did not succeed', () => {
+    expectRejected({ laterConnectionSucceeded: false });
+  });
+
+  it('rejects when transition or reload evidence is absent or too far away', () => {
+    expect(expectRejected({ transitionOrReloadRelated: false }).reason).toBe(
+      'missing-transition-or-reload-evidence',
+    );
+    expect(expectRejected({ transitionOrReloadDeltaMs: undefined }).reason).toBe(
+      'missing-transition-or-reload-evidence',
+    );
+    expect(expectRejected({ transitionOrReloadDeltaMs: 5_001 }).reason).toBe(
+      'missing-transition-or-reload-evidence',
+    );
+  });
+
+  it('rejects an unhealthy Firebase auth state', () => {
+    expectRejected({ firebaseAuthHealthy: false });
+  });
+
+  it('rejects an unhealthy functional state', () => {
+    expectRejected({ functionalHealthPassed: false });
+  });
+
+  it.each(['consoleErrors', 'pageErrors', 'httpErrors', 'serverErrors'] as const)(
+    'rejects when %s is non-zero',
+    (field) => {
+      expectRejected({ [field]: 1 });
+    },
+  );
+
+  it('rejects a reload failure before the ten-second observation minimum', () => {
+    expect(
+      expectRejected({
+        phase: 'reload-after',
+        failureWindow: 'after-readiness',
+        reloadObservationComplete: true,
+        reloadObservationDurationMs: 9_999,
+      }).reason,
+    ).toBe('reload-observation-incomplete');
+  });
+
+  it('rejects reload evidence that is incomplete even when its duration is long enough', () => {
+    expect(
+      expectRejected({
+        phase: 'reload-after',
+        failureWindow: 'after-readiness',
+        reloadObservationComplete: false,
+        reloadObservationDurationMs: 10_000,
+      }).reason,
+    ).toBe('reload-observation-incomplete');
+  });
+
+  it('rejects a failure observed at test termination', () => {
+    expect(expectRejected({ testEndedImmediately: true }).reason).toBe('test-ended-immediately');
+    expect(expectRejected({ testEndedImmediately: undefined }).reason).toBe(
+      'test-ended-immediately',
+    );
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
       '**/dist/**',
       'tests/e2e/**',
       'tests/integration/**', // Playwright integration tests, not Vitest
+      'tests/production/production-readonly-smoke.spec.ts', // Playwright production smoke, not Vitest
       'tests/regression/**',
       'tests/unit/briefing.edge.spec.ts',
       'tests/unit/spClient.schedule.spec.ts',


### PR DESCRIPTION
## Summary

Issue #2523で承認された`LIMITED-FIRESTORE-TRANSPORT-CLOSE-CONTRACT`を、production readonly smokeへ接続します。

このPRは`main`起点の別PRであり、PR #2525は変更しません。

## Scope

- `playwright.production-readonly.config.ts`
- `tests/production/production-readonly-smoke.spec.ts`
- `tests/production/helpers/buildFirestoreTransportCloseEvidence.ts`
- `tests/production/helpers/classifyFirestoreTransportClose.ts`
- `tests/unit/production/buildFirestoreTransportCloseEvidence.spec.ts`
- `tests/unit/production/classifyFirestoreTransportClose.spec.ts`

## Contract

- raw request failures are preserved in JSON attachment
- `rawRequestFailureCount`, `acceptedTransportCloseCount`, and `unclassifiedRequestFailureCount` are asserted for consistency
- gate assertion is `unclassifiedRequestFailureCount === 0`
- fixed POST / Firestore channel / fetch / `net::ERR_ABORTED`
- structured phase, failure window, resource type, lifecycle, auth, functional, HTTP/server error evidence
- reload observation minimum: 10 seconds
- later connection observation window: 10 seconds
- unknown or missing evidence fails closed
- `during-readiness` is rejected

## Validation

- Unit tests: 38 passed
- Targeted ESLint: PASS
- Targeted TypeScript: PASS
- Full lint: PASS
- Full build typecheck: PASS
- Production smoke execution: not run

## Explicitly not included

- PR #2525 Ready conversion or merge
- PR #2514 changes
- Gate 4A rerun
- production access during implementation
- deploy or rollback

Production remains NO-GO.