### PR TITLE
feat(observability): correlate SharePoint proxy health signals

### DIFF
--- a/src/__tests__/worker.spec.ts
+++ b/src/__tests__/worker.spec.ts
@@ -262,6 +262,7 @@ describe('Cloudflare Worker - SharePoint Proxy', () => {
           Authorization: 'Bearer secret-token',
           Cookie: 'session=secret-cookie',
           'cf-ray': 'cf-ray-123',
+          'x-sp-diagnostic-id': 'diag-12345678',
         },
       },
     );
@@ -288,6 +289,7 @@ describe('Cloudflare Worker - SharePoint Proxy', () => {
       sprequestguid: 'sp-123',
       safeErrorCode: 'http_404',
       retryClass: 'none',
+      diagnosticId: 'diag-12345678',
     });
     expect(diagnostic.diagnosticId).toEqual(expect.any(String));
     expect(diagnostic.durationMs).toEqual(expect.any(Number));

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -58,6 +58,8 @@ interface ImportMetaEnv {
   readonly VITE_SP_SITE_ID?: string;
   readonly VITE_SP_SITE_URL?: string;
   readonly VITE_SP_USE_PROXY?: string;
+  /** Opt-in client-side correlation for SharePoint proxy diagnostics. */
+  readonly VITE_SP_PROXY_CORRELATION?: string;
   readonly VITE_WRITE_ENABLED?: string;
   readonly VITE_ALLOW_SHAREPOINT_OUTSIDE_SPFX?: string;
 

--- a/src/features/sp/health/__tests__/spHealthSignalStore.spec.ts
+++ b/src/features/sp/health/__tests__/spHealthSignalStore.spec.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  _resetSpHealthSignalStore,
+  getSpHealthSignal,
+  reportSpHealthEvent,
+} from '../spHealthSignalStore';
+
+describe('SpHealthSignalStore correlation metadata', () => {
+  afterEach(() => {
+    _resetSpHealthSignalStore();
+  });
+
+  it('retains first and latest occurrence times while updating the diagnostic ID', () => {
+    reportSpHealthEvent({
+      severity: 'critical',
+      reasonCode: 'sp_list_unreachable',
+      listName: 'Users_Master',
+      message: 'List not found',
+      occurredAt: '2026-08-04T02:30:00.000Z',
+      source: 'realtime',
+      diagnosticId: 'diag-12345678',
+      httpStatus: 404,
+      httpStatusClass: '4xx',
+      safeErrorCode: 'http_404',
+      failureClass: 'http',
+      retryClass: 'none',
+    });
+    reportSpHealthEvent({
+      severity: 'critical',
+      reasonCode: 'sp_list_unreachable',
+      listName: 'Users_Master',
+      message: 'List not found',
+      occurredAt: '2026-08-04T02:33:00.000Z',
+      source: 'realtime',
+      diagnosticId: 'diag-87654321',
+      httpStatus: 404,
+      httpStatusClass: '4xx',
+      safeErrorCode: 'http_404',
+      failureClass: 'http',
+      retryClass: 'none',
+    });
+
+    expect(getSpHealthSignal()).toMatchObject({
+      occurrenceCount: 2,
+      diagnosticId: 'diag-87654321',
+      firstOccurredAt: '2026-08-04T02:30:00.000Z',
+      lastOccurredAt: '2026-08-04T02:33:00.000Z',
+    });
+  });
+});

--- a/src/features/sp/health/hooks/__tests__/useConnectionStatus.spec.ts
+++ b/src/features/sp/health/hooks/__tests__/useConnectionStatus.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { useConnectionStatus } from '../useConnectionStatus';
 import * as signalStore from '../../spHealthSignalStore';
+import * as correlation from '@/lib/telemetry/spProxyCorrelation';
 
 // Mock dependencies
 vi.mock('../../spHealthSignalStore', () => ({
@@ -21,9 +22,50 @@ vi.mock('@/lib/env', () => ({
   })),
 }));
 
