### PR TITLE
test(e2e): pin transport critical timezone

### DIFF
--- a/.github/workflows/nightly-health.yml
+++ b/.github/workflows/nightly-health.yml
@@ -91,6 +91,7 @@ jobs:
       - name: E2E (nightly transport critical)
         run: npm run test:e2e:transport:critical
         env:
+          TZ: Asia/Tokyo
           VITE_E2E: "1"
           VITE_SKIP_LOGIN: "1"
           VITE_E2E_MSAL_MOCK: "1"

--- a/tests/e2e/exception-center.transport-missing-driver-flow.spec.ts
+++ b/tests/e2e/exception-center.transport-missing-driver-flow.spec.ts
@@ -4,6 +4,8 @@ import { bootstrapDashboard } from './utils/bootstrapApp';
 const COLLAPSED_PARENTS_STORAGE_KEY = 'exception-collapsed-parents';
 const SCHEDULES_STORAGE_KEY = 'e2e:schedules.v1';
 
+test.use({ timezoneId: 'Asia/Tokyo' });
+
 test.describe('ExceptionCenter transport missing-driver child flow', () => {
   test('flat/grouped rendering and child deep-link landing remain consistent', async ({ page }) => {
     await page.addInitScript(({ collapsedParentsKey, schedulesKey }) => {

--- a/tests/e2e/transport-assignments-save-reflects-in-today.spec.ts
+++ b/tests/e2e/transport-assignments-save-reflects-in-today.spec.ts
@@ -6,6 +6,8 @@ import { selectMuiOptionByLabel } from './utils/muiSelect';
 const TARGET_USER_ID = 'U002';
 const TARGET_USER_NAME = '鈴木 美子';
 
+test.use({ timezoneId: 'Asia/Tokyo' });
+
 test.describe('Transport assignments save reflects in today', () => {
   test('assign/save and unassign/save are reflected in today transport vehicle board', async ({ page }) => {
     const today = new Intl.DateTimeFormat('sv-SE', {

--- a/tests/e2e/transport-assignments-week-bulk-apply-reflects-in-today.spec.ts
+++ b/tests/e2e/transport-assignments-week-bulk-apply-reflects-in-today.spec.ts
@@ -11,6 +11,8 @@ const USER_APPLY_NAME = '鈴木 美子';
 const USER_KEEP_ID = 'U001';
 const USER_KEEP_NAME = '田中 太郎';
 
+test.use({ timezoneId: 'Asia/Tokyo' });
+
 test.describe('Transport assignments week bulk apply reflects in today', () => {
   test('bulk apply + save reflects in today board and does not overwrite existing assignment', async ({ page }) => {
     await setupSharePointStubs(page, {

--- a/tests/e2e/transport-course-users-update-reflects-in-transport-assignments.spec.ts
+++ b/tests/e2e/transport-course-users-update-reflects-in-transport-assignments.spec.ts
@@ -8,6 +8,8 @@ const TARGET_DATE = '2026-03-25';
 const TARGET_USER_ID = 'U002';
 const TARGET_USER_NAME = '鈴木 美子';
 
+test.use({ timezoneId: 'Asia/Tokyo' });
+
 test.describe('Users TransportCourse update reflects in transport assignments', () => {
   test('updating TransportCourse on /users is reflected as fixed-course default on /transport/assignments', async ({ page }) => {
     await setupSharePointStubs(page, {


### PR DESCRIPTION
## Summary

- pin the Chromium timezone to `Asia/Tokyo` for the four Nightly transport-critical specs
- set `TZ: Asia/Tokyo` on the Nightly transport-critical workflow step
- keep application date handling, fixtures, Router, authentication, and production configuration unchanged

## Root cause

The Linux runner timezone does not set the Chromium browser timezone. The affected specs expected `2026-03-25` but Chromium rendered `2026-03-24`.

## Validation

- `npm run typecheck:full -- --pretty false --incremental false` — PASS
- `npm run lint` — PASS
- `git diff --check` — PASS
- `TZ=Asia/Tokyo npm run test:e2e:transport:critical -- --retries=0` — timezone assertion cleared; four independent fixture/runtime failures remain

Residual failures intentionally excluded from this PR:

- missing `exception-table`
- target user option not selectable
- bulk summary reports `水 変更なし` instead of `水 1件`
- vehicle card renders `U002` instead of `鈴木 美子`

The prior `2026-03-25` expected / `2026-03-24` received failure is no longer present.
