### PR TITLE
Honor provisioning skip policy during SharePoint bootstrap

### DIFF
--- a/src/app/SpInitBridge.tsx
+++ b/src/app/SpInitBridge.tsx
@@ -16,6 +16,7 @@ import { useUserAuthz } from '@/auth/useUserAuthz';
 import { useToast } from '@/hooks/useToast';
 import { useAuthReady } from '@/auth/useAuthReady';
 import { useNightlySignalIngestion } from '@/features/sp/health/hooks/useNightlySignalIngestion';
+import { shouldRunSharePointProvisioningBootstrap } from './spBootstrapPolicy';
 
 /**
  * SP 初期化ブリッジ — レンダーなし、副作用のみ
@@ -52,23 +53,30 @@ export const SpInitBridge: React.FC = () => {
 
       // 1. SharePoint リストの一括プロビジョニング・検証（SharePoint モードのみ）
       // Demo/Smoke モード（VITE_SKIP_SHAREPOINT=1）ではプロビジョニングをスキップして 404 を回避する
-      const { shouldSkipSharePoint } = await import('@/lib/env');
-      if (providerType !== 'sharepoint' || shouldSkipSharePoint()) return;
-      
-      try {
-        const result = await SharePointProvisioningCoordinator.bootstrap(sp);
+      const { readBool, shouldSkipSharePoint } = await import('@/lib/env');
+      const shouldRunProvisioning = shouldRunSharePointProvisioningBootstrap({
+        providerType,
+        skipSharePoint: shouldSkipSharePoint(),
+        skipProvisioning: readBool('VITE_SKIP_PROVISIONING', false),
+      });
 
-        // 管理者の場合のみ、不具合のあるリストを通知（一度だけ表示）
-        if (role === 'admin' && result.unhealthy > 0 && !globalAdminWarningShown) {
-          globalAdminWarningShown = true;
-          const message = `SharePoint Schema Warning: ${result.unhealthy} lists may need attention. Check logs for details.`;
-          show('warning', message);
+      if (shouldRunProvisioning) {
+        try {
+          const result = await SharePointProvisioningCoordinator.bootstrap(sp);
+
+          // 管理者の場合のみ、不具合のあるリストを通知（一度だけ表示）
+          if (role === 'admin' && result.unhealthy > 0 && !globalAdminWarningShown) {
+            globalAdminWarningShown = true;
+            const message = `SharePoint Schema Warning: ${result.unhealthy} lists may need attention. Check logs for details.`;
+            show('warning', message);
+          }
+        } catch (err) {
+          console.error('[SpInitBridge] Provisioning bootstrap critical failure:', err);
         }
-      } catch (err) {
-        console.error('[SpInitBridge] Provisioning bootstrap critical failure:', err);
       }
 
       // 2. Holiday_Master の読み込み（非同期、失敗しても問題なし）
+      if (providerType !== 'sharepoint' || shouldSkipSharePoint()) return;
       await loadHolidaysFromSharePoint(sp).catch((err) => {
         console.warn('[SpInitBridge] Holiday load failed (non-fatal):', err);
       });

--- a/src/app/spBootstrapPolicy.spec.ts
+++ b/src/app/spBootstrapPolicy.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { shouldRunSharePointProvisioningBootstrap } from './spBootstrapPolicy';
+
+describe('shouldRunSharePointProvisioningBootstrap', () => {
+  it('runs only for SharePoint when provisioning is enabled', () => {
+    expect(shouldRunSharePointProvisioningBootstrap({
+      providerType: 'sharepoint',
+      skipSharePoint: false,
+      skipProvisioning: false,
+    })).toBe(true);
+  });
+
+  it('skips the bootstrap when the provisioning policy is enabled', () => {
+    expect(shouldRunSharePointProvisioningBootstrap({
+      providerType: 'sharepoint',
+      skipSharePoint: false,
+      skipProvisioning: true,
+    })).toBe(false);
+  });
+
+  it('skips non-SharePoint and SharePoint-skip modes', () => {
+    expect(shouldRunSharePointProvisioningBootstrap({
+      providerType: 'localStorage',
+      skipSharePoint: false,
+      skipProvisioning: false,
+    })).toBe(false);
+    expect(shouldRunSharePointProvisioningBootstrap({
+      providerType: 'sharepoint',
+      skipSharePoint: true,
+      skipProvisioning: false,
+    })).toBe(false);
+  });
+});

--- a/src/app/spBootstrapPolicy.ts
+++ b/src/app/spBootstrapPolicy.ts
@@ -1,0 +1,6 @@
+export const shouldRunSharePointProvisioningBootstrap = (options: {
+  providerType: string;
+  skipSharePoint: boolean;
+  skipProvisioning: boolean;
+}): boolean =>
+  options.providerType === 'sharepoint' && !options.skipSharePoint && !options.skipProvisioning;


### PR DESCRIPTION
## Summary

The previous production deployment propagated `VITE_SKIP_PROVISIONING=1` into the Worker runtime, but `SpInitBridge` still ran the full SharePoint provisioning/health bootstrap. That bootstrap produced the production `/api/sp-proxy` failure banner even though the billing read path rendered.

This PR makes the runtime policy effective at the bootstrap boundary:

- skip the SharePoint provisioning/verification bootstrap when `VITE_SKIP_PROVISIONING` is enabled;
- keep the existing Holiday_Master read behavior for SharePoint mode;
- leave billing authorization, data reads, update protection, CI conditions, and Deep classification unchanged.

## Validation

- targeted policy Vitest: 3 passed
- lint: PASS
- typecheck: PASS
- build: PASS
- `test:ci:node`: 5 passed
- act warning guard: 0 warnings
- `git diff --check`: PASS

A previous production smoke incident is recorded on PR #2531. No billing update, retry action, rollback, or force/admin bypass was performed while diagnosing it. This PR must pass its own required CI and the post-deploy read-only smoke before release status can be cleared.