### PR TITLE
fix(regulatory): fail closed on severe addon data gaps

### DIFF
--- a/src/domain/regulatory/__tests__/behaviorScoreResolution.spec.ts
+++ b/src/domain/regulatory/__tests__/behaviorScoreResolution.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { resolveBehaviorScore } from '../behaviorScoreResolution';
+
+describe('resolveBehaviorScore', () => {
+  it.each([0, 9, 10, 12])('accepts valid score %s', value => {
+    expect(resolveBehaviorScore(value)).toEqual({ status: 'valid', value });
+  });
+
+  it.each([
+    [null, 'missing'],
+    [undefined, 'missing'],
+    [NaN, 'not-finite'],
+    [Infinity, 'not-finite'],
+    [-Infinity, 'not-finite'],
+    [-1, 'negative'],
+    ['12', 'invalid-type'],
+  ] as const)('returns indeterminate for %s', (value, reason) => {
+    expect(resolveBehaviorScore(value)).toEqual({ status: 'indeterminate', reason });
+  });
+});

--- a/src/domain/regulatory/__tests__/severeAddonFailClosed.spec.ts
+++ b/src/domain/regulatory/__tests__/severeAddonFailClosed.spec.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { buildHandoffFromAddonFinding } from '../findingToHandoff';
 import { checkUserEligibility, isDefinitelyIneligibleSupportLevel } from '../severeDisabilityAddon';