+vi.mock('@/lib/telemetry/spProxyCorrelation', () => ({
+  recordSpProxyCorrelation: vi.fn(),
+}));
+
 describe('useConnectionStatus', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it('records safe health-signal correlation metadata when a signal is observed', () => {
+    vi.spyOn(signalStore, 'getSpHealthSignal').mockReturnValue({
+      severity: 'critical',
+      reasonCode: 'sp_list_unreachable',
+      listName: 'Users_Master',
+      message: 'List not found',
+      occurredAt: '2026-08-04T02:33:00.000Z',
+      firstOccurredAt: '2026-08-04T02:30:00.000Z',
+      lastOccurredAt: '2026-08-04T02:33:00.000Z',
+      source: 'realtime',
+      occurrenceCount: 2,
+      diagnosticId: 'diag-12345678',
+      httpStatus: 404,
+      httpStatusClass: '4xx',
+      safeErrorCode: 'http_404',
+      failureClass: 'http',
+      retryClass: 'none',
+    });
+
+    renderHook(() => useConnectionStatus());
+
+    expect(correlation.recordSpProxyCorrelation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        diagnosticId: 'diag-12345678',
+        event: 'health_signal',
+        reasonCode: 'sp_list_unreachable',
+        listName: 'Users_Master',
+        occurrenceCount: 2,
+        status: 404,
+        statusClass: '4xx',
+        safeErrorCode: 'http_404',
+        firstOccurredAt: '2026-08-04T02:30:00.000Z',
+        lastOccurredAt: '2026-08-04T02:33:00.000Z',
+      }),
+    );
   });
 
   it('returns connected when there is no health signal', () => {

--- a/src/features/sp/health/hooks/useConnectionStatus.ts
+++ b/src/features/sp/health/hooks/useConnectionStatus.ts
@@ -4,6 +4,7 @@ import { isDemoModeEnabled } from '@/lib/env';
 import { getAppConfig } from '@/lib/env';
 import { auditLog } from '@/lib/debugLogger';
 import { findListEntry } from '@/sharepoint/spListRegistry';
+import { recordSpProxyCorrelation } from '@/lib/telemetry/spProxyCorrelation';
 
 export type ConnectionStatusKind = 'connected' | 'demo' | 'degraded' | 'checking';
 export type ConnectionReason = 
@@ -35,6 +36,32 @@ export const useConnectionStatus = (): ConnectionStatus => {
       setHealthSignal(signal);
     });
   }, []);
+
+  useEffect(() => {
+    if (!healthSignal) return;
+    const lastOccurredAt = healthSignal.lastOccurredAt ?? healthSignal.occurredAt;
+    const lastOccurredMs = Date.parse(lastOccurredAt);
+    recordSpProxyCorrelation({
+      diagnosticId: healthSignal.diagnosticId,
+      event: 'health_signal',
+      occurredAt: new Date().toISOString(),
+      route: typeof window !== 'undefined' ? window.location.pathname : undefined,
+      targetList: healthSignal.listName,
+      reasonCode: healthSignal.reasonCode,
+      listName: healthSignal.listName,
+      severity: healthSignal.severity,
+      source: healthSignal.source,
+      occurrenceCount: healthSignal.occurrenceCount,
+      firstOccurredAt: healthSignal.firstOccurredAt ?? healthSignal.occurredAt,
+      lastOccurredAt,
+      signalAgeMs: Number.isNaN(lastOccurredMs) ? undefined : Math.max(0, Date.now() - lastOccurredMs),
+      status: healthSignal.httpStatus,
+      statusClass: healthSignal.httpStatusClass,
+      safeErrorCode: healthSignal.safeErrorCode,
+      failureClass: healthSignal.failureClass,
+      retryClass: healthSignal.retryClass,
+    });
+  }, [healthSignal]);
 
   const reset = useCallback(() => {
     clearSpHealthSignal();

--- a/src/features/sp/health/spHealthSignalStore.ts
+++ b/src/features/sp/health/spHealthSignalStore.ts
@@ -31,6 +31,16 @@ export type SpHealthReasonCode =
 
 export type SpHealthSignalSource = 'nightly_patrol' | 'realtime';
 
+export type SpHealthFailureClass =
+  | 'http'
+  | 'network'
+  | 'abort'
+  | 'cors_redirect'
+  | 'throttle_redirect'
+  | 'unknown';
+
+export type SpHealthRetryClass = 'none' | 'timeout' | 'throttle' | 'server' | 'network';
+
 /**
  * actionUrl の種別
  * - internal : アプリ内ルート（RouterLink で遷移）
@@ -66,6 +76,15 @@ export interface SpHealthSignal {
   occurrenceCount: number;
   occurredAt: string;
   source: SpHealthSignalSource;
+  /** Safe correlation metadata; never contains headers, tokens, query values, or bodies. */
+  diagnosticId?: string;
+  httpStatus?: number;
+  httpStatusClass?: string;
+  safeErrorCode?: string;
+  failureClass?: SpHealthFailureClass;
+  retryClass?: SpHealthRetryClass;
+  firstOccurredAt?: string;
+  lastOccurredAt?: string;
 }
 
 // ─── reasonCode → Action mapping ──────────────────────────────────────────────
@@ -133,6 +152,8 @@ function enrichWithAction(signal: Omit<SpHealthSignal, 'occurrenceCount'>): SpHe
     actionType: signal.actionType ?? spec?.actionType,
     actionGuide: signal.actionGuide ?? spec?.actionGuide,
     occurrenceCount: 1,
+    firstOccurredAt: signal.firstOccurredAt ?? signal.occurredAt,
+    lastOccurredAt: signal.lastOccurredAt ?? signal.occurredAt,
   };
 }
 
@@ -218,14 +239,29 @@ export function reportSpHealthEvent(signal: Omit<SpHealthSignal, 'occurrenceCoun
         finalSeverity = 'action_required';
       }
 
