### PR TITLE
fix(a11y): restore AppShellV2 skip link

### DIFF
--- a/src/components/layout/AppShellV2.a11y.test.tsx
+++ b/src/components/layout/AppShellV2.a11y.test.tsx
@@ -1,0 +1,46 @@
+import { render, cleanup, fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { afterEach, describe, expect, it } from 'vitest';
+import { AppShellV2 } from './AppShellV2';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('AppShellV2 skip link contract', () => {
+  it.each(['light', 'dark'] as const)('renders the same contract in %s mode', (mode) => {
+    render(
+      <ThemeProvider theme={createTheme({ palette: { mode } })}>
+        <AppShellV2>{null}</AppShellV2>
+      </ThemeProvider>,
+    );
+
+    const skipLink = screen.getByTestId('skip-to-main-link');
+    const main = document.getElementById('app-main-content');
+
+    expect(skipLink).toHaveAttribute('href', '#app-main-content');
+    expect(main).not.toBeNull();
+    expect(document.querySelectorAll('#app-main-content')).toHaveLength(1);
+    expect(main).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('moves keyboard activation focus to the main content', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ThemeProvider theme={createTheme()}>
+        <AppShellV2>{null}</AppShellV2>
+      </ThemeProvider>,
+    );
+
+    const skipLink = screen.getByTestId('skip-to-main-link');
+    const main = document.getElementById('app-main-content');
+    expect(main).not.toBeNull();
+
+    await user.tab();
+    expect(skipLink).toHaveFocus();
+    fireEvent.click(skipLink);
+    expect(main).toHaveFocus();
+  });
+});

--- a/src/components/layout/AppShellV2.tsx
+++ b/src/components/layout/AppShellV2.tsx
@@ -76,6 +76,33 @@ export function AppShellV2({
         bgcolor: 'background.default',
       }}
     >
+      <Box
+        component="a"
+        href={`#${mainId}`}
+        data-testid="skip-to-main-link"
+        onClick={(event) => {
+          const target = document.getElementById(mainId);
+          if (!target) return;
+
+          event.preventDefault();
+          target.focus();
+          if (typeof target.scrollIntoView === 'function') {
+            target.scrollIntoView({ block: 'start' });
+          }
+        }}
+        sx={{
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          zIndex: (theme) => theme.zIndex.tooltip,
+          transform: 'translateY(-200%)',
+          '&:focus': {
+            transform: 'translateY(0)',
+          },
+        }}
+      >
+        メインコンテンツへ移動
+      </Box>
       {/* Header */}
       <Box
         sx={{


### PR DESCRIPTION
## Summary
- AppShellV2に共通skip-linkを追加
- 全ルートでメインコンテンツへ移動できるアクセシビリティ契約を復元
- light/dark、empty/populatedで同一DOM契約を維持

## Root cause
共通レイアウトのAppShellV2にskip-linkが存在せず、call-logsとusersのapp-a11y検証でskip-link focus契約が成立していませんでした。

## Scope
- `src/components/layout/AppShellV2.tsx`
- `src/components/layout/AppShellV2.a11y.test.tsx`

## Validation
- AppShellV2 accessibility contract: 3 passed
- call-logs light/empty: PASS
- call-logs dark/empty: PASS
- users usability: PASS
- typecheck: PASS
- lint: PASS
- build: PASS
- diff check: PASS

## Deep attribution
- baseline app-a11y failures: 11
- current app-a11y failures: 8
- resolved: 3
- new: 0
- common existing failures: 8

Resolved targets:
- call-logs usability light/empty
- call-logs usability dark/empty
- users usability skip-link focus

この結果は対象3件の解消を示すものであり、全app-a11yがPASSしたという判定ではありません。

## Not in scope
- PR #2535
- Users repository契約
- Users E2E
- call-logs機能
- fixture
- workflow
- production設定
- deploy
- Secret変更

## Decision
`PASS — SKIP-LINK TARGETS RESOLVED / NEW FAILURE 0`
DraftのままCI完了後に再評価します。
