### PR TITLE
chore(deps): override ExcelJS uuid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11630,6 +11630,19 @@
         "node": ">=14.14"
       }
     },
+    "node_modules/exceljs/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/execa": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
@@ -21270,6 +21283,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"

--- a/package.json
+++ b/package.json
@@ -219,7 +219,10 @@
   },
   "overrides": {
     "date-fns-tz": "^3.2.0",
-    "react-is": "18.3.1"
+    "react-is": "18.3.1",
+    "exceljs": {
+      "uuid": "^11.1.1"
+    }
   },
   "lint-staged": {
     "**/*.{js,jsx,ts,tsx}": "eslint --fix"


### PR DESCRIPTION
## Summary
- Recreate #2428 from current main (no old branch rebase)
- Add dependency override: exceljs -> uuid@^11.1.1
- Keep changes to package.json and package-lock.json only

## Validation
- npm ci
- npm ls exceljs uuid
  - exceljs@4.4.0 -> uuid@11.1.1
  - @azure/msal-node and @lhci/cli still resolve uuid@8.3.2
- npm audit --omit=dev
  - Remaining: brace-expansion high (existing / unrelated)
- npm run typecheck:full -- --pretty false
  - NOTE: currently fails on repository baseline for tests/unit/records.api.spec.ts missing VITE_MSAL_REDIRECT_URI in test env
- npm run lint -- --max-warnings 0
- git diff --check
- Excel output focused tests
  - tests/unit/official-forms/generateSupportProcedureExcel.spec.ts
  - tests/unit/official-forms/generateSeikatsuKaigoExcel.spec.ts
  - tests/unit/official-forms/uploadToSharePoint.spec.ts

## Notes
- brace-expansion high is unrelated to this change and remains on main path.