+      const correlationMetadata = signal.diagnosticId
+        ? {
+            diagnosticId: signal.diagnosticId,
+            httpStatus: signal.httpStatus,
+            httpStatusClass: signal.httpStatusClass,
+            safeErrorCode: signal.safeErrorCode,
+            failureClass: signal.failureClass,
+            retryClass: signal.retryClass,
+          }
+        : {};
+      const firstOccurredAt = _current.firstOccurredAt ?? _current.occurredAt;
+      const lastOccurredAt = signal.occurredAt;
+
       if (incomingIsHigher || isRealtimeOverNightly || finalSeverity !== signal.severity) {
         _current = { 
           ...enriched, 
           severity: finalSeverity as SpHealthSeverity, 
-          occurrenceCount: nextCount 
+          occurrenceCount: nextCount,
+          firstOccurredAt,
+          lastOccurredAt,
         };
       } else {
-        _current = { ..._current, occurrenceCount: nextCount };
+        _current = { ..._current, ...correlationMetadata, occurrenceCount: nextCount, firstOccurredAt, lastOccurredAt };
       }
       _notify();
       return;

--- a/src/features/sp/index.ts
+++ b/src/features/sp/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Public SharePoint feature surface for non-feature consumers.
+ * Keep health-store internals behind this module boundary.
+ */
+export {
+  _resetSpHealthSignalStore,
+  getSpHealthSignal,
+} from './health/spHealthSignalStore';