+import {
+  resolveSevereAddonUserResolution,
+  resolveSupportLevel,
+} from '../severeAddonUserResolution';
 
 describe('severe add-on fail-closed behavior', () => {
   it.each([null, undefined, NaN, Infinity, -Infinity, -1, '12'] as const)(
@@ -25,6 +29,52 @@ describe('severe add-on fail-closed behavior', () => {
 
   it.each([null, undefined, '', 'unknown', '4', '6'])('does not classify support level %s as definitely ineligible', level => {
     expect(isDefinitelyIneligibleSupportLevel(level)).toBe(false);
+  });
+
+  it.each([
+    [1, 'ineligible'],
+    [3, 'ineligible'],
+    [4, 'valid'],
+    [6, 'valid'],
+    [' 4 ', 'valid'],
+    [null, 'missing'],
+    [undefined, 'missing'],
+    ['', 'missing'],
+    ['   ', 'missing'],
+    ['4x', 'invalid'],
+    ['4.0', 'invalid'],
+    [4.5, 'invalid'],
+    [true, 'invalid'],
+    [{}, 'invalid'],
+  ] as const)('resolves support level %s as %s', (value, status) => {
+    expect(resolveSupportLevel(value).status).toBe(status);
+  });
+
+  it.each([
+    [{ supportLevel: '1', behaviorScore: null }, 'ineligible'],
+    [{ supportLevel: '3', behaviorScore: 'invalid' }, 'ineligible'],
+    [{ supportLevel: '4', behaviorScore: null }, 'indeterminate'],
+    [{ supportLevel: '6', behaviorScore: 'invalid' }, 'indeterminate'],
+    [{ supportLevel: null, behaviorScore: 12 }, 'indeterminate'],
+    [{ supportLevel: '4x', behaviorScore: 12 }, 'indeterminate'],
+    [{ supportLevel: '4', behaviorScore: 12 }, 'valid'],
+  ] as const)('resolves user data %o as %s', (input, status) => {
+    expect(resolveSevereAddonUserResolution(input).status).toBe(status);
+  });
+
+  it('uses separate reasons for support level and behavior score gaps', () => {
+    expect(resolveSevereAddonUserResolution({ supportLevel: null, behaviorScore: 12 })).toEqual({
+      status: 'indeterminate',
+      reason: 'support-level-missing',
+    });
+    expect(resolveSevereAddonUserResolution({ supportLevel: '4', behaviorScore: null })).toEqual({
+      status: 'indeterminate',
+      reason: 'behavior-score-missing',
+    });
+    expect(resolveSevereAddonUserResolution({ supportLevel: '6', behaviorScore: -1 })).toEqual({
+      status: 'indeterminate',
+      reason: 'behavior-score-invalid',
+    });
   });
 
   it('rejects demo findings at the handoff conversion boundary', () => {

--- a/src/domain/regulatory/__tests__/severeAddonFailClosed.spec.ts
+++ b/src/domain/regulatory/__tests__/severeAddonFailClosed.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { buildHandoffFromAddonFinding } from '../findingToHandoff';
+import { checkUserEligibility } from '../severeDisabilityAddon';
+
+describe('severe add-on fail-closed behavior', () => {
+  it.each([null, undefined, NaN, Infinity, -Infinity, -1, '12'] as const)(
+    'does not treat invalid behavior score %s as eligible',
+    value => {
+      const result = checkUserEligibility('6', value as number | null | undefined);
+      expect(result.tier2).toBe(false);
+      expect(result.tier3).toBe(false);
+      expect(result.isUpperTier).toBe(false);
+    },
+  );
+
+  it('keeps score zero valid but not eligible', () => {
+    const result = checkUserEligibility('6', 0);
+    expect(result.tier2).toBe(false);
+    expect(result.tier3).toBe(false);
+  });
+
+  it('rejects demo findings at the handoff conversion boundary', () => {
+    expect(() => buildHandoffFromAddonFinding({
+      id: 'demo-1',
+      type: 'basic_training_ratio_insufficient',
+      severity: 'medium',
+      domain: 'sheet',
+      userId: '__facility__',
+      message: 'demo',
+      detectedAt: '2026-08-03',
+      dataOrigin: 'demo',
+    })).toThrow('Demo finding cannot be handed off');
+  });
+});

--- a/src/domain/regulatory/__tests__/severeAddonFailClosed.spec.ts
+++ b/src/domain/regulatory/__tests__/severeAddonFailClosed.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { buildHandoffFromAddonFinding } from '../findingToHandoff';
-import { checkUserEligibility } from '../severeDisabilityAddon';
+import { checkUserEligibility, isDefinitelyIneligibleSupportLevel } from '../severeDisabilityAddon';
 
 describe('severe add-on fail-closed behavior', () => {
   it.each([null, undefined, NaN, Infinity, -Infinity, -1, '12'] as const)(
@@ -17,6 +17,14 @@ describe('severe add-on fail-closed behavior', () => {
     const result = checkUserEligibility('6', 0);
     expect(result.tier2).toBe(false);
     expect(result.tier3).toBe(false);
+  });
+
+  it.each(['1', '2', '3'])('recognizes support level %s as definitely ineligible', level => {
+    expect(isDefinitelyIneligibleSupportLevel(level)).toBe(true);
+  });
+
+  it.each([null, undefined, '', 'unknown', '4', '6'])('does not classify support level %s as definitely ineligible', level => {
+    expect(isDefinitelyIneligibleSupportLevel(level)).toBe(false);
   });
 
   it('rejects demo findings at the handoff conversion boundary', () => {

--- a/src/domain/regulatory/behaviorScoreResolution.ts
+++ b/src/domain/regulatory/behaviorScoreResolution.ts
@@ -1,0 +1,25 @@
+export type BehaviorScoreIndeterminateReason =
+  | 'missing'
+  | 'invalid-type'
+  | 'not-finite'
+  | 'negative';
+
+export type BehaviorScoreResolution =
+  | { status: 'valid'; value: number }
+  | { status: 'indeterminate'; reason: BehaviorScoreIndeterminateReason };
+
+export function resolveBehaviorScore(value: unknown): BehaviorScoreResolution {
+  if (value === null || value === undefined) {
+    return { status: 'indeterminate', reason: 'missing' };
+  }
+  if (typeof value !== 'number') {
+    return { status: 'indeterminate', reason: 'invalid-type' };
+  }
+  if (!Number.isFinite(value)) {
+    return { status: 'indeterminate', reason: 'not-finite' };
+  }
+  if (value < 0) {
+    return { status: 'indeterminate', reason: 'negative' };
+  }
+  return { status: 'valid', value };
+}

--- a/src/domain/regulatory/findingToHandoff.ts
+++ b/src/domain/regulatory/findingToHandoff.ts
@@ -136,6 +136,9 @@ export function buildHandoffFromRegularFinding(finding: AuditFinding): HandoffFr
  * 加算系 finding から handoff 作成入力を生成する。
  */
 export function buildHandoffFromAddonFinding(finding: SevereAddonFinding): HandoffFromFindingInput {
+  if (finding.dataOrigin === 'demo') {
+    throw new Error('Demo finding cannot be handed off');
+  }
   const typeLabel = SEVERE_ADDON_FINDING_TYPE_LABELS[finding.type];
   const template = ADDON_FINDING_TEMPLATES[finding.type];
   const body = template(finding);

--- a/src/domain/regulatory/severeAddonFindings.ts
+++ b/src/domain/regulatory/severeAddonFindings.ts
@@ -25,6 +25,7 @@ import {
   checkBasicTrainingRatio,
   type UserEligibilityResult,
 } from './severeDisabilityAddon';
+import { resolveBehaviorScore } from './behaviorScoreResolution';
 import {
   isQuarterlyReassessmentOverdue,
   DEFAULT_REASSESSMENT_CYCLE_DAYS,
@@ -74,6 +75,7 @@ export interface SevereAddonFinding {
   overdueDays?: number;
   dueDate?: string;
   detectedAt: string;
+  dataOrigin?: 'live' | 'demo';
 }
 
 // ─────────────────────────────────────────────
@@ -190,6 +192,7 @@ export function buildSevereAddonFindings(input: SevereAddonBulkInput): SevereAdd
 
   // 2. 利用者ごとのチェック
   for (const user of users) {
+    if (resolveBehaviorScore(user.behaviorScore).status !== 'valid') continue;
     const eligibility = checkUserEligibility(user.supportLevel, user.behaviorScore);
 
     // 加算候補

--- a/src/domain/regulatory/severeAddonUserResolution.ts
+++ b/src/domain/regulatory/severeAddonUserResolution.ts
@@ -1,0 +1,85 @@
+import { resolveBehaviorScore } from './behaviorScoreResolution';
+
+export type SupportLevelResolution =
+  | { status: 'valid'; value: 4 | 5 | 6 }
+  | { status: 'ineligible'; value: 1 | 2 | 3 }
+  | { status: 'missing'; reason: 'support-level-missing' }
+  | { status: 'invalid'; reason: 'support-level-invalid' };
+
+export type SevereAddonIndeterminateReason =
+  | 'support-level-missing'
+  | 'support-level-invalid'
+  | 'behavior-score-missing'
+  | 'behavior-score-invalid';
+
+export type SevereAddonUserResolution =
+  | { status: 'valid'; supportLevel: 4 | 5 | 6; behaviorScore: number }
+  | { status: 'ineligible'; supportLevel: 1 | 2 | 3 }
+  | { status: 'indeterminate'; reason: SevereAddonIndeterminateReason };
+
+export const SEVERE_ADDON_INDETERMINATE_REASON_LABELS: Record<SevereAddonIndeterminateReason, string> = {
+  'support-level-missing': '障害支援区分が未入力のため、判定できません。',
+  'support-level-invalid': '障害支援区分が不正なため、判定できません。',
+  'behavior-score-missing': '行動関連点数が未入力のため、判定できません。',
+  'behavior-score-invalid': '行動関連点数が不正なため、判定できません。',
+};
+
+export function resolveSupportLevel(value: unknown): SupportLevelResolution {
+  if (value === null || value === undefined) {
+    return { status: 'missing', reason: 'support-level-missing' };
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) {
+      return { status: 'missing', reason: 'support-level-missing' };
+    }
+    if (!/^[1-6]$/.test(trimmed)) {
+      return { status: 'invalid', reason: 'support-level-invalid' };
+    }
+    return resolveNumericSupportLevel(Number(trimmed));
+  }
+
+  if (typeof value !== 'number' || !Number.isInteger(value)) {
+    return { status: 'invalid', reason: 'support-level-invalid' };
+  }
+
+  return resolveNumericSupportLevel(value);
+}
+
+function resolveNumericSupportLevel(value: number): SupportLevelResolution {
+  if (value < 1 || value > 6) {
+    return { status: 'invalid', reason: 'support-level-invalid' };
+  }
+  if (value <= 3) {
+    return { status: 'ineligible', value: value as 1 | 2 | 3 };
+  }
+  return { status: 'valid', value: value as 4 | 5 | 6 };
+}
+
+export function resolveSevereAddonUserResolution(input: {
+  supportLevel: unknown;
+  behaviorScore: unknown;
+}): SevereAddonUserResolution {
+  const supportLevel = resolveSupportLevel(input.supportLevel);
+  if (supportLevel.status === 'ineligible') {
+    return { status: 'ineligible', supportLevel: supportLevel.value };
+  }
+  if (supportLevel.status !== 'valid') {
+    return { status: 'indeterminate', reason: supportLevel.reason };
+  }
+
+  const behaviorScore = resolveBehaviorScore(input.behaviorScore as number | null | undefined);
+  if (behaviorScore.status === 'indeterminate' && behaviorScore.reason === 'missing') {
+    return { status: 'indeterminate', reason: 'behavior-score-missing' };
+  }
+  if (behaviorScore.status !== 'valid') {
+    return { status: 'indeterminate', reason: 'behavior-score-invalid' };
+  }
+
+  return {
+    status: 'valid',
+    supportLevel: supportLevel.value,
+    behaviorScore: behaviorScore.value,
+  };
+}

--- a/src/domain/regulatory/severeDisabilityAddon.ts
+++ b/src/domain/regulatory/severeDisabilityAddon.ts
@@ -21,6 +21,7 @@
  */
 import type { StaffQualificationProfile } from './staffQualificationProfile';
 import { resolveBehaviorScore } from './behaviorScoreResolution';
+import { resolveSupportLevel } from './severeAddonUserResolution';
 
 // ─────────────────────────────────────────────
 // 定数
@@ -117,7 +118,10 @@ export function checkUserEligibility(
   supportLevel: string | null | undefined,
   behaviorScore: number | null | undefined,
 ): UserEligibilityResult {
-  const level = parseSupportLevel(supportLevel);
+  const supportResolution = resolveSupportLevel(supportLevel);
+  const level = supportResolution.status === 'valid' || supportResolution.status === 'ineligible'
+    ? supportResolution.value
+    : 0;
   const scoreResolution = resolveBehaviorScore(behaviorScore);
   const score = scoreResolution.status === 'valid' ? scoreResolution.value : null;
 
@@ -315,17 +319,6 @@ export function evaluateSevereDisabilityAddOn(params: {
 // 内部ヘルパー
 // ─────────────────────────────────────────────
 
-/**
- * 障害支援区分（文字列）を数値に変換する
- * 無効値は 0 を返す（どの要件も満たさない）
- */
-export function parseSupportLevel(level: string | null | undefined): number {
-  if (level == null) return 0;
-  const num = parseInt(level, 10);
-  return isNaN(num) ? 0 : num;
-}
-
-export function isDefinitelyIneligibleSupportLevel(level: string | null | undefined): boolean {
-  const parsed = parseSupportLevel(level);
-  return parsed >= 1 && parsed <= 3;
+export function isDefinitelyIneligibleSupportLevel(level: unknown): boolean {
+  return resolveSupportLevel(level).status === 'ineligible';
 }

--- a/src/domain/regulatory/severeDisabilityAddon.ts
+++ b/src/domain/regulatory/severeDisabilityAddon.ts
@@ -319,8 +319,13 @@ export function evaluateSevereDisabilityAddOn(params: {
  * 障害支援区分（文字列）を数値に変換する
  * 無効値は 0 を返す（どの要件も満たさない）
  */
-function parseSupportLevel(level: string | null | undefined): number {
+export function parseSupportLevel(level: string | null | undefined): number {
   if (level == null) return 0;
   const num = parseInt(level, 10);
   return isNaN(num) ? 0 : num;
+}
+
+export function isDefinitelyIneligibleSupportLevel(level: string | null | undefined): boolean {
+  const parsed = parseSupportLevel(level);
+  return parsed >= 1 && parsed <= 3;
 }

--- a/src/domain/regulatory/severeDisabilityAddon.ts
+++ b/src/domain/regulatory/severeDisabilityAddon.ts
@@ -20,6 +20,7 @@
  * @see src/domain/regulatory/userRegulatoryProfile.ts
  */
 import type { StaffQualificationProfile } from './staffQualificationProfile';
+import { resolveBehaviorScore } from './behaviorScoreResolution';
 
 // ─────────────────────────────────────────────
 // 定数
@@ -117,14 +118,15 @@ export function checkUserEligibility(
   behaviorScore: number | null | undefined,
 ): UserEligibilityResult {
   const level = parseSupportLevel(supportLevel);
-  const score = behaviorScore ?? 0;
+  const scoreResolution = resolveBehaviorScore(behaviorScore);
+  const score = scoreResolution.status === 'valid' ? scoreResolution.value : null;
 
-  const meetsScore = score >= ADDON_THRESHOLDS.MIN_BEHAVIOR_SCORE;
+  const meetsScore = score !== null && score >= ADDON_THRESHOLDS.MIN_BEHAVIOR_SCORE;
 
   return {
     tier2: meetsScore && level >= ADDON_THRESHOLDS.TIER2_MIN_SUPPORT_LEVEL,
     tier3: meetsScore && level >= ADDON_THRESHOLDS.TIER3_MIN_SUPPORT_LEVEL,
-    isUpperTier: score >= ADDON_THRESHOLDS.UPPER_TIER_BEHAVIOR_SCORE,
+    isUpperTier: score !== null && score >= ADDON_THRESHOLDS.UPPER_TIER_BEHAVIOR_SCORE,
   };
 }
 

--- a/src/features/regulatory/hooks/useSevereAddonRealData.ts
+++ b/src/features/regulatory/hooks/useSevereAddonRealData.ts
@@ -45,6 +45,10 @@ import { AuthRequiredError } from '@/lib/errors';
 import type { IUserMaster } from '@/sharepoint/fields';
 import type { Staff } from '@/types';
 import type { SevereAddonBulkInput, SevereAddonCheckInput } from '@/domain/regulatory/severeAddonFindings';
+import {
+  resolveBehaviorScore,
+  type BehaviorScoreIndeterminateReason,
+} from '@/domain/regulatory/behaviorScoreResolution';
 import type { PlanningSheetListItem } from '@/domain/isp/schema';
 import type { PlanningSheetRepository } from '@/domain/isp/port';
 import type {
@@ -126,12 +130,13 @@ function computeStaffMetrics(staffList: Staff[]): StaffAddonMetrics {
 function toAddonCheckInput(
   user: IUserMaster,
   planningSheetIds: string[],
+  behaviorScore: number,
 ): SevereAddonCheckInput {
   return {
     userId: user.UserID ?? `user-${user.Id}`,
     userName: user.FullName ?? undefined,
     supportLevel: user.DisabilitySupportLevel ?? null,
-    behaviorScore: user.BehaviorScore ?? null,
+    behaviorScore,
     planningSheetIds,
   };
 }
@@ -152,6 +157,11 @@ export interface SevereAddonRealDataResult {
   error: Error | null;
   /** データソースの説明（UI 表示用） */
   dataSourceLabel: string;
+  uncalculableUsers: Array<{
+    userId: string;
+    userName: string;
+    reason: BehaviorScoreIndeterminateReason;
+  }>;
 }
 
 /**
@@ -482,6 +492,22 @@ export function useSevereAddonRealData(
   // ── メイン BulkInput 構築 ──
   const combinedLoading = enabled && (isLoading || (authReady && (sheetsLoading || obsLoading || assignLoading)));
   const combinedError = enabled ? (error || sheetsError || obsError || assignError) : null;
+  const uncalculableUsers = useMemo(() => users
+    .filter(u => u.IsActive !== false)
+    .map(user => {
+      const resolution = resolveBehaviorScore(user.BehaviorScore);
+      if (resolution.status === 'valid') return null;
+      return {
+        userId: user.UserID ?? `user-${user.Id}`,
+        userName: user.FullName ?? '利用者名未設定',
+        reason: resolution.reason,
+      };
+    })
+    .filter((user): user is {
+      userId: string;
+      userName: string;
+      reason: BehaviorScoreIndeterminateReason;
+    } => user !== null), [users]);
 
   const input = useMemo<SevereAddonBulkInput | null>(() => {
     if (!enabled || combinedLoading || combinedError) return null;
@@ -498,10 +524,13 @@ export function useSevereAddonRealData(
     const addonUsers: SevereAddonCheckInput[] = users
       .filter(u => u.IsActive !== false)
       .map(u => {
+        const behaviorScore = resolveBehaviorScore(u.BehaviorScore);
+        if (behaviorScore.status !== 'valid') return null;
         const userId = u.UserID ?? `user-${u.Id}`;
         const sheetIds = planningSheetIdsByUser.get(userId) ?? [];
-        return toAddonCheckInput(u, sheetIds);
-      });
+        return toAddonCheckInput(u, sheetIds, behaviorScore.value);
+      })
+      .filter((user): user is SevereAddonCheckInput => user !== null);
 
     // 候補者のユーザーID
     const candidateUserIds = addonUsers.map(u => u.userId);
@@ -546,6 +575,7 @@ export function useSevereAddonRealData(
     input,
     isLoading: combinedLoading,
     error: combinedError,
-    dataSourceLabel: input ? '実データ' : (enabled ? 'デモデータ' : '無効'),
+    dataSourceLabel: input ? '実データ' : (enabled ? '算定不能' : '無効'),
+    uncalculableUsers,
   };
 }

--- a/src/features/regulatory/hooks/useSevereAddonRealData.ts
+++ b/src/features/regulatory/hooks/useSevereAddonRealData.ts
@@ -45,6 +45,7 @@ import { AuthRequiredError } from '@/lib/errors';
 import type { IUserMaster } from '@/sharepoint/fields';
 import type { Staff } from '@/types';
 import type { SevereAddonBulkInput, SevereAddonCheckInput } from '@/domain/regulatory/severeAddonFindings';
+import { isDefinitelyIneligibleSupportLevel } from '@/domain/regulatory/severeDisabilityAddon';
 import {
   resolveBehaviorScore,
   type BehaviorScoreIndeterminateReason,
@@ -495,6 +496,7 @@ export function useSevereAddonRealData(
   const uncalculableUsers = useMemo(() => users
     .filter(u => u.IsActive !== false)
     .map(user => {
+      if (isDefinitelyIneligibleSupportLevel(user.DisabilitySupportLevel)) return null;
       const resolution = resolveBehaviorScore(user.BehaviorScore);
       if (resolution.status === 'valid') return null;
       return {

--- a/src/features/regulatory/hooks/useSevereAddonRealData.ts
+++ b/src/features/regulatory/hooks/useSevereAddonRealData.ts
@@ -45,11 +45,10 @@ import { AuthRequiredError } from '@/lib/errors';
 import type { IUserMaster } from '@/sharepoint/fields';
 import type { Staff } from '@/types';
 import type { SevereAddonBulkInput, SevereAddonCheckInput } from '@/domain/regulatory/severeAddonFindings';
-import { isDefinitelyIneligibleSupportLevel } from '@/domain/regulatory/severeDisabilityAddon';
 import {
-  resolveBehaviorScore,
-  type BehaviorScoreIndeterminateReason,
-} from '@/domain/regulatory/behaviorScoreResolution';
+  resolveSevereAddonUserResolution,
+  type SevereAddonIndeterminateReason,
+} from '@/domain/regulatory/severeAddonUserResolution';
 import type { PlanningSheetListItem } from '@/domain/isp/schema';
 import type { PlanningSheetRepository } from '@/domain/isp/port';
 import type {
@@ -161,7 +160,7 @@ export interface SevereAddonRealDataResult {
   uncalculableUsers: Array<{
     userId: string;
     userName: string;
-    reason: BehaviorScoreIndeterminateReason;
+    reason: SevereAddonIndeterminateReason;
   }>;
 }
 
@@ -496,9 +495,11 @@ export function useSevereAddonRealData(
   const uncalculableUsers = useMemo(() => users
     .filter(u => u.IsActive !== false)
     .map(user => {
-      if (isDefinitelyIneligibleSupportLevel(user.DisabilitySupportLevel)) return null;
-      const resolution = resolveBehaviorScore(user.BehaviorScore);
-      if (resolution.status === 'valid') return null;
+      const resolution = resolveSevereAddonUserResolution({
+        supportLevel: user.DisabilitySupportLevel,
+        behaviorScore: user.BehaviorScore,
+      });
+      if (resolution.status !== 'indeterminate') return null;
       return {
         userId: user.UserID ?? `user-${user.Id}`,
         userName: user.FullName ?? '利用者名未設定',
@@ -508,7 +509,7 @@ export function useSevereAddonRealData(
     .filter((user): user is {
       userId: string;
       userName: string;
-      reason: BehaviorScoreIndeterminateReason;
+      reason: SevereAddonIndeterminateReason;
     } => user !== null), [users]);
 
   const input = useMemo<SevereAddonBulkInput | null>(() => {
@@ -526,11 +527,14 @@ export function useSevereAddonRealData(
     const addonUsers: SevereAddonCheckInput[] = users
       .filter(u => u.IsActive !== false)
       .map(u => {
-        const behaviorScore = resolveBehaviorScore(u.BehaviorScore);
-        if (behaviorScore.status !== 'valid') return null;
+        const resolution = resolveSevereAddonUserResolution({
+          supportLevel: u.DisabilitySupportLevel,
+          behaviorScore: u.BehaviorScore,
+        });
+        if (resolution.status !== 'valid') return null;
         const userId = u.UserID ?? `user-${u.Id}`;
         const sheetIds = planningSheetIdsByUser.get(userId) ?? [];
-        return toAddonCheckInput(u, sheetIds, behaviorScore.value);
+        return toAddonCheckInput(u, sheetIds, resolution.behaviorScore);
       })
       .filter((user): user is SevereAddonCheckInput => user !== null);
 

--- a/src/pages/RegulatoryDashboardPage.tsx
+++ b/src/pages/RegulatoryDashboardPage.tsx
@@ -60,6 +60,7 @@ import { unifyFindings } from './regulatory-dashboard/types';
 import { generateDemoFindings, generateDemoSevereAddonFindings, generateDemoIcebergEvidence } from './regulatory-dashboard/demoData';
 import { createAddonPresentation } from './regulatory-dashboard/addonPresentation';
 import { resolveRegulatoryAddonDemoMode, type AddonCalculationState } from './regulatory-dashboard/addonSummaryState';
+import { SEVERE_ADDON_INDETERMINATE_REASON_LABELS } from '@/domain/regulatory/severeAddonUserResolution';
 import { SummaryCard, TypeBreakdown, DomainSummary } from './regulatory-dashboard/SummaryPanel';
 import { SevereAddonSummaryPanel } from './regulatory-dashboard/SevereAddonPanel';
 import { FindingsTable } from './regulatory-dashboard/FindingsTable';
@@ -286,11 +287,10 @@ const RegulatoryDashboardPage: React.FC = () => {
       {!isAddonDemoMode && uncalculableUsers.length > 0 && (
         <Alert severity="warning" sx={{ mb: 3 }} data-testid="severe-addon-uncalculable">
           <Typography variant="body2" fontWeight={700}>
-            行動関連点数を確認できないため、強度行動障害に関する加算判定を実行できません。
+            強度行動障害に関する加算判定を実行できない利用者があります。
           </Typography>
           <Typography variant="body2">
-            利用者マスターの行動関連点数を確認してください。
-            {' '}{uncalculableUsers.map(user => user.userName).join('、')}
+            {uncalculableUsers.map(user => `${user.userName}: ${SEVERE_ADDON_INDETERMINATE_REASON_LABELS[user.reason]}`).join('、')}
           </Typography>
         </Alert>
       )}

--- a/src/pages/RegulatoryDashboardPage.tsx
+++ b/src/pages/RegulatoryDashboardPage.tsx
@@ -21,6 +21,7 @@ import GavelIcon from '@mui/icons-material/Gavel';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import { useNavigate } from 'react-router-dom';
+import { isDemoModeEnabled } from '@/lib/env';
 
 import { summarizeFindings } from '@/domain/regulatory';
 import {
@@ -57,6 +58,7 @@ import { usePdcaStopRanking } from '@/features/regulatory/hooks/usePdcaStopRanki
 import type { AuditFindingSeverity, UnifiedFindingRow } from './regulatory-dashboard/types';
 import { unifyFindings } from './regulatory-dashboard/types';
 import { generateDemoFindings, generateDemoSevereAddonFindings, generateDemoIcebergEvidence } from './regulatory-dashboard/demoData';
+import { createAddonPresentation } from './regulatory-dashboard/addonPresentation';
 import { SummaryCard, TypeBreakdown, DomainSummary } from './regulatory-dashboard/SummaryPanel';
 import { SevereAddonSummaryPanel } from './regulatory-dashboard/SevereAddonPanel';
 import { FindingsTable } from './regulatory-dashboard/FindingsTable';
@@ -107,7 +109,13 @@ const RegulatoryDashboardPage: React.FC = () => {
   const summary = useMemo(() => summarizeFindings(findings), [findings]);
 
   // 加算系 findings — 実データ / デモフォールバック
-  const { input: realAddonInput, dataSourceLabel: addonDataSource } = useSevereAddonRealData(
+  const {
+    input: realAddonInput,
+    isLoading: addonLoading,
+    error: addonError,
+    dataSourceLabel: addonDataSource,
+    uncalculableUsers,
+  } = useSevereAddonRealData(
     spUsers,
     spStaff,
     dataLoading,
@@ -116,14 +124,20 @@ const RegulatoryDashboardPage: React.FC = () => {
     localWeeklyObservationRepository,
     localQualificationAssignmentRepository,
   );
-  const addonFindings = useMemo(() => {
-    if (realAddonInput) {
+  const isAddonDemoMode = isDemoModeEnabled();
+  const addonPresentation = useMemo(() => createAddonPresentation({
+    isDemoMode: isAddonDemoMode,
+    input: realAddonInput,
+    buildLiveFindings: input => {
       _resetAddonFindingCounter();
-      return buildSevereAddonFindings(realAddonInput);
-    }
-    return generateDemoSevereAddonFindings();
-  }, [realAddonInput]);
+      return buildSevereAddonFindings(input);
+    },
+    buildDemoFindings: generateDemoSevereAddonFindings,
+  }), [isAddonDemoMode, realAddonInput]);
+  const addonFindings = addonPresentation.liveFindings;
+  const demoAddonFindings = addonPresentation.demoFindings;
   const addonSummary = useMemo(() => summarizeSevereAddonFindings(addonFindings), [addonFindings]);
+  const demoAddonSummary = useMemo(() => summarizeSevereAddonFindings(demoAddonFindings), [demoAddonFindings]);
 
   const {
     ranking: pdcaStopRanking,
@@ -245,13 +259,32 @@ const RegulatoryDashboardPage: React.FC = () => {
           sx={{ fontWeight: 600, fontSize: '0.7rem' }}
         />
         <Chip
-          label={`加算: ${addonDataSource}`}
+          label={`加算: ${isAddonDemoMode ? 'デモ' : addonDataSource}`}
           size="small"
           color={addonDataSource === '実データ' ? 'success' : 'default'}
           variant={addonDataSource === '実データ' ? 'filled' : 'outlined'}
           sx={{ fontWeight: 600, fontSize: '0.7rem' }}
         />
       </Box>
+
+      {!isAddonDemoMode && !addonLoading && !realAddonInput && (
+        <Alert severity="error" sx={{ mb: 3 }} data-testid="severe-addon-data-error">
+          {addonError
+            ? '加算判定に必要な実データを取得できないため、判定を実行できません。'
+            : '加算判定に必要な実データを確認できないため、判定を実行できません。'}
+        </Alert>
+      )}
+      {!isAddonDemoMode && uncalculableUsers.length > 0 && (
+        <Alert severity="warning" sx={{ mb: 3 }} data-testid="severe-addon-uncalculable">
+          <Typography variant="body2" fontWeight={700}>
+            行動関連点数を確認できないため、強度行動障害に関する加算判定を実行できません。
+          </Typography>
+          <Typography variant="body2">
+            利用者マスターの行動関連点数を確認してください。
+            {' '}{uncalculableUsers.map(user => user.userName).join('、')}
+          </Typography>
+        </Alert>
+      )}
 
       {/* 統合集計カード */}
       <Box
@@ -284,7 +317,8 @@ const RegulatoryDashboardPage: React.FC = () => {
       >
         <TypeBreakdown summary={summary} addonSummary={addonSummary} />
         <SevereAddonSummaryPanel
-          addonSummary={addonSummary}
+          addonSummary={isAddonDemoMode ? demoAddonSummary : addonSummary}
+          isDemo={isAddonDemoMode}
           onNavigate={(url) => navigate(url)}
           onFilterAddon={() => {
             setFilterSource('addon');

--- a/src/pages/RegulatoryDashboardPage.tsx
+++ b/src/pages/RegulatoryDashboardPage.tsx
@@ -21,7 +21,7 @@ import GavelIcon from '@mui/icons-material/Gavel';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import { useNavigate } from 'react-router-dom';
-import { isDemoModeEnabled } from '@/lib/env';
+import { isDemo, isDemoModeEnabled } from '@/lib/env';
 
 import { summarizeFindings } from '@/domain/regulatory';
 import {
@@ -59,6 +59,7 @@ import type { AuditFindingSeverity, UnifiedFindingRow } from './regulatory-dashb
 import { unifyFindings } from './regulatory-dashboard/types';
 import { generateDemoFindings, generateDemoSevereAddonFindings, generateDemoIcebergEvidence } from './regulatory-dashboard/demoData';
 import { createAddonPresentation } from './regulatory-dashboard/addonPresentation';
+import { resolveRegulatoryAddonDemoMode, type AddonCalculationState } from './regulatory-dashboard/addonSummaryState';
 import { SummaryCard, TypeBreakdown, DomainSummary } from './regulatory-dashboard/SummaryPanel';
 import { SevereAddonSummaryPanel } from './regulatory-dashboard/SevereAddonPanel';
 import { FindingsTable } from './regulatory-dashboard/FindingsTable';
@@ -124,7 +125,10 @@ const RegulatoryDashboardPage: React.FC = () => {
     localWeeklyObservationRepository,
     localQualificationAssignmentRepository,
   );
-  const isAddonDemoMode = isDemoModeEnabled();
+  const isAddonDemoMode = resolveRegulatoryAddonDemoMode({
+    demoModeEnabled: isDemoModeEnabled(),
+    legacyDemo: isDemo(),
+  });
   const addonPresentation = useMemo(() => createAddonPresentation({
     isDemoMode: isAddonDemoMode,
     input: realAddonInput,
@@ -136,6 +140,11 @@ const RegulatoryDashboardPage: React.FC = () => {
   }), [isAddonDemoMode, realAddonInput]);
   const addonFindings = addonPresentation.liveFindings;
   const demoAddonFindings = addonPresentation.demoFindings;
+  const addonCalculationState: AddonCalculationState = isAddonDemoMode
+    ? 'demo'
+    : addonLoading || addonError || !realAddonInput || uncalculableUsers.length > 0
+      ? 'indeterminate'
+      : 'complete';
   const addonSummary = useMemo(() => summarizeSevereAddonFindings(addonFindings), [addonFindings]);
   const demoAddonSummary = useMemo(() => summarizeSevereAddonFindings(demoAddonFindings), [demoAddonFindings]);
 
@@ -319,6 +328,7 @@ const RegulatoryDashboardPage: React.FC = () => {
         <SevereAddonSummaryPanel
           addonSummary={isAddonDemoMode ? demoAddonSummary : addonSummary}
           isDemo={isAddonDemoMode}
+          calculationState={addonCalculationState}
           onNavigate={(url) => navigate(url)}
           onFilterAddon={() => {
             setFilterSource('addon');

--- a/src/pages/regulatory-dashboard/SevereAddonPanel.tsx
+++ b/src/pages/regulatory-dashboard/SevereAddonPanel.tsx
@@ -21,7 +21,12 @@ import SchoolRoundedIcon from '@mui/icons-material/SchoolRounded';
 import VisibilityRoundedIcon from '@mui/icons-material/VisibilityRounded';
 
 import type { summarizeSevereAddonFindings } from '@/domain/regulatory/severeAddonFindings';
-import { resolveAddonSummaryState, type AddonCalculationState } from './addonSummaryState';
+import {
+  resolveAddonCandidateCountDisplay,
+  resolveAddonRequirementDisplay,
+  resolveAddonSummaryState,
+  type AddonCalculationState,
+} from './addonSummaryState';
 
 // ─────────────────────────────────────────────
 // Constants
@@ -46,19 +51,22 @@ const AddonRequirementRow: React.FC<{
   count: number;
   okText: string;
   ngText: string;
+  indeterminate: boolean;
   onAction?: () => void;
   actionLabel?: string;
-}> = ({ icon, label, count, okText, ngText, onAction, actionLabel }) => (
+}> = ({ icon, label, count, okText, ngText, indeterminate, onAction, actionLabel }) => {
+  const display = resolveAddonRequirementDisplay({ count, indeterminate, okText, ngText });
+  return (
   <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
     {icon}
     <Typography variant="body2" sx={{ minWidth: 100 }} fontWeight={600}>
       {label}
     </Typography>
     <Chip
-      label={count > 0 ? ngText : okText}
+      label={display.label}
       size="small"
-      color={count > 0 ? 'warning' : 'success'}
-      variant={count > 0 ? 'filled' : 'outlined'}
+      color={display.color}
+      variant={display.variant}
       sx={{ fontWeight: 600, fontSize: '0.65rem' }}
     />
     {onAction && (
@@ -74,7 +82,8 @@ const AddonRequirementRow: React.FC<{
       </IconButton>
     )}
   </Box>
-);
+  );
+};
 
 // ─────────────────────────────────────────────
 // Main panel
@@ -139,7 +148,7 @@ export const SevereAddonSummaryPanel: React.FC<SevereAddonSummaryPanelProps> = (
       <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 1.5, mb: 2 }}>
         <Box sx={{ textAlign: 'center' }}>
           <Typography variant="h5" fontWeight={800} color="primary.main">
-            {addonSummary.tier2CandidateCount}
+            {resolveAddonCandidateCountDisplay(addonSummary.tier2CandidateCount, isIndeterminate)}
           </Typography>
           <Typography variant="caption" color="text.secondary">
             加算（Ⅱ）候補
@@ -147,7 +156,7 @@ export const SevereAddonSummaryPanel: React.FC<SevereAddonSummaryPanelProps> = (
         </Box>
         <Box sx={{ textAlign: 'center' }}>
           <Typography variant="h5" fontWeight={800} color="primary.main">
-            {addonSummary.tier3CandidateCount}
+            {resolveAddonCandidateCountDisplay(addonSummary.tier3CandidateCount, isIndeterminate)}
           </Typography>
           <Typography variant="caption" color="text.secondary">
             加算（Ⅲ）候補
@@ -155,7 +164,7 @@ export const SevereAddonSummaryPanel: React.FC<SevereAddonSummaryPanelProps> = (
         </Box>
         <Box sx={{ textAlign: 'center' }}>
           <Typography variant="h5" fontWeight={800} color="secondary.main">
-            {addonSummary.upperTierCandidateCount}
+            {resolveAddonCandidateCountDisplay(addonSummary.upperTierCandidateCount, isIndeterminate)}
           </Typography>
           <Typography variant="caption" color="text.secondary">
             上位区分候補
@@ -165,11 +174,11 @@ export const SevereAddonSummaryPanel: React.FC<SevereAddonSummaryPanelProps> = (
 
       {/* 要件チェック状況 */}
       <Stack spacing={0.75}>
-        <AddonRequirementRow icon={<SchoolRoundedIcon sx={{ fontSize: 16 }} />} label="基礎研修比率" count={addonSummary.trainingRatioInsufficientCount} okText="20%以上を充足" ngText={`${addonSummary.trainingRatioInsufficientCount}件の不足`} onAction={!isDemo && addonSummary.trainingRatioInsufficientCount > 0 ? () => onNavigate(ADDON_REQUIREMENT_LINKS.training.path) : undefined} actionLabel={ADDON_REQUIREMENT_LINKS.training.label} />
-        <AddonRequirementRow icon={<EventRepeatRoundedIcon sx={{ fontSize: 16 }} />} label="3か月再評価" count={addonSummary.reassessmentOverdueCount} okText="全員期限内" ngText={`${addonSummary.reassessmentOverdueCount}件超過`} onAction={!isDemo && addonSummary.reassessmentOverdueCount > 0 ? () => onNavigate(ADDON_REQUIREMENT_LINKS.reassessment.path) : undefined} actionLabel={ADDON_REQUIREMENT_LINKS.reassessment.label} />
-        <AddonRequirementRow icon={<VisibilityRoundedIcon sx={{ fontSize: 16 }} />} label="週次観察" count={addonSummary.weeklyObservationShortageCount} okText="全員実施済" ngText={`${addonSummary.weeklyObservationShortageCount}件不足`} onAction={!isDemo && addonSummary.weeklyObservationShortageCount > 0 ? () => onNavigate(ADDON_REQUIREMENT_LINKS.observation.path) : undefined} actionLabel={ADDON_REQUIREMENT_LINKS.observation.label} />
-        <AddonRequirementRow icon={<EditNoteRoundedIcon sx={{ fontSize: 16 }} />} label="作成者要件" count={addonSummary.authoringRequirementUnmetCount} okText="全員実践研修修了" ngText={`${addonSummary.authoringRequirementUnmetCount}件不備`} onAction={!isDemo && addonSummary.authoringRequirementUnmetCount > 0 ? () => onNavigate(ADDON_REQUIREMENT_LINKS.authoring.path) : undefined} actionLabel={ADDON_REQUIREMENT_LINKS.authoring.label} />
-        <AddonRequirementRow icon={<PersonOffRoundedIcon sx={{ fontSize: 16 }} />} label="配置資格" count={addonSummary.assignmentWithoutQualificationCount} okText="全員資格あり" ngText={`${addonSummary.assignmentWithoutQualificationCount}件不備`} onAction={!isDemo && addonSummary.assignmentWithoutQualificationCount > 0 ? () => onNavigate(ADDON_REQUIREMENT_LINKS.assignment.path) : undefined} actionLabel={ADDON_REQUIREMENT_LINKS.assignment.label} />
+        <AddonRequirementRow icon={<SchoolRoundedIcon sx={{ fontSize: 16 }} />} label="基礎研修比率" count={addonSummary.trainingRatioInsufficientCount} okText="20%以上を充足" ngText={`${addonSummary.trainingRatioInsufficientCount}件の不足`} indeterminate={isIndeterminate} onAction={!isDemo && addonSummary.trainingRatioInsufficientCount > 0 ? () => onNavigate(ADDON_REQUIREMENT_LINKS.training.path) : undefined} actionLabel={ADDON_REQUIREMENT_LINKS.training.label} />
+        <AddonRequirementRow icon={<EventRepeatRoundedIcon sx={{ fontSize: 16 }} />} label="3か月再評価" count={addonSummary.reassessmentOverdueCount} okText="全員期限内" ngText={`${addonSummary.reassessmentOverdueCount}件超過`} indeterminate={isIndeterminate} onAction={!isDemo && addonSummary.reassessmentOverdueCount > 0 ? () => onNavigate(ADDON_REQUIREMENT_LINKS.reassessment.path) : undefined} actionLabel={ADDON_REQUIREMENT_LINKS.reassessment.label} />
+        <AddonRequirementRow icon={<VisibilityRoundedIcon sx={{ fontSize: 16 }} />} label="週次観察" count={addonSummary.weeklyObservationShortageCount} okText="全員実施済" ngText={`${addonSummary.weeklyObservationShortageCount}件不足`} indeterminate={isIndeterminate} onAction={!isDemo && addonSummary.weeklyObservationShortageCount > 0 ? () => onNavigate(ADDON_REQUIREMENT_LINKS.observation.path) : undefined} actionLabel={ADDON_REQUIREMENT_LINKS.observation.label} />
+        <AddonRequirementRow icon={<EditNoteRoundedIcon sx={{ fontSize: 16 }} />} label="作成者要件" count={addonSummary.authoringRequirementUnmetCount} okText="全員実践研修修了" ngText={`${addonSummary.authoringRequirementUnmetCount}件不備`} indeterminate={isIndeterminate} onAction={!isDemo && addonSummary.authoringRequirementUnmetCount > 0 ? () => onNavigate(ADDON_REQUIREMENT_LINKS.authoring.path) : undefined} actionLabel={ADDON_REQUIREMENT_LINKS.authoring.label} />
+        <AddonRequirementRow icon={<PersonOffRoundedIcon sx={{ fontSize: 16 }} />} label="配置資格" count={addonSummary.assignmentWithoutQualificationCount} okText="全員資格あり" ngText={`${addonSummary.assignmentWithoutQualificationCount}件不備`} indeterminate={isIndeterminate} onAction={!isDemo && addonSummary.assignmentWithoutQualificationCount > 0 ? () => onNavigate(ADDON_REQUIREMENT_LINKS.assignment.path) : undefined} actionLabel={ADDON_REQUIREMENT_LINKS.assignment.label} />
       </Stack>
 
       {/* 加算 finding 一覧へ導線 */}

--- a/src/pages/regulatory-dashboard/SevereAddonPanel.tsx
+++ b/src/pages/regulatory-dashboard/SevereAddonPanel.tsx
@@ -83,9 +83,10 @@ interface SevereAddonSummaryPanelProps {
   addonSummary: ReturnType<typeof summarizeSevereAddonFindings>;
   onNavigate: (url: string) => void;
   onFilterAddon: () => void;
+  isDemo?: boolean;
 }
 
-export const SevereAddonSummaryPanel: React.FC<SevereAddonSummaryPanelProps> = ({ addonSummary, onNavigate, onFilterAddon }) => {
+export const SevereAddonSummaryPanel: React.FC<SevereAddonSummaryPanelProps> = ({ addonSummary, onNavigate, onFilterAddon, isDemo = false }) => {
   const hasIssues =
     addonSummary.trainingRatioInsufficientCount > 0 ||
     addonSummary.reassessmentOverdueCount > 0 ||
@@ -146,16 +147,16 @@ export const SevereAddonSummaryPanel: React.FC<SevereAddonSummaryPanelProps> = (
 
       {/* 要件チェック状況 */}
       <Stack spacing={0.75}>
-        <AddonRequirementRow icon={<SchoolRoundedIcon sx={{ fontSize: 16 }} />} label="基礎研修比率" count={addonSummary.trainingRatioInsufficientCount} okText="20%以上を充足" ngText={`${addonSummary.trainingRatioInsufficientCount}件の不足`} onAction={addonSummary.trainingRatioInsufficientCount > 0 ? () => onNavigate(ADDON_REQUIREMENT_LINKS.training.path) : undefined} actionLabel={ADDON_REQUIREMENT_LINKS.training.label} />
-        <AddonRequirementRow icon={<EventRepeatRoundedIcon sx={{ fontSize: 16 }} />} label="3か月再評価" count={addonSummary.reassessmentOverdueCount} okText="全員期限内" ngText={`${addonSummary.reassessmentOverdueCount}件超過`} onAction={addonSummary.reassessmentOverdueCount > 0 ? () => onNavigate(ADDON_REQUIREMENT_LINKS.reassessment.path) : undefined} actionLabel={ADDON_REQUIREMENT_LINKS.reassessment.label} />
-        <AddonRequirementRow icon={<VisibilityRoundedIcon sx={{ fontSize: 16 }} />} label="週次観察" count={addonSummary.weeklyObservationShortageCount} okText="全員実施済" ngText={`${addonSummary.weeklyObservationShortageCount}件不足`} onAction={addonSummary.weeklyObservationShortageCount > 0 ? () => onNavigate(ADDON_REQUIREMENT_LINKS.observation.path) : undefined} actionLabel={ADDON_REQUIREMENT_LINKS.observation.label} />
-        <AddonRequirementRow icon={<EditNoteRoundedIcon sx={{ fontSize: 16 }} />} label="作成者要件" count={addonSummary.authoringRequirementUnmetCount} okText="全員実践研修修了" ngText={`${addonSummary.authoringRequirementUnmetCount}件不備`} onAction={addonSummary.authoringRequirementUnmetCount > 0 ? () => onNavigate(ADDON_REQUIREMENT_LINKS.authoring.path) : undefined} actionLabel={ADDON_REQUIREMENT_LINKS.authoring.label} />
-        <AddonRequirementRow icon={<PersonOffRoundedIcon sx={{ fontSize: 16 }} />} label="配置資格" count={addonSummary.assignmentWithoutQualificationCount} okText="全員資格あり" ngText={`${addonSummary.assignmentWithoutQualificationCount}件不備`} onAction={addonSummary.assignmentWithoutQualificationCount > 0 ? () => onNavigate(ADDON_REQUIREMENT_LINKS.assignment.path) : undefined} actionLabel={ADDON_REQUIREMENT_LINKS.assignment.label} />
+        <AddonRequirementRow icon={<SchoolRoundedIcon sx={{ fontSize: 16 }} />} label="基礎研修比率" count={addonSummary.trainingRatioInsufficientCount} okText="20%以上を充足" ngText={`${addonSummary.trainingRatioInsufficientCount}件の不足`} onAction={!isDemo && addonSummary.trainingRatioInsufficientCount > 0 ? () => onNavigate(ADDON_REQUIREMENT_LINKS.training.path) : undefined} actionLabel={ADDON_REQUIREMENT_LINKS.training.label} />
+        <AddonRequirementRow icon={<EventRepeatRoundedIcon sx={{ fontSize: 16 }} />} label="3か月再評価" count={addonSummary.reassessmentOverdueCount} okText="全員期限内" ngText={`${addonSummary.reassessmentOverdueCount}件超過`} onAction={!isDemo && addonSummary.reassessmentOverdueCount > 0 ? () => onNavigate(ADDON_REQUIREMENT_LINKS.reassessment.path) : undefined} actionLabel={ADDON_REQUIREMENT_LINKS.reassessment.label} />
+        <AddonRequirementRow icon={<VisibilityRoundedIcon sx={{ fontSize: 16 }} />} label="週次観察" count={addonSummary.weeklyObservationShortageCount} okText="全員実施済" ngText={`${addonSummary.weeklyObservationShortageCount}件不足`} onAction={!isDemo && addonSummary.weeklyObservationShortageCount > 0 ? () => onNavigate(ADDON_REQUIREMENT_LINKS.observation.path) : undefined} actionLabel={ADDON_REQUIREMENT_LINKS.observation.label} />
+        <AddonRequirementRow icon={<EditNoteRoundedIcon sx={{ fontSize: 16 }} />} label="作成者要件" count={addonSummary.authoringRequirementUnmetCount} okText="全員実践研修修了" ngText={`${addonSummary.authoringRequirementUnmetCount}件不備`} onAction={!isDemo && addonSummary.authoringRequirementUnmetCount > 0 ? () => onNavigate(ADDON_REQUIREMENT_LINKS.authoring.path) : undefined} actionLabel={ADDON_REQUIREMENT_LINKS.authoring.label} />
+        <AddonRequirementRow icon={<PersonOffRoundedIcon sx={{ fontSize: 16 }} />} label="配置資格" count={addonSummary.assignmentWithoutQualificationCount} okText="全員資格あり" ngText={`${addonSummary.assignmentWithoutQualificationCount}件不備`} onAction={!isDemo && addonSummary.assignmentWithoutQualificationCount > 0 ? () => onNavigate(ADDON_REQUIREMENT_LINKS.assignment.path) : undefined} actionLabel={ADDON_REQUIREMENT_LINKS.assignment.label} />
       </Stack>
 
       {/* 加算 finding 一覧へ導線 */}
-      <Divider sx={{ my: 1.5 }} />
-      <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+      {!isDemo && <Divider sx={{ my: 1.5 }} />}
+      {!isDemo && <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
         <Button
           size="small"
           variant="text"
@@ -167,7 +168,7 @@ export const SevereAddonSummaryPanel: React.FC<SevereAddonSummaryPanelProps> = (
         >
           加算チェック結果を一覧で見る
         </Button>
-      </Box>
+      </Box>}
     </Card>
   );
 };

--- a/src/pages/regulatory-dashboard/SevereAddonPanel.tsx
+++ b/src/pages/regulatory-dashboard/SevereAddonPanel.tsx
@@ -21,6 +21,7 @@ import SchoolRoundedIcon from '@mui/icons-material/SchoolRounded';
 import VisibilityRoundedIcon from '@mui/icons-material/VisibilityRounded';
 
 import type { summarizeSevereAddonFindings } from '@/domain/regulatory/severeAddonFindings';
+import { resolveAddonSummaryState, type AddonCalculationState } from './addonSummaryState';
 
 // ─────────────────────────────────────────────
 // Constants
@@ -84,15 +85,32 @@ interface SevereAddonSummaryPanelProps {
   onNavigate: (url: string) => void;
   onFilterAddon: () => void;
   isDemo?: boolean;
+  calculationState?: AddonCalculationState;
 }
 
-export const SevereAddonSummaryPanel: React.FC<SevereAddonSummaryPanelProps> = ({ addonSummary, onNavigate, onFilterAddon, isDemo = false }) => {
+export const SevereAddonSummaryPanel: React.FC<SevereAddonSummaryPanelProps> = ({ addonSummary, onNavigate, onFilterAddon, isDemo = false, calculationState = 'complete' }) => {
   const hasIssues =
     addonSummary.trainingRatioInsufficientCount > 0 ||
     addonSummary.reassessmentOverdueCount > 0 ||
     addonSummary.weeklyObservationShortageCount > 0 ||
     addonSummary.authoringRequirementUnmetCount > 0 ||
     addonSummary.assignmentWithoutQualificationCount > 0;
+  const summaryState = resolveAddonSummaryState({ calculationState: isDemo ? 'demo' : calculationState, hasIssues });
+  const isIndeterminate = summaryState === 'indeterminate' || summaryState === 'partial';
+  const statusLabel = summaryState === 'demo'
+    ? 'デモ'
+    : summaryState === 'partial'
+      ? '一部算定不能'
+      : summaryState === 'indeterminate'
+        ? '算定不能'
+        : summaryState === 'issues'
+          ? '要対応あり'
+          : '充足';
+  const statusColor: 'default' | 'warning' | 'success' = summaryState === 'demo'
+    ? 'default'
+    : isIndeterminate || hasIssues
+      ? 'warning'
+      : 'success';
 
   return (
     <Card
@@ -100,18 +118,18 @@ export const SevereAddonSummaryPanel: React.FC<SevereAddonSummaryPanelProps> = (
       data-testid="severe-addon-summary-panel"
       sx={{
         p: 2.5,
-        borderLeft: `4px solid ${hasIssues ? '#ed6c02' : '#2e7d32'}`,
+        borderLeft: `4px solid ${isIndeterminate || hasIssues ? '#ed6c02' : '#2e7d32'}`,
       }}
     >
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
-        <AccessibilityNewRoundedIcon sx={{ color: hasIssues ? 'warning.main' : 'success.main' }} />
+        <AccessibilityNewRoundedIcon sx={{ color: isIndeterminate || hasIssues ? 'warning.main' : 'success.main' }} />
         <Typography variant="subtitle1" fontWeight={700}>
           重度障害者支援加算
         </Typography>
         <Chip
-          label={hasIssues ? '要対応あり' : '充足'}
+          label={statusLabel}
           size="small"
-          color={hasIssues ? 'warning' : 'success'}
+          color={statusColor}
           variant="filled"
           sx={{ fontWeight: 700, fontSize: '0.7rem', ml: 'auto' }}
         />

--- a/src/pages/regulatory-dashboard/__tests__/addonPresentation.spec.ts
+++ b/src/pages/regulatory-dashboard/__tests__/addonPresentation.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { createAddonPresentation } from '../addonPresentation';
+
+const input = {
+  users: [],
+  totalLifeSupportStaff: 1,
+  basicTrainingCompletedCount: 1,
+  usersWithoutWeeklyObservation: [],
+  lastReassessmentMap: new Map<string, string | null>(),
+  today: '2026-08-03',
+};
+
+describe('createAddonPresentation', () => {
+  it('keeps demo findings outside the live finding collection', () => {
+    const result = createAddonPresentation({
+      isDemoMode: true,
+      input: null,
+      buildLiveFindings: () => [{ id: 'live', type: 'basic_training_ratio_insufficient', severity: 'medium', domain: 'sheet', userId: '__facility__', message: 'live', detectedAt: '2026-08-03' }],
+      buildDemoFindings: () => [{ id: 'demo', type: 'basic_training_ratio_insufficient', severity: 'medium', domain: 'sheet', userId: '__facility__', message: 'demo', detectedAt: '2026-08-03', dataOrigin: 'demo' }],
+    });
+
+    expect(result.source).toBe('demo');
+    expect(result.liveFindings).toEqual([]);
+    expect(result.demoFindings[0]?.dataOrigin).toBe('demo');
+  });
+
+  it('does not create findings when a non-demo input is unavailable', () => {
+    const result = createAddonPresentation({
+      isDemoMode: false,
+      input: null,
+      buildLiveFindings: () => [],
+      buildDemoFindings: () => [{ id: 'demo', type: 'basic_training_ratio_insufficient', severity: 'medium', domain: 'sheet', userId: '__facility__', message: 'demo', detectedAt: '2026-08-03', dataOrigin: 'demo' }],
+    });
+
+    expect(result).toEqual({ liveFindings: [], demoFindings: [], source: 'indeterminate' });
+  });
+
+  it('uses live findings only when live input is available', () => {
+    const result = createAddonPresentation({
+      isDemoMode: false,
+      input,
+      buildLiveFindings: () => [{ id: 'live', type: 'basic_training_ratio_insufficient', severity: 'medium', domain: 'sheet', userId: '__facility__', message: 'live', detectedAt: '2026-08-03' }],
+      buildDemoFindings: () => [],
+    });
+
+    expect(result.source).toBe('live');
+    expect(result.liveFindings).toHaveLength(1);
+    expect(result.demoFindings).toEqual([]);
+  });
+});

--- a/src/pages/regulatory-dashboard/__tests__/addonSummaryState.spec.ts
+++ b/src/pages/regulatory-dashboard/__tests__/addonSummaryState.spec.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
+  resolveAddonCandidateCountDisplay,
+  resolveAddonRequirementDisplay,
   resolveAddonSummaryState,
   resolveRegulatoryAddonDemoMode,
 } from '../addonSummaryState';
@@ -20,5 +22,28 @@ describe('addon summary state', () => {
     expect(resolveRegulatoryAddonDemoMode({ demoModeEnabled: false, legacyDemo: true })).toBe(true);
     expect(resolveRegulatoryAddonDemoMode({ demoModeEnabled: true, legacyDemo: false })).toBe(true);
     expect(resolveRegulatoryAddonDemoMode({ demoModeEnabled: false, legacyDemo: false })).toBe(false);
+  });
+
+  it('uses a neutral display for an indeterminate requirement with no findings', () => {
+    expect(resolveAddonRequirementDisplay({
+      count: 0,
+      indeterminate: true,
+      okText: '充足',
+      ngText: '1件の不足',
+    })).toEqual({ label: '確認不能', color: 'default', variant: 'outlined' });
+  });
+
+  it('keeps confirmed findings actionable while indeterminate', () => {
+    expect(resolveAddonRequirementDisplay({
+      count: 2,
+      indeterminate: true,
+      okText: '充足',
+      ngText: '2件の不足',
+    })).toEqual({ label: '2件の不足', color: 'warning', variant: 'filled' });
+  });
+
+  it('does not present partial candidate counts as confirmed numbers', () => {
+    expect(resolveAddonCandidateCountDisplay(2, true)).toBe('—');
+    expect(resolveAddonCandidateCountDisplay(2, false)).toBe(2);
   });
 });

--- a/src/pages/regulatory-dashboard/__tests__/addonSummaryState.spec.ts
+++ b/src/pages/regulatory-dashboard/__tests__/addonSummaryState.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resolveAddonSummaryState,
+  resolveRegulatoryAddonDemoMode,
+} from '../addonSummaryState';
+
+describe('addon summary state', () => {
+  it.each([
+    ['demo', false, 'demo'],
+    ['demo', true, 'demo'],
+    ['indeterminate', false, 'indeterminate'],
+    ['indeterminate', true, 'partial'],
+    ['complete', false, 'complete'],
+    ['complete', true, 'issues'],
+  ] as const)('resolves %s with issues=%s to %s', (calculationState, hasIssues, expected) => {
+    expect(resolveAddonSummaryState({ calculationState, hasIssues })).toBe(expected);
+  });
+
+  it('recognizes both current and legacy demo flags', () => {
+    expect(resolveRegulatoryAddonDemoMode({ demoModeEnabled: false, legacyDemo: true })).toBe(true);
+    expect(resolveRegulatoryAddonDemoMode({ demoModeEnabled: true, legacyDemo: false })).toBe(true);
+    expect(resolveRegulatoryAddonDemoMode({ demoModeEnabled: false, legacyDemo: false })).toBe(false);
+  });
+});

--- a/src/pages/regulatory-dashboard/addonPresentation.ts
+++ b/src/pages/regulatory-dashboard/addonPresentation.ts
@@ -1,0 +1,30 @@
+import type { SevereAddonBulkInput, SevereAddonFinding } from '@/domain/regulatory/severeAddonFindings';
+
+export interface AddonPresentation {
+  liveFindings: SevereAddonFinding[];
+  demoFindings: SevereAddonFinding[];
+  source: 'live' | 'demo' | 'indeterminate';
+}
+
+export function createAddonPresentation(params: {
+  isDemoMode: boolean;
+  input: SevereAddonBulkInput | null;
+  buildLiveFindings: (input: SevereAddonBulkInput) => SevereAddonFinding[];
+  buildDemoFindings: () => SevereAddonFinding[];
+}): AddonPresentation {
+  if (params.isDemoMode) {
+    return {
+      liveFindings: [],
+      demoFindings: params.buildDemoFindings(),
+      source: 'demo',
+    };
+  }
+  if (!params.input) {
+    return { liveFindings: [], demoFindings: [], source: 'indeterminate' };
+  }
+  return {
+    liveFindings: params.buildLiveFindings(params.input),
+    demoFindings: [],
+    source: 'live',
+  };
+}

--- a/src/pages/regulatory-dashboard/addonSummaryState.ts
+++ b/src/pages/regulatory-dashboard/addonSummaryState.ts
@@ -1,0 +1,21 @@
+export type AddonCalculationState = 'demo' | 'indeterminate' | 'complete';
+
+export type AddonSummaryState = 'demo' | 'indeterminate' | 'partial' | 'issues' | 'complete';
+
+export function resolveAddonSummaryState(params: {
+  calculationState: AddonCalculationState;
+  hasIssues: boolean;
+}): AddonSummaryState {
+  if (params.calculationState === 'demo') return 'demo';
+  if (params.calculationState === 'indeterminate') {
+    return params.hasIssues ? 'partial' : 'indeterminate';
+  }
+  return params.hasIssues ? 'issues' : 'complete';
+}
+
+export function resolveRegulatoryAddonDemoMode(params: {
+  demoModeEnabled: boolean;
+  legacyDemo: boolean;
+}): boolean {
+  return params.demoModeEnabled || params.legacyDemo;
+}

--- a/src/pages/regulatory-dashboard/addonSummaryState.ts
+++ b/src/pages/regulatory-dashboard/addonSummaryState.ts
@@ -2,6 +2,12 @@ export type AddonCalculationState = 'demo' | 'indeterminate' | 'complete';
 
 export type AddonSummaryState = 'demo' | 'indeterminate' | 'partial' | 'issues' | 'complete';
 
+export type AddonRequirementDisplay = {
+  label: string;
+  color: 'default' | 'warning' | 'success';
+  variant: 'outlined' | 'filled';
+};
+
 export function resolveAddonSummaryState(params: {
   calculationState: AddonCalculationState;
   hasIssues: boolean;
@@ -18,4 +24,23 @@ export function resolveRegulatoryAddonDemoMode(params: {
   legacyDemo: boolean;
 }): boolean {
   return params.demoModeEnabled || params.legacyDemo;
+}
+
+export function resolveAddonRequirementDisplay(params: {
+  count: number;
+  indeterminate: boolean;
+  okText: string;
+  ngText: string;
+}): AddonRequirementDisplay {
+  if (params.indeterminate && params.count === 0) {
+    return { label: '確認不能', color: 'default', variant: 'outlined' };
+  }
+  if (params.count > 0) {
+    return { label: params.ngText, color: 'warning', variant: 'filled' };
+  }
+  return { label: params.okText, color: 'success', variant: 'outlined' };
+}
+
+export function resolveAddonCandidateCountDisplay(count: number, indeterminate: boolean): number | string {
+  return indeterminate ? '—' : count;
 }

--- a/src/pages/regulatory-dashboard/demoData.ts
+++ b/src/pages/regulatory-dashboard/demoData.ts
@@ -86,7 +86,7 @@ export function generateDemoSevereAddonFindings(): SevereAddonFinding[] {
     usersWithoutAuthoringQualification: ['U001'],
     usersWithoutAssignmentQualification: ['U003'],
     today,
-  });
+  }).map(finding => ({ ...finding, dataOrigin: 'demo' as const }));
 }
 
 /**


### PR DESCRIPTION
## Summary

- 非demoモードの実データ取得失敗時にデモfindingを生成しない
- BehaviorScoreの欠損・不正値を点数0へ変換せず、算定不能として分離する
- 算定不能利用者について加算findingを生成しない
- demo表示をlive finding、handoff、業務操作から分離する
- デモfindingのhandoff変換を境界で拒否する

## Scope

- 制度上の閾値、研修割合、観察期間、見直し期間は変更していない
- ABC保存処理、日次支援リンク処理、SharePointスキーマは変更していない

## Verification

- 対象5テストファイル: 5 passed
- Tests: 82 passed
- Skipped: 0
- Failed: 0
- typecheck: passed
- lint: passed
- diff check: passed
- PR CI: 全チェック完了、failure/cancelled/timed_outなし
- E2E opt-in: skipped（失敗ではない）
- SharePoint provider / demo=false read-only stub: 2 passed
- 非demo取得失敗時のデモfinding: 0件
- 非demo取得失敗時のhandoff対象: 0件
- BehaviorScore欠損・不正値: 算定不能
- BehaviorScore 0: 有効値として維持
- デモfinding: live findingから分離
- デモfindingのhandoff: UI・変換境界の双方で拒否
- read-only検証でのPOST/PATCH/PUT/DELETE: 0件

## Not verified

- 実SharePoint認証・実接続
- merge
- deploy
- 実運用

## Status

- Ready for review: PASS
- merge: HOLD
- 実運用: HOLD