### PR TITLE
feat(observability): add opt-in SharePoint proxy diagnostics

### DIFF
--- a/src/__tests__/worker.spec.ts
+++ b/src/__tests__/worker.spec.ts
@@ -230,6 +230,8 @@ describe('Cloudflare Worker - SharePoint Proxy', () => {
       status,
       retryClass: 'none',
     });
+    expect(diagnostic.durationMs).toEqual(expect.any(Number));
+    expect(diagnostic.durationMs as number).toBeGreaterThanOrEqual(0);
     expect(JSON.stringify(diagnostic)).not.toContain('not-logged');
     expect(JSON.stringify(diagnostic)).not.toContain('secret-token');
   });
@@ -288,6 +290,8 @@ describe('Cloudflare Worker - SharePoint Proxy', () => {
       retryClass: 'none',
     });
     expect(diagnostic.diagnosticId).toEqual(expect.any(String));
+    expect(diagnostic.durationMs).toEqual(expect.any(Number));
+    expect(diagnostic.durationMs as number).toBeGreaterThanOrEqual(0);
 
     const serialized = JSON.stringify(diagnostic);
     expect(serialized).not.toContain('secret-token');
@@ -317,6 +321,8 @@ describe('Cloudflare Worker - SharePoint Proxy', () => {
     await expect(response.text()).resolves.toBe('{"ok":true}');
     const diagnostic = JSON.parse(logSpy.mock.calls[0]?.[0] as string) as Record<string, unknown>;
     expect(diagnostic).toMatchObject({ outcome: 'upstream_response', status, safeErrorCode, retryClass });
+    expect(diagnostic.durationMs).toEqual(expect.any(Number));
+    expect(diagnostic.durationMs as number).toBeGreaterThanOrEqual(0);
   });
 
   it('classifies proxy rejection and upstream fetch failure without logging request secrets', async () => {
@@ -339,6 +345,8 @@ describe('Cloudflare Worker - SharePoint Proxy', () => {
       targetPath: '/sites/other/_api/web/lists',
       queryKeys: ['secret'],
     });
+    expect(rejection.durationMs).toEqual(expect.any(Number));
+    expect(rejection.durationMs as number).toBeGreaterThanOrEqual(0);
 
     const fetchMock = vi.fn().mockRejectedValue(new Error('upstream URL and token must not be logged'));
     vi.stubGlobal('fetch', fetchMock);
@@ -358,6 +366,8 @@ describe('Cloudflare Worker - SharePoint Proxy', () => {
       retryClass: 'server',
       queryKeys: ['secret'],
     });
+    expect(fetchFailure.durationMs).toEqual(expect.any(Number));
+    expect(fetchFailure.durationMs as number).toBeGreaterThanOrEqual(0);
 
     const serialized = JSON.stringify(logSpy.mock.calls);
     expect(serialized).not.toContain('secret-token');

--- a/src/__tests__/worker.spec.ts
+++ b/src/__tests__/worker.spec.ts
@@ -97,10 +97,13 @@ describe('Cloudflare Worker - SharePoint Proxy', () => {
       ...defaultEnv,
       ASSETS: { fetch: assetsFetch },
       VITE_SKIP_PROVISIONING: '1',
+      SP_PROXY_DIAGNOSTICS: '1',
     });
 
     expect(response.status).toBe(200);
-    expect(await response.text()).toContain('"VITE_SKIP_PROVISIONING":"1"');
+    const html = await response.text();
+    expect(html).toContain('"VITE_SKIP_PROVISIONING":"1"');
+    expect(html).not.toContain('SP_PROXY_DIAGNOSTICS');
   });
 
   it('allows request targeting VITE_SP_LIST_BILLING_ORDERS_SITE_RELATIVE if configured', async () => {
@@ -183,6 +186,184 @@ describe('Cloudflare Worker - SharePoint Proxy', () => {
     expect(response.headers.get('Content-Type')).toBe('application/json');
     expect(response.headers.get('ETag')).toBe('W/"1"');
     expect(response.headers.get('Cache-Control')).toBe('no-store');
+  });
+
+  it('keeps proxy diagnostics disabled by default', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const fetchMock = vi.fn().mockResolvedValue(new Response('{"d":[]}', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const request = new Request(
+      'https://app.example/api/sp-proxy?url=' +
+        encodeURIComponent('https://example.sharepoint.com/sites/welfare/_api/web/lists'),
+      { headers: { Authorization: 'Bearer secret-token', Cookie: 'session=secret-cookie' } },
+    );
+
+    await worker.fetch(request, defaultEnv);
+
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: 'missing bearer token',
+      request: () => new Request('https://app.example/api/sp-proxy?url=not-logged', { method: 'GET' }),
+      status: 401,
+      safeErrorCode: 'missing_bearer_token',
+    },
+    {
+      name: 'invalid target URL',
+      request: () => new Request('https://app.example/api/sp-proxy?url=not-a-url', { headers: { Authorization: 'Bearer secret-token' } }),
+      status: 400,
+      safeErrorCode: 'invalid_target_url',
+    },
+  ])('classifies $name without logging target values', async ({ request, status, safeErrorCode }) => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const response = await worker.fetch(request(), { ...defaultEnv, SP_PROXY_DIAGNOSTICS: '1' });
+
+    expect(response.status).toBe(status);
+    const diagnostic = JSON.parse(logSpy.mock.calls[0]?.[0] as string) as Record<string, unknown>;
+    expect(diagnostic).toMatchObject({
+      outcome: 'proxy_rejection',
+      safeErrorCode,
+      status,
+      retryClass: 'none',
+    });
+    expect(JSON.stringify(diagnostic)).not.toContain('not-logged');
+    expect(JSON.stringify(diagnostic)).not.toContain('secret-token');
+  });
+
+  it('emits sanitized diagnostics for an upstream response', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('{"error":{"code":"-1, Microsoft.SharePoint.Client.ResourceNotFoundException"}}', {
+        status: 404,
+        statusText: 'Not Found',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': '72',
+          'request-id': 'request-123',
+          sprequestguid: 'sp-123',
+        },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const request = new Request(
+      'https://app.example/api/sp-proxy?url=' +
+        encodeURIComponent(
+          "https://example.sharepoint.com/sites/welfare/_api/web/lists/getbytitle('Users_Master')/items(123)?$filter=UserID%20eq%20'I019'&token=do-not-log",
+        ),
+      {
+        headers: {
+          Authorization: 'Bearer secret-token',
+          Cookie: 'session=secret-cookie',
+          'cf-ray': 'cf-ray-123',
+        },
+      },
+    );
+
+    const response = await worker.fetch(request, { ...defaultEnv, SP_PROXY_DIAGNOSTICS: '1' });
+    expect(response.status).toBe(404);
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const diagnostic = JSON.parse(logSpy.mock.calls[0]?.[0] as string) as Record<string, unknown>;
+    expect(diagnostic).toMatchObject({
+      event: 'sp-proxy',
+      outcome: 'upstream_response',
+      method: 'GET',
+      targetOrigin: 'https://example.sharepoint.com',
+      targetList: 'Users_Master',
+      targetPath: "/sites/welfare/_api/web/lists/getbytitle('Users_Master')/items(?)",
+      queryKeys: ['$filter', 'token'],
+      status: 404,
+      statusText: 'Not Found',
+      contentType: 'application/json',
+      contentLength: 72,
+      requestId: 'request-123',
+      cfRay: 'cf-ray-123',
+      sprequestguid: 'sp-123',
+      safeErrorCode: 'http_404',
+      retryClass: 'none',
+    });
+    expect(diagnostic.diagnosticId).toEqual(expect.any(String));
+
+    const serialized = JSON.stringify(diagnostic);
+    expect(serialized).not.toContain('secret-token');
+    expect(serialized).not.toContain('secret-cookie');
+    expect(serialized).not.toContain('I019');
+    expect(serialized).not.toContain('do-not-log');
+    expect(serialized).not.toContain('ResourceNotFoundException');
+  });
+
+  it.each([
+    { status: 200, safeErrorCode: 'ok', retryClass: 'none' },
+    { status: 429, safeErrorCode: 'http_429', retryClass: 'throttle' },
+    { status: 500, safeErrorCode: 'http_500', retryClass: 'server' },
+  ])('classifies upstream status $status without changing the response', async ({ status, safeErrorCode, retryClass }) => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const fetchMock = vi.fn().mockResolvedValue(new Response('{"ok":true}', { status }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const request = new Request(
+      'https://app.example/api/sp-proxy?url=' +
+        encodeURIComponent('https://example.sharepoint.com/sites/welfare/_api/web/lists'),
+      { headers: { Authorization: 'Bearer secret-token' } },
+    );
+    const response = await worker.fetch(request, { ...defaultEnv, SP_PROXY_DIAGNOSTICS: '1' });
+
+    expect(response.status).toBe(status);
+    await expect(response.text()).resolves.toBe('{"ok":true}');
+    const diagnostic = JSON.parse(logSpy.mock.calls[0]?.[0] as string) as Record<string, unknown>;
+    expect(diagnostic).toMatchObject({ outcome: 'upstream_response', status, safeErrorCode, retryClass });
+  });
+
+  it('classifies proxy rejection and upstream fetch failure without logging request secrets', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const request = new Request(
+      'https://app.example/api/sp-proxy?url=' +
+        encodeURIComponent('https://malicious.example/sites/other/_api/web/lists?secret=do-not-log'),
+      { headers: { Authorization: 'Bearer secret-token', Cookie: 'session=secret-cookie' } },
+    );
+
+    const rejected = await worker.fetch(request, { ...defaultEnv, SP_PROXY_DIAGNOSTICS: '1' });
+    expect(rejected.status).toBe(403);
+    const rejection = JSON.parse(logSpy.mock.calls[0]?.[0] as string) as Record<string, unknown>;
+    expect(rejection).toMatchObject({
+      outcome: 'proxy_rejection',
+      safeErrorCode: 'target_not_allowed',
+      status: 403,
+      retryClass: 'none',
+      targetOrigin: 'https://malicious.example',
+      targetPath: '/sites/other/_api/web/lists',
+      queryKeys: ['secret'],
+    });
+
+    const fetchMock = vi.fn().mockRejectedValue(new Error('upstream URL and token must not be logged'));
+    vi.stubGlobal('fetch', fetchMock);
+    const fetchFailed = await worker.fetch(
+      new Request(
+        'https://app.example/api/sp-proxy?url=' +
+          encodeURIComponent('https://example.sharepoint.com/sites/welfare/_api/web/lists?secret=do-not-log'),
+        { headers: { Authorization: 'Bearer secret-token' } },
+      ),
+      { ...defaultEnv, SP_PROXY_DIAGNOSTICS: '1' },
+    );
+    expect(fetchFailed.status).toBe(502);
+    const fetchFailure = JSON.parse(logSpy.mock.calls[1]?.[0] as string) as Record<string, unknown>;
+    expect(fetchFailure).toMatchObject({
+      outcome: 'upstream_fetch_error',
+      safeErrorCode: 'sharepoint_fetch_failed',
+      retryClass: 'server',
+      queryKeys: ['secret'],
+    });
+
+    const serialized = JSON.stringify(logSpy.mock.calls);
+    expect(serialized).not.toContain('secret-token');
+    expect(serialized).not.toContain('secret-cookie');
+    expect(serialized).not.toContain('do-not-log');
+    expect(serialized).not.toContain('upstream URL and token');
   });
 
   it('returns 401 for Firebase exchange without a bearer token', async () => {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -403,6 +403,7 @@ type ProxyDiagnostic = {
   requestId?: string;
   cfRay?: string;
   sprequestguid?: string;
+  durationMs?: number;
   safeErrorCode: string;
   retryClass: ProxyRetryClass;
 };
@@ -449,11 +450,14 @@ const safeTargetDetails = (target: URL): Pick<ProxyDiagnostic, 'targetOrigin' | 
   };
 };
 
-const logProxyDiagnostic = (env: Env, diagnostic: ProxyDiagnostic): void => {
+const logProxyDiagnostic = (env: Env, diagnostic: ProxyDiagnostic, startedAt: number | undefined): void => {
   if (!proxyDiagnosticsEnabled(env)) return;
   // JSON is intentionally limited to non-secret routing and response metadata.
   // Do not add request headers, query values, response bodies, or exception text.
-  console.log(JSON.stringify(diagnostic));
+  const timedDiagnostic = startedAt === undefined
+    ? diagnostic
+    : { ...diagnostic, durationMs: Math.max(0, Date.now() - startedAt) };
+  console.log(JSON.stringify(timedDiagnostic));
 };
 
 const requestProxyContext = (request: Request): Pick<ProxyDiagnostic, 'method' | 'cfRay'> => ({
@@ -481,18 +485,19 @@ const handleSharePointProxy = async (request: Request, env: Env): Promise<Respon
     return new Response(null, { status: 204 });
   }
 
-  const diagnosticId = proxyDiagnosticsEnabled(env) ? createProxyDiagnosticId() : '';
+  const diagnosticsStartedAt = proxyDiagnosticsEnabled(env) ? Date.now() : undefined;
+  const diagnosticId = diagnosticsStartedAt === undefined ? '' : createProxyDiagnosticId();
 
   const authHeader = request.headers.get('Authorization') ?? '';
   if (!authHeader.startsWith('Bearer ')) {
-    logProxyDiagnostic(env, proxyRejectionDiagnostic(request, diagnosticId, 'missing_bearer_token', { status: 401, statusText: 'Unauthorized' }));
+    logProxyDiagnostic(env, proxyRejectionDiagnostic(request, diagnosticId, 'missing_bearer_token', { status: 401, statusText: 'Unauthorized' }), diagnosticsStartedAt);
     return jsonResponse(401, { error: 'missing_bearer_token' });
   }
 
   const configuredResource = env.VITE_SP_RESOURCE?.trim().replace(/\/+$/, '');
   const configuredSiteRelative = normalizeSiteRelative(env.VITE_SP_SITE_RELATIVE ?? '');
   if (!configuredResource || !configuredSiteRelative) {
-    logProxyDiagnostic(env, proxyRejectionDiagnostic(request, diagnosticId, 'sp_proxy_not_configured', { status: 500, statusText: 'Internal Server Error' }));
+    logProxyDiagnostic(env, proxyRejectionDiagnostic(request, diagnosticId, 'sp_proxy_not_configured', { status: 500, statusText: 'Internal Server Error' }), diagnosticsStartedAt);
     return jsonResponse(500, { error: 'sp_proxy_not_configured' });
   }
 
@@ -501,7 +506,7 @@ const handleSharePointProxy = async (request: Request, env: Env): Promise<Respon
     const sourceUrl = new URL(request.url);
     target = new URL(sourceUrl.searchParams.get('url') ?? '');
   } catch {
-    logProxyDiagnostic(env, proxyRejectionDiagnostic(request, diagnosticId, 'invalid_target_url', { status: 400, statusText: 'Bad Request' }));
+    logProxyDiagnostic(env, proxyRejectionDiagnostic(request, diagnosticId, 'invalid_target_url', { status: 400, statusText: 'Bad Request' }), diagnosticsStartedAt);
     return jsonResponse(400, { error: 'invalid_target_url' });
   }
 
@@ -527,7 +532,7 @@ const handleSharePointProxy = async (request: Request, env: Env): Promise<Respon
       diagnosticId,
       'target_not_allowed',
       { status: 403, statusText: 'Forbidden', ...safeTargetDetails(target) },
-    ));
+    ), diagnosticsStartedAt);
     return jsonResponse(403, { 
       error: 'target_not_allowed',
       details: {
@@ -562,7 +567,7 @@ const handleSharePointProxy = async (request: Request, env: Env): Promise<Respon
       sprequestguid: response.headers.get('sprequestguid') ?? undefined,
       safeErrorCode: response.ok ? 'ok' : `http_${response.status}`,
       retryClass: retryClassForStatus(response.status),
-    });
+    }, diagnosticsStartedAt);
 
     return new Response(response.body, {
       status: response.status,
@@ -578,7 +583,7 @@ const handleSharePointProxy = async (request: Request, env: Env): Promise<Respon
       ...safeTargetDetails(target),
       safeErrorCode: 'sharepoint_fetch_failed',
       retryClass: 'server',
-    });
+    }, diagnosticsStartedAt);
     console.error('[sp-proxy] fetch failed', error);
     return jsonResponse(502, { error: 'sharepoint_fetch_failed' });
   }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -12,6 +12,8 @@ interface Env {
   VITE_SKIP_PROVISIONING?: string;
   VITE_SP_LIST_BILLING_ORDERS?: string;
   VITE_SP_LIST_BILLING_ORDERS_SITE_RELATIVE?: string;
+  /** Server-only, opt-in proxy diagnostics. Never injected into client runtime. */
+  SP_PROXY_DIAGNOSTICS?: string;
   ALLOWED_TENANT_ID?: string;
   ORG_ID_OVERRIDE?: string;
   GOOGLE_SERVICE_ACCOUNT_JSON?: string;
@@ -383,19 +385,114 @@ const pickSharePointResponseHeaders = (response: Response): Headers => {
   return headers;
 };
 
+type ProxyRetryClass = 'none' | 'timeout' | 'throttle' | 'server';
+
+type ProxyDiagnostic = {
+  event: 'sp-proxy';
+  diagnosticId: string;
+  outcome: 'proxy_rejection' | 'upstream_response' | 'upstream_fetch_error';
+  method: string;
+  targetOrigin?: string;
+  targetPath?: string;
+  targetList?: string;
+  queryKeys?: string[];
+  status?: number;
+  statusText?: string;
+  contentType?: string;
+  contentLength?: number;
+  requestId?: string;
+  cfRay?: string;
+  sprequestguid?: string;
+  safeErrorCode: string;
+  retryClass: ProxyRetryClass;
+};
+
+const proxyDiagnosticsEnabled = (env: Env): boolean => env.SP_PROXY_DIAGNOSTICS === '1';
+
+const createProxyDiagnosticId = (): string => {
+  try {
+    return crypto.randomUUID();
+  } catch {
+    return `sp-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+  }
+};
+
+const retryClassForStatus = (status?: number): ProxyRetryClass => {
+  if (status === 408) return 'timeout';
+  if (status === 429) return 'throttle';
+  if (status !== undefined && [500, 502, 503, 504].includes(status)) return 'server';
+  return 'none';
+};
+
+const sanitizeTargetPath = (pathname: string): string =>
+  pathname
+    .replace(/\/items\([^/)]*\)/gi, '/items(?)')
+    .replace(/\/attachments\([^/)]*\)/gi, '/attachments(?)');
+
+const safeTargetDetails = (target: URL): Pick<ProxyDiagnostic, 'targetOrigin' | 'targetPath' | 'targetList' | 'queryKeys'> => {
+  const targetPath = sanitizeTargetPath(target.pathname);
+  const titleMatch = target.pathname.match(/\/lists\/getbytitle\('([^']+)'\)/i);
+  const guidMatch = target.pathname.match(/\/lists\(guid'([^']+)'\)/i);
+  let targetList = guidMatch?.[1];
+  if (titleMatch?.[1]) {
+    try {
+      targetList = decodeURIComponent(titleMatch[1]);
+    } catch {
+      targetList = titleMatch[1];
+    }
+  }
+  return {
+    targetOrigin: target.origin,
+    targetPath,
+    targetList,
+    queryKeys: [...new Set([...target.searchParams.keys()])].sort(),
+  };
+};
+
+const logProxyDiagnostic = (env: Env, diagnostic: ProxyDiagnostic): void => {
+  if (!proxyDiagnosticsEnabled(env)) return;
+  // JSON is intentionally limited to non-secret routing and response metadata.
+  // Do not add request headers, query values, response bodies, or exception text.
+  console.log(JSON.stringify(diagnostic));
+};
+
+const requestProxyContext = (request: Request): Pick<ProxyDiagnostic, 'method' | 'cfRay'> => ({
+  method: request.method,
+  cfRay: request.headers.get('cf-ray') ?? undefined,
+});
+
+const proxyRejectionDiagnostic = (
+  request: Request,
+  diagnosticId: string,
+  safeErrorCode: string,
+  extra: Pick<ProxyDiagnostic, 'targetOrigin' | 'targetPath' | 'targetList' | 'queryKeys' | 'status' | 'statusText'> = {},
+): ProxyDiagnostic => ({
+  event: 'sp-proxy',
+  diagnosticId,
+  outcome: 'proxy_rejection',
+  ...requestProxyContext(request),
+  ...extra,
+  safeErrorCode,
+  retryClass: retryClassForStatus(extra.status),
+});
+
 const handleSharePointProxy = async (request: Request, env: Env): Promise<Response> => {
   if (request.method === 'OPTIONS') {
     return new Response(null, { status: 204 });
   }
 
+  const diagnosticId = proxyDiagnosticsEnabled(env) ? createProxyDiagnosticId() : '';
+
   const authHeader = request.headers.get('Authorization') ?? '';
   if (!authHeader.startsWith('Bearer ')) {
+    logProxyDiagnostic(env, proxyRejectionDiagnostic(request, diagnosticId, 'missing_bearer_token', { status: 401, statusText: 'Unauthorized' }));
     return jsonResponse(401, { error: 'missing_bearer_token' });
   }
 
   const configuredResource = env.VITE_SP_RESOURCE?.trim().replace(/\/+$/, '');
   const configuredSiteRelative = normalizeSiteRelative(env.VITE_SP_SITE_RELATIVE ?? '');
   if (!configuredResource || !configuredSiteRelative) {
+    logProxyDiagnostic(env, proxyRejectionDiagnostic(request, diagnosticId, 'sp_proxy_not_configured', { status: 500, statusText: 'Internal Server Error' }));
     return jsonResponse(500, { error: 'sp_proxy_not_configured' });
   }
 
@@ -404,6 +501,7 @@ const handleSharePointProxy = async (request: Request, env: Env): Promise<Respon
     const sourceUrl = new URL(request.url);
     target = new URL(sourceUrl.searchParams.get('url') ?? '');
   } catch {
+    logProxyDiagnostic(env, proxyRejectionDiagnostic(request, diagnosticId, 'invalid_target_url', { status: 400, statusText: 'Bad Request' }));
     return jsonResponse(400, { error: 'invalid_target_url' });
   }
 
@@ -424,6 +522,12 @@ const handleSharePointProxy = async (request: Request, env: Env): Promise<Respon
     (billingApiPathLower !== '' && targetPathLower.startsWith(billingApiPathLower));
 
   if (targetOriginLower !== allowedOriginLower || !pathAllowed) {
+    logProxyDiagnostic(env, proxyRejectionDiagnostic(
+      request,
+      diagnosticId,
+      'target_not_allowed',
+      { status: 403, statusText: 'Forbidden', ...safeTargetDetails(target) },
+    ));
     return jsonResponse(403, { 
       error: 'target_not_allowed',
       details: {
@@ -443,12 +547,38 @@ const handleSharePointProxy = async (request: Request, env: Env): Promise<Respon
       redirect: 'manual',
     }));
 
+    const responseHeaders = pickSharePointResponseHeaders(response);
+    logProxyDiagnostic(env, {
+      event: 'sp-proxy',
+      diagnosticId,
+      outcome: 'upstream_response',
+      ...requestProxyContext(request),
+      ...safeTargetDetails(target),
+      status: response.status,
+      statusText: response.statusText,
+      contentType: response.headers.get('content-type') ?? undefined,
+      contentLength: Number(response.headers.get('content-length') ?? '') || undefined,
+      requestId: response.headers.get('request-id') ?? undefined,
+      sprequestguid: response.headers.get('sprequestguid') ?? undefined,
+      safeErrorCode: response.ok ? 'ok' : `http_${response.status}`,
+      retryClass: retryClassForStatus(response.status),
+    });
+
     return new Response(response.body, {
       status: response.status,
       statusText: response.statusText,
-      headers: pickSharePointResponseHeaders(response),
+      headers: responseHeaders,
     });
   } catch (error) {
+    logProxyDiagnostic(env, {
+      event: 'sp-proxy',
+      diagnosticId,
+      outcome: 'upstream_fetch_error',
+      ...requestProxyContext(request),
+      ...safeTargetDetails(target),
+      safeErrorCode: 'sharepoint_fetch_failed',
+      retryClass: 'server',
+    });
     console.error('[sp-proxy] fetch failed', error);
     return jsonResponse(502, { error: 'sharepoint_fetch_failed' });
   }


### PR DESCRIPTION
## Summary

- Cloudflare Workers Observability を read-only で確認したところ、production の Observability は Disabled で、設定変更は行っていません。
- `SP_PROXY_DIAGNOSTICS=1` のときだけ Worker 側で構造化された `/api/sp-proxy` 診断ログを出力します。既定値は OFF です。
- 記録は安全な上流パス・対象リスト・status/statusText・content type/size・相関ID・statusベースの retryable/throttle 分類に限定し、Authorization、Cookie、アクセストークン、クエリ値、応答本文、例外本文は記録しません。
- クライアントへ注入される `VITE_*` 環境変数には追加せず、proxy の status/body/許可判定/`sprequestguid` 転送挙動は変更していません。

## Context

通常Dashboardの `/api/sp-proxy` 失敗について、認証済みブラウザの通信証拠を取得できず、既存の本番ログも Observability Disabled のため利用できませんでした。本PRは原因分離のための観測専用変更です。

`Throttled 29` は HTTP 429 の直接証拠として扱いません。

## Validation

- Worker proxy contract tests: 23 passed
- `npm run typecheck:full -- --pretty false`: PASS
- `npm run lint -- --max-warnings 0`: PASS
- `npm run build`: PASS（既存のchunk-size/Browserslist warningのみ）
- `git diff --check`: PASS
- 401/400/403/404/429/500/502/200 の分類と pass-through を検証
- 診断ログに Authorization、Cookie、クエリ値、応答本文が含まれないことを検証
- `SP_PROXY_DIAGNOSTICS` がクライアントHTMLへ注入されないことを検証

## Scope and gates

- 変更ファイルは `src/worker.ts` と `src/__tests__/worker.spec.ts` のみです。
- 本番デプロイ、Cloudflare Observability の有効化、`SP_PROXY_DIAGNOSTICS` の本番設定、SharePointデータ変更、Microsoft 365再ログインは本PRでは行いません。
- 請求・キオスク経路の PASS は維持し、通常Dashboardは原因確定まで HOLD のままとします。
- base は候補SHA `50309c219518466aa5c46568972cc57a5ef79d91` です。