--- a/src/lib/env.schema.ts
+++ b/src/lib/env.schema.ts
@@ -107,6 +107,8 @@ export const envSchema = z.object({
   VITE_FORCE_SHAREPOINT: zBoolFromString.optional().default(false),
   VITE_ALLOW_SHAREPOINT_OUTSIDE_SPFX: zBoolFromString.optional().default(false),
   VITE_SP_USE_PROXY: zBoolFromString.optional().default(false),
+  // Opt-in only; this exposes safe correlation metadata, never credentials.
+  VITE_SP_PROXY_CORRELATION: zBoolFromString.optional().default(false),
   VITE_SKIP_SHAREPOINT: zBoolFromString.optional().default(false),
   VITE_SKIP_LOGIN: zBoolFromString.optional().default(false),
   VITE_SP_ENABLED: z.string().optional().default('false'),

--- a/src/lib/sp/__tests__/helpers.spec.ts
+++ b/src/lib/sp/__tests__/helpers.spec.ts
@@ -1,7 +1,7 @@
 
 import { afterEach, describe, it, expect } from 'vitest';
 import { resolveInternalNamesDetailed, raiseHttpError } from '../helpers';
-import { _resetSpHealthSignalStore, getSpHealthSignal } from '@/features/sp/health/spHealthSignalStore';
+import { _resetSpHealthSignalStore, getSpHealthSignal } from '@/features/sp';
 
 afterEach(() => {
   _resetSpHealthSignalStore();

--- a/src/lib/sp/__tests__/helpers.spec.ts
+++ b/src/lib/sp/__tests__/helpers.spec.ts
@@ -1,6 +1,11 @@
 
-import { describe, it, expect } from 'vitest';
-import { resolveInternalNamesDetailed } from '../helpers';
+import { afterEach, describe, it, expect } from 'vitest';
+import { resolveInternalNamesDetailed, raiseHttpError } from '../helpers';
+import { _resetSpHealthSignalStore, getSpHealthSignal } from '@/features/sp/health/spHealthSignalStore';
+
+afterEach(() => {
+  _resetSpHealthSignalStore();
+});
 
 describe('resolveInternalNamesDetailed - Hardened Drift Resolution', () => {
   const candidates = {
@@ -63,6 +68,25 @@ describe('resolveInternalNamesDetailed - Hardened Drift Resolution', () => {
       const available = new Set(['Reci']);
       const { resolved } = resolveInternalNamesDetailed(available, candidates);
       expect(resolved.recipientCertNumber).toBeUndefined();
+    });
+  });
+
+  it('attaches safe proxy correlation metadata to HTTP health signals', async () => {
+    await expect(
+      raiseHttpError(
+        new Response('', { status: 404, statusText: 'Not Found' }),
+        { method: 'GET', diagnosticId: 'diag-12345678' },
+      ),
+    ).rejects.toMatchObject({ status: 404 });
+
+    expect(getSpHealthSignal()).toMatchObject({
+      reasonCode: 'sp_list_unreachable',
+      diagnosticId: 'diag-12345678',
+      httpStatus: 404,
+      httpStatusClass: '4xx',
+      safeErrorCode: 'http_404',
+      failureClass: 'http',
+      retryClass: 'none',
     });
   });
 });

--- a/src/lib/sp/__tests__/spFetch.retry-guard.spec.ts
+++ b/src/lib/sp/__tests__/spFetch.retry-guard.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createSpFetch, __clearSharePointThrottleCircuitBreakerForTests } from '../spFetch';
 import type { EnvRecord } from '@/lib/env';
+import { clearSpProxyCorrelation, getSpProxyCorrelationSnapshot } from '@/lib/telemetry/spProxyCorrelation';
 
 function createTestEnv(): EnvRecord {
   return {
@@ -32,6 +33,7 @@ function createProxyFetcher() {
     config: {
       ...createTestEnv(),
       VITE_SP_USE_PROXY: '1',
+      VITE_SP_PROXY_CORRELATION: '1',
     },
     retrySettings: { maxAttempts: 4, baseDelay: 2000, capDelay: 30000 },
     debugEnabled: false,
@@ -44,6 +46,7 @@ describe('spFetch retry guard for SharePoint throttle/cors', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     __clearSharePointThrottleCircuitBreakerForTests();
+    clearSpProxyCorrelation();
   });
 
   afterEach(() => {
@@ -110,5 +113,10 @@ describe('spFetch retry guard for SharePoint throttle/cors', () => {
     );
     const headers = init?.headers instanceof Headers ? init.headers : new Headers(init?.headers);
     expect(headers.get('Authorization')).toBe('Bearer test-token');
+    expect(headers.get('X-SP-Diagnostic-ID')).toMatch(/^[A-Za-z0-9_-]{8,128}$/);
+    expect(getSpProxyCorrelationSnapshot().records.map((entry) => entry.event)).toEqual([
+      'request_start',
+      'http_response',
+    ]);
   });
 });

--- a/src/lib/sp/helpers.ts
+++ b/src/lib/sp/helpers.ts
@@ -359,19 +359,39 @@ export const coerceResult = async <T>(res: Response): Promise<T> => {
   return undefined as unknown as T;
 };
 
-import { reportSpHealthEvent } from '@/features/sp/health/spHealthSignalStore';
+import {
+  reportSpHealthEvent,
+  type SpHealthFailureClass,
+  type SpHealthRetryClass,
+} from '@/features/sp/health/spHealthSignalStore';
 
 export const raiseHttpError = async (
   res: Response,
   options: {
     url?: string;
     method?: string;
+    diagnosticId?: string;
     spOptions?: { quietStatuses?: number[]; silent?: boolean };
   } = {},
 ): Promise<never> => {
   const detail = await readErrorPayload(res);
   const AUDIT_DEBUG = isDebugFlag(getAppConfig().VITE_AUDIT_DEBUG);
   const { quietStatuses, silent } = options.spOptions || {};
+  const retryClass: SpHealthRetryClass = res.status === 408
+    ? 'timeout'
+    : res.status === 429
+      ? 'throttle'
+      : [500, 502, 503, 504].includes(res.status)
+        ? 'server'
+        : 'none';
+  const healthMetadata = {
+    diagnosticId: options.diagnosticId,
+    httpStatus: res.status,
+    httpStatusClass: `${Math.floor(res.status / 100)}xx`,
+    safeErrorCode: `http_${res.status}`,
+    failureClass: 'http' as SpHealthFailureClass,
+    retryClass,
+  };
 
   // 1. Report to Global Health Store (Realtime Signal)
   if (res.status === 401 || res.status === 403) {
@@ -381,6 +401,7 @@ export const raiseHttpError = async (
       message: 'SharePoint 認証に失敗しました。MSAL構成またはサイト権限を確認してください。',
       occurredAt: new Date().toISOString(),
       source: 'realtime',
+      ...healthMetadata,
     });
   } else if (res.status === 404) {
     reportSpHealthEvent({
@@ -389,6 +410,7 @@ export const raiseHttpError = async (
       message: 'リストまたはリソースが見つかりません。セットアップが未完了の可能性があります。',
       occurredAt: new Date().toISOString(),
       source: 'realtime',
+      ...healthMetadata,
     });
   }
 

--- a/src/lib/sp/spFetch.ts
+++ b/src/lib/sp/spFetch.ts
@@ -14,6 +14,13 @@ import { startFetchSpan } from '@/telemetry/fetchSpan';
 import { raiseHttpError } from './helpers';
 import type { SpClientOptions } from './types';
 import { spTelemetryStore, type SpFetchTelemetryEvent, type SpMetric } from '@/lib/telemetry/spTelemetryStore';
+import {
+  createSpProxyDiagnosticId,
+  isSpProxyCorrelationEnabled,
+  recordSpProxyCorrelation,
+  type SpProxyFailureClass,
+  type SpProxyRetryClass,
+} from '@/lib/telemetry/spProxyCorrelation';
 
 export type SpLane = 'read' | 'write' | 'provisioning';
 
@@ -208,6 +215,21 @@ function isLikelyCorsOrRedirectFailure(error: unknown): boolean {
     message.includes('networkerror') ||
     message.includes('cors')
   );
+}
+
+function correlationRetryClassForStatus(status?: number): SpProxyRetryClass {
+  if (status === 408) return 'timeout';
+  if (status === 429) return 'throttle';
+  if (status !== undefined && [500, 502, 503, 504].includes(status)) return 'server';
+  return 'none';
+}
+
+function correlationFailureClass(error: unknown): SpProxyFailureClass {
+  if (error instanceof SpThrottleRedirectError) return 'throttle_redirect';
+  if (isAbortError(error)) return 'abort';
+  if (isLikelyCorsOrRedirectFailure(error)) return 'cors_redirect';
+  if (error instanceof Error || error instanceof TypeError) return 'network';
+  return 'unknown';
 }
 
 export class SpThrottleRedirectError extends Error {
@@ -415,6 +437,9 @@ export function createSpFetch(deps: SpFetchDeps) {
     }
 
     const url = resolveUrl(resolvedPath);
+    const isProxyRequest = url.startsWith('/api/sp-proxy');
+    const correlationEnabled = isProxyRequest && isSpProxyCorrelationEnabled(config);
+    const diagnosticId = correlationEnabled ? createSpProxyDiagnosticId() : undefined;
     const queuedAt = Date.now();
 
     // Observability span
@@ -450,6 +475,13 @@ export function createSpFetch(deps: SpFetchDeps) {
       const queuedMs = startedAt - queuedAt;
 
       recordTelemetry('sp:request_start', { url: url.split('?')[0], method, lane, queuedMs });
+      recordSpProxyCorrelation({
+        diagnosticId,
+        event: 'request_start',
+        occurredAt: new Date().toISOString(),
+        method,
+        targetPath: resolvedPath,
+      }, config);
 
       for (let attempt = 1; attempt <= maxRetries + 1; attempt++) {
         const attemptStartedAt = Date.now();
@@ -462,6 +494,7 @@ export function createSpFetch(deps: SpFetchDeps) {
 
         const headers = toHeaders(init.headers);
         if (token) headers.set('Authorization', `Bearer ${token}`);
+        if (diagnosticId) headers.set('X-SP-Diagnostic-ID', diagnosticId);
 
         if (isUpdate) {
           const accept = headers.get('Accept');
@@ -506,6 +539,20 @@ export function createSpFetch(deps: SpFetchDeps) {
           }
 
           const retryAfterMs = parseRetryAfterMs(response);
+
+          recordSpProxyCorrelation({
+            diagnosticId,
+            event: 'http_response',
+            occurredAt: new Date().toISOString(),
+            method,
+            targetPath: resolvedPath,
+            status: response.status,
+            safeErrorCode: response.ok ? 'ok' : `http_${response.status}`,
+            failureClass: 'http',
+            retryClass: correlationRetryClassForStatus(response.status),
+            retryable: !skipRetry && isRetryableStatus(response.status),
+            durationMs: Date.now() - attemptStartedAt,
+          }, config);
 
           if (response.ok) {
             recordTelemetry('sp:request_end', {
@@ -557,6 +604,20 @@ export function createSpFetch(deps: SpFetchDeps) {
               durationMs: Date.now() - attemptStartedAt,
             });
 
+            recordSpProxyCorrelation({
+              diagnosticId,
+              event: 'retry',
+              occurredAt: new Date().toISOString(),
+              method,
+              targetPath: resolvedPath,
+              status: response.status,
+              safeErrorCode: `http_${response.status}`,
+              failureClass: 'http',
+              retryClass: correlationRetryClassForStatus(response.status),
+              retryable: true,
+              durationMs: Date.now() - attemptStartedAt,
+            }, config);
+
             if (onRetry) {
               const reason = response.status === 429 ? 'throttle' : 'server';
               try { onRetry(response, { attempt, status: response.status, reason, delayMs }); }
@@ -591,7 +652,7 @@ export function createSpFetch(deps: SpFetchDeps) {
           span.fail(response.status, 'SpHttpError', attempt - 1);
 
           if (throwOnError) {
-             await raiseHttpError(response, { url, method, spOptions });
+             await raiseHttpError(response, { url, method, diagnosticId, spOptions });
           }
           return response;
 
@@ -611,6 +672,18 @@ export function createSpFetch(deps: SpFetchDeps) {
               durationMs: Date.now() - attemptStartedAt,
               message: error.message,
             });
+            recordSpProxyCorrelation({
+              diagnosticId,
+              event: 'non_http_failure',
+              occurredAt: new Date().toISOString(),
+              method,
+              targetPath: resolvedPath,
+              safeErrorCode: 'throttle_redirect',
+              failureClass: correlationFailureClass(error),
+              retryClass: 'throttle',
+              retryable: false,
+              durationMs: Date.now() - attemptStartedAt,
+            }, config);
             span.error('SpThrottleRedirectError', attempt - 1);
             throw error;
           }
@@ -624,6 +697,18 @@ export function createSpFetch(deps: SpFetchDeps) {
               durationMs: Date.now() - attemptStartedAt,
               message: 'aborted',
             });
+            recordSpProxyCorrelation({
+              diagnosticId,
+              event: 'non_http_failure',
+              occurredAt: new Date().toISOString(),
+              method,
+              targetPath: resolvedPath,
+              safeErrorCode: 'aborted',
+              failureClass: correlationFailureClass(error),
+              retryClass: 'timeout',
+              retryable: false,
+              durationMs: Date.now() - attemptStartedAt,
+            }, config);
             span.error('AbortError', attempt - 1);
             throw error;
           }
@@ -650,6 +735,18 @@ export function createSpFetch(deps: SpFetchDeps) {
               durationMs: Date.now() - attemptStartedAt,
               message: error instanceof Error ? error.message : 'NetworkError',
             });
+            recordSpProxyCorrelation({
+              diagnosticId,
+              event: 'non_http_failure',
+              occurredAt: new Date().toISOString(),
+              method,
+              targetPath: resolvedPath,
+              safeErrorCode: 'cors_or_redirect_failure',
+              failureClass: correlationFailureClass(error),
+              retryClass: 'throttle',
+              retryable: false,
+              durationMs: Date.now() - attemptStartedAt,
+            }, config);
             span.error('SpThrottleRedirectError', attempt - 1);
             openThrottleCircuit();
             throw new SpThrottleRedirectError(url);
@@ -667,6 +764,18 @@ export function createSpFetch(deps: SpFetchDeps) {
               durationMs: Date.now() - attemptStartedAt,
               message: error instanceof Error ? error.message : 'NetworkError',
             });
+            recordSpProxyCorrelation({
+              diagnosticId,
+              event: 'retry',
+              occurredAt: new Date().toISOString(),
+              method,
+              targetPath: resolvedPath,
+              safeErrorCode: 'network_error',
+              failureClass: correlationFailureClass(error),
+              retryClass: 'network',
+              retryable: true,
+              durationMs: Date.now() - attemptStartedAt,
+            }, config);
             await sleep(delayMs, mergedSignal);
             continue;
           }
@@ -679,6 +788,18 @@ export function createSpFetch(deps: SpFetchDeps) {
             durationMs: Date.now() - attemptStartedAt,
             message: error instanceof Error ? error.message : 'NetworkError',
           });
+          recordSpProxyCorrelation({
+            diagnosticId,
+            event: 'non_http_failure',
+            occurredAt: new Date().toISOString(),
+            method,
+            targetPath: resolvedPath,
+            safeErrorCode: 'network_error',
+            failureClass: correlationFailureClass(error),
+            retryClass: 'network',
+            retryable: false,
+            durationMs: Date.now() - attemptStartedAt,
+          }, config);
           span.error('NetworkError', attempt - 1);
           throw error;
         }

--- a/src/lib/telemetry/__tests__/spProxyCorrelation.spec.ts
+++ b/src/lib/telemetry/__tests__/spProxyCorrelation.spec.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  clearSpProxyCorrelation,
+  getSpProxyCorrelationSnapshot,
+  recordSpProxyCorrelation,
+} from '../spProxyCorrelation';
+
+describe('spProxyCorrelation', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_SP_PROXY_CORRELATION', '1');
+    clearSpProxyCorrelation();
+  });
+
+  afterEach(() => {
+    clearSpProxyCorrelation();
+    vi.unstubAllEnvs();
+  });
+
+  it('records only safe correlation metadata', () => {
+    recordSpProxyCorrelation({
+      diagnosticId: 'diag-12345678',
+      event: 'http_response',
+      occurredAt: '2026-08-04T02:34:00.000Z',
+      method: 'get',
+      targetPath: "/_api/web/lists/getbytitle('Users_Master')/items(123)?$filter=secret",
+      targetList: 'Users_Master',
+      status: 403,
+      safeErrorCode: 'http_403',
+      failureClass: 'http',
+      retryClass: 'none',
+      retryable: false,
+      durationMs: 12.8,
+    });
+
+    const snapshot = getSpProxyCorrelationSnapshot();
+    expect(snapshot.records[0]).toMatchObject({
+      diagnosticId: 'diag-12345678',
+      method: 'GET',
+      targetPath: "/_api/web/lists/getbytitle('Users_Master')/items(?)",
+      status: 403,
+      statusClass: '4xx',
+      durationMs: 12,
+    });
+    const serialized = JSON.stringify(snapshot);
+    expect(serialized).not.toContain('secret');
+    expect(snapshot.records[0]?.targetPath).not.toContain('/123');
+  });
+
+  it('is disabled by default', () => {
+    vi.stubEnv('VITE_SP_PROXY_CORRELATION', '0');
+    recordSpProxyCorrelation({
+      diagnosticId: 'diag-12345678',
+      event: 'request_start',
+      occurredAt: new Date().toISOString(),
+    });
+    expect(getSpProxyCorrelationSnapshot().records).toEqual([]);
+  });
+});

