### PR TITLE
fix(billing): make monthly summary auditable in JST

### DIFF
--- a/src/features/billing/hooks/__tests__/useBillingSummary.spec.ts
+++ b/src/features/billing/hooks/__tests__/useBillingSummary.spec.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
-import { BillingPaymentAuthorizationError, useBillingSummary } from '../useBillingSummary';
+import {
+  BillingPaymentAuthorizationError,
+  isOrderDateInJstMonth,
+  useBillingSummary,
+} from '../useBillingSummary';
 import type { BillingOrderRepository } from '../../ports/billingOrderRepository';
 
 const { mockUseBillingOrders } = vi.hoisted(() => ({
@@ -136,6 +140,29 @@ const mockOrders = [
   },
 ];
 
+type MockBillingOrder = (typeof mockOrders)[number];
+
+const makeMockOrder = (
+  id: number,
+  orderDate: string,
+  overrides: Partial<MockBillingOrder> = {}
+): MockBillingOrder => ({
+  id,
+  orderDate,
+  ordererCode: 'U-001',
+  ordererName: 'テスト利用者',
+  orderCount: 1,
+  served: true,
+  item: 'コーヒー',
+  sugar: 'なし',
+  milk: 'なし',
+  drinkPrice: 50,
+  paymentStatus: '',
+  paidAt: '',
+  paidBy: '',
+  ...overrides,
+});
+
 vi.mock('../../useBillingOrders', () => ({
   useBillingOrders: mockUseBillingOrders,
   billingOrdersQueryKey: ['billingOrders', 'list'],
@@ -233,24 +260,105 @@ describe('useBillingSummary', () => {
     expect(mockUseBillingOrders).toHaveBeenCalledWith(mockRepository);
   });
 
-  it('2026年7月のページ境界後もI019・I030を利用者として請求集計し、未提供注文を除外すること', async () => {
+  it('JST月初を含み翌月月初を含まない半開区間で対象月を判定すること', () => {
+    expect(isOrderDateInJstMonth('2026-06-30T14:59:59.999Z', '2026-07')).toBe(false);
+    expect(isOrderDateInJstMonth('2026-06-30T15:00:00.000Z', '2026-07')).toBe(true);
+    expect(isOrderDateInJstMonth('2026-07-31T14:59:59.999Z', '2026-07')).toBe(true);
+    expect(isOrderDateInJstMonth('2026-07-31T15:00:00.000Z', '2026-07')).toBe(false);
+  });
+
+  it('利用可能月をUTC文字列の先頭ではなくJSTの年月から生成すること', async () => {
     mockUseBillingOrders.mockReturnValue({
       data: [
-        {
-          id: 5412,
-          orderDate: '2026-07-13T04:26:00Z',
-          ordererCode: 'I019',
-          ordererName: '匿名利用者019',
-          orderCount: 1,
-          served: false,
-          item: 'sample',
-          sugar: 'none',
-          milk: 'none',
-          drinkPrice: 50,
-          paymentStatus: '',
-          paidAt: '',
-          paidBy: '',
-        },
+        makeMockOrder(1, '2026-06-30T14:59:59.999Z'),
+        makeMockOrder(2, '2026-06-30T15:00:00.000Z'),
+      ],
+      isLoading: false,
+      isError: false,
+    });
+
+    const { result } = renderHook(() => useBillingSummary('2026-07', mockRepository));
+
+    await waitFor(() => {
+      expect(result.current.persistenceDiagnostics?.status).toBe('resolved');
+    });
+    expect(result.current.availableMonths).toEqual(['2026-07', '2026-06']);
+  });
+
+  it('全取得・対象月・提供済み・未提供を行数で数え、杯数とは区別すること', async () => {
+    mockUseBillingOrders.mockReturnValue({
+      data: [
+        makeMockOrder(1, '2026-07-01T00:00:00Z', { orderCount: 3, served: true }),
+        makeMockOrder(2, '2026-07-02T00:00:00Z', { orderCount: 2, served: true }),
+        makeMockOrder(3, '2026-07-03T00:00:00Z', { orderCount: 4, served: false }),
+        makeMockOrder(4, '2026-08-01T00:00:00Z', { served: true }),
+      ],
+      isLoading: false,
+      isError: false,
+    });
+
+    const { result } = renderHook(() => useBillingSummary('2026-07', mockRepository));
+
+    await waitFor(() => {
+      expect(result.current.persistenceDiagnostics?.status).toBe('resolved');
+    });
+    expect(result.current.fetchedOrderCount).toBe(4);
+    expect(result.current.targetMonthOrderCount).toBe(3);
+    expect(result.current.servedOrderCount).toBe(2);
+    expect(result.current.unservedOrderCount).toBe(1);
+    expect(result.current.totalServedCount).toBe(5);
+  });
+
+  it('不正な日時も全取得件数には含めるが対象月件数には含めないこと', async () => {
+    mockUseBillingOrders.mockReturnValue({
+      data: [
+        makeMockOrder(1, 'not-a-date'),
+        makeMockOrder(2, '2026-07-01T00:00:00Z'),
+      ],
+      isLoading: false,
+      isError: false,
+    });
+
+    const { result } = renderHook(() => useBillingSummary('2026-07', mockRepository));
+
+    await waitFor(() => {
+      expect(result.current.persistenceDiagnostics?.status).toBe('resolved');
+    });
+    expect(result.current.fetchedOrderCount).toBe(2);
+    expect(result.current.targetMonthOrderCount).toBe(1);
+    expect(result.current.availableMonths).toEqual(['2026-07']);
+  });
+
+  it('2026年7月全体を543行・提供済み540杯27000円・未提供3行として回帰確認すること', async () => {
+    const julyOrders = Array.from({ length: 543 }, (_, index) =>
+      makeMockOrder(index + 1, '2026-07-15T03:00:00Z', {
+        served: index < 540,
+        orderCount: 1,
+        drinkPrice: 50,
+      })
+    );
+    mockUseBillingOrders.mockReturnValue({
+      data: julyOrders,
+      isLoading: false,
+      isError: false,
+    });
+
+    const { result } = renderHook(() => useBillingSummary('2026-07', mockRepository));
+
+    await waitFor(() => {
+      expect(result.current.persistenceDiagnostics?.status).toBe('resolved');
+    });
+    expect(result.current.fetchedOrderCount).toBe(543);
+    expect(result.current.targetMonthOrderCount).toBe(543);
+    expect(result.current.servedOrderCount).toBe(540);
+    expect(result.current.unservedOrderCount).toBe(3);
+    expect(result.current.totalServedCount).toBe(540);
+    expect(result.current.totalServedAmount).toBe(27_000);
+  });
+
+  it('I019・I030の5行250円を月次全体とは別の部分集計兼ページング境界回帰として扱うこと', async () => {
+    mockUseBillingOrders.mockReturnValue({
+      data: [
         {
           id: 5563,
           orderDate: '2026-07-22T04:11:00Z',
@@ -311,6 +419,21 @@ describe('useBillingSummary', () => {
           paidAt: '',
           paidBy: '',
         },
+        {
+          id: 5750,
+          orderDate: '2026-07-31T04:10:00Z',
+          ordererCode: 'I019',
+          ordererName: '匿名利用者019',
+          orderCount: 1,
+          served: true,
+          item: 'sample',
+          sugar: 'none',
+          milk: 'none',
+          drinkPrice: 50,
+          paymentStatus: '',
+          paidAt: '',
+          paidBy: '',
+        },
       ],
       isLoading: false,
       isError: false,
@@ -327,9 +450,9 @@ describe('useBillingSummary', () => {
 
     expect(i019).toMatchObject({
       category: '利用者',
-      totalCount: 1,
-      totalAmount: 50,
-      orderIds: [5642],
+      totalCount: 2,
+      totalAmount: 100,
+      orderIds: [5642, 5750],
     });
     expect(i030).toMatchObject({
       category: '利用者',
@@ -337,9 +460,12 @@ describe('useBillingSummary', () => {
       totalAmount: 150,
       orderIds: [5563, 5689, 5733],
     });
-    expect(result.current.totalServedCount).toBe(4);
-    expect(result.current.totalServedAmount).toBe(200);
-    expect(result.current.records.flatMap((record) => record.orderIds)).not.toContain(5412);
+    expect(result.current.fetchedOrderCount).toBe(5);
+    expect(result.current.targetMonthOrderCount).toBe(5);
+    expect(result.current.servedOrderCount).toBe(5);
+    expect(result.current.unservedOrderCount).toBe(0);
+    expect(result.current.totalServedCount).toBe(5);
+    expect(result.current.totalServedAmount).toBe(250);
   });
 
   it('個別の精算トグル状態が SharePoint の repository に送られ、query invalidation が走ること', async () => {

--- a/src/features/billing/hooks/__tests__/useBillingSummary.spec.ts
+++ b/src/features/billing/hooks/__tests__/useBillingSummary.spec.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import {
   BillingPaymentAuthorizationError,
+  getBillingServedState,
+  getFallbackPaymentState,
   isOrderDateInJstMonth,
   useBillingSummary,
 } from '../useBillingSummary';
@@ -306,7 +308,67 @@ describe('useBillingSummary', () => {
     expect(result.current.targetMonthOrderCount).toBe(3);
     expect(result.current.servedOrderCount).toBe(2);
     expect(result.current.unservedOrderCount).toBe(1);
+    expect(result.current.unknownOrderCount).toBe(0);
     expect(result.current.totalServedCount).toBe(5);
+  });
+
+  it('空文字・欠損・未知のServed値を不明として未提供件数から分離すること', async () => {
+    mockUseBillingOrders.mockReturnValue({
+      data: [
+        makeMockOrder(1, '2026-07-01T00:00:00Z', { served: true }),
+        makeMockOrder(2, '2026-07-02T00:00:00Z', { served: false }),
+        makeMockOrder(3, '2026-07-03T00:00:00Z', { served: '' }),
+        makeMockOrder(4, '2026-07-04T00:00:00Z', { served: 'pending' }),
+      ],
+      isLoading: false,
+      isError: false,
+    });
+
+    const { result } = renderHook(() => useBillingSummary('2026-07', mockRepository));
+
+    await waitFor(() => {
+      expect(result.current.persistenceDiagnostics?.status).toBe('resolved');
+    });
+    expect(getBillingServedState(true)).toBe('served');
+    expect(getBillingServedState(false)).toBe('unserved');
+    expect(getBillingServedState(undefined)).toBe('unknown');
+    expect(result.current.servedOrderCount).toBe(1);
+    expect(result.current.unservedOrderCount).toBe(1);
+    expect(result.current.unknownOrderCount).toBe(2);
+  });
+
+  it('JSTキーを正本にし、JST境界の旧raw年月キーだけを互換読み取りすること', () => {
+    const legacyStates = { '2026-07:U-001': true };
+    expect(getFallbackPaymentState(
+      legacyStates,
+      '2026-08',
+      ['2026-07-31T16:00:00.000Z'],
+      'U-001'
+    )).toBe(true);
+    expect(getFallbackPaymentState(
+      legacyStates,
+      '2026-08',
+      ['2026-08-02T00:00:00.000Z'],
+      'U-001'
+    )).toBe(false);
+    expect(getFallbackPaymentState(
+      { '2026-08:U-001': false, '2026-07:U-001': true },
+      '2026-08',
+      ['2026-07-31T16:00:00.000Z'],
+      'U-001'
+    )).toBe(false);
+    expect(getFallbackPaymentState(
+      { '2026-07:U-001': true, '2026-08:U-001': true },
+      '2026-08',
+      ['2026-07-31T16:00:00.000Z', '2026-08-01T16:00:00.000Z'],
+      'U-001'
+    )).toBe(true);
+    expect(getFallbackPaymentState(
+      { '2026-07:U-001': true },
+      '2026-08',
+      ['2026-07-31T16:00:00.000Z', '2026-08-01T16:00:00.000Z'],
+      'U-001'
+    )).toBe(false);
   });
 
   it('不正な日時も全取得件数には含めるが対象月件数には含めないこと', async () => {

--- a/src/features/billing/hooks/useBillingSummary.ts
+++ b/src/features/billing/hooks/useBillingSummary.ts
@@ -32,6 +32,7 @@ export interface BillingSummary {
   targetMonthOrderCount: number;
   servedOrderCount: number;
   unservedOrderCount: number;
+  unknownOrderCount: number;
   totalServedCount: number;
   totalServedAmount: number;
   totalPaidCount: number;
@@ -51,13 +52,34 @@ export interface BillingSummary {
   exportCsv: (category: '利用者' | '職員' | 'ゲスト' | 'すべて') => void;
 }
 
-export const isServedOrder = (served: unknown): boolean => {
-  if (served === true) return true;
-  if (typeof served === 'number') return served === 1;
-  if (typeof served !== 'string') return false;
+export type BillingServedState = 'served' | 'unserved' | 'unknown';
+
+export const getBillingServedState = (served: unknown): BillingServedState => {
+  if (served === true) return 'served';
+  if (served === false) return 'unserved';
+  if (typeof served === 'number') {
+    if (served === 1) return 'served';
+    if (served === 0) return 'unserved';
+    return 'unknown';
+  }
+  if (typeof served !== 'string') return 'unknown';
 
   const normalized = served.trim().toLowerCase();
-  return normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'served' || normalized === '提供済み';
+  if (!normalized) return 'unknown';
+  if (normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'served' || normalized === '提供済' || normalized === '提供済み') {
+    return 'served';
+  }
+  if (normalized === 'false' || normalized === '0' || normalized === 'no' || normalized === 'unserved' || normalized === '未提供') {
+    return 'unserved';
+  }
+  return 'unknown';
+};
+
+export const isServedOrder = (served: unknown): boolean => getBillingServedState(served) === 'served';
+
+export const toLegacyRawMonthKey = (orderDate: string): string | null => {
+  const rawMonth = orderDate.slice(0, 7);
+  return /^\d{4}-\d{2}$/.test(rawMonth) ? rawMonth : null;
 };
 
 const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
@@ -94,6 +116,31 @@ export const isOrderDateInJstMonth = (orderDate: string, monthKey: string): bool
   const startUtc = Date.UTC(parsedMonth.year, parsedMonth.monthIndex, 1) - JST_OFFSET_MS;
   const endUtc = Date.UTC(parsedMonth.year, parsedMonth.monthIndex + 1, 1) - JST_OFFSET_MS;
   return timestamp >= startUtc && timestamp < endUtc;
+};
+
+/**
+ * JSTキーを正本とし、JST境界で再分類された注文だけ旧raw年月キーを読む。
+ * 旧キーの状態は次回の操作でJSTキーへ書き込まれるため、読み取り時の破壊的移行は行わない。
+ */
+export const getFallbackPaymentState = (
+  states: Record<string, boolean>,
+  selectedMonth: string,
+  orderDates: string[],
+  ordererCode: string,
+): boolean => {
+  const canonicalKey = `${selectedMonth}:${ordererCode}`;
+  if (Object.prototype.hasOwnProperty.call(states, canonicalKey)) {
+    return states[canonicalKey] === true;
+  }
+
+  const legacyMonths = Array.from(new Set(
+    orderDates
+      .map(toLegacyRawMonthKey)
+      .filter((month): month is string => month !== null)
+  ));
+  if (legacyMonths.length === 0) return false;
+
+  return legacyMonths.every((month) => states[`${month}:${ordererCode}`] === true);
 };
 
 export function useBillingSummary(
@@ -139,12 +186,15 @@ export function useBillingSummary(
   );
 
   const orderCounts = useMemo(() => {
-    const servedOrderCount = targetMonthOrders.filter((order) => isServedOrder(order.served)).length;
+    const servedOrderCount = targetMonthOrders.filter((order) => getBillingServedState(order.served) === 'served').length;
+    const unservedOrderCount = targetMonthOrders.filter((order) => getBillingServedState(order.served) === 'unserved').length;
+    const unknownOrderCount = targetMonthOrders.length - servedOrderCount - unservedOrderCount;
     return {
       fetchedOrderCount: rawOrders.length,
       targetMonthOrderCount: targetMonthOrders.length,
       servedOrderCount,
-      unservedOrderCount: targetMonthOrders.length - servedOrderCount,
+      unservedOrderCount,
+      unknownOrderCount,
     };
   }, [rawOrders.length, targetMonthOrders]);
 
@@ -248,7 +298,7 @@ export function useBillingSummary(
     if (targetMonthOrders.length === 0) return [];
 
     // 1. JST 対象月のうち提供済みだけを請求集計へ含める
-    const filtered = targetMonthOrders.filter((order) => isServedOrder(order.served));
+    const filtered = targetMonthOrders.filter((order) => getBillingServedState(order.served) === 'served');
 
     // 2. 個人ごとに集計
     const groups: Record<string, { 
@@ -257,6 +307,7 @@ export function useBillingSummary(
       count: number; 
       amount: number;
       orderIds: number[];
+      orderDates: string[];
       spPaidCount: number;
       totalOrdersCount: number;
     }> = {};
@@ -271,6 +322,7 @@ export function useBillingSummary(
           count: 0, 
           amount: 0, 
           orderIds: [],
+          orderDates: [],
           spPaidCount: 0,
           totalOrdersCount: 0
         };
@@ -278,6 +330,7 @@ export function useBillingSummary(
       groups[code].count += order.orderCount;
       groups[code].amount += order.orderCount * order.drinkPrice;
       groups[code].orderIds.push(order.id);
+      groups[code].orderDates.push(order.orderDate);
       groups[code].totalOrdersCount++;
       if (order.paymentStatus === '精算済み') {
         groups[code].spPaidCount++;
@@ -310,8 +363,7 @@ export function useBillingSummary(
       if (!isPersistenceMissing && group.totalOrdersCount > 0) {
         isPaid = group.spPaidCount === group.totalOrdersCount;
       } else {
-        const stateKey = `${selectedMonth}:${group.code}`;
-        isPaid = !!fallbackPaymentStates[stateKey];
+        isPaid = getFallbackPaymentState(fallbackPaymentStates, selectedMonth, group.orderDates, group.code);
       }
 
       return {

--- a/src/features/billing/hooks/useBillingSummary.ts
+++ b/src/features/billing/hooks/useBillingSummary.ts
@@ -28,6 +28,10 @@ export interface AggregatedBillingRecord {
 export interface BillingSummary {
   records: AggregatedBillingRecord[];
   availableMonths: string[];
+  fetchedOrderCount: number;
+  targetMonthOrderCount: number;
+  servedOrderCount: number;
+  unservedOrderCount: number;
   totalServedCount: number;
   totalServedAmount: number;
   totalPaidCount: number;
@@ -54,6 +58,42 @@ export const isServedOrder = (served: unknown): boolean => {
 
   const normalized = served.trim().toLowerCase();
   return normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'served' || normalized === '提供済み';
+};
+
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+const MONTH_KEY_PATTERN = /^(\d{4})-(\d{2})$/;
+
+const parseMonthKey = (monthKey: string): { year: number; monthIndex: number } | null => {
+  const match = MONTH_KEY_PATTERN.exec(monthKey);
+  if (!match) return null;
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  if (month < 1 || month > 12) return null;
+
+  return { year, monthIndex: month - 1 };
+};
+
+export const toJstMonthKey = (orderDate: string): string | null => {
+  const timestamp = Date.parse(orderDate);
+  if (!Number.isFinite(timestamp)) return null;
+
+  const jstDate = new Date(timestamp + JST_OFFSET_MS);
+  const year = jstDate.getUTCFullYear();
+  const month = String(jstDate.getUTCMonth() + 1).padStart(2, '0');
+  return `${year}-${month}`;
+};
+
+export const isOrderDateInJstMonth = (orderDate: string, monthKey: string): boolean => {
+  const parsedMonth = parseMonthKey(monthKey);
+  if (!parsedMonth) return false;
+
+  const timestamp = Date.parse(orderDate);
+  if (!Number.isFinite(timestamp)) return false;
+
+  const startUtc = Date.UTC(parsedMonth.year, parsedMonth.monthIndex, 1) - JST_OFFSET_MS;
+  const endUtc = Date.UTC(parsedMonth.year, parsedMonth.monthIndex + 1, 1) - JST_OFFSET_MS;
+  return timestamp >= startUtc && timestamp < endUtc;
 };
 
 export function useBillingSummary(
@@ -85,13 +125,28 @@ export function useBillingSummary(
   const availableMonths = useMemo(() => {
     const months = new Set<string>();
     rawOrders.forEach((order) => {
-      const month = order.orderDate?.slice(0, 7);
-      if (/^\d{4}-\d{2}$/.test(month)) {
+      const month = toJstMonthKey(order.orderDate);
+      if (month) {
         months.add(month);
       }
     });
     return Array.from(months).sort((a, b) => b.localeCompare(a));
   }, [rawOrders]);
+
+  const targetMonthOrders = useMemo(
+    () => rawOrders.filter((order) => isOrderDateInJstMonth(order.orderDate, selectedMonth)),
+    [rawOrders, selectedMonth]
+  );
+
+  const orderCounts = useMemo(() => {
+    const servedOrderCount = targetMonthOrders.filter((order) => isServedOrder(order.served)).length;
+    return {
+      fetchedOrderCount: rawOrders.length,
+      targetMonthOrderCount: targetMonthOrders.length,
+      servedOrderCount,
+      unservedOrderCount: targetMonthOrders.length - servedOrderCount,
+    };
+  }, [rawOrders.length, targetMonthOrders]);
 
   // 1. スキーマ存在チェック
   useEffect(() => {
@@ -190,13 +245,10 @@ export function useBillingSummary(
 
   // 個人ごとの集計およびカテゴリ判別
   const records = useMemo((): AggregatedBillingRecord[] => {
-    if (rawOrders.length === 0) return [];
+    if (targetMonthOrders.length === 0) return [];
 
-    // 1. 月フィルタ & 提供済みフィルタ
-    const filtered = rawOrders.filter((order) => {
-      const orderMonth = order.orderDate.slice(0, 7);
-      return orderMonth === selectedMonth && isServedOrder(order.served);
-    });
+    // 1. JST 対象月のうち提供済みだけを請求集計へ含める
+    const filtered = targetMonthOrders.filter((order) => isServedOrder(order.served));
 
     // 2. 個人ごとに集計
     const groups: Record<string, { 
@@ -272,7 +324,7 @@ export function useBillingSummary(
         orderIds: group.orderIds,
       };
     });
-  }, [rawOrders, selectedMonth, users, staff, isPersistenceMissing, fallbackPaymentStates]);
+  }, [targetMonthOrders, selectedMonth, users, staff, isPersistenceMissing, fallbackPaymentStates]);
 
   // KPI集計
   const summary = useMemo(() => {
@@ -418,6 +470,7 @@ export function useBillingSummary(
   return {
     records,
     availableMonths,
+    ...orderCounts,
     ...summary,
     isLoading,
     isError: !!ordersError,

--- a/src/features/billing/ui/BillingPage.tsx
+++ b/src/features/billing/ui/BillingPage.tsx
@@ -41,19 +41,23 @@ import type { BillingOrderRepository } from '../ports/billingOrderRepository';
 type ActiveTab = '利用者' | '職員' | 'ゲスト' | 'すべて';
 const APP_COMMIT_SHA = typeof __APP_COMMIT_SHA__ === 'string' ? __APP_COMMIT_SHA__ : 'unknown';
 
-const toMonthKey = (date: Date): string => {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+export const toJstMonthKey = (date: Date): string => {
+  const jstDate = new Date(date.getTime() + JST_OFFSET_MS);
+  const year = jstDate.getUTCFullYear();
+  const month = String(jstDate.getUTCMonth() + 1).padStart(2, '0');
   return `${year}-${month}`;
 };
 
 const addMonths = (monthKey: string, offset: number): string => {
   const [year, month] = monthKey.split('-').map(Number);
-  return toMonthKey(new Date(year, month - 1 + offset, 1));
+  const shifted = new Date(Date.UTC(year, month - 1 + offset, 1));
+  return `${shifted.getUTCFullYear()}-${String(shifted.getUTCMonth() + 1).padStart(2, '0')}`;
 };
 
 const buildMonthOptions = (availableMonths: string[], selectedMonth: string): string[] => {
-  const currentMonth = toMonthKey(new Date());
+  const currentMonth = toJstMonthKey(new Date());
   const months = new Set([selectedMonth, currentMonth, ...availableMonths]);
 
   for (let offset = -24; offset <= 3; offset += 1) {
@@ -70,7 +74,7 @@ export type BillingPageProps = {
 };
 
 export default function BillingPage({ repository }: BillingPageProps) {
-  const [selectedMonth, setSelectedMonth] = useState(() => toMonthKey(new Date()));
+  const [selectedMonth, setSelectedMonth] = useState(() => toJstMonthKey(new Date()));
   const [hasUserSelectedMonth, setHasUserSelectedMonth] = useState(false);
   const [activeTab, setActiveTab] = useState<ActiveTab>('利用者');
 
@@ -82,6 +86,7 @@ export default function BillingPage({ repository }: BillingPageProps) {
     targetMonthOrderCount,
     servedOrderCount,
     unservedOrderCount,
+    unknownOrderCount,
     totalServedCount,
     totalServedAmount,
     totalPaidCount,
@@ -282,7 +287,7 @@ export default function BillingPage({ repository }: BillingPageProps) {
           data-testid="billing-audit-summary"
         >
           <Typography variant="body2" sx={{ fontWeight: 600 }}>
-            全取得: {fetchedOrderCount}件 / 対象月: {targetMonthOrderCount}件 / 提供済み: {servedOrderCount}件 / 未提供: {unservedOrderCount}件
+            全取得: {fetchedOrderCount}件 / 対象月: {targetMonthOrderCount}件 / 提供済み: {servedOrderCount}件 / 未提供: {unservedOrderCount}件 / 不明: {unknownOrderCount}件
           </Typography>
           <Typography variant="caption" data-testid="billing-commit-sha" sx={{ fontFamily: 'monospace' }}>
             Commit: {APP_COMMIT_SHA}

--- a/src/features/billing/ui/BillingPage.tsx
+++ b/src/features/billing/ui/BillingPage.tsx
@@ -39,6 +39,7 @@ import { useBillingSummary } from '../hooks/useBillingSummary';
 import type { BillingOrderRepository } from '../ports/billingOrderRepository';
 
 type ActiveTab = '利用者' | '職員' | 'ゲスト' | 'すべて';
+const APP_COMMIT_SHA = typeof __APP_COMMIT_SHA__ === 'string' ? __APP_COMMIT_SHA__ : 'unknown';
 
 const toMonthKey = (date: Date): string => {
   const year = date.getFullYear();
@@ -77,6 +78,10 @@ export default function BillingPage({ repository }: BillingPageProps) {
   const {
     records,
     availableMonths,
+    fetchedOrderCount,
+    targetMonthOrderCount,
+    servedOrderCount,
+    unservedOrderCount,
     totalServedCount,
     totalServedAmount,
     totalPaidCount,
@@ -266,6 +271,22 @@ export default function BillingPage({ repository }: BillingPageProps) {
               </Typography>
             )}
           </Stack>
+        </Stack>
+
+        <Stack
+          direction={{ xs: 'column', md: 'row' }}
+          justifyContent="space-between"
+          alignItems={{ xs: 'flex-start', md: 'center' }}
+          spacing={1}
+          sx={{ mb: 3, color: '#475569' }}
+          data-testid="billing-audit-summary"
+        >
+          <Typography variant="body2" sx={{ fontWeight: 600 }}>
+            全取得: {fetchedOrderCount}件 / 対象月: {targetMonthOrderCount}件 / 提供済み: {servedOrderCount}件 / 未提供: {unservedOrderCount}件
+          </Typography>
+          <Typography variant="caption" data-testid="billing-commit-sha" sx={{ fontFamily: 'monospace' }}>
+            Commit: {APP_COMMIT_SHA}
+          </Typography>
         </Stack>
 
         {/* グラスモルフィズム KPI サマリーカード */}

--- a/tests/unit/BillingPage.csv-confirm.spec.tsx
+++ b/tests/unit/BillingPage.csv-confirm.spec.tsx
@@ -7,6 +7,10 @@ const billingSummaryState = vi.hoisted(() => ({
   hasLocalPaymentState: false,
   localPaymentStateCount: 0,
   canEditPayment: true,
+  fetchedOrderCount: 0,
+  targetMonthOrderCount: 0,
+  servedOrderCount: 0,
+  unservedOrderCount: 0,
   records: [] as Array<{
     ordererCode: string;
     ordererName: string;
@@ -26,6 +30,10 @@ vi.mock('@/features/billing/hooks/useBillingSummary', () => ({
   useBillingSummary: () => ({
     records: billingSummaryState.records,
     availableMonths: ['2026-05'],
+    fetchedOrderCount: billingSummaryState.fetchedOrderCount,
+    targetMonthOrderCount: billingSummaryState.targetMonthOrderCount,
+    servedOrderCount: billingSummaryState.servedOrderCount,
+    unservedOrderCount: billingSummaryState.unservedOrderCount,
     totalServedCount: 0,
     totalServedAmount: 0,
     totalPaidCount: 0,
@@ -53,6 +61,10 @@ describe('BillingPage CSV export confirmation', () => {
     billingSummaryState.hasLocalPaymentState = false;
     billingSummaryState.localPaymentStateCount = 0;
     billingSummaryState.canEditPayment = true;
+    billingSummaryState.fetchedOrderCount = 0;
+    billingSummaryState.targetMonthOrderCount = 0;
+    billingSummaryState.servedOrderCount = 0;
+    billingSummaryState.unservedOrderCount = 0;
     billingSummaryState.records = [];
     exportCsvMock.mockReset();
     togglePaymentStatusMock.mockReset();
@@ -169,5 +181,17 @@ describe('BillingPage CSV export confirmation', () => {
 
     expect(screen.getByRole('button', { name: '選択中のタブを一括精算' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '未精算' })).toBeInTheDocument();
+  });
+
+  it('shows auditable row counts and the build commit SHA', () => {
+    billingSummaryState.fetchedOrderCount = 600;
+    billingSummaryState.targetMonthOrderCount = 543;
+    billingSummaryState.servedOrderCount = 540;
+    billingSummaryState.unservedOrderCount = 3;
+
+    render(<BillingPage repository={repository} />);
+
+    expect(screen.getByText('全取得: 600件 / 対象月: 543件 / 提供済み: 540件 / 未提供: 3件')).toBeInTheDocument();
+    expect(screen.getByTestId('billing-commit-sha')).toHaveTextContent(/^Commit: (?:[0-9a-f]{40}|unknown)$/);
   });
 });

--- a/tests/unit/BillingPage.csv-confirm.spec.tsx
+++ b/tests/unit/BillingPage.csv-confirm.spec.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { BillingPage, type BillingOrderRepository } from '@/features/billing';
+import { toJstMonthKey } from '@/features/billing/ui/BillingPage';
 
 const billingSummaryState = vi.hoisted(() => ({
   isPersistenceMissing: false,
@@ -11,6 +12,8 @@ const billingSummaryState = vi.hoisted(() => ({
   targetMonthOrderCount: 0,
   servedOrderCount: 0,
   unservedOrderCount: 0,
+  unknownOrderCount: 0,
+  availableMonths: ['2026-05'],
   records: [] as Array<{
     ordererCode: string;
     ordererName: string;
@@ -29,11 +32,12 @@ const bulkSettleMock = vi.hoisted(() => vi.fn());
 vi.mock('@/features/billing/hooks/useBillingSummary', () => ({
   useBillingSummary: () => ({
     records: billingSummaryState.records,
-    availableMonths: ['2026-05'],
+    availableMonths: billingSummaryState.availableMonths,
     fetchedOrderCount: billingSummaryState.fetchedOrderCount,
     targetMonthOrderCount: billingSummaryState.targetMonthOrderCount,
     servedOrderCount: billingSummaryState.servedOrderCount,
     unservedOrderCount: billingSummaryState.unservedOrderCount,
+    unknownOrderCount: billingSummaryState.unknownOrderCount,
     totalServedCount: 0,
     totalServedAmount: 0,
     totalPaidCount: 0,
@@ -65,11 +69,32 @@ describe('BillingPage CSV export confirmation', () => {
     billingSummaryState.targetMonthOrderCount = 0;
     billingSummaryState.servedOrderCount = 0;
     billingSummaryState.unservedOrderCount = 0;
+    billingSummaryState.unknownOrderCount = 0;
+    billingSummaryState.availableMonths = ['2026-05'];
     billingSummaryState.records = [];
     exportCsvMock.mockReset();
     togglePaymentStatusMock.mockReset();
     bulkSettleMock.mockReset();
     vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('ブラウザがロサンゼルスでも初期対象月をJST年月で生成すること', () => {
+    const previousTz = process.env.TZ;
+    process.env.TZ = 'America/Los_Angeles';
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-31T15:30:00.000Z'));
+    billingSummaryState.availableMonths = ['2026-08', '2026-07'];
+
+    try {
+      expect(toJstMonthKey(new Date())).toBe('2026-08');
+      render(<BillingPage repository={repository} />);
+      expect(screen.getByRole('combobox')).toHaveTextContent('2026年8月');
+    } finally {
+      if (previousTz === undefined) delete process.env.TZ;
+      else process.env.TZ = previousTz;
+      vi.useRealTimers();
+    }
   });
 
   it('exports CSV without confirmation when payment persistence is available', () => {
@@ -188,10 +213,11 @@ describe('BillingPage CSV export confirmation', () => {
     billingSummaryState.targetMonthOrderCount = 543;
     billingSummaryState.servedOrderCount = 540;
     billingSummaryState.unservedOrderCount = 3;
+    billingSummaryState.unknownOrderCount = 0;
 
     render(<BillingPage repository={repository} />);
 
-    expect(screen.getByText('全取得: 600件 / 対象月: 543件 / 提供済み: 540件 / 未提供: 3件')).toBeInTheDocument();
+    expect(screen.getByText('全取得: 600件 / 対象月: 543件 / 提供済み: 540件 / 未提供: 3件 / 不明: 0件')).toBeInTheDocument();
     expect(screen.getByTestId('billing-commit-sha')).toHaveTextContent(/^Commit: (?:[0-9a-f]{40}|unknown)$/);
   });
 });

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,4 +1,6 @@
 declare global {
+  const __APP_COMMIT_SHA__: string;
+
   interface Window {
     __USERS_DEMO_PRESET__?: 'normal' | 'empty' | 'error';
     __USERS_DEMO__?: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,6 @@
 import legacy from '@vitejs/plugin-legacy'
 import react from '@vitejs/plugin-react'
+import { execFileSync } from 'node:child_process'
 import fs from 'node:fs'
 import path, { resolve } from 'node:path'
 import { fileURLToPath, URL } from 'node:url'
@@ -16,6 +17,20 @@ const fluentStub = fileURLToPath(new URL('./src/stubs/fluentui-react.tsx', impor
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-expect-error -- import.meta is supported in the Vite Node runtime
 const emptyShim = fileURLToPath(new URL('./src/shims/empty.ts', import.meta.url))
+
+const resolveCommitSha = (): string => {
+  const environmentSha = process.env.GITHUB_SHA ?? process.env.CF_PAGES_COMMIT_SHA ?? process.env.VITE_COMMIT_SHA;
+  if (environmentSha?.trim()) return environmentSha.trim();
+
+  try {
+    return execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+    }).trim();
+  } catch {
+    return 'unknown';
+  }
+};
 
 export default defineConfig(({ mode }) => {
   // Load environment variables (.env.test.local will override .env.local in test mode)
@@ -57,6 +72,7 @@ export default defineConfig(({ mode }) => {
   return {
     define: {
       'process.env.NODE_ENV': JSON.stringify(mode),
+      __APP_COMMIT_SHA__: JSON.stringify(resolveCommitSha()),
     },
     plugins: [
       react(),


### PR DESCRIPTION
## Summary

- JSTの月初から翌月月初までの半開区間で対象月を判定
- 全取得行数、対象月行数、提供済み行数、未提供行数を表示
- 月次全体とI019・I030の部分集計をテスト上で分離
- 画面へデプロイ元commit SHAを表示

## Root cause

- 従来の月判定が日時文字列の先頭7文字に依存していた
- 画面上で取得件数と集計対象件数を区別できなかった
- 5行の回帰サンプルが月次全体の期待値と誤解される余地があった
- 本番表示からデプロイ元commitを判別できなかった

## Regression scenarios

- 2026年7月全体：543行
- 提供済み：540杯・27,000円
- 未提供：3杯
- I019・I030：5杯・250円
- I019・I030の5行は部分集計兼ページング境界回帰
- ページング欠落の修正はPR #2540で実施済み

## Validation

- `npx vitest run src/features/billing/domain/__tests__/billingLogic.spec.ts src/features/billing/hooks/__tests__/useBillingSummary.spec.ts src/features/billing/hooks/useBillingOrders.spec.ts src/features/billing/adapters/in-memory/__tests__/InMemoryBillingOrderRepository.spec.ts src/features/billing/adapters/sharepoint/__tests__/DataProviderBillingOrderRepository.spec.ts tests/unit/BillingPage.csv-confirm.spec.tsx --reporter=verbose --pool=forks --maxWorkers=1`
  - 6 files / 61 tests PASS
- `npm run typecheck:full -- --pretty false` PASS
- `npm run lint -- --max-warnings 0` PASS
- `npm run build` PASS
- `git diff --check origin/main...HEAD` PASS
- commit SHA `49efe14abed5362d9dd1a4cc10cf3b8c4212abca` をmodern / legacyの両BillingRouteバンドルで確認

## Out of scope

- 本番デプロイ
- 本番データの再照合
- Microsoft 365への再ログイン
- SharePoint変更
- Power Apps変更
- Power Automate変更
- 取消・承認・月次締め仕様の変更