--- a/src/lib/telemetry/spProxyCorrelation.ts
+++ b/src/lib/telemetry/spProxyCorrelation.ts
@@ -1,0 +1,144 @@
+import { readBool, type EnvRecord } from '@/lib/env';
+
+export type SpProxyCorrelationEvent =
+  | 'request_start'
+  | 'http_response'
+  | 'retry'
+  | 'non_http_failure'
+  | 'health_signal';
+
+export type SpProxyFailureClass =
+  | 'http'
+  | 'network'
+  | 'abort'
+  | 'cors_redirect'
+  | 'throttle_redirect'
+  | 'unknown';
+
+export type SpProxyRetryClass = 'none' | 'timeout' | 'throttle' | 'server' | 'network';
+
+export interface SpProxyCorrelationRecord {
+  diagnosticId?: string;
+  event: SpProxyCorrelationEvent;
+  occurredAt: string;
+  method?: string;
+  targetPath?: string;
+  targetList?: string;
+  route?: string;
+  status?: number;
+  statusClass?: string;
+  safeErrorCode?: string;
+  failureClass?: SpProxyFailureClass;
+  retryClass?: SpProxyRetryClass;
+  retryable?: boolean;
+  durationMs?: number;
+  reasonCode?: string;
+  listName?: string;
+  severity?: string;
+  source?: string;
+  occurrenceCount?: number;
+  firstOccurredAt?: string;
+  lastOccurredAt?: string;
+  signalAgeMs?: number;
+}
+
+const MAX_RECORDS = 300;
+const SAFE_ID_PATTERN = /^[A-Za-z0-9_-]{8,128}$/;
+
+let records: SpProxyCorrelationRecord[] = [];
+
+export const isSpProxyCorrelationEnabled = (envOverride?: EnvRecord): boolean =>
+  readBool('VITE_SP_PROXY_CORRELATION', false, envOverride);
+
+export const createSpProxyDiagnosticId = (): string => {
+  try {
+    return crypto.randomUUID();
+  } catch {
+    return `sp-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+  }
+};
+
+export const statusClassFor = (status?: number): string | undefined => {
+  if (status === undefined || !Number.isFinite(status)) return undefined;
+  return `${Math.floor(status / 100)}xx`;
+};
+
+const sanitizePath = (value: string | undefined): string | undefined => {
+  if (!value) return undefined;
+  try {
+    const url = new URL(value, 'https://app.invalid');
+    return url.pathname
+      .replace(/\/items\([^/)]*\)/gi, '/items(?)')
+      .replace(/\/attachments\([^/)]*\)/gi, '/attachments(?)')
+      .slice(0, 512);
+  } catch {
+    return value.split('?')[0].slice(0, 512);
+  }
+};
+
+const sanitizeListName = (value: string | undefined): string | undefined =>
+  value?.replace(/[\r\n]/g, ' ').slice(0, 128);
+
+const sanitizeDiagnosticId = (value: string | undefined): string | undefined => {
+  if (!value || !SAFE_ID_PATTERN.test(value)) return undefined;
+  return value;
+};
+
+const sanitizeRecord = (record: SpProxyCorrelationRecord): SpProxyCorrelationRecord => {
+  const status = typeof record.status === 'number' && Number.isFinite(record.status)
+    ? Math.trunc(record.status)
+    : undefined;
+  return {
+    diagnosticId: sanitizeDiagnosticId(record.diagnosticId),
+    event: record.event,
+    occurredAt: record.occurredAt,
+    method: record.method?.toUpperCase().slice(0, 12),
+    targetPath: sanitizePath(record.targetPath),
+    targetList: sanitizeListName(record.targetList),
+    route: sanitizePath(record.route),
+    status,
+    statusClass: record.statusClass ?? statusClassFor(status),
+    safeErrorCode: record.safeErrorCode?.replace(/[^A-Za-z0-9_.-]/g, '_').slice(0, 80),
+    failureClass: record.failureClass,
+    retryClass: record.retryClass,
+    retryable: record.retryable,
+    durationMs: typeof record.durationMs === 'number' && Number.isFinite(record.durationMs)
+      ? Math.max(0, Math.trunc(record.durationMs))
+      : undefined,
+    reasonCode: record.reasonCode?.replace(/[^A-Za-z0-9_.-]/g, '_').slice(0, 80),
+    listName: sanitizeListName(record.listName),
+    severity: record.severity?.replace(/[^A-Za-z0-9_.-]/g, '_').slice(0, 32),
+    source: record.source?.replace(/[^A-Za-z0-9_.-]/g, '_').slice(0, 32),
+    occurrenceCount: typeof record.occurrenceCount === 'number' && Number.isFinite(record.occurrenceCount)
+      ? Math.max(0, Math.trunc(record.occurrenceCount))
+      : undefined,
+    firstOccurredAt: record.firstOccurredAt,
+    lastOccurredAt: record.lastOccurredAt,
+    signalAgeMs: typeof record.signalAgeMs === 'number' && Number.isFinite(record.signalAgeMs)
+      ? Math.max(0, Math.trunc(record.signalAgeMs))
+      : undefined,
+  };
+};
+
+export const recordSpProxyCorrelation = (
+  record: SpProxyCorrelationRecord,
+  envOverride?: EnvRecord,
+): void => {
+  if (!isSpProxyCorrelationEnabled(envOverride)) return;
+  records = [...records, sanitizeRecord(record)].slice(-MAX_RECORDS);
+};
+
+export const getSpProxyCorrelationSnapshot = () => ({
+  records: records.map((record) => ({ ...record })),
+  generatedAt: new Date().toISOString(),
+});
+
+export const clearSpProxyCorrelation = (): void => {
+  records = [];
+};
+
+if (typeof window !== 'undefined' && isSpProxyCorrelationEnabled()) {
+  (window as typeof window & {
+    spProxyCorrelation?: typeof getSpProxyCorrelationSnapshot;
+  }).spProxyCorrelation = getSpProxyCorrelationSnapshot;
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -12,6 +12,8 @@ interface Env {
   VITE_SKIP_PROVISIONING?: string;
   VITE_SP_LIST_BILLING_ORDERS?: string;
   VITE_SP_LIST_BILLING_ORDERS_SITE_RELATIVE?: string;
+  /** Client-side correlation flag. Safe non-secret runtime setting. */
+  VITE_SP_PROXY_CORRELATION?: string;
   /** Server-only, opt-in proxy diagnostics. Never injected into client runtime. */
   SP_PROXY_DIAGNOSTICS?: string;
   ALLOWED_TENANT_ID?: string;
@@ -78,6 +80,7 @@ const RUNTIME_ENV_ALLOWLIST = new Set([
   'VITE_SP_SITE_RELATIVE',
   'VITE_SKIP_PROVISIONING',
   'VITE_SP_USE_PROXY',
+  'VITE_SP_PROXY_CORRELATION',
   'VITE_SP_LIST_BILLING_ORDERS',
   'VITE_SP_LIST_BILLING_ORDERS_SITE_RELATIVE',
 ]);
@@ -418,6 +421,11 @@ const createProxyDiagnosticId = (): string => {
   }
 };
 
+const incomingProxyDiagnosticId = (request: Request): string | undefined => {
+  const value = request.headers.get('x-sp-diagnostic-id')?.trim();
+  return value && /^[A-Za-z0-9_-]{8,128}$/.test(value) ? value : undefined;
+};
+
 const retryClassForStatus = (status?: number): ProxyRetryClass => {
   if (status === 408) return 'timeout';
   if (status === 429) return 'throttle';
@@ -486,7 +494,9 @@ const handleSharePointProxy = async (request: Request, env: Env): Promise<Respon
   }
 
   const diagnosticsStartedAt = proxyDiagnosticsEnabled(env) ? Date.now() : undefined;
-  const diagnosticId = diagnosticsStartedAt === undefined ? '' : createProxyDiagnosticId();
+  const diagnosticId = diagnosticsStartedAt === undefined
+    ? ''
+    : incomingProxyDiagnosticId(request) ?? createProxyDiagnosticId();
 
   const authHeader = request.headers.get('Authorization') ?? '';
   if (!authHeader.startsWith('Bearer ')) {


### PR DESCRIPTION
## Summary

- `VITE_SP_PROXY_CORRELATION` を既定OFFで追加し、認証情報を含まないクライアント相関IDを生成
- proxy request、HTTP応答、retry、非HTTP例外、health signalを同一IDで相関
- reasonCode、listName、severity、source、occurrenceCount、初回／最終発生時刻、status分類、safe error code、retry判定、duration／signal ageを安全なメモリ記録へ保存
- Cloudflare Workerはクライアント相関IDを検証して、既存`SP_PROXY_DIAGNOSTICS`ログへ引き継ぐ
- kioskの汎用文言、APIのstatus/body、既存のsprequestguid転送、診断設定の既定OFFは維持

## Safety

- Authorization、Cookie、アクセストークン、クエリ値、応答本文、個人IDは記録しない
- `VITE_SP_PROXY_CORRELATION` は非秘密の観測フラグで、既定値はOFF
- `SP_PROXY_DIAGNOSTICS` の既定値は変更しない
- 本番デプロイ、Observability有効化、SharePointデータ変更、Microsoft 365再ログインは未実施

## Validation

- 対象テスト: 6 files / 44 tests PASS
- `tsc -p tsconfig.ci.json --noEmit --pretty false`: PASS
- `npm run lint -- --max-warnings 0`: PASS
- `npm run build`: PASS
- `git diff --check`: PASS

## Scope

原因修正や通常Dashboardのゲート解除は行わず、診断証拠の相関範囲だけを追加する観測専用Draft PRです。